### PR TITLE
Replaces X-01 taser with a ballistic round, small flashbang tweak

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -28,9 +28,4 @@
 	if(M.flash_act(affect_silicon = 1))
 		M.Paralyze(max(200/max(1,distance), 60))
 //Bang
-	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		M.Paralyze(200)
-		M.soundbang_act(1, 200, 10, 15)
-
-	else
-		M.soundbang_act(1, max(200/max(1,distance), 60), rand(0, 5))
+	M.soundbang_act(1, max(200/max(1,distance), 60), rand(0, 5))

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -10,10 +10,21 @@
 /obj/item/ammo_casing/energy/lasergun/old
 	projectile_type = /obj/item/projectile/beam/laser
 	e_cost = 200
-	select_name = "kill"
+	select_name = "energy"
+
+/obj/item/ammo_casing/energy/laser/old/ballistic
+	projectile_type = /obj/item/projectile/bullet/synthetic
+	e_cost = 200
+	select_name = "ballistic"
+	fire_sound = 'sound/weapons/gunshot.ogg'
 
 /obj/item/ammo_casing/energy/laser/hos
 	e_cost = 120
+	
+/obj/item/ammo_casing/energy/laser/hos/ballistic
+	projectile_type = /obj/item/projectile/bullet/synthetic
+	e_cost = 120
+	fire_sound = 'sound/weapons/gunshot.ogg'
 
 /obj/item/ammo_casing/energy/laser/practice
 	projectile_type = /obj/item/projectile/beam/practice

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -40,10 +40,10 @@
 
 /obj/item/gun/energy/e_gun/old
 	name = "prototype energy gun"
-	desc = "NT-P:01 Prototype Energy Gun. Early stage development of a unique laser rifle that has multifaceted energy lens allowing the gun to alter the form of projectile it fires on command."
+	desc = "NT-P:01 Prototype Energy Gun. Early stage development of a unique laser rifle that has a bluespace focusing lens allowing the gun to print ballistic ammunition."
 	icon_state = "protolaser"
 	ammo_x_offset = 2
-	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/electrode/old)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/laser/old/ballistic)
 
 /obj/item/gun/energy/e_gun/mini/practice_phaser
 	name = "practice phaser"
@@ -53,11 +53,11 @@
 
 /obj/item/gun/energy/e_gun/hos
 	name = "\improper X-01 MultiPhase Energy Gun"
-	desc = "This is an expensive, modern recreation of an antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time."
+	desc = "This is an expensive, modern firearm designed to synthesize ballistic ammunition and fire laser rounds, packed in an antique-style chassis."
 	cell_type = /obj/item/stock_parts/cell{charge = 1200; maxcharge = 1200}
 	icon_state = "hoslaser"
 	force = 10
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler/hos)
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/hos/ballistic, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler/hos)
 	ammo_x_offset = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -37,6 +37,6 @@
 
 //special (energy ballistics)
 
-/obj/item/projectile/bullet/hos
+/obj/item/projectile/bullet/synthetic
 	name = "synthesized bullet"
 	damage = 20

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -34,3 +34,9 @@
 	name = "10mm incendiary bullet"
 	damage = 15
 	fire_stacks = 2
+
+//special (energy ballistics)
+
+/obj/item/projectile/bullet/hos
+	name = "synthesized bullet"
+	damage = 20


### PR DESCRIPTION
## About The Pull Request

-X-01 and the charlie station prototype can now synthesize ballistic rounds instead of firing electrodes
-flashbangs no longer hardstun at point blank

## Why It's Good For The Game
- fixes the last few unprotectable roundstart hardstuns with a fun alternative
-flashbang strange object is no longer useless. flashbangs can now be used in hand. Looking at the note left in code, it seems a coder was salty about sec rushing into rooms with a flashbang in hand

## Changelog
:cl:
tweak: flashbang no longer stuns you at point blank
balance: HOS and charlie station guns now have a ballistic mode in place of taser
balance: Hotel sec's egun now has a lethal mode in place of a taser
/:cl:
