### PR TITLE
Temporarily Disables KiloStation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -52,4 +52,5 @@ map kilostation
     minplayers 30
     maxplayers 80
 	votable
+	disabled
 endmap


### PR DESCRIPTION
## About The Pull Request

This temporarily disables KiloStation as problems of it still need fixing. This is not a permanent removal as it will be re-enabled once finished.

Disable not remove.

## Why It's Good For The Game

We shouldn't be running a non-functional map on a newbie server, however, I do not want to fully discontinue the KiloStation project. Work will continue.

## Changelog
:cl:
del: Temporarily disables KiloStation
/:cl: