### PR TITLE
Resonant Shriek Nerf/Change

### DIFF
--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -13,10 +13,10 @@
 	for(var/mob/living/M in get_hearers_in_view(4, user))
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
+			var/distance = max(0, get_dist(get_turf(src), get_turf(M)))
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
-				C.adjustEarDamage(0, 30)
-				C.confused += 15
 				C.Jitter(20)
+				C.soundbang_act(1, max(200/max(1,distance), 60), rand(0, 5))
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))
 


### PR DESCRIPTION
## About The Pull Request
Makes resonant shriek call `soundbang_act()` instead of just directly applying damage, so that there ARE counters for it. Damage amounts subject to change(?) and I'll add confusion after a check if needed.

## Why It's Good For The Game
Allows people to actually counter resonant shriek, which has been a pain since forever.

## Changelog
:cl:
balance: Resonant shriek can now be countered with ear protection.
/:cl: