### PR TITLE
symptom changes fixed

### DIFF
--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -40,6 +40,22 @@ Bonus
 		bleed = TRUE
 	if(A.properties["transmittable"] >= 8) //extra stamina damage
 		pain = TRUE
+		//[BEGIN BEE EDIT]
+	if(A.properties["stealth"] >= 4)
+		power = .25
+	if(A.properties["stealth"] >= 2)
+		power = .5
+	if(A.properties["stealth"] >= 0)
+		power = .75
+	if(A.properties["stealth"] >= -2)
+		power = 1
+	if(A.properties["stealth"] >= -4)
+		power = 1.25
+	if(A.properties["stealth"] >= -6)
+		power = 1.5
+	if(A.properties["stage_rate"] >= -8)
+		power = 1.75
+		//[END BEE EDIT]
 
 /datum/symptom/flesh_eating/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -41,19 +41,19 @@ Bonus
 	if(A.properties["transmittable"] >= 8) //extra stamina damage
 		pain = TRUE
 		//[BEGIN BEE EDIT]
-	if(A.properties["stealth"] >= 4)
-		power = .25
-	if(A.properties["stealth"] >= 2)
-		power = .5
 	if(A.properties["stealth"] >= 0)
-		power = .75
-	if(A.properties["stealth"] >= -2)
+		power = 0.75
+	if(A.properties["stealth"] >= 2)
+		power = 0.5
+	if(A.properties["stealth"] >= 4)
+		power = 0.25
+	if(A.properties["stealth"] <= -2)
 		power = 1
-	if(A.properties["stealth"] >= -4)
+	if(A.properties["stealth"] <= -4)
 		power = 1.25
-	if(A.properties["stealth"] >= -6)
+	if(A.properties["stealth"] <= -6)
 		power = 1.5
-	if(A.properties["stage_rate"] >= -8)
+	if(A.properties["stealth"] <= -8)
 		power = 1.75
 		//[END BEE EDIT]
 

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -27,14 +27,23 @@ Bonus
 	severity = 1
 	symptom_delay_min = 5
 	symptom_delay_max = 35
-	threshold_desc = "<b>Transmission 9:</b> Increases sneezing range, spreading the virus over a larger area.<br>\
+	threshold_desc = "<b>Transmission 9:</b> The host will sneeze periodically, spreading the disease. <br>\
 					  <b>Stealth 4:</b> The symptom remains hidden until active."
 
 /datum/symptom/sneeze/Start(datum/disease/advance/A)
 	if(!..())
 		return
-	if(A.properties["transmittable"] >= 9) //longer spread range
-		power = 2
+	if(A.properties["transmittable"] >= 9)
+		return
+	var/mob/living/M = A.affected_mob
+	switch(A.stage)
+		if(1, 2, 3)
+			if(!suppress_warning)
+				M.emote("sniff")
+		else
+			M.emote("sneeze")
+			if(M.CanSpreadAirborneDisease()) //don't spread germs if they covered their mouth
+				A.spread(4 + power)
 	if(A.properties["stealth"] >= 4)
 		suppress_warning = TRUE
 
@@ -46,7 +55,3 @@ Bonus
 		if(1, 2, 3)
 			if(!suppress_warning)
 				M.emote("sniff")
-		else
-			M.emote("sneeze")
-			if(M.CanSpreadAirborneDisease()) //don't spread germs if they covered their mouth
-				A.spread(4 + power)

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -15,7 +15,7 @@ Bonus
 
 //////////////////////////////////////
 */
-
+//[BEGIN BEE EDIT]
 /datum/symptom/sneeze
 	name = "Sneezing"
 	desc = "The virus causes irritation of the nasal cavity, making the host sneeze occasionally."
@@ -31,6 +31,11 @@ Bonus
 					  <b>Stealth 4:</b> The symptom remains hidden until active."
 
 /datum/symptom/sneeze/Start(datum/disease/advance/A)
+
+	if(A.properties["stealth"] >= 4)
+		suppress_warning = TRUE
+
+/datum/symptom/sneeze/Activate(datum/disease/advance/A)
 	if(!..())
 		return
 	if(A.properties["transmittable"] >= 9)
@@ -44,14 +49,4 @@ Bonus
 			M.emote("sneeze")
 			if(M.CanSpreadAirborneDisease()) //don't spread germs if they covered their mouth
 				A.spread(4 + power)
-	if(A.properties["stealth"] >= 4)
-		suppress_warning = TRUE
-
-/datum/symptom/sneeze/Activate(datum/disease/advance/A)
-	if(!..())
-		return
-	var/mob/living/M = A.affected_mob
-	switch(A.stage)
-		if(1, 2, 3)
-			if(!suppress_warning)
-				M.emote("sniff")
+				//[END BEE EDIT]

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -38,7 +38,7 @@ Bonus
 /datum/symptom/sneeze/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	if(A.properties["transmittable"] >= 9)
+	if(!A.properties["transmittable"] >= 9)
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -29,7 +29,7 @@ Bonus
 	symptom_delay_min = 25
 	symptom_delay_max = 80
 	var/remove_eyes = FALSE
-	threshold_desc = "<b>Resistance 12:</b> Weakens extraocular muscles, eventually leading to complete detachment of the eyes.<br>\
+	threshold_desc = "<b>Resistance 11:</b> Weakens extraocular muscles, eventually leading to complete detachment of the eyes.<br>\
 					  <b>Stealth 4:</b> The symptom remains hidden until active."
 
 /datum/symptom/visionloss/Start(datum/disease/advance/A)
@@ -37,7 +37,7 @@ Bonus
 		return
 	if(A.properties["stealth"] >= 4)
 		suppress_warning = TRUE
-	if(A.properties["resistance"] >= 12) //goodbye eyes
+	if(A.properties["resistance"] >= 11) //goodbye eyes
 		remove_eyes = TRUE
 
 /datum/symptom/visionloss/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -37,9 +37,10 @@ Bonus
 		return
 	if(A.properties["stealth"] >= 4)
 		suppress_warning = TRUE
+		//[BEGIN BEE EDIT]
 	if(A.properties["resistance"] >= 11) //goodbye eyes
 		remove_eyes = TRUE
-
+//[END BEE EDIT]
 /datum/symptom/visionloss/Activate(datum/disease/advance/A)
 	if(!..())
 		return


### PR DESCRIPTION

## About The Pull Request
-nerfed sneezing
-small buff to hyphema
-fixed necrotizing fasciitis stealth scaling

## Why It's Good For The Game

-Hyphema is a fun symptom, but impossible to spread to its full potential without sneezing, even though it is possible to kill everyone quit easily without sneezing, oddly enough
-sneezing makes spreading a virus way too easy, especially for a starter symptom
-necrotizing fasciitis was supposed to scale inversely with stealth, but did not
## Changelog
:cl:
balance: Nerfed Sneezing, now requires 9 transmission to spread
balance: Lowered hyphema symptom threshold to 11
tweak: necrotizing fasciitis inverse stealth scaling
/:cl:

