### PR TITLE
Adds tiny fans to supply shuttle(s)

### DIFF
--- a/_maps/shuttles/cargo_birdboat.dmm
+++ b/_maps/shuttles/cargo_birdboat.dmm
@@ -4,7 +4,6 @@
 /area/shuttle/supply)
 "e" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "cargoshuttle";
 	name = "cargo shuttle conveyor belt"
 	},
@@ -68,6 +67,7 @@
 	id = "cargoshuttle";
 	name = "cargo shuttle conveyor belt"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "n" = (
@@ -78,11 +78,11 @@
 	name = "Supply Shuttle Airlock";
 	req_access_txt = "31"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "p" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor2";
 	name = "Loading Doors";
 	pixel_x = 24;
@@ -111,6 +111,7 @@
 	dwidth = 3;
 	width = 10
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "r" = (
@@ -123,6 +124,7 @@
 	id = "cargoshuttle";
 	name = "cargo shuttle conveyor belt"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "u" = (
@@ -182,7 +184,6 @@
 /area/shuttle/supply)
 "R" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "cargoshuttle";
 	name = "cargo shuttle conveyor belt"
 	},

--- a/_maps/shuttles/cargo_box.dmm
+++ b/_maps/shuttles/cargo_box.dmm
@@ -14,6 +14,7 @@
 	id = "QMLoaddoor2";
 	name = "supply dock loading door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "g" = (
@@ -21,11 +22,11 @@
 	name = "Supply Shuttle Airlock";
 	req_access_txt = "31"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "h" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor2";
 	name = "Loading Doors";
 	pixel_x = 24;
@@ -47,10 +48,8 @@
 	name = "Supply Shuttle Airlock";
 	req_access_txt = "31"
 	},
-/obj/docking_port/mobile/supply{
-	dwidth = 5;
-	width = 12
-	},
+/obj/docking_port/mobile/supply,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "j" = (
@@ -62,6 +61,7 @@
 	id = "QMLoaddoor";
 	name = "supply dock loading door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "l" = (

--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -70,6 +70,7 @@
 	id = "cargounload";
 	name = "supply dock unloading door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "l" = (
@@ -91,9 +92,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/mobile/supply{
 	dir = 4;
-	dwidth = 4;
-	width = 12
+	dwidth = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "o" = (
@@ -104,7 +105,6 @@
 /area/shuttle/supply)
 "p" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "cargounload";
 	name = "Loading Doors";
 	pixel_x = -24;
@@ -139,6 +139,7 @@
 	req_access_txt = "31"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "s" = (
@@ -150,6 +151,7 @@
 	dir = 4;
 	id = "cargoload"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "t" = (

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -71,7 +71,6 @@
 /area/shuttle/supply)
 "i" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
@@ -80,6 +79,7 @@
 	id = "QMLoad";
 	name = "off ramp"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "j" = (
@@ -122,9 +122,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/mobile/supply{
 	dir = 4;
-	dwidth = 4;
-	width = 12
+	dwidth = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "n" = (
@@ -167,7 +167,6 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "On Ramp Toggle";
@@ -196,6 +195,7 @@
 	req_access_txt = "31"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "s" = (
@@ -211,7 +211,6 @@
 /area/shuttle/supply)
 "t" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
@@ -220,6 +219,7 @@
 	id = "QMLoad2";
 	name = "on ramp"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "u" = (


### PR DESCRIPTION

## About The Pull Request

Adds tiny fans (prevents atmos loss) onto cargo ships. While the cargo techs may leave the blast doors open and vent cargobay atmos, the cargo ship itself won't be depressurized from negligence anymore.

## Why It's Good For The Game

Idiot proofs the cargo shuttle. Quality of life improvement.

![image](https://user-images.githubusercontent.com/15992551/66166169-6836ae00-e5eb-11e9-8a8e-f6e09b330c0a.png)
(On each blast door & airlock)

## Changelog
:cl: Triiodine
add: Added tiny fans to the Supply Shuttle blast doors and airlocks.
/:cl:

