### PR TITLE
Confusion now only works if running

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -137,7 +137,7 @@
 	else
 		move_delay = world.time
 
-	if(L.confused && m_intent == MOVE_INTENT_RUN)
+	if(L.confused && L.m_intent == MOVE_INTENT_RUN)
 		var/newdir = 0
 		if(L.confused > 40)
 			newdir = pick(GLOB.alldirs)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -137,7 +137,7 @@
 	else
 		move_delay = world.time
 
-	if(L.confused && L.m_intent == "run")
+	if(L.confused && L.m_intent == MOVE_INTENT_RUN)
 		var/newdir = 0
 		if(L.confused > 40)
 			newdir = pick(GLOB.alldirs)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -137,7 +137,7 @@
 	else
 		move_delay = world.time
 
-	if(L.confused)
+	if(L.confused && m_intent=="run")
 		var/newdir = 0
 		if(L.confused > 40)
 			newdir = pick(GLOB.alldirs)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -137,7 +137,7 @@
 	else
 		move_delay = world.time
 
-	if(L.confused && m_intent=="run")
+	if(L.confused && m_intent == MOVE_INTENT_RUN)
 		var/newdir = 0
 		if(L.confused > 40)
 			newdir = pick(GLOB.alldirs)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -137,7 +137,7 @@
 	else
 		move_delay = world.time
 
-	if(L.confused && L.m_intent == MOVE_INTENT_RUN)
+	if(L.confused && L.m_intent == "run")
 		var/newdir = 0
 		if(L.confused > 40)
 			newdir = pick(GLOB.alldirs)


### PR DESCRIPTION

## About The Pull Request

Confusion now only works if running. Holding alt or clicking "walk" will negate confusion (also negates wallstun, but that was already in game) at the cost of slowing yourself down.

## Why It's Good For The Game

The wallstun already only worked if running, now this does too. This will slightly inhibit the AOE flash and resonant screech metas, and will help balance other shit to come

## Changelog
:cl:
tweak: Confusion now only works if running
/:cl:
