### PR TITLE
Throatslicing, take II

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -141,6 +141,7 @@
 #define COMSIG_MOB_HUD_CREATED "mob_hud_created"				//! from base of mob/create_mob_hud(): ()
 #define COMSIG_MOB_ATTACK_HAND "mob_attack_hand"				//! from base of
 #define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"				//! from base of /obj/item/attack(): (mob/M, mob/user)
+	#define COMPONENT_ITEM_NO_ATTACK 1
 #define COMSIG_MOB_APPLY_DAMGE	"mob_apply_damage"				//! from base of /mob/living/proc/apply_damage(): (damage, damagetype, def_zone)
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"		//! from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"			//! from base of mob/RangedAttack(): (atom/A, params)

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -77,6 +77,8 @@
 
 #define STATUS_EFFECT_SAWBLEED /datum/status_effect/saw_bleed //! if the bleed builds up enough, takes a ton of damage
 
+#define STATUS_EFFECT_NECKSLICE /datum/status_effect/neck_slice //Creates the flavor messages for the neck-slice
+
 #define STATUS_EFFECT_NECROPOLIS_CURSE /datum/status_effect/necropolis_curse
 #define CURSE_BLINDING	1 //! makes the edges of the target's screen obscured
 #define CURSE_SPAWNING	2 //! spawns creatures that attack the target only

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -55,7 +55,8 @@
 
 
 /obj/item/proc/attack(mob/living/M, mob/living/user)
-	SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK, M, user) & COMPONENT_ITEM_NO_ATTACK)
+		return
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK, M, user)
 	if(item_flags & NOBLUDGEON)
 		return

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -46,7 +46,7 @@
 /datum/component/butchering/proc/startNeckSlice(obj/item/source, mob/living/carbon/human/H, mob/living/user)
 	user.visible_message("<span class='danger'>[user] is slitting [H]'s throat!</span>", \
 					"<span class='danger'>You start slicing [H]'s throat!</span>", \
-					"<span class='hear'>You hear a cutting noise!</span>", ignored_mobs = H)
+					"<span class='hear'>You hear a cutting noise!</span>")
 	H.show_message("<span class='userdanger'>Your throat is being slit by [user]!</span>", \
 					"<span class = 'userdanger'>Something is cutting into your neck!</span>", NONE)
 

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -4,8 +4,9 @@
 	var/bonus_modifier = 0 //percentage increase to bonus item chance
 	var/butcher_sound = 'sound/weapons/slice.ogg' //sound played when butchering
 	var/butchering_enabled = TRUE
+	var/can_be_blunt = FALSE
 
-/datum/component/butchering/Initialize(_speed, _effectiveness, _bonus_modifier, _butcher_sound, disabled)
+/datum/component/butchering/Initialize(_speed, _effectiveness, _bonus_modifier, _butcher_sound, disabled, _can_be_blunt)
 	if(_speed)
 		speed = _speed
 	if(_effectiveness)
@@ -16,6 +17,51 @@
 		butcher_sound = _butcher_sound
 	if(disabled)
 		butchering_enabled = FALSE
+	if(_can_be_blunt)
+		can_be_blunt = _can_be_blunt
+	if(isitem(parent))
+		RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/onItemAttack)		
+
+/datum/component/butchering/proc/onItemAttack(obj/item/source, mob/living/M, mob/living/user)
+	if(user.a_intent == INTENT_HARM && M.stat == DEAD && (M.butcher_results || M.guaranteed_butcher_results)) //can we butcher it?
+		if(butchering_enabled && (can_be_blunt || source.is_sharp()))
+			INVOKE_ASYNC(src, .proc/startButcher, source, M, user)
+			return COMPONENT_ITEM_NO_ATTACK
+	if(user.a_intent == INTENT_HARM && ishuman(M) && source.is_sharp())
+		var/mob/living/carbon/human/H = M
+		if(H.has_status_effect(/datum/status_effect/neck_slice))
+			user.show_message("<span class='danger'>[H]'s neck has already been already cut, you can't make the bleeding any worse!", \
+							"<span class='danger'>Their neck has already been already cut, you can't make the bleeding any worse!")
+			return COMPONENT_ITEM_NO_ATTACK
+		if((H.health <= H.crit_threshold || (user.pulling == H && user.grab_state >= GRAB_NECK) || H.IsSleeping()) && user.zone_selected == BODY_ZONE_HEAD) // Only sleeping, neck grabbed, or crit, can be sliced.
+			INVOKE_ASYNC(src, .proc/startNeckSlice, source, H, user)
+			return COMPONENT_ITEM_NO_ATTACK
+
+/datum/component/butchering/proc/startButcher(obj/item/source, mob/living/M, mob/living/user)
+	to_chat(user, "<span class='notice'>You begin to butcher [M]...</span>")
+	playsound(M.loc, butcher_sound, 50, TRUE, -1)
+	if(do_mob(user, M, speed) && M.Adjacent(source))
+		Butcher(user, M)
+
+/datum/component/butchering/proc/startNeckSlice(obj/item/source, mob/living/carbon/human/H, mob/living/user)
+	user.visible_message("<span class='danger'>[user] is slitting [H]'s throat!</span>", \
+					"<span class='danger'>You start slicing [H]'s throat!</span>", \
+					"<span class='hear'>You hear a cutting noise!</span>", ignored_mobs = H)
+	H.show_message("<span class='userdanger'>Your throat is being slit by [user]!</span>", \
+					"<span class = 'userdanger'>Something is cutting into your neck!</span>", NONE)
+
+	playsound(H.loc, butcher_sound, 50, TRUE, -1)
+	if(do_mob(user, H, CLAMP(500 / source.force, 30, 100)) && H.Adjacent(source))
+		if(H.has_status_effect(/datum/status_effect/neck_slice))
+			user.show_message("<span class='danger'>[H]'s neck has already been already cut, you can't make the bleeding any worse!", \
+							"<span class='danger'>Their neck has already been already cut, you can't make the bleeding any worse!")
+			return
+
+		H.visible_message("<span class='danger'>[user] slits [H]'s throat!</span>", \
+					"<span class='userdanger'>[user] slits your throat...</span>")
+		H.apply_damage(source.force, BRUTE, BODY_ZONE_HEAD)
+		H.bleed_rate = CLAMP(H.bleed_rate + 20, 0, 30)
+		H.apply_status_effect(/datum/status_effect/neck_slice)
 
 /datum/component/butchering/proc/Butcher(mob/living/butcher, mob/living/meat)
 	var/turf/T = meat.drop_location()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -461,6 +461,19 @@
 	else
 		new /obj/effect/temp_visual/bleed(get_turf(owner))
 
+/datum/status_effect/neck_slice
+	id = "neck_slice"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = null
+	duration = -1
+
+/datum/status_effect/neck_slice/tick()
+	var/mob/living/carbon/human/H = owner
+	if(H.stat == DEAD || H.bleed_rate <= 8)
+		H.remove_status_effect(/datum/status_effect/neck_slice)
+	if(prob(10))
+		H.emote(pick("gasp", "gag", "choke"))
+
 /mob/living/proc/apply_necropolis_curse(set_curse)
 	var/datum/status_effect/necropolis_curse/C = has_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE)
 	if(!set_curse)


### PR DESCRIPTION

## About The Pull Request
https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29406288
Port:tgstation/tgstation#46838
Lets you cut someone's throat under certain conditions. Higher damage weapons get the job done faster. Weapon must be sharp, of course.

* Neck grab
* Critical
* Unconsciousness

The bleeding rate is 2.5x Heparin, for comparison.

For me at least, it is a little annoying that there is no way to execute someone in a quick, decisive action with a melee weapon and I am instead stuck stabbing them until they go horizontal. I can go get a gun and do the special execution action, but that's no fun.



## Why It's Good For The Game
It's cool, and it's a much needed way to execute someone a bit faster besides the long and lengthy gun execution.

## Changelog
:cl: Fhaxiris, Mark Suckerberg
add: You cut slice peoples throats now. Select the head on harm intent while they are sleeping, in critical, or neck grabbed.
/:cl:


