### PR TITLE
Grenade Improvements

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -424,9 +424,9 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 #define VOMIT_PURPLE 2
 
 //chem grenades defines
-#define EMPTY 1
-#define WIRED 2
-#define READY 3
+#define GRENADE_EMPTY 1
+#define GRENADE_WIRED 2
+#define GRENADE_READY 3
 
 /// Misc text define. Does 4 spaces. Used as a makeshift tabulator.
 #define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -423,5 +423,10 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 #define VOMIT_TOXIC 1
 #define VOMIT_PURPLE 2
 
+//chem grenades defines
+#define EMPTY 1
+#define WIRED 2
+#define READY 3
+
 /// Misc text define. Does 4 spaces. Used as a makeshift tabulator.
 #define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -1,5 +1,8 @@
+/datum/wires/explosive
+	var/duds_number = 2
+
 /datum/wires/explosive/New(atom/holder)
-	add_duds(2) // In this case duds actually explode.
+	add_duds(duds_number) // In this case duds actually explode.
 	..()
 
 /datum/wires/explosive/on_pulse(index)
@@ -11,6 +14,45 @@
 /datum/wires/explosive/proc/explode()
 	return
 
+/datum/wires/explosive/chem_grenade
+	duds_number = 1
+	holder_type = /obj/item/grenade/chem_grenade
+	randomize = TRUE
+	var/fingerprint
+
+/datum/wires/explosive/chem_grenade/interactable(mob/user)
+	var/obj/item/grenade/chem_grenade/G = holder
+	if(G.stage == WIRED)
+		return TRUE
+
+/datum/wires/explosive/chem_grenade/attach_assembly(color, obj/item/assembly/S)
+	if(istype(S,/obj/item/assembly/timer))
+		var/obj/item/grenade/chem_grenade/G = holder
+		var/obj/item/assembly/timer/T = S
+		G.det_time = T.saved_time*10
+	else if(istype(S,/obj/item/assembly/prox_sensor))
+		var/obj/item/grenade/chem_grenade/G = holder
+		G.landminemode = S
+		S.proximity_monitor.wire = TRUE
+	fingerprint = S.fingerprintslast
+	return ..()
+
+/datum/wires/explosive/chem_grenade/explode()
+	var/obj/item/grenade/chem_grenade/G = holder
+	var/obj/item/assembly/assembly = get_attached(get_wire(1))
+	message_admins("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
+	log_game("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
+	G.prime()
+
+/datum/wires/explosive/chem_grenade/detach_assembly(color)
+	var/obj/item/assembly/S = get_attached(color)
+	if(S && istype(S))
+		assemblies -= color
+		S.connected = null
+		S.forceMove(holder.drop_location())
+		var/obj/item/grenade/chem_grenade/G = holder
+		G.landminemode = null
+		return S
 
 /datum/wires/explosive/c4
 	holder_type = /obj/item/grenade/plastic/c4

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -22,7 +22,7 @@
 
 /datum/wires/explosive/chem_grenade/interactable(mob/user)
 	var/obj/item/grenade/chem_grenade/G = holder
-	if(G.stage == WIRED)
+	if(G.stage == GRENADE_WIRED)
 		return TRUE
 
 /datum/wires/explosive/chem_grenade/attach_assembly(color, obj/item/assembly/S)

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -5,6 +5,7 @@
 	var/list/checkers //list of /obj/effect/abstract/proximity_checkers
 	var/current_range
 	var/ignore_if_not_on_turf	//don't check turfs in range if the host's loc isn't a turf
+	var/wire = FALSE
 
 /datum/proximity_monitor/New(atom/_host, range, _ignore_if_not_on_turf = TRUE)
 	checkers = list()
@@ -58,6 +59,8 @@
 	var/atom/_host = host
 
 	var/atom/loc_to_use = ignore_if_not_on_turf ? _host.loc : get_turf(_host)
+	if(wire && !isturf(loc_to_use)) //it makes assemblies attached on wires work
+		loc_to_use = get_turf(loc_to_use)
 	if(!isturf(loc_to_use))	//only check the host's loc
 		if(range)
 			var/obj/effect/abstract/proximity_checker/pc

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -1,7 +1,3 @@
-#define EMPTY 1
-#define WIRED 2
-#define READY 3
-
 /obj/item/grenade/chem_grenade
 	name = "chemical grenade"
 	desc = "A custom made grenade."
@@ -14,20 +10,24 @@
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
 	var/list/banned_containers = list(/obj/item/reagent_containers/glass/beaker/bluespace) //Containers to exclude from specific grenade subtypes
 	var/affected_area = 3
-	var/obj/item/assembly_holder/nadeassembly = null
-	var/assemblyattacher
 	var/ignition_temp = 10 // The amount of heat added to the reagents when this grenade goes off.
 	var/threatscale = 1 // Used by advanced grenades to make them slightly more worthy.
 	var/no_splash = FALSE //If the grenade deletes even if it has no reagents to splash with. Used for slime core reactions.
 	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10°K upon ignition." // Appears when examining empty casings.
+	var/obj/item/assembly/prox_sensor/landminemode = null
+
+/obj/item/grenade/chem_grenade/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 /obj/item/grenade/chem_grenade/Initialize()
 	. = ..()
 	create_reagents(1000)
 	stage_change() // If no argument is set, it will change the stage to the current stage, useful for stock grenades that start READY.
-
+	wires = new /datum/wires/explosive/chem_grenade(src)
+	
 /obj/item/grenade/chem_grenade/examine(mob/user)
-	display_timer = (stage == READY && !nadeassembly)	//show/hide the timer based on assembly state
+	display_timer = (stage == READY)	//show/hide the timer based on assembly state
 	..()
 	if(user.can_see_reagents())
 		if(beakers.len)
@@ -48,12 +48,13 @@
 
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
 	if(stage == READY && !active)
-		if(nadeassembly)
-			nadeassembly.attack_self(user)
-		else
-			..()
-
+		..()
+	if(stage == WIRED)
+		wires.interact(user)
+		
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
+	if(istype(I,/obj/item/assembly) && stage == WIRED)
+		wires.interact(user)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		if(stage == WIRED)
 			if(beakers.len)
@@ -62,12 +63,15 @@
 				I.play_tool_sound(src, 25)
 			else
 				to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the [initial(name)] assembly!</span>")
-		else if(stage == READY && !nadeassembly)
-			det_time = det_time == 50 ? 30 : 50	//toggle between 30 and 50
-			to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
-		else if(stage == EMPTY)
-			to_chat(user, "<span class='warning'>You need to add an activation mechanism!</span>")
+		else if(stage == READY)
+			det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
+			if(landminemode)
+				landminemode.time = det_time * 0.1	//overwrites the proxy sensor activation timer
 
+			to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
+		else
+			to_chat(user, "<span class='warning'>You need to add a wire!</span>")
+		return
 	else if(stage == WIRED && is_type_in_list(I, allowed_containers))
 		. = TRUE //no afterattack
 		if(is_type_in_list(I, banned_containers))
@@ -86,21 +90,6 @@
 				user.log_message("inserted [I] ([reagent_list]) into [src]",LOG_GAME)
 			else
 				to_chat(user, "<span class='warning'>[I] is empty!</span>")
-
-	else if(stage == EMPTY && istype(I, /obj/item/assembly_holder))
-		. = 1 // no afterattack
-		var/obj/item/assembly_holder/A = I
-		if(isigniter(A.a_left) == isigniter(A.a_right))	//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
-			return
-		if(!user.transferItemToLoc(I, src))
-			return
-
-		nadeassembly = A
-		A.master = src
-		assemblyattacher = user.ckey
-
-		stage_change(WIRED)
-		to_chat(user, "<span class='notice'>You add [A] to the [initial(name)] assembly.</span>")
 
 	else if(stage == EMPTY && istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
@@ -126,13 +115,9 @@
 				user.log_message("removed [O] ([reagent_list]) from [src]", LOG_GAME)
 			beakers = list()
 			to_chat(user, "<span class='notice'>You open the [initial(name)] assembly and remove the payload.</span>")
-			return // First use of the wrench remove beakers, then use the wrench to remove the activation mechanism.
-		if(nadeassembly)
-			nadeassembly.forceMove(drop_location())
-			nadeassembly.master = null
-			nadeassembly = null
-		else // If "nadeassembly = null && stage == WIRED", then it most have been cable_coil that was used.
-			new /obj/item/stack/cable_coil(get_turf(src),1)
+			wires.detach_assembly(wires.get_wire(1))
+			return
+		new /obj/item/stack/cable_coil(get_turf(src),1)
 		stage_change(EMPTY)
 		to_chat(user, "<span class='notice'>You remove the activation mechanism from the [initial(name)] assembly.</span>")
 	else
@@ -153,20 +138,11 @@
 		name = initial(name)
 		desc = initial(desc)
 		icon_state = "[initial(icon_state)]_locked"
-
-
-//assembly stuff
-/obj/item/grenade/chem_grenade/receive_signal()
-	prime()
-
-
-/obj/item/grenade/chem_grenade/Crossed(atom/movable/AM)
-	if(nadeassembly)
-		nadeassembly.Crossed(AM)
-
+		
 /obj/item/grenade/chem_grenade/on_found(mob/finder)
-	if(nadeassembly)
-		nadeassembly.on_found(finder)
+	var/obj/item/assembly/A = wires.get_attached(wires.get_wire(1))
+	if(A)
+		A.on_found(finder)
 
 /obj/item/grenade/chem_grenade/log_grenade(mob/user, turf/T)
 	var/reagent_string = ""
@@ -175,7 +151,28 @@
 		if(!exploded_beaker.reagents)
 			continue
 		reagent_string += " ([exploded_beaker.name] [beaker_number++] : " + pretty_string_from_reagent_list(exploded_beaker.reagents.reagent_list) + ");"
-	log_bomber(user, "primed a", src, "containing:[reagent_string]")
+	if(landminemode)
+		log_bomber(user, "activated a proxy", src, "containing:[reagent_string]")
+	else
+		log_bomber(user, "primed a", src, "containing:[reagent_string]")
+
+/obj/item/grenade/chem_grenade/preprime(mob/user, delayoverride, msg = TRUE, volume = 60)
+	var/turf/T = get_turf(src)
+	log_grenade(user, T) //Inbuilt admin procs already handle null users
+	if(user)
+		add_fingerprint(user)
+		if(msg)
+			if(landminemode)
+				to_chat(user, "<span class='warning'>You prime [src], activating its proximity sensor.</span>")
+			else
+				to_chat(user, "<span class='warning'>You prime [src]! [DisplayTimeText(det_time)]!</span>")
+	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)
+	icon_state = initial(icon_state) + "_active"
+	if(landminemode)
+		landminemode.activate()
+		return
+	active = TRUE
+	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
 /obj/item/grenade/chem_grenade/prime()
 	if(stage != READY)
@@ -194,14 +191,10 @@
 				O.forceMove(drop_location())
 			beakers = list()
 		stage_change(EMPTY)
+		active = FALSE
 		return
 
-	if(nadeassembly)
-		var/mob/M = get_mob_by_ckey(assemblyattacher)
-		var/mob/last = get_mob_by_ckey(nadeassembly.fingerprintslast)
-		message_admins("grenade primed by an assembly, attached by [ADMIN_LOOKUPFLW(M)] and last touched by [ADMIN_LOOKUPFLW(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at [ADMIN_VERBOSEJMP(detonation_turf)]</a>.")
-		log_game("grenade primed by an assembly, attached by [key_name(M)] and last touched by [key_name(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at [AREACOORD(detonation_turf)]")
-
+//	logs from custom assemblies priming are handled by the wire component
 	log_game("A grenade detonated at [AREACOORD(detonation_turf)]")
 
 	update_mob()
@@ -277,16 +270,14 @@
 	var/unit_spread = 10 // Amount of units per repeat. Can be altered with a multitool.
 
 /obj/item/grenade/chem_grenade/adv_release/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_MULTITOOL)
-		switch(unit_spread)
-			if(0 to 24)
-				unit_spread += 5
-			if(25 to 99)
-				unit_spread += 25
-			else
-				unit_spread = 5
-		to_chat(user, "<span class='notice'> You set the time release to [unit_spread] units per detonation.</span>")
-		return
+	if(I.tool_behaviour == TOOL_MULTITOOL && !active)
+		var/newspread = text2num(stripped_input(user, "Please enter a new spread amount", name))
+		if (newspread != null && user.canUseTopic(src, BE_CLOSE))
+			newspread = round(newspread)
+			unit_spread = CLAMP(newspread, 5, 100)
+			to_chat(user, "<span class='notice'>You set the time release to [unit_spread] units per detonation.</span>")
+		if (newspread != unit_spread)
+			to_chat(user, "<span class='notice'>The new value is out of bounds. Minimum spread is 5 units, maximum is 100 units.</span>")
 	..()
 
 /obj/item/grenade/chem_grenade/adv_release/prime()
@@ -298,7 +289,6 @@
 		total_volume += RC.reagents.total_volume
 	if(!total_volume)
 		qdel(src)
-		qdel(nadeassembly)
 		return
 	var/fraction = unit_spread/total_volume
 	var/datum/reagents/reactants = new(unit_spread)
@@ -308,13 +298,7 @@
 	chem_splash(get_turf(src), affected_area, list(reactants), ignition_temp, threatscale)
 
 	var/turf/DT = get_turf(src)
-	if(nadeassembly)
-		var/mob/M = get_mob_by_ckey(assemblyattacher)
-		var/mob/last = get_mob_by_ckey(nadeassembly.fingerprintslast)
-		message_admins("grenade primed by an assembly at [AREACOORD(DT)], attached by [ADMIN_LOOKUPFLW(M)] and last touched by [ADMIN_LOOKUPFLW(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name])</a>.")
-		log_game("grenade primed by an assembly at [AREACOORD(DT)], attached by [key_name(M)] and last touched by [key_name(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name])")
-	else
-		addtimer(CALLBACK(src, .proc/prime), det_time)
+	addtimer(CALLBACK(src, .proc/prime), det_time)
 	log_game("A grenade detonated at [AREACOORD(DT)]")
 
 
@@ -599,7 +583,3 @@
 
 	beakers += B1
 	beakers += B2
-
-#undef READY
-#undef WIRED
-#undef EMPTY

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -5,7 +5,7 @@
 	item_state = "flashbang"
 	w_class = WEIGHT_CLASS_SMALL
 	force = 2
-	var/stage = EMPTY
+	var/stage = GRENADE_EMPTY
 	var/list/obj/item/reagent_containers/glass/beakers = list()
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
 	var/list/banned_containers = list(/obj/item/reagent_containers/glass/beaker/bluespace) //Containers to exclude from specific grenade subtypes
@@ -27,7 +27,7 @@
 	wires = new /datum/wires/explosive/chem_grenade(src)
 	
 /obj/item/grenade/chem_grenade/examine(mob/user)
-	display_timer = (stage == READY)	//show/hide the timer based on assembly state
+	display_timer = (stage == GRENADE_READY)	//show/hide the timer based on assembly state
 	..()
 	if(user.can_see_reagents())
 		if(beakers.len)
@@ -39,7 +39,7 @@
 				to_chat(user, "<span class='notice'>You detect no second beaker in the grenade.</span>")
 		else
 			to_chat(user, "<span class='notice'>You scan the grenade, but detect nothing.</span>")
-	else if(stage != READY && beakers.len)
+	else if(stage != GRENADE_READY && beakers.len)
 		if(beakers.len == 2 && beakers[1].name == beakers[2].name)
 			to_chat(user, "<span class='notice'>You see two [beakers[1].name]s inside the grenade.</span>")
 		else
@@ -47,23 +47,23 @@
 				to_chat(user, "<span class='notice'>You see a [G.name] inside the grenade.</span>")
 
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
-	if(stage == READY && !active)
+	if(stage == GRENADE_READY && !active)
 		..()
-	if(stage == WIRED)
+	if(stage == GRENADE_WIRED)
 		wires.interact(user)
 		
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
-	if(istype(I,/obj/item/assembly) && stage == WIRED)
+	if(istype(I,/obj/item/assembly) && stage == GRENADE_WIRED)
 		wires.interact(user)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		if(stage == WIRED)
+		if(stage == GRENADE_WIRED)
 			if(beakers.len)
 				stage_change(READY)
 				to_chat(user, "<span class='notice'>You lock the [initial(name)] assembly.</span>")
 				I.play_tool_sound(src, 25)
 			else
 				to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the [initial(name)] assembly!</span>")
-		else if(stage == READY)
+		else if(stage == GRENADE_READY)
 			det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
 			if(landminemode)
 				landminemode.time = det_time * 0.1	//overwrites the proxy sensor activation timer
@@ -72,7 +72,7 @@
 		else
 			to_chat(user, "<span class='warning'>You need to add a wire!</span>")
 		return
-	else if(stage == WIRED && is_type_in_list(I, allowed_containers))
+	else if(stage == GRENADE_WIRED && is_type_in_list(I, allowed_containers))
 		. = TRUE //no afterattack
 		if(is_type_in_list(I, banned_containers))
 			to_chat(user, "<span class='warning'>[src] is too small to fit [I]!</span>") // this one hits home huh anon?
@@ -91,21 +91,21 @@
 			else
 				to_chat(user, "<span class='warning'>[I] is empty!</span>")
 
-	else if(stage == EMPTY && istype(I, /obj/item/stack/cable_coil))
+	else if(stage == GRENADE_EMPTY && istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
 		if (C.use(1))
 			det_time = 50 // In case the cable_coil was removed and readded.
-			stage_change(WIRED)
+			stage_change(GRENADE_WIRED)
 			to_chat(user, "<span class='notice'>You rig the [initial(name)] assembly.</span>")
 		else
 			to_chat(user, "<span class='warning'>You need one length of coil to wire the assembly!</span>")
 			return
 
-	else if(stage == READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
-		stage_change(WIRED)
+	else if(stage == GRENADE_READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
+		stage_change(GRENADE_WIRED)
 		to_chat(user, "<span class='notice'>You unlock the [initial(name)] assembly.</span>")
 
-	else if(stage == WIRED && I.tool_behaviour == TOOL_WRENCH)
+	else if(stage == GRENADE_WIRED && I.tool_behaviour == TOOL_WRENCH)
 		if(beakers.len)
 			for(var/obj/O in beakers)
 				O.forceMove(drop_location())
@@ -118,7 +118,7 @@
 			wires.detach_assembly(wires.get_wire(1))
 			return
 		new /obj/item/stack/cable_coil(get_turf(src),1)
-		stage_change(EMPTY)
+		stage_change(GRENADE_EMPTY)
 		to_chat(user, "<span class='notice'>You remove the activation mechanism from the [initial(name)] assembly.</span>")
 	else
 		return ..()
@@ -126,15 +126,15 @@
 /obj/item/grenade/chem_grenade/proc/stage_change(N)
 	if(N)
 		stage = N
-	if(stage == EMPTY)
+	if(stage == GRENADE_EMPTY)
 		name = "[initial(name)] casing"
 		desc = "A do it yourself [initial(name)]! [initial(casedesc)]"
 		icon_state = initial(icon_state)
-	else if(stage == WIRED)
+	else if(stage == GRENADE_WIRED)
 		name = "unsecured [initial(name)]"
 		desc = "An unsecured [initial(name)] assembly."
 		icon_state = "[initial(icon_state)]_ass"
-	else if(stage == READY)
+	else if(stage == GRENADE_READY)
 		name = initial(name)
 		desc = initial(desc)
 		icon_state = "[initial(icon_state)]_locked"
@@ -175,7 +175,7 @@
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
 /obj/item/grenade/chem_grenade/prime()
-	if(stage != READY)
+	if(stage != GRENADE_READY)
 		return
 
 	var/list/datum/reagents/reactants = list()
@@ -190,7 +190,7 @@
 			for(var/obj/O in beakers)
 				O.forceMove(drop_location())
 			beakers = list()
-		stage_change(EMPTY)
+		stage_change(GRENADE_EMPTY)
 		active = FALSE
 		return
 
@@ -214,7 +214,7 @@
 	threatscale = 1.1	// 10% more effective.
 
 /obj/item/grenade/chem_grenade/large/prime()
-	if(stage != READY)
+	if(stage != GRENADE_READY)
 		return
 
 	for(var/obj/item/slime_extract/S in beakers)
@@ -239,7 +239,7 @@
 	//if you do that it must have reagents.  If you're going to
 	//make a special case you might as well do it explicitly. -Sayu
 /obj/item/grenade/chem_grenade/large/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/slime_extract) && stage == WIRED)
+	if(istype(I, /obj/item/slime_extract) && stage == GRENADE_WIRED)
 		if(!user.transferItemToLoc(I, src))
 			return
 		to_chat(user, "<span class='notice'>You add [I] to the [initial(name)] assembly.</span>")
@@ -281,7 +281,7 @@
 	..()
 
 /obj/item/grenade/chem_grenade/adv_release/prime()
-	if(stage != READY)
+	if(stage != GRENADE_READY)
 		return
 
 	var/total_volume = 0
@@ -312,7 +312,7 @@
 /obj/item/grenade/chem_grenade/metalfoam
 	name = "metal foam grenade"
 	desc = "Used for emergency sealing of hull breaches."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/metalfoam/Initialize()
 	. = ..()
@@ -330,7 +330,7 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam
 	name = "smart metal foam grenade"
 	desc = "Used for emergency sealing of hull breaches, while keeping areas accessible."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/smart_metal_foam/Initialize()
 	. = ..()
@@ -348,7 +348,7 @@
 /obj/item/grenade/chem_grenade/incendiary
 	name = "incendiary grenade"
 	desc = "Used for clearing rooms of living things."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/incendiary/Initialize()
 	. = ..()
@@ -366,7 +366,7 @@
 /obj/item/grenade/chem_grenade/antiweed
 	name = "weedkiller grenade"
 	desc = "Used for purging large areas of invasive plant species. Contents under pressure. Do not directly inhale contents."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/antiweed/Initialize()
 	. = ..()
@@ -385,7 +385,7 @@
 /obj/item/grenade/chem_grenade/cleaner
 	name = "cleaner grenade"
 	desc = "BLAM!-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/cleaner/Initialize()
 	. = ..()
@@ -403,7 +403,7 @@
 /obj/item/grenade/chem_grenade/ez_clean
 	name = "cleaner grenade"
 	desc = "Waffle Co.-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/ez_clean/Initialize()
 	. = ..()
@@ -422,7 +422,7 @@
 /obj/item/grenade/chem_grenade/teargas
 	name = "teargas grenade"
 	desc = "Used for nonlethal riot control. Contents under pressure. Do not directly inhale contents."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/teargas/Initialize()
 	. = ..()
@@ -441,7 +441,7 @@
 /obj/item/grenade/chem_grenade/facid
 	name = "acid grenade"
 	desc = "Used for melting armoured opponents."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/facid/Initialize()
 	. = ..()
@@ -461,7 +461,7 @@
 /obj/item/grenade/chem_grenade/colorful
 	name = "colorful grenade"
 	desc = "Used for wide scale painting projects."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/colorful/Initialize()
 	. = ..()
@@ -479,7 +479,7 @@
 /obj/item/grenade/chem_grenade/glitter
 	name = "generic glitter grenade"
 	desc = "You shouldn't see this description."
-	stage = READY
+	stage = GRENADE_READY
 	var/glitter_type = /datum/reagent/glitter
 
 /obj/item/grenade/chem_grenade/glitter/Initialize()
@@ -513,7 +513,7 @@
 /obj/item/grenade/chem_grenade/clf3
 	name = "clf3 grenade"
 	desc = "BURN!-brand foaming clf3. In a special applicator for rapid purging of wide areas."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/clf3/Initialize()
 	. = ..()
@@ -531,7 +531,7 @@
 /obj/item/grenade/chem_grenade/bioterrorfoam
 	name = "Bio terror foam grenade"
 	desc = "Tiger Cooperative chemical foam grenade. Causes temporary irration, blindness, confusion, mutism, and mutations to carbon based life forms. Contains additional spore toxin."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/bioterrorfoam/Initialize()
 	. = ..()
@@ -551,7 +551,7 @@
 /obj/item/grenade/chem_grenade/tuberculosis
 	name = "Fungal tuberculosis grenade"
 	desc = "WARNING: GRENADE WILL RELEASE DEADLY SPORES CONTAINING ACTIVE AGENTS. SEAL SUIT AND AIRFLOW BEFORE USE."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/tuberculosis/Initialize()
 	. = ..()
@@ -571,7 +571,7 @@
 	name = "holy hand grenade"
 	desc = "A vessel of concentrated religious might."
 	icon_state = "holy_grenade"
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/holy/Initialize()
 	. = ..()

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -49,7 +49,7 @@
 /obj/item/grenade/examine(mob/user)
 	..()
 	if(display_timer)
-		if(det_time > 1)
+		if(det_time > 0)
 			to_chat(user, "The timer is set to [DisplayTimeText(det_time)].")
 		else
 			to_chat(user, "\The [src] is set for instant detonation.")
@@ -69,7 +69,7 @@
 	if(user)
 		add_fingerprint(user)
 		if(msg)
-			to_chat(user, "<span class='warning'>You prime [src]! [DisplayTimeText(det_time)]!</span>")
+			to_chat(user, "<span class='warning'>You prime [src]! [capitalize(DisplayTimeText(det_time))]!</span>")
 	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)
 	active = TRUE
 	icon_state = initial(icon_state) + "_active"
@@ -84,23 +84,37 @@
 
 
 /obj/item/grenade/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		switch(det_time)
-			if (1)
-				det_time = 10
-				to_chat(user, "<span class='notice'>You set the [name] for 1 second detonation time.</span>")
-			if (10)
-				det_time = 30
-				to_chat(user, "<span class='notice'>You set the [name] for 3 second detonation time.</span>")
-			if (30)
-				det_time = 50
-				to_chat(user, "<span class='notice'>You set the [name] for 5 second detonation time.</span>")
-			if (50)
-				det_time = 1
-				to_chat(user, "<span class='notice'>You set the [name] for instant detonation.</span>")
-		add_fingerprint(user)
+	if(!active)
+		if(W.tool_behaviour == TOOL_MULTITOOL)
+			var/newtime = text2num(stripped_input(user, "Please enter a new detonation time", name))
+			if (newtime != null && user.canUseTopic(src, BE_CLOSE))
+				change_det_time(newtime)
+				to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
+				if (round(newtime * 10) != det_time)
+					to_chat(user, "<span class='warning'>The new value is out of bounds. The lowest possible time is 3 seconds and highest is 5 seconds. Instant detonations are also possible.</span>")
+			return
+		else if(W.tool_behaviour == TOOL_SCREWDRIVER)
+			change_det_time()
+			to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
 	else
 		return ..()
+
+/obj/item/grenade/proc/change_det_time(time) //Time uses real time.
+	if(time != null)
+		if(time < 3)
+			time = 3
+		det_time = round(CLAMP(time * 10, 0, 50))
+	else
+		var/previous_time = det_time
+		switch(det_time)
+			if (0)
+				det_time = 30
+			if (30)
+				det_time = 50
+			if (50)
+				det_time = 0
+		if(det_time == previous_time)
+			det_time = 50
 
 /obj/item/grenade/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/game/objects/items/grenades/smokebomb.dm
+++ b/code/game/objects/items/grenades/smokebomb.dm
@@ -3,7 +3,6 @@
 	desc = "The word 'Dank' is scribbled on it in crayon."
 	icon = 'icons/obj/grenade.dmi'
 	icon_state = "smokewhite"
-	det_time = 20
 	item_state = "flashbang"
 	slot_flags = ITEM_SLOT_BELT
 	var/datum/effect_system/smoke_spread/bad/smoke

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -107,10 +107,6 @@
 	if(stuffed || grenade)
 		to_chat(user, "<span class='notice'>You pet [src]. D'awww.</span>")
 		if(grenade && !grenade.active)
-			if(istype(grenade, /obj/item/grenade/chem_grenade))
-				var/obj/item/grenade/chem_grenade/G = grenade
-				if(G.nadeassembly) //We're activated through different methods
-					return
 			log_game("[key_name(user)] activated a hidden grenade in [src].")
 			grenade.preprime(user, msg = FALSE, volume = 10)
 	else

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -4,9 +4,8 @@
 	icon_state = "health"
 	materials = list(/datum/material/iron=800, /datum/material/glass=200)
 	attachable = TRUE
-	secured = FALSE
 
-	var/scanning = FALSE
+	var/scanning = TRUE
 	var/health_scan
 	var/alarm_health = HEALTH_THRESHOLD_CRIT
 


### PR DESCRIPTION
## About The Pull Request

Ports the following from /tg/station:

https://github.com/tgstation/tgstation/pull/44258
https://github.com/tgstation/tgstation/pull/44169

## Why it's good for the game

Assemblies work properly now

## Changelog
:cl:
refactor: how to make a custom primed grenade now: apply wire, apply beakers, interact with the wire by multitool or hitting the grenade with an assembly, attach assembly to wire.\n
if its an proxy sensor when you prime it it ll activate the activation mode of the sensor with whatever time it was set in the prox sensor ( you can screwdrive to speed set it to 5 or 3 s)\n
if its a timer it ll change the det_time to whatever the timer had( you can screwdrive to speed set it to 5 or 3 s)\n
balance: The timer of all grenades can now be adjusted with a screwdriver. Possible values are instant, 3 seconds and 5 seconds.
add: You can now adjust the timer of grenades with a multitool. You can put it anywhere between 3 and 5 seconds. Instant detonations are also possible.
tweak: Advanced release grenades now open a window if you want to change the amount of units released.
tweak: The default timer on smoke grenades is now 3 seconds.
/:cl: