### PR TITLE
Fixes Stun Resistance Chemicals.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -80,6 +80,7 @@
 	M.AdjustUnconscious(-20, FALSE)
 	M.AdjustImmobilized(-20, FALSE)
 	M.AdjustParalyzed(-20, FALSE)
+	M.adjustStaminaLoss(-27, 0)
 	..()
 	. = 1
 
@@ -190,7 +191,7 @@
 	M.AdjustUnconscious(-40, FALSE)
 	M.AdjustParalyzed(-40, FALSE)
 	M.AdjustImmobilized(-40, FALSE)
-	M.adjustStaminaLoss(-2, 0)
+	M.adjustStaminaLoss(-35, 0)
 	M.Jitter(2)
 	M.adjustBrainLoss(rand(1,4))
 	if(prob(5))
@@ -356,7 +357,7 @@
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(prob(5))
 		to_chat(M, "<span class='notice'>[high_message]</span>")
-	M.adjustStaminaLoss(-18, 0)
+	M.adjustStaminaLoss(-25, 0)
 	M.adjustToxLoss(0.5, 0)
 	if(prob(50))
 		M.losebreath++

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -357,7 +357,7 @@
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(prob(5))
 		to_chat(M, "<span class='notice'>[high_message]</span>")
-	M.adjustStaminaLoss(-25, 0)
+	M.adjustStaminaLoss(-28, 0)
 	M.adjustToxLoss(0.5, 0)
 	if(prob(50))
 		M.losebreath++

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -80,7 +80,7 @@
 	M.AdjustUnconscious(-20, FALSE)
 	M.AdjustImmobilized(-20, FALSE)
 	M.AdjustParalyzed(-20, FALSE)
-	M.adjustStaminaLoss(-27, 0)
+	M.adjustStaminaLoss(-25, 0)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -575,7 +575,7 @@
 			M.Jitter(10)
 
 	M.AdjustAllImmobility(-20, FALSE)
-	M.adjustStaminaLoss(-1*REM, FALSE)
+	M.adjustStaminaLoss(-10*REM, FALSE)
 	..()
 	return TRUE
 
@@ -935,7 +935,7 @@
 		M.adjustBruteLoss(-1*REM, 0)
 		M.adjustFireLoss(-1*REM, 0)
 	M.AdjustAllImmobility(-60, FALSE)
-	M.adjustStaminaLoss(-5*REM, 0)
+	M.adjustStaminaLoss(-60*REM, 0)
 	..()
 	. = 1
 
@@ -1245,7 +1245,7 @@
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/M as mob)
 	M.AdjustAllImmobility(-20, FALSE)
-	M.adjustStaminaLoss(-1, 0)
+	M.adjustStaminaLoss(-40, 0)
 	..()
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

This fixes stun resistance chemicals, most of which were broken when we switched from tasers and old stun batons to disablers and the reworked stun baton. This also buffs Aranesp.

## Why It's Good For The Game

It fixes broke chemicals, which I will list here.
Stimulants: 60 stamina regeneration
Changeling Adrenaline: 40 stamina regeneration
Meth: 35 stamina regeneration
Crank: 25 stamina regeneration
Aranesp: 28 stamina regeneration (Up from 18)
Ephidrine: 10 stamina regeneration

## Changelog
:cl:
fix: Fixes most of the stun resistance chemicals that weren't working properly. Chemicals include stimulants, Changeling Adrenaline, Meth, Crank, and Ephedrine.
Balance: Buffs the chemical Aranesp to 25 stamina regeneration (Up from 18 stamina regeneration)
/:cl:

