### PR TITLE
Being attacked now shows the correct attacker

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -149,7 +149,7 @@
 	var/attack_message_local = "You're [message_verb][message_hit_area] with [I]!"
 	if(user in viewers(src, null))
 		attack_message = "[user] [message_verb] [src][message_hit_area] with [I]!"
-		attack_message_local = "[src] [message_verb] you[message_hit_area] with [I]!"
+		attack_message_local = "[user] [message_verb] you[message_hit_area] with [I]!"
 	visible_message("<span class='danger'>[attack_message]</span>",\
 		"<span class='userdanger'>[attack_message_local]</span>", null, COMBAT_MESSAGE_RANGE)
 	return 1


### PR DESCRIPTION
If you are attacked by a toolbox (not exclusive), you'll see your own name as the attacker. This'll fix that.

## Changelog

:cl:
fix: Correct attacker is shown when being attacked by items
/:cl: