### PR TITLE
Removes Headslugs from gold slime pool (again) (READ FULL PR)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -23,8 +23,6 @@
 	var/datum/mind/origin
 	var/egg_lain = 0
 
-	gold_core_spawnable = HOSTILE_SPAWN
-
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)
 	egg.Insert(victim)


### PR DESCRIPTION
## About The Pull Request
Reverts BeeStation/BeeStation-Hornet#968, re-removing headslugs from the gold spawn pool.

## The original removal
Taken directly from tgstation/tgstation#42731

> Why?
A couple of reasons. Primarily, it's pretty obvious how overpowered xenobio is these days. Secondly, this isn't really real content, it's just a juxtaposition of content that is normally for antags (changeling). Third, this specific "content" really only benefits the person doing it (the xenobiologist) and is usually just used to validhunt or to killbait.
>
> Or to rephrase, xenolings are only really ever fun for the person doing it and it's either directly or indirectly less fun for everyone else involved. Since there is a real reason to nerf xenobio (it's quite overpowered) this is a pretty good target.
>
> The way that I've gone about this in particular avoids nerfing any of the more interesting interactions in xenobio as well. Something like the mind swap potion, or just gold slime core reactions as they currently work, could have gone away entirely. But this is probably the lesser evil.

## Why it's good for the game
This was merged with no thoughts at all on balance or anything like it. For the millionth and a half time, *it was removed for a reason.* Yes, I've received complaints about "it's to powerful nerf plox," but there's other considerations that people have brought up to me. For example, I had one person get mulligan traitor, and their objective was to kill a xenobio ling. Fair enough, they can be killed. RIght? Well, maybe. First, you have to get to them, which requires some level of skill, then you need to gib/incinerate/whatever you wanna do to them. But here's the issue: *despite the fact they're valid, that doesn't mean sec and bystanders won't just sit around and let some person beat on someone because they're a xenobio ling.* What this means: If you have to kill them for whatever reason, you:
1. Have to disable the ling itself
2. Get past everyone without anyone noticing or the ling reviving and immediately telling the crew over comms
3. Inevitably have to deal with sec as you attempted to kill a crewmember.
4. And more, probably.
5. (yes, this HAS happened already to a few players)

AKA, it's not cool to give someone access to literally just an antag without the actual antag status. It's like... having to go through an hour of reading specific books or something to get wizard. Yes, that sounds cool, but, then every greytider worth his jumpsuit will immediately do that every single round just for the cool shit they can get. (Yes, every round I've been on since the original PR was merged, there has been at *least* one xenoling, and if somehow not, only because the round ended early.) Don't even bring up the D20 of fate, since that's balanced due to not only being a 1/20 but also having SEVERE risks involved. Not to mention, there's only one, and it's not a given thing you can do every round, like this is.Xenobio is VERY POWERFUL as it stands not counting the xenobio lings, and I don't see why they should be buffed further.

## Considerations from comments on the original readding PR:

> We are going to nerf lings to the ground at one point, and there is still a few and quite reliable ways to become antag or become a changeling mainly revolving around xenobiology, And to get head a slug in LRP would recquire at minimum 50 minutes of crossbreeding and plus a few minutes waiting for the egg to hatch once you lay it on a dead body. So lings would also be extremely rare on lrp.

I'd happily support this being readded when it's either rebalanced, changed, or lings in general get 'fixed.'

> Like changelings are still broken as fuck and its common for them to murder the entire station, Now xenobio will create their own anti-ling army.

...right...

...and traitors will now create more lings for the purpose of murderboning...

...along with their already insanely powerful army of sentience potioned monsters.

>This WAS removed for a reason. Things like headslugs in the gold slime pool are fine when it's very, very rare knowledge (like the trick to get normal tator shit on nukies), but when it's become the common knowledge it is today, and is shipped in with full advertisement of this, it's poor balance. I'm sure Ike will agree with me here.

Gonna have to agree, if it was silently readded, it might have been fine, but with the consistent rallying of support and constant announcements of it, literally everyone on the server knows now. I've never seen a fuller xenobio lab ever,

> Honestly? That is a good change. The original removal PR was literally ided

That's not the issue. It's unbalanced, and xenobio is already powerful as is.

## Closing thoughts/tl;dr
I don't see why it was merged in the state it was. Lings need to be fixed as a whole first, and this needs to be rebalanced *at least a little.* All in all: Remove it until it gets fixed

I can't believe I wrote this much for a one-line change

## Changelog
:cl:
del: Removes headslugs from the gold xenobio pool until they get fixed or rebalanced.
/:cl:
