### PR TITLE
Reduces riot suit slowdown from 50% to 20%

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -122,6 +122,7 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
+	slowdown = 0.2
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -122,7 +122,6 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
-	slowdown = 0.5
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/45656

## About The Pull Request
 
Removes the slowdown from riot suits in an effort to make them more useful to security.
## Why It's Good For The Game

Riot suits have for a while firmly sat in the "garbage-tier" for experienced players because slowdown more or less completely obstructs security from doing their jobs as any perp can outrun them. Given Oranges recently expressed a desire for coded changes that make sec less ridiculously vulnerable to tiders and easy to loot, particularly with hallway shoves, I believe making riot armor an actually useful tool to deal with tiders via its innate shove/knockdown immunity could help.
## Changelog

:cl: Dawson1917 & AWalton
balance: Riot suit slowdown is now 20%, down from 50%.
/:cl: