### PR TITLE
[PORT] TG - Correct atmos reaction priority. (#48871)

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -373,6 +373,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			sharer_temperature = max(sharer_temperature + heat/sharer_heat_capacity, TCMB)
 			if(sharer)
 				sharer.temperature = sharer_temperature
+				if (initial(sharer.gc_share))
+					sharer.garbage_collect()
 	return sharer_temperature
 	//thermal energy of the system (self and sharer) is unchanged
 
@@ -408,8 +410,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	if(!length(cached_gases))
 		return
 	var/list/reactions = list()
-	for(var/I in cached_gases)
-		reactions += SSair.gas_reactions[I]
+	for(var/datum/gas_reaction/G in SSair.gas_reactions)
+		if(cached_gases[G.major_gas])
+			reactions += G
 	if(!length(reactions))
 		return
 	reaction_results = new

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -2,8 +2,6 @@
 
 /proc/init_gas_reactions()
 	. = list()
-	for(var/type in subtypesof(/datum/gas))
-		.[type] = list()
 
 	for(var/r in subtypesof(/datum/gas_reaction))
 		var/datum/gas_reaction/reaction = r
@@ -16,26 +14,18 @@
 				var/datum/gas/req_gas = req
 				if (!reaction_key || initial(reaction_key.rarity) > initial(req_gas.rarity))
 					reaction_key = req_gas
-		.[reaction_key] += list(reaction)
-		sortTim(., /proc/cmp_gas_reactions, TRUE)
+		reaction.major_gas = reaction_key
+		. += reaction
+	sortTim(., /proc/cmp_gas_reaction)
 
-/proc/cmp_gas_reactions(list/datum/gas_reaction/a, list/datum/gas_reaction/b) // compares lists of reactions by the maximum priority contained within the list
-	if (!length(a) || !length(b))
-		return length(b) - length(a)
-	var/maxa
-	var/maxb
-	for (var/datum/gas_reaction/R in a)
-		if (R.priority > maxa)
-			maxa = R.priority
-	for (var/datum/gas_reaction/R in b)
-		if (R.priority > maxb)
-			maxb = R.priority
-	return maxb - maxa
+/proc/cmp_gas_reaction(datum/gas_reaction/a, datum/gas_reaction/b) // compares lists of reactions by the maximum priority contained within the list
+	return b.priority - a.priority
 
 /datum/gas_reaction
 	//regarding the requirements lists: the minimum or maximum requirements must be non-zero.
 	//when in doubt, use MINIMUM_MOLE_COUNT.
 	var/list/min_requirements
+	var/major_gas //the highest rarity gas used in the reaction.
 	var/exclude = FALSE //do it this way to allow for addition/removal of reactions midmatch in the future
 	var/priority = 100 //lower numbers are checked/react later than higher numbers. if two reactions have the same priority they may happen in either order
 	var/name = "reaction"


### PR DESCRIPTION
## About The Pull Request

Fixes atmospheric reaction priority by changing the approach of https://github.com/tgstation/tgstation/pull/40367. Instead of using an assoc list it saves the major gas in the reaction datum and uses that. It will of course be slightly slower but it is still better than before with reaction priority being messed.

## Why It's Good For The Game

Fixes broken feature.

## Changelog
:cl:
fix: Atmospheric reaction priority works correctly now, this means hypernob will stop all reactions and reactions should generally be more consistent between rounds.
/:cl:

(cherry picked from commit 09f3b5da1c84ab82f316d6e5ee9d2ef6be563a1a -- https://github.com/tgstation/tgstation/pull/48871)