### PR TITLE
Automatically label and close stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Handle stale PRs"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with: 
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+        stale-pr-label: 'Stale'
+        exempt-pr-label: 'DONT MERGE'  
+        days-before-stale: 30
+        days-before-close: 7


### PR DESCRIPTION
Uses the fancy new GitHub Actions to automatically label a PR as `Stale` if it's been open for 30 days, and will close it 7 days after that if the label persists and there's no new comments.

PRs with the `DONT MERGE` label are ignored.

This is my first time using Actions, please don't hurt me if it's all wrong.