### PR TITLE
[s] Adds a log for href exploit attempts

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -168,6 +168,10 @@
 	if (CONFIG_GET(flag/log_job_debug))
 		WRITE_LOG(GLOB.world_job_debug_log, "JOB: [text]")
 
+/proc/log_href_exploit(atom/user)
+	WRITE_LOG(GLOB.href_exploit_attempt_log, "HREF: [key_name(user)] has potentially attempted an href exploit.")
+	message_admins("[key_name_admin(user)] has potentially attempted an href exploit.")
+
 /* Log to both DD and the logfile. */
 /proc/log_world(text)
 #ifdef USE_CUSTOM_ERROR_HANDLER
@@ -194,7 +198,6 @@
 /* Close open log handles. This should be called as late as possible, and no logging should hapen after. */
 /proc/shutdown_logging()
 	rustg_log_close_all()
-
 
 /* Helper procs for building detailed log lines */
 /proc/key_name(whom, include_link = null, include_name = TRUE)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -38,6 +38,8 @@ GLOBAL_VAR(world_map_error_log)
 GLOBAL_PROTECT(world_map_error_log)
 GLOBAL_VAR(world_paper_log)
 GLOBAL_PROTECT(world_paper_log)
+GLOBAL_VAR(href_exploit_attempt_log)
+GLOBAL_PROTECT(href_exploit_attempt_log)
 
 GLOBAL_LIST_EMPTY(bombers)
 GLOBAL_PROTECT(bombers)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -116,6 +116,7 @@ GLOBAL_VAR(restart_counter)
 	GLOB.query_debug_log = "[GLOB.log_directory]/query_debug.log"
 	GLOB.world_job_debug_log = "[GLOB.log_directory]/job_debug.log"
 	GLOB.world_paper_log = "[GLOB.log_directory]/paper.log"
+	GLOB.href_exploit_attempt_log = "[GLOB.log_directory]/href_exploit_attempt.log"
 
 #ifdef UNIT_TESTS
 	GLOB.test_log = file("[GLOB.log_directory]/tests.log")

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -224,6 +224,7 @@
 			var/obj/item/integrated_circuit/IC = SScircuit.cached_components[build_type]
 			cost = IC.materials[/datum/material/iron]
 		else if(!(build_type in SScircuit.circuit_fabricator_recipe_list["Tools"]))
+			log_href_exploit(usr)
 			return
 
 		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)


### PR DESCRIPTION
There is now a log file and a proc for logging attempts at trying to use an href exploit. Doesn't go back and add it to all previously patched href exploits, that's a PR for another day (if ever). 

But it is something we should try to use from now on, because if we fix or port fixes of href exploits fast enough, we might catch some idiot who thought we hadn't fixed it yet.

No CL for hopefully obvious reasons.