### PR TITLE
Adds Fix Air verb for admins (#45916)

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1207,6 +1207,7 @@
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"
+#include "code\modules\admin\verbs\fix_air.dm"
 #include "code\modules\admin\verbs\fps.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\healall.dm"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -17,7 +17,8 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/reestablish_db_connection, /*reattempt a connection to the database*/
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/
-	/client/proc/stop_sounds
+	/client/proc/stop_sounds,
+	/client/proc/fix_air				/*resets air in designated radius to its default atmos composition*/
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)

--- a/code/modules/admin/verbs/fix_air.dm
+++ b/code/modules/admin/verbs/fix_air.dm
@@ -1,0 +1,21 @@
+// Proc taken from yogstation, credit to nichlas0010 for the original
+/client/proc/fix_air(var/turf/open/T in world)
+	set name = "Fix Air"
+	set category = "Admin"
+	set desc = "Fixes air in specified radius."
+
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.")
+		return
+	if(check_rights(R_ADMIN,1))
+		var/range=input("Enter range:","Num",2) as num
+		message_admins("[key_name_admin(usr)] fixed air with range [range] in area [T.loc.name]")
+		log_game("[key_name_admin(usr)] fixed air with range [range] in area [T.loc.name]")
+		var/datum/gas_mixture/GM = new
+		for(var/turf/open/F in range(range,T))
+			if(F.blocks_air)
+			//skip walls
+				continue
+			GM.parse_gas_string(F.initial_gas_mix)
+			F.copy_air(GM)
+			F.update_visuals() 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/45916
tested and working

## About The Pull Request

Adds a Fix Air verb for admins to quickly reset the air in a radius to what its default composition would be. It's used by right-clicking the floor and entering a number to be used as a radius. All credit goes to nichlas0010 for coding it, and to Flatgub for porting it to AuStation.
Why It's Good For The Game

It provides a much faster and simpler way to clean an area's atmos than the usage of buildmode > mapgen. Most common uses are for when a nonantag "accidentally" leaks plasma/superheated gas into the air, when a sillymin breaks atmos in an area, or when a hallway scrubber was mysteriously set to siphon an hour ago.
Buildmode is also cumbersome, contrary to the beliefs of some

## Changelog

:cl:
add: Ported the Fix Air verb from Yogstation. Admins can use it to quickly reset an area's atmos to its default composition.
/:cl: