### PR TITLE
Fixes windoors bump/hand interactions #44205

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -169,7 +169,7 @@
 			open()
 		else
 			close()
-		return
+		return TRUE
 	if(density)
 		do_animate("deny")
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -55,12 +55,15 @@
 		icon_state = "[base_state]open"
 
 /obj/machinery/door/window/proc/open_and_close()
-	open()
+	if(!open())
+		return
+	autoclose = TRUE
 	if(check_access(null))
 		sleep(50)
 	else //secure doors close faster
 		sleep(20)
-	close()
+	if(!density && autoclose) //did someone change state while we slept?
+		close()
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
 	if( operating || !density )
@@ -282,6 +285,10 @@
 
 /obj/machinery/door/window/interact(mob/user)		//for sillycones
 	try_to_activate_door(user)
+
+/obj/machinery/door/window/try_to_activate_door(mob/user)
+	if (..())
+		autoclose = FALSE
 
 /obj/machinery/door/window/try_to_crowbar(obj/item/I, mob/user)
 	if(!hasPower())


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44205

## About The Pull Request

If you bump into a windoor, you currently have to wait until it closes before you can manually open it to keep it open, or it autocloses anyway. This makes windoors only auto close from bumping if noone has closed it manually already.
## Why It's Good For The Game

Bug fix
## Changelog

:cl: kriskog
fix: windoors can now be closed manually after bumping open without having them close again.
/:cl: