### PR TITLE
[TG Port] Surgery tool refactor

### DIFF
--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -8,7 +8,12 @@
 #define TOOL_ANALYZER		"analyzer"
 #define TOOL_MINING			"mining"
 #define TOOL_SHOVEL			"shovel"
-
+#define TOOL_RETRACTOR	 	"retractor"
+#define TOOL_HEMOSTAT 		"hemostat"
+#define TOOL_CAUTERY 		"cautery"
+#define TOOL_DRILL			"drill"
+#define TOOL_SCALPEL		"scalpel"
+#define TOOL_SAW			"saw"
 
 // If delay between the start and the end of tool operation is less than MIN_TOOL_SOUND_DELAY,
 // tool sound is only played when op is started. If not, it's played twice.

--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -13,6 +13,8 @@
 	energy_drain = 10
 	force = 15
 	harmful = TRUE
+	tool_behaviour = TOOL_DRILL
+	toolspeed = 0.9
 	var/drill_delay = 7
 	var/drill_level = DRILL_BASIC
 
@@ -141,6 +143,7 @@
 	drill_delay = 4
 	drill_level = DRILL_HARDENED
 	force = 15
+	toolspeed = 0.7
 
 
 /obj/item/mecha_parts/mecha_equipment/mining_scanner

--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -8,6 +8,8 @@
 	icon_state = "mecha_clamp"
 	equip_cooldown = 15
 	energy_drain = 10
+	tool_behaviour = TOOL_RETRACTOR
+	toolspeed = 0.8
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
 	harmful = TRUE

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -320,6 +320,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
+	tool_behaviour = TOOL_SAW
+	toolspeed = 1.5 //slower than a real saw
 
 /obj/item/nullrod/claymore/glowing
 	icon_state = "swordon"
@@ -487,6 +489,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
+	tool_behaviour = TOOL_SAW
+	toolspeed = 0.5 //faster than normal saw
 
 
 /obj/item/nullrod/hammmer
@@ -512,6 +516,9 @@
 	sharpness = IS_SHARP
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
+	tool_behaviour = TOOL_SAW
+	toolspeed = 2 //slower than a real saw
+
 
 /obj/item/nullrod/chainsaw/Initialize()
 	. = ..()

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -139,6 +139,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	sharpness = IS_SHARP
 	light_color = "#40ceff"
+	tool_behaviour = TOOL_SAW
+	toolspeed = 0.7 //faster as a saw
 
 /obj/item/melee/transforming/energy/sword/cyborg/saw/cyborg_unequip(mob/user)
 	if(!active)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -579,6 +579,8 @@
 	sharpness = IS_SHARP
 	actions_types = list(/datum/action/item_action/startchainsaw)
 	var/on = FALSE
+	tool_behaviour = TOOL_SAW
+	toolspeed = 0.5
 
 /obj/item/twohanded/required/chainsaw/Initialize()
 	. = ..()

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -444,6 +444,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	sharpness = IS_SHARP
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
+	tool_behaviour = TOOL_SAW
+	toolspeed = 1
 
 /obj/item/mounted_chainsaw/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -285,7 +285,7 @@
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 	else if(istype(W, /obj/item/paicard))
 		insertpai(user, W)
-	else if(istype(W, /obj/item/hemostat) && paicard)
+	else if(istype(W.tool_behaviour == TOOL_HEMOSTAT) && paicard)
 		if(open)
 			to_chat(user, "<span class='warning'>Close the access panel before manipulating the personality slot!</span>")
 		else

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -285,7 +285,7 @@
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 	else if(istype(W, /obj/item/paicard))
 		insertpai(user, W)
-	else if(istype(W.tool_behaviour == TOOL_HEMOSTAT) && paicard)
+	else if((W.tool_behaviour == TOOL_HEMOSTAT) && paicard)
 		if(open)
 			to_chat(user, "<span class='warning'>Close the access panel before manipulating the personality slot!</span>")
 		else

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -385,7 +385,7 @@
 #undef BRAINS_BLOWN_THROW_RANGE
 
 
-
+//TODO: sawing off guns with TOOL_SAW
 /obj/item/gun/ballistic/proc/sawoff(mob/user)
 	if(sawn_off)
 		to_chat(user, "<span class='warning'>\The [src] is already shortened!</span>")

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -225,7 +225,7 @@
 	name = "Searing Tool"
 	desc = "Used to mend tissue togheter."
 	id = "searingtool"
-	build_path = /obj/item/cautery/advanced
+	build_path = /obj/item/surgicaldrill/advanced
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000, /datum/material/plasma = 2000, /datum/material/uranium = 3000, /datum/material/titanium = 3000)
 	category = list("Tool Designs")

--- a/code/modules/surgery/advanced/bioware/experimental_dissection.dm
+++ b/code/modules/surgery/advanced/bioware/experimental_dissection.dm
@@ -22,7 +22,7 @@
 
 /datum/surgery_step/dissection
 	name = "dissection"
-	implements = list(/obj/item/scalpel = 60, /obj/item/kitchen/knife = 30, /obj/item/shard = 15)
+	implements = list(TOOL_SCALPEL = 60, /obj/item/kitchen/knife = 30, /obj/item/shard = 15)
 	time = 125
 
 /datum/surgery_step/dissection/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -27,7 +27,7 @@
 
 /datum/surgery_step/brainwash
 	name = "brainwash"
-	implements = list(/obj/item/hemostat = 85, TOOL_WIRECUTTER = 50, /obj/item/stack/packageWrap = 35, /obj/item/stack/cable_coil = 15)
+	implements = list(TOOL_HEMOSTAT = 85, TOOL_WIRECUTTER = 50, /obj/item/stack/packageWrap = 35, /obj/item/stack/cable_coil = 15)
 	time = 200
 	var/objective
 

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -23,7 +23,7 @@
 
 /datum/surgery_step/lobotomize
 	name = "perform lobotomy"
-	implements = list(/obj/item/scalpel = 85, /obj/item/melee/transforming/energy/sword = 55, /obj/item/kitchen/knife = 35,
+	implements = list(TOOL_SCALPEL = 85, /obj/item/melee/transforming/energy/sword = 55, /obj/item/kitchen/knife = 35,
 		/obj/item/shard = 25, /obj/item = 20)
 	time = 100
 

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -20,7 +20,7 @@
 
 /datum/surgery_step/pacify
 	name = "rewire brain"
-	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
 	time = 40
 
 /datum/surgery_step/pacify/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/advanced/reconstruction.dm
+++ b/code/modules/surgery/advanced/reconstruction.dm
@@ -14,7 +14,7 @@
 
 /datum/surgery_step/reconstruct
 	name = "repair body"
-	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
 	repeatable = TRUE
 	time = 25
 

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -20,7 +20,7 @@
 
 /datum/surgery_step/viral_bond
 	name = "viral bond"
-	implements = list(/obj/item/cautery = 100, TOOL_WELDER = 50, /obj/item = 30) // 30% success with any hot item.
+	implements = list(TOOL_CAUTERY = 100, TOOL_WELDER = 50, /obj/item = 30) // 30% success with any hot item.
 	time = 100
 	chems_needed = list(/datum/reagent/medicine/spaceacillin,/datum/reagent/consumable/virus_food,/datum/reagent/toxin/formaldehyde)
 

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -9,7 +9,7 @@
 
 /datum/surgery_step/sever_limb
 	name = "sever limb"
-	implements = list(/obj/item/scalpel = 100, /obj/item/circular_saw = 100, /obj/item/melee/transforming/energy/sword/cyborg/saw = 100, /obj/item/melee/arm_blade = 80, /obj/item/twohanded/required/chainsaw = 80, /obj/item/mounted_chainsaw = 80, /obj/item/twohanded/fireaxe = 50, /obj/item/hatchet = 40, /obj/item/kitchen/knife/butcher = 25)
+	implements = list(TOOL_SCALPEL = 100, TOOL_SAW = 100, /obj/item/melee/arm_blade = 80, /obj/item/twohanded/fireaxe = 50, /obj/item/hatchet = 40, /obj/item/kitchen/knife/butcher = 25)
 	time = 64
 
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -14,7 +14,7 @@
 
 /datum/surgery_step/fix_brain
 	name = "fix brain"
-	implements = list(/obj/item/hemostat = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
+	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	time = 120 //long and complicated
 
 /datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target)

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -14,7 +14,7 @@
 //extract brain
 /datum/surgery_step/extract_core
 	name = "extract core"
-	implements = list(/obj/item/hemostat = 100, TOOL_CROWBAR = 100)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 100)
 	time = 16
 
 /datum/surgery_step/extract_core/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -8,7 +8,7 @@
 //fix eyes
 /datum/surgery_step/fix_eyes
 	name = "fix eyes"
-	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 45, /obj/item/pen = 25)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 45, /obj/item/pen = 25)
 	time = 64
 
 /datum/surgery/eye_surgery/can_start(mob/user, mob/living/carbon/target)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -89,12 +89,12 @@
 			"<span class='notice'>You remove [I] from [M]'s [parse_zone(selected_zone)].</span>")
 		qdel(S)
 	else if(S.can_cancel)
-		var/close_tool_type = /obj/item/cautery
+		var/required_tool_type = TOOL_CAUTERY
 		var/obj/item/close_tool = user.get_inactive_held_item()
 		var/is_robotic = S.requires_bodypart_type == BODYPART_ROBOTIC
 		if(is_robotic)
-			close_tool_type = /obj/item/screwdriver
-		if(istype(close_tool, close_tool_type) || iscyborg(user))
+			required_tool_type = TOOL_SCREWDRIVER
+		if(close_tool.tool_behaviour == required_tool_type || iscyborg(user))
 			M.surgeries -= S
 			user.visible_message("[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].", \
 				"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -8,7 +8,7 @@
 //extract implant
 /datum/surgery_step/extract_implant
 	name = "extract implant"
-	implements = list(/obj/item/hemostat = 100, TOOL_CROWBAR = 65)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 65)
 	time = 64
 	var/obj/item/implant/I = null
 

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -6,7 +6,7 @@
 
 /datum/surgery_step/replace
 	name = "sever muscles"
-	implements = list(/obj/item/scalpel = 100, TOOL_WIRECUTTER = 55)
+	implements = list(TOOL_SCALPEL = 100, TOOL_WIRECUTTER = 55)
 	time = 32
 
 

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -12,7 +12,7 @@
 //cut fat
 /datum/surgery_step/cut_fat
 	name = "cut excess fat"
-	implements = list(/obj/item/circular_saw = 100, /obj/item/melee/transforming/energy/sword/cyborg/saw = 100, /obj/item/hatchet = 35, /obj/item/kitchen/knife/butcher = 25)
+	implements = list(TOOL_SAW = 100, /obj/item/hatchet = 35, /obj/item/kitchen/knife/butcher = 25)
 	time = 64
 
 /datum/surgery_step/cut_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -25,7 +25,7 @@
 //remove fat
 /datum/surgery_step/remove_fat
 	name = "remove loose fat"
-	implements = list(/obj/item/retractor = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
+	implements = list(TOOL_RETRACTOR = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
 	time = 32
 
 /datum/surgery_step/remove_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -3,7 +3,7 @@
 	name = "unscrew shell"
 	implements = list(
 		TOOL_SCREWDRIVER		= 100,
-		/obj/item/scalpel 		= 75, // med borgs could try to unskrew shell with scalpel
+		TOOL_SCALPEL 			= 75, // med borgs could try to unskrew shell with scalpel
 		/obj/item/kitchen/knife	= 50,
 		/obj/item				= 10) // 10% success with any sharp item.
 	time = 24
@@ -23,7 +23,7 @@
 	name = "screw shell"
 	implements = list(
 		TOOL_SCREWDRIVER		= 100,
-		/obj/item/scalpel 		= 75,
+		TOOL_SCALPEL 			= 75,
 		/obj/item/kitchen/knife	= 50,
 		/obj/item				= 10) // 10% success with any sharp item.
 	time = 24
@@ -43,7 +43,7 @@
 	name = "prepare electronics"
 	implements = list(
 		TOOL_MULTITOOL = 100,
-		/obj/item/hemostat = 10) // try to reboot internal controllers via short circuit with some conductor
+		TOOL_HEMOSTAT = 10) // try to reboot internal controllers via short circuit with some conductor
 	time = 24
 
 /datum/surgery_step/prepare_electronics/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -55,7 +55,7 @@
 	name = "unwrench bolts"
 	implements = list(
 		TOOL_WRENCH = 100,
-		/obj/item/retractor = 10)
+		TOOL_RETRACTOR = 10)
 	time = 24
 
 /datum/surgery_step/mechanic_unwrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -67,7 +67,7 @@
 	name = "wrench bolts"
 	implements = list(
 		TOOL_WRENCH = 100,
-		/obj/item/retractor = 10)
+		TOOL_RETRACTOR = 10)
 	time = 24
 
 /datum/surgery_step/mechanic_wrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -69,7 +69,7 @@
 	name = "manipulate organs"
 	repeatable = 1
 	implements = list(/obj/item/organ = 100, /obj/item/reagent_containers/food/snacks/organ = 0, /obj/item/organ_storage = 100)
-	var/implements_extract = list(/obj/item/hemostat = 100, TOOL_CROWBAR = 55)
+	var/implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 55)
 	var/current_type
 	var/obj/item/organ/I = null
 

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -2,7 +2,7 @@
 //make incision
 /datum/surgery_step/incise
 	name = "make incision"
-	implements = list(/obj/item/scalpel = 100, /obj/item/melee/transforming/energy/sword = 75, /obj/item/kitchen/knife = 65,
+	implements = list(TOOL_SCALPEL = 100, /obj/item/melee/transforming/energy/sword = 75, /obj/item/kitchen/knife = 65,
 		/obj/item/shard = 45, /obj/item = 30) // 30% success with any sharp item.
 	time = 16
 
@@ -19,7 +19,7 @@
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders
 	name = "clamp bleeders"
-	implements = list(/obj/item/hemostat = 100, TOOL_WIRECUTTER = 60, /obj/item/stack/packageWrap = 35, /obj/item/stack/cable_coil = 15)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_WIRECUTTER = 60, /obj/item/stack/packageWrap = 35, /obj/item/stack/cable_coil = 15)
 	time = 24
 
 /datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -35,7 +35,7 @@
 //retract skin
 /datum/surgery_step/retract_skin
 	name = "retract skin"
-	implements = list(/obj/item/retractor = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
+	implements = list(TOOL_RETRACTOR = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
 	time = 24
 
 /datum/surgery_step/retract_skin/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -47,7 +47,7 @@
 //close incision
 /datum/surgery_step/close
 	name = "mend incision"
-	implements = list(/obj/item/cautery = 100, /obj/item/gun/energy/laser = 90, TOOL_WELDER = 70,
+	implements = list(TOOL_CAUTERY = 100, /obj/item/gun/energy/laser = 90, TOOL_WELDER = 70,
 		/obj/item = 30) // 30% success with any hot item.
 	time = 24
 
@@ -71,9 +71,8 @@
 //saw bone
 /datum/surgery_step/saw
 	name = "saw bone"
-	implements = list(/obj/item/circular_saw = 100, /obj/item/melee/transforming/energy/sword/cyborg/saw = 100,
-		/obj/item/melee/arm_blade = 75, /obj/item/mounted_chainsaw = 65, /obj/item/twohanded/required/chainsaw = 50,
-		/obj/item/twohanded/fireaxe = 50, /obj/item/hatchet = 35, /obj/item/kitchen/knife/butcher = 25)
+	implements = list(TOOL_SAW = 100,/obj/item/melee/arm_blade = 75,
+	/obj/item/twohanded/fireaxe = 50, /obj/item/hatchet = 35, /obj/item/kitchen/knife/butcher = 25)
 	time = 54
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
@@ -89,7 +88,7 @@
 //drill bone
 /datum/surgery_step/drill
 	name = "drill bone"
-	implements = list(/obj/item/surgicaldrill = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, /obj/item/mecha_parts/mecha_equipment/drill = 60, TOOL_SCREWDRIVER = 20)
+	implements = list(TOOL_DRILL = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 20)
 	time = 30
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -6,7 +6,7 @@
 //reshape_face
 /datum/surgery_step/reshape_face
 	name = "reshape face"
-	implements = list(/obj/item/scalpel = 100, /obj/item/kitchen/knife = 50, TOOL_WIRECUTTER = 35)
+	implements = list(TOOL_SCALPEL = 100, /obj/item/kitchen/knife = 50, TOOL_WIRECUTTER = 35)
 	time = 64
 
 /datum/surgery_step/reshape_face/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -295,112 +295,68 @@
 
 /obj/item/scalpel/advanced
 	name = "laser scalpel"
-	desc = "An advanced scalpel which uses laser technology to cut. It's set to scalpel mode."
+	desc = "An advanced scalpel which uses laser technology to cut."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "scalpel_a"
 	hitsound = 'sound/weapons/blade1.ogg'
 	force = 16
 	toolspeed = 0.7
 	light_color = LIGHT_COLOR_GREEN
+	sharpness = IS_SHARP_ACCURATE
 
 /obj/item/scalpel/advanced/Initialize()
 	. = ..()
 	set_light(1)
 
 /obj/item/scalpel/advanced/attack_self(mob/user)
-	playsound(get_turf(user),'sound/machines/click.ogg',50,1)
-	var/obj/item/circular_saw/advanced/saw = new /obj/item/circular_saw/advanced(drop_location())
-	to_chat(user, "<span class='notice'>You incease the power, now it can cut bones.</span>")
-	qdel(src)
-	user.put_in_active_hand(saw)
+	playsound(get_turf(user), 'sound/machines/click.ogg', 50, TRUE)
+	if(tool_behaviour == TOOL_SCALPEL)
+		tool_behaviour = TOOL_SAW
+		to_chat(user, "<span class='notice'>You increase the power of [src], now it can cut bones.</span>")
+		set_light(2)
+		force += 1 //we don't want to ruin sharpened stuff
+		icon_state = "saw_a"
+	else
+		tool_behaviour = TOOL_SCALPEL
+		to_chat(user, "<span class='notice'>You lower the power of [src], it can no longer cut bones.</span>")
+		set_light(1)
+		force -= 1
+		icon_state = "scalpel_a"
 
-/obj/item/circular_saw/advanced
-	name = "laser scalpel"
-	desc = "An advanced scalpel which uses laser technology to cut. It's set to saw mode."
-	icon = 'icons/obj/surgery.dmi'
-	icon_state = "saw_a"
-	hitsound = 'sound/weapons/blade1.ogg'
-	force = 17
-	toolspeed = 0.7
-	sharpness = IS_SHARP_ACCURATE
-	light_color = LIGHT_COLOR_GREEN
-
-/obj/item/circular_saw/advanced/Initialize()
-	. = ..()
-	set_light(2)
-
-/obj/item/circular_saw/advanced/attack_self(mob/user)
-	playsound(get_turf(user),'sound/machines/click.ogg',50,1)
-	var/obj/item/scalpel/advanced/scalpel = new /obj/item/scalpel/advanced(drop_location())
-	to_chat(user, "<span class='notice'>You lower the power.</span>")
-	qdel(src)
-	user.put_in_active_hand(scalpel)
+/obj/item/scalpel/advanced/examine()
+	. += " It's set to [tool_behaviour == TOOL_SCALPEL ? "scalpel" : "saw"] mode."
 
 /obj/item/retractor/advanced
 	name = "mechanical pinches"
-	desc = "An agglomerate of rods and gears. It resembles a retractor."
+	desc = "An agglomerate of rods and gears."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "retractor_a"
 	toolspeed = 0.7
 
 /obj/item/retractor/advanced/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/hemostat/advanced/hemostat = new /obj/item/hemostat/advanced(drop_location())
-	to_chat(user, "<span class='notice'>You set the [src] to hemostat mode.</span>")
-	qdel(src)
-	user.put_in_active_hand(hemostat)
+	playsound(get_turf(user), 'sound/items/change_drill.ogg', 50, TRUE)
+	if(tool_behaviour == TOOL_RETRACTOR)
+		tool_behaviour = TOOL_HEMOSTAT
+		to_chat(user, "<span class='notice'>You configure the gears of [src], they are now in hemostat mode.</span>")
+		icon_state = "hemostat_a"
+	else
+		tool_behaviour = TOOL_RETRACTOR
+		to_chat(user, "<span class='notice'>You configure the gears of [src], they are now in retractor mode.</span>")
+		icon_state = "retractor_a"
 
-/obj/item/hemostat/advanced
-	name = "mechanical pinches"
-	desc = "An agglomerate of rods and gears. It resembles an hemostat."
-	icon = 'icons/obj/surgery.dmi'
-	icon_state = "hemostat_a"
-	toolspeed = 0.7
-
-/obj/item/hemostat/advanced/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/retractor/advanced/retractor = new /obj/item/retractor/advanced(drop_location())
-	to_chat(user, "<span class='notice'>You set the [src] to retractor mode.</span>")
-	qdel(src)
-	user.put_in_active_hand(retractor)
+/obj/item/retractor/advanced/examine()
+	. += " It resembles a retractor[tool_behaviour == TOOL_RETRACTOR ? "retractor" : "hemostat"]."
 
 /obj/item/surgicaldrill/advanced
-	name = "searing tool"
-	desc = "It projects a high power laser used for medical application. It's set to drilling mode."
-	icon = 'icons/obj/surgery.dmi'
-	icon_state = "surgicaldrill_a"
-	hitsound = 'sound/items/welder.ogg'
-	toolspeed = 0.7
-	light_color = LIGHT_COLOR_RED
+	playsound(get_turf(user), 'sound/weapons/tap.ogg', 50, TRUE)
+	if(tool_behaviour == TOOL_DRILL)
+		tool_behaviour = TOOL_CAUTERY
+		to_chat(user, "<span class='notice'>You focus the lenses of [src], it is now in mending mode.</span>")
+		icon_state = "cautery_a"
+	else
+		tool_behaviour = TOOL_DRILL
+		to_chat(user, "<span class='notice'>You dilate the lenses of [src], it is now in drilling mode.</span>")
+		icon_state = "surgicaldrill_a"
 
-/obj/item/surgicaldrill/advanced/Initialize()
-	. = ..()
-	set_light(1)
-
-/obj/item/surgicaldrill/advanced/attack_self(mob/user)
-	playsound(get_turf(user),'sound/weapons/tap.ogg',50,1)
-	var/obj/item/cautery/advanced/cautery = new /obj/item/cautery/advanced(drop_location())
-	to_chat(user, "<span class='notice'>You dilate the lenses, setting it to mending mode.</span>")
-	qdel(src)
-	user.put_in_active_hand(cautery)
-
-/obj/item/cautery/advanced
-	name = "searing tool"
-	desc = "It projects a high power laser used for medical application. It's set to mending mode."
-	icon = 'icons/obj/surgery.dmi'
-	icon_state = "cautery_a"
-	hitsound = 'sound/items/welder2.ogg'
-	force = 15
-	toolspeed = 0.7
-	light_color = LIGHT_COLOR_RED
-
-/obj/item/cautery/advanced/Initialize()
-	. = ..()
-	set_light(1)
-
-/obj/item/cautery/advanced/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/welderdeactivate.ogg',50,1)
-	var/obj/item/surgicaldrill/advanced/surgicaldrill = new /obj/item/surgicaldrill/advanced(drop_location())
-	to_chat(user, "<span class='notice'>You focus the lensess, it is now set to drilling mode.</span>")
-	qdel(src)
-	user.put_in_active_hand(surgicaldrill)
+/obj/item/surgicaldrill/advanced/examine()
+	. += " It's set to [tool_behaviour == TOOL_DRILL ? "drilling" : "mending"] mode."

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -293,6 +293,7 @@
 		return TRUE
 	return
 
+
 /obj/item/scalpel/advanced
 	name = "laser scalpel"
 	desc = "An advanced scalpel which uses laser technology to cut."
@@ -348,6 +349,19 @@
 	. += " It resembles a retractor[tool_behaviour == TOOL_RETRACTOR ? "retractor" : "hemostat"]."
 
 /obj/item/surgicaldrill/advanced
+	name = "searing tool"
+	desc = "It projects a high power laser used for medical application."
+	icon = 'icons/obj/surgery.dmi'
+	icon_state = "surgicaldrill_a"
+	hitsound = 'sound/items/welder.ogg'
+	toolspeed = 0.7
+	light_color = LIGHT_COLOR_RED
+
+/obj/item/surgicaldrill/advanced/Initialize()
+	. = ..()
+	set_light(1)
+
+/obj/item/surgicaldrill/advanced/attack_self(mob/user)
 	playsound(get_turf(user), 'sound/weapons/tap.ogg', 50, TRUE)
 	if(tool_behaviour == TOOL_DRILL)
 		tool_behaviour = TOOL_CAUTERY

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -9,6 +9,8 @@
 	materials = list(/datum/material/iron=6000, /datum/material/glass=3000)
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
+	tool_behaviour = TOOL_RETRACTOR
+	toolspeed = 1
 
 
 /obj/item/retractor/augment
@@ -34,6 +36,8 @@
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("attacked", "pinched")
+	tool_behaviour = TOOL_HEMOSTAT
+	toolspeed = 1
 
 
 /obj/item/hemostat/augment
@@ -60,6 +64,8 @@
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("burnt")
+	tool_behaviour = TOOL_CAUTERY
+	toolspeed = 1
 
 
 /obj/item/cautery/augment
@@ -87,6 +93,8 @@
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("drilled")
+	tool_behaviour = TOOL_DRILL
+	toolspeed = 1
 
 /obj/item/surgicaldrill/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] rams [src] into [user.p_their()] chest! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -127,6 +135,8 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = IS_SHARP_ACCURATE
+	tool_behaviour = TOOL_SCALPEL
+	toolspeed = 1
 
 /obj/item/scalpel/Initialize()
 	. = ..()
@@ -172,6 +182,8 @@
 	materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
 	attack_verb = list("attacked", "slashed", "sawed", "cut")
 	sharpness = IS_SHARP
+	tool_behaviour = TOOL_SAW
+	toolspeed = 1
 
 /obj/item/circular_saw/Initialize()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
This implements the [tg#46856](https://github.com/tgstation/tgstation/pull/46856) except the gun sawing part, since we haven't had a vote for that. 

This also makes all chainsaws being percieved as surgical saws because why not? Also different saws saw at different speeds. Also you can use the mech drill as a surgical drill. Idk, the original author might have thought it was funny (it is).

Works on my machine.

## Why It's Good For The Game

Code improvements are good, uh?
Also, this is required for the omnitool PR, since it lets you add surgical tool characteristics to different items.

## Changelog
:cl:
tweak: chainsaws are now viewed as regular saws in surgery
refactor: changed how non-ghetto surgery tools are marked for usability in surgery
/:cl:

