### PR TITLE
Fixes lighting in box fore maintenance

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57456,9 +57456,6 @@
 "sdX" = (
 /turf/closed/wall,
 /area/quartermaster/office)
-"sgn" = (
-/turf/closed/wall,
-/area/space)
 "sjr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/loading_area,
@@ -93464,7 +93461,7 @@ aaa
 aaa
 aaf
 aaf
-atS
+ahn
 ahn
 anE
 aod
@@ -93722,7 +93719,7 @@ aaa
 aaf
 gal
 syg
-sgn
+ahn
 anG
 aoe
 aoL
@@ -93979,7 +93976,7 @@ aaa
 aaa
 aaa
 aaa
-sgn
+ahn
 khB
 ahn
 ahn


### PR DESCRIPTION
![badlighting](https://user-images.githubusercontent.com/31044876/67947135-d6ff2b00-fbda-11e9-861f-0fb17d09ae9a.PNG)

defines this area as fore maintenance 2

:cl:
fix: lighting in fore maintenance on BoxStation
:/cl:
