### PR TITLE
Lowers DeltaStation min pop requirement

### DIFF
--- a/config/Sage/maps.txt
+++ b/config/Sage/maps.txt
@@ -30,7 +30,7 @@ map pubbystation
 endmap
 
 map deltastation
-	minplayers 60
+	minplayers 50
 	votable
 endmap
 

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -30,7 +30,7 @@ map pubbystation
 endmap
 
 map deltastation
-	minplayers 80
+	minplayers 50
 	votable
 endmap
 


### PR DESCRIPTION
Lowers DeltaStation voting requirement to 50 players (previously 80)

:cl:
tweak: DeltaStation now shows up in map rotation at 50 players.
/:cl: