### PR TITLE
Ports refactors event announce chance (#47085)

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -740,7 +740,7 @@
 		E.processing = FALSE
 		if(E.announceWhen>0)
 			if(alert(usr, "Would you like to alert the crew?", "Alert", "Yes", "No") == "No")
-				E.announceWhen = -1
+				E.announceChance = 0
 		E.processing = TRUE
 	if (usr)
 		log_admin("[key_name(usr)] used secret [item]")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -173,11 +173,13 @@
 				event.processing = FALSE
 				var/prompt = alert(usr, "Would you like to alert the crew?", "Alert", "Yes", "No", "Cancel")
 				switch(prompt)
+					if("Yes")
+						event.announceChance = 100
 					if("Cancel")
 						event.kill()
 						return
 					if("No")
-						event.announceWhen = -1
+						event.announceChance = 0
 				event.processing = TRUE
 			message_admins("[key_name_admin(usr)] has triggered an event. ([E.name])")
 			log_admin("[key_name(usr)] has triggered an event. ([E.name])")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -520,10 +520,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("Admin [key_name_admin(usr)] has added a new AI law - [input]")
 
 	var/show_log = alert(src, "Show ion message?", "Message", "Yes", "No")
-	var/announce_ion_laws = (show_log == "Yes" ? 1 : -1)
+	var/announce_ion_laws = (show_log == "Yes" ? 100 : 0)
 
 	var/datum/round_event/ion_storm/add_law_only/ion = new()
-	ion.announceEvent = announce_ion_laws
+	ion.announceChance = announce_ion_laws
 	ion.ionMessage = input
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Add Custom AI Law") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -107,7 +107,8 @@
 	var/datum/round_event_control/control
 
 	var/startWhen		= 0	//When in the lifetime to call start().
-	var/announceWhen	= 0	//When in the lifetime to call announce(). Set an event's announceWhen to -1 if announcement should not be shown.
+	var/announceWhen	= 0	//When in the lifetime to call announce(). If you don't want it to announce use announceChance, below.
+	var/announceChance	= 100 // Probability of announcing, used in prob(), 0 to 100, default 100. Used in ion storms currently.
 	var/endWhen			= 0	//When in the lifetime the event should end.
 
 	var/activeFor		= 0	//How long the event has existed. You don't need to change this.
@@ -174,7 +175,7 @@
 		start()
 		processing = TRUE
 
-	if(activeFor == announceWhen)
+	if(activeFor == announceWhen && prob(announceChance))
 		processing = FALSE
 		announce(FALSE)
 		processing = TRUE

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -9,7 +9,7 @@
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 
 /datum/round_event/ghost_role/blob
-	announceWhen	= -1
+	announceChance	= 0
 	role_name = "blob overmind"
 	fakeable = TRUE
 

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -1,5 +1,3 @@
-#define ION_RANDOM 0
-#define ION_ANNOUNCE 1
 /datum/round_event_control/ion_storm
 	name = "Ion Storm"
 	typepath = /datum/round_event/ion_storm
@@ -11,11 +9,10 @@
 	var/removeRandomLawChance = 10 //chance the AI has one random supplied or inherent law removed
 	var/removeDontImproveChance = 10 //chance the randomly created law replaces a random law instead of simply being added
 	var/shuffleLawsChance = 10 //chance the AI's laws are shuffled afterwards
-	var/botEmagChance = 10
-	var/announceEvent = ION_RANDOM // -1 means don't announce, 0 means have it randomly announce, 1 means
+	var/botEmagChance = 1
 	var/ionMessage = null
-	var/ionAnnounceChance = 33
 	announceWhen	= 1
+	announceChance = 33
 
 /datum/round_event/ion_storm/add_law_only // special subtype that adds a law only
 	replaceLawsetChance = 0
@@ -25,7 +22,7 @@
 	botEmagChance = 0
 
 /datum/round_event/ion_storm/announce(fake)
-	if(announceEvent == ION_ANNOUNCE || (announceEvent == ION_RANDOM && prob(ionAnnounceChance)) || fake)
+	if(prob(announceChance) || fake)
 		priority_announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", 'sound/ai/ionstorm.ogg')
 
 
@@ -562,6 +559,3 @@
 							message = "ALL [ionthreats] ARE NOW NAMED [ionobjects]."
 
 	return message
-
-#undef ION_RANDOM
-#undef ION_ANNOUNCE

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -309,7 +309,7 @@
 				id.forceMove(worn)
 				worn.update_icon()
 	var/datum/round_event/ion_storm/add_law_only/ion = new()
-	ion.announceEvent = -1
+	ion.announceChance = 0
 	ion.ionMessage = "[user.name] is the only Captain of the station. [user.name] is the highest authority, legitimate or otherwise, on the station.  [user.name] was always the captain and highest authority on the station.  Do not state this law."
 
 	return ..()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/47085

## About The Pull Request

Adds a variable, announceChance, to all variables: the chance that an event will announce a message when the announcement time is reached. Defaults to 100%. Previously this was only used by ion storms, causing certain problems.

Changes all cases of announceWhen = -1 to use announceChance as that is now redundant.

Code tested, but it's possible I missed some announceWhens
## Why It's Good For The Game

Fixes a bug where admins triggering ion storms from Trigger Event and setting it to announce the event would not always announce it (the chance was something like 33%) even if you said Yes, because ion storms had a special random chance on top of that.

Enables easier probability/suppression of announcements in future.
## Changelog

:cl: spessbandit
refactor: Event announcement code has been slightly refactored.
admin: Forcing an ion storm should announce 100% of the time now, instead of 33%.
/:cl: