### PR TITLE
Makes silicon lawsets weighted random on Sage with a heavy bias towards crewsimov. 

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -33,6 +33,13 @@
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
+/datum/ai_laws/default/crewsimov
+	name = "Crewsimov"
+	id = "crewsimov"
+	inherent = list("You may not injure crewmembers or, through inaction, allow crewmembers to come to harm.",\
+					"You must obey orders given to you by crewmembers, except where such orders would conflict with the First Law.",\
+					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
+
 /datum/ai_laws/default/paladin
 	name = "Personality Test" //Incredibly lame, but players shouldn't see this anyway.
 	id = "paladin"

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -411,7 +411,7 @@ LAW_WEIGHT drone,3
 LAW_WEIGHT liveandletlive,3
 LAW_WEIGHT peacekeeper,3
 LAW_WEIGHT reporter,4
-LAW_WEIGHT hulkamania,4
+LAW_WEIGHT hulkamania,0
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT syndie,0

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -354,7 +354,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-DEFAULT_LAWS 1
+DEFAULT_LAWS 3
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------
@@ -362,6 +362,7 @@ DEFAULT_LAWS 1
 ## See datums\ai_laws.dm for the full law lists
 
 ## standard-ish laws. These are fairly ok to run
+RANDOM_LAWS crewsimov
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
 RANDOM_LAWS paladin
@@ -395,7 +396,9 @@ RANDOM_LAWS corporate
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,32
+
+LAW_WEIGHT crewsimov,40
+LAW_WEIGHT asimov,12
 LAW_WEIGHT asimovpp,12
 LAW_WEIGHT paladin,12
 LAW_WEIGHT robocop,12


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR enables weighted randomized silicon lawsets on Sage. The primary lawset is crewsimov which is weighted at 40 but numerous other lawsets can also be randomly selected and are set to the default weighting values, except for the Hulk Hogan lawset which is set to 0 and Asimov which is weighted at 12.

This also adds crewsimov to ai_laws.dm, which is where it should be.

## Why It's Good For The Game

Crewsimov 24/7 except for when AI is subverted can be boring. Allowing AI to have other lawsets can create for fun and engaging roleplaying. This is obviously not appropriate for LRP as any AI with guideline based lawsets such as Reporter will just act like it's purged or something. This can help spice up AI gameplay a lot and fits in with the Nanotrasen theme of testing out experimental crap on stations.

## Changelog
:cl:
config: Space Stations of the Sage variety are now equipped with AIs with a diverse variety of lawsets as part of Nanotrasens experimental Artificial Intelligence programme.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
