### PR TITLE
[PORT] Medborg Crew Monitor Upgrade (#46598)

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -349,6 +349,9 @@
 /datum/action/item_action/toggle_helmet_mode
 	name = "Toggle Helmet Mode"
 
+/datum/action/item_action/crew_monitor
+	name = "Interface With Crew Monitor"
+
 /datum/action/item_action/toggle
 
 /datum/action/item_action/toggle/New(Target)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -590,17 +590,18 @@
 
 /obj/item/borg/upgrade/pinpointer
 	name = "medical cyborg crew pinpointer"
-	desc = "A crew pinpointer module for the medical cyborg."
+	desc = "A crew pinpointer module for the medical cyborg. Permits remote access to the crew monitor."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "pinpointer_crew"
 	require_module = TRUE
 	module_type = /obj/item/robot_module/medical
+	var/datum/action/crew_monitor
 
 /obj/item/borg/upgrade/pinpointer/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
 
-		var/obj/item/pinpointer/crew/PP = locate() in R
+		var/obj/item/pinpointer/crew/PP = locate() in R.module
 		if(PP)
 			to_chat(user, "<span class='warning'>This unit is already equipped with a pinpointer module.</span>")
 			return FALSE
@@ -608,13 +609,26 @@
 		PP = new(R.module)
 		R.module.basic_modules += PP
 		R.module.add_module(PP, FALSE, TRUE)
+		crew_monitor = new /datum/action/item_action/crew_monitor(src)
+		crew_monitor.Grant(R)
+		icon_state = "scanner"
+
 
 /obj/item/borg/upgrade/pinpointer/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
+		icon_state = "pinpointer_crew"
+		crew_monitor.Remove(R)
+		QDEL_NULL(crew_monitor)
 		var/obj/item/pinpointer/crew/PP = locate() in R.module
-		if (PP)
-			R.module.remove_module(PP, TRUE)
+		R.module.remove_module(PP, TRUE)
+
+/obj/item/borg/upgrade/pinpointer/ui_action_click()
+	if(..())
+		return
+	var/mob/living/silicon/robot/Cyborg = usr
+	GLOB.crewmonitor.show(Cyborg,Cyborg)
+
 
 /obj/item/borg/upgrade/transform
 	name = "borg module picker (Standard)"


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/46598

* Medborg Crew Monitor Upgrade, tested and working

Adds the crew monitor to medborg upgrades.

Why This is Good for the Game: The important second part of the crew pinpointer; as a result, medborgs no longer have to glue themselves to fixed crew monitor consoles in order to do the paramedicine job they excel at, which is boring and lame.

:cl: Surrealaser
add: Remote access to crew monitoring is now integrated with the crew locator upgrade for Mediborgs.
/:cl:
