### PR TITLE
Buildable IPC parts

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -32,7 +32,7 @@
 								"Phazon",
 								"Exosuit Equipment",
 								"Cyborg Upgrade Modules",
-								"IPC components",
+								"IPC Components",
 								"Misc"
 								)
 

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -114,7 +114,7 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 	user.changeNext_move(CLICK_CD_MELEE)
 	var/obj/machinery/power/apc/A = target
 	var/mob/living/carbon/human/H = user
-	var/obj/item/organ/stomach/cell/cell = H.internal_organs_slot["stomach"]
+	var/obj/item/organ/stomach/cell/cell = locate(/obj/item/organ/stomach/cell) in H.internal_organs
 	if(!cell)
 		to_chat(H, "<span class='warning'>You try to siphon energy from the [A], but your power cell is gone!</span>")
 		return

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -813,7 +813,7 @@
 	id = "robotic_liver"
 	build_type = MECHFAB
 	build_path = /obj/item/organ/liver/cybernetic/upgraded/ipc
-	materials = list(MAT_IRON=2000, MAT_GLASS=1000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	construction_time = 100
 	category = list("IPC Components")
 
@@ -822,7 +822,7 @@
 	id = "robotic_eyes"
 	build_type = MECHFAB
 	build_path = /obj/item/organ/eyes/robotic
-	materials = list(MAT_IRON=1000, MAT_GLASS=2000)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 2000)
 	construction_time = 100
 	category = list("IPC Components")
 
@@ -831,7 +831,7 @@
 	id = "robotic_tongue"
 	build_type = MECHFAB
 	build_path = /obj/item/organ/tongue/robot
-	materials = list(MAT_IRON=2000, MAT_GLASS=1000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	construction_time = 100
 	category = list("IPC Components")
 
@@ -840,7 +840,7 @@
 	id = "robotic_stomach"
 	build_type = MECHFAB
 	build_path = /obj/item/organ/stomach/cell
-	materials = list(MAT_IRON=2000, MAT_GLASS=2000, MAT_PLASMA=200)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 2000, /datum/material/plasma = 200)
 	construction_time = 100
 	category = list("IPC Components")
 
@@ -849,7 +849,7 @@
 	id = "robotic_ears"
 	build_type = MECHFAB
 	build_path = /obj/item/organ/ears/robot
-	materials = list(MAT_IRON=2000, MAT_GLASS=1000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	construction_time = 100
 	category = list("IPC Components")
 
@@ -858,6 +858,6 @@
 	id = "power_cord"
 	build_type = MECHFAB
 	build_path = /obj/item/organ/cyberimp/arm/power_cord
-	materials = list(MAT_IRON=2000, MAT_GLASS=1000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	construction_time = 100
 	category = list("IPC Components") 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -483,6 +483,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 	export_price = 5000
 
+/datum/techweb_node/ipc_organs
+	id = "ipc_organs"
+	display_name = "IPC Parts"
+	description = "We have the technology to replace him."
+	prereq_ids = list("cyber_organs","robotics")
+	design_ids = list("robotic_liver", "robotic_eyes", "robotic_tongue", "robotic_stomach", "robotic_ears", "power_cord")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
+	export_price = 5000
+
 /datum/techweb_node/cyber_implants
 	id = "cyber_implants"
 	display_name = "Cybernetic Implants"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows IPC organs to be made in the exosuit fabricator after researching the new tech node 'IPC Parts' which can be researched after basic robotics and cybernetic organs. Also fixes the power cord organ so that it only restores nutrition if the user has an ipc stomach.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Provides a way to make new organs for ipcs and fixes the power cord so it isn't a free food source for non ipcs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now make IPC organs in the exosuit fabricator by researching IPC parts
fix: Power cord now only works with the ipc stomach
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
