### PR TITLE
Adds an award for the HoP to give

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -170,6 +170,14 @@
 /obj/item/storage/lockbox/medal/cargo/PopulateContents()
 		new /obj/item/clothing/accessory/medal/ribbon/cargo(src)
 
+/obj/item/storage/lockbox/medal/service
+	name = "service award box"
+	desc = "A locked box used to store awards to be given to members of the service department."
+	req_access = list(ACCESS_HOP)
+
+/obj/item/storage/lockbox/medal/service/PopulateContents()
+		new /obj/item/clothing/accessory/medal/silver/excellence(src)
+		
 /obj/item/storage/lockbox/medal/sci
 	name = "science medal box"
 	desc = "A locked box used to store medals to be given to members of the science department."

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -42,6 +42,7 @@
 /obj/structure/closet/secure_closet/hop/PopulateContents()
 	..()
 	new /obj/item/clothing/neck/cloak/hop(src)
+	new /obj/item/storage/lockbox/medal/service(src)
 	new /obj/item/clothing/under/rank/head_of_personnel(src)
 	new /obj/item/clothing/head/hopcap(src)
 	new /obj/item/cartridge/hop(src)

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -192,6 +192,10 @@
 	name = "robust security award"
 	desc = "An award for distinguished combat and sacrifice in defence of Nanotrasen's commercial interests. Often awarded to security staff."
 
+/obj/item/clothing/accessory/medal/silver/excellence
+	name = "the head of personnel award for outstanding achievement in the field of excellence"
+	desc = "Nanotrasen's dictionary defines excellence as \"the quality or condition of being excellent\". This is awarded to those rare crewmembers who fit that definition."
+	
 /obj/item/clothing/accessory/medal/gold
 	name = "gold medal"
 	desc = "A prestigious golden medal."


### PR DESCRIPTION
## About The Pull Request

Adds the head of personnel award for outstanding achievement in the field of excellence as a medal the Head of Personnel can award.
## Why It's Good For The Game

The service department's efforts (which are, doubtless, integral to the station's functioning) have gone unnoticed for far too long. This pull request would add an award to be given to those most valuable crewmembers.
## Changelog

Mirrored from tgstation/tgstation#45290

:cl:
add: The Head Of Personnel award for outstanding achievement in the field of excellence.
/:cl: