### PR TITLE
Traitor Panel now shows the names of blood brothers' brothers. (#44040)

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -31,15 +31,12 @@
 	owner.special_role = null
 	return ..()
 
-/datum/antagonist/brother/proc/give_meeting_area()
-	if(!owner.current || !team || !team.meeting_area)
-		return
-	to_chat(owner.current, "<B>Your designated meeting area:</B> [team.meeting_area]")
-	antag_memory += "<b>Meeting Area</b>: [team.meeting_area]<br>"
+/datum/antagonist/brother/antag_panel_data()
+	return "Conspirators : [get_brother_names()]]"
 
-/datum/antagonist/brother/greet()
-	var/brother_text = ""
+/datum/antagonist/brother/proc/get_brother_names()
 	var/list/brothers = team.members - owner
+	var/brother_text = ""
 	for(var/i = 1 to brothers.len)
 		var/datum/mind/M = brothers[i]
 		brother_text += M.name
@@ -47,6 +44,16 @@
 			brother_text += " and "
 		else if(i != brothers.len)
 			brother_text += ", "
+	return brother_text
+
+/datum/antagonist/brother/proc/give_meeting_area()
+	if(!owner.current || !team || !team.meeting_area)
+		return
+	to_chat(owner.current, "<B>Your designated meeting area:</B> [team.meeting_area]")
+	antag_memory += "<b>Meeting Area</b>: [team.meeting_area]<br>"
+
+/datum/antagonist/brother/greet()
+	var/brother_text = get_brother_names()
 	to_chat(owner.current, "<span class='alertsyndie'>You are the [owner.special_role] of [brother_text].</span>")
 	to_chat(owner.current, "The Syndicate only accepts those that have proven themselves. Prove yourself and prove your [team.member_name]s by completing your objectives together!")
 	owner.announce_objectives()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44040

## About The Pull Request

Exactly what it says in the title, TP now lists blood brothers' names.
## Why It's Good For The Game

Because it helps admins doing investigations and looking in TP. Feel free to suggest other antag shit that should be in TP and isn't.
## Changelog

:cl: harmonyn
admin: TP now shows the names of blood brothers' brothers.
/:cl: