### PR TITLE
Removes running into walls when confused

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -59,13 +59,6 @@
 		return
 	if (buckled || now_pushing)
 		return
-	if(!ismovableatom(A) || is_blocked_turf(A))  // ported from VORE, sue me
-		if((confused || is_blind()) && stat == CONSCIOUS && m_intent=="run")
-			playsound(get_turf(src), "punch", 25, 1, -1)
-			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
-			apply_damage(5, BRUTE)
-			Paralyze(40)
-
 	if(ismob(A))
 		var/mob/M = A
 		if(MobBump(M))


### PR DESCRIPTION
Confusion no longer causes mobs to run into walls. This means:

- Peacekeeper cyborgs can't use their harm alarm to harm humans.
- Changeling shriek no longer causes people to run into walls, get stunned, and be an easy target for the armblade.
- Flashes aren't an AOE stun.
- Hulks/xenos will no longer repeatedly run into walls and take a huge amount of damage when confused.

This gimmicky mechanic broke too many things and unbalanced combat. Tested and working.
:cl:
remove: Confusion no longer forces mobs to run into walls.
fix: Hulks/xenos will no longer repeatedly run into walls and take a huge amount of damage when confused.
/:cl: