### PR TITLE
Revert "Bump babel-preset-es2015-loose from 7.0.0 to 8.0.0 in /tgui"

### DIFF
--- a/tgui/package-lock.json
+++ b/tgui/package-lock.json
@@ -825,11 +825,11 @@
       }
     },
     "babel-preset-es2015-loose": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015-loose/-/babel-preset-es2015-loose-8.0.0.tgz",
-      "integrity": "sha1-gu4pOrMTKcepRoa2RLYq37zcP1c=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015-loose/-/babel-preset-es2015-loose-7.0.0.tgz",
+      "integrity": "sha1-/YDIXTsgy/MJvQzjCjY4DFeEvwY=",
       "requires": {
-        "modify-babel-preset": "^3.1.0"
+        "modify-babel-preset": "^1.0.0"
       }
     },
     "babel-register": {
@@ -5295,9 +5295,9 @@
       }
     },
     "modify-babel-preset": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/modify-babel-preset/-/modify-babel-preset-3.2.1.tgz",
-      "integrity": "sha1-1xcqo8CCLtP8COMI/QlxKVE2q1A=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/modify-babel-preset/-/modify-babel-preset-1.2.0.tgz",
+      "integrity": "sha1-0bfIwkiW4Z28SEc0chPmtxRNG8c=",
       "requires": {
         "require-relative": "^0.8.7"
       }

--- a/tgui/package.json
+++ b/tgui/package.json
@@ -11,7 +11,7 @@
     "babel-plugin-external-helpers": "6.22.0",
     "babel-polyfill": "6.26.0",
     "babel-preset-es2015": "6.24.1",
-    "babel-preset-es2015-loose": "8.0.0",
+    "babel-preset-es2015-loose": "7.0.0",
     "babel-register": "6.26.0",
     "babelify": "7.2.0",
     "babelify-external-helpers": "1.1.0",


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#494

This one actually breaks tgui after further testing. Reverting for now, I'll see about upgrading and fixing it later. 