### PR TITLE
Looting only available on any intent besides help

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -705,7 +705,7 @@
 		var/mob/M = dropping
 		if(ismob(user))
 			var/mob/U = user
-			if(!iscyborg(U) || U.a_intent == INTENT_HARM)
+			if(U.a_intent == INTENT_HARM)
 				M.show_inv(U)
 		else
 			M.show_inv(user)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -705,7 +705,7 @@
 		var/mob/M = dropping
 		if(ismob(user))
 			var/mob/U = user
-			if(U.a_intent == INTENT_HARM)
+			if(U.a_intent != INTENT_HELP  || iscyborg(U) && U.a_intent == INTENT_HARM)
 				M.show_inv(U)
 		else
 			M.show_inv(user)


### PR DESCRIPTION
## About The Pull Request
Makes searches/pickpocketing/looting only able to be done while on harm intent, surprised it hasn't been done before. Also should allow you to pick up people with dwarfism again, as a side effect.

## Why It's Good For The Game
I just think that searches are more of a harm-intent thing, and cyborgs already had to do it this way and it makes no sense to me why everything shouldn't have to do it on harm intent.

## Changelog
:cl:
tweak: Pickpocket/Looting screen only shows up when you're on harm intent
/:cl: