### PR TITLE
Sleeper fix (and some circuit text)

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -27,11 +27,8 @@
 	var/enter_message = "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.</b></span>"
 	payment_department = ACCOUNT_MED
 	fair_market_price = 5
-/obj/machinery/sleeper/Initialize(mapload)
+/obj/machinery/sleeper/Initialize()
 	. = ..()
-	if(mapload)
-		component_parts -= circuit
-		QDEL_NULL(circuit)
 	occupant_typecache = GLOB.typecache_living
 	update_icon()
 	reset_chem_buttons()
@@ -264,6 +261,7 @@
 /obj/machinery/sleeper/syndie/fullupgrade/Initialize()
 	. = ..()
 	component_parts = list()
+	component_parts += new /obj/item/circuitboard/machine/sleeper(null)
 	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
 	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
 	component_parts += new /obj/item/stack/sheet/glass(null)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -170,6 +170,14 @@
 	category = list ("Medical Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+/datum/design/board/sleeper
+	name = "Machine Design (Sleeper Board)"
+	desc = "The circuit board for a sleeper."
+	id = "sleeper"
+	build_path = /obj/item/circuitboard/machine/sleeper
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_MEDICAL
+	category = list ("Medical Machinery")
+
 /datum/design/board/reagentgrinder
 	name = "Machine Design (All-In-One Grinder)"
 	desc = "The circuit board for an All-In-One Grinder."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -56,7 +56,7 @@
 	display_name = "Biological Technology"
 	description = "What makes us tick."	//the MC, silly!
 	prereq_ids = list("base")
-	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "healthanalyzer", "medspray","genescanner")
+	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "sleeper", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "healthanalyzer", "medspray","genescanner")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -118,7 +118,7 @@
 /datum/techweb_node/circuitresearch
 	id = "circuitresearch"
 	display_name = "Circuit Research"
-	description = "Circuits, woo"
+	description = "Modular circuitry adaptable to a wide range of utilities."
 	prereq_ids = list("datatheory")
 	design_ids = list("icprinter")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
@@ -127,7 +127,7 @@
 /datum/techweb_node/circuitupgrades
 	id = "circuitupgrades"
 	display_name = "Advanced Circuit Research"
-	description = "Circuits but better."
+	description = "Advanced designs that expand the possibilities of modular circuits."
 	prereq_ids = list("circuitresearch")
 	design_ids = list("icupgadv", "icupgclo")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
@@ -976,7 +976,7 @@
 	export_price = 20000
 	hidden = TRUE
 	design_ids = list("alienalloy")
-	
+
 /datum/techweb_node/alientech/on_research() //Unlocks the Zeta shuttle for purchase
 		SSshuttle.shuttle_purchase_requirements_met |= SHUTTLE_UNLOCK_ALIENTECH
 


### PR DESCRIPTION
##About The Pull Request

Alright, it was a somewhat serious issue so i dropped my other ports to do this: Revert a handful of changes introduced by the stasis TG pr, wich made sleepers not have boards and that, making them unupgradable and uncraftable, simple as that.

## Why It's Good For The Game

we still have sleepers, so we should be able to upgrade them, dismantle, and overall interact with them besides simple t1 usage.
closes #590 

## Changelog
:cl:
tweak: Fixed some code, making sleepers able to be upgraded and made again.
tweak: made circuit text not as shitty
/:cl: