### PR TITLE
Silicon reach increased #47510

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -583,7 +583,7 @@
 	if(user)
 		if(message)
 			if(authenticated)
-				if(user.canUseTopic(src, BE_CLOSE))
+				if(user.canUseTopic(src, !issilicon(user)))
 					if(!record1 || record1 == active1)
 						if(!record2 || record2 == active2)
 							return 1

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -816,7 +816,7 @@ What a mess.*/
 /obj/machinery/computer/secure_data/proc/canUseSecurityRecordsConsole(mob/user, message1 = 0, record1, record2)
 	if(user)
 		if(authenticated)
-			if(user.canUseTopic(src, BE_CLOSE))
+			if(user.canUseTopic(src, !issilicon(user)))
 				if(!trim(message1))
 					return 0
 				if(!record1 || record1 == active1)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/47510

Missed a follow up, again.
Closes #964

## About The Pull Request

Silicons no longer need to be next to security or medical records consoles to use them.
## Why It's Good For The Game

Fixes #47509
Fixes #45004
## Changelog

:cl: Skoglol
fix: Silicon can once again adjust security and medical record at range.
/:cl: