### PR TITLE
Cultists can now snuff out blood magic by dropping it

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -358,10 +358,6 @@
 	health_cost = source.health_cost
 	..()
 
-/obj/item/melee/blood_magic/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CULT_TRAIT)
-
 /obj/item/melee/blood_magic/Destroy()
 	if(!QDELETED(source))
 		if(uses <= 0)


### PR DESCRIPTION
## About The Pull Request

Cultists can now drop their blood magic to snuff it out.

## Why It's Good for the Game

Quality of life chance, making a cultists life easier.

Mirrored from /tg/. Original PR: https://github.com/tgstation/tgstation/pull/45844

## Changelog

:cl:
tweak: Cultists can now snuff out spells by dropping them.
/:cl: