### PR TITLE
Mopcrafting

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -120,3 +120,18 @@
 
 /obj/item/mop/advanced/cyborg
 	insertable = FALSE
+
+/obj/item/mop/sharp
+	desc = "The logical conclusion of greytide-janitorial crossbreeding. The station is not ready."
+	name = "sharpened mop"
+	icon = 'icons/obj/janitor.dmi'
+	icon_state = "mop"
+	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+	force = 30
+	throwforce = 40
+	throw_speed = 5
+	throw_range = 7
+	w_class = WEIGHT_CLASS_NORMAL
+	attack_verb = list("mopped", "jabbed", "shanked", "stabbed", "jousted")
+	resistance_flags = FLAMMABLE

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -691,3 +691,15 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 	tools = list(TOOL_WIRECUTTER)
+
+	// Shank - Makeshift weapon that can embed on throw
+/datum/crafting_recipe/shank
+	name = "Shank"
+	reqs = list(/obj/item/shard = 1,
+					/obj/item/stack/cable_coil = 10) // 1 glass shard + 10 cable; needs a wirecutter to snip the cable.
+	result = /obj/item/melee/shank
+	tools = list(TOOL_WIRECUTTER)
+	time = 20
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	always_availible = TRUE

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -683,3 +683,11 @@
 	category = CAT_MISC
 	tools = list(TOOL_WRENCH, TOOL_WELDER, TOOL_WIRECUTTER)
 
+	/datum/crafting_recipe/sharpmop
+	name = "Sharpened Mop"
+	result = /obj/item/mop/sharp
+	reqs = list(/obj/item/mop)
+	time = 30
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+	tools = list(TOOL_WIRECUTTER)


### PR DESCRIPTION
Adds sharpened mops.


## About The Pull Request

Adds the Sharpened Mop, which can be made in the crafting tab using wirecutters on a mop.
Mostly a proof-of-concept.

## Why It's Good For The Game

Again, mostly a proof-of-concept, but now janitors can arm up aswell as greytiders.

## Changelog
:cl:
add: Added a new spear for janitors.
/:cl:
