### PR TITLE
Fixes advanced camera console circuit board being invisible

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -16,7 +16,6 @@
 
 /obj/item/circuitboard/computer/advanced_camera
 	name = "Advanced Camera Console (Computer Board)"
-	icon_state = "security"
 	build_path = /obj/machinery/computer/camera_advanced/syndie
 	
 /obj/item/circuitboard/computer/xenobiology


### PR DESCRIPTION
The sprite was invisible before, this has been corrected.

:cl:
fix: Advanced camera console circuit board sprite is no longer invisible.
/:cl: