### PR TITLE
Gives suit storage units the ability to remove radiation from mobs

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -213,13 +213,13 @@
 		add_fingerprint(user)
 
 /obj/machinery/suit_storage_unit/proc/cook()
+	var/mob/living/mob_occupant = occupant
 	if(uv_cycles)
 		uv_cycles--
 		uv = TRUE
 		locked = TRUE
 		update_icon()
 		if(occupant)
-			var/mob/living/mob_occupant = occupant
 			if(uv_super)
 				mob_occupant.adjustFireLoss(rand(20, 36))
 			else
@@ -248,6 +248,7 @@
 				visible_message("<span class='notice'>[src]'s door slides open. The glowing yellow lights dim to a gentle green.</span>")
 			else
 				visible_message("<span class='warning'>[src]'s door slides open, barraging you with the nauseating smell of charred flesh.</span>")
+				mob_occupant.radiation = 0
 			playsound(src, 'sound/machines/airlockclose.ogg', 25, 1)
 			var/list/things_to_clear = list() //Done this way since using GetAllContents on the SSU itself would include circuitry and such.
 			if(suit)


### PR DESCRIPTION
## About The Pull Request

Suit storage units will, in addition to decontaminating items, remove radiation from mobs.

## Why It's Good For The Game

The radiation cleaning machine should clean radiation. This also opens up the ability to perform (extremely painful) ghetto radiation treatment.

Mirrored from https://github.com/tgstation/tgstation/pull/46725

## Changelog

:cl:
tweak: Suit storage units will now also remove radiation from mobs.
/:cl: