### PR TITLE
No more spam-pointing

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -469,6 +469,9 @@
 	set name = "Point To"
 	set category = "Object"
 
+	if(world.time - last_pointed < 2 SECONDS)
+		return 0
+
 	if(!src || !isturf(src.loc) || !(A in view(src.loc)))
 		return FALSE
 	if(istype(A, /obj/effect/temp_visual/point))
@@ -479,6 +482,7 @@
 		return FALSE
 
 	new /obj/effect/temp_visual/point(A,invisibility)
+	last_pointed = world.time
 
 	return TRUE
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -203,3 +203,7 @@
 	var/registered_z = null
 	
 	var/memory_throttle_time = 0
+
+	var/player_logged = FALSE //keep track at login and logout; used for SSD
+
+	var/last_pointed = 0 //for pointing cooldown


### PR DESCRIPTION
## About The Pull Request
Direct from oracle, this has been a problem forever. Only being able to point once every 2 seconds will reduce the unneeded and annoying pointspams.

## Why It's Good For The Game
Fixes an annoying thing people do.

## Changelog
:cl:
tweak: Pointing at things now has a cooldown of two seconds.
/:cl: