### PR TITLE
Ports removes all budget cards except for cargo card, gives cargo small income

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -59,6 +59,7 @@ SUBSYSTEM_DEF(economy)
 	boring_sci_payout() // Payout based on slimes.
 	boring_secmedsrv_payout() // Payout based on crew safety, health, and mood.
 	boring_civ_payout() // Payout based on ??? Profit
+	car_payout() // Cargo's natural gain in the cash moneys.
 	for(var/A in bank_accounts)
 		var/datum/bank_account/B = A
 		B.payday(1)
@@ -74,6 +75,12 @@ SUBSYSTEM_DEF(economy)
 	var/datum/bank_account/D = get_dep_account(ACCOUNT_ENG)
 	if(D)
 		D.adjust_money(engineering_cash)
+
+/datum/controller/subsystem/economy/proc/car_payout()
+	var/cargo_cash = 500
+	var/datum/bank_account/D = get_dep_account(ACCOUNT_CAR)
+	if(D)
+		D.adjust_money(cargo_cash)
 
 /datum/controller/subsystem/economy/proc/boring_secmedsrv_payout()
 	var/crew

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -582,40 +582,10 @@ update_label("John Doe", "Clowny")
 	SSeconomy.dep_cards -= src
 	return ..()
 
-/obj/item/card/id/departmental_budget/civ
-	department_ID = ACCOUNT_CIV
-	department_name = ACCOUNT_CIV_NAME
-	icon_state = "budget"
-
-/obj/item/card/id/departmental_budget/eng
-	department_ID = ACCOUNT_ENG
-	department_name = ACCOUNT_ENG_NAME
-	icon_state = "budget_eng"
-
-/obj/item/card/id/departmental_budget/sci
-	department_ID = ACCOUNT_SCI
-	department_name = ACCOUNT_SCI_NAME
-	icon_state = "budget_sci"
-
-/obj/item/card/id/departmental_budget/med
-	department_ID = ACCOUNT_MED
-	department_name = ACCOUNT_MED_NAME
-	icon_state = "budget_med"
-
-/obj/item/card/id/departmental_budget/srv
-	department_ID = ACCOUNT_SRV
-	department_name = ACCOUNT_SRV_NAME
-	icon_state = "budget_srv"
-
 /obj/item/card/id/departmental_budget/car
 	department_ID = ACCOUNT_CAR
 	department_name = ACCOUNT_CAR_NAME
 	icon_state = "budget_car"
-
-/obj/item/card/id/departmental_budget/sec
-	department_ID = ACCOUNT_SEC
-	department_name = ACCOUNT_SEC_NAME
-	icon_state = "budget_sec"
 
 ///Job Specific ID Cards///
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -32,7 +32,6 @@
 	new /obj/item/circuitboard/machine/techfab/department/engineering(src)
 	new /obj/item/extinguisher/advanced(src)
 	new /obj/item/storage/photo_album/CE(src)
-	new /obj/item/card/id/departmental_budget/eng(src)
 	
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -76,7 +76,6 @@
 	new /obj/item/wallframe/defib_mount(src)
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/CMO(src)
-	new /obj/item/card/id/departmental_budget/med(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -27,4 +27,3 @@
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 	new /obj/item/storage/photo_album/RD(src)
-	new /obj/item/card/id/departmental_budget/sci(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -34,7 +34,6 @@
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/card/id/captains_spare(src)
 	new /obj/item/storage/photo_album/Captain(src)
-	new /obj/item/card/id/departmental_budget/civ(src)
 
 /obj/structure/closet/secure_closet/hop
 	name = "\proper head of personnel's locker"
@@ -63,7 +62,6 @@
 	new /obj/item/door_remote/civillian(src)
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
 	new /obj/item/storage/photo_album/HoP(src)
-	new /obj/item/card/id/departmental_budget/srv(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "\proper head of security's locker"
@@ -97,7 +95,6 @@
 	new /obj/item/pinpointer/nuke(src)
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
 	new /obj/item/storage/photo_album/HoS(src)
-	new /obj/item/card/id/departmental_budget/sec(src)
 
 /obj/structure/closet/secure_closet/warden
 	name = "\proper warden's locker"


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/47256

## **The What**

Removes every departmental budget card from the game, **INCLUDING** the Cargo Departmental Card. Most departmental budgets (besides Cargo) are now only used for paychecks to employees.

Cargo Budget now receives an EXTREMELY small (read: 500 credits) paycheck per cycle.
## **The How**

Removed the individual budget cards items in 'card_ids.dm', changed the secure closet files to make it so said cards (that no longer exist) spawn in their corresponding head's locker. Changed the 'economy.dm' file to have Cargo get the 500 credit paycheck.
## **The Why**

_Oh, boy._

Firstly, the department budgets are super dumb and easy to abuse. Secondly, they were never actually used by their departments except for when the QM would stop by an ask for the card -- which he then got literal tens of thousands of dollars every paycheck to piss around with. So, department budgets (again, with the exception of the Cargo budget) can now ONLY be used to dish out funds for employee's paychecks. No more, no less.

What this means is that Cargo now has to do exports and bounties for any meaningful amount of credits -- if things are going slow, they do have a very small amount of reliable income to work with (enough to buy a medkit every few minutes, if medbay is useless. But not enough to snag combat shotties unless they wait for an extremely long period of time - 80 minutes - and assuming that they have no Cargonians taking away from the budget for paychecks.) Basically, to be useful, they HAVE to do exports and bounties.

So, just to reiterate -- if I want Cargo to actually do exports and bounties, why do they get 500 credits every paycheck? Firstly, this 500 credit paycheck is usually almost completely negated by cargo employee's paycheck. Especially if the department is large. The remaining funds are a laughable amount, meaning Cargo has to save for a _long_ time if they have no source of income outside of their paycheck. To get any meaningful amount of money, they need to start exporting. They can't rely on mooching off of other departmental cards.

'Hold on a minute', you may be asking, 'You didn't actually remove the department's budgets, but just the card. Are you retarded or something?' While the answer may be yes, the retainment of the department budgets is intentional for a simple reason; without them, nobody would get paychecks. However, these 'budgets' now no longer serve ANY purpose besides funding paychecks. Meaning departments can pool together their paychecks to buy things for Cargo, but the money isn't enough to let Cargo get SWAT crates 10 minutes after roundstart.

**TL;DR:** Cargo is more inclined to do exports and bounties since they can't mooch off of other department budgets and have no steady source of income outside of said exports and bounties.
## Changelog

:cl: genessee596
del: Removed all departmental budget cards including Cargo card
tweak: Cargo now gets a flat 500 credits per paycheck, not including exports or bounties
/:cl: