### PR TITLE
Cross Server Ban option

### DIFF
--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS `SS13_ban` (
   `unbanned_ip` int(10) unsigned DEFAULT NULL,
   `unbanned_computerid` varchar(32) DEFAULT NULL,
   `unbanned_round_id` int(11) unsigned DEFAULT NULL,
+  `global_ban` tinyint(1) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `idx_ban_isbanned` (`ckey`,`role`,`unbanned_datetime`,`expiration_time`),
   KEY `idx_ban_isbanned_details` (`ckey`,`ip`,`computerid`,`role`,`unbanned_datetime`,`expiration_time`),

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -9,6 +9,13 @@ INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 2);
 In any query remember to add a prefix to the table names if you use one.
 
 ----------------------------------------------------
+Version 5.3 4 Oct 2019, by Crossedfall
+Adds the ability to apply bans globally or locally when multiple servers are used using the new `global_ban` column in the `ban` table.
+
+ALTER TABLE `ban`
+ADD `global_ban` tinyint unsigned NOT NULL DEFAULT '1';
+
+----------------------------------------------------
 Version 5.2, 22 Sep 2019, by Crossedfall & Qwerty
 Added the `server_name` column to the ban, connection_log, death, legacy_population, and round tables containing the server's name pulled from the `serversqlname` config variable. Updated the `server` column in the messages table to match the standard naming convention (`server_name`).
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -13,7 +13,7 @@ Version 5.3 4 Oct 2019, by Crossedfall
 Adds the ability to apply bans globally or locally when multiple servers are used using the new `global_ban` column in the `ban` table.
 
 ALTER TABLE `ban`
-ADD `global_ban` tinyint unsigned NOT NULL DEFAULT '1';
+ADD `global_ban` tinyint(1) unsigned NOT NULL DEFAULT '1';
 
 ----------------------------------------------------
 Version 5.2, 22 Sep 2019, by Crossedfall & Qwerty

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,6 +1,6 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.2; The query to update the schema revision table is:
+The latest database version is 5.3; The query to update the schema revision table is:
 
 INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 3);
 or

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,9 +2,9 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 5.2; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 2);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 3);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 2);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 3);
 
 In any query remember to add a prefix to the table names if you use one.
 

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -746,7 +746,7 @@
 		if(old_cid)
 			wherelist += "computerid = '[sanitizeSQL(old_cid)]'"
 		where = wherelist.Join(" AND ")
-	var/datum/DBQuery/query_edit_ban = SSdbcore.NewQuery("UPDATE [format_table_name("ban")] SET expiration_time = IF('[duration]' LIKE '', NULL, bantime + INTERVAL [duration ? "[duration]" : "0"] [interval]), applies_to_admins = [applies_to_admins], reason = '[reason]', global_ban = '[global_ban]', ckey = IF('[player_ckey]' LIKE '', NULL, '[player_ckey]'), ip = INET_ATON(IF('[player_ip]' LIKE '', NULL, '[player_ip]')), computerid = IF('[player_cid]' LIKE '', NULL, '[player_cid]'), edits = CONCAT(IFNULL(edits,''),'[sanitizeSQL(usr.client.key)] edited the following [jointext(changes_text, ", ")]<hr>') WHERE [where]")
+	var/datum/DBQuery/query_edit_ban = SSdbcore.NewQuery("UPDATE [format_table_name("ban")] SET expiration_time = IF('[duration]' LIKE '', NULL, bantime + INTERVAL [duration ? "[duration]" : "0"] [interval]), applies_to_admins = [applies_to_admins], reason = '[reason]', global_ban = [global_ban], ckey = IF('[player_ckey]' LIKE '', NULL, '[player_ckey]'), ip = INET_ATON(IF('[player_ip]' LIKE '', NULL, '[player_ip]')), computerid = IF('[player_cid]' LIKE '', NULL, '[player_cid]'), edits = CONCAT(IFNULL(edits,''),'[sanitizeSQL(usr.client.key)] edited the following [jointext(changes_text, ", ")]<hr>') WHERE [where]")
 	if(!query_edit_ban.warn_execute())
 		qdel(query_edit_ban)
 		return

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -112,9 +112,6 @@
 	<label class='inputlabel checkbox'>Applies to Admins
 	<input type='checkbox' id='applyadmins' name='applyadmins' value='1'[applies_to_admins ? " checked": ""]>
 	<div class='inputbox'></div></label>
-	<label class='inputlabel checkbox'>Ban on all Servers
-	<input type='checkbox' id='servbantype' name='servbantype' value='1'[global_ban ? " checked": ""]>
-	<div class='inputbox'></div></label>
 	<input type='submit' value='Submit'>
 	<br>
 	<div class='row'>
@@ -170,6 +167,17 @@
 			<div class='inputbox'></div></label>
 		</div>
 		<div class='column'>
+			Location
+			<br>	
+			<label class='inputlabel radio'>Local
+			<input type='radio' id='servban' name='radioservban' value='permanent'[isnull(global_ban) ? " checked" : ""]>
+			<div class='inputbox'></div></label>
+			<br>
+			<label class='inputlabel radio'>Global
+			<input type='radio' id='servban' name='radioservban' value='permanent'[(global_ban) ? " checked" : ""]>
+			<div class='inputbox'></div></label>
+		</div>
+		<div class='column'>
 			Reason
 			<br>
 			<textarea class='reason' name='reason'>[reason]</textarea>
@@ -187,6 +195,7 @@
 		<input type='hidden' name='oldapplies' value='[applies_to_admins]'>
 		<input type='hidden' name='oldduration' value='[duration]'>
 		<input type='hidden' name='oldreason' value='[reason]'>
+		<input type]'hidden' name='oldglobal' value='[global_ban]'
 		<input type='hidden' name='page' value='[page]'>
 		<input type='hidden' name='adminkey' value='[admin_key]'>
 		<br>
@@ -307,6 +316,7 @@
 	var/old_ip
 	var/old_cid
 	var/old_applies
+	var/old_global
 	var/page
 	var/admin_key
 	var/list/changes = list()
@@ -370,6 +380,9 @@
 		old_applies = text2num(href_list["oldapplies"])
 		if(applies_to_admins != old_applies)
 			changes += list("Applies to admins" = "[old_applies] to [applies_to_admins]")
+		old_global = text2num(href_list["oldglobal"])
+		if(global_ban != old_global)
+			changes += list("Ban Location" = "[old_global] to [global_ban]")
 		if(duration != href_list["oldduration"])
 			changes += list("Duration" = "[href_list["oldduration"]] MINUTE to [duration] [interval]")
 		if(reason != href_list["oldreason"])
@@ -398,7 +411,7 @@
 		to_chat(usr, "<span class='danger'>Ban not [edit_id ? "edited" : "created"] because the following errors were present:\n[error_state.Join("\n")]</span>")
 		return
 	if(edit_id)
-		edit_ban(edit_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, mirror_edit, old_key, old_ip, old_cid, old_applies, page, admin_key, changes)
+		edit_ban(edit_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, mirror_edit, old_key, old_ip, old_cid, old_applies, old_global, page, admin_key, changes)
 	else
 		create_ban(player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, severity, reason, global_ban, roles_to_ban)
 
@@ -654,7 +667,7 @@
 			to_chat(i, "<span class='boldannounce'>[usr.client.key] has removed a ban from [role] for your IP or CID.")
 	unban_panel(player_key, admin_key, player_ip, player_cid, page)
 
-/datum/admins/proc/edit_ban(ban_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, mirror_edit, old_key, old_ip, old_cid, old_applies, admin_key, page, list/changes)
+/datum/admins/proc/edit_ban(ban_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, mirror_edit, old_key, old_ip, old_cid, old_applies, old_global, admin_key, page, list/changes)
 	if(!check_rights(R_BAN))
 		return
 	if(!SSdbcore.Connect())

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -149,7 +149,7 @@
 			<input type='radio' id='role' name='radioban' value='role'[role == "Server" ? "" : " checked"][edit_id ? " disabled" : ""]>
 			<div class='inputbox'></div></label>
 		</div>
-		<div class='column right'>
+		<div class='column middle'>
 			Severity
 			<br>
 			<label class='inputlabel radio'>None
@@ -166,7 +166,7 @@
 			<input type='radio' id='high' name='radioseverity' value='high'[edit_id ? " disabled" : ""]>
 			<div class='inputbox'></div></label>
 		</div>
-		<div class='column'>
+		<div class='column right'>
 			Location
 			<br>	
 			<label class='inputlabel radio'>Local
@@ -412,7 +412,7 @@
 		to_chat(usr, "<span class='danger'>Ban not [edit_id ? "edited" : "created"] because the following errors were present:\n[error_state.Join("\n")]</span>")
 		return
 	if(edit_id)
-		edit_ban(edit_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, mirror_edit, old_key, old_ip, old_cid, old_applies, old_globalban, page, admin_key, changes)
+		edit_ban(edit_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, global_ban, mirror_edit, old_key, old_ip, old_cid, old_applies, old_globalban, page, admin_key, changes)
 	else
 		create_ban(player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, severity, reason, global_ban, roles_to_ban)
 
@@ -556,18 +556,6 @@
 	Admin Key:<input type='text' name='searchunbanadminkey' size='18' value='[admin_key]'>
 	IP:<input type='text' name='searchunbanip' size='12' value='[player_ip]'>
 	CID:<input type='text' name='searchunbancid' size='10' value='[player_cid]'>
-	<div>
-	<div class='column'>
-		Location
-		<br>	
-		<label class='inputlabel radio'>Local
-		<input type='radio' id='servban' name='searchservban' value='[global_ban]'[isnull(global_ban) ? " checked" : ""]>
-		<div class='inputbox'></div></label>
-		<br>
-		<label class='inputlabel radio'>Global
-		<input type='radio' id='servban' name='searchservban' value='[global_ban]'[(global_ban) ? " checked" : ""]>
-		<div class='inputbox'></div></label>
-	</div>
 	<input type='submit' value='Search'>
 	</form>
 	</div>
@@ -583,8 +571,6 @@
 			searchlist += "ip = INET_ATON('[sanitizeSQL(player_ip)]')"
 		if(player_cid)
 			searchlist += "computerid = '[sanitizeSQL(player_cid)]'"
-		if(global_ban)
-			searchlist += "global_ban = '[sanitizeSQL(global_ban)]'"
 		var/search = searchlist.Join(" AND ")
 		var/bancount = 0
 		var/bansperpage = 10
@@ -682,7 +668,7 @@
 			to_chat(i, "<span class='boldannounce'>[usr.client.key] has removed a ban from [role] for your IP or CID.")
 	unban_panel(player_key, admin_key, player_ip, player_cid, page)
 
-/datum/admins/proc/edit_ban(ban_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, mirror_edit, old_key, old_ip, old_cid, old_applies, old_globalban, admin_key, page, list/changes)
+/datum/admins/proc/edit_ban(ban_id, player_key, ip_check, player_ip, cid_check, player_cid, use_last_connection, applies_to_admins, duration, interval, reason, global_ban, mirror_edit, old_key, old_ip, old_cid, old_applies, old_globalban, admin_key, page, list/changes)
 	if(!check_rights(R_BAN))
 		return
 	if(!SSdbcore.Connect())
@@ -716,6 +702,8 @@
 					qdel(query_edit_ban_get_player)
 					return
 		qdel(query_edit_ban_get_player)
+	if(global_ban && (global_ban != old_globalban))
+
 	if(applies_to_admins && (applies_to_admins != old_applies))
 		var/admin_ckey = sanitizeSQL(usr.client.ckey)
 		var/datum/DBQuery/query_check_adminban_count = SSdbcore.NewQuery("SELECT COUNT(DISTINCT bantime) FROM [format_table_name("ban")] WHERE a_ckey = '[admin_ckey]' AND applies_to_admins = 1 AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())")

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -170,11 +170,11 @@
 			Location
 			<br>	
 			<label class='inputlabel radio'>Local
-			<input type='radio' id='servban' name='radioservban' value='1'[isnull(global_ban) ? " checked" : ""]>
+			<input type='radio' id='servban' name='radioservban' value='local'[isnull(global_ban) ? " checked" : ""]>
 			<div class='inputbox'></div></label>
 			<br>
 			<label class='inputlabel radio'>Global
-			<input type='radio' id='servban' name='radioservban' value='1'[(global_ban) ? " checked" : ""]>
+			<input type='radio' id='servban' name='radioservban' value='global'[(global_ban) ? " checked" : ""]>
 			<div class='inputbox'></div></label>
 		</div>
 		<div class='column'>
@@ -348,8 +348,11 @@
 		error_state += "Use last connection was ticked, but neither IP nor CID was."
 	if(href_list["applyadmins"])
 		applies_to_admins = TRUE
-	if(href_list["servbantype"])
-		global_ban = TRUE
+	switch(href_list["radioservban"])
+		if("local")
+			global_ban = FALSE
+		if("global")
+			global_ban = TRUE
 	switch(href_list["radioduration"])
 		if("permanent")
 			duration = null

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -111,6 +111,7 @@
 	<div class='inputbox'></div></label>
 	<label class='inputlabel checkbox'>Applies to Admins
 	<input type='checkbox' id='applyadmins' name='applyadmins' value='1'[applies_to_admins ? " checked": ""]>
+	<div class='inputbox'></div></label>
 	<label class='inputlabel checkbox'>Ban on all Servers
 	<input type='checkbox' id='servbantype' name='servbantype' value='1'[global_ban ? " checked": ""]>
 	<div class='inputbox'></div></label>

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -705,8 +705,6 @@
 					qdel(query_edit_ban_get_player)
 					return
 		qdel(query_edit_ban_get_player)
-	if(global_ban && (global_ban != old_globalban))
-
 	if(applies_to_admins && (applies_to_admins != old_applies))
 		var/admin_ckey = sanitizeSQL(usr.client.ckey)
 		var/datum/DBQuery/query_check_adminban_count = SSdbcore.NewQuery("SELECT COUNT(DISTINCT bantime) FROM [format_table_name("ban")] WHERE a_ckey = '[admin_ckey]' AND applies_to_admins = 1 AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())")
@@ -748,7 +746,7 @@
 		if(old_cid)
 			wherelist += "computerid = '[sanitizeSQL(old_cid)]'"
 		where = wherelist.Join(" AND ")
-	var/datum/DBQuery/query_edit_ban = SSdbcore.NewQuery("UPDATE [format_table_name("ban")] SET expiration_time = IF('[duration]' LIKE '', NULL, bantime + INTERVAL [duration ? "[duration]" : "0"] [interval]), applies_to_admins = [applies_to_admins], reason = '[reason]', ckey = IF('[player_ckey]' LIKE '', NULL, '[player_ckey]'), ip = INET_ATON(IF('[player_ip]' LIKE '', NULL, '[player_ip]')), computerid = IF('[player_cid]' LIKE '', NULL, '[player_cid]'), edits = CONCAT(IFNULL(edits,''),'[sanitizeSQL(usr.client.key)] edited the following [jointext(changes_text, ", ")]<hr>') WHERE [where]")
+	var/datum/DBQuery/query_edit_ban = SSdbcore.NewQuery("UPDATE [format_table_name("ban")] SET expiration_time = IF('[duration]' LIKE '', NULL, bantime + INTERVAL [duration ? "[duration]" : "0"] [interval]), applies_to_admins = [applies_to_admins], reason = '[reason]', global_ban = '[global_ban]', ckey = IF('[player_ckey]' LIKE '', NULL, '[player_ckey]'), ip = INET_ATON(IF('[player_ip]' LIKE '', NULL, '[player_ip]')), computerid = IF('[player_cid]' LIKE '', NULL, '[player_cid]'), edits = CONCAT(IFNULL(edits,''),'[sanitizeSQL(usr.client.key)] edited the following [jointext(changes_text, ", ")]<hr>') WHERE [where]")
 	if(!query_edit_ban.warn_execute())
 		qdel(query_edit_ban)
 		return

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -111,7 +111,7 @@
 	<div class='inputbox'></div></label>
 	<label class='inputlabel checkbox'>Applies to Admins
 	<input type='checkbox' id='applyadmins' name='applyadmins' value='1'[applies_to_admins ? " checked": ""]>
-	<label class='inputlabel checkbox'>Ban on both Servers
+	<label class='inputlabel checkbox'>Ban on all Servers
 	<input type='checkbox' id='servbantype' name='servbantype' value='1'[global_ban ? " checked": ""]>
 	<div class='inputbox'></div></label>
 	<input type='submit' value='Submit'>
@@ -336,7 +336,7 @@
 		error_state += "Use last connection was ticked, but neither IP nor CID was."
 	if(href_list["applyadmins"])
 		applies_to_admins = TRUE
-	if(href_list["global_ban"])
+	if(href_list["servbantype"])
 		global_ban = TRUE
 	switch(href_list["radioduration"])
 		if("permanent")

--- a/html/admin/banpanel.css
+++ b/html/admin/banpanel.css
@@ -8,11 +8,15 @@
 }
 
 .middle {
-    width: 80px;
+    margin-left: 5px;
+    margin-right: 5px;
+    max-width: 125px;
 }
 
 .right {
-    width: 150px;
+    margin-left: 5px;
+    margin-right: 5px;
+    width: 80px;
 }
 
 .row {
@@ -24,7 +28,8 @@
 .reason {
     resize: none;
     min-height: 40px;
-    width: 225px;
+    width: 250px;
+    margin-bottom: 5px;
 }
 
 .rolegroup {

--- a/html/admin/banpanel.css
+++ b/html/admin/banpanel.css
@@ -24,7 +24,7 @@
 .reason {
     resize: none;
     min-height: 40px;
-    width: 340px;
+    width: 225px;
 }
 
 .rolegroup {


### PR DESCRIPTION
## About The Pull Request
Adds the ability to selectively ban people from either the LRP server of the MRP server.

## Why It's Good For The Game
Allows people being banned from MRP for LRP behaviour and such instead of just having a complete ban or a watchlist entry.

## Changelog
:cl:
add:cross server banning 
sql:updated DB changelog and schema
/:cl: