### PR TITLE
Scav rifle

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -20,3 +20,17 @@
 	caliber = "a556"
 	max_ammo = 30
 	multiple_sprites = 2
+
+/obj/item/ammo_box/magazine/pistolm9mm/rifle
+	name = "Scav rifle magazine (9mm)"
+	icon_state = "75-8"
+	ammo_type = /obj/item/ammo_casing/c9mm
+	caliber = "9mm"
+	max_ammo = 20
+
+/obj/item/ammo_box/magazine/pistolm9mm/rifle/update_icon()
+	..()
+	if(ammo_count())
+		icon_state = "75-8"
+	else
+		icon_state = "75-0"

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -20,17 +20,3 @@
 	caliber = "a556"
 	max_ammo = 30
 	multiple_sprites = 2
-
-/obj/item/ammo_box/magazine/pistolm9mm/rifle
-	name = "Scav rifle magazine (9mm)"
-	icon_state = "75-8"
-	ammo_type = /obj/item/ammo_casing/c9mm
-	caliber = "9mm"
-	max_ammo = 20
-
-/obj/item/ammo_box/magazine/pistolm9mm/rifle/update_icon()
-	..()
-	if(ammo_count())
-		icon_state = "75-8"
-	else
-		icon_state = "75-0"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -344,6 +344,7 @@
 	actions_types = list()
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
+
 /obj/item/gun/ballistic/automatic/scav
 	name = "Scav rifle"
 	desc = "A rifle designed by SCAV industries. Uses 9mm ammo."

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -344,3 +344,12 @@
 	actions_types = list()
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
+/obj/item/gun/ballistic/automatic/scav
+	name = "Scav rifle"
+	desc = "A rifle designed by SCAV industries. Uses 9mm ammo."
+	icon_state = "surplus"
+	item_state = "moistnugget"
+	mag_type = /obj/item/ammo_box/magazine/pistolm9mm/rifle
+	can_suppress = FALSE
+	burst_size = 0
+	fire_delay = 2

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -345,12 +345,12 @@
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
 
-/obj/item/gun/ballistic/automatic/scav
-	name = "Scav rifle"
-	desc = "A rifle designed by SCAV industries. Uses 9mm ammo."
+/obj/item/gun/ballistic/automatic/proto/unrestricted/scav
+	name = "Scav gun"
+	desc = "A pipe smg produced by S.C.A.V arms. loads 9mm pistol bulets"
 	icon_state = "surplus"
 	item_state = "moistnugget"
-	mag_type = /obj/item/ammo_box/magazine/pistolm9mm/rifle
+	mag_type = /obj/item/ammo_box/magazine/smgm9mm
 	can_suppress = FALSE
 	burst_size = 0
 	fire_delay = 2


### PR DESCRIPTION
## About The Pull Request

Adds the Scav rifle so that those who wich to make scav themed ruins and to when the scav ship is added give them a gun to use

## Why It's Good For The Game

gives the scavengers a unique gun that is slightly worse than most weapons so that they can have and buy guns without unbalancing the game by making it easy for them to get better weapons than station crew.

## Changelog
:cl:
add: added the scav rifle
/:cl:
