### PR TITLE
Extended xenobiology mutation toxins

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -391,6 +391,7 @@ GLOBAL_LIST_INIT(adamantine_recipes, list(
 	item_state = "sheet-adamantine"
 	singular_name = "adamantine sheet"
 	merge_type = /obj/item/stack/sheet/mineral/adamantine
+	grind_results = list(/datum/reagent/liquidadamantine = 10)
 
 /obj/item/stack/sheet/mineral/adamantine/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.adamantine_recipes

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -589,6 +589,7 @@
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NOEYESPRITES,NOFLASH) //no mutcolors
 	prefix = "Runic"
 	special_names = null
+	random_eligible = FALSE //Zesko claims runic golems break the game
 
 	var/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift/golem/phase_shift
 	var/obj/effect/proc_holder/spell/targeted/abyssal_gaze/abyssal_gaze
@@ -652,7 +653,7 @@
 	prefix = "Clockwork"
 	special_names = list("Remnant", "Relic", "Scrap", "Vestige") //RIP Ratvar
 	var/has_corpse
-
+	
 /datum/species/golem/clockwork/on_species_gain(mob/living/carbon/human/H)
 	. = ..()
 	H.faction |= "ratvar"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -432,21 +432,7 @@
 /datum/reagent/mutationtoxin/proc/mutate(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
-	if (race=="random")
-		to_chat(H, mutationtext)
-		H.set_species(pick(/datum/species/jelly/slime,
-						/datum/species/human,
-						/datum/species/human/felinid,
-						/datum/species/lizard,
-						/datum/species/fly,
-						/datum/species/moth,
-						/datum/species/pod,
-						/datum/species/jelly,
-						/datum/species/golem/random,
-						/datum/species/abductor))
-		H.reagents.del_reagent(type)
-		return
-	var/current_species = H.dna.species.type
+		var/current_species = H.dna.species.type
 	var/datum/species/mutation = race
 	if(mutation && mutation != current_species)
 		to_chat(H, mutationtext)
@@ -467,15 +453,7 @@
 	name = "Unstable Mutation Toxin"
 	description = "A mostly safe mutation toxin."
 	color = "#13BC5E" // rgb: 19, 188, 94
-	race = "random"
-	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels... Different.</span>"
-	process_flags = ORGANIC | SYNTHETIC
-
-/datum/reagent/mutationtoxin/unstable/proc/unstablemutate(mob/living/carbon/human/H) //Special snowflake
-	if(QDELETED(H))
-		return
-	to_chat(H, mutationtext)
-	H.set_species(pick(/datum/species/jelly/slime,
+	race = pick(/datum/species/jelly/slime,
 						/datum/species/human,
 						/datum/species/human/felinid,
 						/datum/species/lizard,
@@ -484,10 +462,9 @@
 						/datum/species/pod,
 						/datum/species/jelly,
 						/datum/species/golem/random,
-						/datum/species/abductor))
-
-	H.reagents.del_reagent(type)
-
+						/datum/species/abductor)
+	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels... Different.</span>"
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/reagent/mutationtoxin/felinid
 	name = "Felinid Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -432,11 +432,7 @@
 /datum/reagent/mutationtoxin/proc/mutate(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
-	var/datum/species/mutation 					//I was taught not to initialise variables on conditions
-	if (race != /datum/species) 				//If it is not a specie, it might be a list of those
-		mutation=pick(race)
-	else
-		mutation = race
+	var/datum/species/mutation = pick(race)			//I honestly feel extremely uncomfortable. I do not like the fact that this works.
 	var/current_species = H.dna.species.type
 	if(mutation && mutation != current_species)
 		to_chat(H, mutationtext)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -432,19 +432,12 @@
 /datum/reagent/mutationtoxin/proc/mutate(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
-	if (race != /datum/species && race=="random")
-		race=(pick(/datum/species/jelly/slime,
-						/datum/species/human,
-						/datum/species/human/felinid,
-						/datum/species/lizard,
-						/datum/species/fly,
-						/datum/species/moth,
-						/datum/species/pod,
-						/datum/species/jelly,
-						/datum/species/abductor))
-		H.reagents.del_reagent(type)
+	var/datum/species/mutation 					//I was taught not to initialise variables on conditions
+	if (race != /datum/species) 				//If it is not a specie, it might be a list of those
+		mutation=pick(race)
+	else
+		mutation = race
 	var/current_species = H.dna.species.type
-	var/datum/species/mutation = race
 	if(mutation && mutation != current_species)
 		to_chat(H, mutationtext)
 		H.set_species(mutation)
@@ -464,7 +457,15 @@
 	name = "Unstable Mutation Toxin"
 	description = "A mostly safe mutation toxin."
 	color = "#13BC5E" // rgb: 19, 188, 94
-	race = "random"
+	race = list(/datum/species/jelly/slime,
+						/datum/species/human,
+						/datum/species/human/felinid,
+						/datum/species/lizard,
+						/datum/species/fly,
+						/datum/species/moth,
+						/datum/species/pod,
+						/datum/species/jelly,
+						/datum/species/abductor)
 	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels... Different.</span>"
 	process_flags = ORGANIC | SYNTHETIC
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -432,7 +432,21 @@
 /datum/reagent/mutationtoxin/proc/mutate(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
-		var/current_species = H.dna.species.type
+	if (race=="random")
+		to_chat(H, mutationtext)
+		H.set_species(pick(/datum/species/jelly/slime,
+						/datum/species/human,
+						/datum/species/human/felinid,
+						/datum/species/lizard,
+						/datum/species/fly,
+						/datum/species/moth,
+						/datum/species/pod,
+						/datum/species/jelly,
+						/datum/species/golem/random,
+						/datum/species/abductor))
+		H.reagents.del_reagent(type)
+		return
+	var/current_species = H.dna.species.type
 	var/datum/species/mutation = race
 	if(mutation && mutation != current_species)
 		to_chat(H, mutationtext)
@@ -453,7 +467,15 @@
 	name = "Unstable Mutation Toxin"
 	description = "A mostly safe mutation toxin."
 	color = "#13BC5E" // rgb: 19, 188, 94
-	race = pick(/datum/species/jelly/slime,
+	race = "random"
+	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels... Different.</span>"
+	process_flags = ORGANIC | SYNTHETIC
+
+/datum/reagent/mutationtoxin/unstable/proc/unstablemutate(mob/living/carbon/human/H) //Special snowflake
+	if(QDELETED(H))
+		return
+	to_chat(H, mutationtext)
+	H.set_species(pick(/datum/species/jelly/slime,
 						/datum/species/human,
 						/datum/species/human/felinid,
 						/datum/species/lizard,
@@ -462,9 +484,10 @@
 						/datum/species/pod,
 						/datum/species/jelly,
 						/datum/species/golem/random,
-						/datum/species/abductor)
-	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels... Different.</span>"
-	process_flags = ORGANIC | SYNTHETIC
+						/datum/species/abductor))
+
+	H.reagents.del_reagent(type)
+
 
 /datum/reagent/mutationtoxin/felinid
 	name = "Felinid Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -433,7 +433,6 @@
 	if(QDELETED(H))
 		return
 	if (race != /datum/species && race=="random")
-		to_chat(H, mutationtext)
 		race=(pick(/datum/species/jelly/slime,
 						/datum/species/human,
 						/datum/species/human/felinid,

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1805,3 +1805,10 @@
 /datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
+
+/datum/reagent/liquidadamantine
+	name = "Liquid Adamantine"
+	description = "A legengary lifegiving metal liquified."
+	color = "#10cca6" //RGB: 16, 204, 166
+	taste_description = "lifegiiving metal"
+	can_synth = FALSE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -432,6 +432,20 @@
 /datum/reagent/mutationtoxin/proc/mutate(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
+	if (race=="random")
+		to_chat(H, mutationtext)
+		H.set_species(pick(/datum/species/jelly/slime,
+						/datum/species/human,
+						/datum/species/human/felinid,
+						/datum/species/lizard,
+						/datum/species/fly,
+						/datum/species/moth,
+						/datum/species/pod,
+						/datum/species/jelly,
+						/datum/species/golem/random,
+						/datum/species/abductor))
+		H.reagents.del_reagent(type)
+		return
 	var/current_species = H.dna.species.type
 	var/datum/species/mutation = race
 	if(mutation && mutation != current_species)
@@ -448,6 +462,32 @@
 	race = /datum/species/jelly/slime
 	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels like slime.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+
+/datum/reagent/mutationtoxin/unstable
+	name = "Unstable Mutation Toxin"
+	description = "A mostly safe mutation toxin."
+	color = "#13BC5E" // rgb: 19, 188, 94
+	race = "random"
+	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels... Different.</span>"
+	process_flags = ORGANIC | SYNTHETIC
+
+/datum/reagent/mutationtoxin/unstable/proc/unstablemutate(mob/living/carbon/human/H) //Special snowflake
+	if(QDELETED(H))
+		return
+	to_chat(H, mutationtext)
+	H.set_species(pick(/datum/species/jelly/slime,
+						/datum/species/human,
+						/datum/species/human/felinid,
+						/datum/species/lizard,
+						/datum/species/fly,
+						/datum/species/moth,
+						/datum/species/pod,
+						/datum/species/jelly,
+						/datum/species/golem/random,
+						/datum/species/abductor))
+
+	H.reagents.del_reagent(type)
+
 
 /datum/reagent/mutationtoxin/felinid
 	name = "Felinid Mutation Toxin"
@@ -517,6 +557,14 @@
 	description = "A robotic toxin."
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/android
+	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
+	process_flags = ORGANIC | SYNTHETIC
+
+/datum/reagent/mutationtoxin/ipc
+	name = "IPC Mutation Toxin"
+	description = "An integrated positronic toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/ipc
 	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
 	process_flags = ORGANIC | SYNTHETIC
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -432,9 +432,9 @@
 /datum/reagent/mutationtoxin/proc/mutate(mob/living/carbon/human/H)
 	if(QDELETED(H))
 		return
-	if (race=="random")
+	if (race != /datum/species && race=="random")
 		to_chat(H, mutationtext)
-		H.set_species(pick(/datum/species/jelly/slime,
+		race=(pick(/datum/species/jelly/slime,
 						/datum/species/human,
 						/datum/species/human/felinid,
 						/datum/species/lizard,
@@ -445,7 +445,6 @@
 						/datum/species/golem/random,
 						/datum/species/abductor))
 		H.reagents.del_reagent(type)
-		return
 	var/current_species = H.dna.species.type
 	var/datum/species/mutation = race
 	if(mutation && mutation != current_species)
@@ -470,24 +469,6 @@
 	race = "random"
 	mutationtext = "<span class='danger'>The pain subsides. Your whole body feels... Different.</span>"
 	process_flags = ORGANIC | SYNTHETIC
-
-/datum/reagent/mutationtoxin/unstable/proc/unstablemutate(mob/living/carbon/human/H) //Special snowflake
-	if(QDELETED(H))
-		return
-	to_chat(H, mutationtext)
-	H.set_species(pick(/datum/species/jelly/slime,
-						/datum/species/human,
-						/datum/species/human/felinid,
-						/datum/species/lizard,
-						/datum/species/fly,
-						/datum/species/moth,
-						/datum/species/pod,
-						/datum/species/jelly,
-						/datum/species/golem/random,
-						/datum/species/abductor))
-
-	H.reagents.del_reagent(type)
-
 
 /datum/reagent/mutationtoxin/felinid
 	name = "Felinid Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -441,7 +441,6 @@
 						/datum/species/moth,
 						/datum/species/pod,
 						/datum/species/jelly,
-						/datum/species/golem/random,
 						/datum/species/abductor))
 		H.reagents.del_reagent(type)
 	var/current_species = H.dna.species.type

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -68,6 +68,17 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i = 1, i <= created_volume, i++)
 		new /obj/item/stack/sheet/mineral/gold(location)
+		
+/datum/chemical_reaction/adamantinesolidification
+	name = "Adamantine Sheet"
+	id = "solidadam"
+	required_reagents = list(/datum/reagent/gold = 5, /datum/reagent/consumable/frostoil = 5, /datum/reagent/liquidadamantine = 10)
+	mob_react = FALSE
+
+/datum/chemical_reaction/adamantinesolidification/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= created_volume, i++)
+		new /obj/item/stack/sheet/mineral/adamantine(location)
 
 /datum/chemical_reaction/capsaicincondensation
 	name = "Capsaicincondensation"
@@ -644,7 +655,7 @@
 	name = /datum/reagent/mutationtoxin/golem
 	id = /datum/reagent/mutationtoxin/golem
 	results = list(/datum/reagent/mutationtoxin/golem = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/silver = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/liquidadamantine = 20)
 
 /datum/chemical_reaction/mutationtoxin/abductor
 	name = /datum/reagent/mutationtoxin/abductor

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -664,7 +664,7 @@
 	name = /datum/reagent/mutationtoxin/skeleton
 	id = /datum/reagent/mutationtoxin/skeleton
 	results = list(/datum/reagent/mutationtoxin/skeleton = 1)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/consumable/milk = 1, /datum/chemical_reaction/facid = 1) //Because acid melts flesh off.
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/consumable/milk = 1, /datum/reagent/toxin/acid/fluacid = 1) //Because acid melts flesh off.
 
 /datum/chemical_reaction/mutationtoxin/zombie
 	name = /datum/reagent/mutationtoxin/zombie
@@ -676,7 +676,7 @@
 	name = /datum/reagent/mutationtoxin/ash
 	id = /datum/reagent/mutationtoxin/ash
 	results = list(/datum/reagent/mutationtoxin/ash = 1)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 1, /datum/reagent/consumable/entpoly = 1)
 	
 /datum/chemical_reaction/mutationtoxin/shadow
 	name = /datum/reagent/mutationtoxin/shadow

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -619,37 +619,37 @@
 	name = /datum/reagent/mutationtoxin
 	id = /datum/reagent/mutationtoxin
 	results = list(/datum/reagent/mutationtoxin = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/blood = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/blood = 10)
 
 /datum/chemical_reaction/mutationtoxin/lizard
 	name = /datum/reagent/mutationtoxin/lizard
 	id = /datum/reagent/mutationtoxin/lizard
 	results = list(/datum/reagent/mutationtoxin/lizard = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/liquidgibs = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/liquidgibs = 10)
 
 /datum/chemical_reaction/mutationtoxin/felinid
 	name = /datum/reagent/mutationtoxin/felinid
 	id = /datum/reagent/mutationtoxin/felinid
 	results = list(/datum/reagent/mutationtoxin/felinid = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/fentanyl = 1, /datum/reagent/impedrezene = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/fentanyl = 10, /datum/reagent/impedrezene = 10)
 	
 /datum/chemical_reaction/mutationtoxin/fly
 	name = /datum/reagent/mutationtoxin/fly
 	id = /datum/reagent/mutationtoxin/fly
 	results = list(/datum/reagent/mutationtoxin/fly = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/mutagen = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/mutagen = 10)
 
 /datum/chemical_reaction/mutationtoxin/moth
 	name = /datum/reagent/mutationtoxin/moth
 	id = /datum/reagent/mutationtoxin/moth
 	results = list(/datum/reagent/mutationtoxin/moth = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/lipolicide = 1) //I know it's the opposite of what moths like, but I am out of ideas for this.
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/lipolicide = 10) //I know it's the opposite of what moths like, but I am out of ideas for this.
 	
 /datum/chemical_reaction/mutationtoxin/pod
 	name = /datum/reagent/mutationtoxin/pod
 	id = /datum/reagent/mutationtoxin/pod
 	results = list(/datum/reagent/mutationtoxin/pod = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/plantnutriment/eznutriment = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/plantnutriment/eznutriment = 10)
 
 /datum/chemical_reaction/mutationtoxin/golem
 	name = /datum/reagent/mutationtoxin/golem
@@ -661,13 +661,13 @@
 	name = /datum/reagent/mutationtoxin/abductor
 	id = /datum/reagent/mutationtoxin/abductor
 	results = list(/datum/reagent/mutationtoxin/abductor = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/toxin/mutetoxin = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/medicine/morphine = 10, /datum/reagent/toxin/mutetoxin = 10)
 	
 /datum/chemical_reaction/mutationtoxin/ipc
 	name = /datum/reagent/mutationtoxin/ipc
 	id = /datum/reagent/mutationtoxin/ipc
 	results = list(/datum/reagent/mutationtoxin/ipc = 1)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/teslium = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/teslium = 20)
 	
 //////////////Mutatuion toxins made out of advanced toxin/////////////
 
@@ -675,7 +675,7 @@
 	name = /datum/reagent/mutationtoxin/skeleton
 	id = /datum/reagent/mutationtoxin/skeleton
 	results = list(/datum/reagent/mutationtoxin/skeleton = 1)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/consumable/milk = 1, /datum/reagent/toxin/acid/fluacid = 1) //Because acid melts flesh off.
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/consumable/milk = 30, /datum/reagent/toxin/acid/fluacid = 30) //Because acid melts flesh off.
 
 ///datum/chemical_reaction/mutationtoxin/zombie //No zombies untill holopara issue is fixed.
 //	name = /datum/reagent/mutationtoxin/zombie
@@ -687,16 +687,16 @@
 	name = /datum/reagent/mutationtoxin/ash
 	id = /datum/reagent/mutationtoxin/ash
 	results = list(/datum/reagent/mutationtoxin/ash = 1)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 1, /datum/reagent/consumable/entpoly = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 10, /datum/reagent/consumable/entpoly = 5)
 	
 /datum/chemical_reaction/mutationtoxin/shadow
 	name = /datum/reagent/mutationtoxin/shadow
 	id = /datum/reagent/mutationtoxin/shadow
 	results = list(/datum/reagent/mutationtoxin/shadow = 1)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/liquid_dark_matter = 1, /datum/reagent/water/holywater = 1) //You need a tiny bit of thinking how to mix it
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/liquid_dark_matter = 30, /datum/reagent/water/holywater = 10) //You need a tiny bit of thinking how to mix it
 	
 /datum/chemical_reaction/mutationtoxin/plasma
 	name = /datum/reagent/mutationtoxin/plasma
 	id = /datum/reagent/mutationtoxin/plasma
 	results = list(/datum/reagent/mutationtoxin/plasma = 1)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/toxin/plasma = 1, /datum/reagent/uranium = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/toxin/plasma = 60, /datum/reagent/uranium = 20)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -666,11 +666,11 @@
 	results = list(/datum/reagent/mutationtoxin/skeleton = 1)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/consumable/milk = 1, /datum/reagent/toxin/acid/fluacid = 1) //Because acid melts flesh off.
 
-/datum/chemical_reaction/mutationtoxin/zombie
-	name = /datum/reagent/mutationtoxin/zombie
-	id = /datum/reagent/mutationtoxin/zombie
-	results = list(/datum/reagent/mutationtoxin/zombie = 1)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/toxin = 1, /datum/reagent/toxin/bad_food = 1) //Because rotting
+///datum/chemical_reaction/mutationtoxin/zombie //No zombies untill holopara issue is fixed.
+//	name = /datum/reagent/mutationtoxin/zombie
+//	id = /datum/reagent/mutationtoxin/zombie
+//	results = list(/datum/reagent/mutationtoxin/zombie = 1)
+//	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/toxin = 1, /datum/reagent/toxin/bad_food = 1) //Because rotting
 
 /datum/chemical_reaction/mutationtoxin/ash
 	name = /datum/reagent/mutationtoxin/ash

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -600,3 +600,92 @@
 	id = /datum/reagent/pax
 	results = list(/datum/reagent/pax = 3)
 	required_reagents  = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/water = 1)
+	
+	
+//////////////////EXPANDED MUTATION TOXINS/////////////////////
+
+/datum/chemical_reaction/mutationtoxin/stable
+	name = /datum/reagent/mutationtoxin
+	id = /datum/reagent/mutationtoxin
+	results = list(/datum/reagent/mutationtoxin = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/blood = 1)
+
+/datum/chemical_reaction/mutationtoxin/lizard
+	name = /datum/reagent/mutationtoxin/lizard
+	id = /datum/reagent/mutationtoxin/lizard
+	results = list(/datum/reagent/mutationtoxin/lizard = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/liquidgibs = 1)
+
+/datum/chemical_reaction/mutationtoxin/felinid
+	name = /datum/reagent/mutationtoxin/felinid
+	id = /datum/reagent/mutationtoxin/felinid
+	results = list(/datum/reagent/mutationtoxin/felinid = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/fentanyl = 1, /datum/reagent/impedrezene = 1)
+	
+/datum/chemical_reaction/mutationtoxin/fly
+	name = /datum/reagent/mutationtoxin/fly
+	id = /datum/reagent/mutationtoxin/fly
+	results = list(/datum/reagent/mutationtoxin/fly = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/mutagen = 1)
+
+/datum/chemical_reaction/mutationtoxin/moth
+	name = /datum/reagent/mutationtoxin/moth
+	id = /datum/reagent/mutationtoxin/moth
+	results = list(/datum/reagent/mutationtoxin/moth = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/lipolicide = 1) //I know it's the opposite of what moths like, but I am out of ideas for this.
+	
+/datum/chemical_reaction/mutationtoxin/pod
+	name = /datum/reagent/mutationtoxin/pod
+	id = /datum/reagent/mutationtoxin/pod
+	results = list(/datum/reagent/mutationtoxin/pod = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/plantnutriment/eznutriment = 1)
+
+/datum/chemical_reaction/mutationtoxin/golem
+	name = /datum/reagent/mutationtoxin/golem
+	id = /datum/reagent/mutationtoxin/golem
+	results = list(/datum/reagent/mutationtoxin/golem = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/silver = 1)
+
+/datum/chemical_reaction/mutationtoxin/abductor
+	name = /datum/reagent/mutationtoxin/abductor
+	id = /datum/reagent/mutationtoxin/abductor
+	results = list(/datum/reagent/mutationtoxin/abductor = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/medicine/morphine = 1, /datum/reagent/toxin/mutetoxin = 1)
+	
+/datum/chemical_reaction/mutationtoxin/ipc
+	name = /datum/reagent/mutationtoxin/ipc
+	id = /datum/reagent/mutationtoxin/ipc
+	results = list(/datum/reagent/mutationtoxin/ipc = 1)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/teslium = 1)
+	
+//////////////Mutatuion toxins made out of advanced toxin/////////////
+
+/datum/chemical_reaction/mutationtoxin/skeleton
+	name = /datum/reagent/mutationtoxin/skeleton
+	id = /datum/reagent/mutationtoxin/skeleton
+	results = list(/datum/reagent/mutationtoxin/skeleton = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/consumable/milk = 1, /datum/chemical_reaction/facid = 1) //Because acid melts flesh off.
+
+/datum/chemical_reaction/mutationtoxin/zombie
+	name = /datum/reagent/mutationtoxin/zombie
+	id = /datum/reagent/mutationtoxin/zombie
+	results = list(/datum/reagent/mutationtoxin/zombie = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/toxin = 1, /datum/reagent/toxin/bad_food = 1) //Because rotting
+
+/datum/chemical_reaction/mutationtoxin/ash
+	name = /datum/reagent/mutationtoxin/ash
+	id = /datum/reagent/mutationtoxin/ash
+	results = list(/datum/reagent/mutationtoxin/ash = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 1)
+	
+/datum/chemical_reaction/mutationtoxin/shadow
+	name = /datum/reagent/mutationtoxin/shadow
+	id = /datum/reagent/mutationtoxin/shadow
+	results = list(/datum/reagent/mutationtoxin/shadow = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/liquid_dark_matter = 1, /datum/reagent/water/holywater = 1) //You need a tiny bit of thinking how to mix it
+	
+/datum/chemical_reaction/mutationtoxin/plasma
+	name = /datum/reagent/mutationtoxin/plasma
+	id = /datum/reagent/mutationtoxin/plasma
+	results = list(/datum/reagent/mutationtoxin/plasma = 1)
+	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/toxin/plasma = 1, /datum/reagent/uranium = 1)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -54,21 +54,14 @@
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
 
-/datum/chemical_reaction/slime/slimehuman
-	name = "Human Mutation Toxin"
-	id = "humanmuttoxin"
-	results = list(/datum/reagent/mutationtoxin = 1)
-	required_reagents = list(/datum/reagent/blood = 1)
-	required_other = TRUE
-	required_container = /obj/item/slime_extract/green
-
-/datum/chemical_reaction/slime/slimelizard
-	name = "Lizard Mutation Toxin"
-	id = "lizardmuttoxin"
-	results = list(/datum/reagent/mutationtoxin/lizard = 1)
+/datum/chemical_reaction/slime/unstabletoxin
+	name = "Unstable Mutation Toxin"
+	id = "unstablemuttoxin"
+	results = list(/datum/reagent/mutationtoxin/unstable = 1)
 	required_reagents = list(/datum/reagent/uranium/radium = 1)
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/green
+
 
 //Metal
 /datum/chemical_reaction/slime/slimemetal


### PR DESCRIPTION
 ## About The Pull Request
Added chemical reactions for most mutation toxins to be obtainable through green slime extracts.

## Why It's Good For The Game
Adds more fun to xenobio green slimes. People have fun lynching xenobio for making all the crew felinides, the entire crew having fun being IPCs and gathering in the AI core to pray to Omnissiah, more fun from sparking a racial holy war between humans and pissed off humanized non-human crew.
(No, the android mutation toxin is still only admin-spawnable.)

## New Recipes 
Unstable mutation toxin = Inject a green slime core with Radium.
Stable mutation toxin = Unstable mutation toxin + 10 Blood
Lizard = Unstable mutation toxin + 10 Liquid Gibs
Felinid = Unstable mutation toxin + 10 Fentanyl + 10 Impedrezene
Fly = Unstable mutation toxin + 10 Unstable Mutagen
Moth = Unstable mutation toxin + 10 Lipolicide
Podperson = Unstable mutation toxin + 10 EZ Nutriment
Golem = Unstable mutation toxin + 20 Liquid Adamantine
Abductor = Unstable mutation toxin + 10 Morphine + 10 Mute Toxin
IPC = Unstable mutation toxin + 20 Teslium
Skeleton = Advanced mutation toxin + 30 Milk + 30 Fluorosulfuric acid
Ashwalker = Advanced mutation toxin + 1 Lizard mutation toxin + 5 Entropic Polypnium
Shadow = Advanced mutation toxin + 30 Liquid Dark Matter + 10 Holy water
Plasmaman = Advanced mutation toxin + 60 Liquid Plasma + 20 Uranium

## Changelog
:cl:
add: Added reactions for most racial mutation toxins.
add: Added Liquid adamantine as well as respective solidification reaction.
tweak: Changed some of the suggested reactions to make a bit more sense than reactions suggested on the wiki.
/:cl:
