### PR TITLE
Adds anomaly core activation effects

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -256,7 +256,7 @@
 /obj/effect/anomaly/pyro
 	name = "pyroclastic anomaly"
 	icon_state = "mustard"
-	var/ticks = 0
+	var/ticks = 4
 
 /obj/effect/anomaly/pyro/anomalyEffect()
 	..()

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -27,6 +27,7 @@
 	var/datum/wires/connected = null
 
 	var/next_activate = 0 //When we're next allowed to activate - for spam control
+	var/activate_delay = 30
 
 /obj/item/assembly/get_part_rating()
 	return 1
@@ -78,7 +79,7 @@
 /obj/item/assembly/proc/activate()
 	if(QDELETED(src) || !secured || (next_activate > world.time))
 		return FALSE
-	next_activate = world.time + 30
+	next_activate = world.time + activate_delay
 	return TRUE
 
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -189,6 +189,7 @@ Code:
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	resistance_flags = FIRE_PROOF
+	activate_delay = 300
 	var/anomaly_type = /obj/effect/anomaly
 
 /obj/item/assembly/signaler/anomaly/receive_signal(datum/signal/signal)
@@ -200,6 +201,16 @@ Code:
 		manual_suicide(suicider)
 	for(var/obj/effect/anomaly/A in get_turf(src))
 		A.anomalyNeutralize()
+	return TRUE
+
+/obj/item/assembly/signaler/anomaly/activate()
+	if(!..())//cooldown processing
+		return FALSE
+	var/type = src.anomaly_type
+	var/obj/effect/anomaly/B = new type(get_turf(src))
+	B.movechance = 0
+	B.anomalyEffect()
+	B.Destroy()
 	return TRUE
 
 /obj/item/assembly/signaler/anomaly/manual_suicide(mob/living/carbon/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes anomaly cores apply their respective anomaly's effect when pulsed by their attached assembly.
I noticed anomaly cores were a type of assembly but didn't do anything when activated so I decided to make them do something interesting.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more uses for anomaly cores.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Anomaly cores now have effects when attached to other assemblies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
