### PR TITLE
Glass Shard nerf / Slipping time reduced

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -6,7 +6,7 @@
 
 	var/cooldown = 0
 
-/datum/component/caltrop/Initialize(_min_damage = 0, _max_damage = 0, _probability = 100,  _flags = NONE)
+/datum/component/caltrop/Initialize(_min_damage = 0, _max_damage = 0, _probability = 66,  _flags = NONE)
 	min_damage = _min_damage
 	max_damage = max(_min_damage, _max_damage)
 	probability = _probability
@@ -47,7 +47,7 @@
 
 		var/damage = rand(min_damage, max_damage)
 		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
-			damage *= 0.75
+			damage *= 0.5
 		H.apply_damage(damage, BRUTE, picked_def_zone)
 
 		if(cooldown < world.time - 10) //cooldown to avoid message spam.
@@ -59,4 +59,4 @@
 						"<span class='userdanger'>You slide on [A]!</span>")
 
 			cooldown = world.time
-		H.Paralyze(60)
+		H.Paralyze(25)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -6,7 +6,7 @@
 
 	var/cooldown = 0
 
-/datum/component/caltrop/Initialize(_min_damage = 0, _max_damage = 0, _probability = 66,  _flags = NONE)
+/datum/component/caltrop/Initialize(_min_damage = 0, _max_damage = 0, _probability = 100,  _flags = NONE)
 	min_damage = _min_damage
 	max_damage = max(_min_damage, _max_damage)
 	probability = _probability
@@ -48,6 +48,8 @@
 		var/damage = rand(min_damage, max_damage)
 		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
 			damage *= 0.5
+		if(is_species(/datum/species/squid))
+			damage *= 1.3
 		H.apply_damage(damage, BRUTE, picked_def_zone)
 
 		if(cooldown < world.time - 10) //cooldown to avoid message spam.
@@ -59,4 +61,7 @@
 						"<span class='userdanger'>You slide on [A]!</span>")
 
 			cooldown = world.time
-		H.Paralyze(25)
+		if(!is_species(/datum/species/squid))
+			H.Paralyze(25)
+		else
+			H.Paralyze(5)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -61,7 +61,7 @@
 						"<span class='userdanger'>You slide on [A]!</span>")
 
 			cooldown = world.time
-		if(!is_species(H, /datum/species/squid))
-			H.Paralyze(25)
-		else
+		if(is_species(H, /datum/species/squid))
 			H.Paralyze(5)
+		else
+			H.Paralyze(25)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -62,6 +62,6 @@
 
 			cooldown = world.time
 		if(is_species(H, /datum/species/squid))
-			H.Paralyze(5)
+			H.Paralyze(10)
 		else
-			H.Paralyze(25)
+			H.Paralyze(40)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -48,7 +48,7 @@
 		var/damage = rand(min_damage, max_damage)
 		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
 			damage *= 0.5
-		if(is_species(/datum/species/squid))
+		if(is_species(H, /datum/species/squid))
 			damage *= 1.3
 		H.apply_damage(damage, BRUTE, picked_def_zone)
 
@@ -61,7 +61,7 @@
 						"<span class='userdanger'>You slide on [A]!</span>")
 
 			cooldown = world.time
-		if(!is_species(/datum/species/squid))
+		if(!is_species(H, /datum/species/squid))
 			H.Paralyze(25)
 		else
 			H.Paralyze(5)

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -246,7 +246,7 @@
 			C.Paralyze(paralyze_amount)
 			C.stop_pulling()
 		else
-			C.Knockdown(20)
+			C.Knockdown(15)
 
 		if(buckled_obj)
 			buckled_obj.unbuckle_mob(C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Glass shard paralyze reduced
Slipping overall knockdown reduced
Light step damage reduction buffed
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Squids are instagibbed by the most robust trash in the game. Who knew! The overall paralyze from slipping for all players is reduced, because someone always leaves the fucking showers on or the frantic TG speed in the halls means you didn't see the janitor sign. The probability of slipping is the same, it just means you won't lie comatose staring at the clouds just because you slipped.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Glass shard paralyze reduction
tweak: Light step damage reduction buffed 25%
tweak: Slip time reduced 25%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
