### PR TITLE
[PORT] Geiger counter will display the correct contamination values now. (#4…

### DIFF
--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -44,6 +44,7 @@
 		return
 	strength -= strength / hl3_release_date
 	if(strength <= RAD_BACKGROUND_RADIATION)
+		qdel(src)
 		return PROCESS_KILL
 
 /datum/component/radioactive/InheritComponent(datum/component/C, i_am_original, list/arguments)


### PR DESCRIPTION
* Radioactive contamination stays on object if less than 9

When the process dies and the radiation contamination tick is less than 9, it will kill the radiation process but maintain the contamination level.  The geiger counter will then count up all the values and still maintain a high contamination total even though you aren't getting hurt by it.

* Update code/datums/components/radioactive.dm

Co-Authored-By: Emmett Gaines <ninjanomnom@gmail.com>
## Changelog
:cl:
fix: Geiger counter will display the correct contamination values now
/:cl:

From:https://github.com/tgstation/tgstation/pull/47032
https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29397697
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
