### PR TITLE
Changeling shriek no longer inflicts confusion.

### DIFF
--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -15,7 +15,6 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.confused += 15
 				C.Jitter(20)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))


### PR DESCRIPTION
About the Pull Request

Changeling shriek no longer confuses anyone that hears it, causing them to run into tables and walls. Could be a controversial change, so I recommend that a vote is held.

Why It's good for the game

Even after the recent nerf, Resonant Shriek still stands as one of the best changeling abilities, for only one evolution point, and 20 chemicals. When a changeling shrieks, you are forced to either stand still and be an easy target, or move and run into walls, stunning you.

Changeling

:cl: Cenrus
balance: Resonant shriek no longer causes confusion.
/ :cl: