### PR TITLE
[port] you now always face the direction you're crawling

### DIFF
--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -15,14 +15,13 @@
 				final_pixel_y = get_standard_pixel_y_offset(lying)
 				if(dir & (EAST|WEST)) //Facing east or west
 					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
-
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++
 		ntransform.Scale(resize)
 		resize = RESIZE_DEFAULT_SIZE
 
 	if(changed)
-		animate(src, transform = ntransform, time = 2, pixel_y = final_pixel_y, dir = final_dir, easing = EASE_IN|EASE_OUT)
+		animate(src, transform = ntransform, time = (lying_prev == 0 || !lying) ? 2 : 0, pixel_y = final_pixel_y, dir = final_dir, easing = (EASE_IN|EASE_OUT))
 		setMovetype(movement_type & ~FLOATING)  // If we were without gravity, the bouncing animation got stopped, so we make sure we restart it in next life().
 
 /mob/living/carbon

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -616,7 +616,7 @@
 	if(lying) 
 		if(direct & EAST)
 			lying = 90
-		if(direct & EAST)
+		if(direct & WEST)
 			lying = 270
 		update_transform()
 		lying_prev = lying

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -613,6 +613,13 @@
 	return
 
 /mob/living/Move(atom/newloc, direct)
+	if(lying) 
+		if(direct & EAST)
+			lying = 90
+		if(direct & EAST)
+			lying = 270
+		update_transform()
+		lying_prev = lying
 	if (buckled && buckled.loc != newloc) //not updating position
 		if (!buckled.anchored)
 			return buckled.Move(newloc, direct)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/47141

## About The Pull Request

When crawling your head will always face the direction you're crawling in
## Why It's Good For The Game
 
More immersive, less people crawling with their legs first
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/30060146/66969269-fb91c980-f056-11e9-975b-e1e30273273a.gif)
## Changelog

:cl: 81Denton 
tweak: people now crawl in the direction their heads are facing
/:cl: