### PR TITLE
Locker lock creation/removal

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -65,6 +65,12 @@
 		density = FALSE
 		mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
+/obj/structure/closet/body_bag/handle_lock_addition()
+	return
+
+/obj/structure/closet/body_bag/handle_lock_removal()
+	return
+
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()
 	if(over_object == usr && Adjacent(usr) && (in_range(src, usr) || usr.contents.Find(src)))

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -54,6 +54,12 @@
 				L.do_alert_animation(L)
 		playsound(loc, 'sound/machines/chime.ogg', 50, FALSE, -5)
 
+/obj/structure/closet/cardboard/handle_lock_addition() //Whoever heard of a lockable cardboard box anyway
+	return
+
+/obj/structure/closet/cardboard/handle_lock_removal()
+	return
+
 /mob/living/proc/do_alert_animation(atom/A)
 	var/image/I = image('icons/obj/closet.dmi', A, "cardboard_special", A.layer+1)
 	flick_overlay_view(I, A, 8)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -110,6 +110,12 @@
 	new /obj/item/storage/fancy/candle_box(src)
 	return
 
+/obj/structure/closet/coffin/handle_lock_addition()
+	return
+
+/obj/structure/closet/coffin/handle_lock_removal()
+	return
+
 /obj/structure/closet/wardrobe/red
 	name = "security wardrobe"
 	icon_door = "red"

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -4,6 +4,18 @@
 	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 	var/registered_name = null
 
+/obj/structure/closet/secure_closet/personal/examine(mob/user)
+	..()
+	if(registered_name)
+		to_chat(user, "<span class='notice'>The display reads, \"Owned by [registered_name]\".</span>")
+
+/obj/structure/closet/secure_closet/personal/check_access(obj/item/card/id/I)
+	. = ..()
+	if(!I || !istype(I))
+		return
+	if(registered_name == I.registered_name)
+		return TRUE
+
 /obj/structure/closet/secure_closet/personal/PopulateContents()
 	..()
 	if(prob(50))
@@ -18,8 +30,8 @@
 	name = "patient's closet"
 
 /obj/structure/closet/secure_closet/personal/patient/PopulateContents()
-	new /obj/item/clothing/under/color/white( src )
-	new /obj/item/clothing/shoes/sneakers/white( src )
+	new /obj/item/clothing/under/color/white(src)
+	new /obj/item/clothing/shoes/sneakers/white(src)
 
 /obj/structure/closet/secure_closet/personal/cabinet
 	icon_state = "cabinet"
@@ -37,21 +49,21 @@
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
 	var/obj/item/card/id/I = W.GetID()
-	if(istype(I))
-		if(broken)
-			to_chat(user, "<span class='danger'>It appears to be broken.</span>")
-			return
-		if(!I || !I.registered_name)
-			return
-		if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
-			//they can open all lockers, or nobody owns this, or they own this locker
-			locked = !locked
-			update_icon()
-
-			if(!registered_name)
-				registered_name = I.registered_name
-				desc = "Owned by [I.registered_name]."
-		else
-			to_chat(user, "<span class='danger'>Access Denied.</span>")
-	else
+	if(!I || !istype(I))
 		return ..()
+	if(!can_lock(user, FALSE)) //Can't do anything if there isn't a lock!
+		return
+	if(I.registered_name && !registered_name)
+		to_chat(user, "<span class='notice'>You claim [src].</span>")
+		registered_name = I.registered_name
+	else
+		..()
+
+/obj/structure/closet/secure_closet/personal/handle_lock_addition() //If lock construction is successful we don't care what access the electronics had, so we override it
+	if(..())
+		req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
+		lockerelectronics.accesses = req_access
+
+/obj/structure/closet/secure_closet/personal/handle_lock_removal()
+	if(..())
+		registered_name = null

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -59,6 +59,12 @@
 		manifest = null
 		update_icon()
 
+/obj/structure/closet/crate/handle_lock_addition()
+	return
+
+/obj/structure/closet/crate/handle_lock_removal()
+	return
+
 /obj/structure/closet/crate/proc/tear_manifest(mob/user)
 	to_chat(user, "<span class='notice'>You tear the manifest off of [src].</span>")
 	playsound(src, 'sound/items/poster_ripped.ogg', 75, 1)
@@ -81,6 +87,13 @@
 	close_sound = 'sound/machines/wooden_closet_close.ogg'
 	open_sound_volume = 25
 	close_sound_volume = 50
+
+/obj/structure/closet/coffin/handle_lock_addition() 
+	return 
+ 
+/obj/structure/closet/coffin/handle_lock_removal() 
+	return 
+ 
 
 /obj/structure/closet/crate/internals
 	desc = "An internals crate."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -786,6 +786,13 @@ Difficulty: Very Hard
 /obj/structure/closet/stasis/ex_act()
 	return
 
+
+/obj/structure/closet/stasis/handle_lock_addition()
+	return
+
+/obj/structure/closet/stasis/handle_lock_removal()
+	return
+
 /obj/effect/proc_holder/spell/targeted/exit_possession
 	name = "Exit Possession"
 	desc = "Exits the body you are possessing."


### PR DESCRIPTION
## About The Pull Request
Near-direct port of OracleStation/OracleStation#994

This PR adds the ability to construct and deconstruct locker locks.

* Use an airlock electronics on a locker without a lock to add one. The locker will inherit the access from the electronics. You can't lock certain lockers such as cardboard boxes.
* Screwdriver a locker to remove its lock. This will give you back the electronics (emagging destroys the electronics). You can only do this to unlocked lockers.

To create a locker lock:

1.  Make sure your locker doesn't have a lock and is closed.
1.  Hit the locker with airlock electronics.
1.  Wait for construction to complete (20 seconds). The locker's access will be updated with the airlock electronics access.

To deconstruct a locker lock:

1.  The locker must be unlocked and closed, and must have either a functional or broken lock.
1.  Use a screwdriver on the locker.
1.  After 10 seconds (better screwdrivers will be faster), the lock will be removed and the airlock electronics (should they exist) will be dropped at your feet.

Emagged/broken locks now show a sparking effect, to differentiate between lockers with no lock and lockers with a broken lock that can be removed.

## Why It's Good For The Game
Allows you to create and remove locks to lockers, as well as replace broken ones.

## Changelog
:cl:
add: You can now use an airlock electronics on a locker to add a lock, and can screwdriver an unlocked locker to remove its lock.
add: You can now remove the locks on broken or emagged lockers.
tweak: Removing the lock from a personal locker now wipes that locker's ID details.
tweak: Broken lockers have had their appearance changed.
/:cl: