### PR TITLE
SHOULD fix sepchems

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -122,10 +122,9 @@
 		for(var/A in T)
 			reagents.reaction(A)
 				qdel(src)
-	else
-		if(seed.get_gene(/datum/plant_gene/trait/noreact)
-			addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
-				playsound(loc, 'sound/effects/fuse.ogg', 75, 1, -3)
+	if(seed.get_gene(/datum/plant_gene/trait/noreact)
+		addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
+			playsound(loc, 'sound/effects/fuse.ogg', 75, 1, -3)
 
 /obj/item/reagent_containers/food/snacks/grown/proc/attack_self(mob/living/user)
 	if(seed.get_gene(/datum/plant_gene/trait/noreact)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -89,7 +89,7 @@
 /obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
 		squash(user)
-			if(seed.get_gene(/datum/plant_gene/trait/noreact)
+			if(seed.get_gene(/datum/plant_gene/trait/noreact))
 				user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
 	..()
 
@@ -124,7 +124,7 @@
 		for(var/A in T)
 			reagents.reaction(A)
 				qdel(src)
-	if(seed.get_gene(/datum/plant_gene/trait/noreact)
+	if(seed.get_gene(/datum/plant_gene/trait/noreact))
 		log_bomber(user, "primed a", src, "for detonation")
 		if(iscarbon(user))
 			var/mob/living/carbon/C = user
@@ -133,7 +133,7 @@
 		addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
 		
 /obj/item/reagent_containers/food/snacks/grown/proc/prime()
-	if(seed.get_gene(/datum/plant_gene/trait/noreact)
+	if(seed.get_gene(/datum/plant_gene/trait/noreact))
 		DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
 			/datum/reagents.proc/handle_reactions
 				qdel(src)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -117,7 +117,6 @@
 	if(seed)
 		for(var/datum/plant_gene/trait/trait in seed.genes)
 			trait.on_squash(src, target)
-				qdel(src)
 	if(!seed.get_gene(/datum/plant_gene/trait/noreact)
 		reagents.reaction(T)
 		for(var/A in T)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -96,7 +96,7 @@
 		if(seed)
 			for(var/datum/plant_gene/trait/T in seed.genes)
 				T.on_throw_impact(src, hit_atom)
-			if(seed.get_gene(/datum/plant_gene/trait/squash))
+			if(seed.get_gene(/datum/plant_gene/trait/squash)
 				squash(hit_atom)
 
 /obj/item/reagent_containers/food/snacks/grown/proc/squash(atom/target)
@@ -117,10 +117,16 @@
 	if(seed)
 		for(var/datum/plant_gene/trait/trait in seed.genes)
 			trait.on_squash(src, target)
-
-	reagents.reaction(T)
-	for(var/A in T)
-		reagents.reaction(A)
+	if(!seed.get_gene(/datum/plant_gene/trait/noreact)
+		reagents.reaction(T)
+		for(var/A in T)
+			reagents.reaction(A)
+	else
+		if(seed.get_gene(/datum/plant_gene/trait/noreact) // so the plant doesn't just spill itself on the floor before mixing
+			addtimer(15)
+				reagents.reaction(T)
+				for(var/A in T)
+					reagents.reaction(A)
 
 	qdel(src)
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -89,6 +89,8 @@
 /obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
 		squash(user)
+			if(seed.get_gene(/datum/plant_gene/trait/noreact)
+				user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -123,12 +125,6 @@
 			reagents.reaction(A)
 				qdel(src)
 	if(seed.get_gene(/datum/plant_gene/trait/noreact)
-		addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
-			playsound(loc, 'sound/effects/fuse.ogg', 75, 1, -3)
-
-/obj/item/reagent_containers/food/snacks/grown/proc/attack_self(mob/living/user)
-	if(seed.get_gene(/datum/plant_gene/trait/noreact)
-		user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
 		log_bomber(user, "primed a", src, "for detonation")
 		if(iscarbon(user))
 			var/mob/living/carbon/C = user

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -98,7 +98,7 @@
 		if(seed)
 			for(var/datum/plant_gene/trait/T in seed.genes)
 				T.on_throw_impact(src, hit_atom)
-			if(seed.get_gene(/datum/plant_gene/trait/squash)
+			if(seed.get_gene(/datum/plant_gene/trait/squash))
 				squash(hit_atom)
 
 /obj/item/reagent_containers/food/snacks/grown/proc/squash(atom/target)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -135,7 +135,7 @@
 		
 /obj/item/reagent_containers/food/snacks/grown/proc/prime()
 	for(var/datum/plant_gene/trait/trait in seed.genes)
-		trait.on_prime(src, target)
+		trait.on_prime(src)
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/On_Consume()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -123,7 +123,7 @@
 		reagents.reaction(T)
 		for(var/A in T)
 			reagents.reaction(A)
-				qdel(src)
+		qdel(src)
 	if(seed.get_gene(/datum/plant_gene/trait/noreact))
 		log_bomber(user, "primed a", src, "for detonation")
 		if(iscarbon(user))

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -89,8 +89,8 @@
 /obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
 		squash(user)
-			if(seed.get_gene(/datum/plant_gene/trait/noreact))
-				user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
+	if(seed.get_gene(/datum/plant_gene/trait/noreact))
+		user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -117,18 +117,32 @@
 	if(seed)
 		for(var/datum/plant_gene/trait/trait in seed.genes)
 			trait.on_squash(src, target)
+				qdel(src)
 	if(!seed.get_gene(/datum/plant_gene/trait/noreact)
 		reagents.reaction(T)
 		for(var/A in T)
 			reagents.reaction(A)
+				qdel(src)
 	else
-		if(seed.get_gene(/datum/plant_gene/trait/noreact) // so the plant doesn't just spill itself on the floor before mixing
-			addtimer(15)
-				reagents.reaction(T)
-				for(var/A in T)
-					reagents.reaction(A)
+		if(seed.get_gene(/datum/plant_gene/trait/noreact)
+			addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
+				playsound(loc, 'sound/effects/fuse.ogg', 75, 1, -3)
 
-	qdel(src)
+/obj/item/reagent_containers/food/snacks/grown/proc/attack_self(mob/living/user)
+	if(seed.get_gene(/datum/plant_gene/trait/noreact)
+		user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
+		log_bomber(user, "primed a", src, "for detonation")
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			C.throw_mode_on()
+		playsound(loc, 'sound/effects/fuse.ogg', 75, 1, -3)
+		addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
+		
+/obj/item/reagent_containers/food/snacks/grown/proc/prime()
+	if(seed.get_gene(/datum/plant_gene/trait/noreact)
+		DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
+			/datum/reagents.proc/handle_reactions
+				qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/On_Consume()
 	if(iscarbon(usr))

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -91,6 +91,10 @@
 		squash(user)
 	if(seed.get_gene(/datum/plant_gene/trait/noreact))
 		user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
+		log_bomber(user, "primed a", src, "for detonation")
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			C.throw_mode_on()
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -125,18 +129,14 @@
 			reagents.reaction(A)
 		qdel(src)
 	if(seed.get_gene(/datum/plant_gene/trait/noreact))
-		log_bomber(user, "primed a", src, "for detonation")
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			C.throw_mode_on()
+		log_bomber(src, "primed for detonation")
 		playsound(loc, 'sound/effects/fuse.ogg', 75, 1, -3)
 		addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
 		
 /obj/item/reagent_containers/food/snacks/grown/proc/prime()
-	if(seed.get_gene(/datum/plant_gene/trait/noreact))
-		DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
-			/datum/reagents.proc/handle_reactions
-				qdel(src)
+	for(var/datum/plant_gene/trait/trait in seed.genes)
+		trait.on_prime(src, target)
+	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/On_Consume()
 	if(iscarbon(usr))

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -91,10 +91,6 @@
 		squash(user)
 	if(seed.get_gene(/datum/plant_gene/trait/noreact))
 		user.visible_message("<span class='warning'>[user] shakes [src] vigorously!</span>", "<span class='userdanger'>You shake [src] vigorously!</span>")
-		log_bomber(user, "primed a", src, "for detonation")
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			C.throw_mode_on()
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -129,7 +125,6 @@
 			reagents.reaction(A)
 		qdel(src)
 	if(seed.get_gene(/datum/plant_gene/trait/noreact))
-		log_bomber(src, "primed for detonation")
 		playsound(loc, 'sound/effects/fuse.ogg', 75, 1, -3)
 		addtimer(CALLBACK(src, .proc/prime), rand(30, 60))
 		

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -119,7 +119,7 @@
 	if(seed)
 		for(var/datum/plant_gene/trait/trait in seed.genes)
 			trait.on_squash(src, target)
-	if(!seed.get_gene(/datum/plant_gene/trait/noreact)
+	if(!seed.get_gene(/datum/plant_gene/trait/noreact))
 		reagents.reaction(T)
 		for(var/A in T)
 			reagents.reaction(A)

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -121,10 +121,10 @@
 		C.throw_mode_on()
 	icon_state = "firelemon_active"
 	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
-	addtimer(CALLBACK(src, .proc/prime), rand(10, 60))
+	addtimer(CALLBACK(src, .proc/lprime), rand(10, 60))
 
 /obj/item/reagent_containers/food/snacks/grown/firelemon/burn()
-	prime()
+	lprime()
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/firelemon/proc/update_mob()
@@ -135,7 +135,7 @@
 /obj/item/reagent_containers/food/snacks/grown/firelemon/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion
 
-/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime()
+/obj/item/reagent_containers/food/snacks/grown/firelemon/proc/lprime()
 	switch(seed.potency) //Combustible lemons are alot like IEDs, lots of flame, very little bang.
 		if(0 to 30)
 			update_mob()

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -141,18 +141,18 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/attack_self(mob/living/user)
 	user.visible_message("<span class='warning'>[user] plucks the stem from [src]!</span>", "<span class='userdanger'>You pluck the stem from [src], which begins to hiss loudly!</span>")
 	log_bomber(user, "primed a", src, "for detonation")
-	prime()
+	cprime()
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/deconstruct(disassembled = TRUE)
 	if(!disassembled)
-		prime()
+		cprime()
 	if(!QDELETED(src))
 		qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/ex_act(severity)
 	qdel(src) //Ensuring that it's deleted by its own explosion. Also prevents mass chain reaction with piles of cherry bombs
 
-/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/cprime()
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, 0)
 	reagents.chem_temp = 1000 //Sets off the black powder

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -316,11 +316,6 @@
 	..()
 	ENABLE_BITFIELD(G.reagents.flags, NO_REACT)
 
-/datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
-	DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
-	addtimer(CALLBACK(G.reagents, /datum/reagents.proc/handle_reactions), 15) // Wait a second and a half before the chemicals reaction on SQUASH
-
-
 /datum/plant_gene/trait/maxchem
 	// 2x to max reagents volume.
 	name = "Densified Chemicals"

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -318,7 +318,7 @@
 
 /datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
-	addtimer(CALLBACK(G.reagents, /datum/reagents.proc/handle_reactions), 10) // Wait half a second before the chemicals reaction on SQUASH
+	addtimer(CALLBACK(G.reagents, /datum/reagents.proc/handle_reactions), 15) // Wait a second and a half before the chemicals reaction on SQUASH
 
 
 /datum/plant_gene/trait/maxchem

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -319,7 +319,7 @@
 	..()
 	ENABLE_BITFIELD(G.reagents.flags, NO_REACT)
 	
-/datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+/datum/plant_gene/trait/noreact/on_prime(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
 	G.reagents.handle_reactions()
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -315,6 +315,10 @@
 /datum/plant_gene/trait/noreact/on_new(obj/item/reagent_containers/food/snacks/grown/G, newloc)
 	..()
 	ENABLE_BITFIELD(G.reagents.flags, NO_REACT)
+	
+/datum/plant_gene/trait/noreact/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	DISABLE_BITFIELD(G.reagents.flags, NO_REACT)
+	G.reagents.handle_reactions()
 
 /datum/plant_gene/trait/maxchem
 	// 2x to max reagents volume.

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -166,6 +166,9 @@
 
 /datum/plant_gene/trait/proc/on_squash(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
 	return
+	
+/datum/plant_gene/trait/proc/on_prime(obj/item/reagent_containers/food/snacks/grown/G, atom/target)
+	return
 
 /datum/plant_gene/trait/proc/on_attackby(obj/item/reagent_containers/food/snacks/grown/G, obj/item/I, mob/user)
 	return


### PR DESCRIPTION

## About The Pull Request

separated chems works again, i think.

## Why It's Good For The Game

Makes sepchems work. If i did this right, instead of a separated chems plant falling to the ground and being deleted immediately after squash, it should instead work like a grenade- detonating in 3-6 seconds if primed or if squashed.

## Changelog
:cl:
fix: fixed sep chems so it actually does something again
balance: but keeps it nerfed to grenade levels
/:cl:
