### PR TITLE
Re-adds separated chemicals to glow berries

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -90,7 +90,7 @@
 	lifespan = 30
 	endurance = 25
 	mutatelist = list()
-	genes = list(/datum/plant_gene/trait/glow/berry, /datum/plant_gene/trait/repeated_harvest)
+	genes = list(/datum/plant_gene/trait/glow/berry, /datum/plant_gene/trait/noreact, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/uranium = 0.25, /datum/reagent/iodine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 


### PR DESCRIPTION

## About The Pull Request

Adds Separated Chemicals to the list of traits of glow berries.

## Why It's Good For The Game

Gives robust botanists more fun things to do.  Gives unrobust botanists something to aspire to.

## Changelog
:cl:
add: added separated chemicals to glow berries.
/:cl:

