### PR TITLE
Makes ghost hud default on, ghost darkness default to NV level #44184

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -13,6 +13,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	density = FALSE
 	see_invisible = SEE_INVISIBLE_OBSERVER
 	see_in_dark = 100
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	invisibility = INVISIBILITY_OBSERVER
 	hud_type = /datum/hud/ghost
 	movement_type = GROUND | FLYING
@@ -135,6 +136,8 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	. = ..()
 
 	grant_all_languages()
+	show_data_huds()
+	data_huds_on = 1
 
 /mob/dead/observer/get_photo_description(obj/item/camera/camera)
 	if(!invisibility || camera.see_ghosts)


### PR DESCRIPTION
## About The Pull Request

Sets the default darkness for observer to night vision level, saving us all some tab switcing and button presses. HUD defaults on, since most people seem to use it.

If you want me to do the hud differently, let me know. Its currently added at the end of observer initialize.

## Why It's Good For The Game

Saves hitting the buttons every time you ghost, a quick deadchat poll had everyone using the upper two levels of darkness. HUD was requested.

## Changelog

:cl:
tweak: Ghost darkness now starts at night vision level by default.
tweak: Ghost hud on by default.
/:cl: