### PR TITLE
Paywall firing pins

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -534,6 +534,15 @@
 /obj/item/storage/box/firingpins/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/firing_pin(src)
+		
+/obj/item/storage/box/firingpins/paywall
+	name = "box of paywall firing pins"
+	desc = "A box full of paywall firing pins, to allow newly-developed firearms to operate behind a custom-set paywall."
+	illustration = "id"
+
+/obj/item/storage/box/firingpins/paywall/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/firing_pin/paywall(src)
 
 /obj/item/storage/box/lasertagpins
 	name = "box of laser tag firing pins"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -394,6 +394,14 @@
 	contains = list(/obj/item/storage/box/firingpins,
 					/obj/item/storage/box/firingpins)
 	crate_name = "firing pins crate"
+	
+/datum/supply_pack/security/firingpins/paywall
+	name = "Paywall Firing Pins Crate"
+	desc = "Specialized firing pins with a built-in configurable paywall. Requires Security access to open."
+	cost = 2500
+	contains = list(/obj/item/storage/box/firingpins/paywall,
+					/obj/item/storage/box/firingpins/paywall)
+	crate_name = "paywall firing pins crate"
 
 /datum/supply_pack/security/justiceinbound
 	name = "Standard Justice Enforcer Crate"

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -185,6 +185,113 @@
 /obj/item/firing_pin/dna/dredd
 	desc = "This is a DNA-locked firing pin which only authorizes one user. Attempt to fire once to DNA-link. It has a small explosive charge on it."
 	selfdestruct = TRUE
+	
+// Paywall pin, brought to you by ARMA 3 DLC.
+// Checks if the user has a valid bank account on an ID and if so attempts to extract a one-time payment to authorize use of the gun. Otherwise fails to shoot.
+/obj/item/firing_pin/paywall
+	name = "paywall firing pin"
+	desc = "A firing pin with a built-in configurable paywall."
+	color = "#FFD700"
+	fail_message = ""
+	var/list/gun_owners = list() //list of people who've accepted the license prompt. If this is the multi-payment pin, then this means they accepted the waiver that each shot will cost them money
+	var/payment_amount //how much gets paid out to license yourself to the gun
+	var/obj/item/card/id/pin_owner
+	var/multi_payment = FALSE //if true, user has to pay everytime they fire the gun
+	var/owned = FALSE
+	var/active_prompt = FALSE //purchase prompt to prevent spamming it
+	
+/obj/item/firing_pin/paywall/attack_self(mob/user)
+	multi_payment = !multi_payment
+	to_chat(user, "<span class='notice'>You set the pin to [( multi_payment ) ? "process payment for every shot" : "one-time license payment"].</span>")
+
+/obj/item/firing_pin/paywall/examine(mob/user)
+	. = ..()
+	if(pin_owner)
+		. += "<span class='notice'>This firing pin is currently authorized to pay into the account of [pin_owner.registered_name].</span>"
+
+/obj/item/firing_pin/paywall/gun_insert(mob/living/user, obj/item/gun/G)
+	if(!pin_owner)
+		to_chat(user, "<span class='warning'>ERROR: Please swipe valid identification card before installing firing pin!</span>")
+		return
+	gun = G
+	forceMove(gun)
+	gun.pin = src
+	if(multi_payment)
+		gun.desc += "<span class='notice'> This [gun.name] has a per-shot cost of [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""].</span>"
+		return
+	gun.desc += "<span class='notice'> This [gun.name] has a license permit cost of [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""].</span>"
+	return
+	
+
+/obj/item/firing_pin/paywall/gun_remove(mob/living/user)
+	gun.desc = initial(desc)
+	..()
+
+/obj/item/firing_pin/paywall/attackby(obj/item/M, mob/user, params)
+	if(istype(M, /obj/item/card/id))
+		var/obj/item/card/id/id = M
+		if(!id.registered_account)
+			to_chat(user, "<span class='warning'>ERROR: Identification card lacks registered bank account!</span>")
+			return
+		if(id != pin_owner && owned)
+			to_chat(user, "<span class='warning'>ERROR: This firing pin has already been authorized!</span>")
+			return
+		if(id == pin_owner)
+			to_chat(user, "<span class='notice'>You unlink the card from the firing pin.</span>")
+			gun_owners -= user
+			pin_owner = null
+			owned = FALSE
+			return
+		var/transaction_amount = input(user, "Insert valid deposit amount for gun purchase", "Money Deposit") as null|num
+		if(transaction_amount < 1)
+			to_chat(user, "<span class='warning'>ERROR: Invalid amount designated.</span>")
+			return
+		if(!transaction_amount)
+			return	
+		pin_owner = id
+		owned = TRUE
+		payment_amount = transaction_amount
+		gun_owners += user
+		to_chat(user, "<span class='notice'>You link the card to the firing pin.</span>")		
+
+/obj/item/firing_pin/paywall/pin_auth(mob/living/user)
+	if(!istype(user))//nice try commie
+		return FALSE
+	if(ishuman(user))
+		var/datum/bank_account/credit_card_details
+		var/mob/living/carbon/human/H = user
+		if(H.get_bank_account())
+			credit_card_details = H.get_bank_account()
+		if(H in gun_owners)
+			if(multi_payment && credit_card_details)
+				if(credit_card_details.adjust_money(-payment_amount))
+					pin_owner.registered_account.adjust_money(payment_amount)
+					return TRUE
+				to_chat(user, "<span class='warning'>ERROR: User balance insufficent for successful transaction!</span>")	
+				return FALSE	
+			return TRUE				
+		if(credit_card_details && !active_prompt)
+			var/license_request = alert(usr, "Do you wish to pay [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""] for [( multi_payment ) ? "each shot of [gun.name]" : "usage license of [gun.name]"]?", "Weapon Purchase", "Yes", "No")
+			active_prompt = TRUE
+			if(!user.canUseTopic(src, BE_CLOSE))
+				active_prompt = FALSE
+				return FALSE
+			switch(license_request)
+				if("Yes")
+					if(credit_card_details.adjust_money(-payment_amount))
+						pin_owner.registered_account.adjust_money(payment_amount)
+						gun_owners += H
+						to_chat(user, "<span class='notice'>Gun license purchased, have a secure day!</span>")
+						active_prompt = FALSE
+						return FALSE //we return false here so you don't click initially to fire, get the prompt, accept the prompt, and THEN the gun
+					to_chat(user, "<span class='warning'>ERROR: User balance insufficent for successful transaction!</span>")
+					return FALSE
+				if("No")
+					to_chat(user, "<span class='warning'>ERROR: User has declined to purchase gun license!</span>")
+					return FALSE
+		to_chat(user, "<span class='warning'>ERROR: User has no valid bank account to substract neccesary funds from!</span>")
+		return FALSE
+
 
 // Laser tag pins
 /obj/item/firing_pin/tag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Shamelessly ported from tgstation/tgstation#45893 and inspired by ARMA 3 where one has to pay to use certain guns.

## About The Pull Request

This PR adds paywall firing pins that can be ordered by cargo. Paywall firing pins can be used in hand to be set to either charge a one time fee to fire a gun or a per-shot fee. Swiping an ID card causes payments to go into the bank account listed on the ID as well as allowing one to customize the amount charged. Works with budget cards as well. 

The firing pin can then be inserted into a firing pinless gun much like a normal firing pin. Examination of the gun reveals cost and if gun is per-shot or not but not which bank account has been set for payment. Attempting to fire the gun either prompts the user for payment of the one-time fee after which the gun will work normally or prompts the user for authorization to subtract money from their bank account on a per-shot basis, after which the gun will not prompt again.

## Why It's Good For The Game

It's a firing pin that charges people to use it. Limitless possibilities! Force sec to pay to use all the guns in the armory, run a gun-store in the commissary or even distribute weapons of war across the station and profit off of the bloodshed! This also incentivizes cargo to actually give guns to other people on-station instead of just keeping all the guns for themselves.

## Changelog
:cl: MMMiracles
add: Paywall firing pins! Force people to properly buy/rent your guns before they try to use them on you! Found where regular firing pins are sold.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
