### PR TITLE
[PORT] Grenade fixes from /TG/, Beaker Panel

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1187,6 +1187,7 @@
 #include "code\modules\admin\verbs\adminpm.dm"
 #include "code\modules\admin\verbs\adminsay.dm"
 #include "code\modules\admin\verbs\atmosdebug.dm"
+#include "code\modules\admin\verbs\beakerpanel.dm"
 #include "code\modules\admin\verbs\bluespacearty.dm"
 #include "code\modules\admin\verbs\borgpanel.dm"
 #include "code\modules\admin\verbs\BrokenInhands.dm"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -427,6 +427,6 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 #define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"
 
 //chem grenades defines
-#define EMPTY 1
-#define WIRED 2
-#define READY 3
+#define GRENADE_EMPTY 1
+#define GRENADE_WIRED 2
+#define GRENADE_READY 3

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -425,3 +425,8 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 
 /// Misc text define. Does 4 spaces. Used as a makeshift tabulator.
 #define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"
+
+//chem grenades defines
+#define EMPTY 1
+#define WIRED 2
+#define READY 3

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -1,5 +1,8 @@
+/datum/wires/explosive
+	var/duds_number = 2
+
 /datum/wires/explosive/New(atom/holder)
-	add_duds(2) // In this case duds actually explode.
+	add_duds(duds_number) // In this case duds actually explode.
 	..()
 
 /datum/wires/explosive/on_pulse(index)
@@ -11,6 +14,45 @@
 /datum/wires/explosive/proc/explode()
 	return
 
+/datum/wires/explosive/chem_grenade
+	duds_number = 1
+	holder_type = /obj/item/grenade/chem_grenade
+	randomize = TRUE
+	var/fingerprint
+
+/datum/wires/explosive/chem_grenade/interactable(mob/user)
+	var/obj/item/grenade/chem_grenade/G = holder
+	if(G.stage == WIRED)
+		return TRUE
+
+/datum/wires/explosive/chem_grenade/attach_assembly(color, obj/item/assembly/S)
+	if(istype(S,/obj/item/assembly/timer))
+		var/obj/item/grenade/chem_grenade/G = holder
+		var/obj/item/assembly/timer/T = S
+		G.det_time = T.saved_time*10
+	else if(istype(S,/obj/item/assembly/prox_sensor))
+		var/obj/item/grenade/chem_grenade/G = holder
+		G.landminemode = S
+		S.proximity_monitor.wire = TRUE
+	fingerprint = S.fingerprintslast
+	return ..()
+
+/datum/wires/explosive/chem_grenade/explode()
+	var/obj/item/grenade/chem_grenade/G = holder
+	var/obj/item/assembly/assembly = get_attached(get_wire(1))
+	message_admins("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
+	log_game("\An [assembly] has pulsed a grenade, which was installed by [fingerprint].")
+	G.prime()
+
+/datum/wires/explosive/chem_grenade/detach_assembly(color)
+	var/obj/item/assembly/S = get_attached(color)
+	if(S && istype(S))
+		assemblies -= color
+		S.connected = null
+		S.forceMove(holder.drop_location())
+		var/obj/item/grenade/chem_grenade/G = holder
+		G.landminemode = null
+		return S
 
 /datum/wires/explosive/c4
 	holder_type = /obj/item/grenade/plastic/c4

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -22,7 +22,7 @@
 
 /datum/wires/explosive/chem_grenade/interactable(mob/user)
 	var/obj/item/grenade/chem_grenade/G = holder
-	if(G.stage == WIRED)
+	if(G.stage == GRENADE_WIRED)
 		return TRUE
 
 /datum/wires/explosive/chem_grenade/attach_assembly(color, obj/item/assembly/S)

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -5,6 +5,7 @@
 	var/list/checkers //list of /obj/effect/abstract/proximity_checkers
 	var/current_range
 	var/ignore_if_not_on_turf	//don't check turfs in range if the host's loc isn't a turf
+	var/wire = FALSE
 
 /datum/proximity_monitor/New(atom/_host, range, _ignore_if_not_on_turf = TRUE)
 	checkers = list()
@@ -58,6 +59,8 @@
 	var/atom/_host = host
 
 	var/atom/loc_to_use = ignore_if_not_on_turf ? _host.loc : get_turf(_host)
+	if(wire && !isturf(loc_to_use)) //it makes assemblies attached on wires work
+		loc_to_use = get_turf(loc_to_use)
 	if(!isturf(loc_to_use))	//only check the host's loc
 		if(range)
 			var/obj/effect/abstract/proximity_checker/pc

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -49,9 +49,11 @@
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
 	if(stage == READY && !active)
 		..()
+	if(stage == WIRED)
+		wires.interact(user)
 
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
-	if((istype(I,/obj/item/assembly) || I.tool_behaviour == TOOL_MULTITOOL) && stage == WIRED)
+	if(istype(I,/obj/item/assembly) && stage == WIRED)
 		wires.interact(user)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		if(stage == WIRED)
@@ -113,6 +115,7 @@
 				user.log_message("removed [O] ([reagent_list]) from [src]", LOG_GAME)
 			beakers = list()
 			to_chat(user, "<span class='notice'>You open the [initial(name)] assembly and remove the payload.</span>")
+			wires.detach_assembly(wires.get_wire(1))
 			return
 		new /obj/item/stack/cable_coil(get_turf(src),1)
 		stage_change(EMPTY)
@@ -135,6 +138,11 @@
 		name = initial(name)
 		desc = initial(desc)
 		icon_state = "[initial(icon_state)]_locked"
+
+/obj/item/grenade/chem_grenade/on_found(mob/finder)
+	var/obj/item/assembly/A = wires.get_attached(wires.get_wire(1))
+	if(A)
+		A.on_found(finder)
 
 /obj/item/grenade/chem_grenade/log_grenade(mob/user, turf/T)
 	var/reagent_string = ""

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -1,7 +1,3 @@
-#define EMPTY 1
-#define WIRED 2
-#define READY 3
-
 /obj/item/grenade/chem_grenade
 	name = "chemical grenade"
 	desc = "A custom made grenade."
@@ -14,20 +10,24 @@
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
 	var/list/banned_containers = list(/obj/item/reagent_containers/glass/beaker/bluespace) //Containers to exclude from specific grenade subtypes
 	var/affected_area = 3
-	var/obj/item/assembly_holder/nadeassembly = null
-	var/assemblyattacher
 	var/ignition_temp = 10 // The amount of heat added to the reagents when this grenade goes off.
 	var/threatscale = 1 // Used by advanced grenades to make them slightly more worthy.
 	var/no_splash = FALSE //If the grenade deletes even if it has no reagents to splash with. Used for slime core reactions.
 	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10°K upon ignition." // Appears when examining empty casings.
+	var/obj/item/assembly/prox_sensor/landminemode = null
+
+/obj/item/grenade/chem_grenade/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 /obj/item/grenade/chem_grenade/Initialize()
 	. = ..()
 	create_reagents(1000)
 	stage_change() // If no argument is set, it will change the stage to the current stage, useful for stock grenades that start READY.
+	wires = new /datum/wires/explosive/chem_grenade(src)
 
 /obj/item/grenade/chem_grenade/examine(mob/user)
-	display_timer = (stage == READY && !nadeassembly)	//show/hide the timer based on assembly state
+	display_timer = (stage == READY)	//show/hide the timer based on assembly state
 	..()
 	if(user.can_see_reagents())
 		if(beakers.len)
@@ -48,12 +48,11 @@
 
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
 	if(stage == READY && !active)
-		if(nadeassembly)
-			nadeassembly.attack_self(user)
-		else
-			..()
+		..()
 
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
+	if((istype(I,/obj/item/assembly) || I.tool_behaviour == TOOL_MULTITOOL) && stage == WIRED)
+		wires.interact(user)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		if(stage == WIRED)
 			if(beakers.len)
@@ -62,12 +61,15 @@
 				I.play_tool_sound(src, 25)
 			else
 				to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the [initial(name)] assembly!</span>")
-		else if(stage == READY && !nadeassembly)
-			det_time = det_time == 50 ? 30 : 50	//toggle between 30 and 50
-			to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
-		else if(stage == EMPTY)
-			to_chat(user, "<span class='warning'>You need to add an activation mechanism!</span>")
+		else if(stage == READY)
+			det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
+			if(landminemode)
+				landminemode.time = det_time * 0.1	//overwrites the proxy sensor activation timer
 
+			to_chat(user, "<span class='notice'>You modify the time delay. It's set for [DisplayTimeText(det_time)].</span>")
+		else
+			to_chat(user, "<span class='warning'>You need to add a wire!</span>")
+		return
 	else if(stage == WIRED && is_type_in_list(I, allowed_containers))
 		. = TRUE //no afterattack
 		if(is_type_in_list(I, banned_containers))
@@ -86,21 +88,6 @@
 				user.log_message("inserted [I] ([reagent_list]) into [src]",LOG_GAME)
 			else
 				to_chat(user, "<span class='warning'>[I] is empty!</span>")
-
-	else if(stage == EMPTY && istype(I, /obj/item/assembly_holder))
-		. = 1 // no afterattack
-		var/obj/item/assembly_holder/A = I
-		if(isigniter(A.a_left) == isigniter(A.a_right))	//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
-			return
-		if(!user.transferItemToLoc(I, src))
-			return
-
-		nadeassembly = A
-		A.master = src
-		assemblyattacher = user.ckey
-
-		stage_change(WIRED)
-		to_chat(user, "<span class='notice'>You add [A] to the [initial(name)] assembly.</span>")
 
 	else if(stage == EMPTY && istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
@@ -126,13 +113,8 @@
 				user.log_message("removed [O] ([reagent_list]) from [src]", LOG_GAME)
 			beakers = list()
 			to_chat(user, "<span class='notice'>You open the [initial(name)] assembly and remove the payload.</span>")
-			return // First use of the wrench remove beakers, then use the wrench to remove the activation mechanism.
-		if(nadeassembly)
-			nadeassembly.forceMove(drop_location())
-			nadeassembly.master = null
-			nadeassembly = null
-		else // If "nadeassembly = null && stage == WIRED", then it most have been cable_coil that was used.
-			new /obj/item/stack/cable_coil(get_turf(src),1)
+			return
+		new /obj/item/stack/cable_coil(get_turf(src),1)
 		stage_change(EMPTY)
 		to_chat(user, "<span class='notice'>You remove the activation mechanism from the [initial(name)] assembly.</span>")
 	else
@@ -154,20 +136,6 @@
 		desc = initial(desc)
 		icon_state = "[initial(icon_state)]_locked"
 
-
-//assembly stuff
-/obj/item/grenade/chem_grenade/receive_signal()
-	prime()
-
-
-/obj/item/grenade/chem_grenade/Crossed(atom/movable/AM)
-	if(nadeassembly)
-		nadeassembly.Crossed(AM)
-
-/obj/item/grenade/chem_grenade/on_found(mob/finder)
-	if(nadeassembly)
-		nadeassembly.on_found(finder)
-
 /obj/item/grenade/chem_grenade/log_grenade(mob/user, turf/T)
 	var/reagent_string = ""
 	var/beaker_number = 1
@@ -175,7 +143,28 @@
 		if(!exploded_beaker.reagents)
 			continue
 		reagent_string += " ([exploded_beaker.name] [beaker_number++] : " + pretty_string_from_reagent_list(exploded_beaker.reagents.reagent_list) + ");"
-	log_bomber(user, "primed a", src, "containing:[reagent_string]")
+	if(landminemode)
+		log_bomber(user, "activated a proxy", src, "containing:[reagent_string]")
+	else
+		log_bomber(user, "primed a", src, "containing:[reagent_string]")
+
+/obj/item/grenade/chem_grenade/preprime(mob/user, delayoverride, msg = TRUE, volume = 60)
+	var/turf/T = get_turf(src)
+	log_grenade(user, T) //Inbuilt admin procs already handle null users
+	if(user)
+		add_fingerprint(user)
+		if(msg)
+			if(landminemode)
+				to_chat(user, "<span class='warning'>You prime [src], activating its proximity sensor.</span>")
+			else
+				to_chat(user, "<span class='warning'>You prime [src]! [DisplayTimeText(det_time)]!</span>")
+	playsound(src, 'sound/weapons/armbomb.ogg', volume, 1)
+	icon_state = initial(icon_state) + "_active"
+	if(landminemode)
+		landminemode.activate()
+		return
+	active = TRUE
+	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
 /obj/item/grenade/chem_grenade/prime()
 	if(stage != READY)
@@ -195,13 +184,7 @@
 			beakers = list()
 		stage_change(EMPTY)
 		return
-
-	if(nadeassembly)
-		var/mob/M = get_mob_by_ckey(assemblyattacher)
-		var/mob/last = get_mob_by_ckey(nadeassembly.fingerprintslast)
-		message_admins("grenade primed by an assembly, attached by [ADMIN_LOOKUPFLW(M)] and last touched by [ADMIN_LOOKUPFLW(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at [ADMIN_VERBOSEJMP(detonation_turf)]</a>.")
-		log_game("grenade primed by an assembly, attached by [key_name(M)] and last touched by [key_name(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name]) at [AREACOORD(detonation_turf)]")
-
+//	logs from custom assemblies priming are handled by the wire component
 	log_game("A grenade detonated at [AREACOORD(detonation_turf)]")
 
 	update_mob()
@@ -298,7 +281,6 @@
 		total_volume += RC.reagents.total_volume
 	if(!total_volume)
 		qdel(src)
-		qdel(nadeassembly)
 		return
 	var/fraction = unit_spread/total_volume
 	var/datum/reagents/reactants = new(unit_spread)
@@ -308,15 +290,8 @@
 	chem_splash(get_turf(src), affected_area, list(reactants), ignition_temp, threatscale)
 
 	var/turf/DT = get_turf(src)
-	if(nadeassembly)
-		var/mob/M = get_mob_by_ckey(assemblyattacher)
-		var/mob/last = get_mob_by_ckey(nadeassembly.fingerprintslast)
-		message_admins("grenade primed by an assembly at [AREACOORD(DT)], attached by [ADMIN_LOOKUPFLW(M)] and last touched by [ADMIN_LOOKUPFLW(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name])</a>.")
-		log_game("grenade primed by an assembly at [AREACOORD(DT)], attached by [key_name(M)] and last touched by [key_name(last)] ([nadeassembly.a_left.name] and [nadeassembly.a_right.name])")
-	else
-		addtimer(CALLBACK(src, .proc/prime), det_time)
+	addtimer(CALLBACK(src, .proc/prime), det_time)
 	log_game("A grenade detonated at [AREACOORD(DT)]")
-
 
 
 
@@ -599,7 +574,3 @@
 
 	beakers += B1
 	beakers += B2
-
-#undef READY
-#undef WIRED
-#undef EMPTY

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -5,7 +5,7 @@
 	item_state = "flashbang"
 	w_class = WEIGHT_CLASS_SMALL
 	force = 2
-	var/stage = EMPTY
+	var/stage = GRENADE_EMPTY
 	var/list/obj/item/reagent_containers/glass/beakers = list()
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
 	var/list/banned_containers = list(/obj/item/reagent_containers/glass/beaker/bluespace) //Containers to exclude from specific grenade subtypes
@@ -27,7 +27,7 @@
 	wires = new /datum/wires/explosive/chem_grenade(src)
 
 /obj/item/grenade/chem_grenade/examine(mob/user)
-	display_timer = (stage == READY)	//show/hide the timer based on assembly state
+	display_timer = (stage == GRENADE_READY)	//show/hide the timer based on assembly state
 	..()
 	if(user.can_see_reagents())
 		if(beakers.len)
@@ -39,7 +39,7 @@
 				to_chat(user, "<span class='notice'>You detect no second beaker in the grenade.</span>")
 		else
 			to_chat(user, "<span class='notice'>You scan the grenade, but detect nothing.</span>")
-	else if(stage != READY && beakers.len)
+	else if(stage != GRENADE_READY && beakers.len)
 		if(beakers.len == 2 && beakers[1].name == beakers[2].name)
 			to_chat(user, "<span class='notice'>You see two [beakers[1].name]s inside the grenade.</span>")
 		else
@@ -47,23 +47,23 @@
 				to_chat(user, "<span class='notice'>You see a [G.name] inside the grenade.</span>")
 
 /obj/item/grenade/chem_grenade/attack_self(mob/user)
-	if(stage == READY && !active)
+	if(stage == GRENADE_READY && !active)
 		..()
-	if(stage == WIRED)
+	if(stage == GRENADE_WIRED)
 		wires.interact(user)
 
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
-	if(istype(I,/obj/item/assembly) && stage == WIRED)
+	if(istype(I,/obj/item/assembly) && stage == GRENADE_WIRED)
 		wires.interact(user)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		if(stage == WIRED)
+		if(stage == GRENADE_WIRED)
 			if(beakers.len)
-				stage_change(READY)
+				stage_change(GRENADE_READY)
 				to_chat(user, "<span class='notice'>You lock the [initial(name)] assembly.</span>")
 				I.play_tool_sound(src, 25)
 			else
 				to_chat(user, "<span class='warning'>You need to add at least one beaker before locking the [initial(name)] assembly!</span>")
-		else if(stage == READY)
+		else if(stage == GRENADE_READY)
 			det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
 			if(landminemode)
 				landminemode.time = det_time * 0.1	//overwrites the proxy sensor activation timer
@@ -72,7 +72,7 @@
 		else
 			to_chat(user, "<span class='warning'>You need to add a wire!</span>")
 		return
-	else if(stage == WIRED && is_type_in_list(I, allowed_containers))
+	else if(stage == GRENADE_WIRED && is_type_in_list(I, allowed_containers))
 		. = TRUE //no afterattack
 		if(is_type_in_list(I, banned_containers))
 			to_chat(user, "<span class='warning'>[src] is too small to fit [I]!</span>") // this one hits home huh anon?
@@ -91,21 +91,21 @@
 			else
 				to_chat(user, "<span class='warning'>[I] is empty!</span>")
 
-	else if(stage == EMPTY && istype(I, /obj/item/stack/cable_coil))
+	else if(stage == GRENADE_EMPTY && istype(I, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/C = I
 		if (C.use(1))
 			det_time = 50 // In case the cable_coil was removed and readded.
-			stage_change(WIRED)
+			stage_change(GRENADE_WIRED)
 			to_chat(user, "<span class='notice'>You rig the [initial(name)] assembly.</span>")
 		else
 			to_chat(user, "<span class='warning'>You need one length of coil to wire the assembly!</span>")
 			return
 
-	else if(stage == READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
-		stage_change(WIRED)
+	else if(stage == GRENADE_READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
+		stage_change(GRENADE_WIRED)
 		to_chat(user, "<span class='notice'>You unlock the [initial(name)] assembly.</span>")
 
-	else if(stage == WIRED && I.tool_behaviour == TOOL_WRENCH)
+	else if(stage == GRENADE_WIRED && I.tool_behaviour == TOOL_WRENCH)
 		if(beakers.len)
 			for(var/obj/O in beakers)
 				O.forceMove(drop_location())
@@ -118,7 +118,7 @@
 			wires.detach_assembly(wires.get_wire(1))
 			return
 		new /obj/item/stack/cable_coil(get_turf(src),1)
-		stage_change(EMPTY)
+		stage_change(GRENADE_EMPTY)
 		to_chat(user, "<span class='notice'>You remove the activation mechanism from the [initial(name)] assembly.</span>")
 	else
 		return ..()
@@ -126,15 +126,15 @@
 /obj/item/grenade/chem_grenade/proc/stage_change(N)
 	if(N)
 		stage = N
-	if(stage == EMPTY)
+	if(stage == GRENADE_EMPTY)
 		name = "[initial(name)] casing"
 		desc = "A do it yourself [initial(name)]! [initial(casedesc)]"
 		icon_state = initial(icon_state)
-	else if(stage == WIRED)
+	else if(stage == GRENADE_WIRED)
 		name = "unsecured [initial(name)]"
 		desc = "An unsecured [initial(name)] assembly."
 		icon_state = "[initial(icon_state)]_ass"
-	else if(stage == READY)
+	else if(stage == GRENADE_READY)
 		name = initial(name)
 		desc = initial(desc)
 		icon_state = "[initial(icon_state)]_locked"
@@ -175,7 +175,7 @@
 	addtimer(CALLBACK(src, .proc/prime), isnull(delayoverride)? det_time : delayoverride)
 
 /obj/item/grenade/chem_grenade/prime()
-	if(stage != READY)
+	if(stage != GRENADE_READY)
 		return
 
 	var/list/datum/reagents/reactants = list()
@@ -190,7 +190,8 @@
 			for(var/obj/O in beakers)
 				O.forceMove(drop_location())
 			beakers = list()
-		stage_change(EMPTY)
+		stage_change(GRENADE_EMPTY)
+		active = FALSE
 		return
 //	logs from custom assemblies priming are handled by the wire component
 	log_game("A grenade detonated at [AREACOORD(detonation_turf)]")
@@ -212,7 +213,7 @@
 	threatscale = 1.1	// 10% more effective.
 
 /obj/item/grenade/chem_grenade/large/prime()
-	if(stage != READY)
+	if(stage != GRENADE_READY)
 		return
 
 	for(var/obj/item/slime_extract/S in beakers)
@@ -237,7 +238,7 @@
 	//if you do that it must have reagents.  If you're going to
 	//make a special case you might as well do it explicitly. -Sayu
 /obj/item/grenade/chem_grenade/large/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/slime_extract) && stage == WIRED)
+	if(istype(I, /obj/item/slime_extract) && stage == GRENADE_WIRED)
 		if(!user.transferItemToLoc(I, src))
 			return
 		to_chat(user, "<span class='notice'>You add [I] to the [initial(name)] assembly.</span>")
@@ -281,7 +282,7 @@
 	..()
 
 /obj/item/grenade/chem_grenade/adv_release/prime()
-	if(stage != READY)
+	if(stage != GRENADE_READY)
 		return
 
 	var/total_volume = 0
@@ -311,7 +312,7 @@
 /obj/item/grenade/chem_grenade/metalfoam
 	name = "metal foam grenade"
 	desc = "Used for emergency sealing of hull breaches."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/metalfoam/Initialize()
 	. = ..()
@@ -329,7 +330,7 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam
 	name = "smart metal foam grenade"
 	desc = "Used for emergency sealing of hull breaches, while keeping areas accessible."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/smart_metal_foam/Initialize()
 	. = ..()
@@ -347,7 +348,7 @@
 /obj/item/grenade/chem_grenade/incendiary
 	name = "incendiary grenade"
 	desc = "Used for clearing rooms of living things."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/incendiary/Initialize()
 	. = ..()
@@ -365,7 +366,7 @@
 /obj/item/grenade/chem_grenade/antiweed
 	name = "weedkiller grenade"
 	desc = "Used for purging large areas of invasive plant species. Contents under pressure. Do not directly inhale contents."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/antiweed/Initialize()
 	. = ..()
@@ -384,7 +385,7 @@
 /obj/item/grenade/chem_grenade/cleaner
 	name = "cleaner grenade"
 	desc = "BLAM!-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/cleaner/Initialize()
 	. = ..()
@@ -402,7 +403,7 @@
 /obj/item/grenade/chem_grenade/ez_clean
 	name = "cleaner grenade"
 	desc = "Waffle Co.-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/ez_clean/Initialize()
 	. = ..()
@@ -421,7 +422,7 @@
 /obj/item/grenade/chem_grenade/teargas
 	name = "teargas grenade"
 	desc = "Used for nonlethal riot control. Contents under pressure. Do not directly inhale contents."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/teargas/Initialize()
 	. = ..()
@@ -440,7 +441,7 @@
 /obj/item/grenade/chem_grenade/facid
 	name = "acid grenade"
 	desc = "Used for melting armoured opponents."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/facid/Initialize()
 	. = ..()
@@ -460,7 +461,7 @@
 /obj/item/grenade/chem_grenade/colorful
 	name = "colorful grenade"
 	desc = "Used for wide scale painting projects."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/colorful/Initialize()
 	. = ..()
@@ -478,7 +479,7 @@
 /obj/item/grenade/chem_grenade/glitter
 	name = "generic glitter grenade"
 	desc = "You shouldn't see this description."
-	stage = READY
+	stage = GRENADE_READY
 	var/glitter_type = /datum/reagent/glitter
 
 /obj/item/grenade/chem_grenade/glitter/Initialize()
@@ -512,7 +513,7 @@
 /obj/item/grenade/chem_grenade/clf3
 	name = "clf3 grenade"
 	desc = "BURN!-brand foaming clf3. In a special applicator for rapid purging of wide areas."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/clf3/Initialize()
 	. = ..()
@@ -530,7 +531,7 @@
 /obj/item/grenade/chem_grenade/bioterrorfoam
 	name = "Bio terror foam grenade"
 	desc = "Tiger Cooperative chemical foam grenade. Causes temporary irration, blindness, confusion, mutism, and mutations to carbon based life forms. Contains additional spore toxin."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/bioterrorfoam/Initialize()
 	. = ..()
@@ -550,7 +551,7 @@
 /obj/item/grenade/chem_grenade/tuberculosis
 	name = "Fungal tuberculosis grenade"
 	desc = "WARNING: GRENADE WILL RELEASE DEADLY SPORES CONTAINING ACTIVE AGENTS. SEAL SUIT AND AIRFLOW BEFORE USE."
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/tuberculosis/Initialize()
 	. = ..()
@@ -570,7 +571,7 @@
 	name = "holy hand grenade"
 	desc = "A vessel of concentrated religious might."
 	icon_state = "holy_grenade"
-	stage = READY
+	stage = GRENADE_READY
 
 /obj/item/grenade/chem_grenade/holy/Initialize()
 	. = ..()

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -107,10 +107,6 @@
 	if(stuffed || grenade)
 		to_chat(user, "<span class='notice'>You pet [src]. D'awww.</span>")
 		if(grenade && !grenade.active)
-			if(istype(grenade, /obj/item/grenade/chem_grenade))
-				var/obj/item/grenade/chem_grenade/G = grenade
-				if(G.nadeassembly) //We're activated through different methods
-					return
 			log_game("[key_name(user)] activated a hidden grenade in [src].")
 			grenade.preprime(user, msg = FALSE, volume = 10)
 	else

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/spawn_floor_cluwne
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
-GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character))
+GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character, /datum/admins/proc/beaker_panel))
 GLOBAL_PROTECT(admin_verbs_spawn)
 GLOBAL_LIST_INIT(admin_verbs_server, world.AVerbsServer())
 GLOBAL_PROTECT(admin_verbs_server)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2209,6 +2209,9 @@
 		show_player_panel(M)
 
 
+	else if(href_list["beakerpanel"])
+		beaker_panel_act(href_list)
+
 /datum/admins/proc/HandleCMode()
 	if(!check_rights(R_ADMIN))
 		return

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -1,0 +1,361 @@
+/proc/reagentsforbeakers()
+	. = list()
+	for(var/t in subtypesof(/datum/reagent))
+		var/datum/reagent/R = t
+		. += list(list("id" = t, "text" = initial(R.name)))
+
+	. = json_encode(.)
+
+/proc/beakersforbeakers()
+	. = list()
+	for(var/t in subtypesof(/obj/item/reagent_containers))
+		var/obj/item/reagent_containers/C = t
+		. += list(list("id" = t, "text" = initial(C.name), "volume" = initial(C.volume)))
+
+	. = json_encode(.)
+
+/datum/admins/proc/beaker_panel_act(list/href_list)
+	switch (href_list["beakerpanel"])
+		if ("spawncontainer")
+			var/containerdata = json_decode(href_list["container"])
+			var/obj/item/reagent_containers/container = beaker_panel_create_container(containerdata, get_turf(usr))
+			log_game("[key_name(usr)] spawned a [container] containing [pretty_string_from_reagent_list(container.reagents.reagent_list)]")
+		if ("spawngrenade")
+			var/obj/item/grenade/chem_grenade/grenade = new(get_turf(usr))
+			var/containersdata = json_decode(href_list["containers"])
+			var/reagent_string
+			for (var/i in 1 to 2)
+				grenade.beakers += beaker_panel_create_container(containersdata[i], grenade)
+				reagent_string += " ([grenade.beakers[i].name] [i] : " + pretty_string_from_reagent_list(grenade.beakers[i].reagents.reagent_list) + ");"
+			grenade.stage_change(3) // ready stage
+			var/grenadedata = json_decode(href_list["grenadedata"])
+			switch (href_list["grenadetype"])
+				if ("normal") // Regular cable coil-timed grenade
+					var/det_time = text2num(grenadedata["grenade-timer"])
+					if (det_time)
+						grenade.det_time = det_time
+				if ("voice")
+					var/voice_mode = text2num(grenadedata["grenade-voice-mode"])
+					var/recording = grenadedata["grenade-voice-recording"]
+					if (voice_mode && recording)
+						var/obj/item/assembly/voice/voice_analyzer = new
+						voice_analyzer.mode = voice_mode
+						voice_analyzer.recorded = recording
+						voice_analyzer.secured = FALSE // needs to be unsecured  because assembly holder assembly toggles it
+						grenade.nadeassembly = beaker_panel_prep_assembly(voice_analyzer, grenade)
+				if ("signaler")
+					var/frq = format_frequency(grenadedata["grenade-signaler-frq"])
+					var/code = text2num(grenadedata["grenade-signaler-code"])
+					if (frq && code)
+						var/obj/item/assembly/signaler/signaler = new
+						signaler.code = code
+						signaler.frequency = frq
+						signaler.secured = FALSE
+						grenade.nadeassembly = beaker_panel_prep_assembly(signaler, grenade)
+
+			log_game("[key_name(usr)] spawned a [grenade] containing: [reagent_string]")
+
+/datum/admins/proc/beaker_panel_prep_assembly(obj/item/assembly/towrap, grenade)
+	var/obj/item/assembly/igniter/igniter = new
+	igniter.secured = FALSE
+	var/obj/item/assembly_holder/assholder = new(grenade)
+	towrap.forceMove(assholder)
+	igniter.forceMove(assholder)
+	assholder.assemble(igniter, towrap, usr)
+	assholder.master = grenade
+	return assholder
+
+/datum/admins/proc/beaker_panel_create_container(list/containerdata, location)
+	var/containertype = text2path(containerdata["container"])
+	var/obj/item/reagent_containers/container =  new containertype(location)
+	var/datum/reagents/reagents = container.reagents
+	for(var/datum/reagent/R in reagents.reagent_list) // clear the container of reagents
+		reagents.remove_reagent(R.type,R.volume)
+	for (var/list/item in containerdata["reagents"])
+		var/datum/reagent/reagenttype = text2path(item["reagent"])
+		var/amount = text2num(item["volume"])
+		if ((reagents.total_volume + amount) > reagents.maximum_volume)
+			reagents.maximum_volume = reagents.total_volume + amount
+		reagents.add_reagent(reagenttype, amount)
+	return container
+
+/datum/admins/proc/beaker_panel()
+	set category = "Debug"
+	set name = "Spawn reagent container"
+	if(!check_rights())
+		return
+
+	var/dat = {"
+		<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+		<html>
+			<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+			<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<head>
+				<link rel='stylesheet' type='text/css' href='common.css'>
+				<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
+				<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.7/js/select2.full.min.js"></script>
+				<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.7/css/select2.min.css">
+				<script type="text/javascript" src="https://kit.fontawesome.com/8d67455b41.js"></script>
+				<style>
+					.select2-search { color: #40628a; background-color: #272727; }
+					.select2-results { color: #40628a; background-color: #272727; }
+					.select2-selection { border-radius: 0px !important; }
+
+					ul {
+					  list-style-type: none; /* Remove bullets */
+					  padding: 0; /* Remove padding */
+					  margin: 0; /* Remove margins */
+					}
+
+					ul li {
+					  margin-top: -1px; /* Prevent double borders */
+					  padding: 12px; /* Add some padding */
+					  color: #ffffff;
+						text-decoration: none;
+						background: #40628a;
+						border: 1px solid #161616;
+						margin: 0 2px 0 0;
+						cursor:default;
+					}
+
+					.remove-reagent {
+					 background-color: #d03000;
+					}
+
+					.container-control {
+					  width: 48%;
+					  float: left;
+					  padding-right: 10px;
+					}
+					.reagent > div, .reagent-div {
+						float: right;
+						width: 200px;
+					}
+					input.reagent {
+					  width: 50%;
+					}
+					.grenade-data {
+					  display: inline-block;
+					}
+				</style>
+				<script>
+				window.onload=function(){
+
+					var reagents = [reagentsforbeakers()];
+
+					var containers = [beakersforbeakers()];
+
+					$('select\[name="containertype"\]').select2({
+						data: containers,
+						escapeMarkup: noEscape,
+						templateResult: formatContainer,
+						templateSelection: textSelection,
+						width: "300px"
+						});
+					$('.select-new-reagent').select2({
+					data: reagents,
+					escapeMarkup: noEscape,
+					templateResult: formatReagent,
+					templateSelection: textSelection
+					});
+
+					$('.remove-reagent').click(function() { $(this).parents('li').remove(); });
+
+					$('#spawn-grenade').click(function() {
+						var containers = $('div.container-control').map(function() {
+					  	  var type = $(this).children('select\[name=containertype\]').select2("data")\[0\].id;
+					      var reagents = $(this).find("li.reagent").map(function() {
+					        return { "reagent": $(this).data("type"), "volume": $(this).find('input').val()};
+					        }).get();
+					     return {"container": type, "reagents": reagents };
+					  }).get();
+						var grenadeType = $('#grenade-type').val()
+						var grenadeData = {};
+						$('.grenade-data.'+grenadeType).find(':input').each(function() {
+							var ret = {};
+							grenadeData\[$(this).attr('name')\] = $(this).val();
+						});
+					  $.ajax({
+					      url: '',
+					      data: {
+									"_src_": "holder",
+									"admin_token": "[RawHrefToken()]",
+									"beakerpanel": "spawngrenade",
+									"containers": JSON.stringify(containers),
+									"grenadetype": grenadeType,
+									"grenadedata": JSON.stringify(grenadeData)
+								}
+					    });
+					});
+
+					$('.spawn-container').click(function() {
+						var container = $(this).parents('div.container-control')\[0\];
+					  var type = $(container).children('select\[name=containertype\]').select2("data")\[0\].id;
+					  var reagents = $(container).find("li.reagent").map(function() {
+					  	return { "reagent": $(this).data("type"), "volume": $(this).find('input').val()};
+					    }).get();
+					  $.ajax({
+					  	url: '',
+					    data: {
+								"_src_": "holder",
+								"admin_token": "[RawHrefToken()]",
+								"beakerpanel": "spawncontainer",
+								"container": JSON.stringify({"container": type, "reagents": reagents }),
+
+							}
+						});
+					});
+
+					$('.add-reagent').click(function() {
+						var select = $(this).parents('li').children('select').select2("data")\[0\];
+					  var amount = $(this).parent().children('input').val();
+					  addReagent($(this).parents('ul'), select.id, select.text, amount)
+					})
+
+					$('.export-reagents').click(function() {
+						var container = $(this).parents('div.container-control')\[0\];
+					  var ret = \[\];
+					  var reagents = $(container).find("li.reagent").each(function() {
+					  	var reagentname = $(this).contents().filter(function(){ return this.nodeType == 3; })\[0\].nodeValue.toLowerCase().replace(/\\W/g, '');
+					    ret.push(reagentname+"="+$(this).find('input').val());
+					    });
+					  prompt("Copy this value", ret.join(';'));
+
+					});
+
+					$('.import-reagents').click(function() {
+						var macro = prompt("Enter a chemistry macro", "");
+					  var parts = macro.split(';');
+					  var container = $(this).parents('div.container-control')\[0\];
+					  var ul = $(container).find("ul");
+
+					  $(parts).each(function() {
+					  	var reagentArr = this.split('=');
+					    var thisReagent = $(reagents).filter(function() { return this.text.toLowerCase().replace(/\\W/g, '') == reagentArr\[0\] })\[0\];
+					    addReagent(ul, thisReagent.id, thisReagent.text, reagentArr\[1\]);
+					  });
+
+					});
+
+					$('#grenade-type').change(function() {
+						$('.grenade-data').hide();
+					  $('.grenade-data.'+$(this).val()).show();
+					})
+
+					function addReagent(ul, reagentType, reagentName, amount)
+					{
+						$('<li class="reagent" data-type="'+reagentType+'">'+reagentName+'<div><input class="reagent" value="'+amount+'" />&nbsp;&nbsp;<button class="remove-reagent"><i class="far fa-trash-alt"></i>&nbsp;Remove</button></div></li>').insertBefore($(ul).children('li').last());
+					  $(ul).children('li').last().prev().find('button').click(function() { $(this).parents('li').remove(); });
+					}
+
+					function textSelection(selection)
+					{
+					return selection.text;
+					}
+
+					function noEscape(markup)
+					{
+					return markup;
+					}
+
+					function formatReagent(result)
+					{
+					return '<span>'+result.text+'</span><br/><span><small>'+result.id+'</small></span>';
+					}
+
+					function formatContainer(result)
+					{
+					return '<span>'+result.text+" ("+result.volume+'u)</span><br/><span><small>'+result.id+'</small></span>';
+					}
+
+
+			}
+			</script>
+			</head>
+			<body scroll=auto>
+				<div class='uiWrapper'>
+					<div class='uiTitleWrapper'><div class='uiTitle'><tt>Beaker panel</tt></div></div>
+					<div class='uiContent'>
+
+		<div class="width: 100%">
+		  <button id="spawn-grenade">
+		<i class="fas fa-bomb"></i>&nbsp;Spawn grenade
+		  </button>
+			<label for="grenade-type">Grenade type: </label>
+		 <select id="grenade-type">
+			 <option value="normal">Normal</option>
+			 <option value="voice">Voice analyzer</option>
+			 <option value="signaler">Signaler</option>
+		 </select>
+		 <div class="grenade-data normal">
+			 <label for="grenade-timer">Timer: </label>
+			 <input id="grenade-timer" name="grenade-timer" value="30" />
+		 </div>
+		 <div class="grenade-data voice" style="display: none;">
+			 <label for="grenade-voice-mode">Mode</label>
+			 <select id="grenade-voice-mode" name="grenade-voice-mode">
+				 <option value="1">Inclusive</option>
+				 <option value="2">Exclusive</option>
+				 <option value="3">Recognizer</option>
+				 <option value="4">Voice sensor</option>
+			 </select>
+			 <label for="grenade-voice-recording">Name or phrase: </label>
+			 <input id="grenade-voice-recording" name="grenade-voice-recording" />
+		 </div>
+		 <div class="grenade-data signaler" style="display: none;">
+			 <label for="grenade-signaler-frq">Frequency: </label>
+			 <input id="grenade-signaler-frq" name="grenade-signaler-frq" />
+			 <label for="grenade-signaler-code">Code: </label>
+			 <input id="grenade-signaler-code" name="grenade-signaler-code" />
+		 </div>
+			<br />
+<small>note: beakers recommended, other containers may have issues</small>
+		</div>
+
+	"}
+	for (var/i in 1 to 2 )
+		dat += {"
+			<div class="container-control">
+			<h4>
+			Container [i]:
+			</h4>
+			<br />
+			<label for="beaker[i]type">Container type</label>
+			<select name="containertype" id="beaker[i]type"></select>
+			<br />
+			<br />
+			<div>
+			<button class="spawn-container">
+			<i class="fas fa-cog"></i>&nbsp;Spawn
+			  </button>
+			  &nbsp;&nbsp;&nbsp;
+				<button class="import-reagents">
+			<i class="fas fa-file-import"></i>&nbsp;Import
+			  </button>
+			  &nbsp;&nbsp;&nbsp;
+			  <button class="export-reagents">
+			<i class="fas fa-file-export"></i>&nbsp;Export
+			  </button>
+
+			</div>
+				 <ul>
+			  <li>
+
+			    <select class="select-new-reagent"></select><div class="reagent-div"><input style="width: 50%" type="text" name="newreagent" value="40" />&nbsp;&nbsp;<button class="add-reagent">
+			  <i class="fas fa-plus"></i>&nbsp;Add
+			  </button>
+
+			  </div>
+			</li>
+			</ul>
+			</div>
+		"}
+
+	dat += {"
+					</div>
+				</div>
+			</body>
+		</html>
+	"}
+
+	usr << browse(dat, "window=beakerpanel;size=1100x720")

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -27,7 +27,7 @@
 			for (var/i in 1 to 2)
 				grenade.beakers += beaker_panel_create_container(containersdata[i], grenade)
 				reagent_string += " ([grenade.beakers[i].name] [i] : " + pretty_string_from_reagent_list(grenade.beakers[i].reagents.reagent_list) + ");"
-			grenade.stage_change(3) // ready stage
+			grenade.stage_change(GRENADE_READY)
 			var/grenadedata = json_decode(href_list["grenadedata"])
 			switch (href_list["grenadetype"])
 				if ("normal") // Regular cable coil-timed grenade

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -34,25 +34,6 @@
 					var/det_time = text2num(grenadedata["grenade-timer"])
 					if (det_time)
 						grenade.det_time = det_time
-				if ("voice")
-					var/voice_mode = text2num(grenadedata["grenade-voice-mode"])
-					var/recording = grenadedata["grenade-voice-recording"]
-					if (voice_mode && recording)
-						var/obj/item/assembly/voice/voice_analyzer = new
-						voice_analyzer.mode = voice_mode
-						voice_analyzer.recorded = recording
-						voice_analyzer.secured = FALSE // needs to be unsecured  because assembly holder assembly toggles it
-						grenade.nadeassembly = beaker_panel_prep_assembly(voice_analyzer, grenade)
-				if ("signaler")
-					var/frq = format_frequency(grenadedata["grenade-signaler-frq"])
-					var/code = text2num(grenadedata["grenade-signaler-code"])
-					if (frq && code)
-						var/obj/item/assembly/signaler/signaler = new
-						signaler.code = code
-						signaler.frequency = frq
-						signaler.secured = FALSE
-						grenade.nadeassembly = beaker_panel_prep_assembly(signaler, grenade)
-
 			log_game("[key_name(usr)] spawned a [grenade] containing: [reagent_string]")
 
 /datum/admins/proc/beaker_panel_prep_assembly(obj/item/assembly/towrap, grenade)
@@ -284,29 +265,8 @@
 			<label for="grenade-type">Grenade type: </label>
 		 <select id="grenade-type">
 			 <option value="normal">Normal</option>
-			 <option value="voice">Voice analyzer</option>
-			 <option value="signaler">Signaler</option>
 		 </select>
 		 <div class="grenade-data normal">
-			 <label for="grenade-timer">Timer: </label>
-			 <input id="grenade-timer" name="grenade-timer" value="30" />
-		 </div>
-		 <div class="grenade-data voice" style="display: none;">
-			 <label for="grenade-voice-mode">Mode</label>
-			 <select id="grenade-voice-mode" name="grenade-voice-mode">
-				 <option value="1">Inclusive</option>
-				 <option value="2">Exclusive</option>
-				 <option value="3">Recognizer</option>
-				 <option value="4">Voice sensor</option>
-			 </select>
-			 <label for="grenade-voice-recording">Name or phrase: </label>
-			 <input id="grenade-voice-recording" name="grenade-voice-recording" />
-		 </div>
-		 <div class="grenade-data signaler" style="display: none;">
-			 <label for="grenade-signaler-frq">Frequency: </label>
-			 <input id="grenade-signaler-frq" name="grenade-signaler-frq" />
-			 <label for="grenade-signaler-code">Code: </label>
-			 <input id="grenade-signaler-code" name="grenade-signaler-code" />
 		 </div>
 			<br />
 <small>note: beakers recommended, other containers may have issues</small>

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -5,7 +5,7 @@
 	materials = list(/datum/material/iron=800, /datum/material/glass=200)
 	attachable = TRUE
 
-	var/scanning = FALSE
+	var/scanning = TRUE
 	var/health_scan
 	var/alarm_health = HEALTH_THRESHOLD_CRIT
 

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -4,7 +4,6 @@
 	icon_state = "health"
 	materials = list(/datum/material/iron=800, /datum/material/glass=200)
 	attachable = TRUE
-	secured = FALSE
 
 	var/scanning = FALSE
 	var/health_scan
@@ -46,7 +45,6 @@
 	var/atom/A = src
 	if(connected?.holder)
 		A = connected.holder
-
 	for(A, A && !ismob(A), A=A.loc);
 	// like get_turf(), but for mobs.
 	var/mob/living/M = A

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -217,13 +217,13 @@
 	air_contents.gases[/datum/gas/oxygen][MOLES] = (O2STANDARD * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 	air_contents.gases[/datum/gas/nitrogen][MOLES] = (N2STANDARD * maximum_pressure * filled) * air_contents.volume / (R_IDEAL_GAS_EQUATION * air_contents.temperature)
 
-#define HOLDING		(1<<0)
-#define CONNECTED	(1<<1)
-#define EMPTY		(1<<2)
-#define LOW			(1<<3)
-#define MEDIUM		(1<<4)
-#define FULL		(1<<5)
-#define DANGER		(1<<6)
+#define CANISTER_UPDATE_HOLDING		(1<<0)
+#define CANISTER_UPDATE_CONNECTED	(1<<1)
+#define CANISTER_UPDATE_EMPTY		(1<<2)
+#define CANISTER_UPDATE_LOW			(1<<3)
+#define CANISTER_UPDATE_MEDIUM		(1<<4)
+#define CANISTER_UPDATE_FULL		(1<<5)
+#define CANISTER_UPDATE_DANGER		(1<<6)
 /obj/machinery/portable_atmospherics/canister/update_icon()
 	if(stat & BROKEN)
 		cut_overlays()
@@ -234,44 +234,44 @@
 	update = 0
 
 	if(holding)
-		update |= HOLDING
+		update |= CANISTER_UPDATE_HOLDING
 	if(connected_port)
-		update |= CONNECTED
+		update |= CANISTER_UPDATE_CONNECTED
 	var/pressure = air_contents.return_pressure()
 	if(pressure < 10)
-		update |= EMPTY
+		update |= CANISTER_UPDATE_EMPTY
 	else if(pressure < 5 * ONE_ATMOSPHERE)
-		update |= LOW
+		update |= CANISTER_UPDATE_LOW
 	else if(pressure < 10 * ONE_ATMOSPHERE)
-		update |= MEDIUM
+		update |= CANISTER_UPDATE_MEDIUM
 	else if(pressure < 40 * ONE_ATMOSPHERE)
-		update |= FULL
+		update |= CANISTER_UPDATE_FULL
 	else
-		update |= DANGER
+		update |= CANISTER_UPDATE_DANGER
 
 	if(update == last_update)
 		return
 
 	cut_overlays()
-	if(update & HOLDING)
+	if(update & CANISTER_UPDATE_HOLDING)
 		add_overlay("can-open")
-	if(update & CONNECTED)
+	if(update & CANISTER_UPDATE_CONNECTED)
 		add_overlay("can-connector")
-	if(update & LOW)
+	if(update & CANISTER_UPDATE_LOW)
 		add_overlay("can-o0")
-	else if(update & MEDIUM)
+	else if(update & CANISTER_UPDATE_MEDIUM)
 		add_overlay("can-o1")
-	else if(update & FULL)
+	else if(update & CANISTER_UPDATE_FULL)
 		add_overlay("can-o2")
-	else if(update & DANGER)
+	else if(update & CANISTER_UPDATE_DANGER)
 		add_overlay("can-o3")
-#undef HOLDING
-#undef CONNECTED
-#undef EMPTY
-#undef LOW
-#undef MEDIUM
-#undef FULL
-#undef DANGER
+#undef CANISTER_UPDATE_HOLDING
+#undef CANISTER_UPDATE_CONNECTED
+#undef CANISTER_UPDATE_EMPTY
+#undef CANISTER_UPDATE_LOW
+#undef CANISTER_UPDATE_MEDIUM
+#undef CANISTER_UPDATE_FULL
+#undef CANISTER_UPDATE_DANGER
 
 /obj/machinery/portable_atmospherics/canister/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature > temperature_resistance)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44258/
https://github.com/tgstation/tgstation/pull/44485/
https://github.com/tgstation/tgstation/pull/44261

Assemblies can be attached to grenades again, custom timers can be set.

:cl: Naksu and Tlaltecuhtli
refactor: how to make a custom primed grenade now: apply wire, apply beakers, interact with the wire by multitool or hitting the grenade with an assembly, attach assembly to wire.\n
if its an proxy sensor when you prime it it ll activate the activation mode of the sensor with whatever time it was set in the prox sensor ( you can screwdrive to speed set it to 5 or 3 s)\n
if its a timer it ll change the det_time to whatever the timer had( you can screwdriver to speed set it to 5 or 3 s)\n
admin: "Spawn reagent container" verb has been added to the Debug tab. It can be used to spawn reagent containers and grenades with fully customized contents.
/:cl: