### PR TITLE
Deletes a single pipe on BoxStation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -51544,9 +51544,6 @@
 /area/engine/engineering)
 "cGu" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},


### PR DESCRIPTION
I fix what's mine and fix some more.

:cl:
fix: Deletes the visible pipe corner by the BoxStation engine.
/:cl: