### PR TITLE
Add log message when player dies (#44855)

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -58,6 +58,7 @@
 
 	if(SSticker.HasRoundStarted())
 		SSblackbox.ReportDeath(src)
+		log_game("[key_name(src)] has died (BRUTE: [src.getBruteLoss()], BURN: [src.getFireLoss()], TOX: [src.getToxLoss()], OXY: [src.getOxyLoss()], CLONE: [src.getCloneLoss()]) ([AREACOORD(src)])")
 	if(is_devil(src))
 		INVOKE_ASYNC(is_devil(src), /datum/antagonist/devil.proc/beginResurrectionCheck, src)
 	if(is_hivemember(src))


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44855/

Logs a message upon player with with name, location, and damage. I
elected to put this in game over attack as it feels more relevant to
game.

:cl: bobbahbrown
tweak: Deaths are now logged to the game log.
/:cl: