### PR TITLE
Saboteur Cyborg gets an emag and zipties

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -666,6 +666,7 @@
 		/obj/item/borg/sight/thermal,
 		/obj/item/construction/rcd/borg/syndicate,
 		/obj/item/pipe_dispenser,
+		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/borg/charger,
 		/obj/item/extinguisher,
 		/obj/item/weldingtool/largetank/cyborg,
@@ -681,6 +682,7 @@
 		/obj/item/stack/tile/plasteel/cyborg,
 		/obj/item/destTagger/borg,
 		/obj/item/stack/cable_coil/cyborg,
+		/obj/item/card/emag,
 		/obj/item/pinpointer/syndicate_cyborg,
 		/obj/item/borg_chameleon,
 		)


### PR DESCRIPTION
About The Pull Request

Gives the syndicate saboteur cyborg zipties for stealth missions, and an emag so that it can subvert cyborgs on the station, like the other syndicate cyborg modules.

Why It's Good For The Game

Saboteur cyborg is the least used syndicate cyborg module, so these changes should make it a stronger pick.

Changelog

:cl: Cenrus
add: Syndicate saboteur cyborgs now have an emag and zipties.
/ :cl: