### PR TITLE
[PORT] Adds a verb to force recreate the chat object #979

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -236,7 +236,22 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 				log_game("GOONCHAT: [key_name(src)] Failed to fix their goonchat window after manually calling start() and forcing a load()")
 
 
-
+/client/verb/force_fix_chat()
+	set name = "Force Recreate Chat"
+	set category = "OOC"
+	var/action = alert(src, "This will force recreate your chat, completely destroying the object and remaking it.\nAre you sure? (All chat history will be lost)", "Warning", "Yes", "No")
+	if(action != "Yes")
+		return
+	// Now we only process if Yes is pressed
+	// Nuke old chat objects
+	winset(src, "output", "is-visible=true;is-disabled=false")
+	winset(src, "browseroutput", "is-visible=false")
+	chatOutput.loaded = FALSE
+	// Now make a new one
+	chatOutput.start()
+	chatOutput.load()
+	alert(src, "Your chat has been force recreated. If this still hasnt fixed issues, please make an issue report, with your BYOND version, Windows version, and IE Version.", "Done", "Ok")
+				
 /client/verb/motd()
 	set name = "MOTD"
 	set category = "OOC"


### PR DESCRIPTION
https://github.com/KeplerStation/KeplerStation/pull/979
https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29934984

## About The Pull Request

This PR adds in a verb which will hard delete a chat object then force recreate it. Sometimes fancy chat fails to load until I manually do the following long-winded procedure:

Fix Chat > Force Reload > Didnt Work > Didnt Work Again > Switch To Old Chat
Fix Chat > Force Reload > Done

This PR adds a verb which does the required steps in less than a second
## Why It's Good For The Game

I should be able to recreate my chat object without having to spend 20 seconds doing it
## Changelog

:cl: AffectedArc07
add: There is now a verb to force-recreate your chat object
/:cl: