### PR TITLE
Fixed charcoal reagent error

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -195,7 +195,7 @@
 	name = "radiation plus pill"
 	desc = "Used to treat heavy radition poisoning."
 	icon_state = "pill3"
-	list_reagents = list(/datum/reagent/medicine/potass_iodide = 50, charcoal = 20)
+	list_reagents = list(/datum/reagent/medicine/potass_iodide = 50, /datum/reagent/medicine/charcoal = 20)
 
 /obj/item/reagent_containers/pill/antirad
 	name = "potassium iodide pill"


### PR DESCRIPTION

## About The Pull Request
Fixes: ```## WARNING: The radiation plus pill attempted to add a reagent called 'charcoal' which doesn't exist. () in code/modules/reagents/chemistry/holder.dm at line 630 src: /datum/reagents usr: .```
## Why It's Good For The Game
The radiation plus pills will now actually contain charcoal.

## Changelog
:cl:
fix: radiation plus pills now actually contain charcoal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
