### PR TITLE
[PORT] Shooting a BSA beam at the SM will make it delaminate

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -468,6 +468,7 @@
 #include "code\datums\diseases\advance\symptoms\weight.dm"
 #include "code\datums\diseases\advance\symptoms\youth.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\bsa_blocker.dm"
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\earhealing.dm"
 #include "code\datums\elements\firestacker.dm"

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -65,6 +65,8 @@
 #define COMSIG_ATOM_RATVAR_ACT "atom_ratvar_act"				//! from base of atom/ratvar_act(): ()
 #define COMSIG_ATOM_RCD_ACT "atom_rcd_act"						//! from base of atom/rcd_act(): (/mob, /obj/item/construction/rcd, passed_mode)
 #define COMSIG_ATOM_SING_PULL "atom_sing_pull"					//! from base of atom/singularity_pull(): (S, current_size)
+#define COMSIG_ATOM_BSA_BEAM "atom_bsa_beam_pass"				//from obj/machinery/bsa/full/proc/fire(): ()
+#define COMSIG_ATOM_BLOCKS_BSA_BEAM 1
 #define COMSIG_ATOM_SET_LIGHT "atom_set_light"					//! from base of atom/set_light(): (l_range, l_power, l_color)
 #define COMSIG_ATOM_DIR_CHANGE "atom_dir_change"				//! from base of atom/setDir(): (old_dir, new_dir)
 #define COMSIG_ATOM_CONTENTS_DEL "atom_contents_del"			//! from base of atom/handle_atom_del(): (atom/deleted)

--- a/code/datums/elements/bsa_blocker.dm
+++ b/code/datums/elements/bsa_blocker.dm
@@ -1,0 +1,10 @@
+//blocks bluespace artillery beams that try to fly through
+//look not all elements need to be fancy
+/datum/element/bsa_blocker/Attach(datum/target)
+	if(!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ATOM_BSA_BEAM, .proc/block_bsa)
+	return ..()
+
+/datum/element/bsa_blocker/proc/block_bsa()
+	return COMSIG_ATOM_BLOCKS_BSA_BEAM

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -37,6 +37,7 @@
 		var/mutable_appearance/alert_overlay = mutable_appearance('icons/effects/cult_effects.dmi', "ghostalertsie")
 		notify_ghosts("Nar'Sie has risen in \the [A.name]. Reach out to the Geometer to be given a new shell for your soul.", source = src, alert_overlay = alert_overlay, action=NOTIFY_ATTACK)
 	INVOKE_ASYNC(src, .proc/narsie_spawn_animation)
+	UnregisterSignal(src, COMSIG_ATOM_BSA_BEAM) //set up in /singularity/Initialize()
 
 /obj/singularity/narsie/large/cult  // For the new cult ending, guaranteed to end the round within 3 minutes
 	var/list/souls_needed = list()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -43,6 +43,8 @@
 		if(singubeacon.active)
 			target = singubeacon
 			break
+	AddElement(/datum/element/bsa_blocker)
+	RegisterSignal(src, COMSIG_ATOM_BSA_BEAM, .proc/bluespace_reaction)
 	return
 
 /obj/singularity/Destroy()
@@ -446,3 +448,7 @@
 	explosion(src.loc,(dist),(dist*2),(dist*4))
 	qdel(src)
 	return(gain)
+
+/obj/singularity/proc/bluespace_reaction()
+	investigate_log("has been shot by bluespace artillery and destroyed.", INVESTIGATE_SINGULO)
+	qdel(src)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -158,6 +158,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(is_main_engine)
 		GLOB.main_supermatter_engine = src
 
+	AddElement(/datum/element/bsa_blocker)
+	RegisterSignal(src, COMSIG_ATOM_BSA_BEAM, .proc/call_explode)
+
 	soundloop = new(list(src), TRUE)
 
 /obj/machinery/power/supermatter_crystal/Destroy()
@@ -294,6 +297,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			var/obj/singularity/energy_ball/E = new(T)
 			E.energy = power
 		qdel(src)
+
+//this is here to eat arguments
+/obj/machinery/power/supermatter_crystal/proc/call_explode()
+	explode()
 
 /obj/machinery/power/supermatter_crystal/process_atmos()
 	var/turf/T = loc

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -200,8 +200,6 @@
 
 	point.Beam(target, icon_state = "bsa_beam", time = 50, maxdistance = world.maxx) //ZZZAP
 
-	new /obj/effect/temp_visual/bsa_splash(point, dir)
-
 	if(!blocker)
 		message_admins("[ADMIN_LOOKUPFLW(user)] has launched an artillery strike targeting [ADMIN_VERBOSEJMP(bullseye)].")
 		log_game("[key_name(user)] has launched an artillery strike targeting [AREACOORD(bullseye)].")

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -177,16 +177,38 @@
 	reload()
 
 /obj/machinery/bsa/full/proc/fire(mob/user, turf/bullseye)
-	var/turf/point = get_front_turf()
-	for(var/turf/T in getline(get_step(point,dir),get_target_turf()))
-		T.ex_act(EXPLODE_DEVASTATE)
-	point.Beam(get_target_turf(),icon_state="bsa_beam",time=50,maxdistance = world.maxx) //ZZZAP
-
-	message_admins("[ADMIN_LOOKUPFLW(user)] has launched an artillery strike targeting [ADMIN_VERBOSEJMP(bullseye)].")
-	log_game("[key_name(user)] has launched an artillery strike targeting [AREACOORD(bullseye)].")
-	explosion(bullseye,ex_power,ex_power*2,ex_power*4)
-
 	reload()
+
+	var/turf/point = get_front_turf()
+	var/turf/target = get_target_turf()
+	var/atom/movable/blocker
+	for(var/turf/T in getline(get_step(point,dir),get_target_turf()))
+		var/turf/tile = T
+		if(SEND_SIGNAL(tile, COMSIG_ATOM_BSA_BEAM) & COMSIG_ATOM_BLOCKS_BSA_BEAM)
+			blocker = tile
+		else
+			for(var/AM in tile)
+				var/atom/movable/stuff = AM
+				if(SEND_SIGNAL(stuff, COMSIG_ATOM_BSA_BEAM) & COMSIG_ATOM_BLOCKS_BSA_BEAM)
+					blocker = stuff
+					break
+		if(blocker) //BYOND's only mechanism for escaping from an inner foreach loop is GOTO. If I did that, this code would GOTO the trash can
+			target = tile
+			break
+		else
+			tile.ex_act(EXPLODE_DEVASTATE) //also fucks everything else on the turf
+
+	point.Beam(target, icon_state = "bsa_beam", time = 50, maxdistance = world.maxx) //ZZZAP
+
+	new /obj/effect/temp_visual/bsa_splash(point, dir)
+
+	if(!blocker)
+		message_admins("[ADMIN_LOOKUPFLW(user)] has launched an artillery strike targeting [ADMIN_VERBOSEJMP(bullseye)].")
+		log_game("[key_name(user)] has launched an artillery strike targeting [AREACOORD(bullseye)].")
+		explosion(bullseye,ex_power,ex_power*2,ex_power*4)
+	else
+		message_admins("[ADMIN_LOOKUPFLW(user)] has launched an artillery strike targeting [ADMIN_VERBOSEJMP(bullseye)] but it was blocked by [blocker] at [ADMIN_VERBOSEJMP(target)].")
+		log_game("[key_name(user)] has launched an artillery strike targeting [AREACOORD(bullseye)] but it was blocked by [blocker] at [AREACOORD(target)].")
 
 /obj/machinery/bsa/full/proc/reload()
 	ready = FALSE
@@ -276,9 +298,10 @@
 /obj/machinery/computer/bsa_control/proc/get_impact_turf()
 	if(istype(target, /area))
 		return pick(get_area_turfs(target))
-	else if(istype(target, /obj/item/gps))
-		return get_turf(target)
-
+	else if(istype(target, /datum/component/gps))
+		var/datum/component/gps/G = target
+		return get_turf(G.parent)
+		
 /obj/machinery/computer/bsa_control/proc/fire(mob/user)
 	if(cannon.stat)
 		notice = "Cannon unpowered!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a BSA beam blocker element that blocks bluespace artillery beams. SM and singulo have it.
The SM will also call explode() when shot, so maybe don't do that.
Keep in mind these are talking about the beam the artillery launches that goes to the edge of the map that destroys everything in its path. After it hits the edge, it's supposed to explode on what you aimed it at (a gps, normally). It didn't do that before, now it does. That explosion is a regular old explosion, nothing special happens if you blow stuff up with that.

See: tgstation/tgstation#47748
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ike pinned it in discord.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: MrPerson
add: If you shoot the supermatter crystal with bluespace artillery, you're gonna have a bad time.
fix: Bluespace artillery will blow its targets up properly instead of doing nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
