### PR TITLE
Gives zombies a big bad message #44986

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -90,7 +90,7 @@
 	playsound(owner.loc, 'sound/hallucinations/far_noise.ogg', 50, 1)
 	owner.do_jitter_animation(living_transformation_time)
 	owner.Stun(living_transformation_time)
-	to_chat(owner, "<span class='alertalien'>You are now a zombie!</span>")
+	to_chat(owner, "<span class='alertalien'>You are now a zombie! Do not seek to be cured, do not help any non-zombies in any way, do not harm your zombie brethren and spread the disease by killing others. You are a creature of hunger and violence.</span>")
 
 /obj/item/organ/zombie_infection/nodamage
 	causes_damage = FALSE


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/44986

Changes the message a player receives when they become a zombie, encouraging them to act more like zombies and spread the disease further

## Why it's good for the game

It sucks when you create zombies only for them to run straight to medbay for a cure or act like normal, at the very least it encourages them to attack people.

## Changelog

:cl:
add: a new line in the you are a zombie message has been added
/:cl: