### PR TITLE
Let service techfab make power cells (#44048)

### DIFF
--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -11,7 +11,7 @@
 	construction_time=100
 	build_path = /obj/item/stock_parts/cell/empty
 	category = list("Misc","Power Designs","Machinery","initial")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/high_cell
 	name = "High-Capacity Power Cell"


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44048

## About The Pull Request

Gives the service techfab the ability to make the first three tiers of power cell.
Why It's Good For The Game

Service techfab allows the printing of a few circuits (booze and soda dispensers, notably) that require the use of power cells to actually build. This allows them to print said power cells, rather than being able to make everything else possible then go to engineering or science and ask for a power cell.
## Changelog

:cl: Putnam3145
tweak: All departments can now print basic power cells from their respective techfab.
/:cl: