### PR TITLE
Gives miner jumpsuits the same protection as sec jumpsuits

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -224,6 +224,7 @@
 
 /obj/item/clothing/under/rank/miner
 	desc = "It's a snappy jumpsuit with a sturdy set of overalls. It is very dirty."
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	name = "shaft miner's jumpsuit"
 	icon_state = "miner"
 	item_state = "miner"
@@ -231,6 +232,7 @@
 
 /obj/item/clothing/under/rank/miner/lavaland
 	desc = "A green uniform for operating in hazardous environments."
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	name = "shaft miner's jumpsuit"
 	icon_state = "explorer"
 	item_state = "explorer"

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -232,7 +232,6 @@
 
 /obj/item/clothing/under/rank/miner/lavaland
 	desc = "A green uniform for operating in hazardous environments."
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 	name = "shaft miner's jumpsuit"
 	icon_state = "explorer"
 	item_state = "explorer"


### PR DESCRIPTION
## About The Pull Request
This PR gives shaft miner jumpsuits, both the original type and the lavaland type, 10 melee protection, 30 fire protection and 30 acid protection, the same as security jumpsuits.

## Why It's Good For The Game
I've seen a lot of shaft miners wear security jumpsuits for additional melee damage resistance they provide. With this PR, shaft miners no longer have to wear another department's jumpsuit to get as much melee damage resistance as they can have for a job where melee damage resistance is extremely useful and the game clearly expects you to have a large amount of it.

having fire resistance is probably useful too if you accidentally walk on lava or something

## Changelog
:cl:
tweak: Shaft miner jumpsuits have the same armor as security jumpsuits
/:cl: