### PR TITLE
[PORT] Adds a solo abductor option to traitor panel

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -28,6 +28,10 @@
 	landmark_type = /obj/effect/landmark/abductor/scientist
 	greet_text = "Use your experimental console and surgical equipment to monitor your agent and experiment upon abducted humans."
 	show_in_antagpanel = TRUE
+	
+/datum/antagonist/abductor/scientist/onemanteam
+	name = "Abductor Solo"
+	outfit = /datum/outfit/abductor/scientist/onemanteam
 
 /datum/antagonist/abductor/create_team(datum/team/abductor_team/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -54,3 +54,16 @@
 	if(!visualsOnly)
 		var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(H)
 		beamplant.implant(H)
+
+/datum/outfit/abductor/scientist/onemanteam
+	name = "Abductor Scientist (w/ agent gear)"
+	head = /obj/item/clothing/head/helmet/abductor
+	suit = /obj/item/clothing/suit/armor/abductor/vest
+	suit_store = /obj/item/abductor/baton
+	belt = /obj/item/storage/belt/military/abductor/full
+
+	backpack_contents = list(
+	/obj/item/abductor/gizmo = 1,
+	/obj/item/gun/energy/alien = 1,
+	/obj/item/abductor/silencer = 1
+	)


### PR DESCRIPTION
tgstation/tgstation/pull/48034

## About The Pull Request

For when admins tc trade for solo abductor, makes it a bit easier on them.

If anything else is missing from traitor panel, now's your time.

## Why It's Good For The Game

Happy admins, happy life.

## Changelog
:cl:
Skoglol
admin: Admins can now pick solo abductor in traitor panel.
/:cl:
