### PR TITLE
Stops corpses from receiving new information about their damaged brain #44028

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -242,12 +242,13 @@
 			else
 				gain_trauma_type(BRAIN_TRAUMA_SEVERE)
 
-	if(prev_brainloss < BRAIN_DAMAGE_MILD && brainloss >= BRAIN_DAMAGE_MILD)
-		to_chat(src, "<span class='warning'>You feel lightheaded.</span>")
-	else if(prev_brainloss < BRAIN_DAMAGE_SEVERE && brainloss >= BRAIN_DAMAGE_SEVERE)
-		to_chat(src, "<span class='warning'>You feel less in control of your thoughts.</span>")
-	else if(prev_brainloss < (BRAIN_DAMAGE_DEATH - 20) && brainloss >= (BRAIN_DAMAGE_DEATH - 20))
-		to_chat(src, "<span class='warning'>You can feel your mind flickering on and off...</span>")
+	if (stat < UNCONSCIOUS) // conscious or soft-crit
+		if(prev_brainloss < BRAIN_DAMAGE_MILD && brainloss >= BRAIN_DAMAGE_MILD)
+			to_chat(src, "<span class='warning'>You feel lightheaded.</span>")
+		else if(prev_brainloss < BRAIN_DAMAGE_SEVERE && brainloss >= BRAIN_DAMAGE_SEVERE)
+			to_chat(src, "<span class='warning'>You feel less in control of your thoughts.</span>")
+		else if(prev_brainloss < (BRAIN_DAMAGE_DEATH - 20) && brainloss >= (BRAIN_DAMAGE_DEATH - 20))
+			to_chat(src, "<span class='warning'>You can feel your mind flickering on and off...</span>")
 
 /mob/living/carbon/setBrainLoss(amount)
 	var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44028

Stops corpses from receiving new information about their damaged brain

:cl: Naksu
fix: corpses no longer feel, light-headed or otherwise
/:cl: