### PR TITLE
Fixes Cyborg Buckling

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -677,7 +677,12 @@
 	. = ..()
 	if(ismob(dropping) && dropping != user)
 		var/mob/M = dropping
-		M.show_inv(user)
+		if(ismob(user))
+			var/mob/U = user
+			if(!iscyborg(U) || U.a_intent == INTENT_HARM)
+				M.show_inv(U)
+		else
+			M.show_inv(user)
 
 ///Is the mob muzzled (default false)
 /mob/proc/is_muzzled()


### PR DESCRIPTION
## About this pull request

Cyborgs now buckle people to themselves on help intent, and open the strip menu on harm intent.

Mirrored from: https://github.com/tgstation/tgstation/pull/46622

## Changelog

:cl:
fix: Click+dragging someone onto yourself while on harm intent as a cyborg should now only search them, not buckle them to yourself.
/:cl: