### PR TITLE
Fixes global server bans and adds new config options

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -7,7 +7,7 @@
 
 /datum/config_entry/flag/auto_deadmin_players
 	protection = CONFIG_ENTRY_LOCKED
-	
+
 /datum/config_entry/flag/auto_deadmin_antagonists
 	protection = CONFIG_ENTRY_LOCKED
 
@@ -494,3 +494,7 @@
 
 /datum/config_entry/string/metacurrency_name
 	config_entry_value = "MetaCoin"
+
+/datum/config_entry/flag/grant_metacurency
+
+/datum/config_entry/flag/respect_global_bans

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -495,6 +495,6 @@
 /datum/config_entry/string/metacurrency_name
 	config_entry_value = "MetaCoin"
 
-/datum/config_entry/flag/grant_metacurency
+/datum/config_entry/flag/grant_metacurrency
 
 /datum/config_entry/flag/respect_global_bans

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -38,7 +38,7 @@
 		to_chat(src, "<span class='rose bold'>Your new metacoin balance is [mc_count]!</span>")
 
 /client/proc/inc_metabalance(mc_count, ann=TRUE, reason=null)
-	if(mc_count >= 0 && !CONFIG_GET(flag/grant_metacurency))
+	if(mc_count >= 0 && !CONFIG_GET(flag/grant_metacurrency))
 		return
 	var/datum/DBQuery/query_inc_metacoins = SSdbcore.NewQuery("UPDATE [format_table_name("player")] SET metacoins = metacoins + '[mc_count]' WHERE ckey = '[ckey]'")
 	query_inc_metacoins.warn_execute()

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -38,6 +38,8 @@
 		to_chat(src, "<span class='rose bold'>Your new metacoin balance is [mc_count]!</span>")
 
 /client/proc/inc_metabalance(mc_count, ann=TRUE, reason=null)
+	if(mc_count >= 0 && !CONFIG_GET(flag/grant_metacurency))
+		return
 	var/datum/DBQuery/query_inc_metacoins = SSdbcore.NewQuery("UPDATE [format_table_name("player")] SET metacoins = metacoins + '[mc_count]' WHERE ckey = '[ckey]'")
 	query_inc_metacoins.warn_execute()
 	qdel(query_inc_metacoins)

--- a/config/config.txt
+++ b/config/config.txt
@@ -478,3 +478,11 @@ DEFAULT_VIEW 15x15
 ## Name your perpetual currency here
 ## This is used within the metashop and earned by playing the game.
 METACURRENCY_NAME BeeCoin
+
+## Grant metacurrency
+## Comment this out if you don't want players to earn metacurrency
+GRANT_METACURRENCY
+
+## Respect global bans
+## Comment this out to ignore global bans
+RESPECT_GLOBAL_BANS


### PR DESCRIPTION
Closes #806 

Also fixes global server bans. `IsBanned()` uses `is_banned_with_details()` to check if a player is banned from the server. @MarkSuckerberg only added a global vs local ban check to `is_banned()`, which is only used to check if someone is jobbanned.

## Changelog
:cl:
fix: Players locally banned from one of the servers are no longer globally banned from both servers. This fix applies to all bans retroactively. We apologize for the inconvenience.
config: Added some new config options.
/:cl:
