### PR TITLE
Removes roburger from fast food ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
@@ -1004,7 +1004,6 @@
 "dE" = (
 /obj/structure/table,
 /obj/structure/table/wood/fancy/blue,
-/obj/item/reagent_containers/food/snacks/burger/roburgerbig,
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/macspace)
 "dF" = (


### PR DESCRIPTION
Roburgers are an exceptionally powerful item, and this ruin has a GPS signal attached to it.

:cl:
remove: removed roburger from MacSpace ruin
/:cl: