### PR TITLE
Radio jammers jam the radio more (#44313)

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -237,13 +237,12 @@
 		freq = frequency
 		channel = null
 
-	// Nearby active jammers severely gibberish the message
+	// Nearby active jammers prevent the message from transmitting
 	var/turf/position = get_turf(src)
 	for(var/obj/item/jammer/jammer in GLOB.active_jammers)
 		var/turf/jammer_turf = get_turf(jammer)
-		if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) < jammer.range))
-			message = Gibberish(message,100)
-			break
+		if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
+			return
 
 	// Determine the identity information which will be attached to the signal.
 	var/atom/movable/virtualspeaker/speaker = new(null, M, src)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44313

Now radio jammers fully prevent outgoing communication. Radio jammers had an issue where if you spammed chat your message would eventually go through in a way that didn't jam the important words. Now, it's impossible to do that. This should also make the jammer not hilariously bad for it's price.

:cl: ghost
balance: Radio jammers fully halt outgoing communications now.
/:cl: