### PR TITLE
Haloperidol and chloral nerfs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1104,7 +1104,8 @@
 	description = "Increases depletion rates for most stimulating/hallucinogenic drugs. Reduces druggy effects and jitteriness. Severe stamina regeneration penalty, causes drowsiness. Small chance of brain damage."
 	reagent_state = LIQUID
 	color = "#27870a"
-	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+	metabolization_rate = 0.6 * REAGENTS_METABOLISM
+	overdose_threshold = 25
 
 /datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/M)
 	for(var/datum/reagent/drug/R in M.reagents.reagent_list)
@@ -1117,6 +1118,17 @@
 	if(prob(20))
 		M.adjustBrainLoss(1*REM, 50)
 	M.adjustStaminaLoss(2.5*REM, 0)
+	..()
+	return TRUE
+
+/datum/reagent/medicine/haloperidol/overdose_process(mob/living/M)
+	M.adjustToxLoss(0.5*REM, 0)
+	M.adjustBrainLoss(3*REM, 80)
+	M.adjustStaminaLoss(1.2*REM, 0)
+	if(prob(2))
+	 M.visible_message("<span class='danger'>[M] starts having a seizure!</span>", "<span class='userdanger'>You have a seizure!</span>")
+	 M.Unconscious(100)
+	 M.Jitter(350)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -268,7 +268,7 @@
 	reagent_state = SOLID
 	color = "#000067" // rgb: 0, 0, 103
 	toxpwr = 0
-	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	metabolization_rate = 2.3 * REAGENTS_METABOLISM
 
 /datum/reagent/toxin/chloralhydrate/on_mob_life(mob/living/carbon/M)
 	switch(current_cycle)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes Haloperidol and Chloral Hydrate to be more balanced

## Why It's Good For The Game
Makes medibots cease stunlocking you for 9000 years and claiming its "not human harm" with haloperidol, and reducing how long chloral hydrates effects last, nerfing it for its relative ease of production.
## Changelog
:cl:
add: Added OD limit and effects for haloperidol
Tweak: Tweaked chloral hydrate and haloperidol's metab rate.
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
