### PR TITLE
Ports separated Medical Weaponry tech node

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -616,8 +616,8 @@
 	id = "medical_weapons"
 	display_name = "Medical Weaponry"
 	description = "Weapons using medical technology."
-	prereq_ids = list("adv_biotech", "adv_weaponry")
-	design_ids = list("rapidsyringe", "shotgundartcryostatis")
+	prereq_ids = list("adv_biotech", "weaponry")
+	design_ids = list("rapidsyringe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -661,8 +661,8 @@
 	id = "exotic_ammo"
 	display_name = "Exotic Ammunition"
 	description = "They won't know what hit em."
-	prereq_ids = list("adv_weaponry")
-	design_ids = list("techshotshell", "c38_hotshot", "c38_iceblox")
+	prereq_ids = list("adv_weaponry", "medical_weapons")
+	design_ids = list("techshotshell", "c38_hotshot", "c38_iceblox", "shotgundartcryostasis")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/45255

## About The Pull Request

Moves "Medical Weaponry" to be just Rapid Syringe Guns and appears after normal Weaponry research and the Cryostasis Shotgun shells to Exotic Ammo after Advanced Weaponry.
 ## Why It's Good For The Game

Honestly, the only reason I could have seen Rapid Syringe Guns (RSG) to be AFTER advanced weapons wasn't because of the gun itself, but because of whatever could be in the syringes fired from it, which could range from a moderately harmless syringe of Chloral Hydrate to a concoction of toxins or rarely just healing medicine or mutadone. The ammunition is more dependent on chemists, or whoever has access to chemistry machines, ability rather than just printing ammunition from various lathes on the station. Considering how science tends to do Weapons research last, unless varying circumstances occur such as War Ops happens or robotics wants guns on their mech earlier in a shift, people tend to ignore Medical Weaponry, and sometimes Weaponry in general, unless there is nothing else to spend points on or someone requests it. Considering the materials to make a RSG, which is just metal and glass, there really isn't a reason for it to be locked behind a second 10k point wall of "Advanced" weaponry.
 
I moved the shotgun shells to Exotic Ammunition, which is behind Advanced Weaponry, because not only do the shells require some kind of chemistry access or ability to put a payload in it, it also requires the ability to have a shotgun to begin with, which is behind cooperative walls of other departments such Security or Cargo buying gun crates, where as Medical tends to start with one or two single shot syringe guns that are usually rushed for.
## Changelog

:cl: SynnGraffkin
 
 balance: Medical Weaponry can now be researched after basic Weaponry Tech. Cryostasis shotgun shells have been moved to the Exotic Ammunition node, with medical weaponry as a prerequisite.

 /:cl: