### PR TITLE
Fugitive Spawn Fix

### DIFF
--- a/code/modules/antagonists/fugitive/fugitive_ship.dm
+++ b/code/modules/antagonists/fugitive/fugitive_ship.dm
@@ -3,7 +3,7 @@
 /obj/machinery/fugitive_capture
 	name = "bluespace capture machine"
 	desc = "Much, MUCH bigger on the inside to transport prisoners safely."
-	icon = 'icons/obj/machines/teleporter.dmi'
+	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "bluespace-prison"
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //ha ha no getting out!!

--- a/code/modules/events/fugitive_spawning.dm
+++ b/code/modules/events/fugitive_spawning.dm
@@ -12,7 +12,7 @@
 	fakeable = FALSE
 
 /datum/round_event/ghost_role/fugitives/spawn_role()
-	var/turf/landing_turf = pick(GLOB.xeno_spawn)
+	var/turf/landing_turf = pick(GLOB.blobstart)
 	if(!landing_turf)
 		message_admins("No valid spawn locations found, aborting...")
 		return MAP_ERROR

--- a/code/modules/events/fugitive_spawning.dm
+++ b/code/modules/events/fugitive_spawning.dm
@@ -104,8 +104,8 @@
 /datum/round_event/ghost_role/fugitives/proc/spawn_hunters()
 	var/backstory = pick("space cop", "russian")
 	var/static/list/hunter_ship_types = list(
-		"space cop"		= /datum/map_template/space_cop_ship,
-		"russian"		= /datum/map_template/russian_ship)
+		"space cop"		= /datum/map_template/shuttle/hunter/space_cop,
+		"russian"		= /datum/map_template/shuttle/hunter/russian)
 
 	var/datum/map_template/ship = hunter_ship_types[backstory]
 	ship = new


### PR DESCRIPTION
## About The Pull Request
Changes the fugitive spawn points from xeno spawns to blob/station loving object spawns. After looking over most of the maps, I thought that if the spawns were linked to blob starts, the fugitives wouldn't spawn in, say, the atmos airmix. Also fixed the bluespace prison icon since apparently it was removed from teleporter.dmi and moved to research.dmi for whatever reason. Also fixed the shuttle paths, since I saw that didn't work.

## Why It's Good For The Game
Doesn't make the fugitives on spawn be forced to suffer a drawn-out(or short, who knows) death due to bad spawn locations.

## Changelog
:cl:
fix: Fugitive spawn locations
fix: Bluespace prison icon
fix: Fugitive hunter shuttle filepath
/:cl: