### PR TITLE
temporarily fixes the circuit issue

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -221,8 +221,7 @@
 			var/obj/item/electronic_assembly/E = SScircuit.cached_assemblies[build_type]
 			cost = E.materials[/datum/material/iron]
 		else if(ispath(build_type, /obj/item/integrated_circuit))
-			var/obj/item/integrated_circuit/IC = SScircuit.cached_components[build_type]
-			cost = IC.materials[/datum/material/iron]
+			cost = 400
 		else if(!(build_type in SScircuit.circuit_fabricator_recipe_list["Tools"]))
 			log_href_exploit(usr)
 			return


### PR DESCRIPTION
description for bwerty;

Since whatever happened fucked up the circuit imprinters ability to find the cost of every part (which by default is 400 as far as i can tell) i have just manually set the code to 400 on each part, and since assemblies dont have an issue, havent changed them.
Ill investigate further what caused this issue in the first place (this was working before the HREF fix) and it seems to be unable to find the cost from the part type. REEE