### PR TITLE
Ling Nerfs

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -434,9 +434,9 @@
 		return
 	else
 		linked_alert.icon_state = "fleshmend"
-	owner.adjustBruteLoss(-10, FALSE)
+	owner.adjustBruteLoss(-6, FALSE)
 	owner.adjustFireLoss(-5, FALSE)
-	owner.adjustOxyLoss(-10)
+	owner.adjustOxyLoss(-6)
 
 /obj/screen/alert/status_effect/fleshmend
 	name = "Fleshmend"

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -1,9 +1,9 @@
 /datum/action/changeling/fleshmend
 	name = "Fleshmend"
-	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Costs 20 chemicals."
+	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Costs 25 chemicals."
 	helptext = "If we are on fire, the healing effect will not function. Does not regrow limbs or restore lost blood. Functions while unconscious."
 	button_icon_state = "fleshmend"
-	chemical_cost = 20
+	chemical_cost = 25
 	dna_cost = 2
 	req_stat = UNCONSCIOUS
 

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -1,8 +1,8 @@
 /datum/action/changeling/humanform
 	name = "Human Form"
-	desc = "We change into a human. Costs 5 chemicals."
+	desc = "We change into a human. Costs 10 chemicals."
 	button_icon_state = "human_form"
-	chemical_cost = 5
+	chemical_cost = 10
 	req_dna = 1
 
 //Transform into a human.

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -1,9 +1,9 @@
 /datum/action/changeling/lesserform
 	name = "Lesser Form"
-	desc = "We debase ourselves and become lesser. We become a monkey. Costs 5 chemicals."
+	desc = "We debase ourselves and become lesser. We become a monkey. Costs 20 chemicals."
 	helptext = "The transformation greatly reduces our size, allowing us to slip out of cuffs and climb through vents."
 	button_icon_state = "lesser_form"
-	chemical_cost = 5
+	chemical_cost = 20
 	dna_cost = 1
 	req_human = 1
 

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -15,13 +15,8 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.confused += 5
+				C.confused += 15
 				C.Jitter(20)
-				if(C.StaminaLoss < 6)
-				C.adjustStaminaLoss(70)
-				C.Knockdown(2 SECONDS)
-				else
-				C.Knockdown(3 SECONDS)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))
 

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -17,7 +17,7 @@
 				C.adjustEarDamage(0, 30)
 				C.Knockdown(2 SECONDS)
 				C.confused += 5
-				C.adjustStaminaLoss(70)
+				C.adjustStaminaLoss(15)
 				C.Jitter(20)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -15,10 +15,13 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.Knockdown(2 SECONDS)
 				C.confused += 5
-				C.adjustStaminaLoss(15)
 				C.Jitter(20)
+				if(C.StaminaLoss < 6)
+				C.adjustStaminaLoss(70)
+				C.Knockdown(2 SECONDS)
+				else
+				C.Knockdown(3 SECONDS)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))
 

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -1,10 +1,10 @@
 /datum/action/changeling/resonant_shriek
 	name = "Resonant Shriek"
-	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 20 chemicals."
+	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 30 chemicals."
 	helptext = "Emits a high-frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 30
-	dna_cost = 1
+	dna_cost = 2
 	req_human = 1
 
 //A flashy ability, good for crowd control and sowing chaos.
@@ -15,7 +15,9 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.confused += 15
+				C.knockdown += 2
+				C.confused += 5
+				C.adjustStaminaLoss(70)
 				C.Jitter(20)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -15,7 +15,7 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.knockdown += 2
+				C.Knockdown(2 SECONDS)
 				C.confused += 5
 				C.adjustStaminaLoss(70)
 				C.Jitter(20)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -240,5 +240,5 @@
 /datum/action/changeling/sting/cryo/sting_action(mob/user, mob/target)
 	log_combat(user, target, "stung", "cryo sting")
 	if(target.reagents)
-		target.reagents.add_reagent(/datum/reagent/consumable/frostoil, 30)
+		target.reagents.add_reagent(/datum/reagent/consumable/frostoil, 15)
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -231,14 +231,14 @@
 
 /datum/action/changeling/sting/cryo
 	name = "Cryogenic Sting"
-	desc = "We silently sting our victim with a cocktail of chemicals that freezes them from the inside. Costs 15 chemicals."
+	desc = "We silently sting our victim with a cocktail of chemicals that freezes them from the inside. Costs 10 chemicals."
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing."
 	button_icon_state = "sting_cryo"
-	chemical_cost = 15
+	chemical_cost = 10
 	dna_cost = 2
 
 /datum/action/changeling/sting/cryo/sting_action(mob/user, mob/target)
 	log_combat(user, target, "stung", "cryo sting")
 	if(target.reagents)
-		target.reagents.add_reagent(/datum/reagent/consumable/frostoil, 15)
+		target.reagents.add_reagent(/datum/reagent/consumable/frostoil, 20)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
EDIT: Shriek nerf was scrapped entirely because Qwerty didn't like it.

Applies nerfs to a few of the key ling abilities to bring them more in line with other antagonists. Nerfs Cryo Sting, Fleshmend,  Resonant Shriek and Lesser Form (Mainly to prevent get out of jail free situations with it)


## Why It's Good For The Game
Next to nobody contests that changelings are too strong currently. This, along with Zeskorion's PR, should bring them more in line with other antagonists in terms of power.

The lesser form nerf is intended to prevent the revive > blind sting > lesser form > escape combo.
## Changelog
:cl:
balance: Increased the cost of Resonant Shriek from 1 to 2
balance: reduced the amount of frost oil cryo sting injects per use, but also reduced chemicals cost
balance: Increased chemical cost of fleshmend from 20 to 25
balance: Reduced Brute/Oxy heal per tick from 10 to 6
balance: increased chemical cost of lesser form and weighted more of the total cost to the activation rather than the deactivation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
