### PR TITLE
Gauze can now be applied to corpses

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -18,7 +18,7 @@
 
 /obj/item/stack/medical/attack(mob/living/M, mob/user)
 
-	if(M.stat == DEAD)
+	if(M.stat == DEAD && !stop_bleeding)
 		var/t_him = "it"
 		if(M.gender == MALE)
 			t_him = "him"


### PR DESCRIPTION
About The Pull Request

title

Why It's Good For The Game

Allows you to gauze somebody's corpse because its handy to keep a patient's corpse intact for defibbing before someone steals the corpse off you and drags it across the station and causes the person to lose like half their blood while dead.

Changelog

🆑 Cenrus
tweak: Rolls of gauze now works on corpses.
/🆑