### PR TITLE
Colossus chest ignores colossus bolts (#44050)

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1057,6 +1057,11 @@
 /obj/structure/closet/crate/necropolis/colossus
 	name = "colossus chest"
 
+/obj/structure/closet/crate/necropolis/colossus/bullet_act(obj/item/projectile/P)
+	if(istype(P, /obj/item/projectile/colossus))
+		return BULLET_ACT_FORCE_PIERCE
+	return ..()
+
 /obj/structure/closet/crate/necropolis/colossus/PopulateContents()
 	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
 	var/random_crystal = pick(choices)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/44050

## Why It's Good For The Game

Colossus can smash its own chest with some projectile lag, destroying all its loot
fixes #44030

## Changelog

:cl: 4dplanner
tweak: colossus chest is intangible to colossus bolts
/:cl: