### PR TITLE
Adds an exile implant to the skeleton ghost role

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -527,8 +527,8 @@
 	assignedrole = "Skeleton"
 
 /obj/effect/mob_spawn/human/skeleton/alive/equip(mob/living/carbon/human/H)
-	var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(H)
-	Implant.implant(H)
+	var/obj/item/implant/exile/implant = new/obj/item/implant/exile(H)
+	implant.implant(H)
 
 /obj/effect/mob_spawn/human/zombie
 	name = "rotting corpse"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -527,8 +527,8 @@
 	assignedrole = "Skeleton"
 
 /obj/effect/mob_spawn/human/skeleton/alive/equip(mob/living/carbon/human/H)
-var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(H)
-Implant/implant(H)
+	var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(H)
+	Implant/implant(H)
 
 /obj/effect/mob_spawn/human/zombie
 	name = "rotting corpse"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -510,7 +510,7 @@
 
 
 /////////////////Spooky Undead//////////////////////
-/*
+
 /obj/effect/mob_spawn/human/skeleton
 	name = "skeletal remains"
 	mob_name = "skeleton"
@@ -525,7 +525,11 @@
 	short_desc = "By unknown powers, your skeletal remains have been reanimated!"
 	flavour_text = "Walk this mortal plain and terrorize all living adventurers who dare cross your path."
 	assignedrole = "Skeleton"
-*/
+
+/obj/effect/mob_spawn/human/skeleton/alive/equip(mob/living/carbon/human/H)
+var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(H)
+Implant.implant(H)
+
 /obj/effect/mob_spawn/human/zombie
 	name = "rotting corpse"
 	mob_name = "zombie"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -510,7 +510,7 @@
 
 
 /////////////////Spooky Undead//////////////////////
-
+/*
 /obj/effect/mob_spawn/human/skeleton
 	name = "skeletal remains"
 	mob_name = "skeleton"
@@ -525,7 +525,7 @@
 	short_desc = "By unknown powers, your skeletal remains have been reanimated!"
 	flavour_text = "Walk this mortal plain and terrorize all living adventurers who dare cross your path."
 	assignedrole = "Skeleton"
-
+*/
 /obj/effect/mob_spawn/human/zombie
 	name = "rotting corpse"
 	mob_name = "zombie"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -528,7 +528,7 @@
 
 /obj/effect/mob_spawn/human/skeleton/alive/equip(mob/living/carbon/human/H)
 	var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(H)
-	Implant/implant(H)
+	Implant.implant(H)
 
 /obj/effect/mob_spawn/human/zombie
 	name = "rotting corpse"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -528,7 +528,7 @@
 
 /obj/effect/mob_spawn/human/skeleton/alive/equip(mob/living/carbon/human/H)
 var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(H)
-Implant.implant(H)
+Implant/implant(H)
 
 /obj/effect/mob_spawn/human/zombie
 	name = "rotting corpse"


### PR DESCRIPTION
Players have been using this ghost role to murderbone the station with broken wizard gear, and the admins are doing nothing about it. The skeleton isn't an antagonist.

:cl:
tweak: Gateway skeleton starts with an exile implant
/:cl: