### PR TITLE
Tasers are no longer an instant win

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -2,8 +2,10 @@
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
-	nodamage = TRUE
-	paralyze = 100
+	damage = 40
+	damage_type = STAMINA
+	nodamage = FALSE
+	knockdown = 30
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
@@ -20,6 +22,7 @@
 		var/mob/living/carbon/C = target
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "tased", /datum/mood_event/tased)
 		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
+		C.confused +=15
 		if(C.dna && C.dna.check_mutation(HULK))
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 		else if((C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE))


### PR DESCRIPTION
## About The Pull Request

Instead of instantly stunning a target for ten seconds, tasers do 3 seconds of knockdown, a bit of confusion, and enough stamina damage to down someone for long enough to cuff with a small grace in three shots (Though my intention is for it to be used as a debuff weapon rather than a win condition)

## Why It's Good For The Game

HOS taser, as well as the gun from charlie station and the hotel shotgun, will instantly win any fight without common counters unless the target has one of very few stun counters. This makes the taser still incredibly dangerous in a fight without being an instant win, and no longer able to singlehandedly destroy small crowds of well-armed opponents. It also  still allows ai turrets to down someone. 

## Changelog
:cl:
balance: taser no longer hardstuns
/:cl:
