### PR TITLE
Ports husking visual fix #45648

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -440,11 +440,12 @@
 
 /mob/living/proc/become_husk(source)
 	if(!HAS_TRAIT(src, TRAIT_HUSK))
+		ADD_TRAIT(src, TRAIT_HUSK, source)
 		ADD_TRAIT(src, TRAIT_DISFIGURED, "husk")
 		update_body()
-		. = TRUE
-	ADD_TRAIT(src, TRAIT_HUSK, source)
-
+	else
+		ADD_TRAIT(src, TRAIT_HUSK, source)
+	
 /mob/living/proc/cure_fakedeath(source)
 	REMOVE_TRAIT(src, TRAIT_FAKEDEATH, source)
 	REMOVE_TRAIT(src, TRAIT_DEATHCOMA, source)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/45648

Closes #45647, husked corpses always update to the special husked skin, most notably fixes changeling husking

:cl:
fix: Husked corpses will now always appear husked
/:cl: