### PR TITLE
Readds Viral aggressive metabolism

### DIFF
--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -78,7 +78,7 @@ Bonus
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/time_to_cure
-	threshold_desc = "<b>Resistance/Stage Speed</b> = "Highest between these determines the amount of time before self-curing.<br>\
+	threshold_desc = "<b>Resistance/Stage Speed</b> = Highest between these determines the amount of time before self-curing.<br>\
 					   <b>Stealth 4</b> = "Doubles the time before the virus self-cures."
 	)
 

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -78,9 +78,9 @@ Bonus
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/time_to_cure
-	threshold_desc = "<b>Resistance/Stage Speed</b> = Highest between these determines the amount of time before self-curing.<br>\
-					   <b>Stealth 4</b> = "Doubles the time before the virus self-cures."
-	)
+	threshold_desc = "<b>Resistance/Stage Speed:</b> Highest between these determines the amount of time before self-curing.<br>\
+					  <b>Stealth 4</b> Doubles the time before the virus self-cures"	
+	
 
 /datum/symptom/viralreverse/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -46,3 +46,61 @@ BONUS
 	stage_speed = 5
 	transmittable = 3
 	level = 3
+
+/*
+//////////////////////////////////////
+
+Viral aggressive metabolism
+
+	Somewhat increased stealth.
+	Abysmal resistance.
+	Increased stage speed.
+	Poor transmitability.
+	Medium Level.
+
+Bonus
+	The virus starts at stage 5, but after a certain time will start curing itself.
+	Stages still increase naturally with stage speed.
+
+//////////////////////////////////////
+*/
+
+/datum/symptom/viralreverse		//Hippie change, brought back cause tg is dumb
+
+	name = "Viral aggressive metabolism"
+	desc = "The virus sacrifices its long term survivability to nearly instantly fully spread inside a host. \
+	The virus will start at the last stage, but will eventually decay and die off by itself."
+	stealth = 1
+	resistance = -4
+	stage_speed = 3
+	transmittable = -3
+	level = 3
+	symptom_delay_min = 1
+	symptom_delay_max = 1
+	var/time_to_cure
+	threshold_descs = list("Resistance/Stage Speed" = "Highest between these determines the amount of time before self-curing.<br>",
+							"Stealth 4" = "Doubles the time before the virus self-cures."
+	)
+
+/datum/symptom/viralreverse/Activate(datum/disease/advance/A)
+	if(!..())
+		return
+	if(time_to_cure > 0)
+		time_to_cure--
+	else
+		var/mob/living/M = A.affected_mob
+		Heal(M, A)
+
+/datum/symptom/viralreverse/proc/Heal(mob/living/M, datum/disease/advance/A)
+	A.stage -= 1
+	if(A.stage < 2)
+		to_chat(M, "<span class='notice'>You suddenly feel healthy.</span>")
+		A.cure()
+
+/datum/symptom/viralreverse/Start(datum/disease/advance/A)
+	if(!..())
+		return
+	A.stage = 5
+	if(A.properties["stealth"] >= 4) //more time before it's cured
+		power = 2
+	time_to_cure = max(A.properties["resistance"], A.properties["stage_rate"]) * 10 * power

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -65,7 +65,7 @@ Bonus
 //////////////////////////////////////
 */
 
-/datum/symptom/viralreverse		//Hippie change, brought back cause tg is dumb
+/datum/symptom/viralreverse		
 
 	name = "Viral aggressive metabolism"
 	desc = "The virus sacrifices its long term survivability to nearly instantly fully spread inside a host. \

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -78,8 +78,8 @@ Bonus
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/time_to_cure
-	threshold_descs = list("Resistance/Stage Speed" = "Highest between these determines the amount of time before self-curing.<br>",
-							"Stealth 4" = "Doubles the time before the virus self-cures."
+	threshold_desc = "<b>Resistance/Stage Speed</b> = "Highest between these determines the amount of time before self-curing.<br>\
+					   <b>Stealth 4</b> = "Doubles the time before the virus self-cures."
 	)
 
 /datum/symptom/viralreverse/Activate(datum/disease/advance/A)


### PR DESCRIPTION
## About The Pull Request

This re-adds a virus symptom that was removed awhile ago (improve dont remove lmao, https://github.com/tgstation/tgstation/pull/36349 ), with nerfed stats. The symptom makes a virus start at full power, but get cured by itself quite fast (If i am reading this right, it should take about 10 ticks to cure per point in stage speed or resistance, whichever is higher. this is doubled if stealth is over four.

## Why It's Good For The Game

This symptom was around before the great virology nerf. I don't know much about the history of that time.

The 1 transmittable stat of this disease allowed it to spread deadly plagues at their most lethal state, which, considering the power of high- tier symptoms, was very easy and deadly, rather than working as intended, which, i assume, was to make a powerful, lethal disease designed to affect only a single target. The stats have been changed to reflect both this and its function, and, due to the deadliest symptoms being moved to level nine, this is no longer as big an issue, [s]and gives viro a way to safely validhunt without killing everyone[/s]


this should be my last addition to viro for awhile, hopefully, until i spot a new shiny that isn't op ass oldviro healing symptoms
## Changelog
:cl:
add: Readds Viral aggressive metabolism
/:cl:
