### PR TITLE
Removes miasma from the lavaland gasses

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -13,7 +13,6 @@
 	)
 	restricted_gases = list(
 		/datum/gas/bz=10,
-		/datum/gas/miasma=10,
 		/datum/gas/plasma=0.1,
 		/datum/gas/water_vapor=0.1,
 	)


### PR DESCRIPTION
Performance reasons. Preventing infinite money farming is just a bonus.

## Changelog
:cl:
del: Miasma can no longer be a roundstart lavaland gas.
/:cl:

