### PR TITLE
Removes all pixel_x/y = 0 vars

### DIFF
--- a/_maps/arenas/lavaland.dmm
+++ b/_maps/arenas/lavaland.dmm
@@ -197,7 +197,7 @@
 /obj/structure/stone_tile/slab/cracked{
 	dir = 8;
 	name = "cracked stone block";
-	pixel_y = 0
+	
 	},
 /turf/open/lava/smooth,
 /area/tdome/arena)
@@ -261,7 +261,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8;
@@ -323,12 +323,12 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 2;
 	pixel_x = -16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 1;
 	pixel_x = -16;
-	pixel_y = 0
+	
 	},
 /turf/open/indestructible/necropolis/air,
 /area/tdome/arena)
@@ -343,12 +343,12 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 4;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block/burnt{

--- a/_maps/arenas/lavaland_arena_2.0.dmm
+++ b/_maps/arenas/lavaland_arena_2.0.dmm
@@ -216,7 +216,7 @@
 /obj/structure/stone_tile/slab/cracked{
 	dir = 8;
 	name = "cracked stone block";
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/slab/cracked{
 	dir = 1
@@ -276,7 +276,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 1;
 	pixel_x = -16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block/cracked{
 	dir = 1
@@ -334,12 +334,12 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 2;
 	pixel_x = -16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1;
 	pixel_x = -16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -546,12 +546,12 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block,
 /turf/open/indestructible/necropolis/air,
@@ -682,7 +682,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile/block{
@@ -691,7 +691,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /turf/open/indestructible/necropolis/air,
 /area/tdome/arena)
@@ -716,13 +716,13 @@
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 1;
 	pixel_x = -16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block/burnt,
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 2;
 	pixel_x = -16;
-	pixel_y = 0
+	
 	},
 /turf/open/indestructible/necropolis/air,
 /area/tdome/arena)
@@ -737,7 +737,7 @@
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 4;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block/burnt{
 	dir = 1
@@ -745,7 +745,7 @@
 /obj/structure/stone_tile/surrounding_tile/burnt{
 	dir = 8;
 	pixel_x = 16;
-	pixel_y = 0
+	
 	},
 /obj/structure/stone_tile/block/burnt,
 /turf/open/indestructible/necropolis/air,

--- a/_maps/arenas/survival pod.dmm
+++ b/_maps/arenas/survival pod.dmm
@@ -11,7 +11,6 @@
 /obj/structure/displaycase{
 	alert = 0;
 	desc = "A display case containing an expensive forgery, probably.";
-	pixel_y = 0;
 	req_access_txt = "48";
 	start_showpiece_type = /obj/item/fakeartefact
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -142,7 +142,7 @@
 	dir = 4;
 	name = "Xenobiology APC";
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -438,7 +438,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -570,7 +569,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
@@ -647,7 +645,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -1090,7 +1087,6 @@
 /obj/machinery/flasher{
 	id = "AI";
 	name = "Meatbag Pacifier";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
@@ -1404,7 +1400,6 @@
 /obj/machinery/flasher{
 	id = "AI";
 	name = "Meatbag Pacifier";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -1479,7 +1474,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
@@ -1774,7 +1769,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
@@ -2183,7 +2178,6 @@
 	id = "lawyer_shutters";
 	name = "Law Office Shutters Toggle";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "38"
 	},
 /turf/open/floor/plasteel/dark,
@@ -2510,7 +2504,7 @@
 	dir = 4;
 	name = "Captain's Office APC";
 	pixel_x = 24;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -2596,8 +2590,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -4028,7 +4021,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light{
 	dir = 1
@@ -4268,7 +4261,6 @@
 "agb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/landmark/event_spawn,
@@ -5256,7 +5248,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
@@ -5879,7 +5871,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/red{
@@ -7103,11 +7094,10 @@
 	},
 /obj/item/radio/intercom{
 	pixel_x = -28;
-	pixel_y = 0
+	
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
@@ -7838,8 +7828,7 @@
 "ale" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -7998,7 +7987,6 @@
 	areastring = "/area/crew_quarters/heads/hos";
 	dir = 1;
 	name = "Head of Security's Office APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -8378,7 +8366,7 @@
 	departmentType = 5;
 	name = "Head of Security RC";
 	pixel_x = -30;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
@@ -8445,7 +8433,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science RC";
-	pixel_x = 0;
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
@@ -8714,7 +8701,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -9203,7 +9189,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science/research)
@@ -9567,7 +9553,7 @@
 	id = "PCell 1";
 	name = "Prisoner Pacifier";
 	pixel_x = 24;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -9678,7 +9664,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -9836,7 +9822,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/showroomfloor,
@@ -10252,7 +10238,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -10438,7 +10423,6 @@
 	},
 /obj/structure/sign/departments/science{
 	name = "ROBOTICS";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable/yellow{
@@ -12039,7 +12023,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
@@ -12182,8 +12166,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
@@ -12707,8 +12690,7 @@
 "arQ" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -12802,7 +12784,7 @@
 	},
 /obj/item/storage/secure/safe{
 	pixel_x = 34;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
@@ -12854,7 +12836,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -13065,7 +13047,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -13565,7 +13547,7 @@
 	id = "hopflash";
 	name = "Crowd Pacifier";
 	pixel_x = 24;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
@@ -14962,7 +14944,7 @@
 	dir = 4;
 	name = "Port Bow Solar APC";
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -15453,7 +15435,7 @@
 	departmentType = 5;
 	name = "Head of Personnel RC";
 	pixel_x = -30;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light{
 	dir = 8
@@ -15890,7 +15872,7 @@
 	},
 /obj/item/cartridge/engineering{
 	pixel_x = 8;
-	pixel_y = 0
+	
 	},
 /obj/item/cartridge/atmos{
 	pixel_x = -6;
@@ -17425,7 +17407,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -17498,7 +17480,6 @@
 /obj/item/hand_labeler,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -17812,7 +17793,6 @@
 /obj/machinery/airalarm/engine{
 	dir = 1;
 	icon_state = "alarm0";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/engine,
@@ -18086,7 +18066,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow{
@@ -18274,7 +18253,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -18553,7 +18532,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -19359,7 +19337,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/extinguisher_cabinet{
@@ -20478,7 +20455,6 @@
 /obj/machinery/door/window/westleft{
 	dir = 8;
 	name = "Monkey Pen";
-	pixel_y = 0;
 	req_access_txt = "9"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -20563,7 +20539,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -21110,7 +21086,7 @@
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -22031,7 +22007,6 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/power/apc{
@@ -22039,7 +22014,7 @@
 	dir = 4;
 	name = "Cryogenics APC";
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -24044,8 +24019,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light{
 	dir = 8
@@ -24997,7 +24971,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
@@ -25082,7 +25056,7 @@
 "aKs" = (
 /obj/machinery/computer/security/telescreen/turbine{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -25573,7 +25547,6 @@
 	areastring = "/area/crew_quarters/heads/cmo";
 	dir = 1;
 	name = "CMO's Office APC";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -25620,7 +25593,6 @@
 	broadcasting = 1;
 	frequency = 1447;
 	name = "Private AI Channel";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/light,
@@ -25712,7 +25684,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/button/door{
@@ -25967,8 +25938,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -26049,8 +26019,7 @@
 	name = "AI Satellite Exterior APC";
 	pixel_x = -30;
 	pixel_y = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -26357,7 +26326,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
@@ -28570,7 +28538,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -29096,8 +29063,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/medbay/central)
@@ -29502,7 +29468,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -30137,7 +30102,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
@@ -30160,7 +30124,6 @@
 	},
 /obj/structure/sign/directions/science{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/supply{
@@ -30506,7 +30469,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby";
@@ -31850,7 +31813,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
@@ -32456,7 +32419,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
@@ -33413,7 +33376,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/grass,
 /area/chapel/main)
@@ -33585,7 +33548,7 @@
 	dir = 2;
 	name = "Medbay Monitor";
 	network = list("medical");
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/medical)
@@ -34170,7 +34133,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -34922,7 +34885,6 @@
 	areastring = "/area/science/robotics/mechbay";
 	dir = 1;
 	name = "Mech Bay APC";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -36530,7 +36492,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/item/crowbar/power,
 /obj/effect/turf_decal/tile/neutral,
@@ -36917,7 +36879,6 @@
 	dir = 8;
 	icon_state = "left";
 	name = "Library Desk Door";
-	pixel_x = 0;
 	req_access_txt = "37"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37747,7 +37708,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/light_switch{
@@ -37915,7 +37875,6 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/disposalpipe/segment{
@@ -37941,7 +37900,7 @@
 	},
 /obj/item/radio/intercom{
 	pixel_x = 28;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
@@ -38318,7 +38277,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light{
 	dir = 8
@@ -38534,7 +38493,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light{
 	dir = 8
@@ -38986,7 +38945,7 @@
 	id = "telelab";
 	name = "Test Chamber Toggle";
 	pixel_x = -24;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -39328,7 +39287,6 @@
 	departmentType = 5;
 	name = "Research Director RC";
 	pixel_x = 30;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -39486,8 +39444,7 @@
 	dir = 1;
 	name = "Research Monitor";
 	network = list("rd");
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -39556,7 +39513,6 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -39572,7 +39528,6 @@
 	departmentType = 2;
 	name = "Science RC";
 	pixel_x = 30;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/structure/window/reinforced,
@@ -39655,7 +39610,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/engine,
@@ -39820,7 +39774,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science RC";
-	pixel_x = 0;
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
@@ -40130,7 +40083,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -40970,7 +40922,6 @@
 /obj/machinery/light,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -41134,7 +41085,6 @@
 /obj/machinery/button/door{
 	id = "Xenolab";
 	name = "Containment Chamber Toggle";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -41198,7 +41148,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -41313,7 +41263,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins Storage";
@@ -41480,7 +41430,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/tile/neutral{
@@ -41781,7 +41731,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -41883,7 +41833,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -41953,7 +41903,6 @@
 	name = "Monkey Pen";
 	dir = 8;
 	pixel_y = 1;
-	pixel_y = 0;
 	req_access_txt = "9"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -42454,7 +42403,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/light_switch{
@@ -42704,7 +42652,6 @@
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Quartermaster RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/extinguisher_cabinet{
@@ -44254,7 +44201,6 @@
 	enabled = 1;
 	icon_state = "control_standby";
 	name = "Antechamber Turret Control";
-	pixel_x = 0;
 	pixel_y = 28;
 	req_access_txt = "65"
 	},
@@ -44518,7 +44464,6 @@
 	areastring = "/area/quartermaster/storage";
 	dir = 1;
 	name = "Cargo Bay APC";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -45016,7 +44961,6 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2";
 	name = "mail belt";
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/box/corners{
@@ -45047,7 +44991,6 @@
 	areastring = "/area/security/checkpoint/supply";
 	dir = 1;
 	name = "Cargo Security APC";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -45714,7 +45657,6 @@
 	dir = 8;
 	id = "QMLoad";
 	name = "off ramp";
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/box/corners{
@@ -45922,7 +45864,6 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2";
 	name = "on ramp";
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/box/corners{
@@ -46518,8 +46459,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
@@ -47062,7 +47002,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/grass,
 /area/hydroponics)
@@ -47432,7 +47372,7 @@
 "bnP" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/structure/tank_dispenser/oxygen{
 	layer = 2.9;
@@ -47445,7 +47385,7 @@
 "bnQ" = (
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/delivery,
@@ -47599,7 +47539,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/grass,
 /area/hydroponics)
@@ -47816,7 +47756,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -49031,7 +48971,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
-	pixel_x = 0
+	
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen)
@@ -49877,7 +49817,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark,
@@ -50079,7 +50018,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
@@ -50200,7 +50139,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -50631,7 +50569,7 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -50995,8 +50933,7 @@
 "bsM" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -51014,7 +50951,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
@@ -51027,7 +50964,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/heads/hop)
@@ -51043,7 +50980,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/heads/hop)
@@ -51294,7 +51231,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 22;
 	prison_radio = 1
 	},
@@ -51683,7 +51619,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bar_1";
@@ -51703,7 +51639,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bar_1";
@@ -51959,7 +51895,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/structure/chair/office{
 	dir = 8
@@ -52001,7 +51937,6 @@
 	departmentType = 2;
 	name = "Bar RC";
 	pixel_x = 30;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -52180,8 +52115,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/dark,
@@ -52314,7 +52248,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_y = -32
@@ -53215,7 +53149,6 @@
 	},
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "27"
 	},
@@ -53717,7 +53650,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -53890,7 +53822,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/grass,
 /area/chapel/main)
@@ -54104,8 +54036,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -54220,8 +54151,7 @@
 "bxF" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54470,7 +54400,7 @@
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
 	name = "BrewMaster 2199";
-	pixel_x = 0
+	
 	},
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -54497,7 +54427,6 @@
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
 	name = "Secure Storage Toggle";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "11"
 	},
@@ -54729,7 +54658,6 @@
 /obj/machinery/flasher{
 	id = "AI";
 	name = "Meatbag Pacifier";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/camera/motion{
@@ -55487,7 +55415,7 @@
 	frequency = 1447;
 	name = "Private AI Channel";
 	pixel_x = 28;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -55510,7 +55438,7 @@
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
 	name = "BrewMaster 2199";
-	pixel_x = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/bot,
@@ -55574,7 +55502,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -55596,7 +55523,6 @@
 	id = "transittube";
 	name = "Transit Tube Lockdown Toggle";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "19"
 	},
 /obj/machinery/camera{
@@ -55965,8 +55891,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
@@ -56159,7 +56084,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/red,
@@ -56212,8 +56136,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -56458,7 +56381,6 @@
 /obj/machinery/requests_console{
 	department = "Detective's office";
 	name = "Detective RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light_switch{
@@ -56692,7 +56614,6 @@
 /obj/item/camera,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -56881,7 +56802,7 @@
 	dir = 8;
 	name = "Port Hallway APC";
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -57295,7 +57216,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/item/analyzer{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/item/analyzer{
@@ -57700,7 +57620,6 @@
 	pixel_y = 6
 	},
 /obj/item/radio{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -58545,7 +58464,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -58624,7 +58543,6 @@
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "RCD Storage";
-	pixel_x = 0;
 	req_access_txt = "19"
 	},
 /obj/structure/cable/yellow{
@@ -58772,7 +58690,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -58920,7 +58838,6 @@
 /obj/effect/spawner/lootdrop/techstorage/AI,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/circuit/green{
@@ -59985,7 +59902,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60423,7 +60340,7 @@
 /obj/structure/closet/crate/hydroponics,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -60464,8 +60381,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/structure/spider/stickyweb,
 /obj/effect/decal/cleanable/blood/old,
@@ -60569,7 +60485,6 @@
 "bGv" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/red{
@@ -62045,8 +61960,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -62441,7 +62355,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
@@ -62942,8 +62856,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -63133,7 +63046,6 @@
 	id = "Cabin_3";
 	name = "Cabin 3 Privacy Lock";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 24;
 	specialfunctions = 4
 	},
@@ -63221,7 +63133,6 @@
 	id = "Cabin_2";
 	name = "Cabin 2 Privacy Lock";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 24;
 	specialfunctions = 4
 	},
@@ -63251,7 +63162,6 @@
 	id = "Cabin_1";
 	name = "Cabin 1 Privacy Lock";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 24;
 	specialfunctions = 4
 	},
@@ -64469,7 +64379,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plating,
 /area/quartermaster/office)
@@ -64714,7 +64624,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -64788,8 +64698,7 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -65041,13 +64950,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -65473,7 +65381,6 @@
 "bNd" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/closed/wall,
@@ -67029,8 +66936,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -67371,8 +67277,7 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -67457,8 +67362,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -67697,8 +67601,7 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -68190,8 +68093,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -68472,7 +68374,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -68525,7 +68426,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow{
@@ -69543,7 +69443,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -69616,8 +69516,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/dark,
@@ -69647,7 +69546,7 @@
 "bSL" = (
 /obj/structure/sign/warning/securearea{
 	name = "EMERGENCY STORAGE";
-	pixel_y = 0
+	
 	},
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -69748,7 +69647,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -69954,7 +69853,6 @@
 "bTj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -71469,7 +71367,7 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -72087,7 +71985,7 @@
 	id = "Cell 6";
 	name = "Cell 6";
 	pixel_x = -32;
-	pixel_y = 0
+	
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 6";
@@ -72146,7 +72044,7 @@
 	id = "Cell 5";
 	name = "Cell 5";
 	pixel_x = -32;
-	pixel_y = 0
+	
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 5";
@@ -72166,7 +72064,7 @@
 	id = "Cell 4";
 	name = "Cell 4";
 	pixel_x = -32;
-	pixel_y = 0
+	
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 4";
@@ -72204,7 +72102,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/disposalpipe/segment{
@@ -72260,7 +72158,7 @@
 	id = "Cell 3";
 	name = "Cell 3";
 	pixel_x = -32;
-	pixel_y = 0
+	
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
@@ -72334,7 +72232,7 @@
 	id = "Cell 2";
 	name = "Cell 2";
 	pixel_x = -32;
-	pixel_y = 0
+	
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -72366,7 +72264,7 @@
 	id = "Cell 1";
 	name = "Cell 1";
 	pixel_x = -32;
-	pixel_y = 0
+	
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -74625,7 +74523,7 @@
 	dir = 4;
 	name = "Starboard Hallway APC";
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -74805,7 +74703,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/item/grenade/clusterbuster/cleaner,
 /turf/open/floor/plasteel/dark,
@@ -75176,7 +75074,7 @@
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -76282,8 +76180,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
@@ -76353,7 +76250,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow{
@@ -77819,7 +77715,6 @@
 /obj/machinery/door/window/westleft{
 	dir = 8;
 	name = "Monkey Pen";
-	pixel_y = 0;
 	req_access_txt = "9"
 	},
 /obj/structure/disposalpipe/segment{
@@ -77966,7 +77861,6 @@
 /obj/machinery/flasher{
 	id = "AI";
 	name = "Meatbag Pacifier";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -79277,7 +79171,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79572,7 +79466,6 @@
 /obj/machinery/light/small,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -80178,7 +80071,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow{
@@ -80326,7 +80218,6 @@
 /obj/machinery/button/door{
 	id = "sidearmory";
 	name = "Armoury Shutter Toggle";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "3"
 	},
@@ -80385,7 +80276,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -80571,7 +80461,6 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -80664,7 +80553,7 @@
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 4;
-	pixel_x = 0
+	
 	},
 /obj/machinery/light{
 	dir = 8
@@ -80684,7 +80573,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -81003,7 +80892,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/item/clipboard{
 	pixel_x = 4
@@ -81512,7 +81401,6 @@
 /obj/machinery/button/door{
 	id = "engsm";
 	name = "Radiation Shutters Toggle";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "10"
 	},
@@ -81695,7 +81583,6 @@
 	id = "gravity";
 	name = "Gravity Generator Lockdown";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_one_access_txt = "19;23"
 	},
 /turf/open/floor/engine,
@@ -81712,7 +81599,6 @@
 /area/space/nearstation)
 "ckf" = (
 /obj/machinery/microwave{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /obj/structure/table/glass,
@@ -81756,7 +81642,6 @@
 	areastring = "/area/maintenance/disposal";
 	dir = 1;
 	name = "Disposals APC";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -82780,7 +82665,6 @@
 	areastring = "/area/engine/gravity_generator";
 	dir = 2;
 	name = "Gravity Generator APC";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable,
@@ -82963,7 +82847,7 @@
 	dir = 4;
 	name = "Port Quarter Solar APC";
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -83246,7 +83130,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83619,7 +83502,7 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26;
-	pixel_y = 0
+	
 	},
 /obj/item/clothing/mask/russian_balaclava,
 /turf/open/floor/plasteel/dark,
@@ -84883,7 +84766,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable/yellow{
@@ -84984,7 +84866,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark,
@@ -85281,7 +85162,7 @@
 	},
 /obj/machinery/status_display/ai{
 	pixel_x = 32;
-	pixel_y = 0
+	
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -85837,7 +85718,6 @@
 /obj/machinery/button/door{
 	id = "greylair";
 	name = "Lair Privacy Toggle";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "0"
 	},
@@ -86362,7 +86242,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light{
 	dir = 4
@@ -87078,7 +86958,7 @@
 	},
 /obj/structure/sign/warning/fire{
 	pixel_x = -32;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
@@ -87431,7 +87311,7 @@
 	dir = 4;
 	name = "Port Maintenance APC";
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -88555,7 +88435,6 @@
 	areastring = "/area/engine/engineering";
 	dir = 1;
 	name = "Engine Room APC";
-	pixel_x = 0;
 	pixel_y = 35
 	},
 /obj/structure/cable/yellow{
@@ -89138,7 +89017,6 @@
 	pixel_y = 6
 	},
 /obj/item/radio{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -89594,8 +89472,7 @@
 /obj/machinery/light,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -90239,8 +90116,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
@@ -90493,7 +90369,6 @@
 	areastring = "/area/maintenance/port/fore";
 	dir = 1;
 	name = "Port Bow Maintenance APC";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plating{
@@ -91528,7 +91403,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/bot,
@@ -92977,7 +92851,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
@@ -93165,7 +93038,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom{
 	pixel_x = -25;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
@@ -93436,7 +93309,7 @@
 	id = "PCell 1";
 	name = "Prisoner Pacifier";
 	pixel_x = 24;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -94042,7 +93915,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
@@ -94406,7 +94278,6 @@
 /obj/machinery/button/door{
 	id = "frontarmory";
 	name = "Armoury Shutter Toggle";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "3"
 	},
@@ -94415,7 +94286,7 @@
 "cDT" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-05";
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -95276,7 +95147,7 @@
 "cFl" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-05";
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -95653,7 +95524,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/machinery/airalarm{
@@ -97042,7 +96912,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/newscaster{
@@ -97140,7 +97009,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
@@ -98018,7 +97887,6 @@
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
 	name = "Prison Intercom (General)";
-	pixel_x = 0;
 	pixel_y = -28;
 	prison_radio = 1
 	},
@@ -98516,7 +98384,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/window/reinforced{
 	dir = 1;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -98855,7 +98723,7 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
@@ -99074,7 +98942,6 @@
 	areastring = "/area/security/main";
 	dir = 2;
 	name = "Security Office APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -99802,7 +99669,6 @@
 	areastring = "/area/maintenance/solars/starboard/fore";
 	dir = 1;
 	name = "Starboard Bow Solar APC";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable/yellow{
@@ -102089,7 +101955,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/engine,
@@ -102967,7 +102832,6 @@
 	name = "Justice Door Lock";
 	normaldoorcontrol = 1;
 	pixel_x = -24;
-	pixel_y = 0;
 	specialfunctions = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
@@ -103045,7 +102909,7 @@
 	id = "PCell 1";
 	name = "Prisoner Pacifier";
 	pixel_x = 24;
-	pixel_y = 0
+	
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -103095,7 +102959,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -103631,7 +103494,7 @@
 	})
 "fee" = (
 /obj/machinery/mineral/processing_unit_console{
-	pixel_x = 0
+	
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -104339,7 +104202,6 @@
 	},
 /obj/machinery/power/apc{
 	name = "Abandoned Outpost APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -231,7 +231,6 @@
 	pixel_y = 6
 	},
 /obj/item/radio{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium,

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -825,8 +825,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -904,7 +903,7 @@
 	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -1160,8 +1159,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21";
-	pixel_x = 0;
-	pixel_y = 0
+	
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -1264,7 +1262,6 @@
 	pixel_y = 6
 	},
 /obj/item/radio{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium,

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -179,7 +179,7 @@
 /obj/structure/table/abductor,
 /obj/item/crowbar/abductor{
 	pixel_x = -13;
-	pixel_y = 0
+	
 	},
 /obj/item/multitool/abductor,
 /turf/open/floor/plating/abductor,

--- a/_maps/shuttles/ferry_kilo.dmm
+++ b/_maps/shuttles/ferry_kilo.dmm
@@ -196,7 +196,6 @@
 	pixel_y = 6
 	},
 /obj/item/radio{
-	pixel_x = 0;
 	pixel_y = 4
 	},
 /obj/machinery/light{


### PR DESCRIPTION
## About The Pull Request
Why it added newlines after some of the deleted vars, I don't know, if it's bad, so be it, I'll try to fix it again. Anyways, this solves a lot of the problems that travis throws over "dirty" pixel_x/y vars. Just want to point out, most of the vars were from Kilostation.

## Why It's Good For The Game
More for coder/mapper QoL than actual gameplay as far as I know

## Changelog
:cl:
code: removed a lot of dirty vars from maps(mostly kilostation)
/:cl: