### PR TITLE
[PORT] Some ghost improvements (#47700)

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -32,6 +32,7 @@
 /datum/mind
 	var/key
 	var/name				//replaces mob/var/original_name
+	var/ghostname			//replaces name for observers name if set
 	var/mob/living/current
 	var/active = 0
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -84,7 +84,10 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 		gender = body.gender
 		if(body.mind && body.mind.name)
-			name = body.mind.name
+			if(body.mind.ghostname)
+				name = body.mind.ghostname
+			else
+				name = body.mind.name
 		else
 			if(body.real_name)
 				name = body.real_name
@@ -733,6 +736,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set_ghost_appearance()
 	if(client?.prefs)
 		deadchat_name = client.prefs.real_name
+		mind.ghostname = client.prefs.real_name
+		name = client.prefs.real_name
 
 /mob/dead/observer/proc/set_ghost_appearance()
 	if((!client) || (!client.prefs))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -848,6 +848,9 @@
 		return FALSE
 	return ..()
 
+/mob/dead/observer/canface()
+	return TRUE
+
 ///Hidden verb to turn east
 /mob/verb/eastface()
 	set hidden = TRUE


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/47700

Ghosts can now change the direction they are facing by using ctrl+dir.
Ghosts that use the "Restore Ghost Character" verb now has their ghost mobs name changed, and gets it reapplied whenever the ghost is made again for the mind.

## Why It's Good For The Game

Ghosts are people too
## Changelog

:cl: Skoglol
add: Ghosts can now turn using the ctrl + direction hotkeys.
fix: The "Restore Ghost Character" verb now changes the name of your ghost mob as well.
/:cl: