### PR TITLE
Small self surgery fixes and feedback

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -30,7 +30,10 @@
 /obj/item/reagent_containers/pill/attack(mob/M, mob/user, def_zone)
 	if(!canconsume(M, user))
 		return FALSE
-
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(/datum/surgery/dental_implant in C.surgeries)
+			return
 	if(M == user)
 		M.visible_message("<span class='notice'>[user] attempts to [apply_method] [src].</span>")
 		if(self_delay)

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -45,6 +45,7 @@
 	requires_bodypart_type = BODYPART_ROBOTIC
 	lying_required = FALSE
 	self_operable = TRUE
+	success_multiplier = 0.8 //on a surgery bed you can do prosthetic manipulation relatively risk-free
 	steps = list(
 		/datum/surgery_step/mechanic_open,
 		/datum/surgery_step/open_hatch,

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -164,4 +164,4 @@
 		else
 			user.visible_message("[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
 				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
-	return 0
+	return ..()


### PR DESCRIPTION

## About The Pull Request

Fixes the long-time bug where you hit the patient with tools on organ manipulation, which had caused you to eat your own organs if you were organ manipulating yourself and implanting organic organs

Pills can no longer be eaten during the dental implant surgery- no more eating the pill before you implant it (This only applies while lying down undergoing the surgery, so an incomplete dental implant wont render you unable to eat the pill)

Mechanical organ manipulation now has a success chance boost enough that it can be done with self surgery freely, as it used to be

## Why It's Good For The Game

fixes

## Changelog
:cl:
fix: no more popping your dental implant pills during the surgery
fix: no more eating your eyeballs when trying to put them back in
tweak: mechanical organ manipulation is now easy to do again
/:cl:

