### PR TITLE
Admins with R_ADMIN can now also restart the server.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -607,7 +607,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/Reboot(reason, end_string, delay)
 	set waitfor = FALSE
-	if(usr && !check_rights(R_ADMIN, TRUE))
+	if(usr && !check_rights(R_ADMIN || R_SERVER, TRUE))
 		return
 
 	if(!delay)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -607,7 +607,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/Reboot(reason, end_string, delay)
 	set waitfor = FALSE
-	if(usr && !check_rights(R_SERVER, TRUE))
+	if(usr && !check_rights(R_ADMIN, TRUE))
 		return
 
 	if(!delay)


### PR DESCRIPTION

## About The Pull Request
Because trialmins want it because they have delay perms. My mistake.
Fixes #966 even though it's closed already.

## Why It's Good For The Game
Prevents trialmins from inadvertently making the round unable to restart.

## Changelog
:cl:
admin: Those with R_ADMIN can now also restart the server.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
