### PR TITLE
Dexalin, Dex+, and two new chems

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1049,7 +1049,7 @@
 	..()
 	. = 1
 
-/datum/reagent/carthatoline
+/datum/reagent/medicine/carthatoline
 	name = "Carthatoline"
 	description = "Carthatoline is strong evacuant used to treat severe poisoning."
 	reagent_state = LIQUID
@@ -1069,9 +1069,8 @@
 	..()
 	. = 1
 
-/datum/reagent/hepanephrodaxon
+/datum/reagent/medicine/hepanephrodaxon
 	name = "Hepanephrodaxon"
-	id = "hepanephrodaxon"
 	description = "Used to repair the common tissues involved in filtration."
 	taste_description = "glue"
 	reagent_state = LIQUID
@@ -1079,23 +1078,22 @@
 	metabolization_rate = REM * 1.5
 	overdose_threshold = 10
 
-/datum/reagent/hepanephrodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/medicine/hepanephrodaxon/on_mob_life(var/mob/living/carbon/M)
 	var/repair_strength = 1
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		for(var/obj/item/organ/I in H.internal_organs)
-			if(I.damage > 0)
-				I.damage = max(I.damage - 4 * removed * repair_strength, 0)
-				H.Confuse(2)
-		if(M.reagents.has_reagent(/datum/reagent/cordradaxon) || M.reagents.has_reagent(/datum/reagent/peridaxon))
-			if(prob(5))
-				H.vomit(1)
-			else if(prob(5))
-				to_chat(H,"<span class='danger'>Something churns inside you.</span>")
-				H.adjustToxLoss(10 * removed)
-				H.vomit(0, 1)
-		else
-			H.adjustToxLoss(-12 * removed) // Carthatoline based, considering cost.
+	var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
+	if(L.damage > 0)
+		L.damage = max(L.damage - 4 * repair_strength, 0)
+		M.confused = (2)
+	M.adjustToxLoss(-12)
+	..()
+	. = 1
+
+/datum/reagent/medicine/hepanephrodaxon/overdose_process(mob/living/M)
+	var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
+	L.damage = max(L.damage + 4, 0)
+	M.confused = (2)
+	..()
+	. = 1
 
 /datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -982,7 +982,7 @@
 	name = "Dexalin"
 	description = "Restores oxygen loss. Overdose causes it instead."
 	reagent_state = LIQUID
-	color = "#C8A5DC"
+	color = "#0080FF"
 	overdose_threshold = 30
 
 /datum/reagent/medicine/dexalin/on_mob_life(mob/living/carbon/M)
@@ -992,6 +992,23 @@
 
 /datum/reagent/medicine/dexalin/overdose_process(mob/living/M)
 	M.adjustOxyLoss(4*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/dexalinp
+	name = "Dexalin Plus"
+	description = "Restores oxygen loss. Overdose causes it instead. It is highly effective."
+	reagent_state = LIQUID
+	color = "#0040FF"
+	overdose_threshold = 25
+
+/datum/reagent/medicine/dexalinp/on_mob_life(mob/living/carbon/M)
+	M.adjustOxyLoss(-4*REM, 0)
+	..()
+	. = 1
+
+/datum/reagent/medicine/dexalinp/overdose_process(mob/living/M)
+	M.adjustOxyLoss(8*REM, 0)
 	..()
 	. = 1
 
@@ -1031,6 +1048,54 @@
 	M.adjustToxLoss(4*REM, 0) // End result is 2 toxin loss taken, because it heals 2 and then removes 4.
 	..()
 	. = 1
+
+/datum/reagent/carthatoline
+	name = "Carthatoline"
+	description = "Carthatoline is strong evacuant used to treat severe poisoning."
+	reagent_state = LIQUID
+	color = "#225722"
+
+/datum/reagent/medicine/carthatoline/on_mob_life(mob/living/carbon/M)
+	M.adjustToxLoss(-5*REM, 0)
+	if(M.getToxLoss() && prob(10))
+		M.vomit(1)
+	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
+		M.reagents.remove_reagent(R.type,1)
+	..()
+	. = 1
+
+/datum/reagent/medicine/carthatoline/overdose_process(mob/living/M)
+	M.adjustToxLoss(10*REM, 0) // End result is 5 toxin loss taken, because it heals 5 and then removes 10.
+	..()
+	. = 1
+
+/datum/reagent/hepanephrodaxon
+	name = "Hepanephrodaxon"
+	id = "hepanephrodaxon"
+	description = "Used to repair the common tissues involved in filtration."
+	taste_description = "glue"
+	reagent_state = LIQUID
+	color = "#D2691E"
+	metabolization_rate = REM * 1.5
+	overdose_threshold = 10
+
+/datum/reagent/hepanephrodaxon/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/repair_strength = 1
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		for(var/obj/item/organ/I in H.internal_organs)
+			if(I.damage > 0)
+				I.damage = max(I.damage - 4 * removed * repair_strength, 0)
+				H.Confuse(2)
+		if(M.reagents.has_reagent(/datum/reagent/cordradaxon) || M.reagents.has_reagent(/datum/reagent/peridaxon))
+			if(prob(5))
+				H.vomit(1)
+			else if(prob(5))
+				to_chat(H,"<span class='danger'>Something churns inside you.</span>")
+				H.adjustToxLoss(10 * removed)
+				H.vomit(0, 1)
+		else
+			H.adjustToxLoss(-12 * removed) // Carthatoline based, considering cost.
 
 /datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -215,6 +215,19 @@
 	results = list(/datum/reagent/medicine/bicaridine = 3)
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 
+/datum/chemical_reaction/dexalin
+	name = "Dexalin"
+	id = "dexalin"
+	result = "dexalin"
+	required_reagents = list(/datum/reagent/oxygen = 5)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
+
+/datum/chemical_reaction/dexalinp
+	name = "Dexalin Plus"
+	id = "dexalinp"
+	result = "dexalinp"
+	required_reagents = list("dexalin" = 1, "carbon" = 1, "iron" = 1)
+
 /datum/chemical_reaction/kelotane
 	name = "Kelotane"
 	id = /datum/reagent/medicine/kelotane
@@ -278,3 +291,17 @@
 	required_reagents = list( /datum/reagent/consumable/ethanol = 1, /datum/reagent/copper = 1, /datum/reagent/silver = 1)
 	required_temp = 370
 	mix_message = "The mixture becomes a metallic slurry."
+
+/datum/chemical_reaction/carthatoline
+	name = "Carthatoline"
+	id = "carthatoline"
+	result = /datum/reagent/carthatoline
+	required_reagents = list(/datum/reagent/antitoxin = 1, /datum/reagent/carbon = 2)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
+
+/datum/chemical_reaction/hepanephrodaxon
+	name = "Hepanephrodaxon"
+	id = "hepanephrodaxon"
+	result = /datum/reagent/hepanephrodaxon
+	required_reagents = list(/datum/reagent/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 5)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -218,15 +218,15 @@
 /datum/chemical_reaction/dexalin
 	name = "Dexalin"
 	id = "dexalin"
-	result = "dexalin"
+	results = list(/datum/reagent/medicine/dexalin = 5)
 	required_reagents = list(/datum/reagent/oxygen = 5)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/dexalinp
 	name = "Dexalin Plus"
 	id = "dexalinp"
-	result = "dexalinp"
-	required_reagents = list("dexalin" = 1, "carbon" = 1, "iron" = 1)
+	results = list(/datum/reagent/medicine/dexalinp = 3)
+	required_reagents = list(/datum/reagent/medicine/dexalin = 1, /datum/reagent/carbon = 1, /datum/reagent/iron = 1)
 
 /datum/chemical_reaction/kelotane
 	name = "Kelotane"
@@ -288,20 +288,20 @@
 	name = "Liquid Solder"
 	id = /datum/reagent/medicine/liquid_solder
 	results = list(/datum/reagent/medicine/liquid_solder = 3)
-	required_reagents = list( /datum/reagent/consumable/ethanol = 1, /datum/reagent/copper = 1, /datum/reagent/silver = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/copper = 1, /datum/reagent/silver = 1)
 	required_temp = 370
 	mix_message = "The mixture becomes a metallic slurry."
 
 /datum/chemical_reaction/carthatoline
 	name = "Carthatoline"
 	id = "carthatoline"
-	result = /datum/reagent/carthatoline
-	required_reagents = list(/datum/reagent/antitoxin = 1, /datum/reagent/carbon = 2)
+	results = list(/datum/reagent/medicine/carthatoline = 3)
+	required_reagents = list(/datum/reagent/medicine/antitoxin = 1, /datum/reagent/carbon = 2)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
 
 /datum/chemical_reaction/hepanephrodaxon
 	name = "Hepanephrodaxon"
 	id = "hepanephrodaxon"
-	result = /datum/reagent/hepanephrodaxon
-	required_reagents = list(/datum/reagent/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
+	results = list(/datum/reagent/medicine/hepanephrodaxon = 5)
+	required_reagents = list(/datum/reagent/medicine/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)


### PR DESCRIPTION
## About The Pull Request
Readds dexalin, adds dexalin+, hepanephrodaxon, and carthatoline.

## Why It's Good For The Game
Might as well readd dex, and if I'm gonna do that, I'll readd dex+ too. The other two are needed 1, because an intermediate toxin purging chem is needed, and 2, there's no way (for people that don't grow omegaweed and sentient fucking tomatoes) to heal liver damage besides replacing said liver.

## Changelog
:cl:
add: Dexalin and Dexalin Plus, chems you may or may not recognize. In short, they heal oxydamage.
add: Hepanephrodaxon, a chem for healing liver damage. For when someone hits the hooch a little *too* hard.
add: Carthatoline, an anti-toxin slightly better than charcoal or anti-toxin itself, used for when you don't want to go all out with pen acid.
/:cl: