### PR TITLE
Squids Color Change ability uses a color picker

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -58,9 +58,6 @@
 	icon_icon = 'icons/mob/actions.dmi'
 	button_icon_state = "squid"
 	var/cooldown = 0
-	var/static/list/squid_colors = list("FFA500", "B19CD9", "ADD8E6", "551A8B", "0000FF",
-    "32CD32", "D3D3D3", "2956B2", "FF0000", "00FF00", "FF69B4", "FFD700", "F58B57", "5AC18E",
-    "FFB6C1", "008B8B")
 
 /datum/action/innate/squid_change/IsAvailable()
     if(cooldown > world.time)
@@ -72,7 +69,6 @@
 	var/new_color = input(usr, "Choose a new skin color:", "Color Change", H.dna.species.fixed_mut_color) as color|null
 	if(new_color)
 		var/temp_hsv = RGBtoHSV(new_color)
-		debug_usr(usr + " chosen " + sanitize_hexcolor(new_color))
 		if(ReadHSV(temp_hsv)[3] >= ReadHSV("#7F7F7F")[3])
 			H.dna.species.fixed_mut_color = sanitize_hexcolor(new_color)
 			H.update_body()

--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -69,10 +69,17 @@
 
 /datum/action/innate/squid_change/Activate()
 	var/mob/living/carbon/human/H = owner
-	H.dna.species.fixed_mut_color = pick(squid_colors)
-	H.update_body()
-	cooldown = world.time + 50
-	active = TRUE
+	var/new_color = input(usr, "Choose a new skin color:", "Color Change", H.dna.species.fixed_mut_color) as color|null
+	if(new_color)
+		var/temp_hsv = RGBtoHSV(new_color)
+		debug_usr(usr + " chosen " + sanitize_hexcolor(new_color))
+		if(ReadHSV(temp_hsv)[3] >= ReadHSV("#7F7F7F")[3])
+			H.dna.species.fixed_mut_color = sanitize_hexcolor(new_color)
+			H.update_body()
+			cooldown = world.time + 50
+			active = TRUE
+		else
+			to_chat(usr, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 	UpdateButtonIcon()
 
 /datum/action/innate/squid_change/Deactivate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Improves squidpeople's color change ability by utilizing a color picker in place of picking from a hard-coded list of colors at random.
![squidgang](https://user-images.githubusercontent.com/39249137/71237716-eb50d180-22c7-11ea-9c52-4d4adc697e66.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the ability more flexible by allowing you to choose more colors. Squid gang squid gang
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: squids can now pick the color they change into
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
