### PR TITLE
Romerol is back

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -612,6 +612,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 6
 	surplus = 50
 
+/datum/uplink_item/role_restricted/romerol_kit
+	name = "Romerol"
+	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. \
+			On death, these nodules take control of the dead body, causing limited revivification, \
+			along with slurred speech, aggression, and the ability to infect others with this agent."
+	item = /obj/item/storage/box/syndie_kit/romerol
+	cost = 25
+	cant_discount = TRUE
+
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"
 	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
@@ -1628,16 +1637,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/gorillacubes
 	cost = 6
 	restricted_roles = list("Geneticist", "Chief Medical Officer")
-
-/datum/uplink_item/role_restricted/romerol_kit
-	name = "Romerol"
-	desc = "A highly experimental bioterror agent which creates dormant nodules to be etched into the grey matter of the brain. \
-			On death, these nodules take control of the dead body, causing limited revivification, \
-			along with slurred speech, aggression, and the ability to infect others with this agent."
-	item = /obj/item/storage/box/syndie_kit/romerol
-	cost = 20
-	cant_discount = TRUE
-	restricted_roles = list("Chief Medical Officer", "Virologist")
 
 /datum/uplink_item/role_restricted/rad_laser
 	name = "Radioactive Microlaser"


### PR DESCRIPTION
Returns Romerol to a 25TC item for all traitors instead of being restricted to the CMO/Virologist as the virologist can make romerol using viruses now.

## Why it's good for the game

I liked the interactions between traitors this item causes, forcing them to team up to buy it and cause an outbreak.

:cl:
tweak: Romerol is no longer role restricted to the CMO and Virologist.
/:cl: