### PR TITLE
Repeated ethereal charging

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -634,10 +634,13 @@
 			var/datum/species/ethereal/eth_species = H.dna?.species
 			if(istype(eth_species))
 				to_chat(H, "<span class='notice'>You start channeling some power through the [fitting] into your body.</span>")
-				if(do_after(user, 50, target = src))
-					to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
-					eth_species.adjust_charge(5)
-					return
+				while(do_after(user, 20, target = src))
+					if(eth_species.ethereal_charge >= ETHEREAL_CHARGE_FULL)
+						to_chat(H, "<span class='notice'>You are now fully charged.</span>")
+						break
+					else
+						to_chat(H, "<span class='notice'>You receive some charge from the [fitting].</span>")
+						eth_species.adjust_charge(5)
 				return
 
 			if(H.gloves)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so when ethereals recharge from lightbulbs they will keep charging until fully charged instead of needing to spam click on the lightbulb.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes charging as an ethereal less annoying
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ethereals will now keep charging at a lightbulb until they move away
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
