### PR TITLE
Adds  an option to specify a minimum playtime requirement in polls

### DIFF
--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -344,6 +344,7 @@ CREATE TABLE IF NOT EXISTS `SS13_poll_question` (
   `createdby_ckey` varchar(32) DEFAULT NULL,
   `createdby_ip` int(10) unsigned NOT NULL,
   `dontshow` tinyint(1) unsigned NOT NULL,
+  `minimumplaytime` int(4) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_pquest_question_time_ckey` (`question`,`starttime`,`endtime`,`createdby_ckey`,`createdby_ip`),
   KEY `idx_pquest_time_admin` (`starttime`,`endtime`,`adminonly`),

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,19 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.3; The query to update the schema revision table is:
+The latest database version is 5.4; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 3);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 4);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 3);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 4);
 
 In any query remember to add a prefix to the table names if you use one.
+
+----------------------------------------------------
+Version 5.4 2 Jan 2020, by ike709
+Adds the ability to specify a minimum playtime requirement (in hours) to vote in a server poll.
+
+ALTER TABLE `poll_question`
+ADD `minimumplaytime` int(4) NOT NULL;
 
 ----------------------------------------------------
 Version 5.3 4 Oct 2019, by Crossedfall

--- a/code/modules/admin/create_poll.dm
+++ b/code/modules/admin/create_poll.dm
@@ -127,9 +127,15 @@
 					add_option = 0
 				else
 					return 0
+
+	var/minimum_player_playtime = input("Minimum player playtime to vote (in hours)","Minimum playtime") as num|null
+	if (minimum_player_playtime == null)
+		minimum_player_playtime = 0
+	minimum_player_playtime = sanitizeSQL(min(minimum_player_playtime, 100)) //max 100 hours
+
 	var/m1 = "[key_name(usr)] has created a new server poll. Poll type: [polltype] - Admin Only: [adminonly ? "Yes" : "No"] - Question: [question]"
 	var/m2 = "[key_name_admin(usr)] has created a new server poll. Poll type: [polltype] - Admin Only: [adminonly ? "Yes" : "No"]<br>Question: [question]"
-	var/datum/DBQuery/query_polladd_question = SSdbcore.NewQuery("INSERT INTO [format_table_name("poll_question")] (polltype, starttime, endtime, question, adminonly, multiplechoiceoptions, createdby_ckey, createdby_ip, dontshow) VALUES ('[polltype]', '[starttime]', '[endtime]', '[question]', '[adminonly]', '[choice_amount]', '[sql_ckey]', INET_ATON('[address]'), '[dontshow]')")
+	var/datum/DBQuery/query_polladd_question = SSdbcore.NewQuery("INSERT INTO [format_table_name("poll_question")] (polltype, starttime, endtime, question, adminonly, multiplechoiceoptions, createdby_ckey, createdby_ip, dontshow, minimumplaytime) VALUES ('[polltype]', '[starttime]', '[endtime]', '[question]', '[adminonly]', '[choice_amount]', '[sql_ckey]', INET_ATON('[address]'), '[dontshow]', '[minimum_player_playtime]')")
 	if(!query_polladd_question.warn_execute())
 		qdel(query_polladd_question)
 		return

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -89,7 +89,7 @@ GLOBAL_PROTECT(exp_to_update)
 				exp_data[category] = text2num(play_records[category])
 			else
 				exp_data[category] = 0
-	
+
 	if((prefs.db_flags & DB_FLAG_EXEMPT) || (prefs.job_exempt))
 		return_text += "<LI>Exempt (all jobs auto-unlocked)</LI>"
 
@@ -125,11 +125,13 @@ GLOBAL_PROTECT(exp_to_update)
 	return return_text
 
 
-/client/proc/get_exp_living()
+/client/proc/get_exp_living(var/format = TRUE)
 	if(!prefs.exp)
 		return "No data"
 	var/exp_living = text2num(prefs.exp[EXP_TYPE_LIVING])
-	return get_exp_format(exp_living)
+	if(format)
+		return get_exp_format(exp_living)
+	return exp_living
 
 /proc/get_exp_format(expnum)
 	if(expnum > 60)
@@ -212,9 +214,9 @@ GLOBAL_PROTECT(exp_to_update)
 		if(mob.stat != DEAD)
 			var/rolefound = FALSE
 			play_records[EXP_TYPE_LIVING] += minutes
-			
+
 			process_ten_minute_living()
-			
+
 			if(announce_changes)
 				to_chat(src,"<span class='notice'>You got: [minutes] Living EXP!</span>")
 			if(mob.mind.assigned_role)

--- a/code/modules/mob/dead/new_player/poll.dm
+++ b/code/modules/mob/dead/new_player/poll.dm
@@ -29,7 +29,7 @@
 	if (!SSdbcore.Connect())
 		to_chat(usr, "<span class='danger'>Failed to establish database connection.</span>")
 		return
-	var/datum/DBQuery/query_poll_get_details = SSdbcore.NewQuery("SELECT starttime, endtime, question, polltype, multiplechoiceoptions FROM [format_table_name("poll_question")] WHERE id = [pollid]")
+	var/datum/DBQuery/query_poll_get_details = SSdbcore.NewQuery("SELECT starttime, endtime, question, polltype, multiplechoiceoptions, minimumplaytime FROM [format_table_name("poll_question")] WHERE id = [pollid]")
 	if(!query_poll_get_details.warn_execute())
 		qdel(query_poll_get_details)
 		return
@@ -38,13 +38,19 @@
 	var/pollquestion = ""
 	var/polltype = ""
 	var/multiplechoiceoptions = 0
+	var/minimumplaytime = 0
 	if(query_poll_get_details.NextRow())
 		pollstarttime = query_poll_get_details.item[1]
 		pollendtime = query_poll_get_details.item[2]
 		pollquestion = query_poll_get_details.item[3]
 		polltype = query_poll_get_details.item[4]
 		multiplechoiceoptions = text2num(query_poll_get_details.item[5])
+		minimumplaytime = text2num(query_poll_get_details.item[6])
 	qdel(query_poll_get_details)
+	var/player_playtime = round(client?.get_exp_living(FALSE) / 60)
+	if(player_playtime && (player_playtime < minimumplaytime))
+		to_chat(usr, "<span class='warning'>You do not have sufficient playtime to vote in this poll. Minimum: [minimumplaytime] hour(s). Your playtime: [player_playtime] hour(s).</span>")
+		return
 	switch(polltype)
 		if(POLLTYPE_OPTION)
 			var/datum/DBQuery/query_option_get_votes = SSdbcore.NewQuery("SELECT optionid FROM [format_table_name("poll_vote")] WHERE pollid = [pollid] AND ckey = '[ckey]'")

--- a/code/modules/mob/dead/new_player/poll.dm
+++ b/code/modules/mob/dead/new_player/poll.dm
@@ -48,7 +48,7 @@
 		minimumplaytime = text2num(query_poll_get_details.item[6])
 	qdel(query_poll_get_details)
 	var/player_playtime = round(client?.get_exp_living(FALSE) / 60)
-	if(player_playtime && (player_playtime < minimumplaytime))
+	if(!isnull(player_playtime) && (player_playtime < minimumplaytime))
 		to_chat(usr, "<span class='warning'>You do not have sufficient playtime to vote in this poll. Minimum: [minimumplaytime] hour(s). Your playtime: [player_playtime] hour(s).</span>")
 		return
 	switch(polltype)


### PR DESCRIPTION
## Changelog
:cl:
add: Admins can now specify a minimum playtime requirement to vote in a server poll.
/:cl:

Don't merge or testmerge until talking to crossed about the DB changes.
