### PR TITLE
Synthflesh cloning port

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -30685,7 +30685,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzm" = (
-/obj/machinery/clonepod/mapped,
+/obj/machinery/clonepod/prefilled,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36,7 +36,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -415,8 +414,7 @@
 "abb" = (
 /obj/structure/displaycase/captain{
 	req_access = null;
-	req_access_txt = "20";
-	req_one_access_txt = "0"
+	req_access_txt = "20"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -536,8 +534,7 @@
 /area/security/execution/transfer)
 "abu" = (
 /obj/machinery/door/poddoor{
-	id = "executionspaceblast";
-	name = "blast door"
+	id = "executionspaceblast"
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -585,7 +582,6 @@
 "abG" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
 	name = "Unisex Showers"
 	},
@@ -681,8 +677,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor";
-	dir = 2
+	c_tag = "Armory Motion Sensor"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -849,7 +844,6 @@
 /area/security/execution/transfer)
 "acb" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "executionburn";
 	pixel_x = 25
 	},
@@ -948,8 +942,8 @@
 /area/ai_monitored/security/armory)
 "acm" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 4;
 	areastring = "/area/ai_monitored/security/armory";
+	dir = 4;
 	name = "Armory APC";
 	pixel_x = 24
 	},
@@ -990,7 +984,6 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -1040,9 +1033,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acA" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -1053,9 +1044,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -1065,7 +1054,6 @@
 /obj/structure/bed,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -1158,16 +1146,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "acN" = (
 /obj/structure/chair/stool/bar,
@@ -1180,7 +1164,6 @@
 "acO" = (
 /obj/structure/closet/l3closet/security,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1367,9 +1350,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -1377,9 +1358,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adk" = (
 /obj/structure/rack,
@@ -1392,9 +1371,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -1402,9 +1379,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adl" = (
 /obj/machinery/door/poddoor/shutters{
@@ -1695,9 +1670,7 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "adQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adR" = (
@@ -1942,7 +1915,6 @@
 /area/security/prison)
 "aer" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/power/apc/auto_name/east,
@@ -2055,7 +2027,6 @@
 /area/security/main)
 "aeC" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2293,7 +2264,6 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -2926,9 +2896,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "agr" = (
@@ -2956,7 +2924,6 @@
 "agv" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3507,9 +3474,7 @@
 /area/security/main)
 "ahD" = (
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Brig Infirmary"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -3739,7 +3704,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/closet/secure_closet/brig_phys,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -3873,7 +3837,6 @@
 /area/security/main)
 "ail" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -3913,7 +3876,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4290,7 +4252,6 @@
 /area/security/brig)
 "aje" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/red{
@@ -4455,7 +4416,6 @@
 /area/security/brig)
 "ajx" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/red{
@@ -4816,11 +4776,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4857,9 +4814,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akl" = (
@@ -4895,7 +4850,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4944,9 +4898,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "akv" = (
@@ -5017,9 +4969,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -5441,7 +5391,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -5470,7 +5419,6 @@
 "aly" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -5538,9 +5486,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "alF" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alG" = (
@@ -5637,8 +5583,7 @@
 "alQ" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Port Bow Solar Control";
-	track = 0
+	name = "Port Bow Solar Control"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -5938,7 +5883,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -6198,7 +6142,6 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6487,7 +6430,6 @@
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -6532,8 +6474,7 @@
 "aoh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Starboard Bow Solar Control";
-	track = 0
+	name = "Starboard Bow Solar Control"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -6642,7 +6583,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6676,7 +6616,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6693,18 +6632,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoA" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoB" = (
@@ -6712,16 +6647,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoC" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoD" = (
@@ -6729,20 +6660,15 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoF" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoH" = (
@@ -7046,7 +6972,6 @@
 	},
 /obj/machinery/power/smes,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -8404,7 +8329,6 @@
 	pixel_y = -27
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -8686,7 +8610,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8813,7 +8736,6 @@
 /area/crew_quarters/dorms)
 "auU" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -9166,7 +9088,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10367,7 +10288,6 @@
 /area/ai_monitored/storage/eva)
 "ayM" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/clothing/head/welding,
@@ -10499,9 +10419,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azd" = (
@@ -10857,9 +10775,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azT" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azU" = (
@@ -11149,9 +11065,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAy" = (
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -11178,9 +11092,7 @@
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "aAB" = (
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -11220,7 +11132,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11420,7 +11331,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -11548,8 +11458,7 @@
 /area/crew_quarters/toilet)
 "aBC" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12";
-	req_one_access_txt = "0"
+	req_access_txt = "12"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11825,7 +11734,6 @@
 /area/ai_monitored/storage/eva)
 "aCj" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11858,7 +11766,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -11867,7 +11774,6 @@
 /obj/structure/table/wood,
 /obj/machinery/requests_console{
 	department = "Theatre";
-	departmentType = 0;
 	name = "theatre RC";
 	pixel_x = -32
 	},
@@ -12065,7 +11971,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -12170,7 +12075,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
 	pixel_y = 30
 	},
 /obj/machinery/camera/autoname,
@@ -12307,9 +12211,7 @@
 /area/maintenance/fore)
 "aDB" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aDC" = (
@@ -12322,11 +12224,8 @@
 "aDE" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12819,7 +12718,6 @@
 	},
 /obj/item/storage/firstaid/regular,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12930,7 +12828,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13114,7 +13011,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13181,7 +13077,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13288,7 +13183,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -14228,12 +14122,8 @@
 	location = "Bar"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aIh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14630,7 +14520,6 @@
 "aJf" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14827,7 +14716,6 @@
 /area/hallway/primary/central)
 "aJz" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -14868,7 +14756,6 @@
 "aJD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;25;26;35;28;22;37;46;38"
 	},
 /obj/structure/disposalpipe/segment,
@@ -14913,9 +14800,6 @@
 /area/chapel/office)
 "aJH" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -14935,12 +14819,8 @@
 	location = "Kitchen"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aJL" = (
 /obj/machinery/navbeacon{
@@ -14949,12 +14829,8 @@
 	location = "Hydroponics"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aJM" = (
 /obj/structure/table/wood,
@@ -15100,9 +14976,7 @@
 /area/maintenance/port/fore)
 "aKj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aKk" = (
@@ -15152,7 +15026,6 @@
 /area/crew_quarters/theatre)
 "aKr" = (
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/wood,
@@ -15350,7 +15223,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -15395,9 +15267,6 @@
 /area/crew_quarters/kitchen)
 "aKV" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
@@ -15437,7 +15306,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -15781,7 +15649,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -15882,7 +15749,6 @@
 /area/crew_quarters/kitchen)
 "aMm" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -16063,7 +15929,6 @@
 /area/chapel/office)
 "aMM" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -16637,7 +16502,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16967,7 +16831,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17519,7 +17382,6 @@
 /area/crew_quarters/locker)
 "aQX" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -17892,7 +17754,6 @@
 /area/library)
 "aRP" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -17999,7 +17860,6 @@
 /area/hallway/secondary/entry)
 "aSf" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18284,9 +18144,7 @@
 /area/maintenance/port)
 "aSY" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
+/obj/item/clothing/head/that,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -18309,9 +18167,7 @@
 /area/library)
 "aTc" = (
 /obj/machinery/door/window/northright{
-	base_state = "right";
 	dir = 8;
-	icon_state = "right";
 	name = "Library Desk Door";
 	req_access_txt = "37"
 	},
@@ -18497,7 +18353,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18610,9 +18465,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTV" = (
@@ -18693,7 +18546,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18771,7 +18623,6 @@
 /area/storage/tools)
 "aUx" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;38"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18786,7 +18637,6 @@
 /area/maintenance/starboard/fore)
 "aUy" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -18988,7 +18838,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19028,7 +18877,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19143,7 +18991,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19364,7 +19211,6 @@
 /area/library)
 "aVV" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -19516,7 +19362,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -19795,16 +19640,14 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWW" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Bridge APC";
 	areastring = "/area/bridge";
+	name = "Bridge APC";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -20066,9 +19909,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXA" = (
@@ -20283,7 +20124,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20317,7 +20157,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20558,7 +20397,6 @@
 "aYT" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20606,7 +20444,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20649,7 +20486,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21388,7 +21224,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -21774,7 +21609,6 @@
 /area/hallway/primary/starboard)
 "bcs" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -21970,18 +21804,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/side,
 /area/hallway/primary/starboard)
 "bdc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel/white/corner{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/starboard)
 "bdd" = (
 /obj/machinery/vending/cola/random,
@@ -22077,7 +21907,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22106,7 +21935,6 @@
 /area/hallway/primary/starboard)
 "bds" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22390,9 +22218,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bed" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	name = "Upload APC";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -22426,9 +22253,7 @@
 /obj/item/aiModule/supplied/oxygen,
 /obj/item/aiModule/zeroth/oneHuman,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -22479,7 +22304,6 @@
 /obj/structure/table/wood,
 /obj/item/storage/lockbox/medal,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -22605,7 +22429,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22774,7 +22597,6 @@
 /area/medical/morgue)
 "beZ" = (
 /obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
 	machinedir = 8
 	},
 /turf/closed/wall,
@@ -23241,7 +23063,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23264,7 +23085,6 @@
 "bgG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23423,7 +23243,6 @@
 /area/medical/chemistry)
 "bhc" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/chem_heater,
@@ -23821,7 +23640,6 @@
 /area/quartermaster/sorting)
 "bhZ" = (
 /obj/machinery/door/window/eastleft{
-	dir = 4;
 	icon_state = "right";
 	name = "Incoming Mail";
 	req_access_txt = "50"
@@ -24141,7 +23959,6 @@
 /area/science/robotics/lab)
 "biO" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "robotics";
 	name = "Shutters Control Button";
 	pixel_x = 6;
@@ -24232,7 +24049,6 @@
 /area/science/lab)
 "biX" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "rnd";
 	name = "Shutters Control Button";
 	pixel_x = -6;
@@ -24246,7 +24062,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -24454,11 +24269,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -24643,9 +24455,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bjU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -24714,7 +24524,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -24753,7 +24562,6 @@
 "bkj" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -24893,7 +24701,6 @@
 	icon_state = "secbot1";
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
-	on = 1;
 	weaponscheck = 1
 	},
 /turf/open/floor/plasteel,
@@ -25236,7 +25043,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -25306,7 +25112,6 @@
 /obj/item/crowbar/large,
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26177,9 +25982,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnO" = (
@@ -26428,7 +26231,6 @@
 	pixel_y = -22
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -26674,9 +26476,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "boM" = (
-/turf/open/floor/plasteel/white/corner{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/corner,
 /area/science/research)
 "boN" = (
 /obj/effect/turf_decal/tile/brown{
@@ -26689,9 +26489,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "boR" = (
 /obj/effect/turf_decal/delivery,
@@ -26760,7 +26558,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
 	name = "Reception Window"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -26768,7 +26565,6 @@
 	dir = 4;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26861,7 +26657,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
@@ -27029,7 +26824,6 @@
 /obj/item/radio/headset/headset_medsci,
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
@@ -27152,9 +26946,7 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bpX" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/side,
 /area/science/research)
 "bpZ" = (
 /turf/open/floor/plasteel/white/side{
@@ -27365,9 +27157,7 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/table,
-/obj/item/paper/guides/jobs/engi/gravity_gen{
-	layer = 3
-	},
+/obj/item/paper/guides/jobs/engi/gravity_gen,
 /obj/item/pen/blue,
 /obj/item/radio/intercom{
 	pixel_y = -35
@@ -27587,9 +27377,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bri" = (
@@ -27643,7 +27431,6 @@
 "brq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
-	dir = 2;
 	id = "robotics2";
 	name = "Shutters Control Button";
 	pixel_x = 24;
@@ -27815,7 +27602,6 @@
 	},
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27957,7 +27743,6 @@
 /area/teleporter)
 "bsk" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -28014,7 +27799,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_y = -30
@@ -28053,7 +27837,6 @@
 	pixel_x = 30
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -28149,7 +27932,6 @@
 /area/science/robotics/lab)
 "bsS" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28230,7 +28012,6 @@
 /area/teleporter)
 "btf" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -28312,24 +28093,22 @@
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
-	req_access_txt = "31";
 	pixel_x = -24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_access_txt = "31"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
-	req_access_txt = "31";
 	pixel_x = -24;
-	pixel_y = 8
+	pixel_y = 8;
+	req_access_txt = "31"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28556,7 +28335,6 @@
 /area/medical/medbay/central)
 "btS" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -28603,9 +28381,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bud" = (
@@ -28629,7 +28405,6 @@
 	pixel_y = -30
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28769,8 +28544,8 @@
 /area/medical/genetics)
 "buB" = (
 /obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad";
-	dir = 8
+	dir = 8;
+	id = "QMLoad"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -29061,7 +28836,6 @@
 /area/science/research)
 "bvf" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -29112,6 +28886,8 @@
 /obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bvo" = (
@@ -29203,7 +28979,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -29224,7 +28999,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29362,7 +29136,6 @@
 /area/hallway/primary/central)
 "bvX" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29430,7 +29203,6 @@
 	pixel_x = -32
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29672,7 +29444,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30023,7 +29794,6 @@
 /area/engine/gravity_generator)
 "bxL" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30631,7 +30401,6 @@
 /obj/item/stack/packageWrap,
 /obj/item/pen,
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -30742,8 +30511,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
 	external_pressure_bound = 140;
-	pressure_checks = 0;
-	name = "server vent"
+	name = "server vent";
+	pressure_checks = 0
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
@@ -30783,7 +30552,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -30857,17 +30625,13 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzH" = (
 /obj/structure/table,
 /obj/item/hemostat,
-/turf/open/floor/plasteel/white/side{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/side,
 /area/medical/sleeper)
 "bzI" = (
 /obj/structure/disposalpipe/segment,
@@ -30893,9 +30657,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "bzM" = (
@@ -30988,9 +30750,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bzU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzV" = (
@@ -31287,7 +31047,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31423,7 +31182,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31521,7 +31279,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31567,7 +31324,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31658,7 +31414,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31764,7 +31519,6 @@
 /area/quartermaster/miningdock)
 "bBJ" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -31978,7 +31732,6 @@
 	pixel_y = -29
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -32014,7 +31767,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -32053,9 +31805,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bCq" = (
@@ -32146,9 +31896,7 @@
 "bCD" = (
 /obj/structure/table,
 /obj/item/retractor,
-/turf/open/floor/plasteel/white/side{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/side,
 /area/medical/sleeper)
 "bCF" = (
 /obj/structure/disposalpipe/segment{
@@ -32265,7 +32013,6 @@
 	pixel_x = -30
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32374,7 +32121,6 @@
 /obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Mining";
-	departmentType = 0;
 	pixel_x = -30
 	},
 /obj/machinery/light{
@@ -32512,7 +32258,6 @@
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32527,9 +32272,7 @@
 /area/medical/medbay/central)
 "bDG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bDH" = (
@@ -32864,7 +32607,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -32937,9 +32679,7 @@
 /area/science/research)
 "bEA" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bEC" = (
@@ -33470,9 +33210,7 @@
 /area/science/mixing)
 "bFW" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -33508,12 +33246,8 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bGe" = (
 /turf/closed/wall,
@@ -33616,9 +33350,7 @@
 /area/science/mixing)
 "bGA" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -33788,9 +33520,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -33912,7 +33642,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33952,9 +33681,7 @@
 /area/hallway/primary/aft)
 "bHl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHm" = (
@@ -34130,9 +33857,7 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bHP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHQ" = (
@@ -34145,7 +33870,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34239,7 +33963,6 @@
 	},
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -34831,9 +34554,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -35085,7 +34806,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35124,7 +34844,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35233,9 +34952,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/aft)
 "bKA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -35450,9 +35167,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKX" = (
@@ -35481,9 +35196,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKZ" = (
@@ -35504,18 +35217,14 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLc" = (
@@ -35525,9 +35234,7 @@
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLd" = (
@@ -35647,8 +35354,8 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
-	luminosity = 2;
-	initial_gas_mix = "o2=0.01;n2=0.01"
+	initial_gas_mix = "o2=0.01;n2=0.01";
+	luminosity = 2
 	},
 /area/science/test_area)
 "bLu" = (
@@ -35941,7 +35648,6 @@
 "bMm" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36007,7 +35713,6 @@
 /area/science/mixing/chamber)
 "bMw" = (
 /obj/machinery/sparker/toxmix{
-	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -36151,7 +35856,6 @@
 /area/engine/atmos)
 "bMP" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -36190,9 +35894,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible,
 /obj/machinery/meter/atmos/distro_loop,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36394,7 +36096,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -36431,9 +36132,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bNF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bNG" = (
@@ -36540,7 +36239,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36717,7 +36415,6 @@
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
-	dir = 2;
 	name = "Science Requests Console";
 	pixel_y = 30;
 	receive_ore_updates = 1
@@ -36770,7 +36467,6 @@
 /area/tcommsat/computer)
 "bOE" = (
 /obj/machinery/sparker/toxmix{
-	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -37483,7 +37179,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37644,7 +37339,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -37806,7 +37500,6 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -38196,7 +37889,6 @@
 "bSt" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38209,7 +37901,6 @@
 /area/space/nearstation)
 "bSv" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -38445,9 +38136,9 @@
 /area/medical/virology)
 "bSX" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/medical/virology";
 	dir = 1;
 	name = "Virology APC";
-	areastring = "/area/medical/virology";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -39306,9 +38997,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bVx" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/plating/airless,
 /area/maintenance/port/aft)
 "bVy" = (
@@ -39401,7 +39090,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -39704,9 +39392,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/server";
 	dir = 1;
 	name = "Telecomms Server APC";
-	areastring = "/area/tcommsat/server";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -39848,7 +39536,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40274,23 +39961,15 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXT" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXU" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -40307,7 +39986,6 @@
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40602,9 +40280,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYK" = (
@@ -40715,7 +40391,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40831,7 +40506,6 @@
 	pixel_y = -27
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41080,7 +40754,6 @@
 "bZZ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41283,7 +40956,6 @@
 	name = "Port to Filter"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41361,9 +41033,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "caP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -41556,7 +41226,6 @@
 /area/maintenance/port/aft)
 "cbl" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -41589,9 +41258,9 @@
 "cbp" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
 	dir = 4;
 	name = "CE Office APC";
-	areastring = "/area/crew_quarters/heads/chief";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -41645,11 +41314,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -41849,7 +41515,6 @@
 "cbV" = (
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -42461,7 +42126,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -42798,7 +42462,6 @@
 /area/engine/break_room)
 "cex" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43082,13 +42745,11 @@
 /area/maintenance/aft)
 "cfr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
-	pressure_checks = 0;
-	name = "killroom vent"
+	name = "killroom vent";
+	pressure_checks = 0
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/circuit/telecomms,
@@ -43354,7 +43015,6 @@
 /area/science/xenobiology)
 "cgl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 2;
 	external_pressure_bound = 120;
 	name = "killroom vent"
 	},
@@ -43471,7 +43131,6 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -43530,7 +43189,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43695,7 +43353,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -43720,7 +43377,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "atmospherics mix pump"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -44045,9 +43701,9 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/engine/engineering";
 	dir = 1;
 	name = "Engineering APC";
-	areastring = "/area/engine/engineering";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -44274,7 +43930,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
@@ -44312,8 +43967,7 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "portsolar";
-	name = "Port Quarter Solar Control";
-	track = 0
+	name = "Port Quarter Solar Control"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -44322,7 +43976,6 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -44455,7 +44108,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -44506,7 +44158,6 @@
 /area/crew_quarters/heads/chief)
 "cjl" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44645,7 +44296,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45059,13 +44709,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"cle" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
 "clf" = (
 /obj/machinery/light{
 	dir = 4
@@ -45200,7 +44843,6 @@
 "cly" = (
 /obj/structure/chair/stool,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45409,12 +45051,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"cmc" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 2
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "cmd" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -45512,8 +45148,7 @@
 /obj/machinery/power/solar_control{
 	dir = 1;
 	id = "starboardsolar";
-	name = "Starboard Quarter Solar Control";
-	track = 0
+	name = "Starboard Quarter Solar Control"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -45665,9 +45300,7 @@
 /turf/open/floor/plasteel,
 /area/construction)
 "cmY" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -45788,16 +45421,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnr" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Engineering Delivery";
 	req_access_txt = "10"
 	},
@@ -45816,7 +45445,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45888,7 +45516,6 @@
 /area/maintenance/aft)
 "cnF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2;
 	name = "Waste Out"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45993,7 +45620,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46289,16 +45915,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "coZ" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -46528,7 +46150,6 @@
 "cpO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /turf/open/space,
@@ -46584,7 +46205,6 @@
 "cpV" = (
 /obj/structure/table,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46681,7 +46301,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/engine,
@@ -46743,7 +46362,6 @@
 /area/engine/engineering)
 "cqp" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -46982,7 +46600,6 @@
 /area/engine/supermatter)
 "crb" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Gas to Chamber"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -47559,7 +47176,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/light/small,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -47815,7 +47431,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -47860,7 +47475,6 @@
 "cud" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	enabled = 1;
 	name = "Antechamber Turret Control";
 	pixel_y = -24;
 	req_access = null;
@@ -47869,7 +47483,6 @@
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -47934,7 +47547,6 @@
 /area/ai_monitored/turret_protected/aisat/service)
 "cun" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Mix to MiniSat"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -48049,7 +47661,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -48080,7 +47691,6 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
-	enabled = 1;
 	name = "Atmospherics Turret Control";
 	pixel_x = -27;
 	req_access = null;
@@ -48093,7 +47703,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48104,7 +47713,6 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/service";
-	enabled = 1;
 	name = "Service Bay Turret Control";
 	pixel_x = 27;
 	req_access = null;
@@ -48174,7 +47782,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -48361,7 +47968,6 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
-	enabled = 1;
 	name = "Chamber Hallway Turret Control";
 	pixel_x = 32;
 	pixel_y = -24;
@@ -48475,7 +48081,6 @@
 "cvx" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -48488,7 +48093,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48506,7 +48110,6 @@
 "cvA" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -48519,7 +48122,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48550,7 +48152,6 @@
 "cvF" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/space,
@@ -48588,7 +48189,6 @@
 "cvK" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/space,
@@ -48872,9 +48472,8 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
+	name = "AI Chamber APC";
 	pixel_y = -23
 	},
 /obj/machinery/flasher{
@@ -48915,7 +48514,6 @@
 "cwT" = (
 /obj/machinery/light/small,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -49661,14 +49259,12 @@
 	pixel_y = -9
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -31
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -49697,7 +49293,6 @@
 "cAU" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/space,
@@ -49730,7 +49325,6 @@
 "cAX" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/space,
@@ -49759,7 +49353,6 @@
 "cBb" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
-	dir = 2;
 	network = list("aicore")
 	},
 /turf/open/floor/circuit,
@@ -49839,7 +49432,6 @@
 "cBn" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -49899,7 +49491,6 @@
 /area/science/xenobiology)
 "cBA" = (
 /obj/machinery/button/massdriver{
-	dir = 2;
 	id = "toxinsdriver";
 	pixel_y = 24
 	},
@@ -50542,7 +50133,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -50586,7 +50176,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -50647,7 +50236,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/engine,
@@ -50828,7 +50416,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Cooling Loop Bypass"
 	},
 /turf/open/floor/engine,
@@ -50862,7 +50449,6 @@
 "cFi" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -51005,7 +50591,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -51351,7 +50936,6 @@
 /area/science/robotics/mechbay)
 "cHF" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 6;
@@ -52136,7 +51720,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering RC";
@@ -52693,8 +52276,7 @@
 	id = "commissaryshutter";
 	name = "Commissary Shutter Control";
 	pixel_x = 26;
-	pixel_y = 6;
-	req_access_txt = "0"
+	pixel_y = 6
 	},
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -53030,9 +52612,7 @@
 /area/hydroponics)
 "fGF" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -53189,9 +52769,7 @@
 /area/hallway/primary/central)
 "gjb" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "gjl" = (
@@ -53271,7 +52849,6 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53946,7 +53523,6 @@
 "iTt" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = 25;
 	pixel_y = -2;
@@ -54117,7 +53693,6 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -54314,9 +53889,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -54943,7 +54516,6 @@
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -55195,14 +54767,12 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "mLS" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -55652,9 +55222,7 @@
 	pixel_x = 25;
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "owD" = (
@@ -55681,7 +55249,6 @@
 /area/storage/primary)
 "oyM" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
-	icon_state = "manifold-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -55753,7 +55320,6 @@
 /area/maintenance/fore)
 "oMw" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
-	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -56400,9 +55966,7 @@
 /area/crew_quarters/fitness)
 "qQC" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -56734,9 +56298,7 @@
 /area/science/lab)
 "rYJ" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "rZp" = (
@@ -56836,9 +56398,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "srt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = -32
 	},
@@ -57132,7 +56692,6 @@
 /area/engine/break_room)
 "tmE" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -57454,7 +57013,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57539,7 +57097,6 @@
 /area/medical/medbay/central)
 "uHA" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
@@ -57560,9 +57117,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "uKC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -57676,9 +57231,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "voe" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vpT" = (
@@ -57741,7 +57294,6 @@
 	pixel_y = -25
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -57801,9 +57353,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vED" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
@@ -57877,9 +57427,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "vMg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -58370,7 +57918,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -96851,11 +96398,11 @@ cfY
 rfW
 ckj
 alE
-cle
+alE
 cli
-cmc
+cme
 cmY
-cmc
+cme
 cop
 cmd
 cmd

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -30685,7 +30685,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzm" = (
-/obj/machinery/clonepod,
+/obj/machinery/clonepod/mapped,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -28886,8 +28886,6 @@
 /obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bvo" = (
@@ -30454,7 +30452,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzm" = (
-/obj/machinery/clonepod,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -30462,6 +30459,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzn" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36,6 +36,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -414,7 +415,8 @@
 "abb" = (
 /obj/structure/displaycase/captain{
 	req_access = null;
-	req_access_txt = "20"
+	req_access_txt = "20";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -534,7 +536,8 @@
 /area/security/execution/transfer)
 "abu" = (
 /obj/machinery/door/poddoor{
-	id = "executionspaceblast"
+	id = "executionspaceblast";
+	name = "blast door"
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -582,6 +585,7 @@
 "abG" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
+	dir = 8;
 	icon_state = "right";
 	name = "Unisex Showers"
 	},
@@ -677,7 +681,8 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor"
+	c_tag = "Armory Motion Sensor";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -844,6 +849,7 @@
 /area/security/execution/transfer)
 "acb" = (
 /obj/machinery/sparker{
+	dir = 2;
 	id = "executionburn";
 	pixel_x = 25
 	},
@@ -942,8 +948,8 @@
 /area/ai_monitored/security/armory)
 "acm" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/security/armory";
 	dir = 4;
+	areastring = "/area/ai_monitored/security/armory";
 	name = "Armory APC";
 	pixel_x = 24
 	},
@@ -984,6 +990,7 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -1033,7 +1040,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acA" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -1044,7 +1053,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "acB" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -1054,6 +1065,7 @@
 /obj/structure/bed,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -1146,12 +1158,16 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "acN" = (
 /obj/structure/chair/stool/bar,
@@ -1164,6 +1180,7 @@
 "acO" = (
 /obj/structure/closet/l3closet/security,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -1350,7 +1367,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -1358,7 +1377,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "adk" = (
 /obj/structure/rack,
@@ -1371,7 +1392,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -1379,7 +1402,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "adl" = (
 /obj/machinery/door/poddoor/shutters{
@@ -1670,7 +1695,9 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "adQ" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adR" = (
@@ -1915,6 +1942,7 @@
 /area/security/prison)
 "aer" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/power/apc/auto_name/east,
@@ -2027,6 +2055,7 @@
 /area/security/main)
 "aeC" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2264,6 +2293,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -2896,7 +2926,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "agr" = (
@@ -2924,6 +2956,7 @@
 "agv" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -3474,7 +3507,9 @@
 /area/security/main)
 "ahD" = (
 /obj/machinery/door/window/westleft{
+	base_state = "left";
 	dir = 4;
+	icon_state = "left";
 	name = "Brig Infirmary"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -3704,6 +3739,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/closet/secure_closet/brig_phys,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -3837,6 +3873,7 @@
 /area/security/main)
 "ail" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -3876,6 +3913,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4252,6 +4290,7 @@
 /area/security/brig)
 "aje" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/red{
@@ -4416,6 +4455,7 @@
 /area/security/brig)
 "ajx" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/red{
@@ -4776,8 +4816,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4814,7 +4857,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akk" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akl" = (
@@ -4850,6 +4895,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4898,7 +4944,9 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "akv" = (
@@ -4969,7 +5017,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/atmospherics,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -5391,6 +5441,7 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -5419,6 +5470,7 @@
 "aly" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -5486,7 +5538,9 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "alF" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alG" = (
@@ -5583,7 +5637,8 @@
 "alQ" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Port Bow Solar Control"
+	name = "Port Bow Solar Control";
+	track = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -5883,6 +5938,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -6142,6 +6198,7 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6430,6 +6487,7 @@
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -6474,7 +6532,8 @@
 "aoh" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Starboard Bow Solar Control"
+	name = "Starboard Bow Solar Control";
+	track = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -6583,6 +6642,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6616,6 +6676,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6632,14 +6693,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoz" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoA" = (
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoB" = (
@@ -6647,12 +6712,16 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoC" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoD" = (
@@ -6660,15 +6729,20 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoF" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoH" = (
@@ -6972,6 +7046,7 @@
 	},
 /obj/machinery/power/smes,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -8329,6 +8404,7 @@
 	pixel_y = -27
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -8610,6 +8686,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8736,6 +8813,7 @@
 /area/crew_quarters/dorms)
 "auU" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -9088,6 +9166,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10288,6 +10367,7 @@
 /area/ai_monitored/storage/eva)
 "ayM" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/clothing/head/welding,
@@ -10419,7 +10499,9 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azd" = (
@@ -10775,7 +10857,9 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azT" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azU" = (
@@ -11065,7 +11149,9 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAy" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes{
+	charge = 0
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -11092,7 +11178,9 @@
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "aAB" = (
-/obj/machinery/power/smes,
+/obj/machinery/power/smes{
+	charge = 0
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -11132,6 +11220,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11331,6 +11420,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -11458,7 +11548,8 @@
 /area/crew_quarters/toilet)
 "aBC" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_access_txt = "12";
+	req_one_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -11734,6 +11825,7 @@
 /area/ai_monitored/storage/eva)
 "aCj" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11766,6 +11858,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -11774,6 +11867,7 @@
 /obj/structure/table/wood,
 /obj/machinery/requests_console{
 	department = "Theatre";
+	departmentType = 0;
 	name = "theatre RC";
 	pixel_x = -32
 	},
@@ -11971,6 +12065,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -12075,6 +12170,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Tool Storage";
+	departmentType = 0;
 	pixel_y = 30
 	},
 /obj/machinery/camera/autoname,
@@ -12211,7 +12307,9 @@
 /area/maintenance/fore)
 "aDB" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aDC" = (
@@ -12224,8 +12322,11 @@
 "aDE" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12718,6 +12819,7 @@
 	},
 /obj/item/storage/firstaid/regular,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12828,6 +12930,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13011,6 +13114,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13077,6 +13181,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -13183,6 +13288,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -14122,8 +14228,12 @@
 	location = "Bar"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/crew_quarters/bar)
 "aIh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -14520,6 +14630,7 @@
 "aJf" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -14716,6 +14827,7 @@
 /area/hallway/primary/central)
 "aJz" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -14756,6 +14868,7 @@
 "aJD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
+	req_access_txt = "0";
 	req_one_access_txt = "12;25;26;35;28;22;37;46;38"
 	},
 /obj/structure/disposalpipe/segment,
@@ -14800,6 +14913,9 @@
 /area/chapel/office)
 "aJH" = (
 /obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -14819,8 +14935,12 @@
 	location = "Kitchen"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/crew_quarters/kitchen)
 "aJL" = (
 /obj/machinery/navbeacon{
@@ -14829,8 +14949,12 @@
 	location = "Hydroponics"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/hydroponics)
 "aJM" = (
 /obj/structure/table/wood,
@@ -14976,7 +15100,9 @@
 /area/maintenance/port/fore)
 "aKj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aKk" = (
@@ -15026,6 +15152,7 @@
 /area/crew_quarters/theatre)
 "aKr" = (
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/wood,
@@ -15223,6 +15350,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -15267,6 +15395,9 @@
 /area/crew_quarters/kitchen)
 "aKV" = (
 /obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
@@ -15306,6 +15437,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -15649,6 +15781,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -15749,6 +15882,7 @@
 /area/crew_quarters/kitchen)
 "aMm" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -15929,6 +16063,7 @@
 /area/chapel/office)
 "aMM" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -16502,6 +16637,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16831,6 +16967,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17382,6 +17519,7 @@
 /area/crew_quarters/locker)
 "aQX" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -17754,6 +17892,7 @@
 /area/library)
 "aRP" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -17860,6 +17999,7 @@
 /area/hallway/secondary/entry)
 "aSf" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18144,7 +18284,9 @@
 /area/maintenance/port)
 "aSY" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -18167,7 +18309,9 @@
 /area/library)
 "aTc" = (
 /obj/machinery/door/window/northright{
+	base_state = "right";
 	dir = 8;
+	icon_state = "right";
 	name = "Library Desk Door";
 	req_access_txt = "37"
 	},
@@ -18353,6 +18497,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18465,7 +18610,9 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTV" = (
@@ -18546,6 +18693,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18623,6 +18771,7 @@
 /area/storage/tools)
 "aUx" = (
 /obj/machinery/door/airlock/maintenance{
+	req_access_txt = "0";
 	req_one_access_txt = "12;38"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18637,6 +18786,7 @@
 /area/maintenance/starboard/fore)
 "aUy" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -18838,6 +18988,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -18877,6 +19028,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18991,6 +19143,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19211,6 +19364,7 @@
 /area/library)
 "aVV" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -19362,6 +19516,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -19640,14 +19795,16 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aWW" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/bridge";
+	dir = 2;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -19909,7 +20066,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXw" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXA" = (
@@ -20124,6 +20283,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20157,6 +20317,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20397,6 +20558,7 @@
 "aYT" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20444,6 +20606,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20486,6 +20649,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21224,6 +21388,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /obj/structure/cable/yellow{
@@ -21609,6 +21774,7 @@
 /area/hallway/primary/starboard)
 "bcs" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -21804,14 +21970,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	dir = 2
+	},
 /area/hallway/primary/starboard)
 "bdc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/white/corner{
+	dir = 2
+	},
 /area/hallway/primary/starboard)
 "bdd" = (
 /obj/machinery/vending/cola/random,
@@ -21907,6 +22077,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21935,6 +22106,7 @@
 /area/hallway/primary/starboard)
 "bds" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22218,8 +22390,9 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "bed" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	dir = 2;
 	name = "Upload APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -22253,7 +22426,9 @@
 /obj/item/aiModule/supplied/oxygen,
 /obj/item/aiModule/zeroth/oneHuman,
 /obj/machinery/door/window{
+	base_state = "left";
 	dir = 8;
+	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -22304,6 +22479,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/lockbox/medal,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -22429,6 +22605,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22597,6 +22774,7 @@
 /area/medical/morgue)
 "beZ" = (
 /obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
 	machinedir = 8
 	},
 /turf/closed/wall,
@@ -23063,6 +23241,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23085,6 +23264,7 @@
 "bgG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23243,6 +23423,7 @@
 /area/medical/chemistry)
 "bhc" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/chem_heater,
@@ -23640,6 +23821,7 @@
 /area/quartermaster/sorting)
 "bhZ" = (
 /obj/machinery/door/window/eastleft{
+	dir = 4;
 	icon_state = "right";
 	name = "Incoming Mail";
 	req_access_txt = "50"
@@ -23959,6 +24141,7 @@
 /area/science/robotics/lab)
 "biO" = (
 /obj/machinery/button/door{
+	dir = 2;
 	id = "robotics";
 	name = "Shutters Control Button";
 	pixel_x = 6;
@@ -24049,6 +24232,7 @@
 /area/science/lab)
 "biX" = (
 /obj/machinery/button/door{
+	dir = 2;
 	id = "rnd";
 	name = "Shutters Control Button";
 	pixel_x = -6;
@@ -24062,6 +24246,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -24269,8 +24454,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 2
+	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -24455,7 +24643,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bjU" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
@@ -24524,6 +24714,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -24562,6 +24753,7 @@
 "bkj" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -24701,6 +24893,7 @@
 	icon_state = "secbot1";
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
+	on = 1;
 	weaponscheck = 1
 	},
 /turf/open/floor/plasteel,
@@ -25043,6 +25236,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -25112,6 +25306,7 @@
 /obj/item/crowbar/large,
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25982,7 +26177,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnN" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnO" = (
@@ -26231,6 +26428,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -26476,7 +26674,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "boM" = (
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/white/corner{
+	dir = 2
+	},
 /area/science/research)
 "boN" = (
 /obj/effect/turf_decal/tile/brown{
@@ -26489,7 +26689,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	dir = 2
+	},
 /area/science/research)
 "boR" = (
 /obj/effect/turf_decal/delivery,
@@ -26558,6 +26760,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
 	dir = 8;
+	icon_state = "left";
 	name = "Reception Window"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -26565,6 +26768,7 @@
 	dir = 4;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
+	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/structure/disposalpipe/segment{
@@ -26657,6 +26861,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
@@ -26824,6 +27029,7 @@
 /obj/item/radio/headset/headset_medsci,
 /obj/machinery/requests_console{
 	department = "Genetics";
+	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
@@ -26946,7 +27152,9 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "bpX" = (
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	dir = 2
+	},
 /area/science/research)
 "bpZ" = (
 /turf/open/floor/plasteel/white/side{
@@ -27157,7 +27365,9 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/table,
-/obj/item/paper/guides/jobs/engi/gravity_gen,
+/obj/item/paper/guides/jobs/engi/gravity_gen{
+	layer = 3
+	},
 /obj/item/pen/blue,
 /obj/item/radio/intercom{
 	pixel_y = -35
@@ -27377,7 +27587,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bri" = (
@@ -27431,6 +27643,7 @@
 "brq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
+	dir = 2;
 	id = "robotics2";
 	name = "Shutters Control Button";
 	pixel_x = 24;
@@ -27602,6 +27815,7 @@
 	},
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27743,6 +27957,7 @@
 /area/teleporter)
 "bsk" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -27799,6 +28014,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	freerange = 0;
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_y = -30
@@ -27837,6 +28053,7 @@
 	pixel_x = 30
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -27932,6 +28149,7 @@
 /area/science/robotics/lab)
 "bsS" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28012,6 +28230,7 @@
 /area/teleporter)
 "btf" = (
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -28093,22 +28312,24 @@
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
+	req_access_txt = "31";
 	pixel_x = -24;
-	pixel_y = -8;
-	req_access_txt = "31"
+	pixel_y = -8
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
+	req_access_txt = "31";
 	pixel_x = -24;
-	pixel_y = 8;
-	req_access_txt = "31"
+	pixel_y = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28335,6 +28556,7 @@
 /area/medical/medbay/central)
 "btS" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -28381,7 +28603,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bud" = (
@@ -28405,6 +28629,7 @@
 	pixel_y = -30
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28544,8 +28769,8 @@
 /area/medical/genetics)
 "buB" = (
 /obj/machinery/conveyor_switch/oneway{
-	dir = 8;
-	id = "QMLoad"
+	id = "QMLoad";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -28836,6 +29061,7 @@
 /area/science/research)
 "bvf" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -28977,6 +29203,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -28997,6 +29224,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -29134,6 +29362,7 @@
 /area/hallway/primary/central)
 "bvX" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29201,6 +29430,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29442,6 +29672,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -29792,6 +30023,7 @@
 /area/engine/gravity_generator)
 "bxL" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30399,6 +30631,7 @@
 /obj/item/stack/packageWrap,
 /obj/item/pen,
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -30452,6 +30685,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzm" = (
+/obj/machinery/clonepod,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -30459,7 +30693,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzn" = (
@@ -30509,8 +30742,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
 	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
+	pressure_checks = 0;
+	name = "server vent"
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
@@ -30550,6 +30783,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -30623,13 +30857,17 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzH" = (
 /obj/structure/table,
 /obj/item/hemostat,
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	dir = 2
+	},
 /area/medical/sleeper)
 "bzI" = (
 /obj/structure/disposalpipe/segment,
@@ -30655,7 +30893,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzL" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "bzM" = (
@@ -30748,7 +30988,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bzU" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzV" = (
@@ -31045,6 +31287,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31180,6 +31423,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31277,6 +31521,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31322,6 +31567,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31412,6 +31658,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31517,6 +31764,7 @@
 /area/quartermaster/miningdock)
 "bBJ" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -31730,6 +31978,7 @@
 	pixel_y = -29
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -31765,6 +32014,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -31803,7 +32053,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bCq" = (
@@ -31894,7 +32146,9 @@
 "bCD" = (
 /obj/structure/table,
 /obj/item/retractor,
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	dir = 2
+	},
 /area/medical/sleeper)
 "bCF" = (
 /obj/structure/disposalpipe/segment{
@@ -32011,6 +32265,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -32119,6 +32374,7 @@
 /obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Mining";
+	departmentType = 0;
 	pixel_x = -30
 	},
 /obj/machinery/light{
@@ -32256,6 +32512,7 @@
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -32270,7 +32527,9 @@
 /area/medical/medbay/central)
 "bDG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bDH" = (
@@ -32605,6 +32864,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -32677,7 +32937,9 @@
 /area/science/research)
 "bEA" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bEC" = (
@@ -33208,7 +33470,9 @@
 /area/science/mixing)
 "bFW" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
@@ -33244,8 +33508,12 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/science/mixing)
 "bGe" = (
 /turf/closed/wall,
@@ -33348,7 +33616,9 @@
 /area/science/mixing)
 "bGA" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -33518,7 +33788,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -33640,6 +33912,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33679,7 +33952,9 @@
 /area/hallway/primary/aft)
 "bHl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHm" = (
@@ -33855,7 +34130,9 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bHP" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHQ" = (
@@ -33868,6 +34145,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33961,6 +34239,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -34552,7 +34831,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -34804,6 +35085,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -34842,6 +35124,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34950,7 +35233,9 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/aft)
 "bKA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -35165,7 +35450,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKX" = (
@@ -35194,7 +35481,9 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKZ" = (
@@ -35215,14 +35504,18 @@
 	name = "Test Chamber";
 	req_access_txt = "55"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLc" = (
@@ -35232,7 +35525,9 @@
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/structure/table,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bLd" = (
@@ -35352,8 +35647,8 @@
 	dir = 8
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
+	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/science/test_area)
 "bLu" = (
@@ -35646,6 +35941,7 @@
 "bMm" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -35711,6 +36007,7 @@
 /area/science/mixing/chamber)
 "bMw" = (
 /obj/machinery/sparker/toxmix{
+	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -35854,6 +36151,7 @@
 /area/engine/atmos)
 "bMP" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -35892,7 +36190,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible,
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 2
+	},
 /obj/machinery/meter/atmos/distro_loop,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -36094,6 +36394,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -36130,7 +36431,9 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bNF" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "bNG" = (
@@ -36237,6 +36540,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36413,6 +36717,7 @@
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
+	dir = 2;
 	name = "Science Requests Console";
 	pixel_y = 30;
 	receive_ore_updates = 1
@@ -36465,6 +36770,7 @@
 /area/tcommsat/computer)
 "bOE" = (
 /obj/machinery/sparker/toxmix{
+	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -37177,6 +37483,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37337,6 +37644,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -37498,6 +37806,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/northleft{
 	dir = 4;
+	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -37887,6 +38196,7 @@
 "bSt" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37899,6 +38209,7 @@
 /area/space/nearstation)
 "bSv" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -38134,9 +38445,9 @@
 /area/medical/virology)
 "bSX" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/medical/virology";
 	dir = 1;
 	name = "Virology APC";
+	areastring = "/area/medical/virology";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -38995,7 +39306,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "bVx" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2
+	},
 /turf/open/floor/plating/airless,
 /area/maintenance/port/aft)
 "bVy" = (
@@ -39088,6 +39401,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -39390,9 +39704,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/server";
 	dir = 1;
 	name = "Telecomms Server APC";
+	areastring = "/area/tcommsat/server";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -39534,6 +39848,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39959,15 +40274,23 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/engine/atmos)
 "bXT" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/engine/atmos)
 "bXU" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -39984,6 +40307,7 @@
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40278,7 +40602,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYK" = (
@@ -40389,6 +40715,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40504,6 +40831,7 @@
 	pixel_y = -27
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40752,6 +41080,7 @@
 "bZZ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40954,6 +41283,7 @@
 	name = "Port to Filter"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41031,7 +41361,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "caP" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -41224,6 +41556,7 @@
 /area/maintenance/port/aft)
 "cbl" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -41256,9 +41589,9 @@
 "cbp" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
 	dir = 4;
 	name = "CE Office APC";
+	areastring = "/area/crew_quarters/heads/chief";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -41312,8 +41645,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 2
+	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -41513,6 +41849,7 @@
 "cbV" = (
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -42124,6 +42461,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -42460,6 +42798,7 @@
 /area/engine/break_room)
 "cex" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42743,11 +43082,13 @@
 /area/maintenance/aft)
 "cfr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 2;
 	external_pressure_bound = 140;
-	name = "killroom vent";
-	pressure_checks = 0
+	pressure_checks = 0;
+	name = "killroom vent"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/circuit/telecomms,
@@ -43013,6 +43354,7 @@
 /area/science/xenobiology)
 "cgl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
 	external_pressure_bound = 120;
 	name = "killroom vent"
 	},
@@ -43129,6 +43471,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -43187,6 +43530,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43351,6 +43695,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -43375,6 +43720,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "atmospherics mix pump"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -43699,9 +44045,9 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/engine/engineering";
 	dir = 1;
 	name = "Engineering APC";
+	areastring = "/area/engine/engineering";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -43928,6 +44274,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
@@ -43965,7 +44312,8 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "portsolar";
-	name = "Port Quarter Solar Control"
+	name = "Port Quarter Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43974,6 +44322,7 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -44106,6 +44455,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -44156,6 +44506,7 @@
 /area/crew_quarters/heads/chief)
 "cjl" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44294,6 +44645,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -44707,6 +45059,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"cle" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "clf" = (
 /obj/machinery/light{
 	dir = 4
@@ -44841,6 +45200,7 @@
 "cly" = (
 /obj/structure/chair/stool,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45049,6 +45409,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"cmc" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "cmd" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -45146,7 +45512,8 @@
 /obj/machinery/power/solar_control{
 	dir = 1;
 	id = "starboardsolar";
-	name = "Starboard Quarter Solar Control"
+	name = "Starboard Quarter Solar Control";
+	track = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -45298,7 +45665,9 @@
 /turf/open/floor/plasteel,
 /area/construction)
 "cmY" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2
+	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -45419,12 +45788,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cnr" = (
 /obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
 	name = "Engineering Delivery";
 	req_access_txt = "10"
 	},
@@ -45443,6 +45816,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45514,6 +45888,7 @@
 /area/maintenance/aft)
 "cnF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2;
 	name = "Waste Out"
 	},
 /obj/structure/disposalpipe/segment{
@@ -45618,6 +45993,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45913,12 +46289,16 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "coZ" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -46148,6 +46528,7 @@
 "cpO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /turf/open/space,
@@ -46203,6 +46584,7 @@
 "cpV" = (
 /obj/structure/table,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46299,6 +46681,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/engine,
@@ -46360,6 +46743,7 @@
 /area/engine/engineering)
 "cqp" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -46598,6 +46982,7 @@
 /area/engine/supermatter)
 "crb" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Gas to Chamber"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -47174,6 +47559,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/light/small,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -47429,6 +47815,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -47473,6 +47860,7 @@
 "cud" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	enabled = 1;
 	name = "Antechamber Turret Control";
 	pixel_y = -24;
 	req_access = null;
@@ -47481,6 +47869,7 @@
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -47545,6 +47934,7 @@
 /area/ai_monitored/turret_protected/aisat/service)
 "cun" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Mix to MiniSat"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -47659,6 +48049,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47689,6 +48080,7 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
+	enabled = 1;
 	name = "Atmospherics Turret Control";
 	pixel_x = -27;
 	req_access = null;
@@ -47701,6 +48093,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -47711,6 +48104,7 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/service";
+	enabled = 1;
 	name = "Service Bay Turret Control";
 	pixel_x = 27;
 	req_access = null;
@@ -47780,6 +48174,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -47966,6 +48361,7 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
+	enabled = 1;
 	name = "Chamber Hallway Turret Control";
 	pixel_x = 32;
 	pixel_y = -24;
@@ -48079,6 +48475,7 @@
 "cvx" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -48091,6 +48488,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48108,6 +48506,7 @@
 "cvA" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -48120,6 +48519,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48150,6 +48550,7 @@
 "cvF" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/space,
@@ -48187,6 +48588,7 @@
 "cvK" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/space,
@@ -48470,8 +48872,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai";
+	dir = 2;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = -23
 	},
 /obj/machinery/flasher{
@@ -48512,6 +48915,7 @@
 "cwT" = (
 /obj/machinery/light/small,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -49257,12 +49661,14 @@
 	pixel_y = -9
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -31
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -49291,6 +49697,7 @@
 "cAU" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/space,
@@ -49323,6 +49730,7 @@
 "cAX" = (
 /obj/structure/lattice,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/space,
@@ -49351,6 +49759,7 @@
 "cBb" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
+	dir = 2;
 	network = list("aicore")
 	},
 /turf/open/floor/circuit,
@@ -49430,6 +49839,7 @@
 "cBn" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -49489,6 +49899,7 @@
 /area/science/xenobiology)
 "cBA" = (
 /obj/machinery/button/massdriver{
+	dir = 2;
 	id = "toxinsdriver";
 	pixel_y = 24
 	},
@@ -50131,6 +50542,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -50174,6 +50586,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -50234,6 +50647,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/engine,
@@ -50414,6 +50828,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Cooling Loop Bypass"
 	},
 /turf/open/floor/engine,
@@ -50447,6 +50862,7 @@
 "cFi" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
@@ -50589,6 +51005,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -50934,6 +51351,7 @@
 /area/science/robotics/mechbay)
 "cHF" = (
 /obj/machinery/button/door{
+	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 6;
@@ -51718,6 +52136,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering RC";
@@ -52274,7 +52693,8 @@
 	id = "commissaryshutter";
 	name = "Commissary Shutter Control";
 	pixel_x = 26;
-	pixel_y = 6
+	pixel_y = 6;
+	req_access_txt = "0"
 	},
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -52610,7 +53030,9 @@
 /area/hydroponics)
 "fGF" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -52767,7 +53189,9 @@
 /area/hallway/primary/central)
 "gjb" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "gjl" = (
@@ -52847,6 +53271,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53521,6 +53946,7 @@
 "iTt" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = 25;
 	pixel_y = -2;
@@ -53691,6 +54117,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/mineral/plasma,
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -53887,7 +54314,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -54514,6 +54943,7 @@
 /obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -54765,12 +55195,14 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "mLS" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -55220,7 +55652,9 @@
 	pixel_x = 25;
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "owD" = (
@@ -55247,6 +55681,7 @@
 /area/storage/primary)
 "oyM" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	icon_state = "manifold-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -55318,6 +55753,7 @@
 /area/maintenance/fore)
 "oMw" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
+	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -55964,7 +56400,9 @@
 /area/crew_quarters/fitness)
 "qQC" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -56296,7 +56734,9 @@
 /area/science/lab)
 "rYJ" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "rZp" = (
@@ -56396,7 +56836,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "srt" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = -32
 	},
@@ -56690,6 +57132,7 @@
 /area/engine/break_room)
 "tmE" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -57011,6 +57454,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57095,6 +57539,7 @@
 /area/medical/medbay/central)
 "uHA" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
@@ -57115,7 +57560,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "uKC" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
@@ -57229,7 +57676,9 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "voe" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vpT" = (
@@ -57292,6 +57741,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -57351,7 +57801,9 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vED" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
@@ -57425,7 +57877,9 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "vMg" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -57916,6 +58370,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 1
 	},
 /obj/structure/cable/yellow{
@@ -96396,11 +96851,11 @@ cfY
 rfW
 ckj
 alE
-alE
+cle
 cli
-cme
+cmc
 cmY
-cme
+cmc
 cop
 cmd
 cmd

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -101171,7 +101171,7 @@
 	},
 /area/maintenance/department/medical/central)
 "dnl" = (
-/obj/machinery/clonepod/mapped,
+/obj/machinery/clonepod/prefilled,
 /obj/structure/window/reinforced{
 	dir = 4
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -100629,7 +100629,6 @@
 	},
 /area/maintenance/department/medical/central)
 "dnl" = (
-/obj/machinery/clonepod,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -100646,6 +100645,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "dnm" = (
@@ -100714,8 +100714,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "dns" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -307,6 +307,7 @@
 	dir = 4
 	},
 /obj/machinery/sleeper{
+	icon_state = "sleeper";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -340,7 +341,9 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -433,7 +436,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -456,6 +461,7 @@
 /area/crew_quarters/cryopods)
 "aba" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -522,6 +528,7 @@
 /area/space/nearstation)
 "abk" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -564,6 +571,7 @@
 /area/crew_quarters/cryopods)
 "abo" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -609,6 +617,7 @@
 /area/crew_quarters/cryopods)
 "abs" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 1;
 	height = 4;
 	name = "escape pod loader";
@@ -740,7 +749,9 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -820,6 +831,7 @@
 /area/crew_quarters/cryopods)
 "abM" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -871,7 +883,9 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 1"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -882,7 +896,9 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -985,7 +1001,9 @@
 /area/maintenance/department/medical/morgue)
 "abZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1029,7 +1047,9 @@
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1350,8 +1370,8 @@
 	height = 17;
 	id = "arrivals_stationary";
 	name = "delta arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/delta;
-	width = 9
+	width = 9;
+	roundstart_template = /datum/map_template/shuttle/arrival/delta
 	},
 /turf/open/space/basic,
 /area/space)
@@ -1716,8 +1736,9 @@
 "adh" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/maintenance/solars/starboard/fore";
+	dir = 2;
 	name = "Starboard Bow Solar APC";
+	areastring = "/area/maintenance/solars/starboard/fore";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1740,7 +1761,8 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "forestarboard";
-	name = "Starboard Bow Solar Control"
+	name = "Starboard Bow Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -1759,7 +1781,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1911,8 +1935,9 @@
 "adz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/medical/morgue";
+	dir = 2;
 	name = "Morgue Maintenance APC";
+	areastring = "/area/maintenance/department/medical/morgue";
 	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
@@ -1940,7 +1965,9 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2210,7 +2237,9 @@
 	name = "Auxiliary Construction Storage";
 	req_one_access_txt = "10;32;47;48"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2631,9 +2660,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/construction/mining/aux_base";
 	dir = 8;
 	name = "Auxiliary Construction APC";
+	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -3074,7 +3103,9 @@
 	name = "Maintenance Hatch";
 	req_one_access_txt = "32;47;48"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3082,6 +3113,7 @@
 /area/maintenance/starboard/fore)
 "aid" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 2;
 	height = 13;
 	id = "ferry_home";
@@ -3497,7 +3529,9 @@
 "ajd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3506,7 +3540,9 @@
 "aje" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3531,7 +3567,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3545,7 +3583,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3772,9 +3812,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/entry";
 	dir = 1;
 	name = "Arrivals Hallway APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3782,6 +3822,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Center Port";
+	dir = 2;
 	name = "arrivals camera"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -4276,7 +4317,9 @@
 /obj/machinery/door/airlock{
 	name = "Auxiliary Storage Closet"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -4300,7 +4343,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -4321,7 +4366,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -5062,9 +5109,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
 	dir = 8;
 	name = "Customs Desk APC";
+	areastring = "/area/security/checkpoint/customs";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -5138,6 +5185,7 @@
 /obj/item/flashlight/lamp,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Center";
+	dir = 2;
 	name = "arrivals camera"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -5760,9 +5808,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard/fore";
 	dir = 1;
 	name = "Starboard Bow Maintenance APC";
+	areastring = "/area/maintenance/starboard/fore";
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6925,7 +6973,9 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -6939,7 +6989,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -6953,7 +7005,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7214,8 +7268,9 @@
 /area/vacant_room/office)
 "aqg" = (
 /obj/machinery/power/apc{
-	areastring = "/area/vacant_room/office";
+	dir = 2;
 	name = "Auxiliary Office APC";
+	areastring = "/area/vacant_room/office";
 	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7703,8 +7758,9 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/electronic_marketing_den";
+	dir = 2;
 	name = "Electronics Marketing APC";
+	areastring = "/area/crew_quarters/electronic_marketing_den";
 	pixel_y = -23
 	},
 /turf/open/floor/wood,
@@ -7732,7 +7788,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7760,7 +7818,9 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7776,7 +7836,9 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7872,6 +7934,7 @@
 /area/maintenance/disposal)
 "ari" = (
 /obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
 	machinedir = 8;
 	pixel_x = 32
 	},
@@ -7912,7 +7975,9 @@
 	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7934,7 +7999,9 @@
 	name = "Reflector Access";
 	req_one_access_txt = "24;10"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7984,7 +8051,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7998,7 +8067,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -8169,6 +8240,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft";
+	dir = 2;
 	name = "arrivals camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -8354,6 +8426,7 @@
 "ash" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
+	dir = 4;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
@@ -9156,7 +9229,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -9264,6 +9339,7 @@
 /area/maintenance/disposal)
 "atF" = (
 /obj/machinery/door/window/eastright{
+	dir = 4;
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
@@ -9603,7 +9679,9 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -9620,7 +9698,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10050,8 +10130,9 @@
 /area/maintenance/disposal)
 "auO" = (
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal";
+	dir = 2;
 	name = "Disposal APC";
+	areastring = "/area/maintenance/disposal";
 	pixel_y = -23
 	},
 /obj/structure/disposalpipe/segment{
@@ -10442,9 +10523,9 @@
 /area/janitor)
 "avB" = (
 /obj/machinery/power/apc{
-	areastring = "/area/janitor";
 	dir = 1;
 	name = "Custodial Closet APC";
+	areastring = "/area/janitor";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -10476,6 +10557,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Custodial Closet";
+	dir = 2;
 	name = "service camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -10581,7 +10663,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10591,8 +10675,11 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/science,
+/obj/structure/sign/directions/science{
+	dir = 2
+	},
 /obj/structure/sign/directions/engineering{
+	dir = 2;
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -10604,7 +10691,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10615,7 +10704,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10627,7 +10718,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10637,8 +10730,11 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical,
+/obj/structure/sign/directions/medical{
+	dir = 2
+	},
 /obj/structure/sign/directions/security{
+	dir = 2;
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -10656,7 +10752,9 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10698,7 +10796,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -11089,6 +11189,7 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Auxiliary Restroom";
+	dir = 2;
 	name = "restroom camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -11209,6 +11310,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Cargo - Warehouse";
+	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plating,
@@ -11488,6 +11590,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
+	dir = 2;
 	network = list("engine")
 	},
 /turf/open/floor/engine,
@@ -11801,8 +11904,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/toilet/auxiliary";
+	dir = 2;
 	name = "Auxiliary Restrooms APC";
+	areastring = "/area/crew_quarters/toilet/auxiliary";
 	pixel_y = -23
 	},
 /turf/open/floor/plating,
@@ -12279,8 +12383,9 @@
 "ayU" = (
 /obj/machinery/light/small,
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
+	dir = 2;
 	name = "Port Bow Maintenance APC";
+	areastring = "/area/maintenance/port/fore";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -12475,7 +12580,9 @@
 /obj/machinery/door/airlock{
 	name = "Toilet Unit"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -12961,7 +13068,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -12972,7 +13081,9 @@
 	id = "custodialshutters";
 	name = "Custodial Closet Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -12990,7 +13101,9 @@
 	req_access_txt = "26"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -14492,9 +14605,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
 	name = "Cargo Warehouse APC";
+	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -14624,7 +14737,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aDg" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -14858,7 +14973,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -15047,6 +15164,7 @@
 /area/quartermaster/storage)
 "aEg" = (
 /obj/machinery/button/door{
+	dir = 2;
 	id = "cargounload";
 	layer = 4;
 	name = "Loading Doors";
@@ -15282,9 +15400,9 @@
 /area/engine/atmospherics_engine)
 "aEz" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/atmospherics_engine";
 	dir = 4;
 	name = "Atmospherics Engine APC";
+	areastring = "/area/engine/atmospherics_engine";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -15426,9 +15544,9 @@
 "aEP" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/bar";
 	dir = 1;
 	name = "Bar APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_y = 23
 	},
 /obj/machinery/light/small{
@@ -15458,6 +15576,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
+	dir = 2;
 	name = "service camera"
 	},
 /turf/open/floor/plasteel/dark,
@@ -15608,9 +15727,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/fore";
 	dir = 8;
 	name = "Port Primary Hallway APC";
+	areastring = "/area/hallway/primary/fore";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -15668,7 +15787,9 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -15974,8 +16095,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/hydroponics/garden/abandoned";
+	dir = 2;
 	name = "Abandoned Garden APC";
+	areastring = "/area/hydroponics/garden/abandoned";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
@@ -16619,6 +16741,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Prison - Garden";
+	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -17038,7 +17161,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -17054,7 +17179,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -17293,6 +17420,7 @@
 "aHK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
+	dir = 2;
 	id = "cargodisposals"
 	},
 /turf/open/floor/plating,
@@ -17744,9 +17872,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal/incinerator";
 	dir = 1;
 	name = "Turbine Generator APC";
+	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -17779,7 +17907,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -17801,7 +17931,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Engine Access";
 	req_one_access_txt = "24;10"
@@ -17844,7 +17976,9 @@
 	req_one_access_txt = "24;10"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -18190,6 +18324,7 @@
 "aJk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
+	dir = 2;
 	id = "cargodisposals"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -18368,7 +18503,8 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "foreport";
-	name = "Port Bow Solar Control"
+	name = "Port Bow Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -18390,8 +18526,9 @@
 "aJG" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/maintenance/solars/port/fore";
+	dir = 2;
 	name = "Port Bow Solar APC";
+	areastring = "/area/maintenance/solars/port/fore";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19208,7 +19345,9 @@
 	id = "justiceblast";
 	name = "Justice Blast door"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -19713,9 +19852,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/supply";
 	dir = 8;
 	name = "Security Post - Cargo APC";
+	areastring = "/area/security/checkpoint/supply";
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/red{
@@ -20100,7 +20239,9 @@
 	name = "Turbine Generator Access";
 	req_one_access_txt = "24;10"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -20121,7 +20262,9 @@
 "aMH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -20144,7 +20287,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Engine Access";
 	req_one_access_txt = "24;10"
@@ -20312,13 +20457,14 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/bar/atrium";
 	dir = 1;
 	name = "Atrium APC";
+	areastring = "/area/crew_quarters/bar/atrium";
 	pixel_y = 23
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
+	dir = 2;
 	name = "service camera"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -20448,6 +20594,7 @@
 "aNp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
+	dir = 2;
 	id = "cargodisposals"
 	},
 /obj/structure/plasticflaps,
@@ -20775,9 +20922,9 @@
 /area/maintenance/disposal/incinerator)
 "aNQ" = (
 /obj/machinery/power/compressor{
-	comp_id = "incineratorturbine";
 	dir = 4;
-	luminosity = 2
+	luminosity = 2;
+	comp_id = "incineratorturbine"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -20816,7 +20963,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
+	dir = 2
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aNU" = (
@@ -21210,9 +21359,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
 	dir = 1;
 	name = "Theatre Backstage APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/red{
@@ -21416,9 +21565,9 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/sorting";
 	dir = 8;
 	name = "Delivery Office APC";
+	areastring = "/area/quartermaster/sorting";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -22884,6 +23033,7 @@
 /obj/machinery/holopad,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom";
 	pixel_y = -28;
 	prison_radio = 1
@@ -23482,7 +23632,9 @@
 	req_access_txt = "50"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23534,7 +23686,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23555,9 +23709,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/storage";
 	dir = 8;
 	name = "Cargo Bay APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -23707,9 +23861,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/qm";
 	dir = 1;
 	name = "Quartermaster's Office APC";
+	areastring = "/area/quartermaster/qm";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -23833,7 +23987,9 @@
 	name = "Cell 3"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23852,7 +24008,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23869,7 +24027,9 @@
 	name = "Cell 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -24749,6 +24909,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
+	dir = 2;
 	name = "cargo camera"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -24763,9 +24924,9 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/office";
 	dir = 1;
 	name = "Cargo Office APC";
+	areastring = "/area/quartermaster/office";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -25202,6 +25363,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Prison - Cell 3";
+	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -25248,6 +25410,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Prison - Cell 2";
+	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -25280,6 +25443,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Prison - Cell 1";
+	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -25427,7 +25591,9 @@
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -26637,8 +26803,9 @@
 "aWp" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/security/execution/education";
+	dir = 2;
 	name = "Education Chamber APC";
+	areastring = "/area/security/execution/education";
 	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -26861,7 +27028,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -26975,9 +27144,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
 	dir = 8;
 	name = "Service Hall APC";
+	areastring = "/area/hallway/secondary/service";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -27316,7 +27485,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
-	req_access_txt = "31"
+	req_access_txt = "31";
+	req_one_access_txt = "0"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27699,7 +27869,9 @@
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -28608,7 +28780,8 @@
 /area/security/prison)
 "aZm" = (
 /obj/machinery/camera{
-	c_tag = "Security - Prison Port"
+	c_tag = "Security - Prison Port";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
@@ -28685,7 +28858,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZt" = (
@@ -28712,7 +28887,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/camera{
-	c_tag = "Security - Prison"
+	c_tag = "Security - Prison";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
@@ -28753,7 +28929,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZx" = (
@@ -28812,7 +28990,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZB" = (
@@ -28949,7 +29129,8 @@
 "aZK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
-	c_tag = "Security - Escape Pod"
+	c_tag = "Security - Escape Pod";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -28970,8 +29151,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
 	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01";
 	temperature = 2.7
 	},
 /area/security/prison)
@@ -29293,7 +29474,9 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -29319,7 +29502,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bax" = (
@@ -29328,7 +29513,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bay" = (
@@ -29362,6 +29549,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room";
+	dir = 2;
 	name = "service camera"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -29568,7 +29756,9 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -29731,8 +29921,9 @@
 "bbk" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/security/prison";
+	dir = 2;
 	name = "Prison Wing APC";
+	areastring = "/area/security/prison";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -30258,7 +30449,9 @@
 "bcm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30270,7 +30463,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30279,7 +30474,9 @@
 "bco" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30298,7 +30495,9 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30498,7 +30697,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30517,7 +30718,9 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30682,8 +30885,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
 	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01";
 	temperature = 2.7
 	},
 /area/security/prison)
@@ -31263,6 +31466,7 @@
 "bdS" = (
 /obj/machinery/camera{
 	c_tag = "Cargo - Waiting Room";
+	dir = 2;
 	name = "cargo camera"
 	},
 /obj/effect/turf_decal/loading_area{
@@ -31874,8 +32078,9 @@
 "bfb" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/kitchen";
+	dir = 2;
 	name = "Kitchen APC";
+	areastring = "/area/crew_quarters/kitchen";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
@@ -32468,7 +32673,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32579,7 +32786,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32595,7 +32804,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32616,7 +32827,9 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32916,14 +33129,18 @@
 /area/quartermaster/miningoffice)
 "bgR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bgS" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32956,8 +33173,8 @@
 	height = 5;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/delta;
-	width = 7
+	width = 7;
+	roundstart_template = /datum/map_template/shuttle/mining/delta
 	},
 /turf/open/space/basic,
 /area/space)
@@ -32974,7 +33191,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33002,7 +33221,9 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33086,9 +33307,9 @@
 /area/engine/atmos)
 "bhj" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/atmos";
 	dir = 1;
 	name = "Atmospherics APC";
+	areastring = "/area/engine/atmos";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -33914,7 +34135,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Medbay"
+	c_tag = "Security - Medbay";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -34036,7 +34258,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Office Fore"
+	c_tag = "Security - Office Fore";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -35248,7 +35471,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Office"
+	c_tag = "Security - Head of Security's Office";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35699,6 +35923,7 @@
 	dir = 4
 	},
 /obj/machinery/door/window/eastleft{
+	dir = 4;
 	name = "Kitchen Desk";
 	req_access_txt = "28"
 	},
@@ -36013,9 +36238,9 @@
 /obj/item/storage/firstaid/regular,
 /obj/machinery/light,
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/miningoffice";
 	dir = 4;
 	name = "Mining Dock APC";
+	areastring = "/area/quartermaster/miningoffice";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -36318,6 +36543,8 @@
 	icon_living = "magicarp";
 	icon_state = "magicarp";
 	maxHealth = 200;
+	melee_damage_lower = 20;
+	melee_damage_upper = 20;
 	name = "Lia"
 	},
 /turf/open/floor/carpet/red,
@@ -36397,7 +36624,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Quarters"
+	c_tag = "Security - Head of Security's Quarters";
+	dir = 2
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -36825,7 +37053,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36864,7 +37094,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36879,7 +37111,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36900,7 +37134,9 @@
 /area/hallway/primary/fore)
 "bnv" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36909,7 +37145,9 @@
 "bnw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36922,7 +37160,9 @@
 "bny" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36951,7 +37191,9 @@
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37054,9 +37296,9 @@
 /area/security/main)
 "bnL" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/main";
 	dir = 8;
 	name = "Security Office APC";
+	areastring = "/area/security/main";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -37412,7 +37654,9 @@
 	name = "Distribution Loop";
 	req_access_txt = "24"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37451,7 +37695,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bor" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -37469,12 +37715,16 @@
 /obj/item/clipboard,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/figure/atmos,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bot" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -37612,6 +37862,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Fore Port";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -37708,6 +37959,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Fore Starboard";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -37755,9 +38007,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/central";
 	dir = 1;
 	name = "Central Primary Hallway APC";
+	areastring = "/area/hallway/primary/central";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -37909,7 +38161,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Transfer Centre"
+	c_tag = "Security - Transfer Centre";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -38424,6 +38677,7 @@
 /area/engine/atmos)
 "bpT" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Pure to Mix"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -38502,7 +38756,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bqa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -38524,7 +38780,9 @@
 /obj/item/clothing/head/welding,
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -38532,7 +38790,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bqc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -39841,7 +40101,9 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility,
 /obj/item/t_scanner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41037,7 +41299,9 @@
 /area/engine/atmos)
 "btU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -41051,7 +41315,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "btV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 2
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41208,9 +41474,9 @@
 /area/hallway/primary/port)
 "bui" = (
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/port";
 	dir = 4;
 	name = "Port Primary Hallway APC";
+	areastring = "/area/hallway/primary/port";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -41255,7 +41521,9 @@
 "bun" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41267,7 +41535,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41277,7 +41547,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41296,7 +41568,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41322,7 +41596,9 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buA" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41552,8 +41828,9 @@
 "buT" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hos";
+	dir = 2;
 	name = "Head of Security's Office APC";
+	areastring = "/area/crew_quarters/heads/hos";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -41674,6 +41951,7 @@
 /area/engine/atmos)
 "bva" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Mix to Distro"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -42218,8 +42496,9 @@
 "bwa" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/security/execution/transfer";
+	dir = 2;
 	name = "Security Transferring APC";
+	areastring = "/area/security/execution/transfer";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/red,
@@ -42510,7 +42789,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -43226,7 +43507,9 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -43805,9 +44088,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/nuke_storage";
 	dir = 4;
 	name = "Vault APC";
+	areastring = "/area/security/nuke_storage";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -44300,7 +44583,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -44477,7 +44762,9 @@
 	req_access_txt = "19;23"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -44789,8 +45076,8 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/delta;
-	width = 9
+	width = 9;
+	roundstart_template = /datum/map_template/shuttle/labour/delta
 	},
 /turf/open/space/basic,
 /area/space)
@@ -45044,6 +45331,7 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	frequency = 1423;
 	name = "Interrogation Intercom";
 	pixel_y = -58
@@ -45334,7 +45622,9 @@
 	req_access_txt = "13"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45414,7 +45704,9 @@
 	name = "Atmospherics Lockdown Blast door"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45428,7 +45720,9 @@
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45446,7 +45740,9 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45696,7 +45992,9 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45714,6 +46012,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
+	dir = 2;
 	freq = 1400;
 	location = "Tool Storage"
 	},
@@ -46242,6 +46541,7 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
+	anyai = 1;
 	broadcasting = 1;
 	frequency = 1423;
 	listening = 0;
@@ -46510,7 +46810,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -46541,7 +46843,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -46691,9 +46995,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/break_room";
 	dir = 1;
 	name = "Engineering Foyer APC";
+	areastring = "/area/engine/break_room";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -47787,6 +48091,7 @@
 /area/security/brig)
 "bEf" = (
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -47799,6 +48104,7 @@
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -47930,6 +48236,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bEm" = (
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -47942,6 +48249,7 @@
 	pixel_x = 27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48453,9 +48761,9 @@
 	},
 /obj/item/stack/cable_coil/white,
 /obj/machinery/power/apc{
-	areastring = "/area/storage/primary";
 	dir = 8;
 	name = "Primary Tool Storage APC";
+	areastring = "/area/storage/primary";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -49149,12 +49457,14 @@
 	pixel_y = -7
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -49855,8 +50165,9 @@
 "bGY" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/bridge";
+	dir = 2;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -50420,7 +50731,9 @@
 /area/engine/gravity_generator)
 "bHQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -50453,7 +50766,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -50471,7 +50786,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -50726,9 +51043,9 @@
 /obj/item/folder/yellow,
 /obj/item/electronics/airlock,
 /obj/machinery/power/apc{
-	areastring = "/area/storage/tech";
 	dir = 8;
 	name = "Technology Storage APC";
+	areastring = "/area/storage/tech";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -51290,9 +51607,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
 	dir = 1;
 	name = "Detective's Office APC";
+	areastring = "/area/security/detectives_office";
 	pixel_y = 23
 	},
 /obj/item/taperecorder,
@@ -51681,9 +51998,9 @@
 	dir = 6
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/ai";
 	dir = 1;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52264,9 +52581,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/bridge/meeting_room/council";
 	dir = 1;
 	name = "Council Chambers APC";
+	areastring = "/area/bridge/meeting_room/council";
 	pixel_y = 23
 	},
 /turf/open/floor/wood,
@@ -52450,7 +52767,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -52946,9 +53265,9 @@
 /area/engine/transit_tube)
 "bLI" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/transit_tube";
 	dir = 1;
 	name = "Transit Tube Access APC";
+	areastring = "/area/engine/transit_tube";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -53549,9 +53868,9 @@
 /area/tcommsat/computer)
 "bMz" = (
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/tcommsat/computer";
 	dir = 1;
 	name = "Telecomms Monitoring APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_y = 23
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -53569,6 +53888,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Monitoring";
+	dir = 2;
 	name = "telecomms camera";
 	network = list("ss13","tcomms")
 	},
@@ -53742,9 +54062,9 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/storage/tools";
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
+	areastring = "/area/storage/tools";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -55839,7 +56159,9 @@
 	req_access_txt = "10"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -56272,8 +56594,9 @@
 /area/crew_quarters/heads/captain)
 "bQV" = (
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/crew_quarters/heads/captain";
+	dir = 2;
 	name = "Captain's Office APC";
+	areastring = "/area/crew_quarters/heads/captain";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -56773,6 +57096,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "AI Satellite - Antechamber";
+	dir = 2;
 	name = "ai camera";
 	network = list("minisat");
 	start_active = 1
@@ -57059,6 +57383,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Chief Engineer's Quarters";
+	dir = 2;
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -57172,7 +57497,9 @@
 	req_access_txt = "23"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -57184,7 +57511,9 @@
 	name = "Primary Tool Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -57195,14 +57524,18 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Primary Tool Storage"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bSv" = (
-/obj/structure/sign/directions/science,
+/obj/structure/sign/directions/science{
+	dir = 2
+	},
 /obj/structure/sign/directions/engineering{
 	dir = 8;
 	pixel_y = 8
@@ -57216,7 +57549,9 @@
 "bSw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -57428,6 +57763,7 @@
 /area/crew_quarters/heads/captain)
 "bSS" = (
 /obj/structure/sign/directions/science{
+	dir = 2;
 	pixel_y = -8
 	},
 /obj/structure/sign/directions/command{
@@ -57608,9 +57944,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/warden";
 	dir = 4;
 	name = "Warden's Office APC";
+	areastring = "/area/security/warden";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -57903,6 +58239,7 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	enabled = 1;
 	name = "Antechamber Turret Control";
 	pixel_x = -32;
 	req_access = null;
@@ -58075,6 +58412,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "AI Satellite - Transit Tube";
+	dir = 2;
 	name = "ai camera";
 	network = list("minisat");
 	start_active = 1
@@ -58411,9 +58749,9 @@
 /area/security/checkpoint/engineering)
 "bUf" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
 	dir = 1;
 	name = "Security Post - Engineering APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58645,6 +58983,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway - Starboard";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -58972,6 +59311,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Hallway - Port";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -61448,8 +61788,9 @@
 "bYk" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/aisat";
+	dir = 2;
 	name = "AI Satellite Exterior APC";
+	areastring = "/area/aisat";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -61622,8 +61963,9 @@
 "bYu" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/chief";
+	dir = 2;
 	name = "Chief Engineer's APC";
+	areastring = "/area/crew_quarters/heads/chief";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -62287,8 +62629,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/starboard";
+	dir = 2;
 	name = "Starboard Primary Hallway APC";
+	areastring = "/area/hallway/primary/starboard";
 	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
@@ -62607,8 +62950,9 @@
 	pixel_x = -26
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 2;
 	name = "MiniSat APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -62927,7 +63271,9 @@
 	req_access_txt = "10"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62951,7 +63297,9 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -63001,7 +63349,9 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -63052,8 +63402,11 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical,
+/obj/structure/sign/directions/medical{
+	dir = 2
+	},
 /obj/structure/sign/directions/security{
+	dir = 2;
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -63277,7 +63630,9 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical,
+/obj/structure/sign/directions/medical{
+	dir = 2
+	},
 /obj/structure/sign/directions/security{
 	dir = 4;
 	pixel_y = 8
@@ -63581,8 +63936,9 @@
 "cbK" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/security/armory";
+	dir = 2;
 	name = "Armoury APC";
+	areastring = "/area/ai_monitored/security/armory";
 	pixel_y = -23
 	},
 /obj/machinery/camera{
@@ -63777,6 +64133,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Fore";
+	dir = 2;
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -63902,7 +64259,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -64137,6 +64496,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 2;
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
@@ -64186,6 +64546,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
@@ -64351,7 +64712,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Courtroom - Fore"
+	c_tag = "Courtroom - Fore";
+	dir = 2
 	},
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
@@ -64510,6 +64872,7 @@
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor/southright{
+	dir = 2;
 	name = "Security Desk";
 	req_access_txt = "63"
 	},
@@ -64610,7 +64973,9 @@
 	id = "armouryaccess";
 	name = "Armoury Access"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -65290,9 +65655,9 @@
 /area/crew_quarters/heads/hop)
 "cer" = (
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hop";
 	dir = 4;
 	name = "HoP Office APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -65312,9 +65677,9 @@
 /area/crew_quarters/heads/hop)
 "cet" = (
 /obj/machinery/power/apc{
-	areastring = "/area/tcommsat/server";
 	dir = 8;
 	name = "Telecomms Server Room APC";
+	areastring = "/area/tcommsat/server";
 	pixel_x = -25
 	},
 /obj/structure/cable/white,
@@ -65600,6 +65965,7 @@
 /area/security/courtroom)
 "ceP" = (
 /obj/structure/chair{
+	dir = 2;
 	name = "Prosecution"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -65615,6 +65981,7 @@
 /area/security/courtroom)
 "ceQ" = (
 /obj/structure/chair{
+	dir = 2;
 	name = "Prosecution"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -65963,16 +66330,17 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/security/brig";
 	dir = 1;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Gear Room"
+	c_tag = "Security - Gear Room";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -66057,8 +66425,8 @@
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmless{
 	fan_out_items = 1;
-	lootcount = 3;
-	lootdoubles = 0
+	lootdoubles = 0;
+	lootcount = 3
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
@@ -66137,8 +66505,8 @@
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmful{
 	fan_out_items = 1;
-	lootcount = 2;
-	lootdoubles = 0
+	lootdoubles = 0;
+	lootcount = 2
 	},
 /obj/item/aiModule/supplied/oxygen{
 	pixel_x = -3;
@@ -66621,8 +66989,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/crew_quarters/heads/captain/private";
+	dir = 2;
 	name = "Captain's Quarters APC";
+	areastring = "/area/crew_quarters/heads/captain/private";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -67628,6 +67997,7 @@
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/machinery/camera{
 	c_tag = "Library";
+	dir = 2;
 	name = "library camera"
 	},
 /turf/open/floor/wood,
@@ -67784,7 +68154,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -67921,9 +68293,9 @@
 	},
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/lawoffice";
 	dir = 8;
 	name = "Law Office APC";
+	areastring = "/area/lawoffice";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -69006,7 +69378,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -69289,9 +69663,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/engine/engineering";
 	dir = 4;
 	name = "Engine Room APC";
+	areastring = "/area/engine/engineering";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
@@ -69454,7 +69828,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -69680,7 +70056,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -69909,8 +70287,8 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/aimodule_neutral{
 	fan_out_items = 1;
-	lootcount = 3;
-	lootdoubles = 0
+	lootdoubles = 0;
+	lootcount = 3
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70304,9 +70682,9 @@
 /obj/structure/table,
 /obj/item/hand_tele,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/teleporter";
 	dir = 1;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -70789,8 +71167,9 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	dir = 2;
 	name = "AI Upload Access APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -70940,7 +71319,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -71552,9 +71933,9 @@
 "coN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	areastring = "/area/security/range";
 	dir = 8;
 	name = "Shooting Range APC";
+	areastring = "/area/security/range";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -71749,7 +72130,9 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 20
 	},
-/obj/item/gps/engineering,
+/obj/item/gps/engineering{
+	gpstag = "ENG0"
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -71815,9 +72198,9 @@
 /area/maintenance/port)
 "cpr" = (
 /obj/machinery/power/apc{
-	areastring = "/area/library";
 	dir = 8;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -72151,9 +72534,9 @@
 /area/security/courtroom)
 "cqb" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/courtroom";
 	dir = 4;
 	name = "Courtroom APC";
+	areastring = "/area/security/courtroom";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -72174,7 +72557,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -72545,7 +72930,9 @@
 	req_access_txt = "61"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -72557,7 +72944,9 @@
 	name = "Teleport Access";
 	req_access_txt = "17"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -72575,7 +72964,9 @@
 	id = "teleportershutters";
 	name = "Teleporter Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -72587,7 +72978,9 @@
 	name = "Teleporter Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73059,7 +73452,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "crX" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73067,7 +73462,9 @@
 /area/engine/engineering)
 "crY" = (
 /obj/effect/decal/cleanable/oil,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73318,9 +73715,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/command";
 	dir = 1;
 	name = "Command Hall APC";
+	areastring = "/area/hallway/secondary/command";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -73362,6 +73759,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Center";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -73648,6 +74046,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room - Fore";
+	dir = 2;
 	name = "dormitories camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -74875,7 +75274,9 @@
 	req_access_txt = "18"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -74888,7 +75289,9 @@
 	req_access_txt = "18"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -75001,7 +75404,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -75132,6 +75537,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory Hallway";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -75375,6 +75781,7 @@
 /obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Recreation - Fore";
+	dir = 2;
 	name = "recreation camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -75628,9 +76035,9 @@
 /area/ai_monitored/storage/eva)
 "cwF" = (
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/storage/eva";
 	dir = 1;
 	name = "E.V.A. Storage APC";
+	areastring = "/area/ai_monitored/storage/eva";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -75667,6 +76074,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Bridge - E.V.A. Fore";
+	dir = 2;
 	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -75784,9 +76192,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/gateway";
 	dir = 1;
 	name = "Gateway APC";
+	areastring = "/area/gateway";
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77695,7 +78103,9 @@
 /obj/machinery/door/airlock{
 	name = "Primary Restroom"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -77823,9 +78233,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/locker";
 	dir = 4;
 	name = "Lockerroom APC";
+	areastring = "/area/crew_quarters/locker";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -77843,7 +78253,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -78325,6 +78737,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Corporate Lounge";
+	dir = 2;
 	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -78611,9 +79024,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/toilet/restrooms";
 	dir = 1;
 	name = "Primary Restroom APC";
+	areastring = "/area/crew_quarters/toilet/restrooms";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -78621,6 +79034,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Primary Restroom";
+	dir = 2;
 	name = "restroom camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -79347,9 +79761,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/bridge/showroom/corporate";
 	dir = 8;
 	name = "Corporate Lounge APC";
+	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -80130,9 +80544,9 @@
 	},
 /obj/item/tank/jetpack/carbondioxide,
 /obj/machinery/power/apc{
-	areastring = "/area/engine/storage";
 	dir = 4;
 	name = "Engineering Storage APC";
+	areastring = "/area/engine/storage";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -80984,6 +81398,7 @@
 "cFG" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Fore";
+	dir = 2;
 	name = "holodeck camera"
 	},
 /turf/open/floor/engine{
@@ -81738,6 +82153,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
+	icon_state = "beer";
 	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
 	name = "Delta-Down";
 	pixel_x = 5;
@@ -82139,7 +82555,9 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82150,7 +82568,9 @@
 	id = "evashutters";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82168,7 +82588,9 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82208,7 +82630,9 @@
 	name = "Gateway Atrium";
 	req_access_txt = "62"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -82227,7 +82651,9 @@
 	req_access_txt = "19"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82239,7 +82665,9 @@
 	name = "Gateway Chamber Shutters"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82250,7 +82678,9 @@
 	id = "gatewayshutters";
 	name = "Gateway Chamber Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82344,7 +82774,9 @@
 	name = "Lockerroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82357,7 +82789,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82473,7 +82907,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82520,6 +82956,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Science Aft";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -82674,6 +83111,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Medbay Aft";
+	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -82745,7 +83183,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82947,6 +83387,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitories - Starboard";
+	dir = 2;
 	name = "dormitories camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -83176,6 +83617,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Holodeck Control";
+	dir = 2;
 	name = "holodeck camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -85085,8 +85527,9 @@
 "cMy" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/dorms";
+	dir = 2;
 	name = "Dormitories APC";
+	areastring = "/area/crew_quarters/dorms";
 	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -85307,7 +85750,9 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85330,7 +85775,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85491,6 +85938,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Killroom Chamber";
+	dir = 2;
 	name = "xenobiology camera";
 	network = list("ss13","xeno","rd")
 	},
@@ -85561,7 +86009,9 @@
 "cNr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85573,7 +86023,9 @@
 /area/science/research)
 "cNt" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85599,7 +86051,9 @@
 	name = "Aft Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85610,7 +86064,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Aft Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85623,7 +86079,9 @@
 	name = "Aft Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85648,7 +86106,9 @@
 /area/medical/medbay/central)
 "cNA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85661,7 +86121,9 @@
 "cNC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86291,6 +86753,7 @@
 /area/science/xenobiology)
 "cOO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 2;
 	external_pressure_bound = 140;
 	name = "killroom vent";
 	pressure_checks = 0
@@ -86302,6 +86765,7 @@
 /area/science/xenobiology)
 "cOQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
@@ -86323,7 +86787,9 @@
 	req_access_txt = "47"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86627,16 +87093,16 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/medical/storage";
 	dir = 8;
 	name = "Medbay Storage APC";
+	areastring = "/area/medical/storage";
 	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Storage";
+	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
@@ -87096,9 +87562,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/electrical";
 	dir = 4;
 	name = "Auxiliary Power APC";
+	areastring = "/area/maintenance/department/electrical";
 	pixel_x = 24
 	},
 /turf/open/floor/plating,
@@ -87127,7 +87593,9 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -87990,6 +88458,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Port";
+	dir = 2;
 	name = "xenobiology camera";
 	network = list("ss13","xeno","rd")
 	},
@@ -88194,7 +88663,9 @@
 	name = "Xenobiology Kill Room";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -88760,7 +89231,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -89113,6 +89586,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
+	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -90942,7 +91416,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -90974,9 +91450,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/fitness/recreation";
 	dir = 8;
 	name = "Recreation Area APC";
+	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -91282,7 +91758,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91298,7 +91776,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91308,7 +91788,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91427,9 +91909,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/science/research";
 	dir = 8;
 	name = "Security Post - Science APC";
+	areastring = "/area/security/checkpoint/science/research";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -91672,9 +92154,9 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Waiting Room";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
@@ -91801,7 +92283,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91813,7 +92297,9 @@
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91843,8 +92329,9 @@
 "cYc" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Break Room";
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 2;
+	name = "medbay camera"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -92523,7 +93010,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -92542,7 +93031,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -92697,9 +93188,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Fore Port";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -92717,9 +93208,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/medical";
 	dir = 8;
 	name = "Security Post - Medical APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -92802,8 +93293,9 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay - Sleepers";
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 2;
+	name = "medbay camera"
 	},
 /obj/item/book/manual/wiki/medicine,
 /obj/item/stack/medical/gauze,
@@ -93244,7 +93736,9 @@
 	name = "Engineering Auxiliary Power";
 	req_access_txt = "10"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -93726,9 +94220,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
 	dir = 1;
 	name = "Chemistry Lab APC";
+	areastring = "/area/medical/chemistry";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -94214,9 +94708,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/port";
 	dir = 1;
 	name = "Port Maintenance APC";
+	areastring = "/area/maintenance/port";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -94371,6 +94865,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
+	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -94421,6 +94916,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
+	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -94475,6 +94971,7 @@
 	name = "Creature Cell #3"
 	},
 /obj/machinery/door/window/brigdoor{
+	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -94569,9 +95066,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/xenobiology";
 	dir = 4;
 	name = "Xenobiology Lab APC";
+	areastring = "/area/science/xenobiology";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -96047,7 +96544,9 @@
 	name = "Xenobiology Lab";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96074,7 +96573,9 @@
 "dfg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96083,7 +96584,9 @@
 "dfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96134,7 +96637,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96151,7 +96656,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96172,9 +96679,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/lab";
 	dir = 8;
 	name = "Research and Development Lab APC";
+	areastring = "/area/science/lab";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -96309,9 +96816,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chemistry";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
@@ -96366,7 +96873,9 @@
 	name = "Medical Cell";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96375,7 +96884,9 @@
 "dfF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96384,7 +96895,9 @@
 "dfG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96399,7 +96912,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96417,7 +96932,9 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96605,9 +97122,9 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/abandoned_gambling_den";
 	dir = 1;
 	name = "Abandoned Gambling Den APC";
+	areastring = "/area/crew_quarters/abandoned_gambling_den";
 	pixel_y = 23
 	},
 /turf/open/floor/plating,
@@ -96846,6 +97363,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science - Port";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -96930,6 +97448,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science - Center";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -97340,8 +97859,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Center";
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 2;
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -98742,6 +99262,7 @@
 "djC" = (
 /obj/machinery/camera{
 	c_tag = "Science - Experimentation Lab";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -99263,9 +99784,9 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Port";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -99393,9 +99914,9 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Starboard";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
@@ -99459,8 +99980,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/medical/abandoned";
+	dir = 2;
 	name = "Abandoned Medical Lab APC";
+	areastring = "/area/medical/abandoned";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -99907,7 +100429,9 @@
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100020,7 +100544,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100030,7 +100556,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100038,7 +100566,9 @@
 /area/hallway/primary/aft)
 "dlR" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100052,7 +100582,9 @@
 	pixel_x = 24
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100068,7 +100600,9 @@
 	req_access_txt = "5; 33"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100091,7 +100625,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100102,7 +100638,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100121,7 +100659,9 @@
 	name = "Surgery Observation"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100136,7 +100676,9 @@
 /obj/machinery/door/airlock/medical{
 	name = "Surgery Observation"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -100566,9 +101108,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/science/robotics/mechbay";
 	dir = 1;
 	name = "Mech Bay APC";
+	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -100629,6 +101171,7 @@
 	},
 /area/maintenance/department/medical/central)
 "dnl" = (
+/obj/machinery/clonepod,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -100645,7 +101188,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "dnm" = (
@@ -100704,9 +101246,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/medical/genetics/cloning";
 	dir = 1;
 	name = "Cloning Lab APC";
+	areastring = "/area/medical/genetics/cloning";
 	pixel_y = 23
 	},
 /obj/item/folder/white,
@@ -100974,7 +101516,9 @@
 "dnP" = (
 /obj/machinery/pipedispenser,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100982,7 +101526,9 @@
 /area/hallway/secondary/construction)
 "dnQ" = (
 /obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100990,7 +101536,9 @@
 /area/hallway/secondary/construction)
 "dnR" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -102995,7 +103543,9 @@
 /obj/machinery/door/airlock/medical{
 	name = "Surgery Observation"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -103112,6 +103662,7 @@
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
 	areastring = "/area/science/misc_lab/range";
+	dir = 2;
 	name = "Testing Range APC";
 	pixel_x = 1;
 	pixel_y = -23
@@ -103291,7 +103842,9 @@
 	id = "rdtoxins";
 	name = "Toxins Lab Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -103306,9 +103859,9 @@
 /area/science/mixing)
 "drX" = (
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hor";
 	dir = 8;
 	name = "Research Director's Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_x = -25
 	},
 /obj/structure/cable/white,
@@ -103600,9 +104153,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Cloning Lab";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
@@ -103680,9 +104233,9 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/item/book/manual/wiki/medicine,
 /obj/item/clothing/neck/stethoscope,
@@ -104114,7 +104667,9 @@
 	name = "Genetics Desk Maintenance";
 	req_access_txt = "9"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -104150,7 +104705,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -104169,9 +104726,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/central";
 	dir = 8;
 	name = "Medbay APC";
+	areastring = "/area/medical/medbay/central";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -104263,9 +104820,9 @@
 /obj/machinery/iv_drip,
 /obj/machinery/camera{
 	c_tag = "Medbay - Recovery Room";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -105833,9 +106390,9 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/geneticist,
 /obj/machinery/power/apc{
-	areastring = "/area/medical/genetics";
 	dir = 4;
 	name = "Genetics Lab APC";
+	areastring = "/area/medical/genetics";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -105862,9 +106419,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Lab";
+	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -26
@@ -106527,7 +107084,9 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -106547,7 +107106,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -106557,7 +107118,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -106591,7 +107154,9 @@
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -106604,7 +107169,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -106623,9 +107190,9 @@
 /obj/item/storage/box/disks,
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Desk";
+	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -107055,15 +107622,16 @@
 "dyI" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/medical/surgery";
+	dir = 2;
 	name = "Surgery APC";
+	areastring = "/area/medical/surgery";
 	pixel_y = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -107158,8 +107726,9 @@
 /area/hallway/secondary/construction)
 "dyP" = (
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/construction";
+	dir = 2;
 	name = "Auxiliary Construction Zone APC";
+	areastring = "/area/hallway/secondary/construction";
 	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
@@ -107801,9 +108370,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Port";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/item/clipboard,
 /obj/item/healthanalyzer,
@@ -107874,16 +108443,16 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/cmo";
 	dir = 4;
 	name = "Chief Medical Officer's Office APC";
+	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Office";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -107917,7 +108486,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -107933,7 +108504,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -108046,9 +108619,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
 	dir = 8;
 	name = "Toxins Lab APC";
+	areastring = "/area/science/mixing";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -109196,9 +109769,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/aft";
 	dir = 4;
 	name = "Aft Primary Hallway APC";
+	areastring = "/area/hallway/primary/aft";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -109220,7 +109793,9 @@
 	req_access_txt = "9"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -109311,9 +109886,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Starboard";
+	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -109513,8 +110088,9 @@
 "dDc" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/maintenance/solars/starboard/aft";
+	dir = 2;
 	name = "Starboard Quarter Solar APC";
+	areastring = "/area/maintenance/solars/starboard/aft";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -109533,7 +110109,8 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control"
+	name = "Starboard Quarter Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm{
@@ -109701,7 +110278,9 @@
 	id = "rdtoxins";
 	name = "Toxins Lab Shutters"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -110147,7 +110726,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -110631,7 +111212,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dFl" = (
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/autodrobe{
+	req_access_txt = "0"
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -110642,9 +111225,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre/abandoned";
 	dir = 1;
 	name = "Abandoned Theatre APC";
+	areastring = "/area/crew_quarters/theatre/abandoned";
 	pixel_y = 23
 	},
 /turf/open/floor/plating,
@@ -110811,6 +111394,7 @@
 /obj/item/clothing/mask/gas,
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Launch Site";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -110853,7 +111437,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -110975,9 +111561,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/server";
 	dir = 8;
 	name = "Research Division Server Room APC";
+	areastring = "/area/science/server";
 	pixel_x = -25
 	},
 /obj/machinery/light_switch{
@@ -111110,9 +111696,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/robotics/lab";
 	dir = 8;
 	name = "Robotics Lab APC";
+	areastring = "/area/science/robotics/lab";
 	pixel_x = -25
 	},
 /obj/structure/disposalpipe/trunk{
@@ -112252,9 +112838,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office/private_investigators_office";
 	dir = 8;
 	name = "Private Investigator's Office APC";
+	areastring = "/area/security/detectives_office/private_investigators_office";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -112299,6 +112885,7 @@
 /area/science/test_area)
 "dIj" = (
 /obj/machinery/button/massdriver{
+	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = -24
 	},
@@ -112321,7 +112908,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIm" = (
@@ -112329,14 +112918,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIo" = (
@@ -112347,7 +112940,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -112600,6 +113195,7 @@
 /area/science/storage)
 "dIF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 2;
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
@@ -112622,6 +113218,7 @@
 /area/science/server)
 "dIH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 2;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
@@ -112677,9 +113274,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/research";
 	dir = 4;
 	name = "Research Division APC";
+	areastring = "/area/science/research";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -112801,8 +113398,9 @@
 "dIV" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
+	dir = 2;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_y = -23
 	},
 /turf/open/floor/plating,
@@ -112829,9 +113427,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/structure/sign/poster/official/bless_this_spess{
 	pixel_y = -32
@@ -112914,9 +113512,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Quarters";
+	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera";
-	network = list("ss13","medbay")
+	name = "medbay camera"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -113399,9 +113997,9 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	areastring = "/area/science/storage";
 	dir = 4;
 	name = "Toxins Storage APC";
+	areastring = "/area/science/storage";
 	pixel_x = 24
 	},
 /obj/structure/cable/white,
@@ -113472,7 +114070,9 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -113514,7 +114114,9 @@
 	name = "Virology Access";
 	req_access_txt = "39"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -113663,7 +114265,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -113680,7 +114284,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -113712,7 +114318,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -114332,7 +114940,9 @@
 /area/science/test_area)
 "dLG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "dLH" = (
@@ -114370,7 +114980,9 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dLM" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -114826,8 +115438,9 @@
 	},
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/aft";
+	dir = 2;
 	name = "Aft Maintenance APC";
+	areastring = "/area/maintenance/aft";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -115531,7 +116144,9 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -115551,7 +116166,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -115562,7 +116179,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departures Lounge"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -115575,7 +116194,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116130,7 +116751,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116147,7 +116770,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116177,7 +116802,9 @@
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116404,7 +117031,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -116604,9 +117233,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
 	dir = 1;
 	name = "Port Quarter Maintenance APC";
+	areastring = "/area/maintenance/port/aft";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -116905,9 +117534,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Containment Lock";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera";
-	network = list("ss13","medbay")
+	name = "virology camera"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -117169,7 +117798,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -117416,7 +118047,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -117435,7 +118068,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -117581,9 +118216,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera";
-	network = list("ss13","medbay")
+	name = "virology camera"
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -118366,7 +119001,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -118463,7 +119100,9 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -118510,7 +119149,9 @@
 	name = "Departures Lounge"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -118521,7 +119162,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departures Lounge"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -118675,9 +119318,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/library/abandoned";
 	dir = 8;
 	name = "Abandoned Library APC";
+	areastring = "/area/library/abandoned";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -118844,13 +119487,14 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dTG" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 23
 	},
 /obj/machinery/camera{
 	c_tag = "Departures - Fore";
+	dir = 2;
 	name = "departures camera"
 	},
 /obj/structure/cable/yellow{
@@ -119425,9 +120069,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/medical/virology";
 	dir = 4;
 	name = "Virology Satellite APC";
+	areastring = "/area/medical/virology";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -119695,8 +120339,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
-	name = "virology camera";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	name = "virology camera"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -119719,9 +120363,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Hallway";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera";
-	network = list("ss13","medbay")
+	name = "virology camera"
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -120670,7 +121314,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -121691,6 +122337,7 @@
 /obj/effect/landmark/start/assistant,
 /obj/machinery/camera{
 	c_tag = "Departures - Center";
+	dir = 2;
 	name = "departures camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -121829,9 +122476,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
+	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera";
-	network = list("ss13","medbay")
+	name = "virology camera"
 	},
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
@@ -121950,9 +122597,9 @@
 /area/chapel/office)
 "dZQ" = (
 /obj/machinery/power/apc{
-	areastring = "/area/chapel/main";
 	dir = 8;
 	name = "Chapel APC";
+	areastring = "/area/chapel/main";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -122083,6 +122730,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "eab" = (
 /obj/docking_port/stationary{
+	dheight = 0;
 	dir = 4;
 	dwidth = 11;
 	height = 18;
@@ -122146,7 +122794,9 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -122507,7 +123157,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -122525,7 +123177,9 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -122542,7 +123196,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -122555,7 +123211,9 @@
 	req_access_txt = "18"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -123085,7 +123743,8 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "aftport";
-	name = "Port Quarter Solar Control"
+	name = "Port Quarter Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -123107,8 +123766,9 @@
 "ecm" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/maintenance/solars/port/aft";
+	dir = 2;
 	name = "Port Quarter Solar APC";
+	areastring = "/area/maintenance/solars/port/aft";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -124146,7 +124806,9 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124169,7 +124831,9 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124190,7 +124854,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124231,7 +124897,9 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124360,6 +125028,7 @@
 	pixel_x = -26
 	},
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -124385,9 +125054,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/chapel/office";
 	dir = 1;
 	name = "Chapel Quarters APC";
+	areastring = "/area/chapel/office";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -124405,6 +125074,7 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Chapel Quarters";
+	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -124521,7 +125191,8 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Departures Port"
+	c_tag = "Security - Departures Port";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -124684,7 +125355,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eeT" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124874,7 +125547,9 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -125493,7 +126168,9 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -125577,7 +126254,9 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/engineering)
 "ehy" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -125645,7 +126324,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "ehM" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -125832,7 +126513,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -126113,7 +126796,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -126366,6 +127051,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Science - Experimentation Lab";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -126439,6 +127125,7 @@
 "jEz" = (
 /obj/machinery/camera{
 	c_tag = "Science - Lab Access";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -128048,9 +128735,9 @@
 /area/engine/storage_shared)
 "vGz" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/gravity_generator";
 	dir = 1;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_y = 23
 	},
 /obj/structure/cable{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -307,7 +307,6 @@
 	dir = 4
 	},
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -341,9 +340,7 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -436,9 +433,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -461,7 +456,6 @@
 /area/crew_quarters/cryopods)
 "aba" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -528,7 +522,6 @@
 /area/space/nearstation)
 "abk" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -571,7 +564,6 @@
 /area/crew_quarters/cryopods)
 "abo" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -617,7 +609,6 @@
 /area/crew_quarters/cryopods)
 "abs" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 1;
 	height = 4;
 	name = "escape pod loader";
@@ -749,9 +740,7 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -831,7 +820,6 @@
 /area/crew_quarters/cryopods)
 "abM" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -883,9 +871,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 1"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -896,9 +882,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1001,9 +985,7 @@
 /area/maintenance/department/medical/morgue)
 "abZ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1047,9 +1029,7 @@
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1370,8 +1350,8 @@
 	height = 17;
 	id = "arrivals_stationary";
 	name = "delta arrivals";
-	width = 9;
-	roundstart_template = /datum/map_template/shuttle/arrival/delta
+	roundstart_template = /datum/map_template/shuttle/arrival/delta;
+	width = 9
 	},
 /turf/open/space/basic,
 /area/space)
@@ -1736,9 +1716,8 @@
 "adh" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Starboard Bow Solar APC";
 	areastring = "/area/maintenance/solars/starboard/fore";
+	name = "Starboard Bow Solar APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1761,8 +1740,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "forestarboard";
-	name = "Starboard Bow Solar Control";
-	track = 0
+	name = "Starboard Bow Solar Control"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -1781,9 +1759,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -1935,9 +1911,8 @@
 "adz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Morgue Maintenance APC";
 	areastring = "/area/maintenance/department/medical/morgue";
+	name = "Morgue Maintenance APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
@@ -1965,9 +1940,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2237,9 +2210,7 @@
 	name = "Auxiliary Construction Storage";
 	req_one_access_txt = "10;32;47;48"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2660,9 +2631,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/construction/mining/aux_base";
 	dir = 8;
 	name = "Auxiliary Construction APC";
-	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -3103,9 +3074,7 @@
 	name = "Maintenance Hatch";
 	req_one_access_txt = "32;47;48"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3113,7 +3082,6 @@
 /area/maintenance/starboard/fore)
 "aid" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 2;
 	height = 13;
 	id = "ferry_home";
@@ -3529,9 +3497,7 @@
 "ajd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3540,9 +3506,7 @@
 "aje" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3567,9 +3531,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3583,9 +3545,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -3812,9 +3772,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/entry";
 	dir = 1;
 	name = "Arrivals Hallway APC";
-	areastring = "/area/hallway/secondary/entry";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3822,7 +3782,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Center Port";
-	dir = 2;
 	name = "arrivals camera"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -4317,9 +4276,7 @@
 /obj/machinery/door/airlock{
 	name = "Auxiliary Storage Closet"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -4343,9 +4300,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -4366,9 +4321,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -5109,9 +5062,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/customs";
 	dir = 8;
 	name = "Customs Desk APC";
-	areastring = "/area/security/checkpoint/customs";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -5185,7 +5138,6 @@
 /obj/item/flashlight/lamp,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Center";
-	dir = 2;
 	name = "arrivals camera"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -5808,9 +5760,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/starboard/fore";
 	dir = 1;
 	name = "Starboard Bow Maintenance APC";
-	areastring = "/area/maintenance/starboard/fore";
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -6973,9 +6925,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -6989,9 +6939,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7005,9 +6953,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7268,9 +7214,8 @@
 /area/vacant_room/office)
 "aqg" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Auxiliary Office APC";
 	areastring = "/area/vacant_room/office";
+	name = "Auxiliary Office APC";
 	pixel_y = -23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -7758,9 +7703,8 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Electronics Marketing APC";
 	areastring = "/area/crew_quarters/electronic_marketing_den";
+	name = "Electronics Marketing APC";
 	pixel_y = -23
 	},
 /turf/open/floor/wood,
@@ -7788,9 +7732,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7818,9 +7760,7 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7836,9 +7776,7 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7934,7 +7872,6 @@
 /area/maintenance/disposal)
 "ari" = (
 /obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
 	machinedir = 8;
 	pixel_x = 32
 	},
@@ -7975,9 +7912,7 @@
 	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -7999,9 +7934,7 @@
 	name = "Reflector Access";
 	req_one_access_txt = "24;10"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -8051,9 +7984,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -8067,9 +7998,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -8240,7 +8169,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft";
-	dir = 2;
 	name = "arrivals camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -8426,7 +8354,6 @@
 "ash" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
-	dir = 4;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
@@ -9229,9 +9156,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -9339,7 +9264,6 @@
 /area/maintenance/disposal)
 "atF" = (
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
@@ -9679,9 +9603,7 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -9698,9 +9620,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10130,9 +10050,8 @@
 /area/maintenance/disposal)
 "auO" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Disposal APC";
 	areastring = "/area/maintenance/disposal";
+	name = "Disposal APC";
 	pixel_y = -23
 	},
 /obj/structure/disposalpipe/segment{
@@ -10523,9 +10442,9 @@
 /area/janitor)
 "avB" = (
 /obj/machinery/power/apc{
+	areastring = "/area/janitor";
 	dir = 1;
 	name = "Custodial Closet APC";
-	areastring = "/area/janitor";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -10557,7 +10476,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Custodial Closet";
-	dir = 2;
 	name = "service camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -10663,9 +10581,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10675,11 +10591,8 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/science{
-	dir = 2
-	},
+/obj/structure/sign/directions/science,
 /obj/structure/sign/directions/engineering{
-	dir = 2;
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -10691,9 +10604,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10704,9 +10615,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10718,9 +10627,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10730,11 +10637,8 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical{
-	dir = 2
-	},
+/obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/security{
-	dir = 2;
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -10752,9 +10656,7 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10796,9 +10698,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -11189,7 +11089,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Auxiliary Restroom";
-	dir = 2;
 	name = "restroom camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -11310,7 +11209,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Cargo - Warehouse";
-	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plating,
@@ -11590,7 +11488,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
-	dir = 2;
 	network = list("engine")
 	},
 /turf/open/floor/engine,
@@ -11904,9 +11801,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Auxiliary Restrooms APC";
 	areastring = "/area/crew_quarters/toilet/auxiliary";
+	name = "Auxiliary Restrooms APC";
 	pixel_y = -23
 	},
 /turf/open/floor/plating,
@@ -12383,9 +12279,8 @@
 "ayU" = (
 /obj/machinery/light/small,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Port Bow Maintenance APC";
 	areastring = "/area/maintenance/port/fore";
+	name = "Port Bow Maintenance APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -12580,9 +12475,7 @@
 /obj/machinery/door/airlock{
 	name = "Toilet Unit"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -13068,9 +12961,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -13081,9 +12972,7 @@
 	id = "custodialshutters";
 	name = "Custodial Closet Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -13101,9 +12990,7 @@
 	req_access_txt = "26"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -14605,9 +14492,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
 	name = "Cargo Warehouse APC";
-	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/brown,
@@ -14737,9 +14624,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aDg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -14973,9 +14858,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -15164,7 +15047,6 @@
 /area/quartermaster/storage)
 "aEg" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "cargounload";
 	layer = 4;
 	name = "Loading Doors";
@@ -15400,9 +15282,9 @@
 /area/engine/atmospherics_engine)
 "aEz" = (
 /obj/machinery/power/apc{
+	areastring = "/area/engine/atmospherics_engine";
 	dir = 4;
 	name = "Atmospherics Engine APC";
-	areastring = "/area/engine/atmospherics_engine";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -15544,9 +15426,9 @@
 "aEP" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/bar";
 	dir = 1;
 	name = "Bar APC";
-	areastring = "/area/crew_quarters/bar";
 	pixel_y = 23
 	},
 /obj/machinery/light/small{
@@ -15576,7 +15458,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
-	dir = 2;
 	name = "service camera"
 	},
 /turf/open/floor/plasteel/dark,
@@ -15727,9 +15608,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/fore";
 	dir = 8;
 	name = "Port Primary Hallway APC";
-	areastring = "/area/hallway/primary/fore";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -15787,9 +15668,7 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -16095,9 +15974,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Abandoned Garden APC";
 	areastring = "/area/hydroponics/garden/abandoned";
+	name = "Abandoned Garden APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
@@ -16741,7 +16619,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Prison - Garden";
-	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -17161,9 +17038,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -17179,9 +17054,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -17420,7 +17293,6 @@
 "aHK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "cargodisposals"
 	},
 /turf/open/floor/plating,
@@ -17872,9 +17744,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/disposal/incinerator";
 	dir = 1;
 	name = "Turbine Generator APC";
-	areastring = "/area/maintenance/disposal/incinerator";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -17907,9 +17779,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -17931,9 +17801,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Engine Access";
 	req_one_access_txt = "24;10"
@@ -17976,9 +17844,7 @@
 	req_one_access_txt = "24;10"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -18324,7 +18190,6 @@
 "aJk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "cargodisposals"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -18503,8 +18368,7 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "foreport";
-	name = "Port Bow Solar Control";
-	track = 0
+	name = "Port Bow Solar Control"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -18526,9 +18390,8 @@
 "aJG" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Port Bow Solar APC";
 	areastring = "/area/maintenance/solars/port/fore";
+	name = "Port Bow Solar APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -19345,9 +19208,7 @@
 	id = "justiceblast";
 	name = "Justice Blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -19852,9 +19713,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/supply";
 	dir = 8;
 	name = "Security Post - Cargo APC";
-	areastring = "/area/security/checkpoint/supply";
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/red{
@@ -20239,9 +20100,7 @@
 	name = "Turbine Generator Access";
 	req_one_access_txt = "24;10"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -20262,9 +20121,7 @@
 "aMH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -20287,9 +20144,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Engine Access";
 	req_one_access_txt = "24;10"
@@ -20457,14 +20312,13 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/bar/atrium";
 	dir = 1;
 	name = "Atrium APC";
-	areastring = "/area/crew_quarters/bar/atrium";
 	pixel_y = 23
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre Stage";
-	dir = 2;
 	name = "service camera"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -20594,7 +20448,6 @@
 "aNp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "cargodisposals"
 	},
 /obj/structure/plasticflaps,
@@ -20922,9 +20775,9 @@
 /area/maintenance/disposal/incinerator)
 "aNQ" = (
 /obj/machinery/power/compressor{
+	comp_id = "incineratorturbine";
 	dir = 4;
-	luminosity = 2;
-	comp_id = "incineratorturbine"
+	luminosity = 2
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -20963,9 +20816,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "aNU" = (
@@ -21359,9 +21210,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
 	dir = 1;
 	name = "Theatre Backstage APC";
-	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/red{
@@ -21565,9 +21416,9 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/sorting";
 	dir = 8;
 	name = "Delivery Office APC";
-	areastring = "/area/quartermaster/sorting";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -23033,7 +22884,6 @@
 /obj/machinery/holopad,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom";
 	pixel_y = -28;
 	prison_radio = 1
@@ -23632,9 +23482,7 @@
 	req_access_txt = "50"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23686,9 +23534,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -23709,9 +23555,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/storage";
 	dir = 8;
 	name = "Cargo Bay APC";
-	areastring = "/area/quartermaster/storage";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -23861,9 +23707,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/qm";
 	dir = 1;
 	name = "Quartermaster's Office APC";
-	areastring = "/area/quartermaster/qm";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -23987,9 +23833,7 @@
 	name = "Cell 3"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -24008,9 +23852,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -24027,9 +23869,7 @@
 	name = "Cell 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -24909,7 +24749,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
-	dir = 2;
 	name = "cargo camera"
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -24924,9 +24763,9 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/office";
 	dir = 1;
 	name = "Cargo Office APC";
-	areastring = "/area/quartermaster/office";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -25363,7 +25202,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Prison - Cell 3";
-	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -25410,7 +25248,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Prison - Cell 2";
-	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -25443,7 +25280,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Prison - Cell 1";
-	dir = 2;
 	name = "prison camera";
 	network = list("ss13","prison")
 	},
@@ -25591,9 +25427,7 @@
 	name = "Security External Airlock";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -26803,9 +26637,8 @@
 "aWp" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Education Chamber APC";
 	areastring = "/area/security/execution/education";
+	name = "Education Chamber APC";
 	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
@@ -27028,9 +26861,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -27144,9 +26975,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
 	dir = 8;
 	name = "Service Hall APC";
-	areastring = "/area/hallway/secondary/service";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -27485,8 +27316,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
-	req_access_txt = "31";
-	req_one_access_txt = "0"
+	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27869,9 +27699,7 @@
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -28780,8 +28608,7 @@
 /area/security/prison)
 "aZm" = (
 /obj/machinery/camera{
-	c_tag = "Security - Prison Port";
-	dir = 2
+	c_tag = "Security - Prison Port"
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
@@ -28858,9 +28685,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZt" = (
@@ -28887,8 +28712,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/camera{
-	c_tag = "Security - Prison";
-	dir = 2
+	c_tag = "Security - Prison"
 	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
@@ -28929,9 +28753,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZx" = (
@@ -28990,9 +28812,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aZB" = (
@@ -29129,8 +28949,7 @@
 "aZK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
-	c_tag = "Security - Escape Pod";
-	dir = 2
+	c_tag = "Security - Escape Pod"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -29151,8 +28970,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	luminosity = 2;
 	initial_gas_mix = "o2=0.01;n2=0.01";
+	luminosity = 2;
 	temperature = 2.7
 	},
 /area/security/prison)
@@ -29474,9 +29293,7 @@
 	req_access_txt = "35"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -29502,9 +29319,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bax" = (
@@ -29513,9 +29328,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bay" = (
@@ -29549,7 +29362,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room";
-	dir = 2;
 	name = "service camera"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -29756,9 +29568,7 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -29921,9 +29731,8 @@
 "bbk" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Prison Wing APC";
 	areastring = "/area/security/prison";
+	name = "Prison Wing APC";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -30449,9 +30258,7 @@
 "bcm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30463,9 +30270,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30474,9 +30279,7 @@
 "bco" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30495,9 +30298,7 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30697,9 +30498,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30718,9 +30517,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -30885,8 +30682,8 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
-	luminosity = 2;
 	initial_gas_mix = "o2=0.01;n2=0.01";
+	luminosity = 2;
 	temperature = 2.7
 	},
 /area/security/prison)
@@ -31466,7 +31263,6 @@
 "bdS" = (
 /obj/machinery/camera{
 	c_tag = "Cargo - Waiting Room";
-	dir = 2;
 	name = "cargo camera"
 	},
 /obj/effect/turf_decal/loading_area{
@@ -32078,9 +31874,8 @@
 "bfb" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Kitchen APC";
 	areastring = "/area/crew_quarters/kitchen";
+	name = "Kitchen APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/bot,
@@ -32673,9 +32468,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32786,9 +32579,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32804,9 +32595,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -32827,9 +32616,7 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33129,18 +32916,14 @@
 /area/quartermaster/miningoffice)
 "bgR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bgS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33173,8 +32956,8 @@
 	height = 5;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	width = 7;
-	roundstart_template = /datum/map_template/shuttle/mining/delta
+	roundstart_template = /datum/map_template/shuttle/mining/delta;
+	width = 7
 	},
 /turf/open/space/basic,
 /area/space)
@@ -33191,9 +32974,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33221,9 +33002,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33307,9 +33086,9 @@
 /area/engine/atmos)
 "bhj" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/atmos";
 	dir = 1;
 	name = "Atmospherics APC";
-	areastring = "/area/engine/atmos";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -34135,8 +33914,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Medbay";
-	dir = 2
+	c_tag = "Security - Medbay"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -34258,8 +34036,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Office Fore";
-	dir = 2
+	c_tag = "Security - Office Fore"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -35471,8 +35248,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Office";
-	dir = 2
+	c_tag = "Security - Head of Security's Office"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35923,7 +35699,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/eastleft{
-	dir = 4;
 	name = "Kitchen Desk";
 	req_access_txt = "28"
 	},
@@ -36238,9 +36013,9 @@
 /obj/item/storage/firstaid/regular,
 /obj/machinery/light,
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/miningoffice";
 	dir = 4;
 	name = "Mining Dock APC";
-	areastring = "/area/quartermaster/miningoffice";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -36543,8 +36318,6 @@
 	icon_living = "magicarp";
 	icon_state = "magicarp";
 	maxHealth = 200;
-	melee_damage_lower = 20;
-	melee_damage_upper = 20;
 	name = "Lia"
 	},
 /turf/open/floor/carpet/red,
@@ -36624,8 +36397,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Quarters";
-	dir = 2
+	c_tag = "Security - Head of Security's Quarters"
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -37053,9 +36825,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37094,9 +36864,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fore Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37111,9 +36879,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37134,9 +36900,7 @@
 /area/hallway/primary/fore)
 "bnv" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37145,9 +36909,7 @@
 "bnw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37160,9 +36922,7 @@
 "bny" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37191,9 +36951,7 @@
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37296,9 +37054,9 @@
 /area/security/main)
 "bnL" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/main";
 	dir = 8;
 	name = "Security Office APC";
-	areastring = "/area/security/main";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -37654,9 +37412,7 @@
 	name = "Distribution Loop";
 	req_access_txt = "24"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -37695,9 +37451,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bor" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -37715,16 +37469,12 @@
 /obj/item/clipboard,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/figure/atmos,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bot" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -37862,7 +37612,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Fore Port";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -37959,7 +37708,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Fore Starboard";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -38007,9 +37755,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/central";
 	dir = 1;
 	name = "Central Primary Hallway APC";
-	areastring = "/area/hallway/primary/central";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -38161,8 +37909,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Transfer Centre";
-	dir = 2
+	c_tag = "Security - Transfer Centre"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -38677,7 +38424,6 @@
 /area/engine/atmos)
 "bpT" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Pure to Mix"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -38756,9 +38502,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bqa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -38780,9 +38524,7 @@
 /obj/item/clothing/head/welding,
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -38790,9 +38532,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bqc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -40101,9 +39841,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility,
 /obj/item/t_scanner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41299,9 +41037,7 @@
 /area/engine/atmos)
 "btU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -41315,9 +41051,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "btV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41474,9 +41208,9 @@
 /area/hallway/primary/port)
 "bui" = (
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/port";
 	dir = 4;
 	name = "Port Primary Hallway APC";
-	areastring = "/area/hallway/primary/port";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -41521,9 +41255,7 @@
 "bun" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41535,9 +41267,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41547,9 +41277,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41568,9 +41296,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41596,9 +41322,7 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "buA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -41828,9 +41552,8 @@
 "buT" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Head of Security's Office APC";
 	areastring = "/area/crew_quarters/heads/hos";
+	name = "Head of Security's Office APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -41951,7 +41674,6 @@
 /area/engine/atmos)
 "bva" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Mix to Distro"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -42496,9 +42218,8 @@
 "bwa" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Security Transferring APC";
 	areastring = "/area/security/execution/transfer";
+	name = "Security Transferring APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/red,
@@ -42789,9 +42510,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -43507,9 +43226,7 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -44088,9 +43805,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/nuke_storage";
 	dir = 4;
 	name = "Vault APC";
-	areastring = "/area/security/nuke_storage";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -44583,9 +44300,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Access";
 	req_one_access_txt = "24;10"
@@ -44762,9 +44477,7 @@
 	req_access_txt = "19;23"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45076,8 +44789,8 @@
 	height = 5;
 	id = "laborcamp_home";
 	name = "fore bay 1";
-	width = 9;
-	roundstart_template = /datum/map_template/shuttle/labour/delta
+	roundstart_template = /datum/map_template/shuttle/labour/delta;
+	width = 9
 	},
 /turf/open/space/basic,
 /area/space)
@@ -45331,7 +45044,6 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	frequency = 1423;
 	name = "Interrogation Intercom";
 	pixel_y = -58
@@ -45622,9 +45334,7 @@
 	req_access_txt = "13"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45704,9 +45414,7 @@
 	name = "Atmospherics Lockdown Blast door"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45720,9 +45428,7 @@
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45740,9 +45446,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -45992,9 +45696,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -46012,7 +45714,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
-	dir = 2;
 	freq = 1400;
 	location = "Tool Storage"
 	},
@@ -46541,7 +46242,6 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /obj/item/radio/intercom{
-	anyai = 1;
 	broadcasting = 1;
 	frequency = 1423;
 	listening = 0;
@@ -46810,9 +46510,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -46843,9 +46541,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -46995,9 +46691,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/break_room";
 	dir = 1;
 	name = "Engineering Foyer APC";
-	areastring = "/area/engine/break_room";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -48091,7 +47787,6 @@
 /area/security/brig)
 "bEf" = (
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -48104,7 +47799,6 @@
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48236,7 +47930,6 @@
 /area/ai_monitored/turret_protected/ai)
 "bEm" = (
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -48249,7 +47942,6 @@
 	pixel_x = 27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -48761,9 +48453,9 @@
 	},
 /obj/item/stack/cable_coil/white,
 /obj/machinery/power/apc{
+	areastring = "/area/storage/primary";
 	dir = 8;
 	name = "Primary Tool Storage APC";
-	areastring = "/area/storage/primary";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -49457,14 +49149,12 @@
 	pixel_y = -7
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -50165,9 +49855,8 @@
 "bGY" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Bridge APC";
 	areastring = "/area/bridge";
+	name = "Bridge APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -50731,9 +50420,7 @@
 /area/engine/gravity_generator)
 "bHQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -50766,9 +50453,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -50786,9 +50471,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -51043,9 +50726,9 @@
 /obj/item/folder/yellow,
 /obj/item/electronics/airlock,
 /obj/machinery/power/apc{
+	areastring = "/area/storage/tech";
 	dir = 8;
 	name = "Technology Storage APC";
-	areastring = "/area/storage/tech";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -51607,9 +51290,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/detectives_office";
 	dir = 1;
 	name = "Detective's Office APC";
-	areastring = "/area/security/detectives_office";
 	pixel_y = 23
 	},
 /obj/item/taperecorder,
@@ -51998,9 +51681,9 @@
 	dir = 6
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	dir = 1;
 	name = "AI Chamber APC";
-	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52581,9 +52264,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/bridge/meeting_room/council";
 	dir = 1;
 	name = "Council Chambers APC";
-	areastring = "/area/bridge/meeting_room/council";
 	pixel_y = 23
 	},
 /turf/open/floor/wood,
@@ -52767,9 +52450,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -53265,9 +52946,9 @@
 /area/engine/transit_tube)
 "bLI" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/transit_tube";
 	dir = 1;
 	name = "Transit Tube Access APC";
-	areastring = "/area/engine/transit_tube";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -53868,9 +53549,9 @@
 /area/tcommsat/computer)
 "bMz" = (
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/tcommsat/computer";
 	dir = 1;
 	name = "Telecomms Monitoring APC";
-	areastring = "/area/tcommsat/computer";
 	pixel_y = 23
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -53888,7 +53569,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Monitoring";
-	dir = 2;
 	name = "telecomms camera";
 	network = list("ss13","tcomms")
 	},
@@ -54062,9 +53742,9 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/storage/tools";
 	dir = 1;
 	name = "Auxiliary Tool Storage APC";
-	areastring = "/area/storage/tools";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -56159,9 +55839,7 @@
 	req_access_txt = "10"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -56594,9 +56272,8 @@
 /area/crew_quarters/heads/captain)
 "bQV" = (
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Captain's Office APC";
 	areastring = "/area/crew_quarters/heads/captain";
+	name = "Captain's Office APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -57096,7 +56773,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "AI Satellite - Antechamber";
-	dir = 2;
 	name = "ai camera";
 	network = list("minisat");
 	start_active = 1
@@ -57383,7 +57059,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Chief Engineer's Quarters";
-	dir = 2;
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -57497,9 +57172,7 @@
 	req_access_txt = "23"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -57511,9 +57184,7 @@
 	name = "Primary Tool Storage"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -57524,18 +57195,14 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Primary Tool Storage"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bSv" = (
-/obj/structure/sign/directions/science{
-	dir = 2
-	},
+/obj/structure/sign/directions/science,
 /obj/structure/sign/directions/engineering{
 	dir = 8;
 	pixel_y = 8
@@ -57549,9 +57216,7 @@
 "bSw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -57763,7 +57428,6 @@
 /area/crew_quarters/heads/captain)
 "bSS" = (
 /obj/structure/sign/directions/science{
-	dir = 2;
 	pixel_y = -8
 	},
 /obj/structure/sign/directions/command{
@@ -57944,9 +57608,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/warden";
 	dir = 4;
 	name = "Warden's Office APC";
-	areastring = "/area/security/warden";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
@@ -58239,7 +57903,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	enabled = 1;
 	name = "Antechamber Turret Control";
 	pixel_x = -32;
 	req_access = null;
@@ -58412,7 +58075,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "AI Satellite - Transit Tube";
-	dir = 2;
 	name = "ai camera";
 	network = list("minisat");
 	start_active = 1
@@ -58749,9 +58411,9 @@
 /area/security/checkpoint/engineering)
 "bUf" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
 	dir = 1;
 	name = "Security Post - Engineering APC";
-	areastring = "/area/security/checkpoint/engineering";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58983,7 +58645,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway - Starboard";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -59311,7 +58972,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Hallway - Port";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -61788,9 +61448,8 @@
 "bYk" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "AI Satellite Exterior APC";
 	areastring = "/area/aisat";
+	name = "AI Satellite Exterior APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -61963,9 +61622,8 @@
 "bYu" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Chief Engineer's APC";
 	areastring = "/area/crew_quarters/heads/chief";
+	name = "Chief Engineer's APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -62629,9 +62287,8 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Starboard Primary Hallway APC";
 	areastring = "/area/hallway/primary/starboard";
+	name = "Starboard Primary Hallway APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
@@ -62950,9 +62607,8 @@
 	pixel_x = -26
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "MiniSat APC";
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	name = "MiniSat APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -63271,9 +62927,7 @@
 	req_access_txt = "10"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -63297,9 +62951,7 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -63349,9 +63001,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -63402,11 +63052,8 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical{
-	dir = 2
-	},
+/obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/security{
-	dir = 2;
 	pixel_y = 8
 	},
 /turf/closed/wall,
@@ -63630,9 +63277,7 @@
 /obj/structure/sign/directions/evac{
 	pixel_y = -8
 	},
-/obj/structure/sign/directions/medical{
-	dir = 2
-	},
+/obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/security{
 	dir = 4;
 	pixel_y = 8
@@ -63936,9 +63581,8 @@
 "cbK" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Armoury APC";
 	areastring = "/area/ai_monitored/security/armory";
+	name = "Armoury APC";
 	pixel_y = -23
 	},
 /obj/machinery/camera{
@@ -64133,7 +63777,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Fore";
-	dir = 2;
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -64259,9 +63902,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -64496,7 +64137,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
@@ -64546,7 +64186,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 2;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
@@ -64712,8 +64351,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Courtroom - Fore";
-	dir = 2
+	c_tag = "Courtroom - Fore"
 	},
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
@@ -64872,7 +64510,6 @@
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor/southright{
-	dir = 2;
 	name = "Security Desk";
 	req_access_txt = "63"
 	},
@@ -64973,9 +64610,7 @@
 	id = "armouryaccess";
 	name = "Armoury Access"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -65655,9 +65290,9 @@
 /area/crew_quarters/heads/hop)
 "cer" = (
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hop";
 	dir = 4;
 	name = "HoP Office APC";
-	areastring = "/area/crew_quarters/heads/hop";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -65677,9 +65312,9 @@
 /area/crew_quarters/heads/hop)
 "cet" = (
 /obj/machinery/power/apc{
+	areastring = "/area/tcommsat/server";
 	dir = 8;
 	name = "Telecomms Server Room APC";
-	areastring = "/area/tcommsat/server";
 	pixel_x = -25
 	},
 /obj/structure/cable/white,
@@ -65965,7 +65600,6 @@
 /area/security/courtroom)
 "ceP" = (
 /obj/structure/chair{
-	dir = 2;
 	name = "Prosecution"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -65981,7 +65615,6 @@
 /area/security/courtroom)
 "ceQ" = (
 /obj/structure/chair{
-	dir = 2;
 	name = "Prosecution"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -66330,17 +65963,16 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/security/brig";
 	dir = 1;
 	name = "Brig APC";
-	areastring = "/area/security/brig";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Gear Room";
-	dir = 2
+	c_tag = "Security - Gear Room"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -66425,8 +66057,8 @@
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmless{
 	fan_out_items = 1;
-	lootdoubles = 0;
-	lootcount = 3
+	lootcount = 3;
+	lootdoubles = 0
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
@@ -66505,8 +66137,8 @@
 	},
 /obj/effect/spawner/lootdrop/aimodule_harmful{
 	fan_out_items = 1;
-	lootdoubles = 0;
-	lootcount = 2
+	lootcount = 2;
+	lootdoubles = 0
 	},
 /obj/item/aiModule/supplied/oxygen{
 	pixel_x = -3;
@@ -66989,9 +66621,8 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Captain's Quarters APC";
 	areastring = "/area/crew_quarters/heads/captain/private";
+	name = "Captain's Quarters APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/white,
@@ -67997,7 +67628,6 @@
 /obj/structure/bookcase/manuals/research_and_development,
 /obj/machinery/camera{
 	c_tag = "Library";
-	dir = 2;
 	name = "library camera"
 	},
 /turf/open/floor/wood,
@@ -68154,9 +67784,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -68293,9 +67921,9 @@
 	},
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
+	areastring = "/area/lawoffice";
 	dir = 8;
 	name = "Law Office APC";
-	areastring = "/area/lawoffice";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -69378,9 +69006,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -69663,9 +69289,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/engine/engineering";
 	dir = 4;
 	name = "Engine Room APC";
-	areastring = "/area/engine/engineering";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/bot,
@@ -69828,9 +69454,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -70056,9 +69680,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -70287,8 +69909,8 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/aimodule_neutral{
 	fan_out_items = 1;
-	lootdoubles = 0;
-	lootcount = 3
+	lootcount = 3;
+	lootdoubles = 0
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70682,9 +70304,9 @@
 /obj/structure/table,
 /obj/item/hand_tele,
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/teleporter";
 	dir = 1;
 	name = "Teleporter APC";
-	areastring = "/area/teleporter";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -71167,9 +70789,8 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "AI Upload Access APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	name = "AI Upload Access APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -71319,9 +70940,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -71933,9 +71552,9 @@
 "coN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
+	areastring = "/area/security/range";
 	dir = 8;
 	name = "Shooting Range APC";
-	areastring = "/area/security/range";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -72130,9 +71749,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 20
 	},
-/obj/item/gps/engineering{
-	gpstag = "ENG0"
-	},
+/obj/item/gps/engineering,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -72198,9 +71815,9 @@
 /area/maintenance/port)
 "cpr" = (
 /obj/machinery/power/apc{
+	areastring = "/area/library";
 	dir = 8;
 	name = "Library APC";
-	areastring = "/area/library";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -72534,9 +72151,9 @@
 /area/security/courtroom)
 "cqb" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/courtroom";
 	dir = 4;
 	name = "Courtroom APC";
-	areastring = "/area/security/courtroom";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -72557,9 +72174,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -72930,9 +72545,7 @@
 	req_access_txt = "61"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -72944,9 +72557,7 @@
 	name = "Teleport Access";
 	req_access_txt = "17"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -72964,9 +72575,7 @@
 	id = "teleportershutters";
 	name = "Teleporter Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -72978,9 +72587,7 @@
 	name = "Teleporter Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73452,9 +73059,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "crX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73462,9 +73067,7 @@
 /area/engine/engineering)
 "crY" = (
 /obj/effect/decal/cleanable/oil,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -73715,9 +73318,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/command";
 	dir = 1;
 	name = "Command Hall APC";
-	areastring = "/area/hallway/secondary/command";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -73759,7 +73362,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Center";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -74046,7 +73648,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room - Fore";
-	dir = 2;
 	name = "dormitories camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -75274,9 +74875,7 @@
 	req_access_txt = "18"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -75289,9 +74888,7 @@
 	req_access_txt = "18"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -75404,9 +75001,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -75537,7 +75132,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory Hallway";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -75781,7 +75375,6 @@
 /obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Recreation - Fore";
-	dir = 2;
 	name = "recreation camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -76035,9 +75628,9 @@
 /area/ai_monitored/storage/eva)
 "cwF" = (
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/storage/eva";
 	dir = 1;
 	name = "E.V.A. Storage APC";
-	areastring = "/area/ai_monitored/storage/eva";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -76074,7 +75667,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Bridge - E.V.A. Fore";
-	dir = 2;
 	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -76192,9 +75784,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/gateway";
 	dir = 1;
 	name = "Gateway APC";
-	areastring = "/area/gateway";
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -78103,9 +77695,7 @@
 /obj/machinery/door/airlock{
 	name = "Primary Restroom"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -78233,9 +77823,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/locker";
 	dir = 4;
 	name = "Lockerroom APC";
-	areastring = "/area/crew_quarters/locker";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -78253,9 +77843,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -78737,7 +78325,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Corporate Lounge";
-	dir = 2;
 	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -79024,9 +78611,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/toilet/restrooms";
 	dir = 1;
 	name = "Primary Restroom APC";
-	areastring = "/area/crew_quarters/toilet/restrooms";
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -79034,7 +78621,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Primary Restroom";
-	dir = 2;
 	name = "restroom camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -79761,9 +79347,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/bridge/showroom/corporate";
 	dir = 8;
 	name = "Corporate Lounge APC";
-	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -80544,9 +80130,9 @@
 	},
 /obj/item/tank/jetpack/carbondioxide,
 /obj/machinery/power/apc{
+	areastring = "/area/engine/storage";
 	dir = 4;
 	name = "Engineering Storage APC";
-	areastring = "/area/engine/storage";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -81398,7 +80984,6 @@
 "cFG" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Fore";
-	dir = 2;
 	name = "holodeck camera"
 	},
 /turf/open/floor/engine{
@@ -82153,7 +81738,6 @@
 	},
 /obj/item/reagent_containers/food/drinks/beer{
 	desc = "Whatever it is, it reeks of foul, putrid froth.";
-	icon_state = "beer";
 	list_reagents = list(/datum/reagent/consumable/ethanol/bacchus_blessing = 15);
 	name = "Delta-Down";
 	pixel_x = 5;
@@ -82555,9 +82139,7 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82568,9 +82150,7 @@
 	id = "evashutters";
 	name = "E.V.A. Storage Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82588,9 +82168,7 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82630,9 +82208,7 @@
 	name = "Gateway Atrium";
 	req_access_txt = "62"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -82651,9 +82227,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82665,9 +82239,7 @@
 	name = "Gateway Chamber Shutters"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82678,9 +82250,7 @@
 	id = "gatewayshutters";
 	name = "Gateway Chamber Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82774,9 +82344,7 @@
 	name = "Lockerroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82789,9 +82357,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82907,9 +82473,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -82956,7 +82520,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Science Aft";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -83111,7 +82674,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Medbay Aft";
-	dir = 2;
 	name = "hallway camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -83183,9 +82745,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -83387,7 +82947,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitories - Starboard";
-	dir = 2;
 	name = "dormitories camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -83617,7 +83176,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Holodeck Control";
-	dir = 2;
 	name = "holodeck camera"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -85527,9 +85085,8 @@
 "cMy" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Dormitories APC";
 	areastring = "/area/crew_quarters/dorms";
+	name = "Dormitories APC";
 	pixel_y = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -85750,9 +85307,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85775,9 +85330,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -85938,7 +85491,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Killroom Chamber";
-	dir = 2;
 	name = "xenobiology camera";
 	network = list("ss13","xeno","rd")
 	},
@@ -86009,9 +85561,7 @@
 "cNr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86023,9 +85573,7 @@
 /area/science/research)
 "cNt" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86051,9 +85599,7 @@
 	name = "Aft Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86064,9 +85610,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Aft Primary Hallway"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86079,9 +85623,7 @@
 	name = "Aft Primary Hallway"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86106,9 +85648,7 @@
 /area/medical/medbay/central)
 "cNA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86121,9 +85661,7 @@
 "cNC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -86753,7 +86291,6 @@
 /area/science/xenobiology)
 "cOO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
 	name = "killroom vent";
 	pressure_checks = 0
@@ -86765,7 +86302,6 @@
 /area/science/xenobiology)
 "cOQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 2;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
@@ -86787,9 +86323,7 @@
 	req_access_txt = "47"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -87093,16 +86627,16 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/storage";
 	dir = 8;
 	name = "Medbay Storage APC";
-	areastring = "/area/medical/storage";
 	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Storage";
-	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
@@ -87562,9 +87096,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/electrical";
 	dir = 4;
 	name = "Auxiliary Power APC";
-	areastring = "/area/maintenance/department/electrical";
 	pixel_x = 24
 	},
 /turf/open/floor/plating,
@@ -87593,9 +87127,7 @@
 	req_access_txt = "47"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -88458,7 +87990,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Port";
-	dir = 2;
 	name = "xenobiology camera";
 	network = list("ss13","xeno","rd")
 	},
@@ -88663,9 +88194,7 @@
 	name = "Xenobiology Kill Room";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -89231,9 +88760,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -89586,7 +89113,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -91416,9 +90942,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91450,9 +90974,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/fitness/recreation";
 	dir = 8;
 	name = "Recreation Area APC";
-	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -91758,9 +91282,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91776,9 +91298,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91788,9 +91308,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -91909,9 +91427,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/science/research";
 	dir = 8;
 	name = "Security Post - Science APC";
-	areastring = "/area/security/checkpoint/science/research";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -92154,9 +91672,9 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Waiting Room";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2{
@@ -92283,9 +91801,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -92297,9 +91813,7 @@
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -92329,9 +91843,8 @@
 "cYc" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Break Room";
-	network = list("ss13","medbay");
-	dir = 2;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -93010,9 +92523,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -93031,9 +92542,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -93188,9 +92697,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Fore Port";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -93208,9 +92717,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/medical";
 	dir = 8;
 	name = "Security Post - Medical APC";
-	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -93293,9 +92802,8 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay - Sleepers";
-	network = list("ss13","medbay");
-	dir = 2;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/item/book/manual/wiki/medicine,
 /obj/item/stack/medical/gauze,
@@ -93736,9 +93244,7 @@
 	name = "Engineering Auxiliary Power";
 	req_access_txt = "10"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -94220,9 +93726,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/chemistry";
 	dir = 1;
 	name = "Chemistry Lab APC";
-	areastring = "/area/medical/chemistry";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -94708,9 +94214,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/port";
 	dir = 1;
 	name = "Port Maintenance APC";
-	areastring = "/area/maintenance/port";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -94865,7 +94371,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -94916,7 +94421,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -94971,7 +94475,6 @@
 	name = "Creature Cell #3"
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
@@ -95066,9 +94569,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/xenobiology";
 	dir = 4;
 	name = "Xenobiology Lab APC";
-	areastring = "/area/science/xenobiology";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -96544,9 +96047,7 @@
 	name = "Xenobiology Lab";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96573,9 +96074,7 @@
 "dfg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96584,9 +96083,7 @@
 "dfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96637,9 +96134,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96656,9 +96151,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96679,9 +96172,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/lab";
 	dir = 8;
 	name = "Research and Development Lab APC";
-	areastring = "/area/science/lab";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -96816,9 +96309,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chemistry";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
@@ -96873,9 +96366,7 @@
 	name = "Medical Cell";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96884,9 +96375,7 @@
 "dfF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96895,9 +96384,7 @@
 "dfG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96912,9 +96399,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -96932,9 +96417,7 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -97122,9 +96605,9 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/abandoned_gambling_den";
 	dir = 1;
 	name = "Abandoned Gambling Den APC";
-	areastring = "/area/crew_quarters/abandoned_gambling_den";
 	pixel_y = 23
 	},
 /turf/open/floor/plating,
@@ -97363,7 +96846,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science - Port";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -97448,7 +96930,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science - Center";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -97859,9 +97340,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Center";
-	network = list("ss13","medbay");
-	dir = 2;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -99262,7 +98742,6 @@
 "djC" = (
 /obj/machinery/camera{
 	c_tag = "Science - Experimentation Lab";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -99784,9 +99263,9 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Port";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -99914,9 +99393,9 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay - Starboard";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
@@ -99980,9 +99459,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Abandoned Medical Lab APC";
 	areastring = "/area/medical/abandoned";
+	name = "Abandoned Medical Lab APC";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -100429,9 +99907,7 @@
 	name = "Research Division Access";
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100544,9 +100020,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100556,9 +100030,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100566,9 +100038,7 @@
 /area/hallway/primary/aft)
 "dlR" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100582,9 +100052,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100600,9 +100068,7 @@
 	req_access_txt = "5; 33"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100625,9 +100091,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100638,9 +100102,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100659,9 +100121,7 @@
 	name = "Surgery Observation"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -100676,9 +100136,7 @@
 /obj/machinery/door/airlock/medical{
 	name = "Surgery Observation"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -101108,9 +100566,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/science/robotics/mechbay";
 	dir = 1;
 	name = "Mech Bay APC";
-	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -101246,9 +100704,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/medical/genetics/cloning";
 	dir = 1;
 	name = "Cloning Lab APC";
-	areastring = "/area/medical/genetics/cloning";
 	pixel_y = 23
 	},
 /obj/item/folder/white,
@@ -101256,6 +100714,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "dns" = (
@@ -101516,9 +100976,7 @@
 "dnP" = (
 /obj/machinery/pipedispenser,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -101526,9 +100984,7 @@
 /area/hallway/secondary/construction)
 "dnQ" = (
 /obj/machinery/pipedispenser/disposal,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -101536,9 +100992,7 @@
 /area/hallway/secondary/construction)
 "dnR" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -103543,9 +102997,7 @@
 /obj/machinery/door/airlock/medical{
 	name = "Surgery Observation"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -103662,7 +103114,6 @@
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
 	areastring = "/area/science/misc_lab/range";
-	dir = 2;
 	name = "Testing Range APC";
 	pixel_x = 1;
 	pixel_y = -23
@@ -103842,9 +103293,7 @@
 	id = "rdtoxins";
 	name = "Toxins Lab Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -103859,9 +103308,9 @@
 /area/science/mixing)
 "drX" = (
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hor";
 	dir = 8;
 	name = "Research Director's Office APC";
-	areastring = "/area/crew_quarters/heads/hor";
 	pixel_x = -25
 	},
 /obj/structure/cable/white,
@@ -104153,9 +103602,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Cloning Lab";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
@@ -104233,9 +103682,9 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/item/book/manual/wiki/medicine,
 /obj/item/clothing/neck/stethoscope,
@@ -104667,9 +104116,7 @@
 	name = "Genetics Desk Maintenance";
 	req_access_txt = "9"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -104705,9 +104152,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -104726,9 +104171,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/medbay/central";
 	dir = 8;
 	name = "Medbay APC";
-	areastring = "/area/medical/medbay/central";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -104820,9 +104265,9 @@
 /obj/machinery/iv_drip,
 /obj/machinery/camera{
 	c_tag = "Medbay - Recovery Room";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -106390,9 +105835,9 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/geneticist,
 /obj/machinery/power/apc{
+	areastring = "/area/medical/genetics";
 	dir = 4;
 	name = "Genetics Lab APC";
-	areastring = "/area/medical/genetics";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -106419,9 +105864,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Lab";
-	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light_switch{
 	pixel_x = -26
@@ -107084,9 +106529,7 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -107106,9 +106549,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -107118,9 +106559,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -107154,9 +106593,7 @@
 	name = "Robotics Lab";
 	req_access_txt = "29"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -107169,9 +106606,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -107190,9 +106625,9 @@
 /obj/item/storage/box/disks,
 /obj/machinery/camera{
 	c_tag = "Medbay - Genetics Desk";
-	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -107622,16 +107057,15 @@
 "dyI" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Surgery APC";
 	areastring = "/area/medical/surgery";
+	name = "Surgery APC";
 	pixel_y = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -107726,9 +107160,8 @@
 /area/hallway/secondary/construction)
 "dyP" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Auxiliary Construction Zone APC";
 	areastring = "/area/hallway/secondary/construction";
+	name = "Auxiliary Construction Zone APC";
 	pixel_y = -23
 	},
 /obj/structure/cable/yellow{
@@ -108370,9 +107803,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Port";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/item/clipboard,
 /obj/item/healthanalyzer,
@@ -108443,16 +107876,16 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/cmo";
 	dir = 4;
 	name = "Chief Medical Officer's Office APC";
-	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Office";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -108486,9 +107919,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -108504,9 +107935,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -108619,9 +108048,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
 	dir = 8;
 	name = "Toxins Lab APC";
-	areastring = "/area/science/mixing";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -109769,9 +109198,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/aft";
 	dir = 4;
 	name = "Aft Primary Hallway APC";
-	areastring = "/area/hallway/primary/aft";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -109793,9 +109222,7 @@
 	req_access_txt = "9"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -109886,9 +109313,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Aft Starboard";
-	network = list("ss13","medbay");
 	dir = 4;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -110088,9 +109515,8 @@
 "dDc" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Starboard Quarter Solar APC";
 	areastring = "/area/maintenance/solars/starboard/aft";
+	name = "Starboard Quarter Solar APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -110109,8 +109535,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control";
-	track = 0
+	name = "Starboard Quarter Solar Control"
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm{
@@ -110278,9 +109703,7 @@
 	id = "rdtoxins";
 	name = "Toxins Lab Shutters"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -110726,9 +110149,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -111212,9 +110633,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dFl" = (
-/obj/machinery/vending/autodrobe{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/autodrobe,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -111225,9 +110644,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre/abandoned";
 	dir = 1;
 	name = "Abandoned Theatre APC";
-	areastring = "/area/crew_quarters/theatre/abandoned";
 	pixel_y = 23
 	},
 /turf/open/floor/plating,
@@ -111394,7 +110813,6 @@
 /obj/item/clothing/mask/gas,
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Launch Site";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -111437,9 +110855,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -111561,9 +110977,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/server";
 	dir = 8;
 	name = "Research Division Server Room APC";
-	areastring = "/area/science/server";
 	pixel_x = -25
 	},
 /obj/machinery/light_switch{
@@ -111696,9 +111112,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/robotics/lab";
 	dir = 8;
 	name = "Robotics Lab APC";
-	areastring = "/area/science/robotics/lab";
 	pixel_x = -25
 	},
 /obj/structure/disposalpipe/trunk{
@@ -112838,9 +112254,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/detectives_office/private_investigators_office";
 	dir = 8;
 	name = "Private Investigator's Office APC";
-	areastring = "/area/security/detectives_office/private_investigators_office";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -112885,7 +112301,6 @@
 /area/science/test_area)
 "dIj" = (
 /obj/machinery/button/massdriver{
-	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = -24
 	},
@@ -112908,9 +112323,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIm" = (
@@ -112918,18 +112331,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dIo" = (
@@ -112940,9 +112349,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -113195,7 +112602,6 @@
 /area/science/storage)
 "dIF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
 	name = "server vent";
 	pressure_checks = 0
@@ -113218,7 +112624,6 @@
 /area/science/server)
 "dIH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 2;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
@@ -113274,9 +112679,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/research";
 	dir = 4;
 	name = "Research Division APC";
-	areastring = "/area/science/research";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -113398,9 +112803,8 @@
 "dIV" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Morgue APC";
 	areastring = "/area/medical/morgue";
+	name = "Morgue APC";
 	pixel_y = -23
 	},
 /turf/open/floor/plating,
@@ -113427,9 +112831,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Medbay - Morgue";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/structure/sign/poster/official/bless_this_spess{
 	pixel_y = -32
@@ -113512,9 +112916,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Quarters";
-	network = list("ss13","medbay");
 	dir = 1;
-	name = "medbay camera"
+	name = "medbay camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -113997,9 +113401,9 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
+	areastring = "/area/science/storage";
 	dir = 4;
 	name = "Toxins Storage APC";
-	areastring = "/area/science/storage";
 	pixel_x = 24
 	},
 /obj/structure/cable/white,
@@ -114070,9 +113474,7 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -114114,9 +113516,7 @@
 	name = "Virology Access";
 	req_access_txt = "39"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -114265,9 +113665,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -114284,9 +113682,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -114318,9 +113714,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -114940,9 +114334,7 @@
 /area/science/test_area)
 "dLG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "dLH" = (
@@ -114980,9 +114372,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "dLM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -115438,9 +114828,8 @@
 	},
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Aft Maintenance APC";
 	areastring = "/area/maintenance/aft";
+	name = "Aft Maintenance APC";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -116144,9 +115533,7 @@
 	req_access_txt = "19"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116166,9 +115553,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116179,9 +115564,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departures Lounge"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116194,9 +115577,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116751,9 +116132,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116770,9 +116149,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -116802,9 +116179,7 @@
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -117031,9 +116406,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -117233,9 +116606,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/aft";
 	dir = 1;
 	name = "Port Quarter Maintenance APC";
-	areastring = "/area/maintenance/port/aft";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -117534,9 +116907,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Containment Lock";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera"
+	name = "virology camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -117798,9 +117171,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -118047,9 +117418,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -118068,9 +117437,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -118216,9 +117583,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera"
+	name = "virology camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -119001,9 +118368,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -119100,9 +118465,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -119149,9 +118512,7 @@
 	name = "Departures Lounge"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -119162,9 +118523,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departures Lounge"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -119318,9 +118677,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/library/abandoned";
 	dir = 8;
 	name = "Abandoned Library APC";
-	areastring = "/area/library/abandoned";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -119487,14 +118846,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dTG" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 23
 	},
 /obj/machinery/camera{
 	c_tag = "Departures - Fore";
-	dir = 2;
 	name = "departures camera"
 	},
 /obj/structure/cable/yellow{
@@ -120069,9 +119427,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/virology";
 	dir = 4;
 	name = "Virology Satellite APC";
-	areastring = "/area/medical/virology";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -120339,8 +119697,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
-	network = list("ss13","medbay");
-	name = "virology camera"
+	name = "virology camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -120363,9 +119721,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Virology - Hallway";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera"
+	name = "virology camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -121314,9 +120672,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -122337,7 +121693,6 @@
 /obj/effect/landmark/start/assistant,
 /obj/machinery/camera{
 	c_tag = "Departures - Center";
-	dir = 2;
 	name = "departures camera"
 	},
 /obj/effect/turf_decal/bot,
@@ -122476,9 +121831,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
-	network = list("ss13","medbay");
 	dir = 8;
-	name = "virology camera"
+	name = "virology camera";
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/white,
@@ -122597,9 +121952,9 @@
 /area/chapel/office)
 "dZQ" = (
 /obj/machinery/power/apc{
+	areastring = "/area/chapel/main";
 	dir = 8;
 	name = "Chapel APC";
-	areastring = "/area/chapel/main";
 	pixel_x = -25;
 	pixel_y = 3
 	},
@@ -122730,7 +122085,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "eab" = (
 /obj/docking_port/stationary{
-	dheight = 0;
 	dir = 4;
 	dwidth = 11;
 	height = 18;
@@ -122794,9 +122148,7 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -123157,9 +122509,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -123177,9 +122527,7 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -123196,9 +122544,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -123211,9 +122557,7 @@
 	req_access_txt = "18"
 	},
 /obj/structure/barricade/wooden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -123743,8 +123087,7 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "aftport";
-	name = "Port Quarter Solar Control";
-	track = 0
+	name = "Port Quarter Solar Control"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -123766,9 +123109,8 @@
 "ecm" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Port Quarter Solar APC";
 	areastring = "/area/maintenance/solars/port/aft";
+	name = "Port Quarter Solar APC";
 	pixel_y = -23
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -124806,9 +124148,7 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124831,9 +124171,7 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124854,9 +124192,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -124897,9 +124233,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -125028,7 +124362,6 @@
 	pixel_x = -26
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -125054,9 +124387,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/chapel/office";
 	dir = 1;
 	name = "Chapel Quarters APC";
-	areastring = "/area/chapel/office";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -125074,7 +124407,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Chapel Quarters";
-	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -125191,8 +124523,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Departures Port";
-	dir = 2
+	c_tag = "Security - Departures Port"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -125355,9 +124686,7 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/escape)
 "eeT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -125547,9 +124876,7 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -126168,9 +125495,7 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -126254,9 +125579,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/engineering)
 "ehy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -126324,9 +125647,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "ehM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -126513,9 +125834,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -126796,9 +126115,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -127051,7 +126368,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Science - Experimentation Lab";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -127125,7 +126441,6 @@
 "jEz" = (
 /obj/machinery/camera{
 	c_tag = "Science - Lab Access";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -128735,9 +128050,9 @@
 /area/engine/storage_shared)
 "vGz" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/gravity_generator";
 	dir = 1;
 	name = "Gravity Generator APC";
-	areastring = "/area/engine/gravity_generator";
 	pixel_y = 23
 	},
 /obj/structure/cable{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -101171,7 +101171,7 @@
 	},
 /area/maintenance/department/medical/central)
 "dnl" = (
-/obj/machinery/clonepod,
+/obj/machinery/clonepod/mapped,
 /obj/structure/window/reinforced{
 	dir = 4
 	},

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -13783,7 +13783,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGh" = (
-/obj/machinery/clonepod/mapped,
+/obj/machinery/clonepod/prefilled,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGi" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -12,7 +12,6 @@
 	network = list("ss13","Medical")
 	},
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68,8 +67,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Left Wing 3";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -98,8 +96,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Right Wing 3";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -107,7 +104,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aan" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -340,9 +336,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Cremator";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Chapel Cremator"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -384,7 +378,6 @@
 /area/quartermaster/storage)
 "abb" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 3;
 	height = 5;
 	id = "mining_home";
@@ -421,7 +414,6 @@
 /area/quartermaster/storage)
 "abe" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 5;
 	height = 7;
 	id = "supply_home";
@@ -443,8 +435,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Right Wing 2";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -478,7 +469,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Mining";
-	departmentType = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
@@ -619,7 +609,6 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 1";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -1058,7 +1047,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Storage";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -1449,9 +1437,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Mass Driver";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Chapel Mass Driver"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -1460,9 +1446,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Airlock";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Chapel Airlock"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -1768,9 +1752,7 @@
 /area/ai_monitored/turret_protected/aisat/service)
 "aeK" = (
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Main 2";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Chapel Main 2"
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -2551,9 +2533,9 @@
 /area/quartermaster/miningdock)
 "agx" = (
 /obj/machinery/mass_driver{
-	name = "Holy Driver";
 	dir = 1;
-	id = "chapelgun"
+	id = "chapelgun";
+	name = "Holy Driver"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/window/southleft{
@@ -2832,7 +2814,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Starboard Aux Solars Access";
-	dir = 2;
 	network = list("ss13","Engineering")
 	},
 /turf/open/floor/plating,
@@ -3077,9 +3058,7 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "ahJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "ahK" = (
@@ -4047,7 +4026,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4637,9 +4615,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Dorm Fitness 2";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Dorm Fitness 2"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -4760,7 +4736,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/cargo,
 /obj/machinery/button/door{
-	dir = 2;
 	id = "cargoload";
 	layer = 4;
 	name = "Loading Doors";
@@ -5143,7 +5118,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -5251,8 +5225,7 @@
 	dir = 6
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Captain's Private Quarters";
-	dir = 2
+	c_tag = "Bridge - Captain's Private Quarters"
 	},
 /obj/structure/sign/plaques/golden/captain{
 	pixel_y = 32
@@ -5330,7 +5303,6 @@
 "anq" = (
 /obj/machinery/camera{
 	c_tag = "Research - Experimentor Bay";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/engine,
@@ -5851,7 +5823,6 @@
 "aoM" = (
 /obj/machinery/camera{
 	c_tag = "Research - Main 4";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/plasteel/white/side{
@@ -6194,7 +6165,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera{
 	c_tag = "Engineering - Job Equipment";
-	dir = 2;
 	network = list("ss13","Engineering","Engine")
 	},
 /obj/structure/cable/yellow{
@@ -6458,7 +6428,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
-	icon_state = "soda_dispenser";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -6515,8 +6484,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control";
-	track = 0
+	name = "Starboard Quarter Solar Control"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -6785,9 +6753,7 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
-	c_tag = "Civilian - Dorm Main 1";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Dorm Main 1"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -6807,8 +6773,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Holodeck";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -7491,7 +7456,6 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
 	pixel_x = -30
 	},
 /obj/item/t_scanner,
@@ -7517,10 +7481,10 @@
 	maxcharge = 15000
 	},
 /obj/item/stock_parts/cell/high{
-	pixel_x = 2;
-	pixel_y = 2;
 	charge = 100;
-	maxcharge = 15000
+	maxcharge = 15000;
+	pixel_x = 2;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
@@ -7647,7 +7611,6 @@
 "asL" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access_txt = "0";
 	req_one_access_txt = "6;22"
 	},
 /turf/open/floor/plasteel/dark,
@@ -7809,9 +7772,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Dorm Laundry Room";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Dorm Laundry Room"
 	},
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -7826,7 +7787,6 @@
 "atf" = (
 /obj/machinery/space_heater,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8293,9 +8253,7 @@
 /area/crew_quarters/fitness)
 "auk" = (
 /obj/machinery/door/window/eastright{
-	base_state = "right";
 	dir = 8;
-	icon_state = "right";
 	name = "Fitness Ring"
 	},
 /obj/structure/window/reinforced{
@@ -8410,9 +8368,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -8420,9 +8376,7 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "auw" = (
 /obj/structure/table,
@@ -8769,7 +8723,6 @@
 /area/ai_monitored/storage/eva)
 "avp" = (
 /obj/docking_port/stationary/random{
-	dir = 1;
 	id = "pod_lavaland2";
 	name = "lavaland"
 	},
@@ -8777,7 +8730,6 @@
 /area/space/nearstation)
 "avq" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 1;
 	height = 4;
 	name = "escape pod loader";
@@ -8804,9 +8756,9 @@
 	pixel_y = -2
 	},
 /obj/item/stack/sheet/rglass{
+	amount = 50;
 	pixel_x = 5;
-	pixel_y = 1;
-	amount = 50
+	pixel_y = 1
 	},
 /obj/item/stack/rods/fifty,
 /obj/item/stack/rods/fifty{
@@ -10119,7 +10071,6 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /obj/machinery/camera{
@@ -10163,7 +10114,6 @@
 "ayt" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Foyer";
-	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -10853,8 +10803,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Main 3";
-	dir = 2
+	c_tag = "Bridge - Main 3"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -11238,16 +11187,12 @@
 /area/science/xenobiology)
 "aAR" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
 "aAS" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
 "aAT" = (
@@ -11706,7 +11651,6 @@
 "aBQ" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 3";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -12143,7 +12087,6 @@
 "aCO" = (
 /obj/machinery/camera{
 	c_tag = "Research - Server Room";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -12724,7 +12667,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -12842,15 +12784,11 @@
 	pixel_y = -3
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aEp" = (
 /obj/structure/table/glass,
@@ -13076,16 +13014,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aEN" = (
 /turf/open/floor/wood,
@@ -13148,7 +13082,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Genetics";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -13294,7 +13227,6 @@
 /area/medical/genetics)
 "aFh" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -13302,7 +13234,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Front Lobby";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /mob/living/simple_animal/bot/cleanbot{
@@ -13438,7 +13369,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -2;
 	pixel_y = 25;
@@ -13996,7 +13926,6 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -14060,7 +13989,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_y = -30
 	},
@@ -14069,6 +13997,8 @@
 	dir = 1;
 	network = list("ss13","Medical")
 	},
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGN" = (
@@ -14529,7 +14459,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Backroom";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -14830,7 +14759,6 @@
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Isolation B";
-	dir = 2;
 	network = list("ss13","Medical","Virology")
 	},
 /turf/open/floor/plasteel/white,
@@ -14992,7 +14920,6 @@
 "aJd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "6;20"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -15159,7 +15086,6 @@
 "aJu" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 2";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -15370,9 +15296,7 @@
 /area/medical/surgery)
 "aJQ" = (
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/white/side{
-	dir = 2
-	},
+/turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
 "aJR" = (
 /obj/structure/table/glass,
@@ -15549,7 +15473,6 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Isolation A";
-	dir = 2;
 	network = list("ss13","Medical","Virology")
 	},
 /turf/open/floor/plasteel/white,
@@ -15903,7 +15826,6 @@
 /obj/machinery/button/door{
 	id = "podescape";
 	name = "Pod Bay Control";
-	normaldoorcontrol = 0;
 	pixel_x = 8;
 	pixel_y = 24
 	},
@@ -17368,7 +17290,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -18150,7 +18071,6 @@
 "aQA" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
-	req_access_txt = "0";
 	req_one_access_txt = "35;28"
 	},
 /turf/open/floor/plasteel,
@@ -18964,7 +18884,6 @@
 "aSv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "atmospherics mix pump"
 	},
 /turf/open/floor/plasteel,
@@ -19159,7 +19078,6 @@
 "aST" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /turf/open/space/basic,
@@ -19201,12 +19119,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
-"aSY" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 2
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "aSZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19246,9 +19158,7 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "aTe" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = 8;
 	pixel_y = 24
@@ -19958,7 +19868,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -22244,14 +22153,12 @@
 /area/maintenance/department/security)
 "aYZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 2;
 	external_pressure_bound = 140;
-	pressure_checks = 0;
-	name = "killroom vent"
+	name = "killroom vent";
+	pressure_checks = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Northen Kill Chamber";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/circuit/telecomms,
@@ -23251,8 +23158,7 @@
 /area/security/main)
 "baM" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12;1";
-	req_one_access_txt = "0"
+	req_access_txt = "12;1"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25626,8 +25532,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12;63";
-	req_one_access_txt = "0"
+	req_access_txt = "12;63"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -25923,9 +25828,9 @@
 	pixel_y = 7
 	},
 /obj/item/flashlight/lamp/green{
+	on = 0;
 	pixel_x = 6;
-	pixel_y = 6;
-	on = 0
+	pixel_y = 6
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -25960,7 +25865,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Cell 2";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -26400,7 +26304,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;22"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -26499,7 +26402,6 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -26823,7 +26725,6 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 3";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -26833,7 +26734,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -2;
 	pixel_y = 25;
@@ -27205,7 +27105,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Main Hall 3";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -27809,9 +27708,9 @@
 "bko" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hor";
 	dir = 8;
 	name = "RD Office APC";
-	areastring = "/area/crew_quarters/heads/hor";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
@@ -27985,7 +27884,6 @@
 "bkF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical/Science Maintenance Access";
-	req_access_txt = "0";
 	req_one_access_txt = "5;47"
 	},
 /obj/structure/disposalpipe/segment{
@@ -28195,8 +28093,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Fitness 3";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -28251,7 +28148,6 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 4";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -28359,7 +28255,6 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "robotics2";
 	name = "Shutters Control Button";
 	pixel_y = 24;
@@ -29006,8 +28901,8 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/ten,
 /obj/item/stack/sheet/glass{
-	pixel_y = 3;
-	amount = 10
+	amount = 10;
+	pixel_y = 3
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -29108,7 +29003,6 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 24;
@@ -29617,7 +29511,6 @@
 "bnK" = (
 /obj/structure/table,
 /obj/machinery/button/massdriver{
-	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = 5
 	},
@@ -29718,19 +29611,19 @@
 	name = "SUPER package wrapper"
 	},
 /obj/item/destTagger{
-	name = "kitchen destination tagger";
-	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
-	pixel_x = 1;
 	currTag = 20;
-	locked_destination = 1
+	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
+	locked_destination = 1;
+	name = "kitchen destination tagger";
+	pixel_x = 1
 	},
 /obj/item/destTagger{
-	name = "kitchen destination tagger";
-	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
-	pixel_x = 4;
-	pixel_y = 3;
 	currTag = 20;
-	locked_destination = 1
+	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
+	locked_destination = 1;
+	name = "kitchen destination tagger";
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -31631,16 +31524,12 @@
 	name = "navigation beacon (Kitchen Delivery)"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/door/window/northleft{
 	name = "Kitchen Delivery Access";
 	req_access_txt = "28"
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen/coldroom)
 "brC" = (
 /obj/machinery/light/small{
@@ -31807,7 +31696,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Main 3";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /obj/structure/closet/firecloset,
@@ -31827,8 +31715,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control";
-	track = 0
+	name = "Starboard Quarter Solar Control"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -32029,8 +31916,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Docking Bay";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -32252,8 +32138,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Fitness 1";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -32403,7 +32288,6 @@
 /area/hallway/primary/central)
 "bsQ" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "6;12;50"
 	},
 /obj/structure/cable/yellow{
@@ -32754,8 +32638,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Commissary";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
@@ -33717,8 +33600,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Main 2";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
@@ -35492,7 +35374,6 @@
 "byV" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35550,8 +35431,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Quartermaster's Office";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -35713,8 +35593,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Main 2";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -35959,7 +35838,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Airlock";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -36227,7 +36105,6 @@
 	},
 /obj/structure/transit_tube/station/reverse/flipped,
 /obj/structure/transit_tube_pod{
-	icon_state = "pod";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -36278,7 +36155,6 @@
 "bAH" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;20"
 	},
 /obj/structure/cable/yellow{
@@ -36511,8 +36387,7 @@
 "bBf" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Main 3";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -37384,9 +37259,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -37578,7 +37451,6 @@
 /area/maintenance/disposal)
 "bCZ" = (
 /obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
 	machinedir = 8
 	},
 /turf/closed/wall,
@@ -37611,16 +37483,12 @@
 	name = "navigation beacon (Hydroponics Delivery)"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery Access";
 	req_access_txt = "35"
 	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bDd" = (
 /obj/docking_port/stationary{
@@ -38267,8 +38135,7 @@
 /obj/item/screwdriver,
 /obj/machinery/camera{
 	c_tag = "Cargo - Main 1";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -38815,8 +38682,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Front Lobby";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -38896,7 +38762,6 @@
 "bFq" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Nitrous Oxide Tank";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /turf/open/floor/engine/n2o{
@@ -39087,8 +38952,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "12;1";
-	req_one_access_txt = "0"
+	req_access_txt = "12;1"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -40281,9 +40145,7 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -40317,7 +40179,6 @@
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -40951,7 +40812,6 @@
 "bJz" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Core North";
-	dir = 2;
 	network = list("AISat")
 	},
 /turf/open/floor/plasteel/dark,
@@ -41077,7 +40937,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Distro Loop";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -41690,7 +41549,6 @@
 "bLg" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
-	enabled = 1;
 	name = "AI Chamber Foyer Control";
 	pixel_y = -24;
 	req_access = null;
@@ -42004,7 +41862,6 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai";
-	enabled = 1;
 	name = "AI Chamber Turret Control";
 	pixel_x = 32;
 	pixel_y = -24;
@@ -42386,7 +42243,6 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Secure - External Telecomm Sat South";
-	dir = 2;
 	network = list("Telecom")
 	},
 /turf/open/space/basic,
@@ -42446,7 +42302,6 @@
 "bMM" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -42459,7 +42314,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -42470,7 +42324,6 @@
 "bMN" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -42483,7 +42336,6 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -42550,14 +42402,12 @@
 	pixel_y = -9
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -31
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -42775,7 +42625,6 @@
 "bNk" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI External South";
-	dir = 2;
 	network = list("AISat")
 	},
 /obj/structure/lattice,
@@ -43005,7 +42854,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/camera{
 	c_tag = "Medical - Surgery Observatory";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/dark,
@@ -43142,7 +42990,6 @@
 "bNP" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 1";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -43382,8 +43229,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Main 3";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -43419,8 +43265,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Garden Main 1";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
@@ -43428,8 +43273,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Civilian - Garden Main 2";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
@@ -43439,8 +43283,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Main 2";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -43456,16 +43299,14 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Lounge";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
 "bOy" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Main 1";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -43653,8 +43494,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Secure - Gateway";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -43928,8 +43768,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Morgue";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -44097,8 +43936,7 @@
 	dir = 6
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Central Southeast 1";
-	dir = 2
+	c_tag = "Hallway - Central Southeast 1"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -44125,8 +43963,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Central West 1";
-	dir = 2
+	c_tag = "Hallway - Central West 1"
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
@@ -44150,8 +43987,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Central West 2";
-	dir = 2
+	c_tag = "Hallway - Central West 2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -44168,8 +44004,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Breakroom";
-	dir = 2
+	c_tag = "Bridge - Breakroom"
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -44191,8 +44026,7 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Captain's Office";
-	dir = 2
+	c_tag = "Bridge - Captain's Office"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -44825,9 +44659,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
+/obj/item/clothing/head/that,
 /obj/item/toy/figure/bartender,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -45342,14 +45174,14 @@
 /area/maintenance/department/security)
 "bSA" = (
 /obj/item/clothing/head/helmet/old{
+	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50);
 	pixel_x = -3;
-	pixel_y = 3;
-	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	pixel_y = 3
 	},
 /obj/item/clothing/head/helmet/old{
+	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50);
 	pixel_x = 1;
-	pixel_y = -2;
-	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	pixel_y = -2
 	},
 /obj/structure/rack,
 /obj/structure/sign/poster/contraband/fun_police{
@@ -45600,9 +45432,7 @@
 	},
 /obj/item/clothing/suit/apron/purple_bartender,
 /obj/item/clothing/suit/apron/purple_bartender,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
+/obj/item/clothing/head/that,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTc" = (
@@ -46153,8 +45983,8 @@
 /area/science/mixing)
 "bUg" = (
 /obj/machinery/atmospherics/components/binary/valve{
-	name = "mix to port";
-	dir = 1
+	dir = 1;
+	name = "mix to port"
 	},
 /obj/machinery/button/door/incinerator_vent_toxmix{
 	pixel_y = 28
@@ -46353,9 +46183,9 @@
 /area/quartermaster/warehouse)
 "bUF" = (
 /obj/machinery/power/apc{
+	areastring = "/area/engine/gravity_generator";
 	dir = 8;
 	name = "Gravity Generator APC";
-	areastring = "/area/engine/gravity_generator";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -46421,8 +46251,7 @@
 /obj/structure/table/wood,
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Main 1";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -46652,9 +46481,7 @@
 /area/maintenance/fore)
 "bVr" = (
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Office";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Chapel Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -47224,9 +47051,9 @@
 /obj/structure/table,
 /obj/item/stack/sheet/iron/twenty,
 /obj/item/stack/sheet/glass{
+	amount = 20;
 	pixel_x = 3;
-	pixel_y = 3;
-	amount = 20
+	pixel_y = 3
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -48717,7 +48544,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
-	icon_state = "booze_dispenser";
 	dir = 4
 	},
 /obj/structure/sign/poster/official/high_class_martini{
@@ -48765,16 +48591,12 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "caD" = (
 /obj/structure/table,
@@ -49450,10 +49272,10 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen{
-	name = "Test Chamber Monitor";
 	dir = 4;
-	pixel_y = 2;
-	network = list("xeno")
+	name = "Test Chamber Monitor";
+	network = list("xeno");
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -49489,7 +49311,6 @@
 "ccm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer{
-	icon_state = "0";
 	dir = 4
 	},
 /obj/item/circuitboard/computer/powermonitor,
@@ -49600,7 +49421,6 @@
 /area/construction)
 "ccB" = (
 /obj/structure/transit_tube_pod{
-	icon_state = "pod";
 	dir = 4
 	},
 /obj/structure/transit_tube/station/reverse{
@@ -49935,8 +49755,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Left Wing 2";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white/side{
@@ -49978,9 +49797,9 @@
 	amount = 5
 	},
 /obj/item/stack/cable_coil{
+	amount = 5;
 	pixel_x = -3;
-	pixel_y = 3;
-	amount = 5
+	pixel_y = 3
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 10
@@ -50067,7 +49886,6 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
-	enabled = 1;
 	name = "AI Chamber Foyer Control";
 	pixel_y = -24;
 	req_access = null;
@@ -50194,7 +50012,6 @@
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
-	dir = 2;
 	freq = 1400;
 	location = "Atmospherics";
 	name = "navigation beacon (Atmospherics Delivery)"
@@ -50202,7 +50019,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/southleft{
 	name = "Atmospherics Delivery Access";
-	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel,
@@ -51104,7 +50920,6 @@
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/engine/engine_room";
-	dir = 2;
 	name = "Engine Room APC";
 	pixel_y = -23
 	},
@@ -51464,7 +51279,6 @@
 /obj/machinery/button/door{
 	id = "podescape";
 	name = "Pod Bay Control";
-	normaldoorcontrol = 0;
 	pixel_x = -8;
 	pixel_y = 24
 	},
@@ -51530,7 +51344,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research - Research Director's Office";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -51780,7 +51593,6 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "supermatter_external";
 	name = "Supermatter External Lockdown";
 	pixel_x = 36;
@@ -51804,7 +51616,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = 24;
@@ -51848,7 +51659,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/library/lounge";
-	dir = 2;
 	name = "Lounge APC";
 	pixel_y = -23
 	},
@@ -51934,7 +51744,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_x = -30
 	},
@@ -52008,7 +51817,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/science";
-	dir = 2;
 	name = "Science Checkpoint APC";
 	pixel_y = -23
 	},
@@ -52163,7 +51971,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/dorms";
-	dir = 2;
 	name = "Sleeping Quarters APC";
 	pixel_y = -23
 	},
@@ -52466,9 +52273,7 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -52510,7 +52315,6 @@
 "hYL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	dir = 2;
 	name = "AI Upload APC";
 	pixel_y = -23
 	},
@@ -52526,7 +52330,6 @@
 "ibF" = (
 /obj/machinery/power/apc{
 	areastring = "/area/lawoffice";
-	dir = 2;
 	name = "Lawyer's Office APC";
 	pixel_y = -23
 	},
@@ -52601,7 +52404,6 @@
 "ili" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white/side{
@@ -53105,7 +52907,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/lobby";
-	dir = 2;
 	name = "Medical Lobby APC";
 	pixel_y = -24
 	},
@@ -53215,7 +53016,6 @@
 /obj/item/paper/monitorkey,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/chief";
-	dir = 2;
 	name = "CE Office APC";
 	pixel_y = -23
 	},
@@ -53278,7 +53078,6 @@
 /obj/machinery/ntnet_relay,
 /obj/machinery/power/apc{
 	areastring = "/area/tcommsat/server";
-	dir = 2;
 	name = "Telecomms Servers APC";
 	pixel_y = -23
 	},
@@ -53313,7 +53112,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -53528,7 +53326,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
-	dir = 2;
 	name = "Theatre APC";
 	pixel_y = -23
 	},
@@ -53632,7 +53429,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/gateway";
-	dir = 2;
 	name = "Gateway APC";
 	pixel_y = -23
 	},
@@ -53832,7 +53628,6 @@
 "naE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
-	dir = 2;
 	name = "Brig APC";
 	pixel_y = -23
 	},
@@ -53882,7 +53677,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -54026,11 +53820,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Right Wing 1";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -54420,7 +54212,6 @@
 "oMw" = (
 /obj/machinery/camera{
 	c_tag = "Research - Toxins Main 2";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54466,9 +54257,8 @@
 /area/engine/engine_room/external)
 "oVG" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "AI Chamber APC";
 	areastring = "/area/ai_monitored/turret_protected/ai";
+	name = "AI Chamber APC";
 	pixel_y = -23
 	},
 /obj/machinery/flasher{
@@ -54778,7 +54568,6 @@
 /obj/structure/table,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics/cloning";
-	dir = 2;
 	name = "Cloning Bay APC";
 	pixel_y = -23
 	},
@@ -54858,7 +54647,6 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -54867,7 +54655,6 @@
 /obj/structure/table/glass,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/virology";
-	dir = 2;
 	name = "Virology APC";
 	pixel_y = -23
 	},
@@ -54915,7 +54702,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/button/door{
-	dir = 2;
 	id = "supermatter_external";
 	name = "Supermatter External Lockdown";
 	pixel_x = 5;
@@ -54977,7 +54763,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/medical";
-	dir = 2;
 	name = "Medical Maintenance APC";
 	pixel_y = -24
 	},
@@ -54994,7 +54779,6 @@
 	pixel_y = 3
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -55594,9 +55378,7 @@
 	req_access_txt = "13"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -55815,7 +55597,6 @@
 	pixel_x = 24
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/wood,
@@ -55923,11 +55704,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Left Wing 1";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -56095,7 +55874,6 @@
 "uzG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research";
-	dir = 2;
 	name = "Science Main APC";
 	pixel_y = -23
 	},
@@ -56597,7 +56375,6 @@
 /area/engine/atmos)
 "vUd" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Mix Bypass"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -56674,8 +56451,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Tool Storage";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -56756,7 +56532,6 @@
 "wrV" = (
 /obj/structure/kitchenspike,
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -56889,7 +56664,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Research - Toxins Storage";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/machinery/power/apc{
@@ -57114,7 +56888,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Main Airlock";
-	dir = 2;
 	network = list("ss13","Engineering","Engine")
 	},
 /turf/open/floor/plasteel,
@@ -90907,7 +90680,7 @@ aSx
 aSL
 aSQ
 aTe
-aSY
+aSQ
 aTb
 aSP
 aSP

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -13713,7 +13713,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGh" = (
-/obj/machinery/clonepod,
+/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGi" = (
@@ -13997,8 +13997,6 @@
 	dir = 1;
 	network = list("ss13","Medical")
 	},
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGN" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -12,6 +12,7 @@
 	network = list("ss13","Medical")
 	},
 /obj/machinery/sleeper{
+	icon_state = "sleeper";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67,7 +68,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Left Wing 3";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -96,7 +98,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Right Wing 3";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -104,6 +107,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aan" = (
 /obj/machinery/sleeper{
+	icon_state = "sleeper";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -336,7 +340,9 @@
 	pixel_y = 5
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Cremator"
+	c_tag = "Civilian - Chapel Cremator";
+	dir = 2;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -378,6 +384,7 @@
 /area/quartermaster/storage)
 "abb" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 3;
 	height = 5;
 	id = "mining_home";
@@ -414,6 +421,7 @@
 /area/quartermaster/storage)
 "abe" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 5;
 	height = 7;
 	id = "supply_home";
@@ -435,7 +443,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Right Wing 2";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -469,6 +478,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Mining";
+	departmentType = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
@@ -609,6 +619,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 1";
+	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -1047,6 +1058,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Storage";
+	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -1437,7 +1449,9 @@
 	pixel_y = 3
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Mass Driver"
+	c_tag = "Civilian - Chapel Mass Driver";
+	dir = 2;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -1446,7 +1460,9 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Airlock"
+	c_tag = "Civilian - Chapel Airlock";
+	dir = 2;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -1752,7 +1768,9 @@
 /area/ai_monitored/turret_protected/aisat/service)
 "aeK" = (
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Main 2"
+	c_tag = "Civilian - Chapel Main 2";
+	dir = 2;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -2533,9 +2551,9 @@
 /area/quartermaster/miningdock)
 "agx" = (
 /obj/machinery/mass_driver{
+	name = "Holy Driver";
 	dir = 1;
-	id = "chapelgun";
-	name = "Holy Driver"
+	id = "chapelgun"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/window/southleft{
@@ -2814,6 +2832,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Starboard Aux Solars Access";
+	dir = 2;
 	network = list("ss13","Engineering")
 	},
 /turf/open/floor/plating,
@@ -3058,7 +3077,9 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "ahJ" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "ahK" = (
@@ -4026,6 +4047,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4615,7 +4637,9 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Dorm Fitness 2"
+	c_tag = "Civilian - Dorm Fitness 2";
+	dir = 2;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -4736,6 +4760,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/computer/cargo,
 /obj/machinery/button/door{
+	dir = 2;
 	id = "cargoload";
 	layer = 4;
 	name = "Loading Doors";
@@ -5118,6 +5143,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -5225,7 +5251,8 @@
 	dir = 6
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Captain's Private Quarters"
+	c_tag = "Bridge - Captain's Private Quarters";
+	dir = 2
 	},
 /obj/structure/sign/plaques/golden/captain{
 	pixel_y = 32
@@ -5303,6 +5330,7 @@
 "anq" = (
 /obj/machinery/camera{
 	c_tag = "Research - Experimentor Bay";
+	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/engine,
@@ -5823,6 +5851,7 @@
 "aoM" = (
 /obj/machinery/camera{
 	c_tag = "Research - Main 4";
+	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/plasteel/white/side{
@@ -6165,6 +6194,7 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera{
 	c_tag = "Engineering - Job Equipment";
+	dir = 2;
 	network = list("ss13","Engineering","Engine")
 	},
 /obj/structure/cable/yellow{
@@ -6428,6 +6458,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
+	icon_state = "soda_dispenser";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -6484,7 +6515,8 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control"
+	name = "Starboard Quarter Solar Control";
+	track = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -6753,7 +6785,9 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
-	c_tag = "Civilian - Dorm Main 1"
+	c_tag = "Civilian - Dorm Main 1";
+	dir = 2;
+	network = list("ss13")
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -6773,7 +6807,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Holodeck";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -7456,6 +7491,7 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
+	departmentType = 0;
 	pixel_x = -30
 	},
 /obj/item/t_scanner,
@@ -7481,10 +7517,10 @@
 	maxcharge = 15000
 	},
 /obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 2;
-	pixel_y = 2
+	pixel_y = 2;
+	charge = 100;
+	maxcharge = 15000
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
@@ -7611,6 +7647,7 @@
 "asL" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
+	req_access_txt = "0";
 	req_one_access_txt = "6;22"
 	},
 /turf/open/floor/plasteel/dark,
@@ -7772,7 +7809,9 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Dorm Laundry Room"
+	c_tag = "Civilian - Dorm Laundry Room";
+	dir = 2;
+	network = list("ss13")
 	},
 /obj/item/radio/intercom{
 	pixel_y = 24
@@ -7787,6 +7826,7 @@
 "atf" = (
 /obj/machinery/space_heater,
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8253,7 +8293,9 @@
 /area/crew_quarters/fitness)
 "auk" = (
 /obj/machinery/door/window/eastright{
+	base_state = "right";
 	dir = 8;
+	icon_state = "right";
 	name = "Fitness Ring"
 	},
 /obj/structure/window/reinforced{
@@ -8368,7 +8410,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -8376,7 +8420,9 @@
 	dir = 1;
 	pixel_y = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "auw" = (
 /obj/structure/table,
@@ -8723,6 +8769,7 @@
 /area/ai_monitored/storage/eva)
 "avp" = (
 /obj/docking_port/stationary/random{
+	dir = 1;
 	id = "pod_lavaland2";
 	name = "lavaland"
 	},
@@ -8730,6 +8777,7 @@
 /area/space/nearstation)
 "avq" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 1;
 	height = 4;
 	name = "escape pod loader";
@@ -8756,9 +8804,9 @@
 	pixel_y = -2
 	},
 /obj/item/stack/sheet/rglass{
-	amount = 50;
 	pixel_x = 5;
-	pixel_y = 1
+	pixel_y = 1;
+	amount = 50
 	},
 /obj/item/stack/rods/fifty,
 /obj/item/stack/rods/fifty{
@@ -10071,6 +10119,7 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /obj/machinery/camera{
@@ -10114,6 +10163,7 @@
 "ayt" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Foyer";
+	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -10803,7 +10853,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Main 3"
+	c_tag = "Bridge - Main 3";
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -11187,12 +11238,16 @@
 /area/science/xenobiology)
 "aAR" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "aAS" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "aAT" = (
@@ -11651,6 +11706,7 @@
 "aBQ" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 3";
+	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -12087,6 +12143,7 @@
 "aCO" = (
 /obj/machinery/camera{
 	c_tag = "Research - Server Room";
+	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -12667,6 +12724,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -12784,11 +12842,15 @@
 	pixel_y = -3
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "aEp" = (
 /obj/structure/table/glass,
@@ -13014,12 +13076,16 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "aEN" = (
 /turf/open/floor/wood,
@@ -13082,6 +13148,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Genetics";
+	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -13227,6 +13294,7 @@
 /area/medical/genetics)
 "aFh" = (
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -13234,6 +13302,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Front Lobby";
+	dir = 2;
 	network = list("ss13","Medical")
 	},
 /mob/living/simple_animal/bot/cleanbot{
@@ -13369,6 +13438,7 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -2;
 	pixel_y = 25;
@@ -13713,7 +13783,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGh" = (
-/obj/machinery/clonepod/mapped,
+/obj/machinery/clonepod,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGi" = (
@@ -13926,6 +13996,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -13989,6 +14060,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
+	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_y = -30
 	},
@@ -14457,6 +14529,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Backroom";
+	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -14757,6 +14830,7 @@
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Isolation B";
+	dir = 2;
 	network = list("ss13","Medical","Virology")
 	},
 /turf/open/floor/plasteel/white,
@@ -14918,6 +14992,7 @@
 "aJd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
+	req_access_txt = "0";
 	req_one_access_txt = "6;20"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -15084,6 +15159,7 @@
 "aJu" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 2";
+	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -15294,7 +15370,9 @@
 /area/medical/surgery)
 "aJQ" = (
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/white/side{
+	dir = 2
+	},
 /area/medical/surgery)
 "aJR" = (
 /obj/structure/table/glass,
@@ -15471,6 +15549,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Isolation A";
+	dir = 2;
 	network = list("ss13","Medical","Virology")
 	},
 /turf/open/floor/plasteel/white,
@@ -15824,6 +15903,7 @@
 /obj/machinery/button/door{
 	id = "podescape";
 	name = "Pod Bay Control";
+	normaldoorcontrol = 0;
 	pixel_x = 8;
 	pixel_y = 24
 	},
@@ -17288,6 +17368,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -18069,6 +18150,7 @@
 "aQA" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
+	req_access_txt = "0";
 	req_one_access_txt = "35;28"
 	},
 /turf/open/floor/plasteel,
@@ -18882,6 +18964,7 @@
 "aSv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "atmospherics mix pump"
 	},
 /turf/open/floor/plasteel,
@@ -19076,6 +19159,7 @@
 "aST" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /turf/open/space/basic,
@@ -19117,6 +19201,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
+"aSY" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "aSZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19156,7 +19246,9 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "aTe" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2
+	},
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = 8;
 	pixel_y = 24
@@ -19866,6 +19958,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -22151,12 +22244,14 @@
 /area/maintenance/department/security)
 "aYZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 2;
 	external_pressure_bound = 140;
-	name = "killroom vent";
-	pressure_checks = 0
+	pressure_checks = 0;
+	name = "killroom vent"
 	},
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Northen Kill Chamber";
+	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/circuit/telecomms,
@@ -23156,7 +23251,8 @@
 /area/security/main)
 "baM" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12;1"
+	req_access_txt = "12;1";
+	req_one_access_txt = "0"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25530,7 +25626,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12;63"
+	req_access_txt = "12;63";
+	req_one_access_txt = "0"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -25826,9 +25923,9 @@
 	pixel_y = 7
 	},
 /obj/item/flashlight/lamp/green{
-	on = 0;
 	pixel_x = 6;
-	pixel_y = 6
+	pixel_y = 6;
+	on = 0
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -25863,6 +25960,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Cell 2";
+	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -26302,6 +26400,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
+	req_access_txt = "0";
 	req_one_access_txt = "12;22"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -26400,6 +26499,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -26723,6 +26823,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 3";
+	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -26732,6 +26833,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -2;
 	pixel_y = 25;
@@ -27103,6 +27205,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Main Hall 3";
+	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -27706,9 +27809,9 @@
 "bko" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hor";
 	dir = 8;
 	name = "RD Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow,
@@ -27882,6 +27985,7 @@
 "bkF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical/Science Maintenance Access";
+	req_access_txt = "0";
 	req_one_access_txt = "5;47"
 	},
 /obj/structure/disposalpipe/segment{
@@ -28091,7 +28195,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Fitness 3";
-	dir = 1
+	dir = 1;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -28146,6 +28251,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 4";
+	dir = 2;
 	network = list("ss13","Security")
 	},
 /turf/open/floor/plasteel,
@@ -28253,6 +28359,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "robotics2";
 	name = "Shutters Control Button";
 	pixel_y = 24;
@@ -28899,8 +29006,8 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/ten,
 /obj/item/stack/sheet/glass{
-	amount = 10;
-	pixel_y = 3
+	pixel_y = 3;
+	amount = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -29001,6 +29108,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 24;
@@ -29509,6 +29617,7 @@
 "bnK" = (
 /obj/structure/table,
 /obj/machinery/button/massdriver{
+	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = 5
 	},
@@ -29609,19 +29718,19 @@
 	name = "SUPER package wrapper"
 	},
 /obj/item/destTagger{
-	currTag = 20;
-	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
-	locked_destination = 1;
 	name = "kitchen destination tagger";
-	pixel_x = 1
+	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
+	pixel_x = 1;
+	currTag = 20;
+	locked_destination = 1
 	},
 /obj/item/destTagger{
-	currTag = 20;
-	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
-	locked_destination = 1;
 	name = "kitchen destination tagger";
+	desc = "Used to set the destination of properly wrapped packages. This one seemed locked to the Kitchen as a destination.";
 	pixel_x = 4;
-	pixel_y = 3
+	pixel_y = 3;
+	currTag = 20;
+	locked_destination = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -31522,12 +31631,16 @@
 	name = "navigation beacon (Kitchen Delivery)"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/machinery/door/window/northleft{
 	name = "Kitchen Delivery Access";
 	req_access_txt = "28"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/crew_quarters/kitchen/coldroom)
 "brC" = (
 /obj/machinery/light/small{
@@ -31694,6 +31807,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Main 3";
+	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /obj/structure/closet/firecloset,
@@ -31713,7 +31827,8 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control"
+	name = "Starboard Quarter Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -31914,7 +32029,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Docking Bay";
-	dir = 1
+	dir = 1;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -32136,7 +32252,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Fitness 1";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -32286,6 +32403,7 @@
 /area/hallway/primary/central)
 "bsQ" = (
 /obj/machinery/door/airlock/maintenance{
+	req_access_txt = "0";
 	req_one_access_txt = "6;12;50"
 	},
 /obj/structure/cable/yellow{
@@ -32636,7 +32754,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Commissary";
-	dir = 1
+	dir = 1;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
@@ -33598,7 +33717,8 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Main 2";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
@@ -35372,6 +35492,7 @@
 "byV" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
+	req_access_txt = "0";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35429,7 +35550,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Quartermaster's Office";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -35591,7 +35713,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Main 2";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -35836,6 +35959,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Airlock";
+	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -36103,6 +36227,7 @@
 	},
 /obj/structure/transit_tube/station/reverse/flipped,
 /obj/structure/transit_tube_pod{
+	icon_state = "pod";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -36153,6 +36278,7 @@
 "bAH" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
+	req_access_txt = "0";
 	req_one_access_txt = "12;20"
 	},
 /obj/structure/cable/yellow{
@@ -36385,7 +36511,8 @@
 "bBf" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Main 3";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -37257,7 +37384,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -37449,6 +37578,7 @@
 /area/maintenance/disposal)
 "bCZ" = (
 /obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
 	machinedir = 8
 	},
 /turf/closed/wall,
@@ -37481,12 +37611,16 @@
 	name = "navigation beacon (Hydroponics Delivery)"
 	},
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/machinery/door/window/eastright{
 	name = "Hydroponics Delivery Access";
 	req_access_txt = "35"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/hydroponics)
 "bDd" = (
 /obj/docking_port/stationary{
@@ -38133,7 +38267,8 @@
 /obj/item/screwdriver,
 /obj/machinery/camera{
 	c_tag = "Cargo - Main 1";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -38680,7 +38815,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Front Lobby";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -38760,6 +38896,7 @@
 "bFq" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Nitrous Oxide Tank";
+	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /turf/open/floor/engine/n2o{
@@ -38950,7 +39087,8 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "12;1"
+	req_access_txt = "12;1";
+	req_one_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -40143,7 +40281,9 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -40177,6 +40317,7 @@
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -40810,6 +40951,7 @@
 "bJz" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Core North";
+	dir = 2;
 	network = list("AISat")
 	},
 /turf/open/floor/plasteel/dark,
@@ -40935,6 +41077,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Distro Loop";
+	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -41547,6 +41690,7 @@
 "bLg" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
+	enabled = 1;
 	name = "AI Chamber Foyer Control";
 	pixel_y = -24;
 	req_access = null;
@@ -41860,6 +42004,7 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai";
+	enabled = 1;
 	name = "AI Chamber Turret Control";
 	pixel_x = 32;
 	pixel_y = -24;
@@ -42241,6 +42386,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Secure - External Telecomm Sat South";
+	dir = 2;
 	network = list("Telecom")
 	},
 /turf/open/space/basic,
@@ -42300,6 +42446,7 @@
 "bMM" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -42312,6 +42459,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -42322,6 +42470,7 @@
 "bMN" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -42334,6 +42483,7 @@
 	pixel_y = 5
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -42400,12 +42550,14 @@
 	pixel_y = -9
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -31
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -42623,6 +42775,7 @@
 "bNk" = (
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI External South";
+	dir = 2;
 	network = list("AISat")
 	},
 /obj/structure/lattice,
@@ -42852,6 +43005,7 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/camera{
 	c_tag = "Medical - Surgery Observatory";
+	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/dark,
@@ -42988,6 +43142,7 @@
 "bNP" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 1";
+	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -43227,7 +43382,8 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Main 3";
-	dir = 1
+	dir = 1;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -43263,7 +43419,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Garden Main 1";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
@@ -43271,7 +43428,8 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Civilian - Garden Main 2";
-	dir = 1
+	dir = 1;
+	network = list("ss13")
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
@@ -43281,7 +43439,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Main 2";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -43297,14 +43456,16 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Lounge";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
 "bOy" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Main 1";
-	dir = 8
+	dir = 8;
+	network = list("ss13")
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -43492,7 +43653,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Secure - Gateway";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
@@ -43766,7 +43928,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Morgue";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -43934,7 +44097,8 @@
 	dir = 6
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Central Southeast 1"
+	c_tag = "Hallway - Central Southeast 1";
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -43961,7 +44125,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Central West 1"
+	c_tag = "Hallway - Central West 1";
+	dir = 2
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
@@ -43985,7 +44150,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Central West 2"
+	c_tag = "Hallway - Central West 2";
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -44002,7 +44168,8 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Breakroom"
+	c_tag = "Bridge - Breakroom";
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -44024,7 +44191,8 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Captain's Office"
+	c_tag = "Bridge - Captain's Office";
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -44657,7 +44825,9 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table,
-/obj/item/clothing/head/that,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
 /obj/item/toy/figure/bartender,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -45172,14 +45342,14 @@
 /area/maintenance/department/security)
 "bSA" = (
 /obj/item/clothing/head/helmet/old{
-	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50);
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 3;
+	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	},
 /obj/item/clothing/head/helmet/old{
-	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50);
 	pixel_x = 1;
-	pixel_y = -2
+	pixel_y = -2;
+	armor = list("melee" = 20, "bullet" = 15, "laser" = 15, "energy" = 5, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	},
 /obj/structure/rack,
 /obj/structure/sign/poster/contraband/fun_police{
@@ -45430,7 +45600,9 @@
 	},
 /obj/item/clothing/suit/apron/purple_bartender,
 /obj/item/clothing/suit/apron/purple_bartender,
-/obj/item/clothing/head/that,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTc" = (
@@ -45981,8 +46153,8 @@
 /area/science/mixing)
 "bUg" = (
 /obj/machinery/atmospherics/components/binary/valve{
-	dir = 1;
-	name = "mix to port"
+	name = "mix to port";
+	dir = 1
 	},
 /obj/machinery/button/door/incinerator_vent_toxmix{
 	pixel_y = 28
@@ -46181,9 +46353,9 @@
 /area/quartermaster/warehouse)
 "bUF" = (
 /obj/machinery/power/apc{
-	areastring = "/area/engine/gravity_generator";
 	dir = 8;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -46249,7 +46421,8 @@
 /obj/structure/table/wood,
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Main 1";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -46479,7 +46652,9 @@
 /area/maintenance/fore)
 "bVr" = (
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Office"
+	c_tag = "Civilian - Chapel Office";
+	dir = 2;
+	network = list("ss13")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -47049,9 +47224,9 @@
 /obj/structure/table,
 /obj/item/stack/sheet/iron/twenty,
 /obj/item/stack/sheet/glass{
-	amount = 20;
 	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 3;
+	amount = 20
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -48542,6 +48717,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
+	icon_state = "booze_dispenser";
 	dir = 4
 	},
 /obj/structure/sign/poster/official/high_class_martini{
@@ -48589,12 +48765,16 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/ai_monitored/security/armory)
 "caD" = (
 /obj/structure/table,
@@ -49270,10 +49450,10 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen{
-	dir = 4;
 	name = "Test Chamber Monitor";
-	network = list("xeno");
-	pixel_y = 2
+	dir = 4;
+	pixel_y = 2;
+	network = list("xeno")
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -49309,6 +49489,7 @@
 "ccm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer{
+	icon_state = "0";
 	dir = 4
 	},
 /obj/item/circuitboard/computer/powermonitor,
@@ -49419,6 +49600,7 @@
 /area/construction)
 "ccB" = (
 /obj/structure/transit_tube_pod{
+	icon_state = "pod";
 	dir = 4
 	},
 /obj/structure/transit_tube/station/reverse{
@@ -49753,7 +49935,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Left Wing 2";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/white/side{
@@ -49795,9 +49978,9 @@
 	amount = 5
 	},
 /obj/item/stack/cable_coil{
-	amount = 5;
 	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 3;
+	amount = 5
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 10
@@ -49884,6 +50067,7 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
+	enabled = 1;
 	name = "AI Chamber Foyer Control";
 	pixel_y = -24;
 	req_access = null;
@@ -50010,6 +50194,7 @@
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
+	dir = 2;
 	freq = 1400;
 	location = "Atmospherics";
 	name = "navigation beacon (Atmospherics Delivery)"
@@ -50017,6 +50202,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/southleft{
 	name = "Atmospherics Delivery Access";
+	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
 /turf/open/floor/plasteel,
@@ -50918,6 +51104,7 @@
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/engine/engine_room";
+	dir = 2;
 	name = "Engine Room APC";
 	pixel_y = -23
 	},
@@ -51277,6 +51464,7 @@
 /obj/machinery/button/door{
 	id = "podescape";
 	name = "Pod Bay Control";
+	normaldoorcontrol = 0;
 	pixel_x = -8;
 	pixel_y = 24
 	},
@@ -51342,6 +51530,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research - Research Director's Office";
+	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -51591,6 +51780,7 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "supermatter_external";
 	name = "Supermatter External Lockdown";
 	pixel_x = 36;
@@ -51614,6 +51804,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = 24;
@@ -51657,6 +51848,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/library/lounge";
+	dir = 2;
 	name = "Lounge APC";
 	pixel_y = -23
 	},
@@ -51742,6 +51934,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
+	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_x = -30
 	},
@@ -51815,6 +52008,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/science";
+	dir = 2;
 	name = "Science Checkpoint APC";
 	pixel_y = -23
 	},
@@ -51969,6 +52163,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/dorms";
+	dir = 2;
 	name = "Sleeping Quarters APC";
 	pixel_y = -23
 	},
@@ -52271,7 +52466,9 @@
 	name = "External Airlock";
 	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -52313,6 +52510,7 @@
 "hYL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	dir = 2;
 	name = "AI Upload APC";
 	pixel_y = -23
 	},
@@ -52328,6 +52526,7 @@
 "ibF" = (
 /obj/machinery/power/apc{
 	areastring = "/area/lawoffice";
+	dir = 2;
 	name = "Lawyer's Office APC";
 	pixel_y = -23
 	},
@@ -52402,6 +52601,7 @@
 "ili" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white/side{
@@ -52905,6 +53105,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/lobby";
+	dir = 2;
 	name = "Medical Lobby APC";
 	pixel_y = -24
 	},
@@ -53014,6 +53215,7 @@
 /obj/item/paper/monitorkey,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/chief";
+	dir = 2;
 	name = "CE Office APC";
 	pixel_y = -23
 	},
@@ -53076,6 +53278,7 @@
 /obj/machinery/ntnet_relay,
 /obj/machinery/power/apc{
 	areastring = "/area/tcommsat/server";
+	dir = 2;
 	name = "Telecomms Servers APC";
 	pixel_y = -23
 	},
@@ -53110,6 +53313,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -53324,6 +53528,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
+	dir = 2;
 	name = "Theatre APC";
 	pixel_y = -23
 	},
@@ -53427,6 +53632,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/gateway";
+	dir = 2;
 	name = "Gateway APC";
 	pixel_y = -23
 	},
@@ -53626,6 +53832,7 @@
 "naE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
+	dir = 2;
 	name = "Brig APC";
 	pixel_y = -23
 	},
@@ -53675,6 +53882,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -53818,9 +54026,11 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Right Wing 1";
-	dir = 1
+	dir = 1;
+	network = list("ss13")
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -54210,6 +54420,7 @@
 "oMw" = (
 /obj/machinery/camera{
 	c_tag = "Research - Toxins Main 2";
+	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54255,8 +54466,9 @@
 /area/engine/engine_room/external)
 "oVG" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai";
+	dir = 2;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = -23
 	},
 /obj/machinery/flasher{
@@ -54566,6 +54778,7 @@
 /obj/structure/table,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics/cloning";
+	dir = 2;
 	name = "Cloning Bay APC";
 	pixel_y = -23
 	},
@@ -54645,6 +54858,7 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -54653,6 +54867,7 @@
 /obj/structure/table/glass,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/virology";
+	dir = 2;
 	name = "Virology APC";
 	pixel_y = -23
 	},
@@ -54700,6 +54915,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/button/door{
+	dir = 2;
 	id = "supermatter_external";
 	name = "Supermatter External Lockdown";
 	pixel_x = 5;
@@ -54761,6 +54977,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/medical";
+	dir = 2;
 	name = "Medical Maintenance APC";
 	pixel_y = -24
 	},
@@ -54777,6 +54994,7 @@
 	pixel_y = 3
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -55376,7 +55594,9 @@
 	req_access_txt = "13"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -55595,6 +55815,7 @@
 	pixel_x = 24
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/wood,
@@ -55702,9 +55923,11 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Hallway - Escape Left Wing 1";
-	dir = 1
+	dir = 1;
+	network = list("ss13")
 	},
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -55872,6 +56095,7 @@
 "uzG" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research";
+	dir = 2;
 	name = "Science Main APC";
 	pixel_y = -23
 	},
@@ -56373,6 +56597,7 @@
 /area/engine/atmos)
 "vUd" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Mix Bypass"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -56449,7 +56674,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Tool Storage";
-	dir = 4
+	dir = 4;
+	network = list("ss13")
 	},
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -56530,6 +56756,7 @@
 "wrV" = (
 /obj/structure/kitchenspike,
 /obj/item/radio/intercom{
+	dir = 2;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
@@ -56662,6 +56889,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Research - Toxins Storage";
+	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/machinery/power/apc{
@@ -56886,6 +57114,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Main Airlock";
+	dir = 2;
 	network = list("ss13","Engineering","Engine")
 	},
 /turf/open/floor/plasteel,
@@ -90678,7 +90907,7 @@ aSx
 aSL
 aSQ
 aTe
-aSQ
+aSY
 aTb
 aSP
 aSP

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -13783,7 +13783,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGh" = (
-/obj/machinery/clonepod,
+/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "aGi" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -26778,7 +26778,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/clonepod/mapped,
+/obj/machinery/clonepod/prefilled,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "aNw" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -26778,7 +26778,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/clonepod,
+/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "aNw" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -63700,7 +63700,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cvw" = (
-/obj/machinery/clonepod/mapped{
+/obj/machinery/clonepod/prefilled{
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -63699,9 +63699,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cvw" = (
-/obj/machinery/clonepod{
-	pixel_y = 2
-	},
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
@@ -63719,6 +63716,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cvx" = (
@@ -66051,6 +66049,7 @@
 /obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
+/obj/item/paper,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -66066,8 +66065,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "czY" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4311,8 +4311,7 @@
 /obj/structure/displaycase/captain{
 	pixel_y = 5;
 	req_access = null;
-	req_access_txt = "20";
-	req_one_access_txt = "0"
+	req_access_txt = "20"
 	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -66052,7 +66051,6 @@
 /obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
-/obj/item/paper,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -66068,6 +66066,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "czY" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -63700,7 +63700,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cvw" = (
-/obj/machinery/clonepod{
+/obj/machinery/clonepod/mapped{
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4311,7 +4311,8 @@
 /obj/structure/displaycase/captain{
 	pixel_y = 5;
 	req_access = null;
-	req_access_txt = "20"
+	req_access_txt = "20";
+	req_one_access_txt = "0"
 	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -63699,6 +63700,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cvw" = (
+/obj/machinery/clonepod{
+	pixel_y = 2
+	},
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
@@ -63716,7 +63720,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
 "cvx" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -28430,7 +28430,7 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bpy" = (
-/obj/machinery/clonepod,
+/obj/machinery/clonepod/prefilled,
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -28314,7 +28314,6 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bpy" = (
-/obj/machinery/clonepod,
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
@@ -28330,6 +28329,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "bpz" = (
@@ -30463,8 +30463,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btY" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -51,16 +51,18 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	dir = 4;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 4
 	},
 /obj/machinery/sleeper{
+	icon_state = "sleeper";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "aag" = (
 /obj/machinery/sleeper{
+	icon_state = "sleeper";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68,7 +70,8 @@
 "aah" = (
 /obj/structure/displaycase/captain{
 	req_access = null;
-	req_access_txt = "20"
+	req_access_txt = "20";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
@@ -170,6 +173,7 @@
 "acj" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -193,6 +197,7 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber Center";
+	dir = 2;
 	network = list("minisat")
 	},
 /obj/machinery/light/small{
@@ -211,13 +216,14 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/ai";
 	dir = 1;
 	name = "AI Chamber APC";
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 23
 	},
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -346,12 +352,14 @@
 	pixel_y = -9
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -31
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -395,6 +403,7 @@
 "acD" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
+	dir = 2;
 	network = list("minisat")
 	},
 /obj/machinery/light{
@@ -600,9 +609,9 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	dir = 8;
 	name = "MiniSat Antechamber APC";
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	pixel_x = -25
 	},
 /obj/machinery/recharger,
@@ -893,6 +902,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Port Fore";
+	dir = 2;
 	network = list("minisat")
 	},
 /turf/open/space,
@@ -920,6 +930,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Starboard Fore";
+	dir = 2;
 	network = list("minisat")
 	},
 /turf/open/space,
@@ -1268,9 +1279,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/AIsatextAP";
 	dir = 8;
 	name = "MiniSat Port Maintenance APC";
+	areastring = "/area/ai_monitored/turret_protected/AIsatextAP";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -1296,6 +1307,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Port Aft";
+	dir = 2;
 	network = list("minisat")
 	},
 /obj/structure/cable/yellow{
@@ -1368,6 +1380,7 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
+	dir = 2;
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -1419,6 +1432,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Starboard Aft";
+	dir = 2;
 	network = list("minisat")
 	},
 /obj/structure/cable/yellow{
@@ -1435,9 +1449,9 @@
 "afm" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/AIsatextAS";
 	dir = 4;
 	name = "MiniSat Starboard Maintenance APC";
+	areastring = "/area/ai_monitored/turret_protected/AIsatextAS";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -1754,7 +1768,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "agi" = (
 /obj/machinery/door/poddoor{
-	id = "executionspaceblast"
+	id = "executionspaceblast";
+	name = "blast door"
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -1783,8 +1798,10 @@
 "ago" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
+	dir = 8;
 	icon_state = "right";
-	name = "Unisex Showers"
+	name = "Unisex Showers";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1899,7 +1916,8 @@
 /area/security/prison)
 "agC" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom"
+	name = "Unisex Restroom";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1939,6 +1957,7 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -1966,6 +1985,7 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1983,6 +2003,7 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -2013,6 +2034,7 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -2129,6 +2151,7 @@
 "ahh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/showcase/cyborg/old{
+	dir = 2;
 	pixel_y = 20
 	},
 /turf/open/space,
@@ -2237,6 +2260,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Entrance";
+	dir = 2;
 	network = list("minisat")
 	},
 /turf/open/space,
@@ -2377,6 +2401,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/computer/security/telescreen/prison{
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2651,7 +2676,8 @@
 "aik" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor"
+	c_tag = "Armory Motion Sensor";
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3710,6 +3736,7 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/item/bedsheet/dorms,
@@ -3927,6 +3954,7 @@
 	icon_state = "secbot1";
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
+	on = 1;
 	weaponscheck = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -4186,7 +4214,9 @@
 /area/security/brig)
 "alt" = (
 /obj/machinery/door/window/westleft{
+	base_state = "left";
 	dir = 4;
+	icon_state = "left";
 	name = "Brig Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -4958,7 +4988,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Control Room"
+	c_tag = "Brig Control Room";
+	dir = 2
 	},
 /obj/item/radio/intercom{
 	dir = 4;
@@ -5077,7 +5108,8 @@
 /area/space/nearstation)
 "anm" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Pete's Speakeasy"
+	name = "Pete's Speakeasy";
+	req_access_txt = "0"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
@@ -5408,6 +5440,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	dir = 2;
 	name = "Head of Security's Office APC";
 	pixel_y = -23
 	},
@@ -6402,7 +6435,8 @@
 /area/security/brig)
 "aqq" = (
 /obj/machinery/camera{
-	c_tag = "Brig Cells"
+	c_tag = "Brig Cells";
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6725,6 +6759,7 @@
 /area/crew_quarters/dorms)
 "aqY" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 2;
 	height = 6;
 	id = "monastery_shuttle_station";
@@ -7020,7 +7055,8 @@
 "arL" = (
 /obj/machinery/computer/card,
 /obj/machinery/camera{
-	c_tag = "Bridge - Central"
+	c_tag = "Bridge - Central";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8179,8 +8215,8 @@
 "aud" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
+	network = list("vault");
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -8287,6 +8323,7 @@
 /area/crew_quarters/dorms)
 "aun" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8335,6 +8372,7 @@
 "aux" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -8710,7 +8748,8 @@
 	dir = 10
 	},
 /obj/machinery/camera{
-	c_tag = "Dormitories Fore"
+	c_tag = "Dormitories Fore";
+	dir = 2
 	},
 /obj/machinery/light{
 	dir = 1
@@ -9360,7 +9399,8 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Fitness Room"
+	c_tag = "Fitness Room";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9386,9 +9426,9 @@
 	icon_state = "plant-05"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/fitness/recreation";
 	dir = 1;
 	name = "Fitness Room APC";
+	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -9538,7 +9578,9 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
-/obj/item/reagent_containers/food/snacks/donut,
+/obj/item/reagent_containers/food/snacks/donut{
+	layer = 3
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -9552,7 +9594,9 @@
 /area/security/brig)
 "awQ" = (
 /obj/structure/table/reinforced,
-/obj/item/pen,
+/obj/item/pen{
+	layer = 3
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -9891,7 +9935,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Captain's Quarters"
+	c_tag = "Captain's Quarters";
+	dir = 2
 	},
 /obj/item/clothing/suit/armor/riot/knight/blue,
 /obj/item/clothing/head/helmet/knight/blue,
@@ -10078,7 +10123,8 @@
 /obj/machinery/button/door{
 	id = "Dorm2Shutters";
 	name = "Privacy Shutters Control";
-	pixel_y = 26
+	pixel_y = 26;
+	req_access_txt = "0"
 	},
 /obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
@@ -10101,6 +10147,7 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -10201,7 +10248,8 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "portsolar";
-	name = "Port Solar Control"
+	name = "Port Solar Control";
+	track = 0
 	},
 /obj/structure/cable/yellow{
 	cable_color = "red";
@@ -10560,9 +10608,9 @@
 "azo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/bridge";
 	dir = 4;
 	name = "Bridge APC";
+	areastring = "/area/bridge";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -11370,9 +11418,9 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aBx" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	dir = 1;
 	name = "Upload APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -11442,7 +11490,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Head of Personnel's Office"
+	c_tag = "Head of Personnel's Office";
+	dir = 2
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -11522,7 +11571,8 @@
 /obj/machinery/button/door{
 	id = "Dorm1Shutters";
 	name = "Privacy Shutters Control";
-	pixel_y = 26
+	pixel_y = 26;
+	req_access_txt = "0"
 	},
 /obj/item/bedsheet/dorms,
 /turf/open/floor/plasteel/grimy,
@@ -11545,6 +11595,7 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -11784,6 +11835,7 @@
 /obj/item/analyzer,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
+	departmentType = 0;
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -12645,7 +12697,8 @@
 "aEc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Dormitories"
+	name = "Dormitories";
+	req_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -12655,7 +12708,8 @@
 /area/crew_quarters/toilet/restrooms)
 "aEe" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
+	name = "Unisex Restrooms";
+	req_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
@@ -12931,7 +12985,9 @@
 /obj/item/aiModule/supplied/oxygen,
 /obj/item/aiModule/zeroth/oneHuman,
 /obj/machinery/door/window{
+	base_state = "left";
 	dir = 8;
+	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -13313,6 +13369,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/northleft{
 	dir = 2;
+	icon_state = "left";
 	name = "Reception Window"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -13388,7 +13445,8 @@
 /area/crew_quarters/toilet/restrooms)
 "aFK" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Showers"
+	name = "Unisex Showers";
+	req_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14064,7 +14122,8 @@
 /area/hallway/primary/central)
 "aHn" = (
 /obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage"
+	name = "Starboard Emergency Storage";
+	req_access_txt = "0"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable/yellow{
@@ -14807,7 +14866,8 @@
 /area/hallway/primary/central)
 "aJn" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
+	name = "Unisex Restrooms";
+	req_access_txt = "0"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14914,7 +14974,8 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Departure Lounge Fore"
+	c_tag = "Departure Lounge Fore";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14936,9 +14997,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -15216,7 +15277,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Dormitory Cyborg Recharging Station"
+	c_tag = "Dormitory Cyborg Recharging Station";
+	dir = 2
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/freezer,
@@ -15838,7 +15900,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Security Post"
+	c_tag = "Cargo Security Post";
+	dir = 2
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -15990,6 +16053,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel,
@@ -16016,7 +16080,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Warehouse"
+	c_tag = "Cargo Warehouse";
+	dir = 2
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16040,9 +16105,9 @@
 	dir = 9
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
 	name = "Cargo Warehouse APC";
+	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -16292,6 +16357,7 @@
 "aNa" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
+	dir = 2;
 	name = "Cafeteria APC";
 	pixel_y = -23
 	},
@@ -16318,6 +16384,7 @@
 "aNe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
+	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	pixel_y = -23
 	},
@@ -16641,6 +16708,7 @@
 	id = "garbagestacked"
 	},
 /obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
 	machinedir = 8;
 	pixel_x = -32;
 	pixel_y = 32
@@ -17092,6 +17160,7 @@
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/caution/red{
+	icon_state = "caution_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17827,7 +17896,8 @@
 "aQU" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera{
-	c_tag = "Bar Backroom"
+	c_tag = "Bar Backroom";
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -17870,6 +17940,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	dir = 2;
 	name = "EVA Storage APC";
 	pixel_y = -23
 	},
@@ -18609,7 +18680,9 @@
 	location = "Kitchen"
 	},
 /obj/machinery/door/window/southleft{
+	base_state = "left";
 	dir = 8;
+	icon_state = "left";
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
@@ -19028,6 +19101,7 @@
 /area/solar/starboard)
 "aTH" = (
 /obj/docking_port/stationary{
+	dheight = 0;
 	dir = 8;
 	dwidth = 4;
 	height = 15;
@@ -19170,7 +19244,8 @@
 /area/crew_quarters/kitchen)
 "aTZ" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
+	c_tag = "Kitchen Cold Room";
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -19626,6 +19701,9 @@
 /area/crew_quarters/kitchen)
 "aVc" = (
 /obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -19908,17 +19986,18 @@
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
+	req_access_txt = "31";
 	pixel_x = 24;
-	pixel_y = -8;
-	req_access_txt = "31"
+	pixel_y = -8
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
+	req_access_txt = "31";
 	pixel_x = 24;
-	pixel_y = 8;
-	req_access_txt = "31"
+	pixel_y = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Supply Dock";
@@ -20075,6 +20154,7 @@
 /area/crew_quarters/kitchen)
 "aVX" = (
 /obj/machinery/power/apc{
+	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -23
 	},
@@ -20139,7 +20219,8 @@
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Bar Access"
+	c_tag = "Bar Access";
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20565,7 +20646,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aXb" = (
@@ -20581,7 +20664,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aXd" = (
@@ -20649,6 +20734,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Theatre";
+	departmentType = 0;
 	name = "theatre RC";
 	pixel_x = -32;
 	pixel_y = -32
@@ -21085,6 +21171,7 @@
 "aYd" = (
 /obj/machinery/door/airlock{
 	name = "Service Access";
+	req_access_txt = "0";
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
 /obj/structure/disposalpipe/segment,
@@ -21582,6 +21669,7 @@
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 3;
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -22306,8 +22394,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/office";
+	dir = 2;
 	name = "Cargo Office APC";
+	areastring = "/area/quartermaster/office";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -22355,6 +22444,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	dir = 2;
 	name = "Cargo Bay APC";
 	pixel_y = -23
 	},
@@ -22464,6 +22554,7 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "papersplease";
 	name = "Shutters Control Button";
 	pixel_x = -26;
@@ -22519,6 +22610,7 @@
 /area/security/checkpoint/customs)
 "baU" = (
 /obj/machinery/power/apc{
+	dir = 2;
 	name = "Security Checkpoint APC";
 	pixel_x = 1;
 	pixel_y = -23
@@ -22548,6 +22640,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
 	pixel_x = 25;
@@ -22566,6 +22659,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
 	pixel_x = -25;
@@ -22727,7 +22821,9 @@
 /area/crew_quarters/bar)
 "bbs" = (
 /obj/item/cane,
-/obj/item/clothing/head/that,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet{
 	icon_state = "carpetsymbol"
@@ -23341,7 +23437,8 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "starboardsolar";
-	name = "Starboard Solar Control"
+	name = "Starboard Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -23626,9 +23723,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/qm";
 	dir = 8;
 	name = "Quartermaster APC";
+	areastring = "/area/quartermaster/qm";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -23692,6 +23789,7 @@
 "bdM" = (
 /obj/machinery/requests_console{
 	department = "Mining";
+	departmentType = 0;
 	pixel_x = 32
 	},
 /obj/machinery/computer/security/mining{
@@ -25396,6 +25494,7 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 25;
@@ -25409,6 +25508,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = -25;
@@ -25596,7 +25696,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29"
+	req_access_txt = "29";
+	req_one_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25736,8 +25837,9 @@
 	pixel_y = 5
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/lounge";
+	dir = 2;
 	name = "Lounge APC";
+	areastring = "/area/crew_quarters/lounge";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -25814,7 +25916,9 @@
 "biW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/maintenance{
-	name = "Port Emergency Storage"
+	name = "Port Emergency Storage";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -25830,6 +25934,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
+	opacity = 1;
 	req_access_txt = "6"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26327,7 +26432,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29"
+	req_access_txt = "29";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -26340,6 +26446,7 @@
 "bkz" = (
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab Chamber";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
@@ -26444,7 +26551,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Foyer";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/power/apc{
@@ -26773,6 +26881,7 @@
 "blH" = (
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/structure/sink/kitchen{
@@ -26965,6 +27074,7 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Genetics Maintenance";
+	req_access_txt = "0";
 	req_one_access_txt = "12;45;5;9"
 	},
 /turf/open/floor/plating,
@@ -27047,9 +27157,9 @@
 /area/medical/morgue)
 "bms" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/medical";
 	dir = 8;
 	name = "Medbay Security APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -27057,8 +27167,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Security Post";
-	dir = 4;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/med,
 /obj/effect/turf_decal/tile/red{
@@ -27412,6 +27522,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Cloning";
+	req_access_txt = "0";
 	req_one_access_txt = "5;9"
 	},
 /obj/structure/cable/yellow{
@@ -27931,6 +28042,7 @@
 /area/medical/medbay/central)
 "boH" = (
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -27992,8 +28104,8 @@
 /obj/structure/bed/roller,
 /obj/machinery/camera{
 	c_tag = "Medbay Entrance";
-	dir = 1;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -28101,6 +28213,7 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "robotics";
 	name = "Shutters Control Button";
 	pixel_x = -26;
@@ -28150,6 +28263,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/camera{
 	c_tag = "Server Room";
+	dir = 2;
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -28231,6 +28345,7 @@
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
+	dir = 2;
 	name = "Science Requests Console";
 	pixel_y = 30;
 	receive_ore_updates = 1
@@ -28242,6 +28357,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab Central";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -28314,6 +28430,7 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bpy" = (
+/obj/machinery/clonepod,
 /obj/item/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
@@ -28329,7 +28446,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/clonepod/mapped,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "bpz" = (
@@ -28398,6 +28514,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "Morgue";
+	opacity = 1;
 	req_access_txt = "6"
 	},
 /obj/structure/cable/yellow{
@@ -28429,6 +28546,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
+	dir = 2;
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28462,6 +28580,7 @@
 	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
+	opacity = 1;
 	req_access_txt = "6"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28918,6 +29037,7 @@
 "bqH" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
+	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #5";
 	req_access_txt = "55"
@@ -28960,6 +29080,7 @@
 "bqK" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
+	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #6";
 	req_access_txt = "55"
@@ -28989,6 +29110,7 @@
 /area/science/xenobiology)
 "bqO" = (
 /obj/machinery/door/airlock/maintenance{
+	req_access_txt = "0";
 	req_one_access_txt = "12; 55"
 	},
 /obj/structure/cable/yellow{
@@ -29000,9 +29122,9 @@
 /area/maintenance/department/cargo)
 "bqS" = (
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/entry";
 	dir = 4;
 	name = "Arrivals APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -29095,6 +29217,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "GeneticsDoor";
 	name = "Cloning";
+	req_access_txt = "0";
 	req_one_access_txt = "5;9"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
@@ -29667,6 +29790,7 @@
 "bsf" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Starboard";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/structure/sign/departments/xenobio{
@@ -29726,8 +29850,8 @@
 /obj/machinery/dna_scannernew,
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 4
 	},
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
@@ -29894,7 +30018,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/camera,
+/obj/machinery/camera{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsF" = (
@@ -30350,7 +30476,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -30359,7 +30486,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
+	name = "Port Docking Bay 2";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -30565,9 +30693,9 @@
 	pixel_x = -28
 	},
 /obj/machinery/camera{
+	network = list("ss13","medbay");
 	c_tag = "Chemistry";
-	dir = 4;
-	network = list("ss13","medbay")
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -30664,7 +30792,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
-	req_access_txt = "29"
+	req_access_txt = "29";
+	req_one_access_txt = "0"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -30932,8 +31061,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay Port Hallway";
-	dir = 4;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -31200,6 +31329,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Science Access Airlock";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
@@ -31437,6 +31567,7 @@
 /area/maintenance/department/science)
 "bwn" = (
 /obj/machinery/door/airlock/maintenance{
+	req_access_txt = "0";
 	req_one_access_txt = "12; 55"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31571,6 +31702,7 @@
 /area/medical/genetics)
 "bwB" = (
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -31836,6 +31968,7 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "R&D Lab";
+	req_access_txt = "0";
 	req_one_access_txt = "7;29;30"
 	},
 /obj/effect/turf_decal/delivery,
@@ -31996,6 +32129,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"bxv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/explab)
 "bxw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -32134,6 +32279,7 @@
 "bxN" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
+	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #1";
 	req_access_txt = "55"
@@ -32170,6 +32316,7 @@
 "bxQ" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
+	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #2";
 	req_access_txt = "55"
@@ -32202,6 +32349,7 @@
 "bxS" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
+	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #3";
 	req_access_txt = "55"
@@ -33357,6 +33505,7 @@
 "bAm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Lab Maintenance";
+	req_access_txt = "0";
 	req_one_access_txt = "7;29"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33384,7 +33533,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
 	name = "Research Director's Office";
-	req_access_txt = "30"
+	req_access_txt = "30";
+	req_one_access_txt = "0"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -33629,6 +33779,7 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
+	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_x = 32
 	},
@@ -33790,8 +33941,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
-	dir = 8;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -34019,6 +34170,7 @@
 "bBF" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /turf/open/floor/engine,
@@ -34150,6 +34302,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/camera{
 	c_tag = "Toxins Lab Starboard";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/machinery/light{
@@ -34306,7 +34459,8 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34850,7 +35004,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "bDg" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bDh" = (
@@ -35006,9 +35162,9 @@
 /area/crew_quarters/heads/cmo)
 "bDx" = (
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/cmo";
 	dir = 4;
 	name = "CMO's Office APC";
+	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -36168,6 +36324,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 25;
 	pixel_y = 4;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/open/floor/plating,
@@ -36274,6 +36431,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -36744,7 +36902,9 @@
 /turf/open/floor/plating,
 /area/chapel/dock)
 "bGG" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2
+	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -37231,6 +37391,7 @@
 /area/science/mixing)
 "bHC" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37250,8 +37411,12 @@
 /area/science/mixing)
 "bHE" = (
 /obj/structure/window/reinforced,
-/obj/machinery/doppler_array/research/science,
-/obj/effect/turf_decal/bot,
+/obj/machinery/doppler_array/research/science{
+	dir = 2
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -37354,7 +37519,8 @@
 "bHY" = (
 /obj/machinery/camera{
 	c_tag = "Virology";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37423,8 +37589,8 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay Equipment Room";
-	dir = 1;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -37504,8 +37670,8 @@
 "bIm" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	dir = 8;
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37561,6 +37727,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery";
+	dir = 2;
 	network = list("ss13","surgery")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37764,6 +37931,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
+"bIK" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 2
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "bIL" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
@@ -37842,7 +38015,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bIX" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -38024,6 +38199,7 @@
 /area/medical/virology)
 "bJo" = (
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -38222,7 +38398,9 @@
 	c_tag = "Research Division Entrance";
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -38312,7 +38490,9 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bJQ" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2
+	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -38346,7 +38526,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
-	req_access_txt = "8"
+	req_access_txt = "8";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -38555,7 +38736,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Patient Room";
-	network = list("ss13","medbay")
+	network = list("ss13","medbay");
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38727,6 +38909,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/structure/cable/yellow{
@@ -38911,7 +39094,8 @@
 /area/chapel/dock)
 "bLq" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Monastery Transit"
+	name = "Monastery Transit";
+	opacity = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38989,7 +39173,8 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /obj/item/stack/sheet/mineral/plasma{
-	amount = 2
+	amount = 2;
+	layer = 3
 	},
 /obj/item/storage/box/monkeycubes{
 	layer = 3.1
@@ -39017,7 +39202,9 @@
 /area/medical/virology)
 "bLF" = (
 /obj/structure/table,
-/obj/item/clipboard,
+/obj/item/clipboard{
+	toppaper = null
+	},
 /obj/item/pen{
 	layer = 3.1
 	},
@@ -39351,7 +39538,8 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "8"
+	req_access_txt = "8";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -39654,6 +39842,7 @@
 "bMU" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway Atmospherics";
+	dir = 2;
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40612,7 +40801,8 @@
 /area/space/nearstation)
 "bPn" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+	name = "Chapel";
+	opacity = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40631,7 +40821,8 @@
 /area/chapel/dock)
 "bPo" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+	name = "Chapel";
+	opacity = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40963,7 +41154,8 @@
 /area/engine/gravity_generator)
 "bQo" = (
 /obj/machinery/camera{
-	c_tag = "Gravity Generator"
+	c_tag = "Gravity Generator";
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -41065,11 +41257,13 @@
 	light_color = "#cee5d2"
 	},
 /obj/machinery/camera{
-	c_tag = "Tech Storage"
+	c_tag = "Tech Storage";
+	dir = 2
 	},
 /obj/item/circuitboard/computer/monastery_shuttle,
 /obj/effect/spawner/lootdrop/techstorage/service,
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/green{
@@ -41152,8 +41346,8 @@
 /area/storage/tech)
 "bQB" = (
 /obj/machinery/power/apc{
-	dir = 8;
 	name = "Aft Hall APC";
+	dir = 8;
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -41188,6 +41382,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/northleft{
 	dir = 4;
+	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -41241,8 +41436,12 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/engine/atmos)
 "bQL" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -41254,12 +41453,17 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel{
+	dir = 2
+	},
 /area/engine/atmos)
 "bQN" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 1
+	dir = 1;
+	on = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41391,6 +41595,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41401,7 +41606,8 @@
 "bRe" = (
 /obj/structure/closet/radiation,
 /obj/machinery/camera{
-	c_tag = "Gravity Generator Foyer"
+	c_tag = "Gravity Generator Foyer";
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -41533,6 +41739,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/northleft{
 	dir = 4;
+	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -41935,8 +42142,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
+	name = "plasma mixer";
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -42322,6 +42529,7 @@
 /area/maintenance/department/engine)
 "bTf" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2;
 	name = "Virology Waste to Space"
 	},
 /turf/open/floor/plating{
@@ -42330,6 +42538,7 @@
 /area/maintenance/department/engine)
 "bTg" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Virology Waste to Atmospherics"
 	},
 /turf/open/floor/plating,
@@ -42410,7 +42619,9 @@
 	pixel_y = 1
 	},
 /obj/structure/table,
-/obj/item/paper/guides/jobs/engi/gravity_gen,
+/obj/item/paper/guides/jobs/engi/gravity_gen{
+	layer = 3
+	},
 /obj/item/pen/blue,
 /obj/machinery/power/terminal{
 	dir = 8
@@ -42565,8 +42776,9 @@
 /area/storage/tech)
 "bTB" = (
 /obj/machinery/power/apc{
-	areastring = "/area/storage/tech";
+	dir = 2;
 	name = "Tech Storage APC";
+	areastring = "/area/storage/tech";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -42654,7 +42866,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics Entrance"
+	c_tag = "Atmospherics Entrance";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42729,7 +42942,8 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
-	c_tag = "Atmospherics Mixing"
+	c_tag = "Atmospherics Mixing";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42759,7 +42973,8 @@
 /area/engine/atmos)
 "bTU" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 1
+	dir = 1;
+	on = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -43095,7 +43310,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Chief Engineer's Office"
+	c_tag = "Chief Engineer's Office";
+	dir = 2
 	},
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 30
@@ -43110,6 +43326,7 @@
 /area/crew_quarters/heads/chief)
 "bUK" = (
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/machinery/computer/apc_control,
@@ -43188,7 +43405,8 @@
 	},
 /obj/machinery/power/smes/engineering,
 /obj/machinery/camera{
-	c_tag = "Engineering Power Storage"
+	c_tag = "Engineering Power Storage";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -43642,9 +43860,9 @@
 	pixel_y = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
 	dir = 8;
 	name = "Engineering Security APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -43865,6 +44083,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
+	dir = 2;
 	pixel_x = 22
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -44179,7 +44398,8 @@
 /area/chapel/main/monastery)
 "bWW" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+	name = "Chapel";
+	opacity = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -44188,7 +44408,8 @@
 /area/chapel/main/monastery)
 "bWX" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+	name = "Chapel";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -44292,9 +44513,9 @@
 /obj/item/stack/rods/fifty,
 /obj/item/stack/cable_coil,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/engine/engine_smes";
 	dir = 8;
 	name = "Engine Room APC";
+	areastring = "/area/engine/engine_smes";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -44862,7 +45083,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Port Fore"
+	c_tag = "Engineering Port Fore";
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -44944,6 +45166,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45103,7 +45326,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Starboard Fore"
+	c_tag = "Engineering Starboard Fore";
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45177,6 +45401,7 @@
 	pixel_x = -25
 	},
 /obj/machinery/airalarm/unlocked{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/structure/cable/yellow{
@@ -45716,7 +45941,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
+	dir = 2
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caN" = (
@@ -45752,6 +45979,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Turbine Chamber";
+	dir = 2;
 	network = list("turbine")
 	},
 /turf/open/floor/engine/vacuum,
@@ -45882,7 +46110,9 @@
 	id = "SupermatterExternal";
 	name = "radiation shutters"
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -46021,7 +46251,8 @@
 /area/chapel/main/monastery)
 "cbR" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Access"
+	name = "Chapel Access";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -46132,6 +46363,7 @@
 "ccf" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Center";
+	dir = 2;
 	network = list("ss13","engine");
 	pixel_x = 23
 	},
@@ -46322,7 +46554,9 @@
 	id = "SupermatterExternal";
 	name = "radiation shutters"
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ccX" = (
@@ -46409,6 +46643,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Port Access";
+	dir = 2;
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
@@ -46655,6 +46890,7 @@
 "ceg" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Chapel Office";
+	opacity = 1;
 	req_access_txt = "22"
 	},
 /obj/structure/cable/yellow{
@@ -46674,7 +46910,8 @@
 /area/chapel/office)
 "cei" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+	name = "Chapel";
+	opacity = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46686,21 +46923,24 @@
 /area/chapel/main/monastery)
 "cej" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+	name = "Chapel";
+	opacity = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cek" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+	name = "Chapel";
+	opacity = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cel" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Access"
+	name = "Chapel Access";
+	opacity = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
@@ -46791,6 +47031,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Crematorium";
+	dir = 2;
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
@@ -46883,6 +47124,7 @@
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching telecomms.";
+	dir = 2;
 	layer = 4;
 	name = "Telecomms Telescreen";
 	network = list("tcomms");
@@ -46975,7 +47217,8 @@
 /area/chapel/office)
 "cfl" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Access"
+	name = "Chapel Access";
+	opacity = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -47265,6 +47508,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/camera{
 	c_tag = "Monastery Garden";
+	dir = 2;
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/grass,
@@ -47733,7 +47977,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cit" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "ciy" = (
@@ -47922,7 +48168,8 @@
 /area/chapel/main/monastery)
 "cjl" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Monastery Cemetary"
+	name = "Monastery Cemetary";
+	opacity = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47999,7 +48246,8 @@
 /area/chapel/main/monastery)
 "cjH" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Garden"
+	name = "Chapel Garden";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -48709,9 +48957,9 @@
 /area/tcommsat/computer)
 "cmk" = (
 /obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
 	dir = 1;
 	name = "Telecomms Monitoring APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -49117,6 +49365,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port Aft";
+	dir = 2;
 	network = list("tcomms")
 	},
 /turf/open/space,
@@ -49125,6 +49374,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard Aft";
+	dir = 2;
 	network = list("tcomms")
 	},
 /turf/open/space,
@@ -49168,7 +49418,8 @@
 "cnN" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/camera{
-	c_tag = "Brig Equipment Room"
+	c_tag = "Brig Equipment Room";
+	dir = 2
 	},
 /obj/item/radio/intercom{
 	pixel_y = 29
@@ -49290,7 +49541,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Dormitories"
+	name = "Dormitories";
+	req_access_txt = "0"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -49300,7 +49552,8 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "public external airlock"
+	name = "public external airlock";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
@@ -49472,7 +49725,8 @@
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Bar Drinks"
+	c_tag = "Bar Drinks";
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -49922,7 +50176,9 @@
 	c_tag = "Research Division Hallway";
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 2
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -50427,6 +50683,7 @@
 "csC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
+	name = "flask of holy water";
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -50529,6 +50786,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Starboard Access";
+	dir = 2;
 	network = list("ss13","monastery")
 	},
 /obj/structure/chair/wood/normal,
@@ -50619,7 +50877,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctu" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -50699,6 +50959,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Fore";
+	dir = 2;
 	network = list("ss13","monastery")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -50940,7 +51201,9 @@
 /area/hydroponics/garden/monastery)
 "cuG" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuH" = (
@@ -52016,6 +52279,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Fore";
+	dir = 2;
 	network = list("ss13","monastery")
 	},
 /obj/machinery/firealarm{
@@ -52347,7 +52611,9 @@
 	dir = 4
 	},
 /obj/machinery/door/window/northright{
+	base_state = "right";
 	dir = 2;
+	icon_state = "right";
 	name = "Curator Desk Door";
 	req_access_txt = "37"
 	},
@@ -52514,7 +52780,8 @@
 /obj/machinery/button/door{
 	id = "supplybridge";
 	name = "Space Bridge Control";
-	pixel_y = 27
+	pixel_y = 27;
+	req_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -52746,7 +53013,9 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cPy" = (
-/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2
+	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32;
 	pixel_y = 32
@@ -52819,6 +53088,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
 	base_state = "left";
+	dir = 4;
 	icon_state = "left";
 	name = "Research Division Delivery";
 	req_access_txt = "47"
@@ -52993,6 +53263,7 @@
 /area/chapel/office)
 "dqw" = (
 /obj/machinery/door/airlock/maintenance{
+	req_access_txt = "0";
 	req_one_access_txt = "12; 55"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -53658,7 +53929,9 @@
 /area/maintenance/department/engine)
 "fdS" = (
 /obj/machinery/door/window/southleft{
+	base_state = "left";
 	dir = 4;
+	icon_state = "left";
 	name = "Engineering Delivery";
 	req_access_txt = "10"
 	},
@@ -53863,6 +54136,7 @@
 "fwi" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engine Containment Starboard Fore";
+	dir = 2;
 	network = list("engine")
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -54065,6 +54339,7 @@
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
+	req_access_txt = "0";
 	req_one_access_txt = "35;28"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -54421,6 +54696,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "research_shutters_2";
 	name = "Shutters Control Button";
 	pixel_x = -28;
@@ -54829,6 +55105,7 @@
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
+	req_access_txt = "0";
 	req_one_access_txt = "32;47;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55589,6 +55866,7 @@
 	dir = 8
 	},
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering RC";
@@ -55939,7 +56217,9 @@
 /area/science/mixing/chamber)
 "kfM" = (
 /obj/structure/closet,
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 2
+	},
 /obj/item/storage/book/bible,
 /obj/item/storage/book/bible,
 /obj/item/storage/book/bible,
@@ -56097,6 +56377,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm{
+	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -56135,7 +56416,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "kDf" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 2
+	},
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "kDJ" = (
@@ -56279,6 +56562,7 @@
 "kNf" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
+	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #4";
 	req_access_txt = "55"
@@ -56372,7 +56656,9 @@
 /area/engine/engineering)
 "kSO" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Port Emergency Storage"
+	name = "Port Emergency Storage";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
@@ -56666,7 +56952,8 @@
 /area/maintenance/department/science)
 "lKL" = (
 /obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage"
+	name = "Starboard Emergency Storage";
+	req_access_txt = "0"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable/yellow{
@@ -56999,7 +57286,9 @@
 /area/bridge)
 "mzl" = (
 /obj/structure/chair,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mzU" = (
@@ -57230,6 +57519,7 @@
 "nku" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
+	opacity = 1;
 	req_access_txt = "27"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57306,9 +57596,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/construction/mining/aux_base";
 	dir = 8;
 	name = "Auxillary Base Construction APC";
+	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -57504,6 +57794,7 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
+	dir = 2;
 	network = list("tcomms")
 	},
 /obj/structure/cable/yellow{
@@ -57854,7 +58145,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Arrivals Port Fore"
+	c_tag = "Arrivals Port Fore";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -58451,6 +58743,7 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Area";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/structure/sign/poster/official/random{
@@ -59040,6 +59333,7 @@
 /area/maintenance/department/engine)
 "rfe" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -59227,7 +59521,9 @@
 	location = "Medbay"
 	},
 /obj/machinery/door/window/southleft{
+	base_state = "left";
 	dir = 4;
+	icon_state = "left";
 	name = "Medbay Delivery";
 	req_access_txt = "6"
 	},
@@ -59319,6 +59615,7 @@
 "rJZ" = (
 /obj/docking_port/stationary{
 	dheight = 4;
+	dir = 1;
 	dwidth = 4;
 	height = 9;
 	id = "aux_base_zone";
@@ -59351,7 +59648,8 @@
 /obj/machinery/button/door{
 	id = "shootshut";
 	name = "shutters control";
-	pixel_x = 28
+	pixel_x = 28;
+	req_access_txt = "0"
 	},
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plating,
@@ -59432,7 +59730,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "public external airlock"
+	name = "public external airlock";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
@@ -59793,6 +60092,7 @@
 	},
 /obj/machinery/door/airlock/centcom{
 	name = "Chapel Office";
+	opacity = 1;
 	req_access_txt = "22"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -59965,6 +60265,7 @@
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	pixel_x = -26;
+	req_access_txt = "0";
 	req_one_access_txt = "32;47;48"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -60983,7 +61284,8 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Port Storage"
+	c_tag = "Engineering Port Storage";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -61762,7 +62064,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xxw" = (
-/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "xxO" = (
@@ -61835,10 +62139,10 @@
 /area/maintenance/department/engine)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/server";
 	dir = 1;
 	layer = 4;
 	name = "Telecomms Server APC";
+	areastring = "/area/tcommsat/server";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -61895,7 +62199,9 @@
 /area/space/nearstation)
 "xOC" = (
 /obj/machinery/door/airlock/external{
-	name = "Construction Zone"
+	name = "Construction Zone";
+	req_access_txt = "0";
+	req_one_access_txt = "0"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
@@ -61921,7 +62227,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
-	name = "Port Emergency Storage"
+	name = "Port Emergency Storage";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
@@ -100490,7 +100797,7 @@ brD
 bte
 buw
 bvM
-bxr
+bxv
 byU
 bAA
 bBE
@@ -104354,9 +104661,9 @@ bEb
 bFn
 bGt
 bHz
-bIM
+bIK
 bJQ
-bIM
+bIK
 bMl
 bNp
 bOt

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -51,18 +51,16 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	network = list("ss13","medbay");
-	dir = 4
+	dir = 4;
+	network = list("ss13","medbay")
 	},
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "aag" = (
 /obj/machinery/sleeper{
-	icon_state = "sleeper";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70,8 +68,7 @@
 "aah" = (
 /obj/structure/displaycase/captain{
 	req_access = null;
-	req_access_txt = "20";
-	req_one_access_txt = "0"
+	req_access_txt = "20"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
@@ -173,7 +170,6 @@
 "acj" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -197,7 +193,6 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber Center";
-	dir = 2;
 	network = list("minisat")
 	},
 /obj/machinery/light/small{
@@ -216,14 +211,13 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/ai";
 	dir = 1;
 	name = "AI Chamber APC";
-	areastring = "/area/ai_monitored/turret_protected/ai";
 	pixel_y = 23
 	},
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -352,14 +346,12 @@
 	pixel_y = -9
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -31
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -403,7 +395,6 @@
 "acD" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
-	dir = 2;
 	network = list("minisat")
 	},
 /obj/machinery/light{
@@ -609,9 +600,9 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	dir = 8;
 	name = "MiniSat Antechamber APC";
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	pixel_x = -25
 	},
 /obj/machinery/recharger,
@@ -902,7 +893,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Port Fore";
-	dir = 2;
 	network = list("minisat")
 	},
 /turf/open/space,
@@ -930,7 +920,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Bridge Starboard Fore";
-	dir = 2;
 	network = list("minisat")
 	},
 /turf/open/space,
@@ -1279,9 +1268,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/AIsatextAP";
 	dir = 8;
 	name = "MiniSat Port Maintenance APC";
-	areastring = "/area/ai_monitored/turret_protected/AIsatextAP";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -1307,7 +1296,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Port Aft";
-	dir = 2;
 	network = list("minisat")
 	},
 /obj/structure/cable/yellow{
@@ -1380,7 +1368,6 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
-	dir = 2;
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -1432,7 +1419,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Maintenance Starboard Aft";
-	dir = 2;
 	network = list("minisat")
 	},
 /obj/structure/cable/yellow{
@@ -1449,9 +1435,9 @@
 "afm" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/AIsatextAS";
 	dir = 4;
 	name = "MiniSat Starboard Maintenance APC";
-	areastring = "/area/ai_monitored/turret_protected/AIsatextAS";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -1768,8 +1754,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "agi" = (
 /obj/machinery/door/poddoor{
-	id = "executionspaceblast";
-	name = "blast door"
+	id = "executionspaceblast"
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
@@ -1798,10 +1783,8 @@
 "ago" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1916,8 +1899,7 @@
 /area/security/prison)
 "agC" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom";
-	req_access_txt = "0"
+	name = "Unisex Restroom"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1957,7 +1939,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -1985,7 +1966,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -2003,7 +1983,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -2034,7 +2013,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -2151,7 +2129,6 @@
 "ahh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/showcase/cyborg/old{
-	dir = 2;
 	pixel_y = 20
 	},
 /turf/open/space,
@@ -2260,7 +2237,6 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Entrance";
-	dir = 2;
 	network = list("minisat")
 	},
 /turf/open/space,
@@ -2401,7 +2377,6 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/computer/security/telescreen/prison{
-	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2676,8 +2651,7 @@
 "aik" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor";
-	dir = 2
+	c_tag = "Armory Motion Sensor"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -3736,7 +3710,6 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/item/bedsheet/dorms,
@@ -3954,7 +3927,6 @@
 	icon_state = "secbot1";
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
-	on = 1;
 	weaponscheck = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -4214,9 +4186,7 @@
 /area/security/brig)
 "alt" = (
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Brig Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -4988,8 +4958,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Control Room";
-	dir = 2
+	c_tag = "Brig Control Room"
 	},
 /obj/item/radio/intercom{
 	dir = 4;
@@ -5108,8 +5077,7 @@
 /area/space/nearstation)
 "anm" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Pete's Speakeasy";
-	req_access_txt = "0"
+	name = "Pete's Speakeasy"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
@@ -5440,7 +5408,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Head of Security's Office APC";
 	pixel_y = -23
 	},
@@ -6435,8 +6402,7 @@
 /area/security/brig)
 "aqq" = (
 /obj/machinery/camera{
-	c_tag = "Brig Cells";
-	dir = 2
+	c_tag = "Brig Cells"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -6759,7 +6725,6 @@
 /area/crew_quarters/dorms)
 "aqY" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 2;
 	height = 6;
 	id = "monastery_shuttle_station";
@@ -7055,8 +7020,7 @@
 "arL" = (
 /obj/machinery/computer/card,
 /obj/machinery/camera{
-	c_tag = "Bridge - Central";
-	dir = 2
+	c_tag = "Bridge - Central"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -8215,8 +8179,8 @@
 "aud" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	network = list("vault");
-	dir = 1
+	dir = 1;
+	network = list("vault")
 	},
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -8323,7 +8287,6 @@
 /area/crew_quarters/dorms)
 "aun" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8372,7 +8335,6 @@
 "aux" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -8748,8 +8710,7 @@
 	dir = 10
 	},
 /obj/machinery/camera{
-	c_tag = "Dormitories Fore";
-	dir = 2
+	c_tag = "Dormitories Fore"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -9399,8 +9360,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Fitness Room";
-	dir = 2
+	c_tag = "Fitness Room"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9426,9 +9386,9 @@
 	icon_state = "plant-05"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/fitness/recreation";
 	dir = 1;
 	name = "Fitness Room APC";
-	areastring = "/area/crew_quarters/fitness/recreation";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -9578,9 +9538,7 @@
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
-/obj/item/reagent_containers/food/snacks/donut{
-	layer = 3
-	},
+/obj/item/reagent_containers/food/snacks/donut,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -9594,9 +9552,7 @@
 /area/security/brig)
 "awQ" = (
 /obj/structure/table/reinforced,
-/obj/item/pen{
-	layer = 3
-	},
+/obj/item/pen,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -9935,8 +9891,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Captain's Quarters";
-	dir = 2
+	c_tag = "Captain's Quarters"
 	},
 /obj/item/clothing/suit/armor/riot/knight/blue,
 /obj/item/clothing/head/helmet/knight/blue,
@@ -10123,8 +10078,7 @@
 /obj/machinery/button/door{
 	id = "Dorm2Shutters";
 	name = "Privacy Shutters Control";
-	pixel_y = 26;
-	req_access_txt = "0"
+	pixel_y = 26
 	},
 /obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
@@ -10147,7 +10101,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -10248,8 +10201,7 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "portsolar";
-	name = "Port Solar Control";
-	track = 0
+	name = "Port Solar Control"
 	},
 /obj/structure/cable/yellow{
 	cable_color = "red";
@@ -10608,9 +10560,9 @@
 "azo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/bridge";
 	dir = 4;
 	name = "Bridge APC";
-	areastring = "/area/bridge";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -11418,9 +11370,9 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aBx" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	dir = 1;
 	name = "Upload APC";
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -11490,8 +11442,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
-	dir = 2
+	c_tag = "Head of Personnel's Office"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -11571,8 +11522,7 @@
 /obj/machinery/button/door{
 	id = "Dorm1Shutters";
 	name = "Privacy Shutters Control";
-	pixel_y = 26;
-	req_access_txt = "0"
+	pixel_y = 26
 	},
 /obj/item/bedsheet/dorms,
 /turf/open/floor/plasteel/grimy,
@@ -11595,7 +11545,6 @@
 	name = "Dorm Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -11835,7 +11784,6 @@
 /obj/item/analyzer,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -12697,8 +12645,7 @@
 "aEc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Dormitories";
-	req_access_txt = "0"
+	name = "Dormitories"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -12708,8 +12655,7 @@
 /area/crew_quarters/toilet/restrooms)
 "aEe" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
@@ -12985,9 +12931,7 @@
 /obj/item/aiModule/supplied/oxygen,
 /obj/item/aiModule/zeroth/oneHuman,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -13369,7 +13313,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/northleft{
 	dir = 2;
-	icon_state = "left";
 	name = "Reception Window"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -13445,8 +13388,7 @@
 /area/crew_quarters/toilet/restrooms)
 "aFK" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14122,8 +14064,7 @@
 /area/hallway/primary/central)
 "aHn" = (
 /obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage";
-	req_access_txt = "0"
+	name = "Starboard Emergency Storage"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable/yellow{
@@ -14866,8 +14807,7 @@
 /area/hallway/primary/central)
 "aJn" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14974,8 +14914,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Departure Lounge Fore";
-	dir = 2
+	c_tag = "Departure Lounge Fore"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14997,9 +14936,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -15277,8 +15216,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Dormitory Cyborg Recharging Station";
-	dir = 2
+	c_tag = "Dormitory Cyborg Recharging Station"
 	},
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel/freezer,
@@ -15900,8 +15838,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Security Post";
-	dir = 2
+	c_tag = "Cargo Security Post"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -16053,7 +15990,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel,
@@ -16080,8 +16016,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Warehouse";
-	dir = 2
+	c_tag = "Cargo Warehouse"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16105,9 +16040,9 @@
 	dir = 9
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
 	name = "Cargo Warehouse APC";
-	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -16357,7 +16292,6 @@
 "aNa" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Cafeteria APC";
 	pixel_y = -23
 	},
@@ -16384,7 +16318,6 @@
 "aNe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
 	name = "Auxiliary Restrooms APC";
 	pixel_y = -23
 	},
@@ -16708,7 +16641,6 @@
 	id = "garbagestacked"
 	},
 /obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
 	machinedir = 8;
 	pixel_x = -32;
 	pixel_y = 32
@@ -17160,7 +17092,6 @@
 /obj/machinery/light/small,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/caution/red{
-	icon_state = "caution_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17896,8 +17827,7 @@
 "aQU" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera{
-	c_tag = "Bar Backroom";
-	dir = 2
+	c_tag = "Bar Backroom"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -17940,7 +17870,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "EVA Storage APC";
 	pixel_y = -23
 	},
@@ -18680,9 +18609,7 @@
 	location = "Kitchen"
 	},
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
@@ -19101,7 +19028,6 @@
 /area/solar/starboard)
 "aTH" = (
 /obj/docking_port/stationary{
-	dheight = 0;
 	dir = 8;
 	dwidth = 4;
 	height = 15;
@@ -19244,8 +19170,7 @@
 /area/crew_quarters/kitchen)
 "aTZ" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen Cold Room";
-	dir = 2
+	c_tag = "Kitchen Cold Room"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -19701,9 +19626,6 @@
 /area/crew_quarters/kitchen)
 "aVc" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -19986,18 +19908,17 @@
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
-	req_access_txt = "31";
 	pixel_x = 24;
-	pixel_y = -8
+	pixel_y = -8;
+	req_access_txt = "31"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
-	req_access_txt = "31";
 	pixel_x = 24;
-	pixel_y = 8
+	pixel_y = 8;
+	req_access_txt = "31"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Supply Dock";
@@ -20154,7 +20075,6 @@
 /area/crew_quarters/kitchen)
 "aVX" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -23
 	},
@@ -20219,8 +20139,7 @@
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Bar Access";
-	dir = 2
+	c_tag = "Bar Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -20646,9 +20565,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 2
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aXb" = (
@@ -20664,9 +20581,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 2
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aXd" = (
@@ -20734,7 +20649,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Theatre";
-	departmentType = 0;
 	name = "theatre RC";
 	pixel_x = -32;
 	pixel_y = -32
@@ -21171,7 +21085,6 @@
 "aYd" = (
 /obj/machinery/door/airlock{
 	name = "Service Access";
-	req_access_txt = "0";
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
 /obj/structure/disposalpipe/segment,
@@ -21669,7 +21582,6 @@
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
-	layer = 3;
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -22394,9 +22306,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Office APC";
 	areastring = "/area/quartermaster/office";
+	name = "Cargo Office APC";
 	pixel_x = 1;
 	pixel_y = -23
 	},
@@ -22444,7 +22355,6 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Cargo Bay APC";
 	pixel_y = -23
 	},
@@ -22554,7 +22464,6 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "papersplease";
 	name = "Shutters Control Button";
 	pixel_x = -26;
@@ -22610,7 +22519,6 @@
 /area/security/checkpoint/customs)
 "baU" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Security Checkpoint APC";
 	pixel_x = 1;
 	pixel_y = -23
@@ -22640,7 +22548,6 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
 	pixel_x = 25;
@@ -22659,7 +22566,6 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "jangarage";
 	name = "Custodial Closet Shutters Control";
 	pixel_x = -25;
@@ -22821,9 +22727,7 @@
 /area/crew_quarters/bar)
 "bbs" = (
 /obj/item/cane,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
+/obj/item/clothing/head/that,
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet{
 	icon_state = "carpetsymbol"
@@ -23437,8 +23341,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "starboardsolar";
-	name = "Starboard Solar Control";
-	track = 0
+	name = "Starboard Solar Control"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -23723,9 +23626,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/qm";
 	dir = 8;
 	name = "Quartermaster APC";
-	areastring = "/area/quartermaster/qm";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -23789,7 +23692,6 @@
 "bdM" = (
 /obj/machinery/requests_console{
 	department = "Mining";
-	departmentType = 0;
 	pixel_x = 32
 	},
 /obj/machinery/computer/security/mining{
@@ -25494,7 +25396,6 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 25;
@@ -25508,7 +25409,6 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = -25;
@@ -25696,8 +25596,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -25837,9 +25736,8 @@
 	pixel_y = 5
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Lounge APC";
 	areastring = "/area/crew_quarters/lounge";
+	name = "Lounge APC";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -25916,9 +25814,7 @@
 "biW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/maintenance{
-	name = "Port Emergency Storage";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "Port Emergency Storage"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -25934,7 +25830,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
-	opacity = 1;
 	req_access_txt = "6"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26432,8 +26327,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -26446,7 +26340,6 @@
 "bkz" = (
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab Chamber";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
@@ -26551,8 +26444,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Foyer";
-	network = list("ss13","medbay");
-	dir = 2
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/power/apc{
@@ -26881,7 +26773,6 @@
 "blH" = (
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/structure/sink/kitchen{
@@ -27074,7 +26965,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Genetics Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;45;5;9"
 	},
 /turf/open/floor/plating,
@@ -27157,9 +27047,9 @@
 /area/medical/morgue)
 "bms" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/medical";
 	dir = 8;
 	name = "Medbay Security APC";
-	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -27167,8 +27057,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Security Post";
-	network = list("ss13","medbay");
-	dir = 4
+	dir = 4;
+	network = list("ss13","medbay")
 	},
 /obj/structure/closet/secure_closet/security/med,
 /obj/effect/turf_decal/tile/red{
@@ -27522,7 +27412,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Cloning";
-	req_access_txt = "0";
 	req_one_access_txt = "5;9"
 	},
 /obj/structure/cable/yellow{
@@ -28042,7 +27931,6 @@
 /area/medical/medbay/central)
 "boH" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -28104,8 +27992,8 @@
 /obj/structure/bed/roller,
 /obj/machinery/camera{
 	c_tag = "Medbay Entrance";
-	network = list("ss13","medbay");
-	dir = 1
+	dir = 1;
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -28213,7 +28101,6 @@
 	dir = 4
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "robotics";
 	name = "Shutters Control Button";
 	pixel_x = -26;
@@ -28263,7 +28150,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/camera{
 	c_tag = "Server Room";
-	dir = 2;
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -28345,7 +28231,6 @@
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
-	dir = 2;
 	name = "Science Requests Console";
 	pixel_y = 30;
 	receive_ore_updates = 1
@@ -28357,7 +28242,6 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab Central";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -28514,7 +28398,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "Morgue";
-	opacity = 1;
 	req_access_txt = "6"
 	},
 /obj/structure/cable/yellow{
@@ -28546,7 +28429,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 2;
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28580,7 +28462,6 @@
 	},
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
-	opacity = 1;
 	req_access_txt = "6"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29037,7 +28918,6 @@
 "bqH" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #5";
 	req_access_txt = "55"
@@ -29080,7 +28960,6 @@
 "bqK" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #6";
 	req_access_txt = "55"
@@ -29110,7 +28989,6 @@
 /area/science/xenobiology)
 "bqO" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12; 55"
 	},
 /obj/structure/cable/yellow{
@@ -29122,9 +29000,9 @@
 /area/maintenance/department/cargo)
 "bqS" = (
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/entry";
 	dir = 4;
 	name = "Arrivals APC";
-	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
@@ -29217,7 +29095,6 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "GeneticsDoor";
 	name = "Cloning";
-	req_access_txt = "0";
 	req_one_access_txt = "5;9"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
@@ -29790,7 +29667,6 @@
 "bsf" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Starboard";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/structure/sign/departments/xenobio{
@@ -29850,8 +29726,8 @@
 /obj/machinery/dna_scannernew,
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	network = list("ss13","medbay");
-	dir = 4
+	dir = 4;
+	network = list("ss13","medbay")
 	},
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
@@ -30018,9 +29894,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/camera{
-	dir = 2
-	},
+/obj/machinery/camera,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsF" = (
@@ -30476,8 +30350,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2";
-	req_access_txt = "0"
+	name = "Port Docking Bay 2"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -30486,8 +30359,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2";
-	req_access_txt = "0"
+	name = "Port Docking Bay 2"
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
@@ -30591,6 +30463,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btY" = (
@@ -30693,9 +30567,9 @@
 	pixel_x = -28
 	},
 /obj/machinery/camera{
-	network = list("ss13","medbay");
 	c_tag = "Chemistry";
-	dir = 4
+	dir = 4;
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -30792,8 +30666,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -31061,8 +30934,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Medbay Port Hallway";
-	network = list("ss13","medbay");
-	dir = 4
+	dir = 4;
+	network = list("ss13","medbay")
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -31329,7 +31202,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Science Access Airlock";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
@@ -31567,7 +31439,6 @@
 /area/maintenance/department/science)
 "bwn" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12; 55"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31702,7 +31573,6 @@
 /area/medical/genetics)
 "bwB" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -31968,7 +31838,6 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "R&D Lab";
-	req_access_txt = "0";
 	req_one_access_txt = "7;29;30"
 	},
 /obj/effect/turf_decal/delivery,
@@ -32129,18 +31998,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"bxv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/explab)
 "bxw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -32279,7 +32136,6 @@
 "bxN" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #1";
 	req_access_txt = "55"
@@ -32316,7 +32172,6 @@
 "bxQ" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #2";
 	req_access_txt = "55"
@@ -32349,7 +32204,6 @@
 "bxS" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #3";
 	req_access_txt = "55"
@@ -33505,7 +33359,6 @@
 "bAm" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Lab Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "7;29"
 	},
 /obj/structure/disposalpipe/segment,
@@ -33533,8 +33386,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
 	name = "Research Director's Office";
-	req_access_txt = "30";
-	req_one_access_txt = "0"
+	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -33779,7 +33631,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_x = 32
 	},
@@ -33941,8 +33792,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
-	network = list("ss13","medbay");
-	dir = 8
+	dir = 8;
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -34170,7 +34021,6 @@
 "bBF" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /turf/open/floor/engine,
@@ -34302,7 +34152,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/camera{
 	c_tag = "Toxins Lab Starboard";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/machinery/light{
@@ -34459,8 +34308,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
-	network = list("ss13","medbay");
-	dir = 2
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -35004,9 +34852,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bDg" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bDh" = (
@@ -35162,9 +35008,9 @@
 /area/crew_quarters/heads/cmo)
 "bDx" = (
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/cmo";
 	dir = 4;
 	name = "CMO's Office APC";
-	areastring = "/area/crew_quarters/heads/cmo";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -36324,7 +36170,6 @@
 	normaldoorcontrol = 1;
 	pixel_x = 25;
 	pixel_y = 4;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/open/floor/plating,
@@ -36431,7 +36276,6 @@
 	pixel_y = 2
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -36902,9 +36746,7 @@
 /turf/open/floor/plating,
 /area/chapel/dock)
 "bGG" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -37391,7 +37233,6 @@
 /area/science/mixing)
 "bHC" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37411,12 +37252,8 @@
 /area/science/mixing)
 "bHE" = (
 /obj/structure/window/reinforced,
-/obj/machinery/doppler_array/research/science{
-	dir = 2
-	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/machinery/doppler_array/research/science,
+/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -37519,8 +37356,7 @@
 "bHY" = (
 /obj/machinery/camera{
 	c_tag = "Virology";
-	network = list("ss13","medbay");
-	dir = 2
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37589,8 +37425,8 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medbay Equipment Room";
-	network = list("ss13","medbay");
-	dir = 1
+	dir = 1;
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -37670,8 +37506,8 @@
 "bIm" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	network = list("ss13","medbay");
-	dir = 8
+	dir = 8;
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37727,7 +37563,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery";
-	dir = 2;
 	network = list("ss13","surgery")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37931,12 +37766,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
-"bIK" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 2
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
 "bIL" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
@@ -38015,9 +37844,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bIX" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/tank/air,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -38199,7 +38026,6 @@
 /area/medical/virology)
 "bJo" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -38398,9 +38224,7 @@
 	c_tag = "Research Division Entrance";
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -38490,9 +38314,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bJQ" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -38526,8 +38348,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
-	req_access_txt = "8";
-	req_one_access_txt = "0"
+	req_access_txt = "8"
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -38736,8 +38557,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Patient Room";
-	network = list("ss13","medbay");
-	dir = 2
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -38909,7 +38729,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/structure/cable/yellow{
@@ -39094,8 +38913,7 @@
 /area/chapel/dock)
 "bLq" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Monastery Transit";
-	opacity = 1
+	name = "Monastery Transit"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -39173,8 +38991,7 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /obj/item/stack/sheet/mineral/plasma{
-	amount = 2;
-	layer = 3
+	amount = 2
 	},
 /obj/item/storage/box/monkeycubes{
 	layer = 3.1
@@ -39202,9 +39019,7 @@
 /area/medical/virology)
 "bLF" = (
 /obj/structure/table,
-/obj/item/clipboard{
-	toppaper = null
-	},
+/obj/item/clipboard,
 /obj/item/pen{
 	layer = 3.1
 	},
@@ -39538,8 +39353,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/external{
-	req_access_txt = "8";
-	req_one_access_txt = "0"
+	req_access_txt = "8"
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -39842,7 +39656,6 @@
 "bMU" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway Atmospherics";
-	dir = 2;
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40801,8 +40614,7 @@
 /area/space/nearstation)
 "bPn" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
+	name = "Chapel"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -40821,8 +40633,7 @@
 /area/chapel/dock)
 "bPo" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
+	name = "Chapel"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41154,8 +40965,7 @@
 /area/engine/gravity_generator)
 "bQo" = (
 /obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 2
+	c_tag = "Gravity Generator"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -41257,13 +41067,11 @@
 	light_color = "#cee5d2"
 	},
 /obj/machinery/camera{
-	c_tag = "Tech Storage";
-	dir = 2
+	c_tag = "Tech Storage"
 	},
 /obj/item/circuitboard/computer/monastery_shuttle,
 /obj/effect/spawner/lootdrop/techstorage/service,
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/green{
@@ -41346,8 +41154,8 @@
 /area/storage/tech)
 "bQB" = (
 /obj/machinery/power/apc{
-	name = "Aft Hall APC";
 	dir = 8;
+	name = "Aft Hall APC";
 	pixel_x = -25;
 	pixel_y = 1
 	},
@@ -41382,7 +41190,6 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -41436,12 +41243,8 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQL" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -41453,17 +41256,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQN" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -41595,7 +41393,6 @@
 	dir = 1
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -41606,8 +41403,7 @@
 "bRe" = (
 /obj/structure/closet/radiation,
 /obj/machinery/camera{
-	c_tag = "Gravity Generator Foyer";
-	dir = 2
+	c_tag = "Gravity Generator Foyer"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -41739,7 +41535,6 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Atmospherics Desk";
 	req_access_txt = "24"
 	},
@@ -42142,8 +41937,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/trinary/mixer{
-	name = "plasma mixer";
-	dir = 1
+	dir = 1;
+	name = "plasma mixer"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -42529,7 +42324,6 @@
 /area/maintenance/department/engine)
 "bTf" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2;
 	name = "Virology Waste to Space"
 	},
 /turf/open/floor/plating{
@@ -42538,7 +42332,6 @@
 /area/maintenance/department/engine)
 "bTg" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Virology Waste to Atmospherics"
 	},
 /turf/open/floor/plating,
@@ -42619,9 +42412,7 @@
 	pixel_y = 1
 	},
 /obj/structure/table,
-/obj/item/paper/guides/jobs/engi/gravity_gen{
-	layer = 3
-	},
+/obj/item/paper/guides/jobs/engi/gravity_gen,
 /obj/item/pen/blue,
 /obj/machinery/power/terminal{
 	dir = 8
@@ -42776,9 +42567,8 @@
 /area/storage/tech)
 "bTB" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Tech Storage APC";
 	areastring = "/area/storage/tech";
+	name = "Tech Storage APC";
 	pixel_y = -23
 	},
 /obj/structure/cable,
@@ -42866,8 +42656,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics Entrance";
-	dir = 2
+	c_tag = "Atmospherics Entrance"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42942,8 +42731,7 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
-	c_tag = "Atmospherics Mixing";
-	dir = 2
+	c_tag = "Atmospherics Mixing"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -42973,8 +42761,7 @@
 /area/engine/atmos)
 "bTU" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -43310,8 +43097,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Chief Engineer's Office";
-	dir = 2
+	c_tag = "Chief Engineer's Office"
 	},
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 30
@@ -43326,7 +43112,6 @@
 /area/crew_quarters/heads/chief)
 "bUK" = (
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/machinery/computer/apc_control,
@@ -43405,8 +43190,7 @@
 	},
 /obj/machinery/power/smes/engineering,
 /obj/machinery/camera{
-	c_tag = "Engineering Power Storage";
-	dir = 2
+	c_tag = "Engineering Power Storage"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -43860,9 +43644,9 @@
 	pixel_y = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
 	dir = 8;
 	name = "Engineering Security APC";
-	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -44083,7 +43867,6 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	dir = 2;
 	pixel_x = 22
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -44398,8 +44181,7 @@
 /area/chapel/main/monastery)
 "bWW" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
+	name = "Chapel"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -44408,8 +44190,7 @@
 /area/chapel/main/monastery)
 "bWX" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
+	name = "Chapel"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -44513,9 +44294,9 @@
 /obj/item/stack/rods/fifty,
 /obj/item/stack/cable_coil,
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/engine/engine_smes";
 	dir = 8;
 	name = "Engine Room APC";
-	areastring = "/area/engine/engine_smes";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -45083,8 +44864,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Port Fore";
-	dir = 2
+	c_tag = "Engineering Port Fore"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45166,7 +44946,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45326,8 +45105,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Starboard Fore";
-	dir = 2
+	c_tag = "Engineering Starboard Fore"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45401,7 +45179,6 @@
 	pixel_x = -25
 	},
 /obj/machinery/airalarm/unlocked{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/structure/cable/yellow{
@@ -45941,9 +45718,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caN" = (
@@ -45979,7 +45754,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Turbine Chamber";
-	dir = 2;
 	network = list("turbine")
 	},
 /turf/open/floor/engine/vacuum,
@@ -46110,9 +45884,7 @@
 	id = "SupermatterExternal";
 	name = "radiation shutters"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -46251,8 +46023,7 @@
 /area/chapel/main/monastery)
 "cbR" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Access";
-	opacity = 1
+	name = "Chapel Access"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -46363,7 +46134,6 @@
 "ccf" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Center";
-	dir = 2;
 	network = list("ss13","engine");
 	pixel_x = 23
 	},
@@ -46554,9 +46324,7 @@
 	id = "SupermatterExternal";
 	name = "radiation shutters"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ccX" = (
@@ -46643,7 +46411,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Port Access";
-	dir = 2;
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
@@ -46890,7 +46657,6 @@
 "ceg" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Chapel Office";
-	opacity = 1;
 	req_access_txt = "22"
 	},
 /obj/structure/cable/yellow{
@@ -46910,8 +46676,7 @@
 /area/chapel/office)
 "cei" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
+	name = "Chapel"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46923,24 +46688,21 @@
 /area/chapel/main/monastery)
 "cej" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
+	name = "Chapel"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cek" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel";
-	opacity = 1
+	name = "Chapel"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cel" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Access";
-	opacity = 1
+	name = "Chapel Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
@@ -47031,7 +46793,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Crematorium";
-	dir = 2;
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/plasteel/dark,
@@ -47124,7 +46885,6 @@
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching telecomms.";
-	dir = 2;
 	layer = 4;
 	name = "Telecomms Telescreen";
 	network = list("tcomms");
@@ -47217,8 +46977,7 @@
 /area/chapel/office)
 "cfl" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Access";
-	opacity = 1
+	name = "Chapel Access"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -47508,7 +47267,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/camera{
 	c_tag = "Monastery Garden";
-	dir = 2;
 	network = list("ss13","monastery")
 	},
 /turf/open/floor/grass,
@@ -47977,9 +47735,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cit" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "ciy" = (
@@ -48168,8 +47924,7 @@
 /area/chapel/main/monastery)
 "cjl" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Monastery Cemetary";
-	opacity = 1
+	name = "Monastery Cemetary"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -48246,8 +48001,7 @@
 /area/chapel/main/monastery)
 "cjH" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Chapel Garden";
-	opacity = 1
+	name = "Chapel Garden"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -48957,9 +48711,9 @@
 /area/tcommsat/computer)
 "cmk" = (
 /obj/machinery/power/apc{
+	areastring = "/area/tcommsat/computer";
 	dir = 1;
 	name = "Telecomms Monitoring APC";
-	areastring = "/area/tcommsat/computer";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -49365,7 +49119,6 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Port Aft";
-	dir = 2;
 	network = list("tcomms")
 	},
 /turf/open/space,
@@ -49374,7 +49127,6 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Starboard Aft";
-	dir = 2;
 	network = list("tcomms")
 	},
 /turf/open/space,
@@ -49418,8 +49170,7 @@
 "cnN" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 2
+	c_tag = "Brig Equipment Room"
 	},
 /obj/item/radio/intercom{
 	pixel_y = 29
@@ -49541,8 +49292,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Dormitories";
-	req_access_txt = "0"
+	name = "Dormitories"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -49552,8 +49302,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "public external airlock";
-	req_access_txt = "0"
+	name = "public external airlock"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
@@ -49725,8 +49474,7 @@
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Bar Drinks";
-	dir = 2
+	c_tag = "Bar Drinks"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -50176,9 +49924,7 @@
 	c_tag = "Research Division Hallway";
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 2
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -50683,7 +50429,6 @@
 "csC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
-	name = "flask of holy water";
 	pixel_x = -2;
 	pixel_y = 2
 	},
@@ -50786,7 +50531,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Starboard Access";
-	dir = 2;
 	network = list("ss13","monastery")
 	},
 /obj/structure/chair/wood/normal,
@@ -50877,9 +50621,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctu" = (
-/obj/machinery/light/small{
-	dir = 2
-	},
+/obj/machinery/light/small,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -50959,7 +50701,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Fore";
-	dir = 2;
 	network = list("ss13","monastery")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -51201,9 +50942,7 @@
 /area/hydroponics/garden/monastery)
 "cuG" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/light/small{
-	dir = 2
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuH" = (
@@ -52279,7 +52018,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Fore";
-	dir = 2;
 	network = list("ss13","monastery")
 	},
 /obj/machinery/firealarm{
@@ -52611,9 +52349,7 @@
 	dir = 4
 	},
 /obj/machinery/door/window/northright{
-	base_state = "right";
 	dir = 2;
-	icon_state = "right";
 	name = "Curator Desk Door";
 	req_access_txt = "37"
 	},
@@ -52780,8 +52516,7 @@
 /obj/machinery/button/door{
 	id = "supplybridge";
 	name = "Space Bridge Control";
-	pixel_y = 27;
-	req_access_txt = "0"
+	pixel_y = 27
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -53013,9 +52748,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cPy" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32;
 	pixel_y = 32
@@ -53088,7 +52821,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright{
 	base_state = "left";
-	dir = 4;
 	icon_state = "left";
 	name = "Research Division Delivery";
 	req_access_txt = "47"
@@ -53263,7 +52995,6 @@
 /area/chapel/office)
 "dqw" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12; 55"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -53929,9 +53660,7 @@
 /area/maintenance/department/engine)
 "fdS" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Engineering Delivery";
 	req_access_txt = "10"
 	},
@@ -54136,7 +53865,6 @@
 "fwi" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engine Containment Starboard Fore";
-	dir = 2;
 	network = list("engine")
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -54339,7 +54067,6 @@
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
-	req_access_txt = "0";
 	req_one_access_txt = "35;28"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -54696,7 +54423,6 @@
 	pixel_y = 3
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "research_shutters_2";
 	name = "Shutters Control Button";
 	pixel_x = -28;
@@ -55105,7 +54831,6 @@
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
-	req_access_txt = "0";
 	req_one_access_txt = "32;47;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55866,7 +55591,6 @@
 	dir = 8
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering RC";
@@ -56217,9 +55941,7 @@
 /area/science/mixing/chamber)
 "kfM" = (
 /obj/structure/closet,
-/obj/machinery/light/small{
-	dir = 2
-	},
+/obj/machinery/light/small,
 /obj/item/storage/book/bible,
 /obj/item/storage/book/bible,
 /obj/item/storage/book/bible,
@@ -56377,7 +56099,6 @@
 	dir = 1
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -56416,9 +56137,7 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "kDf" = (
-/obj/machinery/light/small{
-	dir = 2
-	},
+/obj/machinery/light/small,
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "kDJ" = (
@@ -56562,7 +56281,6 @@
 "kNf" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #4";
 	req_access_txt = "55"
@@ -56656,9 +56374,7 @@
 /area/engine/engineering)
 "kSO" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Port Emergency Storage";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "Port Emergency Storage"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
@@ -56952,8 +56668,7 @@
 /area/maintenance/department/science)
 "lKL" = (
 /obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage";
-	req_access_txt = "0"
+	name = "Starboard Emergency Storage"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable/yellow{
@@ -57286,9 +57001,7 @@
 /area/bridge)
 "mzl" = (
 /obj/structure/chair,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "mzU" = (
@@ -57519,7 +57232,6 @@
 "nku" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
-	opacity = 1;
 	req_access_txt = "27"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57596,9 +57308,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/construction/mining/aux_base";
 	dir = 8;
 	name = "Auxillary Base Construction APC";
-	areastring = "/area/construction/mining/aux_base";
 	pixel_x = -25
 	},
 /obj/structure/cable/yellow{
@@ -57794,7 +57506,6 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms Monitoring";
-	dir = 2;
 	network = list("tcomms")
 	},
 /obj/structure/cable/yellow{
@@ -58145,8 +57856,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Arrivals Port Fore";
-	dir = 2
+	c_tag = "Arrivals Port Fore"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -58743,7 +58453,6 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Area";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/structure/sign/poster/official/random{
@@ -59333,7 +59042,6 @@
 /area/maintenance/department/engine)
 "rfe" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -59521,9 +59229,7 @@
 	location = "Medbay"
 	},
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Medbay Delivery";
 	req_access_txt = "6"
 	},
@@ -59615,7 +59321,6 @@
 "rJZ" = (
 /obj/docking_port/stationary{
 	dheight = 4;
-	dir = 1;
 	dwidth = 4;
 	height = 9;
 	id = "aux_base_zone";
@@ -59648,8 +59353,7 @@
 /obj/machinery/button/door{
 	id = "shootshut";
 	name = "shutters control";
-	pixel_x = 28;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plating,
@@ -59730,8 +59434,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "public external airlock";
-	req_access_txt = "0"
+	name = "public external airlock"
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
@@ -60092,7 +59795,6 @@
 	},
 /obj/machinery/door/airlock/centcom{
 	name = "Chapel Office";
-	opacity = 1;
 	req_access_txt = "22"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -60265,7 +59967,6 @@
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	pixel_x = -26;
-	req_access_txt = "0";
 	req_one_access_txt = "32;47;48"
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -61284,8 +60985,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Port Storage";
-	dir = 2
+	c_tag = "Engineering Port Storage"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -62064,9 +61764,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xxw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "xxO" = (
@@ -62139,10 +61837,10 @@
 /area/maintenance/department/engine)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/server";
 	dir = 1;
 	layer = 4;
 	name = "Telecomms Server APC";
-	areastring = "/area/tcommsat/server";
 	pixel_y = 23
 	},
 /obj/structure/cable/yellow{
@@ -62199,9 +61897,7 @@
 /area/space/nearstation)
 "xOC" = (
 /obj/machinery/door/airlock/external{
-	name = "Construction Zone";
-	req_access_txt = "0";
-	req_one_access_txt = "0"
+	name = "Construction Zone"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
@@ -62227,8 +61923,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
-	name = "Port Emergency Storage";
-	req_access_txt = "0"
+	name = "Port Emergency Storage"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
@@ -100797,7 +100492,7 @@ brD
 bte
 buw
 bvM
-bxv
+bxr
 byU
 bAA
 bBE
@@ -104661,9 +104356,9 @@ bEb
 bFn
 bGt
 bHz
-bIK
+bIM
 bJQ
-bIK
+bIM
 bMl
 bNp
 bOt

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -568,9 +568,9 @@
 
 	flesh_number = unattached_flesh.len
 
-/obj/machinery/clonepod/mapped
+/obj/machinery/clonepod/prefilled
 
-/obj/machinery/clonepod/mapped/Initialize()
+/obj/machinery/clonepod/prefilled/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/medicine/synthflesh, 100)
 

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -25,6 +25,8 @@
 	var/speed_coeff
 	var/efficiency
 
+	var/fleshamnt = 1 //Amount of synthflesh needed per cloning cycle, is divided by efficiency
+
 	var/datum/mind/clonemind
 	var/grab_ghost_when = CLONER_MATURE_CLONE
 
@@ -41,6 +43,8 @@
 	fair_market_price = 5 // He nodded, because he knew I was right. Then he swiped his credit card to pay me for arresting him.
 	payment_department = ACCOUNT_MED
 /obj/machinery/clonepod/Initialize()
+	create_reagents(100, OPENCONTAINER)
+
 	. = ..()
 
 	countdown = new(src)
@@ -65,10 +69,16 @@
 	. = ..()
 
 /obj/machinery/clonepod/RefreshParts()
-	speed_coeff = 2
-	efficiency = 2
+	speed_coeff = 0
+	efficiency = 0
+	reagents.maximum_volume = 0
+	fleshamnt = 1
+	for(var/obj/item/reagent_containers/glass/G in component_parts)
+		reagents.maximum_volume += G.volume
+		G.reagents.trans_to(src, G.reagents.total_volume)
 	for(var/obj/item/stock_parts/scanning_module/S in component_parts)
 		efficiency += S.rating
+		fleshamnt = 1/max(efficiency-1, 1)
 	for(var/obj/item/stock_parts/manipulator/P in component_parts)
 		speed_coeff += P.rating
 	heal_level = (efficiency * 15) + 10
@@ -77,11 +87,30 @@
 	if(heal_level > 100)
 		heal_level = 100
 
+/obj/machinery/clonepod/attack_hand(mob/user)
+	. = ..()
+	if(.)
+		return
+	user.examinate(src)
+
+/obj/machinery/clonepod/AltClick(mob/user)
+	. = ..()
+	if (alert(user, "Are you sure you want to empty the cloning pod?", "Empty Reagent Storage:", "Yes", "No") != "Yes")
+		return
+	to_chat(user, "<span class='notice'>You empty \the [src]'s release valve onto the floor.</span>")
+	reagents.reaction(user.loc)
+	src.reagents.clear_reagents()
+
+/obj/machinery/clonepod/attack_ai(mob/user)
+	return attack_hand(user)
+
 /obj/machinery/clonepod/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The <i>linking</i> device can be <i>scanned<i> with a multitool.</span>"
+	. += "<span class='notice'>The <i>linking</i> device can be <i>scanned<i> with a multitool. It can be emptied by Alt-Clicking it.</span>"
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Cloning speed at <b>[speed_coeff*50]%</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b>.<span>"
+		. += "<span class='notice'>The status display reads: Cloning speed at <b>[speed_coeff*50]%</b>.<br>Predicted amount of cellular damage: <b>[100-heal_level]%</b><br> Storing up to <b>[reagents.maximum_volume]cm<sup>3</sup></b> of synthflesh.<br>"
+		. += "Synthflesh consumption at <b>[round(fleshamnt*90, 1)]cm<sup>3</sup></b> per clone.</span><br>"
+		. += "<span class='notice'>The reagent display reads: [round(reagents.total_volume, 1)] / [reagents.maximum_volume] cm<sup>3</sup></span>"
 		if(efficiency > 5)
 			. += "<span class='notice'>Pod has been upgraded to support autoprocessing and apply beneficial mutations.<span>"
 
@@ -140,7 +169,10 @@
 	return examine(user)
 
 //Start growing a human clone in the pod!
-/obj/machinery/clonepod/proc/growclone(clonename, ui, mutation_index, mindref, last_death, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance, list/traumas, empty)
+/obj/machinery/clonepod/proc/growclone(clonename, ui, mutation_index, mindref, last_death, blood_type, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance, list/traumas, empty)
+	if(!reagents.has_reagent(/datum/reagent/medicine/synthflesh, fleshamnt))
+		connected_message("Cannot start cloning: Not enough synthflesh.")
+		return NONE
 	if(panel_open)
 		return NONE
 	if(mess || attempting)
@@ -249,7 +281,13 @@
 			connected_message("Clone Ejected: Loss of power.")
 
 	else if(mob_occupant && (mob_occupant.loc == src))
-		if(SSeconomy.full_ancap)
+		if(!reagents.has_reagent(/datum/reagent/medicine/synthflesh, fleshamnt))
+			go_out()
+			log_cloning("[key_name(mob_occupant)] ejected from [src] at [AREACOORD(src)] due to insufficient material.")
+			connected_message("Clone Ejected: Not enough material.")
+			if(internal_radio)
+				SPEAK("The cloning of [mob_occupant.real_name] has been ended prematurely due to insufficient material.")
+		else if(SSeconomy.full_ancap)
 			if(!current_insurance)
 				go_out()
 				log_cloning("[key_name(mob_occupant)] ejected from [src] at [AREACOORD(src)] due to invalid bank account.")
@@ -278,7 +316,11 @@
 			mob_occupant.Unconscious(80)
 			var/dmg_mult = CONFIG_GET(number/damage_multiplier)
 			 //Slowly get that clone healed and finished.
-			mob_occupant.adjustCloneLoss(-((speed_coeff / 1.75) * dmg_mult))
+			mob_occupant.adjustCloneLoss(-((speed_coeff / 2) * dmg_mult))
+			if(reagents.has_reagent(/datum/reagent/medicine/synthflesh, fleshamnt))
+				reagents.remove_reagent(/datum/reagent/medicine/synthflesh, fleshamnt)
+			else if(reagents.has_reagent(/datum/reagent/blood, fleshamnt*3))
+				reagents.remove_reagent(/datum/reagent/blood, fleshamnt*3)
 			var/progress = CLONE_INITIAL_DAMAGE - mob_occupant.getCloneLoss()
 			// To avoid the default cloner making incomplete clones
 			progress += (100 - MINIMUM_HEAL_LEVEL)
@@ -486,6 +528,8 @@
 	playsound(src,'sound/hallucinations/wail.ogg', 100, TRUE)
 
 /obj/machinery/clonepod/deconstruct(disassembled = TRUE)
+	for(var/obj/item/reagent_containers/glass/G in component_parts)
+		reagents.trans_to(G, G.reagents.maximum_volume)
 	if(occupant)
 		var/mob/living/mob_occupant = occupant
 		go_out()
@@ -523,6 +567,12 @@
 		unattached_flesh += organ
 
 	flesh_number = unattached_flesh.len
+
+/obj/machinery/clonepod/mapped
+
+/obj/machinery/clonepod/mapped/Initialize()
+	. = ..()
+	reagents.add_reagent(/datum/reagent/medicine/synthflesh, 100)
 
 /*
  *	Manual -- A big ol' manual.

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -169,7 +169,7 @@
 	return examine(user)
 
 //Start growing a human clone in the pod!
-/obj/machinery/clonepod/proc/growclone(clonename, ui, mutation_index, mindref, last_death, blood_type, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance, list/traumas, empty)
+/obj/machinery/clonepod/proc/growclone(clonename, ui, mutation_index, mindref, last_death, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance, list/traumas, empty)
 	if(!reagents.has_reagent(/datum/reagent/medicine/synthflesh, fleshamnt))
 		connected_message("Cannot start cloning: Not enough synthflesh.")
 		return NONE

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -29,7 +29,8 @@
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/stock_parts/scanning_module = 2,
 		/obj/item/stock_parts/manipulator = 2,
-		/obj/item/stack/sheet/glass = 1)
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/reagent_containers/glass/beaker = 2)
 
 /obj/item/circuitboard/machine/clonepod/experimental
 	name = "Experimental Clone Pod (Machine Board)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/WaspStation/WaspStation-1.0/pull/55

ROUNDSTART CLONERS START WITH (some) SYNTHFLESH, SO DON'T WORRY TOO MUCH!
You now need to add synthflesh to the cloning pod to clone people.

t1 parts -> 90u/clone
t4 parts -> ~13u/clone

![image](https://user-images.githubusercontent.com/58159167/75192036-57a4e280-5708-11ea-9575-c956ea492529.png)
![image](https://user-images.githubusercontent.com/58159167/75192055-5f648700-5708-11ea-931b-8ed1f17c99fc.png)


## Why It's Good For The Game
Balances cloning without removing it, unlike /tg/.

## Changelog
:cl:
tweak: Cloners now need some synthflesh to operate.
add: Clonepods now have 100u of synthflesh in them at roundstart
tweak: Roundstart cloning is now 100% speed instead of 200% (slower cloning roundstart)
/:cl: