### PR TITLE
Thrown objects phase through thrower #44208

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -160,7 +160,7 @@ SUBSYSTEM_DEF(throwing)
 /datum/thrownthing/proc/hitcheck()
 	for (var/thing in get_turf(thrownthing))
 		var/atom/movable/AM = thing
-		if (AM == thrownthing)
+		if (AM == thrownthing || (AM == thrower && !ismob(thrownthing)))
 			continue
 		if (AM.density && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags_1 & ON_BORDER_1))
 			finalize(hit=TRUE, target=AM)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -1003,6 +1003,6 @@
 							continue
 						throw_at(Next, 3, 1, D.thrower)
 						return
-					throw_at(D.thrower, 7, 1, D.thrower)
+					throw_at(D.thrower, 7, 1, null)
 	else
 		..()

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -9,7 +9,7 @@
 		var/obj/item/projectile/P = mover
 		return !P.can_hit_target(src, P.permutated, src == P.original, TRUE)
 	if(mover.throwing)
-		return (!density || !(mobility_flags & MOBILITY_STAND))
+		return (!density || !(mobility_flags & MOBILITY_STAND) || (mover.throwing.thrower == src && !ismob(mover)))
 	if(buckled == mover)
 		return TRUE
 	if(ismob(mover))


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44208

## About The Pull Request

Thrown objects don't collide with the (living) mob that threw them
## Why It's Good For The Game

Stops you from hitting yourself throwing while running

fixes #18670

Discussion there called it a hacky fix, but there's been no better fix for multiple years. I personally think it's fine, but even if it wasn't it's not OK to leave the game in a broken state for aesthetic reasons.
## Changelog

:cl: 4dplanner
fix: thrown objects (but not mobs) no longer hit the thrower
fix: mirror shield rebound no longer depends on the original thrower's momentum
/:cl: