### PR TITLE
Lists number of connected players on Status panel

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -737,6 +737,7 @@
 		stat(null, "Round Time: [worldtime2text()]")
 		stat(null, "Station Time: [station_time_timestamp()]")
 		stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
+		stat(null, "Players Connected: [GLOB.clients.len]")
 		if(SSshuttle.emergency)
 			var/ETA = SSshuttle.emergency.getModeStr()
 			if(ETA)


### PR DESCRIPTION
## Changelog
:cl:
add: Number of players connected is now always listed on the Status panel.
/:cl:

There's already methods of seeing the number of connected players, showing it on the Status panel just makes it more prominent.