### PR TITLE
MMI holders used for IPC brains (IPC brains actually work now)

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -218,20 +218,33 @@
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"
 	icon_state = "brain-x"
 
-/obj/item/organ/brain/positron
-	name = "positronic brain"
+/obj/item/organ/brain/mmi_holder
+	name = "brain"
 	slot = "brain"
 	zone = "chest"
 	status = ORGAN_ROBOTIC
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top."
-	icon = 'icons/obj/assemblies.dmi'
-	icon_state = "posibrain-occupied"
+	remove_on_qdel = FALSE
+	var/obj/item/mmi/stored_mmi
 
-/obj/item/organ/brain/positron/Insert(mob/living/carbon/C, special = 0, no_id_transfer = FALSE)
+/obj/item/organ/brain/mmi_holder/Destroy()
+	QDEL_NULL(stored_mmi)
+	return ..()
+
+/obj/item/organ/brain/mmi_holder/Insert(mob/living/carbon/C, special = 0, no_id_transfer = FALSE)
 	owner = C
 	C.internal_organs |= src
 	C.internal_organs_slot[slot] = src
 	loc = null
+	//the above bits are copypaste from organ/proc/Insert, because I couldn't go through the parent here.
+
+	if(stored_mmi.brainmob)
+		if(C.key)
+			C.ghostize()
+		var/mob/living/brain/B = stored_mmi.brainmob
+		if(stored_mmi.brainmob.mind)
+			B.mind.transfer_to(C)
+		else
+			C.key = B.key
 
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
@@ -239,14 +252,58 @@
 			if(H.health > 0 && !H.hellbound)
 				H.revive(0)
 
-/obj/item/organ/brain/positron/emp_act(severity)
+	update_from_mmi()
+
+/obj/item/organ/brain/mmi_holder/Remove(var/mob/living/user, special = 0)
+	if(!special)
+		if(stored_mmi)
+			. = stored_mmi
+			if(owner.mind)
+				owner.mind.transfer_to(stored_mmi.brainmob)
+			stored_mmi.loc = owner.loc
+			if(stored_mmi.brainmob)
+				var/mob/living/brain/B = stored_mmi.brainmob
+				spawn(0)
+					if(B)
+						B.stat = 0
+			stored_mmi = null
+
+	..()
+	spawn(0)//so it can properly keep surgery going
+		qdel(src)
+
+/obj/item/organ/brain/mmi_holder/proc/update_from_mmi()
+	if(!stored_mmi)
+		return
+	name = stored_mmi.name
+	desc = stored_mmi.desc
+	icon = stored_mmi.icon
+	icon_state = stored_mmi.icon_state
+
+/obj/item/organ/brain/mmi_holder/posibrain/New(var/obj/item/mmi/MMI)
+	. = ..()
+	if(MMI)
+		stored_mmi = MMI
+		MMI.forceMove(src)
+	else
+		stored_mmi = new /obj/item/mmi/posibrain/ipc(src)
+	spawn(5)
+		if(owner && stored_mmi)
+			stored_mmi.name = "positronic brain ([owner.real_name])"
+			stored_mmi.brainmob.real_name = owner.real_name
+			stored_mmi.brainmob.name = stored_mmi.brainmob.real_name
+			stored_mmi.icon_state = "posibrain-occupied"
+			update_from_mmi()
+
+/obj/item/organ/brain/mmi_holder/emp_act(severity)
 	switch(severity)
 		if(1)
 			owner.adjustBrainLoss(75)
 			to_chat(owner, "<span class='warning'>Alert: Posibrain heavily damaged.</span>")
 		if(2)
 			owner.adjustBrainLoss(25)
-			to_chat(owner, "<span class='warning'>Alert: Posibrain damaged.</span>") 
+			to_chat(owner, "<span class='warning'>Alert: Posibrain damaged.</span>")
+
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -280,7 +280,7 @@
 	icon = stored_mmi.icon
 	icon_state = stored_mmi.icon_state
 
-/obj/item/organ/brain/mmi_holder/posibrain/New(var/obj/item/mmi/MMI)
+/obj/item/organ/brain/mmi_holder/posibrain/Initialize(var/obj/item/mmi/MMI)
 	. = ..()
 	if(MMI)
 		stored_mmi = MMI

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -177,3 +177,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		icon_state = "[initial(icon_state)]-occupied"
 	else
 		icon_state = initial(icon_state)
+
+/obj/item/mmi/posibrain/ipc
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top."
+	autoping = FALSE

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -6,7 +6,7 @@
 	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,TRAIT_EASYDISMEMBER,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH) //all of these + whatever we inherit from the real species
 	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_VIRUSIMMUNE,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
-	mutant_brain = /obj/item/organ/brain/positron
+	mutant_brain = /obj/item/organ/brain/mmi_holder/posibrain
 	mutanteyes = /obj/item/organ/eyes/robotic
 	mutanttongue = /obj/item/organ/tongue/robot
 	mutantliver = /obj/item/organ/liver/cybernetic/upgraded/ipc

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -68,7 +68,7 @@
 	time = 64
 	name = "manipulate organs"
 	repeatable = 1
-	implements = list(/obj/item/organ = 100, /obj/item/reagent_containers/food/snacks/organ = 0, /obj/item/organ_storage = 100)
+	implements = list(/obj/item/organ = 100, /obj/item/reagent_containers/food/snacks/organ = 0, /obj/item/organ_storage = 100, /obj/item/mmi = 100)
 	var/implements_extract = list(/obj/item/hemostat = 100, TOOL_CROWBAR = 55)
 	var/current_type
 	var/obj/item/organ/I = null
@@ -94,7 +94,8 @@
 		if(target_zone != I.zone || target.getorganslot(I.slot))
 			to_chat(user, "<span class='notice'>There is no room for [I] in [target]'s [parse_zone(target_zone)]!</span>")
 			return -1
-	if(istype(tool, /obj/item/organ/brain/positron))
+	if(istype(tool, /obj/item/mmi))//this whole thing is only used for robotic surgery in organ_mani_robotic.dm :*
+		current_type = "posibrain"
 		var/obj/item/bodypart/affected = target.get_bodypart(check_zone(target_zone))
 		if(!affected)
 			return -1
@@ -106,8 +107,15 @@
 			return -1
 		if(target_zone != "chest")
 			to_chat(user, "<span class='notice'>You have to install [tool] in [target]'s chest!</span>")
-		if(target.internal_organs_slot["brain"])
+			return -1
+		if(target.internal_organs_slot[ORGAN_SLOT_BRAIN])
 			to_chat(user, "<span class='notice'>[target] already has a brain! You'd rather not find out what would happen with two in there.</span>")
+			return -1
+		var/obj/item/mmi/P = tool
+		if(!istype(P))
+			return -1
+		if(!P.brainmob || !P.brainmob.client)
+			to_chat(user, "<span class='notice'>[tool] has no life in it, this would be pointless!</span>")
 			return -1
 		user.visible_message("<span class='notice'>[user] begins to insert [tool] into [target]'s [parse_zone(target_zone)].</span>",
 			"<span class='notice'>You begin to insert [tool] into [target]'s [parse_zone(target_zone)]...</span>")
@@ -139,7 +147,21 @@
 		return -1
 
 /datum/surgery_step/manipulate_organs/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(current_type == "insert")
+	if(current_type == "posibrain")
+		if(istype(tool, /obj/item/organ_storage))
+			tool.icon_state = "evidenceobj"
+			tool.desc = "A container for holding body parts."
+			tool.cut_overlays()
+			tool = tool.contents[1]
+
+		user.temporarilyRemoveItemFromInventory(tool)
+		spawn(1)
+			I = new /obj/item/organ/brain/mmi_holder/posibrain(tool)
+			I.Insert(target)
+			user.visible_message("<span class='notice'>[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!</span>",
+				"<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>")
+
+	else if(current_type == "insert")
 		if(istype(tool, /obj/item/organ_storage))
 			I = tool.contents[1]
 			tool.icon_state = initial(tool.icon_state)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -15,6 +15,8 @@
 	var/vital = 0
 	//Was this organ implanted/inserted/etc, if true will not be removed during species change.
 	var/external = FALSE
+	//whether to call Remove() when qdeling the organ.
+	var/remove_on_qdel = TRUE
 	var/synthetic = FALSE // To distinguish between organic and synthetic organs
 	var/maxHealth = STANDARD_ORGAN_THRESHOLD
 	var/damage = 0		//total damage this organ has sustained
@@ -108,7 +110,7 @@
 
 
 /obj/item/organ/Destroy()
-	if(owner)
+	if(owner && remove_on_qdel)
 		// The special flag is important, because otherwise mobs can die
 		// while undergoing transformation into different mobs.
 		Remove(owner, special=TRUE)


### PR DESCRIPTION
## About The Pull Request
Changes the existing IPC brains which are just reskinned normal brains that react to EMPs to an object that holds a positronic brain. Taken from Oracle.

## Why It's Good For The Game
Allows IPC brains to be removed and used as posit brains, and allows putting produced positrons into IPC bodies(which are still unproducable atm)

## Changelog
:cl:
tweak: IPC brains are now actually (more or less) positronic brains.
/:cl: