### PR TITLE
Adds 2% chance xeno egg to the maps that don't have it

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57365,6 +57365,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"pFf" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "pFh" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -102603,7 +102607,7 @@ bzx
 bAC
 bBW
 bDb
-bEm
+pFf
 bEm
 bEm
 bDb

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -126361,6 +126361,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"exx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "exE" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -154574,7 +154588,7 @@ cea
 cLs
 cOE
 cMY
-cNd
+exx
 cNd
 cNd
 cWV


### PR DESCRIPTION
Box and Delta now have a 2% chance for a round start facehugger egg in xenobiology. Previously only Meta and Pubby had this.

:cl:
rscadd: round start facehugger egg chance in Box and Delta
/:cl: