### PR TITLE
Sentient disease: Faster adaptation

### DIFF
--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -42,7 +42,7 @@ the new instance inside the host to be updated to the template's stats.
 	var/move_delay = 1
 
 	var/next_adaptation_time = 0
-	var/adaptation_cooldown = 1200
+	var/adaptation_cooldown = 300
 
 	var/list/purchased_abilities
 	var/list/unpurchased_abilities


### PR DESCRIPTION


## About The Pull Request

sentient diseases can now adapt every thirty seconds instead of every two minutes


## Why It's Good For The Game

Sentient disease spawns late in the round, and is typically too slow to get any meaningful progress on on short bee rounds, especially because most people have no idea how to play viro. It's a hard antag and this makes it slightly more forgiving (but wont save you if a high transmission disease is already going around)

## Changelog
:cl:
balance: Sentient disease adaptation cooldown lowered
/:cl:

