### PR TITLE
ZA WARDUO ( Alternative Timestop )

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -143,6 +143,13 @@
 	name = "Time Stop"
 	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop
 	category = "Defensive"
+	cost = 2
+
+/datum/spellbook_entry/timestop/enlarged
+	name = "Enlargened Timestop"
+	spell_type = /obj/effect/proc_holder/spell/aoe_turf/conjure/timestop/thicc
+	category = "Defensive"
+	cost = 8
 
 /datum/spellbook_entry/smoke
 	name = "Smoke"

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -50,6 +50,11 @@
 	check_anti_magic = TRUE
 	duration = 100
 
+/obj/effect/timestop/thicc
+	check_anti_magic = TRUE
+	duration = 90
+	freezerange = 60
+
 /datum/proximity_monitor/advanced/timestop
 	name = "chronofield"
 	setup_field_turfs = TRUE
@@ -117,14 +122,14 @@
 	A.move_resist = frozen_things[A]
 	frozen_things -= A
 	global_frozen_atoms -= A
-	
+
 
 /datum/proximity_monitor/advanced/timestop/proc/freeze_mecha(obj/mecha/M)
 	M.completely_disabled = TRUE
 
 /datum/proximity_monitor/advanced/timestop/proc/unfreeze_mecha(obj/mecha/M)
 	M.completely_disabled = FALSE
-	
+
 
 /datum/proximity_monitor/advanced/timestop/proc/freeze_throwing(atom/movable/AM)
 	var/datum/thrownthing/T = AM.throwing

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -170,6 +170,35 @@
 
 	summon_type = list(/obj/effect/timestop/wizard)
 
+
+/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop/thicc
+	name = "Large Timestop"
+	desc = "A modified version of timestop that has been designed to cover a large area."
+	charge_max = 3000 // 300 seconds ( 5 minutes )
+	clothes_req = TRUE
+	invocation = "ZA WARUDO TOKI WO TOMARE"
+	invocation_type = "shout"
+	range = 0
+	cooldown_min = 2500 //250 seconds
+	summon_amt = 1
+	action_icon_state = "time"
+
+	summon_type = list(/obj/effect/timestop/thicc)
+	
+/obj/effect/proc_holder/spell/aoe_turf/conjure/timestop/badmin
+	name = "Badmin"
+	desc = "A modified version of timestop that has been designed to cover a large area."
+	charge_max = 1 // 1tick
+	clothes_req = TRUE
+	invocation = "IS THAT A FUCKING JOJOKE REFERENCE?"
+	invocation_type = "shout"
+	range = 0
+	cooldown_min = 1 //250 seconds
+	summon_amt = 1
+	action_icon_state = "time"
+
+	summon_type = list(/obj/effect/timestop/thicc)
+
 /obj/effect/proc_holder/spell/aoe_turf/conjure/carp
 	name = "Summon Carp"
 	desc = "This spell conjures a simple carp."
@@ -281,7 +310,7 @@
 		var/atom/movable/AM = am
 		if(AM == user || AM.anchored)
 			continue
-		
+
 		if(ismob(AM))
 			var/mob/M = AM
 			if(M.anti_magic_check(anti_magic_check, FALSE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new form of timestop for 8 spell points (allows you to buy tarot cards  - hehe funny jojoke)
It has a range of 60 tiles, on a 5 minute cooldown (3000 ticks, or 300 seconds)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People wanted a better timestop that isnt on a 90 or so second cooldown, with a longer range and benefit for actually taking it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds an alternate form of timestop
change: changes original timestop price to have a cost var of 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
