### PR TITLE
[PORT] Fixes R&D Materials Exploit.

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -62,7 +62,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/datum/component/material_container/storage = linked_console?.linked_lathe?.materials.mat_container
 	if(storage) //Also sends salvaged materials to a linked protolathe, if any.
 		for(var/material in thing.materials)
-			var/can_insert = min((storage.max_amount - storage.total_amount), (min(thing.custom_materials[material]*(decon_mod/10), thing.custom_materials[material])))
+			var/can_insert = min((storage.max_amount - storage.total_amount), (min(thing.materials[material]*(decon_mod/10), thing.materials[material])))
 			storage.insert_amount_mat(can_insert, material)
 			. += can_insert
 		if (.)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -62,7 +62,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/datum/component/material_container/storage = linked_console?.linked_lathe?.materials.mat_container
 	if(storage) //Also sends salvaged materials to a linked protolathe, if any.
 		for(var/material in thing.materials)
-			var/can_insert = min((storage.max_amount - storage.total_amount), (max(thing.materials[material]*(decon_mod/10), thing.materials[material])))
+			var/can_insert = min((storage.max_amount - storage.total_amount), (min(thing.custom_materials[material]*(decon_mod/10), thing.custom_materials[material])))
 			storage.insert_amount_mat(can_insert, material)
 			. += can_insert
 		if (.)


### PR DESCRIPTION
## About The Pull Request
Fixes being able to exploit fully upgraded destructive analyzers to multiply materials

From:https://github.com/tgstation/tgstation/pull/47174
https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29397741

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes being able to exploit fully upgraded destructive analyzers to multiply materials
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
