### PR TITLE
Adds surgical equipment to Brig on all stations except Kilo

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2653,10 +2653,8 @@
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/clothing/suit/straight_jacket,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afG" = (
@@ -3468,6 +3466,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/storage/backpack/duffelbag/sec/surgery,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ahv" = (
@@ -4137,12 +4136,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aiF" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aiG" = (
@@ -4241,14 +4239,15 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/computer/operating{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -22951,6 +22951,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/glass/bottle/morphine,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aQX" = (
@@ -22966,12 +22968,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/storage/backpack/duffelbag/sec/surgery,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aQY" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -22979,6 +22979,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aQZ" = (
@@ -23960,20 +23961,20 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aSD" = (
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aSE" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/blindfold,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aSF" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -4082,6 +4082,11 @@
 "akc" = (
 /obj/structure/table,
 /obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "akd" = (
@@ -12662,14 +12667,15 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/computer/operating{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -12858,12 +12864,11 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aEr" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aEs" = (
@@ -26279,6 +26284,7 @@
 	dir = 4
 	},
 /obj/item/storage/box/bodybags,
+/obj/item/storage/backpack/duffelbag/sec/surgery,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bhu" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1254,6 +1254,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "acO" = (
@@ -1276,6 +1282,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Prison Sanitarium";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "acP" = (
@@ -1286,21 +1296,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "acR" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/morphine{
-	pixel_y = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Sanitarium";
-	network = list("ss13","prison")
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "acS" = (
@@ -1538,6 +1540,9 @@
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "adh" = (
@@ -1547,13 +1552,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "adi" = (
-/obj/structure/bed,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/mask/muzzle,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "adj" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2260,8 +2260,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ahu" = (
-/obj/structure/table/glass,
-/obj/item/flashlight/lamp,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -2274,6 +2272,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahv" = (
@@ -58537,6 +58536,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "oXQ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds surgery to Security on every station except for Kilo. On Delta and Metastation, this has been done by removing a bed + table from the Sanitorium and all the stuff on the bed/table to the other bed/tables. It also adds a security surgery bag to the sanitorium as well. Yes, I know there is already a security surgical bag in the Prisoner Transfer Centre. However, the Prisoner Transfer Centre is sort of "under the radar" from the AI and the surgical shit in there is typically used for forceborging. For RP purposes you would probably use a different set of tools for execution than for healing or "treating" people in the brig. The AI might also get suspicious about why there are surgical tools in the Prisoner Transfer Centre and honestly I don't know why I'm spending this much time justifying why there should be two surgical duffel bags in the brig. 

Meta Station and Delta Station respectively:

![metastationsecinfirmary](https://user-images.githubusercontent.com/8888654/70883437-fb537300-1fa0-11ea-96ef-6320ed9e3874.PNG)

![deltastationsanitorium](https://user-images.githubusercontent.com/8888654/70883443-00b0bd80-1fa1-11ea-8753-5813fe2527c5.PNG)

On Donut and Box Station, the existing infirmary is the new location of the surgery. Below is respectively Box and Donut Station. The straitjackets and what not have been moved to permabrig proper along with the electropacks etc.

![boxstationsecinfirmary](https://user-images.githubusercontent.com/8888654/70883809-28545580-1fa2-11ea-9c8b-9e5644f6ed42.PNG)

![donutstationinfirmary](https://user-images.githubusercontent.com/8888654/70883877-5a65b780-1fa2-11ea-91bb-b0347dfc1673.PNG)

Pubby on the other hand has the surgery inside the prisoner transfer centre. There is no second duffel bag. This is because Pubby is special and different so this change keeps with that design philosophy. In addition, PubbyStation unlike all the other stations already had a surgical table inside of the Prisoner Transfer Centre. It's pretty clear that this was an intentional design choice to locate surgery inside of the Prisoner Transfer Centre unlike all the other stations where there was no "actual" surgery, only tools meant for crude forceborging. Therefore I've decided to keep surgery inside of the Prisoner Transfer Centre as this PR is meant to add a "legitimate" way to perform surgeries at roundstart to every sec department on maps currently in rotation for gameplay reasons. This means trying to change as little with respect to the design of the Security department as possible.

![pubbystationprisonercentre](https://user-images.githubusercontent.com/8888654/70883913-6c475a80-1fa2-11ea-80dc-3b0eabfe5430.PNG)

I am willing to change Pubby's design to be in line with the other maps, preferably moving the surgical table to the infirmary as well as putting an additional set of surgical tools there but I believe that change should be a separate PR. I'm also willing to atomize the changes I'm currently proposing to Pubby as well if that's necessary.

## Why It's Good For The Game

This PR buffs Sec and helps encourage interesting gameplay. While it's pretty trivial to build a operating table in Sec easily on the fly, it's more difficult to build an operating computer as that requires tools and a motivated as well as intelligent security. Building an operating table also requires knowledge that many security players don't have.

A round-start, easily usable operating table in security creates a lot of interesting possibilities. It can be used to remove implants, it can be used for pacification surgery, and it can be used to cure "creep" antagonists of their disease. There's also many non obvious uses, such as revival surgery when Security doesn't trust cloning or can't gain access to it on Rev rounds for example.

## Changelog
:cl:
add: All Nanotrasen brand space station brigs are now equipped with an easily accessible surgical table, operating computer, and surgical tools! Locations may vary by station type.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
