### PR TITLE
Allows the AI and cyborgs to join midround

### DIFF
--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -42,5 +42,5 @@ Warden=1,1
 Detective=1,1
 Security Officer=5,5
 
-AI=0,1
-Cyborg=0,1
+AI=1,1
+Cyborg=1,1


### PR DESCRIPTION
## About this pull request

The code for midround AI connections was functional, but no midround AI or cyborg positions were available. Now it is possible for the AI and one cyborg to join midround. 

## Why it's good for the game

More job options for players who join the shift late.

## Changelog

:cl:
add: AIs and cyborgs can now latejoin.
/:cl: