### PR TITLE
[PORT] Fix the newline problem in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
 [*]
-insert_final_newline = true
 indent_style = tab
 indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.yml]
 indent_style = space


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
With current editor config, if you have trailing whitespace on final new line, it doesn't get trimmed, and no extra newline gets added, which breaks linters.

Whitespace trimming is good overall. And an additional "utf-8" enforcement.

Webedit kung-fu.

From:https://github.com/tgstation/tgstation/pull/48002
https://github.com/tgstation/tgstation/pull/48002
## Changelog
:cl:
add: Whitespace trimming is good overall. And an additional "utf-8" enforcement.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
