### PR TITLE
Better movement slowdown and longer softcrit

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -41,7 +41,7 @@
 
 //Health Defines
 #define HEALTH_THRESHOLD_CRIT 0
-#define HEALTH_THRESHOLD_FULLCRIT -30
+#define HEALTH_THRESHOLD_FULLCRIT -40
 #define HEALTH_THRESHOLD_DEAD -100
 
 #define HEALTH_THRESHOLD_NEARDEATH -90 //Not used mechanically, but to determine if someone is so close to death they hear the other side

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1131,6 +1131,15 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 // MOVE SPEED //
 ////////////////
 
+
+/// MOVESPEED HEALTH DEFICIENCY DELAY FACTORS ///
+//  YOU PROBABLY SHOULDN'T TOUCH THESE UNLESS YOU GRAPH EM OUT
+#define HEALTH_DEF_MOVESPEED_DAMAGE_MIN 30
+#define HEALTH_DEF_MOVESPEED_DELAY_MAX 15
+#define HEALTH_DEF_MOVESPEED_DIV 350
+#define HEALTH_DEF_MOVESPEED_FLIGHT_DIV 1050
+#define HEALTH_DEF_MOVESPEED_POW 1.6
+
 /datum/species/proc/movement_delay(mob/living/carbon/human/H)
 	. = 0	//We start at 0.
 	var/flight = 0	//Check for flight and flying items
@@ -1152,11 +1161,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				. += I.slowdown
 		if(!HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
 			var/health_deficiency = max(H.maxHealth - H.health, H.staminaloss)
-			if(health_deficiency >= 40)
+			if(health_deficiency >= HEALTH_DEF_MOVESPEED_DAMAGE_MIN)
 				if(flight)
-					. += (health_deficiency / 75)
+					. += min(((health_deficiency) ** HEALTH_DEF_MOVESPEED_POW) / HEALTH_DEF_MOVESPEED_FLIGHT_DIV, HEALTH_DEF_MOVESPEED_DELAY_MAX)
 				else
-					. += (health_deficiency / 25)
+					. += min(((health_deficiency) ** HEALTH_DEF_MOVESPEED_POW) / HEALTH_DEF_MOVESPEED_DIV, HEALTH_DEF_MOVESPEED_DELAY_MAX)
 		if(CONFIG_GET(flag/disable_human_mood))
 			if(!HAS_TRAIT(H, TRAIT_NOHUNGER))
 				var/hungry = (500 - H.nutrition) / 5 //So overeat would be 100 and default level would be 80
@@ -1177,6 +1186,13 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTCOLD))
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
 	return .
+
+
+#undef HEALTH_DEF_MOVESPEED_DAMAGE_MIN
+#undef HEALTH_DEF_MOVESPEED_DELAY_MAX
+#undef HEALTH_DEF_MOVESPEED_DIV
+#undef HEALTH_DEF_MOVESPEED_FLIGHT_DIV
+#undef HEALTH_DEF_MOVESPEED_POW
 
 //////////////////
 // ATTACK PROCS //


### PR DESCRIPTION
## About The Pull Request

This changes the function that is used to calculate slowdown while damaged. A comparison from the original (red) and the new (green) is shown below.

![image](https://user-images.githubusercontent.com/24400628/67630544-64e3ba80-f857-11e9-9837-cb69054e676a.png)

The blue vertical line is when you enter softcrit and the red vertical line is when you enter hardcrit.

Speaking of crit, softcrit now is from 0 to -40 instead of -30.

## Why It's Good For The Game

Many fights are based on who gets the first hit. If you have a bad start it can be hard to recover from that bad start as you are given the handicap of slowness. This changes the function to curve up the more damage you take. Less slowdown at less damage is made up for by more slowdown at more damage.

## Changelog
:cl:
tweak: The slowness from damage function has been tweaked to give less slowdown at lower levels of damage but much more at higher levels of damage, in the form of a curve instead of linearly.
tweak: Softcrit now has a bigger health range.
/:cl:

