### PR TITLE
Catwalk bugfix

### DIFF
--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -20,8 +20,13 @@
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
 	if(C.tool_behaviour == TOOL_WELDER)
-		to_chat(user, "<span class='notice'>You slice off [src]</span>")
-		deconstruct()
+		if(!C.tool_start_check(user, amount=0))
+			return FALSE
+		to_chat(user, "<span class='notice'>You begin slicing through the outer plating...</span>")
+		if(C.use_tool(src, user, 25, volume=100))
+			to_chat(user, "<span class='notice'>You slice off [src]</span>")
+			deconstruct()
+			return TRUE
 
 /obj/structure/lattice/catwalk/ratvar_act()
 	new /obj/structure/lattice/catwalk/clockwork(loc)

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -57,7 +57,7 @@
 			return
 		if (istype(C, /obj/item/stack/rods))
 			var/obj/item/stack/rods/R = C
-			if (R.use(1))
+			if (R.use(2))
 				to_chat(user, "<span class='notice'>You lay down the catwalk.</span>")
 				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 				new /obj/structure/lattice/catwalk/over(src)
@@ -76,7 +76,7 @@
 				if (R.get_amount() >= 1 && !istype(src, /turf/open/floor/engine))
 					PlaceOnTop(/turf/open/floor/engine)
 					playsound(src, 'sound/items/deconstruct.ogg', 80, 1)
-					R.use(2)
+					R.use(1)
 					to_chat(user, "<span class='notice'>You reinforce the floor.</span>")
 				return
 	else if(istype(C, /obj/item/stack/tile) && !locate(/obj/structure/lattice/catwalk, src))

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -57,7 +57,7 @@
 			return
 		if (istype(C, /obj/item/stack/rods))
 			var/obj/item/stack/rods/R = C
-			if (R.use(2))
+			if (R.use(1))
 				to_chat(user, "<span class='notice'>You lay down the catwalk.</span>")
 				playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
 				new /obj/structure/lattice/catwalk/over(src)
@@ -79,7 +79,7 @@
 					R.use(2)
 					to_chat(user, "<span class='notice'>You reinforce the floor.</span>")
 				return
-	else if(istype(C, /obj/item/stack/tile))
+	else if(istype(C, /obj/item/stack/tile) && !locate(/obj/structure/lattice/catwalk, src))
 		if(!broken && !burnt)
 			for(var/obj/O in src)
 				if(O.level == 1) //ex. pipes laid underneath a tile


### PR DESCRIPTION
## About The Pull Request
#636 with an additional bugfix and no sprites

## Why It's Good For The Game
Bugs are bad

## Changelog
:cl:
fix: Can no longer place tiles over catwalks
tweak: catwalks now need to be welded off instead of instantly cut off.
fix: no more infinite iron sheets from reinforced floors
/:cl:
