### PR TITLE
Adds white no slip tiles to MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13441,10 +13441,8 @@
 /turf/open/space,
 /area/space/nearstation)
 "aze" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
 /area/library)
 "azg" = (
@@ -21975,6 +21973,9 @@
 /area/quartermaster/qm)
 "aQr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aQs" = (
@@ -22665,9 +22666,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aRL" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -22678,6 +22676,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aRM" = (
@@ -27722,6 +27721,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "bbe" = (
@@ -39078,10 +39078,6 @@
 /obj/item/reagent_containers/glass/rag{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bwL" = (
@@ -55308,7 +55304,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/noslip/white,
 /area/medical/medbay/central)
 "cdz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -57058,7 +57054,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/noslip/white,
 /area/medical/sleeper)
 "cgU" = (
 /obj/machinery/door/firedoor,
@@ -57992,7 +57988,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/noslip/white,
 /area/science/research)
 "ciI" = (
 /obj/structure/cable/yellow{
@@ -58524,7 +58520,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/noslip/white,
 /area/medical/medbay/central)
 "cjS" = (
 /obj/item/stack/sheet/mineral/plasma,
@@ -59332,7 +59328,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/noslip/white,
 /area/science/research)
 "clG" = (
 /obj/structure/cable/yellow{
@@ -69929,7 +69925,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/noslip/white,
 /area/medical/virology)
 "cFM" = (
 /obj/structure/sink{
@@ -69941,7 +69937,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/noslip/white,
 /area/medical/virology)
 "cFN" = (
 /obj/structure/sign/warning/securearea{
@@ -69956,7 +69952,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/noslip/white,
 /area/medical/virology)
 "cFO" = (
 /obj/machinery/firealarm{
@@ -72429,12 +72425,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cJQ" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cJR" = (
@@ -75411,10 +75405,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cPJ" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -75448,9 +75440,7 @@
 /area/chapel/main)
 "cPN" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
@@ -83685,15 +83675,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "mNe" = (
-/obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/paicard,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)


### PR DESCRIPTION
the yellow ones were too outstanding, I have replaced them with white no slip tiles and added two more to the science airlock.

:cl:
tweak: White no-slip tiles added to MetaStation medbay.
/:cl: