### PR TITLE
Multi-z plating decon works properly now

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -61,11 +61,12 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		if(null)
 			return
 		if(/turf/baseturf_bottom)
-			path = SSmapping.level_trait(z, ZTRAIT_BASETURF) || /turf/open/space
+			path = SSmapping.level_trait(z, ZTRAIT_BASETURF)
 			if (!ispath(path))
-				path = text2path(path)
-				if (!ispath(path))
-					warning("Z-level [z] has invalid baseturf '[SSmapping.level_trait(z, ZTRAIT_BASETURF)]'")
+				var/turf/T = below()
+				if(T && !istype(T, /turf/open/space))
+					path = /turf/open/openspace
+				else
 					path = /turf/open/space
 		if(/turf/open/space/basic)
 			// basic doesn't initialize and this will cause issues


### PR DESCRIPTION
Now if you decon a plating and there's a linked z-level below, and the turf below it isn't space, it'll make an openspace turf instead of a space turf.

Tested locally on the middle z-level and the bottom z-level, seems to work for both cases.