### PR TITLE
Should fix AI being able to die and continue doomsday

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -191,7 +191,7 @@
 	SSshuttle.autoEvac()
 	qdel(eyeobj) // No AI, no Eye
 	malfhack = null
-
+	ShutOffDoomsdayDevice()
 	. = ..()
 
 /mob/living/silicon/ai/IgniteMob()


### PR DESCRIPTION
Gay shit fixed, speedmerge as usual

## Changelog
:cl:
fix:fixed malf ai being able to doomsday even when dead due to a bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
