### PR TITLE
[BOUNTY] Zesko separated chems

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -318,7 +318,7 @@
 
 /datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
-	G.reagents.handle_reactions()
+	addtimer(CALLBACK(G.reagents, /datum/reagents.proc/handle_reactions), 5) // Wait half a second before the chemicals reaction on SQUASH
 
 
 /datum/plant_gene/trait/maxchem

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -318,7 +318,7 @@
 
 /datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
-	addtimer(CALLBACK(G.reagents, /datum/reagents.proc/handle_reactions), 5) // Wait half a second before the chemicals reaction on SQUASH
+	addtimer(CALLBACK(G.reagents, /datum/reagents.proc/handle_reactions), 10) // Wait half a second before the chemicals reaction on SQUASH
 
 
 /datum/plant_gene/trait/maxchem


### PR DESCRIPTION
## About The Pull Request

It adds a half-second delay before chems react on squash, when said plant has the roreact trait.

## Why It's Good For The Game

No more instakill wheat

## Changelog
:cl:
balance: Separated chems now have a delay on react.
/:cl:

Zesko help me find the sweet spot number for this.