### PR TITLE
event gamemode

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -586,6 +586,7 @@
 #include "code\game\gamemodes\dynamic\dynamic_rulesets_latejoin.dm"
 #include "code\game\gamemodes\dynamic\dynamic_rulesets_midround.dm"
 #include "code\game\gamemodes\dynamic\dynamic_rulesets_roundstart.dm"
+#include "code\game\gamemodes\events\event.dm"
 #include "code\game\gamemodes\extended\extended.dm"
 #include "code\game\gamemodes\gangs\dominator.dm"
 #include "code\game\gamemodes\gangs\gang_items.dm"

--- a/code/game/gamemodes/events/event.dm
+++ b/code/game/gamemodes/events/event.dm
@@ -1,0 +1,26 @@
+/// A blank slate gamemode for running events. Like the old secret_extended. Can be inherited
+/datum/game_mode/event
+	name = "event"
+	config_tag = "event"
+	announce_text = "An admin is running an event!"
+	false_report_weight = 0
+	required_players = 0
+
+	title_icon = null
+
+	// A few vars that the admins can set if they wish
+	var/endround_report = "The event has concluded!"
+	var/intercept_message
+
+/datum/game_mode/event/pre_setup()
+	return 1
+
+/datum/game_mode/event/generate_report()
+	return endround_report
+
+/datum/game_mode/event/send_intercept(report = 0)
+	if(intercept_message)
+		priority_announce(intercept_message, "Security Report", 'sound/ai/commandreport.ogg')
+
+/datum/game_mode/event/generate_station_goals()
+	return

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -1,8 +1,8 @@
 /datum/game_mode/extended
-	name = "secret extended"
-	config_tag = "secret_extended"
+	name = "extended"
+	config_tag = "extended"
 	report_type = "extended"
-	false_report_weight = 5
+	false_report_weight = 0
 	required_players = 0
 
 	announce_span = "notice"
@@ -16,16 +16,11 @@
 /datum/game_mode/extended/generate_report()
 	return "The transmission mostly failed to mention your sector. It is possible that there is nothing in the Syndicate that could threaten your station during this shift."
 
-/datum/game_mode/extended/announced
-	name = "extended"
-	config_tag = "extended"
-	false_report_weight = 0
-
-/datum/game_mode/extended/announced/generate_station_goals()
+/datum/game_mode/extended/generate_station_goals()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/G = new T
 		station_goals += G
 		G.on_report()
 
-/datum/game_mode/extended/announced/send_intercept(report = 0)
+/datum/game_mode/extended/send_intercept(report = 0)
 	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/ai/commandreport.ogg')


### PR DESCRIPTION
This gamemode basically replaces secret_extended with event gamemode, since secret_extended was only really used for running events.

This is meant to be a blank slate for admins to use to run an event, and can also be inherited if any admin wishes to write special code for their extra spicy event.

Adds a directory to sort all event code into.

## Changelog
:cl:
add: Event gamemode
/:cl:
