### PR TITLE
Viro Fixes/Rebalances (Semi-urgent)

### DIFF
--- a/code/datums/diseases/advance/symptoms/lubefeet.dm
+++ b/code/datums/diseases/advance/symptoms/lubefeet.dm
@@ -12,7 +12,7 @@
 	var/morelube = FALSE
 	var/clownshoes = TRUE
 	threshold_desc = "<b>Transmission 10:</b> The host sweats even more profusely, lubing almost every tile they walk over<br>\
-					  <b>Resistance 12:</b> The host's feet turn into a pair of clown shoes."				
+					  <b>Resistance 12:</b> The host's feet turn into a pair of clown shoes."
 
 /datum/symptom/lubefeet/Start(datum/disease/advance/A)
 	if(!..())
@@ -45,7 +45,7 @@
 			to_chat(M, "<span class='danger'>The lube pools into a puddle!</span>")
 			OT.MakeSlippery(TURF_WET_LUBE, min_wet_time = 20 SECONDS, wet_time_to_add = 10 SECONDS)
 
-/datum/symptom/pierrot/End(datum/disease/advance/A)
+/datum/symptom/lubefeet/End(datum/disease/advance/A)
 	..()
 	if(ishuman(A.affected_mob))
 		var/mob/living/carbon/human/M = A.affected_mob
@@ -54,11 +54,11 @@
 
 /datum/symptom/lubefeet/proc/give_clown_shoes(datum/disease/advance/A)
 	if(ishuman(A.affected_mob))
-		var/mob/living/carbon/human/M = A.affected_mob 
+		var/mob/living/carbon/human/M = A.affected_mob
 		if(!istype(M.shoes, /obj/item/clothing/shoes/clown_shoes))
 			if(!M.dropItemToGround(M.shoes))
 				qdel(M.shoes)
 		var/obj/item/clothing/C = new /obj/item/clothing/shoes/clown_shoes(M)
 		ADD_TRAIT(C, TRAIT_NODROP, DISEASE_TRAIT)
 		M.equip_to_slot_or_del(C, SLOT_SHOES)
-		return		
+		return

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -435,7 +435,7 @@
 		/obj/item/reagent_containers/glass/bottle/plasma = 1,
 		/obj/item/reagent_containers/glass/bottle/synaptizine = 1,
 		/obj/item/reagent_containers/glass/bottle/formaldehyde = 1,
-		/obj/item/reagent_containers/glass/bottle/adminvirusfood = 1)
+		/obj/item/reagent_containers/glass/bottle/viralbase = 1)
 
 // ----------------------------
 // Disk """fridge"""

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1604,10 +1604,16 @@
 	color = "#ffa6ff" //rgb: 255,166,255
 	taste_description = "a bad idea"
 
-/datum/reagent/medicine/adminordrazine/adminvirusfood
+/datum/reagent/consumable/virus_food/advvirusfood
 	name = "highly unstable virus food"
 	color = "#ffffff" //rgb: 255,255,255 ITS PURE WHITE CMON
 	taste_description = "an EXTREMELY bad idea"
+
+/datum/reagent/consumable/virus_food/viralbase
+	name = "Experimental viral base"
+	description = "Recently discovered by Nanotrasen's top scientists after years of research, this substance can be used as the base for extremely rare and extremely dangerous viruses once exposed to uranium."
+	color = "#fff0da"
+	taste_description = "tears of scientists"
 
 // Bee chemicals
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -68,7 +68,7 @@
 	var/location = get_turf(holder.my_atom)
 	for(var/i = 1, i <= created_volume, i++)
 		new /obj/item/stack/sheet/mineral/gold(location)
-		
+
 /datum/chemical_reaction/adamantinesolidification
 	name = "Adamantine Sheet"
 	id = "solidadam"
@@ -220,8 +220,9 @@
 /datum/chemical_reaction/virus_food_admin
 	name = "Highly unstable virus Food"
 	id = "virusfood_admin"
-	results = list(/datum/reagent/medicine/adminordrazine/adminvirusfood = 1)
-	required_reagents = list(/datum/reagent/medicine/adminordrazine = 5, /datum/reagent/consumable/virus_food = 1)
+	results = list(/datum/reagent/consumable/virus_food/advvirusfood = 1)
+	required_reagents = list(/datum/reagent/consumable/virus_food/viralbase = 1, /datum/reagent/uranium = 20)
+	mix_message = "The mixture turns every colour of the rainbow, soon settling on a bright white. There's no way this isn't a good idea."
 
 /datum/chemical_reaction/mix_virus
 	name = "Mix Virus"
@@ -341,7 +342,7 @@
 
 	name = "Mix Virus 14"
 	id = "mixvirus14"
-	required_reagents = list(/datum/reagent/medicine/adminordrazine/adminvirusfood = 1)
+	required_reagents = list(/datum/reagent/consumable/virus_food/advvirusfood = 1)
 	level_min = 9
 	level_max = 9
 
@@ -639,8 +640,8 @@
 	id = /datum/reagent/pax
 	results = list(/datum/reagent/pax = 3)
 	required_reagents  = list(/datum/reagent/toxin/mindbreaker = 1, /datum/reagent/medicine/synaptizine = 1, /datum/reagent/water = 1)
-	
-	
+
+
 //////////////////EXPANDED MUTATION TOXINS/////////////////////
 
 /datum/chemical_reaction/mutationtoxin/stable
@@ -660,7 +661,7 @@
 	id = /datum/reagent/mutationtoxin/felinid
 	results = list(/datum/reagent/mutationtoxin/felinid = 1)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/fentanyl = 10, /datum/reagent/impedrezene = 10)
-	
+
 /datum/chemical_reaction/mutationtoxin/fly
 	name = /datum/reagent/mutationtoxin/fly
 	id = /datum/reagent/mutationtoxin/fly
@@ -672,7 +673,7 @@
 	id = /datum/reagent/mutationtoxin/moth
 	results = list(/datum/reagent/mutationtoxin/moth = 1)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/toxin/lipolicide = 10) //I know it's the opposite of what moths like, but I am out of ideas for this.
-	
+
 /datum/chemical_reaction/mutationtoxin/pod
 	name = /datum/reagent/mutationtoxin/pod
 	id = /datum/reagent/mutationtoxin/pod
@@ -690,7 +691,7 @@
 	id = /datum/reagent/mutationtoxin/abductor
 	results = list(/datum/reagent/mutationtoxin/abductor = 1)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/medicine/morphine = 10, /datum/reagent/toxin/mutetoxin = 10)
-	
+
 /datum/chemical_reaction/mutationtoxin/squid
 	name = /datum/reagent/mutationtoxin/squid
 	id = /datum/reagent/mutationtoxin/squid
@@ -702,7 +703,7 @@
 	id = /datum/reagent/mutationtoxin/ipc
 	results = list(/datum/reagent/mutationtoxin/ipc = 1)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 1, /datum/reagent/consumable/sodiumchloride = 10, /datum/reagent/water = 20)
-	
+
 //////////////Mutatuion toxins made out of advanced toxin/////////////
 
 /datum/chemical_reaction/mutationtoxin/skeleton
@@ -728,13 +729,13 @@
 	id = /datum/reagent/mutationtoxin/ash
 	results = list(/datum/reagent/mutationtoxin/ash = 1)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/mutationtoxin/lizard = 1, /datum/reagent/ash = 10, /datum/reagent/consumable/entpoly = 5)
-	
+
 /datum/chemical_reaction/mutationtoxin/shadow
 	name = /datum/reagent/mutationtoxin/shadow
 	id = /datum/reagent/mutationtoxin/shadow
 	results = list(/datum/reagent/mutationtoxin/shadow = 1)
 	required_reagents  = list(/datum/reagent/aslimetoxin = 1, /datum/reagent/liquid_dark_matter = 30, /datum/reagent/water/holywater = 10) //You need a tiny bit of thinking how to mix it
-	
+
 /datum/chemical_reaction/mutationtoxin/plasma
 	name = /datum/reagent/mutationtoxin/plasma
 	id = /datum/reagent/mutationtoxin/plasma

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -99,10 +99,10 @@
 	icon_state = "holyflask"
 	list_reagents = list(/datum/reagent/medicine/adminordrazine = 30)
 
-/obj/item/reagent_containers/glass/bottle/adminvirusfood
+/obj/item/reagent_containers/glass/bottle/viralbase
 	name = "Highly Unstable Virus Food Bottle"
-	desc = "A small bottle. Contains a small amount of highly experimental virus food. This is rare, so don't expect any more of it."
-	list_reagents = list(/datum/reagent/medicine/adminordrazine/adminvirusfood = 1)
+	desc = "A small bottle. Contains a trace amount of a substance found by scientists that can be used to create extremely advanced diseases once exposed to uranium."
+	list_reagents = list(/datum/reagent/consumable/virus_food/advvirusfood = 1)
 
 /obj/item/reagent_containers/glass/bottle/capsaicin
 	name = "Capsaicin Bottle"

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -100,9 +100,9 @@
 	list_reagents = list(/datum/reagent/medicine/adminordrazine = 30)
 
 /obj/item/reagent_containers/glass/bottle/viralbase
-	name = "Highly Unstable Virus Food Bottle"
+	name = "Highly potent Viral Base Bottle"
 	desc = "A small bottle. Contains a trace amount of a substance found by scientists that can be used to create extremely advanced diseases once exposed to uranium."
-	list_reagents = list(/datum/reagent/consumable/virus_food/advvirusfood = 1)
+	list_reagents = list(/datum/reagent/consumable/virus_food/viralbase = 1)
 
 /obj/item/reagent_containers/glass/bottle/capsaicin
 	name = "Capsaicin Bottle"


### PR DESCRIPTION

## About The Pull Request
Needed fixes and rebalances for the viro additions I've screwed up countless times now

## Why It's Good For The Game
No more unremovable clown shoes that viro can make roundstart

## Changelog
:cl:
fix: clown shoes are actually cured once diseases with ductapod are cured
tweak: advanced virus food is now locked behind a uranium "wall." You need to mix the roundstart bottle viro gets with 20u of uranium for it to work!
add: viral base, which if added to 20u of uranium becomes normal advanced virus food.
code: changed advanced virus food to be a subset of virus food and not adminorizine, also renamed advanced virus food.
/:cl: