### PR TITLE
You can now set actual objectives to the make everyone traitor option.

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -346,10 +346,8 @@
 			if(!SSticker.HasRoundStarted())
 				alert("The game hasn't started yet!")
 				return
-
 			if(!GLOB.admin_objective_list)
 				generate_admin_objective_list()
-
 			var/def_value
 			var/selected_type = input("Select objective type:", "Objective type", def_value) as null|anything in GLOB.admin_objective_list
 			selected_type = GLOB.admin_objective_list[selected_type]

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -346,10 +346,17 @@
 			if(!SSticker.HasRoundStarted())
 				alert("The game hasn't started yet!")
 				return
-			var/objective = copytext(sanitize(input("Enter an objective")),1,MAX_MESSAGE_LEN)
-			if(!objective)
+
+			if(!GLOB.admin_objective_list)
+				generate_admin_objective_list()
+
+			var/def_value
+			var/selected_type = input("Select objective type:", "Objective type", def_value) as null|anything in GLOB.admin_objective_list
+			selected_type = GLOB.admin_objective_list[selected_type]
+			if(!selected_type)
 				return
-			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Traitor All", "[objective]"))
+			var/objective_explanation = new selected_type
+			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Traitor All", "[objective_explanation]"))
 			for(var/mob/living/H in GLOB.player_list)
 				if(!(ishuman(H)||istype(H, /mob/living/silicon/)))
 					continue
@@ -359,13 +366,13 @@
 					continue
 				var/datum/antagonist/traitor/T = new()
 				T.give_objectives = FALSE
-				var/datum/objective/new_objective = new
+				var/datum/objective/new_objective = new selected_type
 				new_objective.owner = H
-				new_objective.explanation_text = objective
+				new_objective.admin_edit(H)
 				T.add_objective(new_objective)
 				H.mind.add_antag_datum(T)
-			message_admins("<span class='adminnotice'>[key_name_admin(usr)] used everyone is a traitor secret. Objective is [objective]</span>")
-			log_admin("[key_name(usr)] used everyone is a traitor secret. Objective is [objective]")
+			message_admins("<span class='adminnotice'>[key_name_admin(usr)] used everyone is a traitor secret. Objective is [objective_explanation]</span>")
+			log_admin("[key_name(usr)] used everyone is a traitor secret. Objective is [objective_explanation]")
 
 		if("changebombcap")
 			if(!check_rights(R_FUN))


### PR DESCRIPTION
Allows for cool things like giving every single person on the station the objective to steal the disk and watch the chaos ensue.
Still allows for custom objectives, exactly the same as TP objective, but applies to all.

## About The Pull Request

Changes the make all traitor buttons custom objective to be a choice between objectives, meaning it is now possible to actually win!

## Why It's Good For The Game

This is a good feature for admins who want to run events where the objective isn't 'kill everyone' but you will always fail

## Changelog
:cl:
admin: Changed secret traitor all button's objective to be a choice of objectives.
/:cl: