### PR TITLE
APC UI autoupdates properly

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -810,8 +810,6 @@
 	if(!ui)
 		ui = new(user, src, ui_key, "apc", name, 535, 515, master_ui, state)
 		ui.open()
-	if(ui)
-		ui.set_autoupdate(state = (failure_timer ? 1 : 0))
 
 /obj/machinery/power/apc/ui_data(mob/user)
 	var/list/data = list(


### PR DESCRIPTION
over 3 years ago seems to have copypasted a line erroneously in attempting to port grid checks, making APC uis only autoupdate when power failed.

[https://github.com/tgstation/tgstation/pull/20028/files#diff-ad09118440f5c936a8bbee05e2d3c8bbR631](https://github.com/tgstation/tgstation/pull/20028/files#diff-ad09118440f5c936a8bbee05e2d3c8bbR631)

I initially assumed this was for optimization reasons considering that APCs are placed in so many places, but that doesn't make any sense because 1. UIs are only autoupdated when open, and 2. this specific change is completely unmentioned in the original PR, and in the original baycode.

This deletes that block making APCs always autoupdate no matter what state of their ui, you no longer need to click them again to get them to update.

# Changelog
🆑
fix: APC UI autoupdates correctly
/🆑