### PR TITLE
Adds anti-rad kits to radsuit lockers

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -258,6 +258,14 @@
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/charcoal(src)
 
+/obj/item/storage/pill_bottle/antirad
+	name = "bottle of anti-radiation pills"
+	desc = "Contains pills used to treat the effects of minor radiation."
+
+/obj/item/storage/pill_bottle/antirad/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/antirad(src)
+
 /obj/item/storage/pill_bottle/epinephrine
 	name = "bottle of epinephrine pills"
 	desc = "Contains pills used to stabilize patients."

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -135,6 +135,10 @@
 	new /obj/item/geiger_counter(src)
 	new /obj/item/clothing/suit/radiation(src)
 	new /obj/item/clothing/head/radiation(src)
+	if(prob(50))
+		new /obj/item/storage/firstaid/radbgone(src)
+	else
+		new /obj/item/storage/pill_bottle/antirad(src)
 
 /*
  * Bombsuit closet


### PR DESCRIPTION
## About The Pull Request
Adds either Deb's full anti-rad kits or a pill bottle containing potasssium-iodine to radsuit lockers.

## Why It's Good For The Game
Allows people to get medication that should be in engineering anyways for obvious reasons

## Changelog
:cl:
add: Added anti-rad medications to radsuit lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
