### PR TITLE
Exclude the Narsie rune from scribe time reduction (#44495)

### DIFF
--- a/code/modules/antagonists/cult/ritual.dm
+++ b/code/modules/antagonists/cult/ritual.dm
@@ -116,7 +116,7 @@ This file contains the cult dagger and rune list code
 	if(user.blood_volume)
 		user.apply_damage(initial(rune_to_scribe.scribe_damage), BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 	var/scribe_mod = initial(rune_to_scribe.scribe_delay)
-	if(istype(get_turf(user), /turf/open/floor/engine/cult))
+	if(istype(get_turf(user), /turf/open/floor/engine/cult) && !(ispath(rune_to_scribe, /obj/effect/rune/narsie)))
 		scribe_mod *= 0.5
 	if(!do_after(user, scribe_mod, target = get_turf(user)))
 		for(var/V in shields)


### PR DESCRIPTION
Simple check that's thrown when scribing runes. If you're on runed tiles,
and not scribing the Nar'Sie rune, its scribe time is cut in half.
Nar'Sie rune is therefore exempt. First PR, I've tested the code to
ensure that the Nar'Sie rune takes the full 50 seconds regardless of
tile, and that other runes are left untouched.

Given the movement speed reductions, a 25 second timer on the Nar'Sie
rune scribing means that on larger stations you will only just have
reached the summon location by the time it's done. To make the end game
for cult more balanced across stations, and with the recent movement
speed reductions, the Nar'Sie rune is locked at its intended scribe time,
with no means of reduction.

Mirrored from: https://github.com/tgstation/tgstation/pull/44495