### PR TITLE
Adds click interactions and extended examine text to heater/freezer port

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -51,6 +51,13 @@
 	if(showpipe)
 		add_overlay(getpipeimage(icon, "scrub_cap", initialize_directions))
 
+/obj/machinery/atmospherics/components/unary/thermomachine/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>The thermostat is set to [target_temperature]K ([(T0C-target_temperature)*-1]C).</span>"
+	if(in_range(user, src) || isobserver(user))
+		. += "<span class='notice'>The status display reads: Efficiency <b>[(heat_capacity/5000)*100]%</b>.</span>"
+		. += "<span class='notice'>Temperature range <b>[min_temperature]K - [max_temperature]K ([(T0C-min_temperature)*-1]C - [(T0C-max_temperature)*-1]C)</b>.</span>"
+
 /obj/machinery/atmospherics/components/unary/thermomachine/process_atmos()
 	..()
 	if(!on || !nodes[1])
@@ -161,6 +168,12 @@
 
 	update_icon()
 
+/obj/machinery/atmospherics/components/unary/thermomachine/CtrlClick(mob/living/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
+		return
+	on = !on
+	update_icon()
+
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer
 	name = "freezer"
 	icon_state = "freezer"
@@ -194,6 +207,11 @@
 		L += M.rating
 	min_temperature = max(T0C - (initial(min_temperature) + L * 15), TCMB) //73.15K with T1 stock parts
 
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/AltClick(mob/living/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
+		return
+	target_temperature = min_temperature
+
 /obj/machinery/atmospherics/components/unary/thermomachine/heater
 	name = "heater"
 	icon_state = "heater"
@@ -214,3 +232,8 @@
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		L += M.rating
 	max_temperature = T20C + (initial(max_temperature) * L) //573.15K with T1 stock parts
+
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/AltClick(mob/living/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))
+		return
+	target_temperature = max_temperature


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
https://github.com/tgstation/tgstation/pull/44785

## About The Pull Request

Adds ctrl click to turn on/off heater/freezers, and alt click to max/min their temperature out.
Also adds examine readout for current setting and parts.

## Why It's Good For The Game
Less ui window interactions.

## Changelog
:cl:Skoglol
add: Heaters/freezers now support ctrl clicking to turn on and alt clicking to min/max target temperature.
add: Heaters/freezers now shows target temperature and part status on examine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
