### PR TITLE
Disables Kilo due to frequent crashes

### DIFF
--- a/config/Sage/maps.txt
+++ b/config/Sage/maps.txt
@@ -50,4 +50,5 @@ endmap
 
 map kilostation
 	maxplayers 60
+	disabled
 endmap

--- a/config/Sage/maps.txt
+++ b/config/Sage/maps.txt
@@ -50,6 +50,4 @@ endmap
 
 map kilostation
 	maxplayers 60
-	votable
-	disabled
 endmap

--- a/config/Sage/maps.txt
+++ b/config/Sage/maps.txt
@@ -51,4 +51,5 @@ endmap
 map kilostation
 	maxplayers 60
 	votable
+	disabled
 endmap


### PR DESCRIPTION
/tg/ has reported the same problem and disabled the map accordingly. Kilo will return to active map rotation once they figure out how to fix the crashing.

:cl:
config: Temporarily disables KiloStation due to frequent crashing.
/:cl: