### PR TITLE
Tweak: Percentages of antags, slightly

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -73,17 +73,17 @@
 /datum/config_entry/flag/economy	//money money money money money money money money money money money money
 
 /datum/config_entry/number/traitor_scaling_coeff	//how much does the amount of players get divided by to determine traitors
-	config_entry_value = 6
+	config_entry_value = 8
 	integer = FALSE
 	min_val = 1
 
 /datum/config_entry/number/brother_scaling_coeff	//how many players per brother team
-	config_entry_value = 25
+	config_entry_value = 30
 	integer = FALSE
 	min_val = 1
 
 /datum/config_entry/number/changeling_scaling_coeff	//how much does the amount of players get divided by to determine changelings
-	config_entry_value = 6
+	config_entry_value = 10
 	integer = FALSE
 	min_val = 1
 
@@ -93,7 +93,7 @@
 	min_val = 1
 
 /datum/config_entry/number/abductor_scaling_coeff	//how many players per abductor team
-	config_entry_value = 15
+	config_entry_value = 20
 	integer = FALSE
 	min_val = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Antags slightly reduced by changing the the divisor for population.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Antag modes are great, but I don't think the code was built to house 100+ players. The game kind of puts in a scrollable list of 25+ antags, and the ship is fucking obliterated in minutes. This stabilizes the game just enough to where there's now 12 traitors instead of 16, 10 lings instead of 16, etc. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Antag divisor increased slightly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
