### PR TITLE
Viral cures rebalance

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -34,38 +34,113 @@
 	var/oldres
 	// The order goes from easy to cure to hard to cure.
 	var/static/list/advance_cures = 	list(
-																		list(	// level 1
-										/datum/reagent/copper, /datum/reagent/silver, /datum/reagent/iodine, /datum/reagent/iron, /datum/reagent/carbon
+																		list(	// level 1 basic cures. Can be found in the chem dispenser and harmless. tg unchanged.
+										/datum/reagent/copper, 
+										/datum/reagent/silver, 
+										/datum/reagent/iodine, 
+										/datum/reagent/iron, 
+										/datum/reagent/carbon
 									),
-									list(	// level 2
-										/datum/reagent/potassium, /datum/reagent/consumable/ethanol, /datum/reagent/lithium, /datum/reagent/silicon, /datum/reagent/bromine
+									list(	// level 2 normal cures. May have some side effects. again found in the chem dispenser. tg unchanged.
+										/datum/reagent/potassium, 
+										/datum/reagent/consumable/ethanol, 
+										/datum/reagent/lithium, 
+										/datum/reagent/silicon, 
+										/datum/reagent/bromine
 									),
-									list(	// level 3
-										/datum/reagent/consumable/sodiumchloride, /datum/reagent/consumable/sugar, /datum/reagent/consumable/orangejuice, /datum/reagent/consumable/tomatojuice, /datum/reagent/consumable/milk
+									list(	// level 3 runaround cures. requires you to run around a bit, but still easy to obtain. Usually found at the bar. mostly tg unchanged.
+										/datum/reagent/consumable/sodiumchloride, 
+										/datum/reagent/consumable/sugar, 
+										/datum/reagent/consumable/orangejuice, 
+										/datum/reagent/consumable/tomatojuice, 
+										/datum/reagent/consumable/milk, 
+										/datum/reagent/drug/nicotine
 									),
-									list(	//level 4
-										/datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/epinephrine, /datum/reagent/medicine/charcoal
+									list(	//level 4 Vendor cures. Usually limited, but can be made in chemistry.
+										/datum/reagent/medicine/spaceacillin, 
+										/datum/reagent/medicine/salglu_solution, 
+										/datum/reagent/medicine/epinephrine, 
+										/datum/reagent/medicine/charcoal, 
+										/datum/reagent/lye, 
+										/datum/reagent/space_cleaner/sterilizine, 
+										/datum/reagent/medicine/morphine, 
+										/datum/reagent/medicine/insulin,
+										/datum/reagent/toxin/plantbgone
 									),
-									list(	//level 5
-										/datum/reagent/oil, /datum/reagent/medicine/synaptizine, /datum/reagent/medicine/mannitol, /datum/reagent/drug/space_drugs, /datum/reagent/cryptobiolin
+									list(	//level 5 chemical cures that require minor knowledge to obtain. These are mostly tg level 5 AND 6, since I am planning to make 6+ cures harder to get/be toxic otherwise
+										/datum/reagent/oil, 
+										/datum/reagent/medicine/synaptizine, 
+										/datum/reagent/medicine/mannitol, 
+										/datum/reagent/drug/space_drugs, 
+										/datum/reagent/cryptobiolin, 
+										/datum/reagent/phenol, 
+										/datum/reagent/medicine/inacusiate, 
+										/datum/reagent/medicine/oculine, 
+										/datum/reagent/medicine/antihol
+										
 									),
 									list(	// level 6
-										/datum/reagent/phenol, /datum/reagent/medicine/inacusiate, /datum/reagent/medicine/oculine, /datum/reagent/medicine/antihol
+										/datum/reagent/consumable/capsaicin, 
+										/datum/reagent/consumable/condensedcapsaicin, 
+										/datum/reagent/concentrated_barbers_aid, 
+										/datum/reagent/barbers_aid, 
+										/datum/reagent/stabilizing_agent, 
+										/datum/reagent/medicine/ephedrine, 
+										/datum/reagent/toxin/bad_food,
+										/datum/reagent/medicine/clonexadone,
+										/datum/reagent/consumable/enzyme
 									),
-									list(	// level 7
-										/datum/reagent/medicine/leporazine, /datum/reagent/toxin/mindbreaker, /datum/reagent/medicine/corazone
+									list(	// level 7 these are mostly poisons.
+										/datum/reagent/toxin/mutagen, 
+										/datum/reagent/pax, 
+										/datum/reagent/drug/happiness, 
+										/datum/reagent/toxin/lipolicide, 
+										/datum/reagent/toxin/fentanyl, 
+										/datum/reagent/toxin/sulfonal, 
+										/datum/reagent/toxin/histamine, 
+										/datum/reagent/medicine/atropine,
+										/datum/reagent/toxin/acid/fluacid
 									),
-									list(	// level 8
-										/datum/reagent/pax, /datum/reagent/drug/happiness, /datum/reagent/medicine/ephedrine
+									list(	// level 8 you will need to run around to get these.
+										/datum/reagent/consumable/entpoly, 
+										/datum/reagent/consumable/tinlux, 
+										/datum/reagent/consumable/vitfro, 
+										/datum/reagent/toxin/minttoxin, 
+										/datum/reagent/toxin/mutetoxin, 
+										/datum/reagent/toxin/bonehurtingjuice,
+										/datum/reagent/water/holywater,
+										/datum/reagent/consumable/astrotame,
+										/datum/reagent/colorful_reagent,
+										/datum/reagent/glitter/pink,
+										/datum/reagent/glitter/white,
+										/datum/reagent/glitter/blue
 									),
-									list(	// level 9
-										/datum/reagent/toxin/lipolicide, /datum/reagent/medicine/sal_acid
+									list(	// level 9 CMO, you didn't empty your hypospray, right?
+										/datum/reagent/consumable/honey, 
+										/datum/reagent/medicine/omnizine, 
+										/datum/reagent/medicine/earthsblood,
+										/datum/reagent/consumable/ethanol/lizardwine,
+										/datum/reagent/medicine/strange_reagent,
+										/datum/reagent/consumable/liquidelectricity
 									),
-									list(	// level 10
-										/datum/reagent/medicine/haloperidol, /datum/reagent/drug/aranesp, /datum/reagent/medicine/diphenhydramine
+									list(	// level 10 oh god....
+										/datum/reagent/medicine/lavaland_extract, 
+										/datum/reagent/toxin/amanitin,
+										/datum/reagent/medicine/pyroxadone,
+										/datum/reagent/toxin/slimejelly,
+										/datum/reagent/teslium/energized_jelly,
+										/datum/reagent/growthserum
+										
+										
 									),
-									list(	//level 11
-										/datum/reagent/medicine/modafinil, /datum/reagent/toxin/anacea
+									list(	//level 11 why.... (I just stick here chemicals that should be extremely hard to obtain. Because gold? Pffff, come on!)
+										/datum/reagent/consumable/ethanol/blazaam, 
+										/datum/reagent/toxin/ghoulpowder, 
+										/datum/reagent/medicine/regen_jelly,
+										/datum/reagent/royal_bee_jelly,
+										/datum/chemical_reaction/mimesbane,
+										/datum/reagent/medicine/lavaland_extract,
+										/datum/reagent/tranquility
 									)
 								)
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -31,13 +31,42 @@
 	var/id = ""
 	var/processing = FALSE
 	var/mutable = TRUE //set to FALSE to prevent most in-game methods of altering the disease via virology
-
+	var/oldres
 	// The order goes from easy to cure to hard to cure.
 	var/static/list/advance_cures = 	list(
-									/datum/reagent/consumable/sodiumchloride, /datum/reagent/consumable/sugar, /datum/reagent/consumable/orangejuice,
-									/datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/salglu_solution, /datum/reagent/consumable/ethanol,
-									/datum/reagent/medicine/leporazine, /datum/reagent/medicine/synaptizine, /datum/reagent/toxin/lipolicide,
-									/datum/reagent/silver, /datum/reagent/gold
+																		list(	// level 1
+										/datum/reagent/copper, /datum/reagent/silver, /datum/reagent/iodine, /datum/reagent/iron, /datum/reagent/carbon
+									),
+									list(	// level 2
+										/datum/reagent/potassium, /datum/reagent/consumable/ethanol, /datum/reagent/lithium, /datum/reagent/silicon, /datum/reagent/bromine
+									),
+									list(	// level 3
+										/datum/reagent/consumable/sodiumchloride, /datum/reagent/consumable/sugar, /datum/reagent/consumable/orangejuice, /datum/reagent/consumable/tomatojuice, /datum/reagent/consumable/milk
+									),
+									list(	//level 4
+										/datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/epinephrine, /datum/reagent/medicine/charcoal
+									),
+									list(	//level 5
+										/datum/reagent/oil, /datum/reagent/medicine/synaptizine, /datum/reagent/medicine/mannitol, /datum/reagent/drug/space_drugs, /datum/reagent/cryptobiolin
+									),
+									list(	// level 6
+										/datum/reagent/phenol, /datum/reagent/medicine/inacusiate, /datum/reagent/medicine/oculine, /datum/reagent/medicine/antihol
+									),
+									list(	// level 7
+										/datum/reagent/medicine/leporazine, /datum/reagent/toxin/mindbreaker, /datum/reagent/medicine/corazone
+									),
+									list(	// level 8
+										/datum/reagent/pax, /datum/reagent/drug/happiness, /datum/reagent/medicine/ephedrine
+									),
+									list(	// level 9
+										/datum/reagent/toxin/lipolicide, /datum/reagent/medicine/sal_acid
+									),
+									list(	// level 10
+										/datum/reagent/medicine/haloperidol, /datum/reagent/drug/aranesp, /datum/reagent/medicine/diphenhydramine
+									),
+									list(	//level 11
+										/datum/reagent/medicine/modafinil, /datum/reagent/toxin/anacea
+									)
 								)
 
 /*
@@ -263,7 +292,11 @@
 /datum/disease/advance/proc/GenerateCure()
 	if(properties && properties.len)
 		var/res = CLAMP(properties["resistance"] - (symptoms.len / 2), 1, advance_cures.len)
-		cures = list(advance_cures[res])
+
+		if(res == oldres)
+			return
+		cures = list(pick(advance_cures[res]))
+		oldres = res
 
 		// Get the cure name from the cure_id
 		var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]

--- a/code/modules/antagonists/disease/disease_disease.dm
+++ b/code/modules/antagonists/disease/disease_disease.dm
@@ -51,7 +51,7 @@
 	if(cures.len)
 		return
 	var/list/not_used = advance_cures.Copy()
-	cures = list(pick_n_take(not_used), pick_n_take(not_used))
+	cures = list(pick(pick_n_take(not_used)), pick(pick_n_take(not_used)))
 
 	// Get the cure name from the cure_id
 	var/datum/reagent/D1 = GLOB.chemical_reagents_list[cures[1]]


### PR DESCRIPTION
## About The Pull Request
This implements the new tgstation viral cure system, where the cure is randomly selected from a list for each cure tier. The cures are also different.


## Why It's Good For The Game
Current high-tier cures are just insanely easy to make. If you get the top tier cure requirement, you just grind one resource. If it's second to highest, it is cured easier than the worst disease, providing you have a chem dispenser. Which is dumb, since the cures for "something in the middle" are much harder to make.
This PR should make strong viruses really hard to cure, unlike TG where the cures wary from a minor inconvenience to moderate pain in the ass. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: More different cures per resistance tier ported from TG.
balance: makes hard to cure viruses actually being hard to cure.
/:cl:
