### PR TITLE
IPC Solder and System Cleaner fix

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -268,13 +268,13 @@
 /datum/chemical_reaction/system_cleaner
 	name = "System Cleaner"
 	id = /datum/reagent/medicine/system_cleaner
-	results = list("system_cleaner" = 4)
+	results = list(/datum/reagent/medicine/system_cleaner = 4)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/chlorine = 1, /datum/reagent/phenol = 2, /datum/reagent/potassium = 1)
 
 /datum/chemical_reaction/liquid_solder
 	name = "Liquid Solder"
 	id = /datum/reagent/medicine/liquid_solder
-	results = list("liquid_solder" = 3)
+	results = list(/datum/reagent/medicine/liquid_solder = 3)
 	required_reagents = list( /datum/reagent/consumable/ethanol = 1, /datum/reagent/copper = 1, /datum/reagent/silver = 1)
 	required_temp = 370
 	mix_message = "The mixture becomes a metallic slurry."


### PR DESCRIPTION


## About The Pull Request

The Liquid solder and system cleaner are impossible to make. This PR makes it possible to make them.

## Why It's Good For The Game

Being able to heal toxin and brain damage done to IPCs is good.
## Changelog
:cl:
fix: Fixed Liquid solder and system cleaner being impossible to make.
/:cl:
