### PR TITLE
auto map voting

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -263,6 +263,9 @@
 	//stop collecting feedback during grifftime
 	SSblackbox.Seal()
 
+	if(CONFIG_GET(flag/automapvote))
+		SSvote.initiate_vote("map", "BeeBot", forced=TRUE) //automatic map voting
+
 	sleep(50)
 	ready_for_reboot = TRUE
 	standard_reboot()

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -288,6 +288,8 @@
 
 /datum/config_entry/flag/maprotation
 
+/datum/config_entry/flag/automapvote
+
 /datum/config_entry/number/maprotatechancedelta
 	config_entry_value = 0.75
 	min_val = 0

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -153,7 +153,7 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/submit_vote(vote)
 	if(mode)
-		if(CONFIG_GET(flag/no_dead_vote) && (usr.stat == DEAD && !isnewplayer(usr)) && !usr.client.holder) // BEE EDIT: newplayers can vote even if nodeadvote is enabled
+		if(CONFIG_GET(flag/no_dead_vote) && (usr.stat == DEAD && !isnewplayer(usr)) && !usr.client.holder && mode != "map") // BEE EDIT: newplayers can vote even if nodeadvote is enabled
 			return 0
 		if(!(usr.ckey in voted))
 			if(vote && 1<=vote && vote<=choices.len)
@@ -162,7 +162,7 @@ SUBSYSTEM_DEF(vote)
 				return vote
 	return 0
 
-/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)
+/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, forced=FALSE)
 	if(!mode)
 		if(started_time)
 			var/next_allowed_time = (started_time + CONFIG_GET(number/vote_delay))
@@ -172,7 +172,7 @@ SUBSYSTEM_DEF(vote)
 
 			var/admin = FALSE
 			var/ckey = ckey(initiator_key)
-			if(GLOB.admin_datums[ckey])
+			if(GLOB.admin_datums[ckey] || forced)
 				admin = TRUE
 
 			if(next_allowed_time > world.time && !admin)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -395,6 +395,10 @@ MAPROTATION
 ## When it's set to zero, the map will be randomly picked each round
 PREFERENCE_MAP_VOTING 1
 
+## Automatic Map Vote
+## Whether a map vote will be triggered at roundend.
+#AUTOMAPVOTE
+
 ## Map rotate chance delta
 ## This is the chance of map rotation factored to the round length.
 ## A value of 1 would mean the map rotation chance is the round length in minutes (hour long round == 60% rotation chance)


### PR DESCRIPTION
## About The Pull Request

Adds a config option where a map vote will be automatically triggered at round end. The map will also automatically switch when the vote ends.

Kev or CF plees add the following to the config:

```
## Automatic Map Vote
## Whether a map vote will be triggered at roundend.
AUTOMAPVOTE
```

## Why It's Good For The Game

Democracy FTW.

## Changelog
:cl:
add: Automatic map vote
/:cl: