### PR TITLE
Removes Spirit Board from curators spectral kit

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -110,7 +110,6 @@
 	name = "Spectre Inspector - 1980's."
 
 /obj/item/storage/box/hero/ghostbuster/PopulateContents()
-	new /obj/item/choice_beacon/ouija(src)
 	new /obj/item/clothing/glasses/welding/ghostbuster(src)
 	new /obj/item/storage/belt/fannypack/bustin(src)	
 	new /obj/item/clothing/gloves/color/black(src)


### PR DESCRIPTION

## About The Pull Request
Simply removes the spirit board spawner from the box of the spectral kit.
## Why It's Good For The Game
Ghosts literally know every antag. Ghosts would give up cult leaders names, changelings names, base locations, round type, etc etc. I plan to nerf this later and readd it, but for now this is ruining peoples games.


## Changelog
:cl:
del: Nanotrasen has removed the Spirit Board from the curators spectral kit, on suspicion of black magic! The board still exists, however...
/:cl: