### PR TITLE
no more branch checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ dist: xenial
 sudo: false
 
 branches:
-  except:
-  - ___TGS3TempBranch
-  - ___TGSTempBranch
+  only:
+    - master
 
 matrix:
   include:


### PR DESCRIPTION
## About The Pull Request

Removes the branch check for travis.

## Why It's Good For The Game

So I can live out my speedmerging lifestyle. Travis queuing causes two checks not to really be able to start at the same time. This shaves off about 2 minutes from checks. 

We never really needed branch checks anyway since we will only ever use the master branch in prod.

## Changelog
:cl:
del: Travis Branch Checks
/:cl: