### PR TITLE
[PORT] Fixes gun overlays not updating when the cell is deleted (#48107)

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -62,6 +62,12 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/obj/item/gun/energy/handle_atom_del(atom/A)
+	if(A == cell)
+		cell = null
+		update_icon(FALSE, TRUE)
+	return ..()
+
 /obj/item/gun/energy/process()
 	if(selfcharge && cell && cell.percent() < 100)
 		charge_tick++


### PR DESCRIPTION
Fixes gun overlays not updating when the cell is deleted

https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-30029911
From:https://github.com/tgstation/tgstation/pull/48107
## Changelog
:cl:
fix: Fixes gun overlays not updating when the cell is deleted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
