### PR TITLE
Prevents roundstart suicide on Sage

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -395,3 +395,5 @@
 	config_entry_value = 100
 /datum/config_entry/number/max_slimes
 	config_entry_value = 100
+
+/datum/config_entry/flag/restricted_suicide

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -232,9 +232,13 @@
 
 /mob/living/proc/suicide_log()
 	log_game("[key_name(src)] committed suicide at [AREACOORD(src)] as [src.type].")
+	if(CONFIG_GET(flag/restricted_suicide))
+		message_admins("[key_name(src)] committed suicide at [AREACOORD(src)] as [src.type].")
 
 /mob/living/carbon/human/suicide_log()
 	log_game("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) committed suicide at [AREACOORD(src)].")
+	if(CONFIG_GET(flag/restricted_suicide))
+		message_admins("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) committed suicide at [AREACOORD(src)].")
 
 /mob/living/proc/canSuicide()
 	switch(stat)
@@ -254,4 +258,14 @@
 	if(!(mobility_flags & MOBILITY_USE))	//just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
 		to_chat(src, "You can't commit suicide whilst immobile! ((You can type Ghost instead however.))")
 		return
+	if(CONFIG_GET(flag/restricted_suicide))
+		if(alert("Commiting suicide is strongly discouraged, and in some cases may be against the rules. Consider entering the cryopods or contacting admins. Are you sure you want to continue?",,"Confirm","Cancel") != "Confirm")
+			return
+		if(world.time < (SSticker.round_start_time + (15 MINUTES)))
+			var/timeleft = ((SSticker.round_start_time + (15 MINUTES)) - world.time)
+			to_chat(src, "<span class='boldannounce'>Committing suicide at the start of the round is not allowed. Time until suicide is possible: [DisplayTimeText(timeleft)].</span>")
+			if(src.job)
+				message_admins("[key_name(src)] (job: [src.job]) attempted to commit suicide at [AREACOORD(src)]. Time until suicide is possible: [DisplayTimeText(timeleft)].")
+			return
+
 	return TRUE

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -571,3 +571,6 @@ ECONOMY
 
 ## Crew objectives
 ALLOW_CREW_OBJECTIVES
+
+## Uncomment to restrict suiciding. Adds an additional confirmation dialogue, additional logging, and prevents suicide within the first 15 minutes of the round.
+RESTRICTED_SUICIDE

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -569,3 +569,6 @@ ALLOW_CREW_OBJECTIVES
 MAX_CUBE_MONKEYS 100
 MAX_CHICKENS 100
 MAX_SLIMES 100
+
+## Uncomment to restrict suiciding. Adds an additional confirmation dialogue, additional logging, and prevents suicide within the first 15 minutes of the round.
+#RESTRICTED_SUICIDE


### PR DESCRIPTION
Closes #1044 

This PR prevents people from committing suicide within the first 15 minutes of a round on sage and adds an additional confirmation dialogue that makes it clear that suicide may be against the rules. Alternative to #1044 

It's a simple config option if people want this enabled on Golden too.

## Changelog
:cl:
add: You can no longer commit suicide in the first 15 minutes of the round on Sage. Consider using the cryopods or contacting admins instead.
/:cl:

