### PR TITLE
Don't teleport anchored objs (#46646)

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -167,6 +167,8 @@
 					on_chair = " (on a chair)"
 				else
 					continue
+			else
+				continue
 		if(!first)
 			log_msg += ", "
 		if(ismob(ROI))


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/46646

## About The Pull Request

Fix telepad's bug, that make able to teleport anchored objs. Was buggy because it could teleport things like air alarms, APCs, and windows.

## Changelog

:cl: Archemagus
fix: Telepad can't move airlocks and other anchored objs!
/:cl: