### PR TITLE
SImplemob Limiters

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -230,7 +230,7 @@
 #define GALOSHES_DONT_HELP		(1<<2)
 #define SLIDE_ICE				(1<<3)
 
-#define MAX_CHICKENS 50
+
 
 
 #define INCORPOREAL_MOVE_BASIC 1

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -27,3 +27,8 @@ GLOBAL_VAR(bible_icon_state)
 GLOBAL_VAR(bible_item_state)
 GLOBAL_VAR(holy_weapon_type)
 GLOBAL_VAR(holy_armor_type)
+
+// Monkeycube/chicken/slime spam prevention
+GLOBAL_VAR_INIT(total_cube_monkeys, 0)
+GLOBAL_VAR_INIT(total_chickens, 0)
+GLOBAL_VAR_INIT(total_slimes, 0)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -379,16 +379,12 @@
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM
 
-/datum/config_entry/number/monkeycap
-	config_entry_value = 64
-	min_val = 0
-
 /datum/config_entry/flag/allow_crew_objectives
 
 //Mob spam prevention
-CONFIG_DEF(number/max_cube_monkeys)
-	value = 100
-CONFIG_DEF(number/max_chickens)
-	value = 100
-CONFIG_DEF(number/max_slimes)
-	value = 100
+/datum/config_entry/number/max_cube_monkeys
+	config_entry_value = 100
+/datum/config_entry/number/max_chickens
+	config_entry_value = 100
+/datum/config_entry/number/max_slimes
+	config_entry_value = 100

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -384,3 +384,11 @@
 	min_val = 0
 
 /datum/config_entry/flag/allow_crew_objectives
+
+//Mob spam prevention
+CONFIG_DEF(number/max_cube_monkeys)
+	value = 100
+CONFIG_DEF(number/max_chickens)
+	value = 100
+CONFIG_DEF(number/max_slimes)
+	value = 100

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -193,6 +193,9 @@
 	var/spawned_mob = /mob/living/carbon/monkey
 
 /obj/item/reagent_containers/food/snacks/monkeycube/proc/Expand()
+	if(GLOB.total_cube_monkeys >= CONFIG_GET(number/max_cube_monkeys))
+		visible_message("<span class='warning'>[src] refuses to expand!</span>")
+		return
 	var/mob/spammer = get_mob_by_key(fingerprintslast)
 	var/mob/living/bananas = new spawned_mob(drop_location(), TRUE, spammer)
 	if(faction)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -31,7 +31,7 @@
 	. = ..()
 
 	if (cubespawned)
-		var/cap = CONFIG_GET(number/monkeycap)
+		var/cap = CONFIG_GET(number/max_cube_monkeys)
 		if (LAZYLEN(SSmobs.cubemonkeys) > cap)
 			if (spawner)
 				to_chat(spawner, "<span class='warning'>Bluespace harmonics prevent the spawning of more than [cap] monkeys on the station at one time!</span>")

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -177,3 +177,19 @@
 		var/obj/item/clothing/head/helmet/justice/escape/helmet = new(src)
 		equip_to_slot_or_del(helmet,SLOT_HEAD)
 		helmet.attack_self(src) // todo encapsulate toggle
+
+
+//Special monkeycube subtype to track the number of them and prevent spam
+/mob/living/carbon/monkey/cube/Initialize()
+	. = ..()
+	GLOB.total_cube_monkeys++
+
+/mob/living/carbon/monkey/cube/death(gibbed)
+	GLOB.total_cube_monkeys--
+	..()
+
+//In case admins delete them before they die
+/mob/living/carbon/monkey/cube/Destroy()
+	if(stat != DEAD)
+		GLOB.total_cube_monkeys--
+	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -156,7 +156,7 @@
 	cats_deployed = 1
 	for(var/cat_type in family)
 		if(family[cat_type] > 0)
-			for(var/i in 1 to min(family[cat_type],100)) //Limits to about 500 cats, you wouldn't think this would be needed (BUT IT IS)
+			for(var/i in 1 to min(family[cat_type],25)) //Limits to about 25 cats, whoever thought leaving the max at 500 was a genius. Prevents catsplosions.
 				new cat_type(loc)
 
 /mob/living/simple_animal/pet/cat/Proc

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -217,6 +217,7 @@
 	. = ..()
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
+	GLOB.total_chickens++
 
 /mob/living/simple_animal/chick/Life()
 	. =..()
@@ -227,6 +228,15 @@
 		if(amount_grown >= 100)
 			new /mob/living/simple_animal/chicken(src.loc)
 			qdel(src)
+
+/mob/living/simple_animal/chick/death(gibbed)
+	GLOB.total_chickens--
+	..()
+
+/mob/living/simple_animal/chick/Destroy()
+	if(stat != DEAD)
+		GLOB.total_chickens--
+	return ..()
 
 /mob/living/simple_animal/chick/holo/Life()
 	..()
@@ -280,10 +290,15 @@
 	icon_dead = "[icon_prefix]_[body_color]_dead"
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
-	++chicken_count
+	GLOB.total_chickens++
+
+/mob/living/simple_animal/chicken/death(gibbed)
+	GLOB.total_chickens--
+	..()
 
 /mob/living/simple_animal/chicken/Destroy()
-	--chicken_count
+	if(stat != DEAD)
+		GLOB.total_chickens--
 	return ..()
 
 /mob/living/simple_animal/chicken/attackby(obj/item/O, mob/user, params)
@@ -302,14 +317,14 @@
 	. =..()
 	if(!.)
 		return
-	if((!stat && prob(3) && eggsleft > 0) && egg_type)
-		visible_message("<span class='alertalien'>[src] [pick(layMessage)]</span>")
+	if((!stat && prob(3) && eggsleft > 0) && egg_type && GLOB.total_chickens < CONFIG_GET(number/max_chickens))
+		visible_message("[src] [pick(layMessage)]")
 		eggsleft--
 		var/obj/item/E = new egg_type(get_turf(src))
 		E.pixel_x = rand(-6,6)
 		E.pixel_y = rand(-6,6)
 		if(eggsFertile)
-			if(chicken_count < MAX_CHICKENS && prob(25))
+			if(prob(25))
 				START_PROCESSING(SSobj, E)
 
 /obj/item/reagent_containers/food/snacks/egg/var/amount_grown = 0

--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -21,6 +21,7 @@
 	if(buckled)
 		Feedstop(silent = TRUE) //releases ourselves from the mob we fed on.
 
+	GLOB.total_slimes--
 	stat = DEAD
 	cut_overlays()
 
@@ -32,3 +33,12 @@
 /mob/living/simple_animal/slime/gib()
 	death(TRUE)
 	qdel(src)
+
+
+/mob/living/simple_animal/slime/Destroy()
+	for(var/obj/machinery/computer/camera_advanced/xenobio/X in GLOB.machines)
+		if(src in X.stored_slimes)
+			X.stored_slimes -= src
+	if(stat != DEAD)
+		GLOB.total_slimes--
+	return ..()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -171,7 +171,9 @@
 			if(stat)
 				to_chat(src, "<i>I must be conscious to do this...</i>")
 				return
-
+			if(GLOB.total_slimes >= CONFIG_GET(number/max_slimes))
+				to_chat(src, "<i>There are too many of us...</i>")
+				return
 			var/list/babies = list()
 			var/new_nutrition = round(nutrition * 0.9)
 			var/new_powerlevel = round(powerlevel / 4)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -83,6 +83,7 @@
 
 
 /mob/living/simple_animal/slime/Initialize(mapload, new_colour="grey", new_is_adult=FALSE)
+	GLOB.total_slimes++
 	var/datum/action/innate/slime/feed/F = new
 	F.Grant(src)
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -553,11 +553,13 @@ ROUNDSTART_TRAITS
 ## Sets shift time to server time at roundstart. Overridden by RANDOMIZE_SHIFT_TIME ##
 #SHIFT_TIME_REALTIME
 
-## A cap on how many monkeys may be created via monkey cubes
-MONKEYCAP 64
-
 ## Enable the capitalist agenda on your server.
 ECONOMY
 
 ## Crew objectives
 ALLOW_CREW_OBJECTIVES
+
+## Mob spam prevention. The number of each mobtype that can be alive at once. Stops people from crashing the server with chickens/monkeycubes/slimes. Altering these values is recommended based on server hardware.
+MAX_CUBE_MONKEYS 100
+MAX_CHICKENS 100
+MAX_SLIMES 100


### PR DESCRIPTION
## About The Pull Request
a port of OracleStation/OracleStation#581, which sets a maximum cap for monkies, chickens, and slimes. Currently set to 100 for each by default.
and a fix for catsplosions. Tested and seems to be working.

## Why It's Good For The Game
lag is bad

crashing the server is bad

## Changelog
:cl:
tweak: There is now a cap on the number of chickens, slimes, and monkeycube monkeys that can be alive at once. No more crashing the server with 200 monkeys/chickens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
