### PR TITLE
Fixes Taste that have been absent for 5 months.

### DIFF
--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -27,7 +27,7 @@
 			text_output = pick("spiders","dreams","nightmares","the future","the past","victory",\
 			"defeat","pain","bliss","revenge","poison","time","space","death","life","truth","lies","justice","memory",\
 			"regrets","your soul","suffering","music","noise","blood","hunger","the american way")
-		if((text_output != last_taste_text || last_taste_time + 100 < world.time) && !NO_TASTE_SENSITIVITY)
+		if((text_output != last_taste_text || last_taste_time + 100 < world.time) && (taste_sensitivity != NO_TASTE_SENSITIVITY))
 			to_chat(src, "<span class='notice'>You can taste [text_output].</span>")
 			// "something indescribable" -> too many tastes, not enough flavor.
 


### PR DESCRIPTION

## About The Pull Request

Another one-line fix. Nuff said.

## Why It's Good For The Game

Tasting cyanide before you die is good for survival.

## Changelog
:cl:
fix: Fixed a bug that prevented anyone from feeling taste. Now you can tell that your drink has cyanide in it.
/:cl:
