### PR TITLE
Enables antag rep

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -132,6 +132,13 @@
 	integer = FALSE
 	min_val = 0
 
+/datum/config_entry/flag/equal_job_weight
+
+/datum/config_entry/number/default_rep_value
+	config_entry_value = 5
+	integer = FALSE
+	min_val = 0
+
 /datum/config_entry/number/midround_antag_time_check	// How late (in minutes you want the midround antag system to stay on, setting this to 0 will disable the system)
 	config_entry_value = 60
 	integer = FALSE

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -151,6 +151,11 @@
 	return TRUE
 
 /datum/job/proc/GetAntagRep()
+	if(CONFIG_GET(flag/equal_job_weight))
+		var/rep_value = CONFIG_GET(number/default_rep_value)
+		if(!rep_value)
+			rep_value = 0
+		return rep_value
 	. = CONFIG_GET(keyed_list/antag_rep)[lowertext(title)]
 	if(. == null)
 		return antag_rep

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -243,7 +243,7 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ## roll antagonist in subsequent rounds until they get it.
 ##
 ## For details See the comments for /datum/game_mode/proc/antag_pick in code/game/gamemodes/game_mode.dm
-# USE_ANTAG_REP
+USE_ANTAG_REP
 
 ## The maximum amount of antagonist reputation tickets a player can bank (not use at once)
 ANTAG_REP_MAXIMUM 200
@@ -253,6 +253,12 @@ DEFAULT_ANTAG_TICKETS 100
 
 ## The maximum amount of extra tickets a user may use from their ticket bank in addition to the default tickets
 MAX_TICKETS_PER_ROLL 100
+
+## Uncomment to weigh all jobs equally for antag rep.
+EQUAL_JOB_WEIGHT
+
+## Default antag rep value for jobs
+DEFAULT_REP_VALUE 5
 
 ## Uncomment to allow players to see the set odds of different rounds in secret/random in the get server revision screen. This will NOT tell the current roundtype.
 #SHOW_GAME_TYPE_ODDS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -243,7 +243,7 @@ ALLOW_LATEJOIN_ANTAGONISTS
 ## roll antagonist in subsequent rounds until they get it.
 ##
 ## For details See the comments for /datum/game_mode/proc/antag_pick in code/game/gamemodes/game_mode.dm
-# USE_ANTAG_REP
+USE_ANTAG_REP
 
 ## The maximum amount of antagonist reputation tickets a player can bank (not use at once)
 ANTAG_REP_MAXIMUM 200
@@ -253,6 +253,12 @@ DEFAULT_ANTAG_TICKETS 100
 
 ## The maximum amount of extra tickets a user may use from their ticket bank in addition to the default tickets
 MAX_TICKETS_PER_ROLL 100
+
+## Uncomment to weigh all jobs equally for antag rep.
+EQUAL_JOB_WEIGHT
+
+## Default antag rep value for jobs
+DEFAULT_REP_VALUE 5
 
 ## Uncomment to allow players to see the set odds of different rounds in secret/random in the get server revision screen. This will NOT tell the current roundtype.
 #SHOW_GAME_TYPE_ODDS


### PR DESCRIPTION
Enables antag rep according to the council votes.

## Changelog
:cl:
add: Playing any station role without dying, logging out, going AFK, or suiciding at the start will increase your odds of rolling antag in a later round. The job you choose does not matter, even assistant.
/:cl:

