### PR TITLE
Krav Maga rework port

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -89,11 +89,14 @@
 /datum/martial_art/krav_maga/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(D.stat || D.IsParalyzed())
 		return 0
+	var/obj/item/bodypart/affecting = D.get_bodypart(BODY_ZONE_CHEST)
+	var/armor_block = D.run_armor_check(affecting, "melee")
 	D.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>", \
-					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
-	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
-	D.apply_damage(5, BRUTE)
-	D.Paralyze(40)
+					"<span class='userdanger'>Your legs are sweeped by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, A)
+	to_chat(A, "<span class='danger'>You leg sweep [D]!</span>")
+	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+	D.apply_damage(rand(20,30), STAMINA, affecting, armor_block)
+	D.Knockdown(60)
 	log_combat(A, D, "leg sweeped")
 	return 1
 
@@ -127,13 +130,15 @@
 	if(check_streak(A,D))
 		return 1
 	log_combat(A, D, "punched")
-	var/picked_hit_type = pick("punches", "kicks")
-	var/bonus_damage = 10
+	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
+	var/armor_block = D.run_armor_check(affecting, "melee")
+	var/picked_hit_type = pick("punch", "kick")
+	var/bonus_damage = 0
 	if(!(D.mobility_flags & MOBILITY_STAND))
 		bonus_damage += 5
-		picked_hit_type = "stomps on"
-	D.apply_damage(bonus_damage, A.dna.species.attack_type)
-	if(picked_hit_type == "kicks" || picked_hit_type == "stomps on")
+		picked_hit_type = "stomp"
+	D.apply_damage(rand(5,10) + bonus_damage, A.dna.species.attack_type, affecting, armor_block)
+	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
 		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 		playsound(get_turf(D), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	else
@@ -147,20 +152,27 @@
 /datum/martial_art/krav_maga/disarm_act(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(check_streak(A,D))
 		return 1
-	var/obj/item/I = null
-	if(prob(60))
-		I = D.get_active_held_item()
-		if(I)
-			if(D.temporarilyRemoveItemFromInventory(I))
-				A.put_in_hands(I)
-		D.visible_message("<span class='danger'>[A] disarms [D]!</span>", \
-							"<span class='userdanger'>[A] disarms you!</span>", null, COMBAT_MESSAGE_RANGE)
-		playsound(D, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-	else
-		D.visible_message("<span class='danger'>[A] fails to disarm [D]!</span>", \
-							"<span class='userdanger'>[A] fails to disarm you!</span>", null, COMBAT_MESSAGE_RANGE)
-		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-	log_combat(A, D, "disarmed (Krav Maga)", "[I ? " removing \the [I]" : ""]")
+	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
+	var/armor_block = D.run_armor_check(affecting, "melee")
+	if((D.mobility_flags & MOBILITY_STAND))
+		D.visible_message("<span class='danger'>[A] reprimands [D]!</span>", \
+					"<span class='userdanger'>You're slapped by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='danger'>You jab [D]!</span>")
+		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+		D.apply_damage(rand(5,10), STAMINA, affecting, armor_block)
+		log_combat(A, D, "punched nonlethally")
+	if(!(D.mobility_flags & MOBILITY_STAND))
+		D.visible_message("<span class='danger'>[A] reprimands [D]!</span>", \
+					"<span class='userdanger'>You're manhandled by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='danger'>You stomp [D]!</span>")
+		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
+		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+		D.apply_damage(rand(10,15), STAMINA, affecting, armor_block)
+		log_combat(A, D, "stomped nonlethally")
+	if(prob(D.getStaminaLoss()))
+		D.visible_message("<span class='warning'>[D] sputters and recoils in pain!</span>", "<span class='userdanger'>You recoil in pain as you are jabbed in a nerve!</span>")
+		D.drop_all_held_items()
 	return 1
 
 //Krav Maga Gloves


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
https://github.com/tgstation/tgstation/pull/49103

## About The Pull Request

* Replaces legsweep hardstun with a knockdown, which also lasts longer and does stamina damage. 
* Disarm intent now does a stamina damage strike which does more damage to targets who are on the floor. They also have a chance to disarm based on stamina loss, which makes them much stronger against people with high stamina damage.
* All strikes now respect armour. 

## Why It's Good For The Game

Hardstuns make for easy wins without being able to fight back, basically making them a one-hit kill. This change adds room for counterplay. 

Disarms were crap and there was previously no non-lethal options, the new Disarm strikes offers the user an alternative to having to stomp out or baton threats. And finally strikes which ignore armour yet are not magical in origin are dumb. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:necromanceranne
balance: Removes the stun from Krav Maga and makes it a high duration knockdown with stamina damage (20-30), respecting chest armor for the damage.
adds: Disarm intent is now a nonlethal jab that does (5-10) stamina damage. If used on people who are prone, it does (10-15) stamina damage. It also has a chance to completely disarm someone based on the amount of stamina damage they have.
balance: Krav Maga harm stomps/punches now respect armor and have a variance of (5-10) for punches and (5-10+5) for stomps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
