### PR TITLE
Adrenals buffing

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -39,7 +39,7 @@
 	imp_in.SetUnconscious(0)
 	imp_in.SetParalyzed(0)
 	imp_in.SetImmobilized(0)
-	imp_in.adjustStaminaLoss(-75)
+	imp_in.adjustStaminaLoss(-100)
 	imp_in.set_resting(FALSE)
 	imp_in.update_mobility()
 

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -39,7 +39,7 @@
 	imp_in.SetUnconscious(0)
 	imp_in.SetParalyzed(0)
 	imp_in.SetImmobilized(0)
-	imp_in.adjustStaminaLoss(-100)
+	imp_in.adjustStaminaLoss(-200)
 	imp_in.set_resting(FALSE)
 	imp_in.update_mobility()
 

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -20,5 +20,5 @@
 	user.SetParalyzed(0)
 	user.reagents.add_reagent(/datum/reagent/medicine/changelingadrenaline, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/changelinghaste, 2) //For a really quick burst of speed
-	user.adjustStaminaLoss(-75)
+	user.adjustStaminaLoss(-100)
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -20,5 +20,5 @@
 	user.SetParalyzed(0)
 	user.reagents.add_reagent(/datum/reagent/medicine/changelingadrenaline, 10)
 	user.reagents.add_reagent(/datum/reagent/medicine/changelinghaste, 2) //For a really quick burst of speed
-	user.adjustStaminaLoss(-100)
+	user.adjustStaminaLoss(-200)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Buffs both ling adrenaline and traitor adrenals to 200 instant stamina gain on use, up from the original 75 they had.

## Why It's Good For The Game

Seems like an oversight to me that these two don't fully heal your stam loss, especially now that stam damage is the main stun method.

## Changelog
:cl:

buff: Both forms of adrenal (traitor and changeling) now instantly regen 200 stamina damage on use, instead of 75.

/:cl:
