### PR TITLE
No more cargo pod steal shuttle ports. (#45962)

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/structure/extraction_point,
 		/obj/machinery/syndicatebomb,
 		/obj/item/hilbertshotel,
+		/obj/item/swapper,
 		/obj/docking_port
 	)))
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/45962

:cl: Dennok
fix: No more cargo pod steal shuttle ports.
/:cl: