### PR TITLE
Traitor Item Rebalance

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -921,7 +921,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A box that contains five EMP grenades and an EMP implant with three uses. Useful to disrupt communications, \
 			security's energy weapons and silicon lifeforms when you're in a tight spot."
 	item = /obj/item/storage/box/syndie_kit/emp
-	cost = 2
+	cost = 4
 
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"
@@ -1169,7 +1169,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Radio Jammer"
 	desc = "This device will disrupt any nearby outgoing radio communication when activated. Does not affect binary chat."
 	item = /obj/item/jammer
-	cost = 5
+	cost = 3
 
 /datum/uplink_item/stealthy_tools/smugglersatchel
 	name = "Smuggler's Satchel"


### PR DESCRIPTION
## About The Pull Request
Rebalances two traitor items, the EMP kit and the radio jammer. Changes are in the log.
## Why It's Good For The Game
These items have always been a bit of a meme, in their own way. For two TC, the EMP kit could negate radios, disable guns, and dab on borgs with it's large radius, making it an incredibly versatile pick for any traitor. The EMP implant alone was worth more than two TC, capable of three charges, with no way to prevent the user from activating it, short of being in crit.
The radio jammer on the other hand has always been sort of pathetic, always overshadowed by the EMP kit, with it's one perk being done better by the kit. I've only ever used this thing once, when it was heavily discounted, and I've never seen any one else take it.
I'm honestly not entirely happy with this change, so I may revisit this later, however, this fixes most of my issue with both items.
## Changelog
🆑
balance: The EMP kit now costs 4 TC (Up from 2 TC)
balance: The Radio Jammer now costs 3 TC (Down from 5 TC)
/🆑