### PR TITLE
fixes swat suit mask burning off

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -540,7 +540,6 @@
 	desc = "A tactical SWAT helmet MK.II."
 	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 25, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR //we want to see the mask
 	heat_protection = HEAD
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	actions_types = list()


### PR DESCRIPTION
## About The Pull Request
 swat suit mkII/III no longer has an exposed mask
## Why It's Good For The Game

a fireproof hardsuit's mask no longer burns off in intense heat
fixes https://github.com/BeeStation/BeeStation-Hornet/issues/796
## Changelog
:cl:

fix: swat suit mask will no longer burn off
/:cl:
