### PR TITLE
Changed delay round end to +ADMIN

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -599,7 +599,7 @@
 		check_antagonists()
 
 	else if(href_list["delay_round_end"])
-		if(!check_rights(R_SERVER))
+		if(!check_rights(R_ADMIN))
 			return
 		if(!SSticker.delay_end)
 			SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text


### PR DESCRIPTION
## About The Pull Request
Changed the permission needed to delay the round end for whatever reason from +SERVER to +ADMIN.

## Why It's Good For The Game
I'm tired as hell of joining a server for 10 seconds just to delay a round because only trial admins are on and tickets are taking forever. It hasn't been happening lately, but this will prevent that from ever happening again.

## Changelog
:cl:
admin: Trialmins and any other admin with +ADMIN can now delay round end instead of needing +SERVER.
/:cl:
