### PR TITLE
Sergei's Map Modernization Project

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1150,7 +1150,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
@@ -2608,9 +2607,6 @@
 /area/security/prison)
 "afG" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/item/storage/box/hug,
 /obj/item/razor{
 	pixel_x = -6
@@ -2618,6 +2614,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -5677,7 +5676,9 @@
 /area/engine/atmos)
 "alY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 4
+	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -15054,10 +15055,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "aKd" = (
@@ -18504,7 +18501,6 @@
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/table,
 /obj/item/camera_film,
 /obj/item/camera,
@@ -21514,6 +21510,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bbL" = (
@@ -38019,7 +38016,6 @@
 "bRS" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/depsec/engineering,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
@@ -40999,9 +40995,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/valve/layer1{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bZR" = (
@@ -41366,7 +41360,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "caQ" = (
@@ -41386,7 +41380,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/layer1{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -45541,6 +45535,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cmA" = (
@@ -45697,9 +45692,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
-	dir = 8
-	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "cnb" = (
@@ -45767,16 +45759,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"cnm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "cnn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45791,6 +45773,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnp" = (
@@ -45800,7 +45783,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera/autoname{
 	icon_state = "camera";
 	dir = 8
@@ -45949,6 +45931,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnN" = (
@@ -46138,9 +46121,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cox" = (
@@ -47642,6 +47623,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctu" = (
@@ -48364,15 +48346,14 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cve" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
@@ -48384,6 +48365,9 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cvf" = (
@@ -52326,6 +52310,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"dhg" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dhq" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 25
@@ -52567,9 +52558,6 @@
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -53587,9 +53575,7 @@
 	},
 /area/science/research)
 "hqh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "hqp" = (
@@ -53792,6 +53778,12 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ioM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "ipA" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -53988,6 +53980,7 @@
 	name = "Cryogenic Lounge"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "jac" = (
@@ -54191,6 +54184,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
 "jRY" = (
@@ -54684,6 +54678,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"lgg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lhk" = (
 /obj/structure/chair{
 	dir = 4
@@ -55207,6 +55209,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
+"mLV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "mMA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -55644,6 +55653,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"owD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "oxm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -55660,6 +55675,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"oyM" = (
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	icon_state = "manifold-2";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ozs" = (
 /obj/structure/table/glass,
 /obj/item/storage/fancy/candle_box,
@@ -55725,6 +55747,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"oMw" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "pipe11-2";
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oMN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -55901,6 +55930,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
 "ppk" = (
@@ -56095,6 +56125,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"pQd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "pRO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -56228,6 +56262,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
+"qrJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "qrU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -56895,8 +56936,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness)
@@ -56905,6 +56946,17 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sPT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "sQB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -57082,7 +57134,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -74384,11 +74435,11 @@ aSg
 aSg
 aWl
 aSg
-aSg
-aSg
+oMw
+oyM
 bbK
-aTu
-dfx
+qrJ
+dhg
 bdD
 dfx
 bjg
@@ -74645,7 +74696,7 @@ aWk
 baM
 bbJ
 bcL
-aWk
+sPT
 bdC
 aQM
 aQM
@@ -80866,7 +80917,7 @@ cjJ
 ckw
 clC
 cmy
-cnm
+clC
 cnL
 cov
 cpj
@@ -84618,7 +84669,7 @@ abB
 acG
 adI
 aei
-aeO
+lgg
 afG
 acd
 agK
@@ -93634,7 +93685,7 @@ vTE
 tmE
 auB
 asq
-whX
+owD
 sNT
 qOk
 avz
@@ -93890,8 +93941,8 @@ dhq
 jRm
 poI
 iZX
-whX
-whX
+pQd
+ioM
 auv
 avA
 erv
@@ -96025,7 +96076,7 @@ aku
 alf
 cjr
 cjr
-cjr
+mLV
 clh
 cfj
 aoV

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -27,10 +27,6 @@
 	pixel_x = 30;
 	receive_ore_updates = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
 	dir = 8
@@ -38,6 +34,10 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -139,10 +139,6 @@
 	},
 /obj/machinery/hydroponics/soil,
 /obj/item/plant_analyzer,
-/obj/machinery/camera{
-	c_tag = "Prison Common Room";
-	network = list("ss13","prison")
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -150,6 +146,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aar" = (
@@ -980,14 +977,14 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -30
 	},
-/obj/machinery/camera{
-	c_tag = "Head of Security's Office";
-	dir = 4
-	},
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
 /obj/structure/table/wood,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "act" = (
@@ -1058,10 +1055,6 @@
 /area/security/execution/transfer)
 "acC" = (
 /obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Prison Cell 3";
-	network = list("ss13","prison")
-	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
 	dir = 2;
@@ -1070,6 +1063,7 @@
 	prison_radio = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acD" = (
@@ -1087,22 +1081,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"acE" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Prison Cell 2";
-	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "acF" = (
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -1114,22 +1092,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"acH" = (
-/obj/structure/bed,
-/obj/machinery/camera{
-	c_tag = "Prison Cell 1";
-	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
-	prison_radio = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acI" = (
@@ -1210,8 +1172,8 @@
 /area/crew_quarters/bar)
 "acO" = (
 /obj/structure/closet/l3closet/security,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1939,16 +1901,13 @@
 /obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
 	},
-/obj/machinery/camera{
-	c_tag = "Prison Hallway";
-	network = list("ss13","prison")
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aep" = (
@@ -2098,8 +2057,8 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aeC" = (
-/obj/machinery/camera{
-	c_tag = "Security Escape Pod";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2323,10 +2282,6 @@
 	departmentType = 5;
 	pixel_x = -30
 	},
-/obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -2339,6 +2294,10 @@
 /obj/item/clothing/mask/gas/sechailer{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -3003,11 +2962,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "agv" = (
-/obj/machinery/camera{
-	c_tag = "Mining Dock";
+/obj/machinery/computer/security/mining,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
-/obj/machinery/computer/security/mining,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "agw" = (
@@ -3789,10 +3748,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ahW" = (
-/obj/machinery/camera{
-	c_tag = "Brig Infirmary";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -3801,6 +3756,10 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/closet/secure_closet/brig_phys,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ahX" = (
@@ -3931,10 +3890,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ail" = (
-/obj/machinery/camera{
-	c_tag = "Brig Interrogation";
-	dir = 8;
-	network = list("interrogation")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -3965,16 +3923,16 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiq" = (
-/obj/machinery/camera{
-	c_tag = "Security Office";
-	dir = 1
-	},
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -4249,15 +4207,13 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aiQ" = (
-/obj/machinery/camera{
-	c_tag = "Brig East"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aiS" = (
@@ -4422,10 +4378,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/machinery/camera{
-	c_tag = "Courtroom North"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajk" = (
@@ -4492,9 +4446,7 @@
 	},
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock North"
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aju" = (
@@ -4887,12 +4839,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Brig West";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 2
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4965,8 +4917,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Brig Central";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6002,13 +5954,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "amB" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Treatment Center";
-	network = list("ss13","medbay");
-	dir = 8
-	},
 /obj/machinery/sleeper{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -6269,8 +6220,8 @@
 	pixel_x = -25;
 	pixel_y = 3
 	},
-/obj/machinery/camera{
-	c_tag = "Fore Port Solar Control";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6552,15 +6503,15 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/machinery/camera{
-	c_tag = "Courtroom South";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -6585,11 +6536,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aob" = (
-/obj/machinery/camera{
-	c_tag = "Detective's Office";
-	dir = 2
-	},
 /obj/machinery/computer/secure_data,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aof" = (
@@ -6625,12 +6573,10 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aoj" = (
-/obj/machinery/camera{
-	c_tag = "Fore Port Solar Access"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aok" = (
@@ -6710,10 +6656,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock South";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -6722,6 +6664,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aov" = (
@@ -6743,10 +6689,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aox" = (
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway West";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -6755,6 +6697,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -6802,16 +6748,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoD" = (
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway East";
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 2
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -7134,14 +7080,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "apB" = (
-/obj/machinery/camera{
-	c_tag = "Fore Starboard Solars";
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "apC" = (
@@ -7757,9 +7703,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Fore Starboard Solar Access"
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aru" = (
@@ -8061,9 +8005,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "asq" = (
-/obj/machinery/camera{
-	c_tag = "Fitness Room"
-	},
 /obj/structure/closet/masks,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -8071,6 +8012,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "asr" = (
@@ -8509,10 +8451,6 @@
 /area/maintenance/port/fore)
 "atK" = (
 /obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Law Office";
-	dir = 1
-	},
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -8521,6 +8459,10 @@
 /obj/machinery/computer/security/telescreen/prison{
 	dir = 1;
 	pixel_y = -27
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -8791,11 +8733,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "auz" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck"
-	},
 /obj/machinery/airalarm{
 	pixel_y = 24
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -8910,15 +8853,13 @@
 	department = "Crew Quarters";
 	pixel_y = 30
 	},
-/obj/machinery/camera{
-	c_tag = "Dormitory North"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "auU" = (
@@ -9269,16 +9210,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Auxillary Base Construction";
-	dir = 8
-	},
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -10457,9 +10398,7 @@
 /area/maintenance/fore)
 "ayK" = (
 /obj/structure/closet/crate/rcd,
-/obj/machinery/camera/motion{
-	c_tag = "EVA Motion Sensor"
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "ayL" = (
@@ -11327,12 +11266,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aAH" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 1 North";
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aAI" = (
@@ -11522,10 +11461,6 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "aBh" = (
-/obj/machinery/camera{
-	c_tag = "EVA Maintenance";
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -11536,6 +11471,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBi" = (
@@ -11917,9 +11856,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aCf" = (
-/obj/machinery/camera{
-	c_tag = "Theatre Storage"
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -11948,8 +11885,8 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
 "aCj" = (
-/obj/machinery/camera{
-	c_tag = "EVA East";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11975,15 +11912,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aCp" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals North";
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -12283,14 +12220,12 @@
 /obj/item/screwdriver{
 	pixel_y = 16
 	},
-/obj/machinery/camera{
-	c_tag = "Primary Tool Storage"
-	},
 /obj/machinery/requests_console{
 	department = "Tool Storage";
 	departmentType = 0;
 	pixel_y = 30
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDl" = (
@@ -12439,12 +12374,12 @@
 "aDE" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "EVA Storage";
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -12920,15 +12855,15 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aER" = (
-/obj/machinery/camera{
-	c_tag = "Gateway";
-	dir = 4
-	},
 /obj/structure/table,
 /obj/structure/sign/warning/biohazard{
 	pixel_x = -32
 	},
 /obj/item/storage/firstaid/regular,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/gateway)
 "aES" = (
@@ -13024,10 +12959,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aFe" = (
-/obj/machinery/camera{
-	c_tag = "Dormitory South";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13039,6 +12970,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -13208,10 +13143,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aFI" = (
-/obj/machinery/camera{
-	c_tag = "Security Checkpoint";
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -13226,6 +13157,10 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
@@ -13286,13 +13221,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aFO" = (
-/obj/machinery/camera{
-	c_tag = "Garden";
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -13393,14 +13328,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/camera/motion{
-	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
@@ -13922,10 +13856,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aHh" = (
@@ -14461,10 +14392,7 @@
 /area/library)
 "aIs" = (
 /obj/structure/chair/office,
-/obj/machinery/camera{
-	c_tag = "Library North";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/wood,
 /area/library)
 "aIt" = (
@@ -14582,16 +14510,13 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aIO" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Lounge";
-	dir = 2
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aIP" = (
@@ -14736,11 +14661,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "aJf" = (
-/obj/machinery/camera{
-	c_tag = "EVA South";
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aJg" = (
@@ -14831,10 +14756,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Central Hallway North";
-	dir = 2
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -14842,6 +14763,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJp" = (
@@ -14934,8 +14856,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJz" = (
-/obj/machinery/camera{
-	c_tag = "Dormitory Toilets";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -15255,10 +15177,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/camera{
-	c_tag = "Theatre Stage";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aKr" = (
@@ -15432,9 +15351,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -15442,6 +15358,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKN" = (
@@ -15488,9 +15405,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKS" = (
-/obj/machinery/camera{
-	c_tag = "Bar Storage"
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKT" = (
@@ -15537,11 +15452,11 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel Crematorium";
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -15810,13 +15725,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLL" = (
-/obj/machinery/camera{
-	c_tag = "Port Hallway 2";
-	dir = 2
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLM" = (
@@ -15851,10 +15763,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLQ" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway North-East";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLR" = (
@@ -15899,13 +15808,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLW" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway North-West";
-	dir = 2
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLX" = (
@@ -16177,9 +16083,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aMM" = (
-/obj/machinery/camera{
-	c_tag = "Chapel North";
-	dir = 2
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -16571,16 +16477,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aNU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Port Hallway";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "aNV" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -16655,13 +16551,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aOe" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 1 South"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aOf" = (
@@ -16749,12 +16643,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOp" = (
-/obj/machinery/camera{
-	c_tag = "Port Hallway 3";
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -16972,10 +16866,7 @@
 /area/hydroponics)
 "aOW" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/camera{
-	c_tag = "Hydroponics North";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aOX" = (
@@ -17073,10 +16964,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Escape Arm Holding Area";
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_x = -25
 	},
@@ -17084,6 +16971,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17890,11 +17781,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 2
-	},
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRC" = (
@@ -18004,8 +17892,8 @@
 /turf/open/floor/wood,
 /area/library)
 "aRP" = (
-/obj/machinery/camera{
-	c_tag = "Library South";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -18083,14 +17971,11 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage";
-	dir = 2
-	},
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/storage/box/lights/mixed,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aSb" = (
@@ -18119,8 +18004,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aSf" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Hallway";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18608,12 +18493,12 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/camera{
-	c_tag = "Locker Room East";
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -18800,13 +18685,13 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/camera{
-	c_tag = "Bar West";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -18894,8 +18779,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aUy" = (
-/obj/machinery/camera{
-	c_tag = "Vacant Office";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -18967,13 +18852,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit)
-"aUM" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 2";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "aUN" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -19091,12 +18969,12 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aVe" = (
-/obj/machinery/camera{
-	c_tag = "Bridge West";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19135,13 +19013,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway";
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -19251,12 +19129,12 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVr" = (
-/obj/machinery/camera{
-	c_tag = "Bridge East";
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -19305,16 +19183,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVv" = (
-/obj/machinery/camera{
-	c_tag = "Bridge East Entrance";
-	dir = 2
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVw" = (
@@ -19478,8 +19353,8 @@
 /turf/open/floor/wood,
 /area/library)
 "aVV" = (
-/obj/machinery/camera{
-	c_tag = "Chapel South";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -19618,15 +19493,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aWo" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room West";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -19926,13 +19801,13 @@
 	name = "AI Upload turret control";
 	pixel_y = -25
 	},
-/obj/machinery/camera{
-	c_tag = "Bridge Center";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -20415,8 +20290,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/camera{
-	c_tag = "Vacant Commissary";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20445,13 +20320,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYn" = (
-/obj/machinery/camera{
-	c_tag = "Bridge West Entrance";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20694,11 +20569,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "aYT" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics South";
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYU" = (
@@ -20735,12 +20610,12 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aZb" = (
-/obj/machinery/camera{
-	c_tag = "Bar South";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20779,12 +20654,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aZm" = (
-/obj/machinery/camera{
-	c_tag = "Escape Arm Airlocks";
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -20863,10 +20738,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "aZy" = (
-/obj/machinery/camera{
-	c_tag = "Conference Room";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "aZz" = (
@@ -21517,14 +21389,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "bbr" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room South";
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bbs" = (
@@ -21581,10 +21453,7 @@
 	},
 /area/hallway/primary/starboard)
 "bbA" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 2";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -21908,10 +21777,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcr" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcs" = (
@@ -21943,13 +21809,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
 	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"bcx" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 5";
-	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -22215,16 +22074,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bdn" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway East";
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -22251,8 +22110,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bds" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 4";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22629,11 +22488,11 @@
 /area/crew_quarters/heads/captain)
 "ben" = (
 /obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Captain's Office";
+/obj/item/storage/lockbox/medal,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/item/storage/lockbox/medal,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "beo" = (
@@ -22753,12 +22612,12 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "beB" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 3";
-	dir = 1
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -23288,15 +23147,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bgi" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Bay 3 & 4";
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bgj" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -23405,10 +23255,6 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
 	},
-/obj/machinery/camera{
-	c_tag = "Cargo Delivery Office";
-	dir = 4
-	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
@@ -23421,6 +23267,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23441,11 +23291,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bgG" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway West";
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgH" = (
@@ -23601,15 +23451,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhc" = (
-/obj/machinery/camera{
-	c_tag = "Chemistry";
-	dir = 2
-	},
 /obj/machinery/firealarm{
 	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/chem_heater,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhd" = (
@@ -23654,10 +23501,6 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "bhj" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Medbay";
-	dir = 2
-	},
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
@@ -23669,6 +23512,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bhk" = (
@@ -24320,11 +24164,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biO" = (
-/obj/machinery/camera{
-	c_tag = "Robotics Lab";
-	dir = 2;
-	network = list("ss13","rd")
-	},
 /obj/machinery/button/door{
 	dir = 2;
 	id = "robotics";
@@ -24345,6 +24184,7 @@
 /obj/item/stack/sheet/mineral/copper{
 	amount = 5
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "biP" = (
@@ -24375,10 +24215,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "biS" = (
-/obj/machinery/camera{
-	c_tag = "Research Division Access";
-	dir = 2
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
@@ -24386,6 +24222,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "biT" = (
@@ -24418,12 +24255,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "biX" = (
-/obj/machinery/camera{
-	c_tag = "Research and Development";
-	dir = 2;
-	network = list("ss13","rd");
-	pixel_x = 22
-	},
 /obj/machinery/button/door{
 	dir = 2;
 	id = "rnd";
@@ -24437,6 +24268,10 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -24560,10 +24395,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bjo" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay North"
-	},
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bjp" = (
@@ -24635,12 +24468,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjy" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 2
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
@@ -24887,14 +24720,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bkb" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Morgue";
-	network = list("ss13","medbay");
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -25411,12 +25243,11 @@
 /area/medical/medbay/central)
 "bln" = (
 /obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "Medbay Foyer";
-	network = list("ss13","medbay");
+/obj/machinery/cell_charger,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/machinery/cell_charger,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "blo" = (
@@ -25492,11 +25323,11 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/crowbar/large,
-/obj/machinery/camera{
-	c_tag = "Mech Bay";
+/obj/machinery/light,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blu" = (
@@ -27041,8 +26872,8 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Captain's Quarters";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
@@ -27678,11 +27509,7 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay West";
-	network = list("ss13","medbay");
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqV" = (
@@ -28006,11 +27833,11 @@
 	departmentType = 2;
 	pixel_x = -30
 	},
-/obj/machinery/camera{
-	c_tag = "Cargo Office";
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
-/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "brP" = (
@@ -28173,12 +28000,10 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bsn" = (
-/obj/machinery/camera{
-	c_tag = "Teleporter"
-	},
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bso" = (
@@ -28247,11 +28072,9 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = 30
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay East";
-	network = list("ss13","medbay");
-	dir = 8;
-	pixel_y = -22
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -28345,10 +28168,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bsS" = (
-/obj/machinery/camera{
-	c_tag = "Robotics Lab - South";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -28506,10 +28328,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "btr" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Receiving Dock";
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "QMLoaddoor";
 	layer = 4;
@@ -28529,6 +28347,10 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -28587,10 +28409,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "btA" = (
-/obj/machinery/camera{
-	c_tag = "Research Division West";
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "btB" = (
@@ -28837,8 +28656,8 @@
 	name = "Head of Personnel RC";
 	pixel_y = -30
 	},
-/obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29122,15 +28941,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Foyer"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "buT" = (
@@ -29271,8 +29088,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bvf" = (
-/obj/machinery/camera{
-	c_tag = "Research Division North";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -29405,11 +29222,6 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "bvy" = (
-/obj/machinery/camera{
-	c_tag = "Genetics Research";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -29417,6 +29229,10 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29432,14 +29248,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bvB" = (
-/obj/machinery/camera{
-	c_tag = "Genetics Access";
-	network = list("ss13","medbay");
-	dir = 8;
-	pixel_y = -22
-	},
 /obj/structure/sign/departments/minsky/research/research{
 	pixel_x = 32
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -29574,8 +29388,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bvX" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay South";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29635,16 +29449,16 @@
 /turf/closed/wall,
 /area/security/checkpoint/supply)
 "bwf" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay Entrance";
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
 /obj/structure/sign/departments/minsky/supply/cargo{
 	pixel_x = -32
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -29771,13 +29585,10 @@
 /area/medical/medbay/central)
 "bww" = (
 /obj/structure/chair,
-/obj/machinery/camera{
-	c_tag = "Surgery Observation";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "bwx" = (
@@ -29854,13 +29665,9 @@
 /area/medical/sleeper)
 "bwJ" = (
 /obj/structure/table/glass,
-/obj/machinery/camera{
-	c_tag = "Medbay Cryogenics";
-	network = list("ss13","medbay");
-	dir = 2
-	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwK" = (
@@ -29873,11 +29680,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwL" = (
-/obj/machinery/camera{
-	c_tag = "Genetics Cloning";
-	network = list("ss13","medbay");
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/firealarm{
 	dir = 4;
@@ -29890,6 +29692,10 @@
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30233,8 +30039,8 @@
 /turf/closed/wall,
 /area/engine/gravity_generator)
 "bxL" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway South-East";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30991,12 +30797,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "bzy" = (
-/obj/machinery/camera{
-	c_tag = "Server Room";
-	dir = 2;
-	network = list("ss13","rd");
-	pixel_x = 22
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Server Room APC";
@@ -31005,6 +30805,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -31500,11 +31304,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "bAE" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Science";
-	dir = 4;
-	network = list("ss13","rd")
-	},
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
@@ -31517,6 +31316,10 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
@@ -31634,10 +31437,6 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bAS" = (
-/obj/machinery/camera{
-	c_tag = "Quartermaster's Office";
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = -35
 	},
@@ -31653,6 +31452,10 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -31735,10 +31538,6 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/machinery/camera{
-	c_tag = "Security Post - Cargo";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -31748,6 +31547,10 @@
 	},
 /obj/machinery/computer/security/mining{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -31791,8 +31594,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway South-West";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31882,8 +31685,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway South";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -32209,13 +32012,12 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("ss13","rd")
-	},
 /obj/item/radio/intercom{
 	pixel_y = -29
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
@@ -32245,14 +32047,13 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "bCl" = (
-/obj/machinery/camera{
-	c_tag = "Experimentor Lab Chamber";
-	dir = 1;
-	network = list("ss13","rd")
-	},
 /obj/machinery/light,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -32430,11 +32231,7 @@
 /area/medical/sleeper)
 "bCL" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/machinery/camera{
-	c_tag = "Medbay Storage";
-	network = list("ss13","medbay");
-	dir = 2
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCM" = (
@@ -32505,9 +32302,8 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay South";
-	network = list("ss13","medbay");
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32702,10 +32498,6 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bDy" = (
-/obj/machinery/camera{
-	c_tag = "Tech Storage";
-	dir = 2
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Tech Storage APC";
@@ -32715,6 +32507,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bDz" = (
@@ -32762,12 +32555,11 @@
 /obj/machinery/vending/wallmed{
 	pixel_x = 28
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay Recovery Room";
-	network = list("ss13","medbay");
+/obj/machinery/iv_drip,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bDF" = (
@@ -32811,10 +32603,8 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/camera{
-	c_tag = "Custodial Closet"
-	},
 /obj/vehicle/ridden/janicart,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDL" = (
@@ -33100,17 +32890,15 @@
 /obj/item/radio/intercom{
 	pixel_x = 25
 	},
-/obj/machinery/camera{
-	c_tag = "Chief Medical Office";
-	network = list("ss13","medbay");
-	dir = 8;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -33118,14 +32906,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bEn" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
-	dir = 2;
-	network = list("xeno","rd")
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bEo" = (
@@ -33819,13 +33603,10 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bGs" = (
-/obj/machinery/camera{
-	c_tag = "Secure Tech Storage";
-	dir = 2
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "bGt" = (
@@ -34167,12 +33948,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins Storage";
-	dir = 4;
-	network = list("ss13","rd")
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bHf" = (
@@ -34399,12 +34179,12 @@
 /area/storage/tech)
 "bHR" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 2";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -34497,13 +34277,11 @@
 /obj/machinery/vending/wallmed{
 	pixel_y = -28
 	},
-/obj/machinery/camera{
-	c_tag = "Surgery Operating";
-	network = list("ss13","medbay");
-	dir = 1;
-	pixel_x = 22
-	},
 /obj/machinery/light,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bIe" = (
@@ -34825,13 +34603,10 @@
 	pixel_x = 5;
 	pixel_y = 29
 	},
-/obj/machinery/camera{
-	c_tag = "Virology Break Room";
-	network = list("ss13","medbay")
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIJ" = (
@@ -35343,12 +35118,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bKd" = (
-/obj/machinery/camera{
-	c_tag = "Toxins Launch Room Access";
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -35383,12 +35158,12 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bKj" = (
-/obj/machinery/camera{
-	c_tag = "Mining Dock External";
-	dir = 8
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKk" = (
@@ -36456,13 +36231,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMS" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics North East"
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Distro to Waste"
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMT" = (
@@ -36679,17 +36452,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
 "bNz" = (
-/obj/machinery/camera{
-	c_tag = "Toxins Lab East";
-	dir = 8;
-	network = list("ss13","rd");
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -36820,25 +36591,22 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Monitoring";
-	dir = 2
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/checker,
 /area/engine/atmos)
 "bNT" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics North West";
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36946,14 +36714,10 @@
 /area/tcommsat/computer)
 "bOp" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/camera{
-	c_tag = "Virology Airlock";
-	network = list("ss13","medbay");
-	dir = 2
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bOq" = (
@@ -37335,9 +37099,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bPk" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Waste Tank"
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bPl" = (
@@ -37773,10 +37535,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQq" = (
-/obj/machinery/camera{
-	c_tag = "Security Post - Engineering";
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	dir = 4;
 	pixel_x = 27
@@ -37790,6 +37548,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37942,15 +37704,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology North";
-	dir = 8;
-	network = list("ss13","rd")
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bQO" = (
@@ -38500,10 +38261,9 @@
 /area/maintenance/port/aft)
 "bSt" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/camera{
-	c_tag = "Telecomms Monitoring";
-	dir = 8;
-	network = list("tcomms")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -38514,8 +38274,8 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bSv" = (
-/obj/machinery/camera{
-	c_tag = "Construction Area";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -38759,10 +38519,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Virology Module";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bSY" = (
@@ -39706,10 +39463,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bVN" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics Access";
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -39718,6 +39471,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -40136,10 +39893,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics West";
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -40151,6 +39904,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWT" = (
@@ -40599,16 +40356,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXV" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics East";
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Plasma Outlet Pump"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41010,10 +40767,9 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology South";
-	dir = 4;
-	network = list("ss13","rd")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -41123,13 +40879,13 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bZu" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Foyer";
-	dir = 1
-	},
 /obj/structure/noticeboard{
 	dir = 1;
 	pixel_y = -27
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -41383,10 +41139,9 @@
 /area/science/xenobiology)
 "bZZ" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/camera{
-	c_tag = "Testing Lab";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -41584,12 +41339,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Central";
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Filter"
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41860,10 +41615,9 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/port/aft)
 "cbl" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room";
-	dir = 4;
-	network = list("tcomms")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -41951,13 +41705,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 1";
-	dir = 8;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 2
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -42159,12 +41912,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cbV" = (
-/obj/machinery/camera{
-	c_tag = "Testing Chamber";
-	dir = 1;
-	network = list("test","rd")
-	},
 /obj/machinery/light,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "cbZ" = (
@@ -42309,10 +42061,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "ccn" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Access"
-	},
 /obj/structure/closet/radiation,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cco" = (
@@ -42777,12 +42527,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/camera{
-	c_tag = "Aft Starboard Solar Access";
-	dir = 1
-	},
 /obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_y = -32
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -43123,8 +42873,8 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cex" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics South West";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43413,10 +43163,9 @@
 	pressure_checks = 0;
 	name = "killroom vent"
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Kill Room";
-	dir = 4;
-	network = list("ss13","rd")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
@@ -43798,14 +43547,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "cgD" = (
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Access";
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/structure/closet/emcloset,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cgE" = (
@@ -43857,13 +43606,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cgQ" = (
-/obj/machinery/camera{
-	c_tag = "Engineering East";
-	dir = 8
-	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44016,10 +43765,6 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "chf" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics South East";
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
 	name = "Air Outlet Pump"
@@ -44029,6 +43774,10 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/engine/atmos)
@@ -44605,10 +44354,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	dir = 4;
-	network = list("turbine")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -44659,11 +44407,11 @@
 	pixel_x = 24;
 	pixel_y = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Control";
+/obj/structure/cable/yellow,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
-/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ciS" = (
@@ -44783,10 +44531,6 @@
 	name = "Chief Engineer RC";
 	pixel_x = -32
 	},
-/obj/machinery/camera{
-	c_tag = "Chief Engineer's Office";
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -44796,6 +44540,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
@@ -44844,8 +44592,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjl" = (
-/obj/machinery/camera{
-	c_tag = "Engineering MiniSat Access";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44979,8 +44727,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Secure Storage";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45539,8 +45287,8 @@
 /area/maintenance/solars/starboard/aft)
 "cly" = (
 /obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Aft Starboard Solar Control";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -46135,11 +45883,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "SMES Room";
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnr" = (
@@ -46154,10 +45902,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnt" = (
-/obj/machinery/camera{
-	c_tag = "Engineering West";
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -46166,6 +45910,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46336,14 +46084,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "SMES Access";
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cnU" = (
@@ -46937,11 +46685,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cpV" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Storage";
+/obj/structure/table,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
-/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpW" = (
@@ -47032,14 +46780,12 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -47099,8 +46845,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqp" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Escape Pod";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47913,14 +47659,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctj" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat Pod Access";
-	dir = 1;
-	network = list("minisat");
-	start_active = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/light/small,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cto" = (
@@ -48171,17 +47915,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctX" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat Teleporter";
-	dir = 1;
-	network = list("minisat");
-	start_active = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -48232,12 +47974,11 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/light/small,
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Foyer";
-	dir = 1;
-	network = list("minisat")
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cue" = (
@@ -48406,18 +48147,16 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Atmospherics";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
 	},
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -48446,12 +48185,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Antechamber";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
-	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
 	enabled = 1;
@@ -48464,6 +48197,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48529,12 +48266,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Service Bay";
-	dir = 8;
-	network = list("minisat");
-	start_active = 1
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -48547,6 +48278,10 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -48929,11 +48664,9 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvF" = (
 /obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External NorthWest";
-	dir = 8;
-	network = list("minisat");
-	start_active = 1
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -48969,11 +48702,9 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cvK" = (
 /obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External NorthEast";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -49302,11 +49033,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "cwT" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Escape Pod 2";
+/obj/machinery/light/small,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cwV" = (
@@ -49414,14 +49145,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cxY" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Escape Pod 1";
-	dir = 8
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "cya" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -50095,11 +49818,9 @@
 /area/ai_monitored/turret_protected/ai)
 "cAU" = (
 /obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External SouthWest";
-	dir = 8;
-	network = list("minisat");
-	start_active = 1
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 9
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -50130,11 +49851,9 @@
 /area/ai_monitored/turret_protected/ai)
 "cAX" = (
 /obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External SouthEast";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 5
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -50192,12 +49911,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "cBf" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat External South";
-	dir = 2;
-	network = list("minisat");
-	start_active = 1
-	},
+/obj/machinery/camera/autoname,
 /turf/open/space,
 /area/space/nearstation)
 "cBg" = (
@@ -50245,11 +49959,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cBn" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room Toilets";
+/obj/effect/landmark/event_spawn,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "cBo" = (
@@ -50943,12 +50657,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
-	dir = 4;
-	network = list("ss13","engine")
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -50991,10 +50704,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 8;
-	network = list("ss13","engine")
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -51050,14 +50762,12 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "cEu" = (
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 2;
-	network = list("engine");
-	pixel_x = 23
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -51270,8 +50980,8 @@
 /area/engine/supermatter)
 "cFi" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/camera{
-	c_tag = "Research Division South";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -51409,15 +51119,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
-	dir = 2;
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -52418,9 +52126,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Power Storage"
-	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cSS" = (
@@ -53644,15 +53350,15 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "gsz" = (
-/obj/machinery/camera{
-	c_tag = "Fitness Room South";
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "gtq" = (
@@ -54260,10 +53966,8 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "iNn" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
-	},
 /obj/structure/reagent_dispensers/cooking_oil,
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "iTt" = (
@@ -55211,13 +54915,12 @@
 	},
 /area/chapel/main)
 "lQm" = (
-/obj/machinery/camera{
-	c_tag = "Nanite Lab";
-	dir = 4;
-	network = list("ss13","rd")
-	},
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "lQs" = (
@@ -55447,11 +55150,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Experimentor Lab";
-	dir = 2;
-	network = list("ss13","rd")
-	},
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55461,6 +55159,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -57590,13 +57292,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Toxins Lab South";
-	dir = 1;
-	network = list("ss13","rd")
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -57874,8 +57575,8 @@
 	pixel_x = 25;
 	pixel_y = -25
 	},
-/obj/machinery/camera{
-	c_tag = "Cryogenics Lounge";
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -67578,7 +67279,7 @@ aaa
 aAC
 auO
 auP
-cxY
+cwT
 arB
 aaa
 aaa
@@ -69388,7 +69089,7 @@ awW
 awZ
 ayl
 ayl
-bgi
+aAH
 awW
 aaa
 aaa
@@ -71435,7 +71136,7 @@ ayl
 ayl
 ayl
 aTr
-aUM
+aSf
 ayl
 pPH
 aWc
@@ -79654,7 +79355,7 @@ aJe
 aKw
 med
 aMR
-aNU
+aOp
 aPG
 aPG
 aPG
@@ -84495,7 +84196,7 @@ adO
 oDL
 aat
 acd
-acE
+acC
 add
 acd
 aej
@@ -85523,7 +85224,7 @@ aat
 aat
 aat
 acd
-acH
+acC
 adc
 acd
 aej
@@ -104593,7 +104294,7 @@ aRS
 aRS
 aCP
 aCR
-bcx
+bcr
 aXq
 aYV
 bfY

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5595,7 +5595,6 @@
 /area/maintenance/fore/secondary)
 "alL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -5609,6 +5608,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -5721,6 +5723,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -5900,6 +5905,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "amz" = (
@@ -6144,6 +6150,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -6745,7 +6754,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -6792,6 +6800,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aoO" = (
@@ -7234,7 +7243,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqk" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -7412,6 +7420,7 @@
 "aqK" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aqL" = (
@@ -7458,12 +7467,10 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "aqT" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aqW" = (
@@ -7476,6 +7483,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
@@ -8099,6 +8109,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "asO" = (
@@ -8464,6 +8476,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "auc" = (
@@ -8489,6 +8504,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -8974,6 +8992,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avv" = (
@@ -9382,6 +9404,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awu" = (
@@ -9684,6 +9709,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/entry)
 "axc" = (
@@ -9929,6 +9957,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -9943,6 +9974,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -10039,6 +10073,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axW" = (
@@ -10128,6 +10165,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -10505,6 +10545,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -10929,7 +10972,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/power/apc/auto_name/south,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
@@ -11071,7 +11113,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAw" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -11081,6 +11122,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAx" = (
@@ -11089,6 +11133,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -11187,7 +11234,6 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aAL" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -11250,6 +11296,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -11367,7 +11417,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBi" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -11392,6 +11441,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -11992,6 +12044,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "aDb" = (
@@ -12037,6 +12091,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDe" = (
@@ -12072,6 +12129,10 @@
 /area/hydroponics/garden)
 "aDh" = (
 /obj/machinery/vending/assist,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aDi" = (
@@ -12457,6 +12518,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEc" = (
@@ -12468,6 +12532,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -12485,7 +12552,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEg" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -12495,6 +12561,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEh" = (
@@ -12503,6 +12572,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -12516,6 +12588,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -12576,6 +12651,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEC" = (
@@ -12590,6 +12668,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -12897,6 +12978,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aFl" = (
@@ -12955,6 +13038,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFw" = (
@@ -12966,10 +13052,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFy" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -13425,6 +13513,9 @@
 	dir = 4;
 	sortType = 20
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGC" = (
@@ -13487,6 +13578,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -13556,6 +13650,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14011,6 +14108,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aHT" = (
@@ -14088,12 +14188,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aIb" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aIc" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14113,6 +14207,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIg" = (
@@ -14130,7 +14227,6 @@
 	},
 /area/crew_quarters/bar)
 "aIh" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
@@ -14153,6 +14249,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14198,7 +14297,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIn" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -14226,6 +14324,10 @@
 /area/hydroponics)
 "aIr" = (
 /obj/structure/filingcabinet,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/wood,
 /area/library)
 "aIs" = (
@@ -14240,6 +14342,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -14269,6 +14374,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aIz" = (
@@ -14288,6 +14396,10 @@
 "aIB" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "crematoriumChapel"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -14328,6 +14440,10 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -14459,6 +14575,10 @@
 "aJa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -14678,6 +14798,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aJy" = (
@@ -14710,6 +14833,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aJB" = (
@@ -14721,6 +14847,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14746,6 +14875,10 @@
 /obj/structure/table/wood,
 /obj/item/stack/spacecash/c10,
 /obj/item/stack/spacecash/c100,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aJF" = (
@@ -14949,7 +15082,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -15133,6 +15265,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKE" = (
@@ -15178,6 +15313,10 @@
 "aKK" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKL" = (
@@ -15243,6 +15382,10 @@
 /area/crew_quarters/bar)
 "aKT" = (
 /obj/structure/closet/secure_closet/freezer/meat,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aKV" = (
@@ -15446,6 +15589,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aLv" = (
@@ -16090,12 +16236,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"aNo" = (
+"aNp" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aNq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -16303,6 +16457,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNV" = (
@@ -16483,6 +16640,9 @@
 "aOq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -16892,6 +17052,9 @@
 "aPD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aPE" = (
@@ -16908,6 +17071,9 @@
 "aPH" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Storage"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
@@ -17329,6 +17495,9 @@
 /area/crew_quarters/locker)
 "aQT" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQU" = (
@@ -17383,6 +17552,9 @@
 "aRc" = (
 /obj/machinery/door/airlock{
 	name = "Port Emergency Storage"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
@@ -17687,7 +17859,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
@@ -17855,6 +18026,9 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aSm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aSn" = (
@@ -18303,6 +18477,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTD" = (
@@ -18323,6 +18500,7 @@
 "aTE" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTF" = (
@@ -18336,10 +18514,13 @@
 /obj/structure/table,
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "aTH" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aTI" = (
@@ -18575,6 +18756,9 @@
 "aUs" = (
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUw" = (
@@ -18711,6 +18895,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aUU" = (
@@ -18733,6 +18920,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUY" = (
@@ -18742,6 +18932,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -19238,6 +19431,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aWd" = (
@@ -19262,6 +19458,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
@@ -19316,6 +19515,9 @@
 	icon_state = "camera";
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aWp" = (
@@ -19358,7 +19560,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWw" = (
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -19817,6 +20018,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "aXq" = (
@@ -19924,6 +20128,9 @@
 	name = "Cargo Bay Warehouse Maintenance";
 	req_access_txt = "31"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aXN" = (
@@ -19935,6 +20142,7 @@
 /area/vacant_room/office)
 "aXP" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aXQ" = (
@@ -19977,6 +20185,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "aXY" = (
@@ -19999,7 +20210,6 @@
 /turf/open/floor/carpet,
 /area/vacant_room/office)
 "aYa" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -20354,6 +20564,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aYV" = (
@@ -20920,6 +21134,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "baI" = (
@@ -20967,6 +21184,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "baP" = (
@@ -21062,6 +21281,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bbd" = (
@@ -21073,6 +21295,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -21086,6 +21311,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -21158,6 +21386,9 @@
 /obj/machinery/camera/autoname{
 	icon_state = "camera";
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -21260,7 +21491,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bbI" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -21339,6 +21569,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "bbR" = (
@@ -21368,6 +21601,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -21401,6 +21637,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bca" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/bridge/meeting_room)
 "bcb" = (
@@ -21555,6 +21794,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcv" = (
@@ -21893,6 +22135,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bdv" = (
@@ -22019,6 +22264,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bdI" = (
@@ -22544,7 +22792,6 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "bfc" = (
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -22555,6 +22802,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfg" = (
@@ -22586,7 +22836,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -22635,6 +22884,9 @@
 	pixel_y = -30
 	},
 /obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bfr" = (
@@ -22911,7 +23163,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -23024,6 +23275,9 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
 "bgI" = (
@@ -23032,6 +23286,8 @@
 /area/bridge/meeting_room)
 "bgJ" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable/yellow,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "bgL" = (
@@ -23289,7 +23545,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bhp" = (
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -23304,6 +23559,9 @@
 "bhr" = (
 /obj/machinery/door/airlock{
 	name = "Starboard Emergency Storage"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
@@ -23604,6 +23862,9 @@
 	},
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
 "bif" = (
@@ -23774,10 +24035,14 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "biC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "biD" = (
 /obj/item/storage/box/lights/mixed,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "biE" = (
@@ -23813,6 +24078,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "biH" = (
@@ -24030,6 +24296,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bjf" = (
@@ -24039,6 +24308,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -24101,6 +24373,10 @@
 /obj/structure/table,
 /obj/item/clothing/head/soft,
 /obj/item/clothing/head/soft,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bjo" = (
@@ -24194,6 +24470,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjB" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjC" = (
@@ -24441,6 +24720,8 @@
 /area/medical/morgue)
 "bkc" = (
 /obj/machinery/space_heater,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
 "bkd" = (
@@ -24637,6 +24918,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bkD" = (
@@ -24780,10 +25064,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bkX" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -24961,7 +25247,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -24971,6 +25256,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "blp" = (
@@ -25375,6 +25661,7 @@
 "bmp" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bmr" = (
@@ -26069,6 +26356,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bod" = (
@@ -26183,6 +26473,10 @@
 /area/medical/genetics)
 "boo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boq" = (
@@ -26531,6 +26825,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -27222,6 +27520,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqZ" = (
@@ -28247,6 +28548,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "btS" = (
@@ -28993,6 +29297,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bvR" = (
@@ -29293,6 +29598,10 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bwE" = (
@@ -29507,6 +29816,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bwY" = (
@@ -29519,6 +29831,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -30104,6 +30419,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byK" = (
@@ -30116,6 +30434,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
@@ -30227,6 +30548,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byU" = (
@@ -30828,7 +31151,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -31141,6 +31463,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -32086,6 +32411,10 @@
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/storage/box/mousetraps,
 /obj/item/storage/box/mousetraps,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDs" = (
@@ -32149,7 +32478,6 @@
 /area/storage/tech)
 "bDA" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -32218,6 +32546,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bDJ" = (
@@ -32247,6 +32578,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32290,6 +32624,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bDT" = (
@@ -32312,6 +32649,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -32798,6 +33138,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
 "bFh" = (
@@ -32843,7 +33186,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -32891,6 +33233,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -33057,6 +33402,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33511,6 +33859,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bHa" = (
@@ -33528,6 +33879,10 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -33862,6 +34217,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -34476,6 +34834,9 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJu" = (
@@ -34991,7 +35352,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKL" = (
@@ -35056,7 +35416,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKS" = (
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -36492,6 +36851,10 @@
 "bOM" = (
 /obj/structure/table,
 /obj/item/paper_bin,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bON" = (
@@ -36943,6 +37306,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bPR" = (
@@ -37242,6 +37608,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bQL" = (
@@ -38294,6 +38663,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bTJ" = (
@@ -38597,10 +38969,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUB" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -39252,6 +39626,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWu" = (
@@ -39265,6 +39642,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWv" = (
@@ -39273,6 +39653,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -39366,6 +39749,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bWK" = (
@@ -39379,6 +39765,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bWL" = (
@@ -40095,6 +40484,7 @@
 /obj/structure/closet/crate,
 /obj/item/clothing/under/color/lightpurple,
 /obj/item/stack/spacecash/c200,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bYt" = (
@@ -40183,6 +40573,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bYG" = (
@@ -42893,7 +43286,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfX" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
@@ -43053,6 +43445,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "cgB" = (
@@ -44154,6 +44547,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cjw" = (
@@ -44462,6 +44859,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "ckv" = (
@@ -44836,6 +45234,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -49208,6 +49609,9 @@
 /area/maintenance/disposal)
 "cAJ" = (
 /obj/structure/closet,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cAK" = (
@@ -49761,6 +50165,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -51301,7 +51708,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNL" = (
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -51768,6 +52174,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "cTE" = (
@@ -51876,6 +52283,13 @@
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"cWf" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plating,
+/area/storage/emergency/port)
 "cYY" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/xeno_spawn,
@@ -52200,6 +52614,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "elL" = (
@@ -52270,6 +52687,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"eyO" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "eAi" = (
 /obj/machinery/button/door{
 	id = "commissaryshutter";
@@ -52312,6 +52738,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"eGs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "eHb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -52357,6 +52795,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -52615,6 +53056,9 @@
 "fNU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "fNZ" = (
@@ -52702,6 +53146,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ger" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "gey" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -52777,6 +53230,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"goW" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gpE" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -52834,6 +53291,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gui" = (
@@ -52849,6 +53309,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"gwn" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "gxa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -52909,6 +53373,18 @@
 	dir = 1
 	},
 /area/science/explab)
+"gKu" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "gLd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52931,6 +53407,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -52988,6 +53467,17 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"gQQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
 "gUr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
@@ -53015,6 +53505,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gXs" = (
@@ -53203,6 +53696,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"hJF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "hKl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
@@ -53213,6 +53718,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"hOL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "hRk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -53261,6 +53771,12 @@
 	dir = 4
 	},
 /area/science/explab)
+"igW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/storage/art)
 "ijc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -53277,6 +53793,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ipA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "iqg" = (
@@ -53375,6 +53894,18 @@
 /obj/item/stack/sheet/mineral/copper,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"izv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "iAb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -53390,6 +53921,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"iCT" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -53515,7 +54051,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/lawoffice)
 "jwc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53607,6 +54143,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"jJK" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/tcommsat/computer)
 "jKE" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -53794,6 +54336,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"klY" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kma" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -53922,6 +54469,21 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
 /area/science/explab)
+"kJy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"kJA" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "kJQ" = (
 /obj/structure/sign/departments/minsky/research/robotics{
 	pixel_y = -32
@@ -54017,6 +54579,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"kTx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "kTA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -54105,6 +54677,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lff" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "lhk" = (
 /obj/structure/chair{
 	dir = 4
@@ -54208,6 +54787,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"lvv" = (
+/obj/structure/table/wood,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "lxd" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -54223,6 +54808,13 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"lxt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "lyy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -54549,6 +55141,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"mCE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "mEX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -54662,6 +55263,16 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"mZy" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "naq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -54729,6 +55340,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "nkd" = (
@@ -54738,6 +55352,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -54759,6 +55376,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "noD" = (
@@ -54929,6 +55549,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"odd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ofT" = (
 /obj/machinery/computer/bounty,
 /turf/open/floor/plasteel,
@@ -54953,6 +55579,24 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"ojR" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "olh" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -55152,6 +55796,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "oXS" = (
@@ -55189,6 +55836,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -55451,6 +56101,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"pSt" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "pUr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -55790,6 +56449,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"ric" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "rmR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -55846,6 +56511,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "rzz" = (
@@ -55876,6 +56544,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rEC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "rFX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56108,7 +56785,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "soQ" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -56277,6 +56953,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"sYn" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "sYI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -56600,6 +57282,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "tUB" = (
@@ -56751,6 +57437,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uxM" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "uzl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -56784,6 +57476,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -56828,6 +57523,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"uQR" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "uUy" = (
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -56959,10 +57658,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "vsa" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -56971,6 +57666,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -57213,6 +57911,17 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"wbj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "wcA" = (
 /obj/effect/landmark/start/brig_phys,
 /turf/open/floor/plasteel/white,
@@ -57368,6 +58077,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"wMl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
 "wOO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -57570,6 +58295,14 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"xrA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "xwM" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -57577,6 +58310,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xxQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	icon_state = "camera";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "xBJ" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -57729,6 +58475,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"yaf" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/tcommsat/server)
 "yay" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
@@ -57794,6 +58544,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -71061,7 +71815,7 @@ aUO
 aUy
 aWm
 aWf
-aUQ
+lvv
 czK
 bbU
 bcl
@@ -72866,8 +73620,8 @@ bcI
 aPz
 bdt
 aUT
-aSg
-aYf
+odd
+kJy
 bkD
 aaa
 aaa
@@ -75163,7 +75917,7 @@ oxW
 oxW
 aJZ
 aLk
-aNo
+aNk
 aOo
 aPA
 aQQ
@@ -75420,7 +76174,7 @@ aDo
 aDo
 aKp
 aLE
-aLE
+aNm
 aOn
 aPA
 aQP
@@ -75677,14 +76431,14 @@ aDo
 aIX
 aBQ
 aLE
-aLE
+aNm
 aOp
 aPA
 aQR
 aQN
 aTA
 aTz
-aWq
+eGs
 aXs
 aYH
 ydA
@@ -75934,7 +76688,7 @@ aDo
 aIW
 aBQ
 aLE
-aLE
+aNm
 aOl
 aPC
 aQN
@@ -76191,7 +76945,7 @@ aHD
 aIZ
 aBQ
 aLE
-aLE
+aOx
 aOq
 aPD
 aQT
@@ -76430,7 +77184,7 @@ ank
 alU
 aoV
 alU
-amC
+gwn
 amC
 amC
 amC
@@ -77237,9 +77991,9 @@ aSg
 aYb
 aZE
 bjn
-bjr
-hfz
-bmh
+uxM
+izv
+pSt
 boK
 bpz
 boK
@@ -78001,7 +78755,7 @@ aWu
 aYa
 aWk
 aWk
-baM
+aNp
 aWk
 aWk
 aWk
@@ -78248,10 +79002,10 @@ aaa
 aKt
 aLN
 aLE
-aOl
+rEC
 aPH
-aRa
-aRa
+igW
+igW
 aTG
 aPG
 aWw
@@ -78505,7 +79259,7 @@ aJd
 aKv
 aLN
 aLE
-aOl
+mCE
 aPF
 aQZ
 aRa
@@ -78515,7 +79269,7 @@ aSX
 gjl
 baS
 aZI
-baS
+hOL
 baS
 bdS
 bdU
@@ -78762,7 +79516,7 @@ aJe
 aKw
 med
 aMR
-aOp
+xxQ
 aPG
 aPG
 aPG
@@ -79027,7 +79781,7 @@ aRb
 aRb
 aWx
 gjl
-baS
+xrA
 baS
 bbP
 baS
@@ -79282,9 +80036,9 @@ aPK
 aPK
 aPK
 aPK
-aSX
+ojR
 aXM
-baS
+lxt
 cBi
 bbS
 bcS
@@ -79790,8 +80544,8 @@ aaa
 aKx
 aLN
 aMS
-tEs
-aLE
+gKu
+aPc
 aRc
 aSm
 aTJ
@@ -80050,7 +80804,7 @@ aMS
 tEs
 aPL
 aPK
-aSm
+cWf
 aTI
 aPK
 aWB
@@ -80569,7 +81323,7 @@ aPQ
 aPQ
 tav
 aYi
-aYZ
+wbj
 aqW
 bbQ
 bLG
@@ -82087,7 +82841,7 @@ alp
 aqS
 arP
 asS
-aqR
+uQR
 arP
 awd
 axv
@@ -82591,7 +83345,7 @@ ajt
 akc
 akJ
 alr
-alq
+lff
 aiU
 anu
 alq
@@ -82667,7 +83421,7 @@ bVI
 bWB
 bWB
 bYz
-bYz
+yaf
 cag
 cbl
 bYz
@@ -82918,7 +83672,7 @@ aaa
 aaa
 aaa
 bCq
-ciT
+klY
 bAx
 bVI
 bWD
@@ -83401,7 +84155,7 @@ aZu
 bbY
 bcY
 bdX
-bbX
+kJA
 bgH
 bie
 bjB
@@ -85235,7 +85989,7 @@ bNI
 bUB
 bVJ
 bOl
-bXG
+jJK
 bPQ
 bQK
 bYF
@@ -91587,9 +92341,9 @@ ajn
 trb
 akA
 amr
-amY
-amY
-rfr
+mZy
+ger
+hJF
 ajo
 apt
 aqm
@@ -93436,7 +94190,7 @@ bpN
 bqX
 uFk
 nok
-xQL
+kTx
 xQL
 xQL
 xQL
@@ -93920,7 +94674,7 @@ aaa
 aaf
 alP
 aGH
-aIc
+aIb
 aJC
 aKO
 aMw
@@ -96235,7 +96989,7 @@ alP
 aGB
 aIf
 aJA
-aKC
+gQQ
 aKC
 ryK
 aON
@@ -98563,8 +99317,8 @@ cBg
 bam
 aYV
 aYV
-aYV
-aYV
+bez
+ric
 bhr
 biC
 bkc
@@ -98820,7 +99574,7 @@ bam
 aYV
 aYV
 aYV
-aYV
+sYn
 beE
 bfS
 biE
@@ -99077,13 +99831,13 @@ ban
 aYV
 aYV
 aYV
-bez
+eyO
 bfP
 bfS
 bfS
 bfS
 bfS
-cTO
+wMl
 bon
 bpK
 brd
@@ -100330,7 +101084,7 @@ aaa
 aaa
 aaa
 apC
-anf
+goW
 alP
 alP
 apE
@@ -104712,7 +105466,7 @@ aAz
 asB
 ozs
 aEh
-aFz
+iCT
 aFz
 aFz
 lrU

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1655,12 +1655,7 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "adN" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	areastring = "/area/crew_quarters/heads/hos";
-	name = "Head of Security's Office APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -1943,12 +1938,7 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Prison Wing APC";
-	areastring = "/area/security/prison";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -2822,12 +2812,7 @@
 "agg" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Prisoner Transfer Centre";
-	areastring = "/area/security/execution/transfer";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "agh" = (
@@ -3428,15 +3413,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ahv" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Brig Control APC";
-	areastring = "/area/security/warden";
-	pixel_x = -25
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahw" = (
@@ -3657,12 +3637,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahN" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Security Office APC";
-	areastring = "/area/security/main";
-	pixel_x = 24
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -3671,6 +3645,7 @@
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahP" = (
@@ -4488,12 +4463,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajy" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Brig APC";
-	areastring = "/area/security/brig";
-	pixel_y = 23
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -4506,6 +4475,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajz" = (
@@ -5625,12 +5595,7 @@
 /area/maintenance/fore/secondary)
 "alL" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Courtroom APC";
-	areastring = "/area/security/courtroom";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -6213,13 +6178,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Port Bow Solar APC";
-	areastring = "/area/maintenance/solars/port/fore";
-	pixel_x = -25;
-	pixel_y = 3
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/machinery/camera/autoname{
 	icon_state = "camera";
 	dir = 1
@@ -6786,12 +6745,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Fitness Room APC";
-	areastring = "/area/crew_quarters/fitness";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -6971,12 +6925,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Fore Maintenance APC";
-	areastring = "/area/maintenance/fore/secondary";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7070,13 +7019,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Starboard Bow Solar APC";
-	areastring = "/area/maintenance/solars/starboard/fore";
-	pixel_x = -25;
-	pixel_y = 3
-	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "apB" = (
@@ -7291,12 +7234,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqk" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Dormitory APC";
-	areastring = "/area/crew_quarters/dorms";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -7495,13 +7433,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Port Bow Maintenance APC";
-	areastring = "/area/maintenance/port/fore";
-	pixel_x = -1;
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -7526,12 +7458,7 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "aqT" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Labor Shuttle Dock APC";
-	areastring = "/area/security/processing";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -7688,12 +7615,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ars" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Starboard Bow Maintenance APC";
-	areastring = "/area/maintenance/starboard/fore";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -9166,12 +9088,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Electrical Maintenance APC";
-	areastring = "/area/maintenance/department/electrical";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -9283,12 +9200,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awd" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Fore Maintenance APC";
-	areastring = "/area/maintenance/fore";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -10436,12 +10348,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "ayP" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "EVA Storage APC";
-	areastring = "/area/ai_monitored/storage/eva";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -11022,13 +10929,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Security Checkpoint APC";
-	areastring = "/area/security/checkpoint/auxiliary";
-	pixel_x = 1;
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
@@ -11170,13 +11071,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAw" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Garden APC";
-	areastring = "/area/hydroponics/garden";
-	pixel_x = 24;
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -11292,13 +11187,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aAL" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Primary Tool Storage APC";
-	areastring = "/area/storage/primary";
-	pixel_x = 1;
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -11478,13 +11367,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBi" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Gateway APC";
-	areastring = "/area/gateway";
-	pixel_x = -25;
-	pixel_y = -1
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -11718,12 +11601,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aBU" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Vault APC";
-	areastring = "/area/ai_monitored/nuke_storage";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -12607,12 +12485,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEg" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Chapel APC";
-	areastring = "/area/chapel/main";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -12682,12 +12555,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "aEz" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Entry Hall APC";
-	areastring = "/area/hallway/secondary/entry";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -12999,12 +12867,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aFi" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Dormitory Bathrooms APC";
-	areastring = "/area/crew_quarters/toilet";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -13106,12 +12969,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFy" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Chapel Office APC";
-	areastring = "/area/chapel/office";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14230,22 +14088,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aIb" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Theatre APC";
-	areastring = "/area/crew_quarters/theatre";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIc" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Bar APC";
-	areastring = "/area/crew_quarters/bar";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14282,12 +14130,7 @@
 	},
 /area/crew_quarters/bar)
 "aIh" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Kitchen APC";
-	areastring = "/area/crew_quarters/kitchen";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
@@ -14355,12 +14198,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIn" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Hydroponics APC";
-	areastring = "/area/hydroponics";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -15111,12 +14949,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Auxillary Base Construction APC";
-	areastring = "/area/construction/mining/aux_base";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -15687,12 +15520,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	name = "Port Hall APC";
-	areastring = "/area/hallway/primary/port";
-	dir = 1;
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLH" = (
@@ -17859,12 +17687,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Library APC";
-	areastring = "/area/library";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
@@ -17925,12 +17748,7 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "aRV" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Auxiliary Tool Storage APC";
-	areastring = "/area/storage/tools";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -19004,12 +18822,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aVh" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Fore Primary Hallway APC";
-	areastring = "/area/hallway/primary/fore";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -19545,12 +19358,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWw" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Art Storage";
-	areastring = "/area/storage/art";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -19580,30 +19388,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aWz" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Port Emergency Storage APC";
-	areastring = "/area/storage/emergency/port";
-	pixel_y = 23
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aWB" = (
@@ -20215,13 +19999,7 @@
 /turf/open/floor/carpet,
 /area/vacant_room/office)
 "aYa" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Port Maintenance APC";
-	areastring = "/area/maintenance/port";
-	pixel_x = -25;
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -20440,12 +20218,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYF" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Central Hall APC";
-	areastring = "/area/hallway/primary/central";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -21108,12 +20881,7 @@
 /turf/open/floor/carpet/green,
 /area/chapel/main)
 "baD" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Escape Hallway APC";
-	areastring = "/area/hallway/secondary/exit";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -21184,13 +20952,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Locker Restrooms APC";
-	areastring = "/area/crew_quarters/toilet/locker";
-	pixel_x = 24;
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -21410,12 +21172,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bbu" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Captain's Office APC";
-	areastring = "/area/crew_quarters/heads/captain";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -21503,12 +21260,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bbI" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Vacant Office APC";
-	areastring = "/area/vacant_room/office";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -22330,18 +22082,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"bdT" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Disposal APC";
-	areastring = "/area/maintenance/disposal";
-	pixel_x = -25
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bdU" = (
 /obj/structure/closet/crate/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -22804,12 +22544,7 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "bfc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Locker Room APC";
-	areastring = "/area/crew_quarters/locker";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -22851,13 +22586,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Bay APC";
-	areastring = "/area/quartermaster/storage";
-	pixel_x = 1;
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -23002,12 +22731,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfP" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Starboard Primary Hallway APC";
-	areastring = "/area/hallway/primary/starboard";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow,
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -23187,12 +22911,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Mech Bay APC";
-	areastring = "/area/science/robotics/mechbay";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -23425,12 +23144,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgZ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Chemistry APC";
-	areastring = "/area/medical/chemistry";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -23575,12 +23289,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bhp" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Morgue APC";
-	areastring = "/area/medical/morgue";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -25074,12 +24783,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bkX" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Conference Room APC";
-	areastring = "/area/bridge/meeting_room";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -25257,12 +24961,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Starboard Emergency Storage APC";
-	areastring = "/area/storage/emergency/starboard";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -25275,12 +24974,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "blp" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Medbay Security APC";
-	areastring = "/area/security/checkpoint/medical";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -26507,12 +26201,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bos" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Robotics Lab APC";
-	areastring = "/area/science/robotics/lab";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -27029,12 +26718,7 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "bpG" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Genetics APC";
-	areastring = "/area/medical/genetics";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -27380,13 +27064,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Gravity Generator APC";
-	areastring = "/area/engine/gravity_generator";
-	pixel_x = -25;
-	pixel_y = 1
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/table,
 /obj/item/paper/guides/jobs/engi/gravity_gen{
 	layer = 3
@@ -28483,12 +28161,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btI" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Teleporter APC";
-	areastring = "/area/teleporter";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -28621,13 +28294,7 @@
 /area/quartermaster/storage)
 "buc" = (
 /obj/machinery/light,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Office APC";
-	areastring = "/area/quartermaster/office";
-	pixel_x = 1;
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -30351,12 +30018,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "byA" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Quartermaster APC";
-	areastring = "/area/quartermaster/qm";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -30409,12 +30071,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "byF" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Mining Dock APC";
-	areastring = "/area/quartermaster/miningdock";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -30797,12 +30454,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/server)
 "bzy" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Server Room APC";
-	areastring = "/area/science/server";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -31176,13 +30828,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Cargo Security APC";
-	areastring = "/area/security/checkpoint/supply";
-	pixel_x = 1;
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -31930,12 +31576,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCa" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Science Security APC";
-	areastring = "/area/security/checkpoint/science";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -31988,12 +31629,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bCf" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "RD Office APC";
-	areastring = "/area/crew_quarters/heads/hor";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_y = -23
@@ -32498,12 +32134,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bDy" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Tech Storage APC";
-	areastring = "/area/storage/tech";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -32518,12 +32149,7 @@
 /area/storage/tech)
 "bDA" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Treatment Center APC";
-	areastring = "/area/medical/sleeper";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -32926,12 +32552,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bEq" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Misc Research APC";
-	areastring = "/area/science/research";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -33222,12 +32843,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Custodial Closet APC";
-	areastring = "/area/janitor";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -33514,12 +33130,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bFX" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Toxins Lab APC";
-	areastring = "/area/science/mixing";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -33939,12 +33550,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bHe" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Toxins Storage APC";
-	areastring = "/area/science/storage";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -34211,12 +33817,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bHV" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Aft Maintenance APC";
-	areastring = "/area/maintenance/aft";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -35390,12 +34991,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Medbay APC";
-	areastring = "/area/medical/medbay/central";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKL" = (
@@ -35460,12 +35056,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKS" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "CM Office APC";
-	areastring = "/area/crew_quarters/heads/cmo";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -35633,12 +35224,7 @@
 /area/crew_quarters/heads/hor)
 "bLi" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing/chamber";
-	dir = 8;
-	name = "Toxins Chamber APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
@@ -35785,13 +35371,7 @@
 /area/security/detectives_office)
 "bLF" = (
 /obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Delivery Office APC";
-	areastring = "/area/quartermaster/sorting";
-	pixel_x = 1;
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -35967,12 +35547,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bMg" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Xenobiology APC";
-	areastring = "/area/science/xenobiology";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -36928,12 +36503,7 @@
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "bOO" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Engineering Security APC";
-	areastring = "/area/security/checkpoint/engineering";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -37171,12 +36741,7 @@
 /obj/item/paper_bin{
 	pixel_y = 6
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Testing Lab APC";
-	areastring = "/area/science/misc_lab";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -38732,13 +38297,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bTJ" = (
-/obj/machinery/power/apc{
-	name = "Aft Hall APC";
-	areastring = "/area/hallway/primary/aft";
-	dir = 8;
-	pixel_x = -25;
-	pixel_y = 1
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -39041,12 +38600,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bUB" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Telecomms Monitoring APC";
-	areastring = "/area/tcommsat/computer";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -40978,12 +40532,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bZF" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Atmospherics APC";
-	areastring = "/area/engine/atmos";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -41715,18 +41264,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cbu" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Engineering Foyer APC";
-	areastring = "/area/engine/break_room";
-	pixel_x = -25
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cbv" = (
@@ -42518,12 +42062,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cds" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Starboard Quarter Maintenance APC";
-	areastring = "/area/maintenance/starboard/aft";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -42696,13 +42235,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cdW" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Port Quarter Maintenance APC";
-	areastring = "/area/maintenance/port/aft";
-	pixel_x = -25;
-	pixel_y = 1
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -43360,12 +42893,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfX" = (
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Incinerator APC";
-	areastring = "/area/maintenance/disposal/incinerator";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
@@ -44400,13 +43928,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ciR" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Port Quarter Solar APC";
-	areastring = "/area/maintenance/solars/port/aft";
-	pixel_x = 24;
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/machinery/camera/autoname{
 	icon_state = "camera";
@@ -44929,13 +44451,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "ckt" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Starboard Quarter Solar APC";
-	areastring = "/area/maintenance/solars/starboard/aft";
-	pixel_x = -25;
-	pixel_y = 3
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -46650,12 +46166,7 @@
 /area/maintenance/port/aft)
 "cpS" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "SMES room APC";
-	areastring = "/area/engine/engine_smes";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -47902,12 +47413,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "MiniSat Foyer APC";
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -48296,12 +47802,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "cuM" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "MiniSat Atmospherics APC";
-	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -48394,12 +47895,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cuX" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "MiniSat Service Bay APC";
-	areastring = "/area/ai_monitored/turret_protected/aisat/service";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -48784,12 +48280,7 @@
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cwa" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "MiniSat Chamber Hallway APC";
-	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cwc" = (
@@ -49697,12 +49188,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	dir = 2;
-	name = "Head of Personnel APC";
-	areastring = "/area/crew_quarters/heads/hop";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -51815,12 +51301,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Central Maintenance APC";
-	areastring = "/area/maintenance/central";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -51845,12 +51326,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNS" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Starboard Maintenance APC";
-	areastring = "/area/maintenance/starboard";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -52284,12 +51760,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Central Maintenance APC";
-	areastring = "/area/maintenance/central/secondary";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -52359,12 +51830,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cTM" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Morgue Maintenance APC";
-	areastring = "/area/maintenance/department/medical/morgue";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -53511,12 +52977,7 @@
 	pixel_y = 3
 	},
 /obj/item/stock_parts/scanning_module,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Research Lab APC";
-	areastring = "/area/science/lab";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -53580,26 +53041,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"hcE" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Cargo Warehouse APC";
-	areastring = "/area/quartermaster/warehouse";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "hcK" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54026,12 +53467,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "jhL" = (
@@ -54074,12 +53510,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "jsv" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Law Office APC";
-	areastring = "/area/lawoffice";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -54781,11 +54212,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/nanite";
-	name = "Nanite Lab APC";
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -55371,11 +54798,7 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "nxv" = (
-/obj/machinery/power/apc{
-	name = "Construction Area APC";
-	areastring = "/area/construction";
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -56685,13 +56108,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "soQ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/vacant_room/commissary";
-	dir = 4;
-	name = "Vacant Commissary APC";
-	pixel_x = 24;
-	pixel_y = 2
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -57542,12 +56959,7 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "vsa" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
-	dir = 8;
-	name = "Detective's Office APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -58056,12 +57468,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "xfD" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Experimentation Lab APC";
-	areastring = "/area/science/explab";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -73201,7 +72608,7 @@ czK
 bbg
 bdG
 bdu
-bdT
+bbI
 beO
 bjf
 beO
@@ -78594,7 +78001,7 @@ aWu
 aYa
 aWk
 aWk
-hcE
+baM
 aWk
 aWk
 aWk
@@ -80132,7 +79539,7 @@ aPK
 aSl
 aTH
 aPK
-aWz
+aWw
 gjl
 gjl
 gjl


### PR DESCRIPTION
## About The Pull Request
This PR is the start of a series to help move modern mapping tools into use on the legacy maps of SS13, thus permitting mapping standards to be better maintained, and for stations to serve as better examples to novice mappers.

Specifically this PR changes non-motion sensitive cameras and APCs to now use the autonaming and respective directional type paths. 

Edit: This PR is also removing superfilous piping from Box that was disconnected in some places, or enables such pipes to be re-connected to the pipe network.

## Why It's Good For The Game
Having legacy maps upgraded with modern mapping objects will help ease future changes to said maps, and as previously mentioned, allow for legacy maps to serve as a better example for novice, and even experienced mappers.


## Changelog
:cl:
tweak: Changed cameras to autoname variety, so they now name based off of area
tweak: changed APCs to autoname variety, also forcing many to move out of maintenance and thus enabling the AI to access them
tweak: makes some areas of the pipe net once again connect to the main net.
Remove: some superfilous pipes that were bypassed at one point during an atmos rework
/:cl:

