### PR TITLE
Reduces travis log spam

### DIFF
--- a/code/modules/oracle_ui/themed.dm
+++ b/code/modules/oracle_ui/themed.dm
@@ -25,10 +25,12 @@ GLOBAL_LIST_EMPTY(oui_file_cache)
 		var/data = file2text(path)
 		GLOB.oui_file_cache[path] = data
 		return data
+#ifndef TRAVISBUILDING //For some reason this error occurs only in travis
 	else
 		var/errormsg = "MISSING PATH '[path]'"
 		log_world(errormsg)
 		return errormsg
+#endif
 
 /datum/oracle_ui/themed/proc/get_content_file(filename)
 	return get_file("html/oracle_ui/content/[content_root]/[filename]")

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -7,46 +7,46 @@ shopt -s globstar
 st=0
 
 if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
-    echo "Non-TGM formatted map detected. Please convert it using Map Merger!"
+    echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
     st=1
 fi;
 if grep -P '^\ttag = \"icon' _maps/**/*.dmm;	then
-    echo "tag vars from icon state generation detected in maps, please remove them."
+    echo "ERROR: tag vars from icon state generation detected in maps, please remove them."
     st=1
 fi;
-if grep 'step_[xy]' _maps/**/*.dmm;	then
-    echo "step_x/step_y variables detected in maps, please remove them."
+if grep -P 'step_[xy]' _maps/**/*.dmm;	then
+    echo "ERROR: step_x/step_y variables detected in maps, please remove them."
     st=1
 fi;
-if grep -m 1 'pixel_[xy] = 0' _maps/**/*.dmm;	then
-    echo "pixel_x/pixel_y = 0 variables detected in maps, please review to ensure they are not dirty varedits."
+if grep -P -m 1 'pixel_[xy] = 0' _maps/**/*.dmm;	then
+    echo "ERROR: pixel_x/pixel_y = 0 variables detected in maps, please review to ensure they are not dirty varedits."
 fi;
 if grep -P '\td[1-2] =' _maps/**/*.dmm;	then
-    echo "d1/d2 cable variables detected in maps, please remove them."
+    echo "ERROR: d1/d2 cable variables detected in maps, please remove them."
     st=1
 fi;
-if grep '^/area/.+[\{]' _maps/**/*.dmm;	then
-    echo "Vareditted /area path use detected in maps, please replace with proper paths."
+if grep -P '^/area/.+[\{]' _maps/**/*.dmm;	then
+    echo "ERROR: Vareditted /area path use detected in maps, please replace with proper paths."
     st=1
 fi;
-if grep '\W\/turf\s*[,\){]' _maps/**/*.dmm; then
-    echo "base /turf path use detected in maps, please replace with proper paths."
+if grep -P '\W\/turf\s*[,\){]' _maps/**/*.dmm; then
+    echo "ERROR: base /turf path use detected in maps, please replace with proper paths."
     st=1
 fi;
-if grep '^/*var/' code/**/*.dm; then
-    echo "Unmanaged global var use detected in code, please use the helpers."
+if grep -P '^/*var/' code/**/*.dm; then
+    echo "ERROR: Unmanaged global var use detected in code, please use the helpers."
     st=1
 fi;
 if grep -i 'centcomm' code/**/*.dm; then
-    echo "Misspelling(s) of CENTCOM detected in code, please remove the extra M(s)."
+    echo "ERROR: Misspelling(s) of CENTCOM detected in code, please remove the extra M(s)."
     st=1
 fi;
 if grep -i 'centcomm' _maps/**/*.dmm; then
-    echo "Misspelling(s) of CENTCOM detected in maps, please remove the extra M(s)."
+    echo "ERROR: Misspelling(s) of CENTCOM detected in maps, please remove the extra M(s)."
     st=1
 fi;
 if ls _maps/*.json | grep -P "[A-Z]"; then
-    echo "Uppercase in a map json detected, these must be all lowercase."
+    echo "ERROR: Uppercase in a map json detected, these must be all lowercase."
 	st=1
 fi;
 for json in _maps/*.json
@@ -54,7 +54,7 @@ do
     filename="_maps/$(jq -r '.map_path' $json)/$(jq -r '.map_file' $json)"
     if [ ! -f $filename ]
     then
-        echo "Found invalid file reference to $filename in _maps/$json"
+        echo "ERROR: Found invalid file reference to $filename in _maps/$json"
         st=1
     fi
 done

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -18,14 +18,14 @@ if grep -P 'step_[xy]' _maps/**/*.dmm;	then
     echo "ERROR: step_x/step_y variables detected in maps, please remove them."
     st=1
 fi;
-if grep -P -m 1 'pixel_[xy] = 0' _maps/**/*.dmm;	then
+if grep -m 1 'pixel_[xy] = 0' _maps/**/*.dmm;	then
     echo "ERROR: pixel_x/pixel_y = 0 variables detected in maps, please review to ensure they are not dirty varedits."
 fi;
 if grep -P '\td[1-2] =' _maps/**/*.dmm;	then
     echo "ERROR: d1/d2 cable variables detected in maps, please remove them."
     st=1
 fi;
-if grep -P '^/area/.+[\{]' _maps/**/*.dmm;	then
+if grep '^/area/.+[\{]' _maps/**/*.dmm;	then
     echo "ERROR: Vareditted /area path use detected in maps, please replace with proper paths."
     st=1
 fi;

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -18,7 +18,7 @@ if grep 'step_[xy]' _maps/**/*.dmm;	then
     echo "step_x/step_y variables detected in maps, please remove them."
     st=1
 fi;
-if grep 'pixel_[xy] = 0' _maps/**/*.dmm;	then
+if grep -m 1 'pixel_[xy] = 0' _maps/**/*.dmm;	then
     echo "pixel_x/pixel_y = 0 variables detected in maps, please review to ensure they are not dirty varedits."
 fi;
 if grep -P '\td[1-2] =' _maps/**/*.dmm;	then

--- a/tools/travis/check_grep.sh
+++ b/tools/travis/check_grep.sh
@@ -45,5 +45,18 @@ if grep -i 'centcomm' _maps/**/*.dmm; then
     echo "Misspelling(s) of CENTCOM detected in maps, please remove the extra M(s)."
     st=1
 fi;
+if ls _maps/*.json | grep -P "[A-Z]"; then
+    echo "Uppercase in a map json detected, these must be all lowercase."
+	st=1
+fi;
+for json in _maps/*.json
+do
+    filename="_maps/$(jq -r '.map_path' $json)/$(jq -r '.map_file' $json)"
+    if [ ! -f $filename ]
+    then
+        echo "Found invalid file reference to $filename in _maps/$json"
+        st=1
+    fi
+done
 
 exit $st


### PR DESCRIPTION
Travis log now only prints the first instance of a dirty `pixel_` var in a map file. The total number of occurrences in a file is irrelevant and just spams the log, making it harder to find actual errors.