### PR TITLE
Splits advanced data theory into two separate nodes

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -4,6 +4,10 @@
 		to_chat(src, "<span class='warning'>Your holochassis emitters are still too unstable! Please wait for automatic repair.</span>")
 		return FALSE
 
+	if(istype(remote_control,/obj/item/integrated_circuit/input/pAI_connector))
+		to_chat(src,"<span class='notice'>The connector is too small to allow you to change form in it.</span>")
+		return FALSE
+
 	if(!canholo && !force)
 		to_chat(src, "<span class='warning'>Your master or another force has disabled your holochassis emitters!</span>")
 		return FALSE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -115,16 +115,23 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
-/datum/techweb_node/adv_datatheory
-	id = "adv_datatheory"
-	display_name = "Advanced Data Theory"
-	description = "Better insight into programming and data."
+/datum/techweb_node/circuitresearch
+	id = "circuitresearch"
+	display_name = "Circuit Research"
+	description = "Circuits, woo"
 	prereq_ids = list("datatheory")
-	design_ids = list("icprinter", "icupgadv", "icupgclo")
+	design_ids = list("icprinter")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
-
+/datum/techweb_node/circuitupgrades
+	id = "circuitupgrades"
+	display_name = "Advanced Circuit Research"
+	description = "Circuits but better."
+	prereq_ids = list("circuitresearch")
+	design_ids = list("icupgadv", "icupgclo")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	export_price = 5000
 
 /////////////////////////engineering tech/////////////////////////
 /datum/techweb_node/engineering


### PR DESCRIPTION
Becouse of Deb's bitching about circuits costing too little, also possibly maybe makes them researchable?
## Changelog
:cl:
tweak: split advanced data theory into two nodes
/:cl:
