### PR TITLE
foolish attempt to stop atmos from getting out of hand

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -33,7 +33,7 @@
 #define EXCITED_GROUP_BREAKDOWN_CYCLES				4		//number of FULL air controller ticks before an excited group breaks down (averages gas contents across turfs)
 #define EXCITED_GROUP_DISMANTLE_CYCLES				16		//number of FULL air controller ticks before an excited group dismantles and removes its turfs from active
 #define MINIMUM_AIR_RATIO_TO_SUSPEND				0.1		//Ratio of air that must move to/from a tile to reset group processing
-#define MINIMUM_AIR_RATIO_TO_MOVE					0.001	//Minimum ratio of air that must move to/from a tile
+#define MINIMUM_AIR_RATIO_TO_MOVE					0.01	//Minimum ratio of air that must move to/from a tile
 #define MINIMUM_AIR_TO_SUSPEND						(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_SUSPEND)	//Minimum amount of air that has to move before a group processing can be suspended
 #define MINIMUM_MOLES_DELTA_TO_MOVE					(MOLES_CELLSTANDARD*MINIMUM_AIR_RATIO_TO_MOVE) //Either this must be active
 #define MINIMUM_TEMPERATURE_TO_MOVE					(T20C+100)			//or this (or both, obviously)


### PR DESCRIPTION
## About The Pull Request

I did some tests and this seems to reduce the amount of active atmos turfs, reducing lag. When there is a big station explosion it creates a huge gradient of atmos all slowly flowing out causing a lot of active turfs. This basically stops that gradient from getting too big by changing the minimum amount of gas that can flow from one turf to another.

## Why It's Good For The Game

Reduce the atmos lag we see every round. Also nerfs breaches (a tiny bit) which is kind of good for a new player server I guess.

## Changelog
:cl:
tweak: How far atmos gas will travel
/:cl: