### PR TITLE
Added captain access requirement for antique laser cases.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -412,6 +412,14 @@
 /obj/structure/grille/broken,
 /turf/open/space,
 /area/space/nearstation)
+"abb" = (
+/obj/structure/displaycase/captain{
+	req_access = null;
+	req_access_txt = "20";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "abc" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
@@ -21735,10 +21743,6 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/royalblue,
-/area/crew_quarters/heads/captain)
-"bcn" = (
-/obj/structure/displaycase/captain,
-/turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bco" = (
 /obj/machinery/navbeacon{
@@ -90885,7 +90889,7 @@ aXg
 aYF
 aZV
 iXl
-bcn
+abb
 iXl
 ben
 bfE

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -112,6 +112,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"aao" = (
+/obj/structure/displaycase/captain{
+	req_access = null;
+	req_access_txt = "20"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain/private)
 "aap" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -2287,10 +2294,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"afT" = (
-/obj/structure/displaycase/captain,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain/private)
 "afU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -104715,7 +104718,7 @@ anR
 aiV
 bDK
 bHO
-afT
+aao
 aea
 azS
 ahz

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9423,7 +9423,11 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "aop" = (
-/obj/structure/displaycase/captain,
+/obj/structure/displaycase/captain{
+	req_access = null;
+	req_access_txt = "20";
+	req_one_access_txt = "0"
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4307,6 +4307,18 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ahR" = (
+/obj/structure/displaycase/captain{
+	pixel_y = 5;
+	req_access = null;
+	req_access_txt = "20";
+	req_one_access_txt = "0"
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain/private)
 "ahS" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -34437,15 +34449,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"boD" = (
-/obj/structure/displaycase/captain{
-	pixel_y = 5
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain/private)
 "boE" = (
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -113753,7 +113756,7 @@ bht
 bjg
 bkK
 bjg
-boD
+ahR
 bqV
 btc
 buG

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -67,6 +67,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
+"aah" = (
+/obj/structure/displaycase/captain{
+	req_access = null;
+	req_access_txt = "20";
+	req_one_access_txt = "0"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
 "aaX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -11924,10 +11932,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aCy" = (
-/obj/structure/displaycase/captain,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
 "aCz" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -89698,7 +89702,7 @@ axR
 ayX
 aAt
 aBk
-aCy
+aah
 aDC
 aEx
 aFw


### PR DESCRIPTION
Captains Antique Laser gun case openable on all maps with captain access. 

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Currently, deltastation is the only map the antique laser gun case can be unlocked using an ID with the captain's access, now its possible on all maps.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Captains no longer need to break their gun case on non-delta maps.
## Changelog
:cl:
add: Captains Display Case: req_access_txt = "20"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
