### PR TITLE
Social Anxiety Change

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -426,7 +426,7 @@
 		if(H.client)
 			nearby_people++
 	var/mob/living/carbon/human/H = quirk_holder
-	if(prob(2 + nearby_people))
+	if(prob(2 + 2^nearby_people))
 		H.stuttering = max(3, H.stuttering)
 	else if(prob(0.5) && dumb_thing)
 		to_chat(H, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -428,9 +428,6 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	if(prob(2 + nearby_people))
 		H.stuttering = max(3, H.stuttering)
-	else if(prob(min(3, nearby_people)) && !H.silent)
-		to_chat(H, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
-		H.silent = max(10, H.silent)
 	else if(prob(0.5) && dumb_thing)
 		to_chat(H, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
 		dumb_thing = FALSE //only once per life


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the "you retreat into yourself" part of social anxiety (it silences you) and increases the stutter chance based on the number of people around you exponentially.

## Why It's Good For The Game

This thing is 1 point trait perk that has one of the most oppressive side effects in the game (silence). This makes it actually worth 1 point, and removes annoying interactions where you have to wait two minutes for the chemist you're talking with to stop panicking.

## Changelog
:cl:
tweak: Social Anxiety no longer silences you. It now increases your stutter chance based on the number of people around you.
/:cl: