### PR TITLE
Additional Loadout Gear: Accessories

### DIFF
--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -18,7 +18,64 @@
 	path = /obj/item/clothing/neck/scarf/darkblue
 	cost = 1000
 
+/datum/gear/accessory/scarf/zebra
+	display_name = "scarf, zebra"
+	path = /obj/item/clothing/neck/scarf/zebra
+	cost = 1200
+
+/datum/gear/accessory/scarf/stripedred
+	display_name = "scarf, striped red"
+	path = /obj/item/clothing/neck/stripedredscarf
+	cost = 1200
+
+/datum/gear/accessory/scarf/stripedblue
+	display_name = "scarf, striped blue"
+	path = /obj/item/clothing/neck/stripedbluescarf
+	cost = 1200
+
 /datum/gear/accessory/armband_red
 	display_name = "armband"
 	path = /obj/item/clothing/accessory/armband
 	cost = 1000
+
+/datum/gear/accessory/tie/blue
+	display_name = "tie, blue"
+	path = /obj/item/clothing/neck/tie/blue
+	cost = 1500
+
+/datum/gear/accessory/tie/red
+	display_name = "tie, red"
+	path = /obj/item/clothing/neck/tie/red
+	cost = 1500
+
+/datum/gear/accessory/tie/black
+	display_name = "tie, black"
+	path = /obj/item/clothing/neck/tie/black
+	cost = 2000
+
+/datum/gear/accessory/tie/horrible
+	display_name = "tie, horrible"
+	path = /obj/item/clothing/neck/tie/horrible
+	cost = 1000
+
+/datum/gear/accessory/petcollar
+	display_name = "pet collar"
+	path = /obj/item/clothing/neck/petcollar
+	cost = 20000
+
+/datum/gear/accessory/necklace
+	display_name = "necklace, gold"
+	path = /obj/item/clothing/neck/necklace/dope
+	cost = 25000
+
+/datum/gear/accessory/eyepatch
+	display_name = "eyepatch"
+	slot = SLOT_GLASSES
+	path = /obj/item/clothing/glasses/eyepatch
+	cost = 1200
+
+/datum/gear/accessory/monocle
+	display_name = "monocle"
+	slot = SLOT_GLASSES
+	path = /obj/item/clothing/glasses/monocle
+	cost = 1200

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1180,14 +1180,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				equipped_gear -= TG.display_name
 			else
 				var/list/type_blacklist = list()
+				var/list/slot_blacklist = list()
 				for(var/gear_name in equipped_gear)
 					var/datum/gear/G = GLOB.gear_datums[gear_name]
 					if(istype(G))
-						if(G.subtype_path in type_blacklist)
-							continue
-						type_blacklist += G.subtype_path
+						if(!(G.subtype_path in type_blacklist))
+							type_blacklist += G.subtype_path
+						if(!(G.slot in slot_blacklist))
+							slot_blacklist += G.slot
 				if((TG.display_name in purchased_gear))
-					if(!(TG.subtype_path in type_blacklist))
+					if(!(TG.subtype_path in type_blacklist) || !(TG.slot in slot_blacklist))
 						equipped_gear += TG.display_name
 					else
 						to_chat(user, "<span class='warning'>Can't equip [TG.display_name]. It conflicts with an already-equipped item.</span>")
@@ -1199,6 +1201,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			gear_tab = href_list["select_category"]
 		else if(href_list["clear_loadout"])
 			equipped_gear.Cut()
+			save_preferences()
 
 		ShowChoices(user)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm adding new items on a category-by-category basis. First is accessories. Also makes gear conflicts less restrictive, you can now equip multiple items from the same category as long as they use different slots.

TODO:
- [x] Get qwerty to sign off on the prices.

## Changelog
:cl:
add: Several new items have been added to the beecoin shop's Accessories category.
tweak: Multiple loadout items from the same category can be equipped if they use different slots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
