### PR TITLE
Adds a new server restart option: regular restart with a custom delay time

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -474,7 +474,7 @@
 	if (!usr.client.holder)
 		return
 
-	var/list/options = list("Regular Restart", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
+	var/list/options = list("Regular Restart", "Regular Restart (with delay)", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
 	if(world.TgsAvailable())
 		options += "Server Restart (Kill and restart DD)";
 
@@ -492,6 +492,11 @@
 			switch(result)
 				if("Regular Restart")
 					SSticker.Reboot(init_by, "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", 10)
+				if("Regular Restart (with delay)")
+					var/delay = input("What delay should the restart have (in seconds)?", "Restart Delay", 5) as num|null
+					if(!delay)
+						return FALSE
+					SSticker.Reboot(init_by, "admin reboot - by [usr.key] [usr.client.holder.fakekey ? "(stealth)" : ""]", delay * 10)
 				if("Hard Restart (No Delay, No Feeback Reason)")
 					to_chat(world, "World reboot - [init_by]")
 					world.Reboot()


### PR DESCRIPTION

## About The Pull Request
https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29398601
port: tgstation/tgstation#47870

Exactly what it says on the tin, this adds the ability to restart a server after a delay. The default is 5 seconds but this is an arbitrary value. Tested and working.
## Why It's Good For The Game
Handy for when you're doing a lot of compiling and restarting. You can tell DM to compile and set your restart to roughly the same time. Then your server will restart as DM is done compiling.

## Changelog
:cl: SteelSlayer/Mark Suckerberg
admin: Adds a new server restart option: regular restart with a custom delay time that the user can specify
/:cl: