### PR TITLE
Blocks netspeak

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -92,6 +92,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if(!message || message == "")
 		return
+	//[BEGIN BEE EDIT]
+	var/static/regex/netspeak = regex("lol|brb|wtf|idk|omg")
+	if(findtext(message, netspeak))
+		to_chat(src, "<span class='warning'>Netspeak is not permitted in character!</span>")
+		return
+	//[END BEE EDIT]
 
 	var/datum/saymode/saymode = SSradio.saymodes[talk_key]
 	var/message_mode = get_message_mode(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message || message == "")
 		return
 	//[BEGIN BEE EDIT]
-	var/static/regex/netspeak = regex("lol|brb|wtf|idk|omg")
+	var/static/regex/netspeak = regex("\\b(lol|brb|wtf|idk|omg)\\b", "i")
 	if(findtext(message, netspeak))
 		to_chat(src, "<span class='warning'>Netspeak is not permitted in character!</span>")
 		return


### PR DESCRIPTION
## About The Pull Request

Blocks any netspeak in IC chat from sending. 

If this is too severe, I'd be willing to change it to a confirmation popup like the "Meant for OOC?" check. It'd definitely say something like "Are you sure you want to broadcast your stupidity?"

Suggestions welcome.

## Why It's Good For The Game

>muh immershun

Tired of seeing Heads of Staff walking around saying "lol" and "wtf".

## Changelog
:cl: ike709
add: Blocked netspeak in IC chat.
/:cl: