### PR TITLE
"Autophagocytosis Necrosis" can now conditionally create romerol

### DIFF
--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -84,7 +84,7 @@ Bonus
 /datum/symptom/flesh_death
 
 	name = "Autophagocytosis Necrosis"
-	desc = "The virus rapidly consumes infected cells, leading to heavy and widespread damage."
+	desc = "The virus rapidly consumes infected cells, leading to heavy and widespread damage. Contains dormant prions- expert virologists believe it to be the precursor to Romerol, though the mechanism through which they are activated is largely unknown"
 	stealth = -2
 	resistance = -2
 	stage_speed = 1
@@ -106,6 +106,8 @@ Bonus
 		suppress_warning = TRUE
 	if(A.properties["stage_rate"] >= 7) //bleeding and hunger
 		chems = TRUE
+	if((A.properties["stealth"] >= 2) && (A.properties["stage_rate"] >= 12))
+		zombie = TRUE
 
 /datum/symptom/flesh_death/Activate(datum/disease/advance/A)
 	if(!..())


### PR DESCRIPTION
## About The Pull Request

autophagocytosis necrosis can now synthesize romerol if a difficult symptom threshold is met. a vote for this pr has already been made so as to avoid people looking at the pr to find the threshold once it is posted- even though that is inevitable, it can be lessened to keep this threshold somewhat unknown, though i can easily make it widely visible. vote closed at 32 up and 3 down

## Why It's Good For The Game

makes the most boring of the five level nines not boring. people enjoy zombie rounds more than rounds where viro releases a disease that just murders the fuck out of everyone.

## Changelog
:cl:
add: there is now a way to activate autophageocytosis necrosis' zombie threshold
/:cl:
