### PR TITLE
recycler safe mode is now safe  (#46395)

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -116,7 +116,7 @@
 		if(brain_holder)
 			emergency_stop(AM)
 		else if(isliving(AM))
-			if((obj_flags & EMAGGED)||((!allowed(AM))&&(!ishuman(AM))))
+			if(obj_flags & EMAGGED)
 				crush_living(AM)
 			else
 				emergency_stop(AM)
@@ -173,7 +173,6 @@
 	else
 		playsound(src, 'sound/effects/splat.ogg', 50, 1)
 
-	// By default, the emagged recycler will gib all non-carbons. (human simple animal mobs don't count)
 	if(iscarbon(L))
 		if(L.stat == CONSCIOUS)
 			L.say("ARRRRRRRRRRRGH!!!", forced="recycler grinding")


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/46395/files

## About The Pull Request

the nonemagged recycler now doesnt consume mobs
## Why It's Good For The Game

most players dont know about it at all and run into the recycler as a stand, xeno, monkey, instantly dying
## Changelog

🆑
balance: the recycler when not emagged wont grind any mobs anymore
/🆑