### PR TITLE
fixes holocarp type chooser

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -688,6 +688,6 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	name = "Holocarp fishstick kit"
 	
 /obj/item/storage/box/syndie_kit/carpian/PopulateContents()
-	new /obj/item/guardiancreator/carp(src)
+	new /obj/item/guardiancreator/carp/choose(src)
 	new /obj/item/paper/guides/antag/guardian(src)
 


### PR DESCRIPTION

## About The Pull Request
Allows the chef to pick the type of holocarp he wants.
## Why It's Good For The Game
Bugs are bad. Plus, this almost got me striked twice.
## Changelog
:cl:
fix: The syndicate have improved their praises to carpsie! Thanks to advanced prayer techniques, the chef can now pick their holocarp type.
/:cl: