### PR TITLE
Adds the ability to put all small items into boots

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -19,6 +19,11 @@
 	max_items = 1
 	attack_hand_interact = FALSE
 
+/datum/component/storage/concrete/pockets/exo
+	max_items = 2
+	max_w_class = WEIGHT_CLASS_SMALL
+	attack_hand_interact = TRUE
+
 /datum/component/storage/concrete/pockets/tiny
 	max_items = 1
 	max_w_class = WEIGHT_CLASS_TINY
@@ -28,30 +33,18 @@
 	attack_hand_interact = TRUE // so the detectives would discover pockets in their hats
 
 /datum/component/storage/concrete/pockets/shoes
+	max_items = 2
 	attack_hand_interact = FALSE
+	max_w_class = WEIGHT_CLASS_SMALL
 	quickdraw = TRUE
 	silent = TRUE
 
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
-	cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	can_hold = typecacheof(list(
-		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
-		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
-		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
-		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin
-		))
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()
 	. = ..()
-	cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
-	can_hold = typecacheof(list(
-		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
-		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
-		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
-		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin, /obj/item/bikehorn))
+
 
 /datum/component/storage/concrete/pockets/pocketprotector
 	max_items = 3

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -19,11 +19,6 @@
 	max_items = 1
 	attack_hand_interact = FALSE
 
-/datum/component/storage/concrete/pockets/exo
-	max_items = 2
-	max_w_class = WEIGHT_CLASS_SMALL
-	attack_hand_interact = TRUE
-
 /datum/component/storage/concrete/pockets/tiny
 	max_items = 1
 	max_w_class = WEIGHT_CLASS_TINY


### PR DESCRIPTION
## About The Pull Request
It just gets rid of the list of things boots could hold and replaces it with only the weight constraint. Also, was told to do this so don't blame me for whatever reason

## Why It's Good For The Game
Boots never get used to store things since they don't store much in the way of accessible, useful items.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
change:made boots fit up to small items instead of a specific list
/:cl: