### PR TITLE
Wait until greentexts are credited before displaying round end message and rolling credits

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -185,17 +185,11 @@
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	set waitfor = FALSE
 
-	to_chat(world, "<BR><BR><BR><span class='big bold'>The round has ended.</span>")
-	log_game("The round has ended.")
-	if(LAZYLEN(GLOB.round_end_notifiees))
-		send2irc("Notice", "[GLOB.round_end_notifiees.Join(", ")] the round has ended.")
-
 	for(var/I in round_end_events)
 		var/datum/callback/cb = I
 		cb.InvokeAsync()
 	LAZYCLEARLIST(round_end_events)
 
-	RollCredits()
 	for(var/client/C in GLOB.clients)
 		if(C)
 
@@ -211,6 +205,12 @@
 							C.inc_beecoin_count(BEECOIN_CO_REWARD, reason="Completed your crew objective!")
 							break
 
+	to_chat(world, "<BR><BR><BR><span class='big bold'>The round has ended.</span>")
+	log_game("The round has ended.")
+	if(LAZYLEN(GLOB.round_end_notifiees))
+		send2irc("Notice", "[GLOB.round_end_notifiees.Join(", ")] the round has ended.")
+	
+	RollCredits()
 
 	var/popcount = gather_roundend_feedback()
 	display_report(popcount)


### PR DESCRIPTION
because some admins feel the need to maxcap the shuttle at roundend and then players complain about not getting their greentexts when the admin does it one second too early