### PR TITLE
[PORT] Health analyzer font scaling hotfix

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -270,24 +270,25 @@ GENE SCANNER
 		if(length(damaged)>0 || oxy_loss>0 || tox_loss>0 || fire_loss>0)
 			// Body part damage report
 			var/list/dmgreport = list()
-			dmgreport += "<table style='margin-left:33px'><tr><font face='Verdana'>\
-							<td style='width: 90px;'><font color='#0000CC'>Damage:</font></td>\
-							<td style='width: 55px;'><font color='red'><b>Brute</b></font></td>\
-							<td style='width: 45px;'><font color='orange'><b>Burn</b></font></td>\
-							<td style='width: 45px;'><font color='green'><b>Toxin</b></font></td>\
-							<td style='width: 90px;'><font color='purple'><b>Suffocation</b></font></td></tr>\
+			dmgreport += "<table style='margin-left:3em'><tr><font face='Verdana'>\
+							<td style='width:7em;'><font color='#0000CC'>Damage:</font></td>\
+							<td style='width:5em;'><font color='red'><b>Brute</b></font></td>\
+							<td style='width:4em;'><font color='orange'><b>Burn</b></font></td>\
+							<td style='width:4em;'><font color='green'><b>Toxin</b></font></td>\
+							<td style='width:8em;'><font color='purple'><b>Suffocation</b></font></td></tr>\
+
 							<tr><td><font color='#0000CC'>Overall:</font></td>\
-							<td><font color='red'>[brute_loss]</font></td>\
-							<td><font color='orange'>[fire_loss]</font></td>\
-							<td><font color='green'>[tox_loss]</font></td>\
-							<td><font color='purple'>[oxy_loss]</font></td></tr>"
+							<td><font color='red'>[round(brute_loss,1)]</font></td>\
+							<td><font color='orange'>[round(fire_loss,1)]</font></td>\
+							<td><font color='green'>[round(tox_loss,1)]</font></td>\
+							<td><font color='purple'>[round(oxy_loss,1)]</font></td></tr>"
 
 			for(var/o in damaged)
 				var/obj/item/bodypart/org = o //head, left arm, right arm, etc.
 				dmgreport += "<tr><td><font color='#0000CC'>[capitalize(org.name)]:</font></td>\
-								<td><font color='red'>[(org.brute_dam > 0) ? "[org.brute_dam]" : "0"]</font></td>\
-								<td><font color='orange'>[(org.burn_dam > 0) ? "[org.burn_dam]" : "0"]</font></td></tr>"
-			dmgreport += "</table>"
+								<td><font color='red'>[(org.brute_dam > 0) ? "[round(org.brute_dam,1)]" : "0"]</font></td>\
+								<td><font color='orange'>[(org.burn_dam > 0) ? "[round(org.burn_dam,1)]" : "0"]</font></td></tr>"
+			dmgreport += "</font></table>"
 			to_chat(user, dmgreport.Join())
 
 	// Species and body temperature


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes my overlook of not making the health analyzer's damage report table scaleable by changing the units from px to em (percent didn't work). Also rounds the damage numbers.
![image](https://user-images.githubusercontent.com/57132226/69890468-9e836780-12d4-11ea-8768-9c9afac7f719.png)

From:https://github.com/tgstation/tgstation/pull/47095
https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29397588
Here's how it looks with a small font:
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
add: Health analyzer font scaling hotfix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
