### PR TITLE
Fix defib paddles burning desync (#44827)

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -40,6 +40,16 @@
 	update_icon()
 	return
 
+/obj/item/defibrillator/fire_act(exposed_temperature, exposed_volume)
+	. = ..()
+	if(paddles?.loc == src)
+		paddles.fire_act(exposed_temperature, exposed_volume)
+
+/obj/item/defibrillator/extinguish()
+	. = ..()
+	if(paddles?.loc == src)
+		paddles.extinguish()
+
 /obj/item/defibrillator/update_icon()
 	update_power()
 	update_overlays()
@@ -285,6 +295,7 @@
 	force = 0
 	throwforce = 6
 	w_class = WEIGHT_CLASS_BULKY
+	resistance_flags = INDESTRUCTIBLE
 
 	var/revivecost = 1000
 	var/cooldown = FALSE
@@ -309,6 +320,12 @@
 /obj/item/twohanded/shockpaddles/Moved()
 	. = ..()
 	check_range()
+
+
+/obj/item/twohanded/shockpaddles/fire_act(exposed_temperature, exposed_volume)
+	. = ..()
+	if((req_defib && defib) && loc != defib)
+		defib.fire_act(exposed_temperature, exposed_volume)
 
 /obj/item/twohanded/shockpaddles/proc/check_range()
 	if(!req_defib)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44827

:cl: ShizCalev
fix: Setting a defibrillator unit on fire will now make it's paddles appear on fire too when pulled out!
fix: Setting defibrillator paddles on fire will now cause the flames to run along it's cables and set the main unit on fire as well.
/:cl: