### PR TITLE
New Cryopod features

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -88,6 +88,10 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 		message = CompileText(arrival, user, rank)
 	else if(message_type == "NEWHEAD" && newheadToggle)
 		message = CompileText(newhead, user, rank)
+	else if(message_type == "AIWIPE" && newheadToggle)
+		message = CompileText("%PERSON has been moved to intelligence storage.", user, rank)
+	else if(message_type == "CRYOSTORAGE")
+		message = CompileText("%PERSON, %RANK has been moved to cryo storage.", user, rank)
 	else if(message_type == "ARRIVALS_BROKEN")
 		message = "The arrivals shuttle has been damaged. Docking for repairs..."
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -326,6 +326,38 @@
 /mob/living/silicon/ai/cancel_camera()
 	view_core()
 
+/mob/living/silicon/ai/verb/wipe_core()
+	set name = "Wipe Core"
+	set category = "OOC"
+	set desc = "Wipe your core. This is functionally equivalent to cryo, freeing up your job slot."
+
+	// Guard against misclicks, this isn't the sort of thing we want happening accidentally
+	if(alert("WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo). Are you entirely sure you want to do this?",
+					"Wipe Core", "No", "No", "Yes") != "Yes")
+		return
+
+	// We warned you.
+	var/obj/structure/AIcore/latejoin_inactive/inactivecore = New(loc)
+	transfer_fingerprints_to(inactivecore)
+
+	if(GLOB.announcement_systems.len)
+		var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
+		announcer.announce("AIWIPE", real_name, mind.assigned_role, list())
+
+	SSjob.FreeRole(mind.assigned_role)
+
+	if(mind.objectives.len)
+		mind.objectives.Cut()
+		mind.special_role = null
+
+	if(!get_ghost(1))
+		if(world.time < 30 * 600)//before the 30 minute mark
+			ghostize(0) // Players despawned too early may not re-enter the game
+	else
+		ghostize(1)
+
+	QDEL_NULL(src)
+
 /mob/living/silicon/ai/verb/toggle_anchor()
 	set category = "AI Commands"
 	set name = "Toggle Floor Bolts"


### PR DESCRIPTION


## About The Pull Request
Thank god for Oracle (Another direct port). This PR adds the ability to "Wipe Core," which is basically just the equivalent of cryostorage. It also frees up the job slot, allowing another player to take over. The other feature added is that when someone (AI or otherwise) goes into cryo, the automated announcement system will announce that "[x], [x's job] has been moved into cryo storage." This prevents the frantic panic that happens when nobody hears from the DC'd captain without knowing they cryo'd. 

## Why It's Good For The Game
Some good QoL changes, mostly detailed above.

## Changelog
:cl:
add: "Wipe Core" verb in the OOC tab for AIs, basically just the equivalent of cryo
add: the Automated announcement system now announces when someone has been cryo'd.
/:cl: