### PR TITLE
Small changeling nerfs

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -75,7 +75,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	for(var/datum/mind/changeling in changelings)
 		log_game("[key_name(changeling)] has been selected as a changeling")
 		var/datum/antagonist/changeling/new_antag = new()
-		new_antag.team_mode = TRUE
+		new_antag.team_mode = FALSE //Should stop team lings from spawning
 		changeling.add_antag_datum(new_antag)
 	..()
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -107,7 +107,7 @@
 	cost = 30
 	requirements = list(80,70,60,50,40,20,20,10,10,10)
 	high_population_requirement = 10
-	var/team_mode_probability = 30
+	var/team_mode_probability = 0
 
 /datum/dynamic_ruleset/roundstart/changeling/pre_execute()
 	var/num_changelings = min(round(mode.candidates.len / 10) + 1, candidates.len)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -729,7 +729,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 /datum/objective/absorb/update_explanation_text()
 	. = ..()
-	explanation_text = "Extract [target_amount] compatible genome\s."
+	explanation_text = "Extract [target_amount] compatible genome\s. Absorption is unecessary to complete this objective"
 
 /datum/objective/absorb/admin_edit(mob/admin)
 	var/count = input(admin,"How many people to absorb?","absorb",target_amount) as num|null
@@ -895,7 +895,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/changeling_team_objective //Abstract type
 	martyr_compatible = 0	//Suicide is not teamwork!
 	explanation_text = "Changeling Friendship!"
-	var/min_lings = 3 //Minimum amount of lings for this team objective to be possible
+	var/min_lings = 100 //Minimum amount of lings for this team objective to be possible //set to 100 to stop teamlings just in case
 	var/escape_objective_compatible = FALSE
 
 /datum/objective/changeling_team_objective/proc/prepare()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -1,4 +1,4 @@
-#define LING_FAKEDEATH_TIME					400 //40 seconds
+#define LING_FAKEDEATH_TIME					1200 //2 minutes
 #define LING_DEAD_GENETICDAMAGE_HEAL_CAP	50	//The lowest value of geneticdamage handle_changeling() can take it to while dead.
 #define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 

--- a/code/modules/antagonists/changeling/powers/hivemind.dm
+++ b/code/modules/antagonists/changeling/powers/hivemind.dm
@@ -4,7 +4,7 @@
 	desc = "We tune our senses to the airwaves to allow us to discreetly communicate and exchange DNA with other changelings."
 	helptext = "We will be able to talk with other changelings with :g. Exchanged DNA do not count towards absorb objectives."
 	needs_button = FALSE
-	dna_cost = 0
+	dna_cost = -1
 	chemical_cost = -1
 
 /datum/action/changeling/hivemind_comms/on_purchase(mob/user, is_respec)

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -4,7 +4,7 @@
 	helptext = "Emits a high-frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 30
-	dna_cost = 1
+	dna_cost = 2
 	req_human = 1
 
 //A flashy ability, good for crowd control and sowing chaos.

--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -4,8 +4,8 @@
 	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 3 DNA absorptions."
 	button_icon_state = "spread_infestation"
 	chemical_cost = 45
-	dna_cost = 1
-	req_absorbs = 3
+	dna_cost = 2
+	req_absorbs = 0
 
 //Makes some spiderlings. Good for setting traps and causing general trouble.
 /datum/action/changeling/spiders/sting_action(mob/user)


### PR DESCRIPTION

## About The Pull Request

- increases changeling regen time
- changelings no longer spawn as teams
- hivemind chat is now disabled- no more getting ganged up on by lings
- resonant shriek cost increased to two. it's a temporary change for something new as a whole
- slightly changes absorb objective's text to not encourage murderboning
- increases spider cost and removes absorb req to not encourage murderboning
## Why It's Good For The Game

- team objectives are broken, and are unfun for all parties even when they work
- team changelings mean the antags automatically team up. it can be fun if there is an absorb ling, but it's otherwise a curbstomp if the changelings communicate and work together. Hivemind does this as well- eliminating the automatic, unstoppable communication already makes lings far easier to handle
- regenerative stasis was only forty seconds. increased to two minutes- this makes it less useful to get out of sticky situations, and indirectly buffs Last Resort. 
- shriek's cost was increased to make it take a bit more investment.
- changed some things to discourage random absorptions
## Changelog
:cl:
del: disables ling team objectives and hivemind
tweak: changed absorb objective text
tweak: changed spiders to not require absorption, but increased cost
balance: increased resonant shriek cost
balance: increased time needed to regen
/:cl:

