### PR TITLE
adds the knockback stick

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -469,3 +469,42 @@
 	held_sausage.name = "[target.name]-roasted [held_sausage.name]"
 	held_sausage.desc = "[held_sausage.desc] It has been cooked to perfection on \a [target]."
 	update_icon()
+
+
+
+
+/obj/item/melee/knockback_stick
+	name = "Knockback Stick"
+	desc = "An portable anti-gravity generator which knocks people back upon contact."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "telebaton_1"
+	item_state = "nullrod"
+	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+	slot_flags = ITEM_SLOT_BELT
+	force = 0
+	throwforce = 0
+	w_class = WEIGHT_CLASS_NORMAL
+	attack_verb = list("repelled")
+	var/cooldown = 0
+	var/knockbackpower = 6
+
+/obj/item/melee/knockback_stick/attack(mob/living/target, mob/living/user)
+	add_fingerprint(user)
+
+	if(cooldown <= world.time)
+		playsound(get_turf(src), 'sound/effects/woodhit.ogg', 75, 1, -1)
+		log_combat(user, target, "knockedbacked", src)
+		target.visible_message("<span class ='danger'>[user] has knocked back [target] with [src]!</span>", \
+			"<span class ='userdanger'>[user] has knocked back [target] with [src]!</span>")
+
+		var/throw_dir = get_dir(user,target)
+		var/turf/throw_at = get_ranged_target_turf(target, throw_dir, knockbackpower)
+		target.throw_at(throw_at, throw_range, 3)
+
+		if(!iscarbon(user))
+			target.LAssailant = null
+		else
+			target.LAssailant = user
+
+		cooldown = world.time + 15


### PR DESCRIPTION
because why not

## Changelog
:cl:
add: Added the knockback stick
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
