### PR TITLE
Some bags and belts can hold more stuff port

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -193,8 +193,13 @@
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.max_combined_w_class = 100
 	STR.max_items = 100
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/food/snacks/grown, /obj/item/seeds, /obj/item/grown, /obj/item/reagent_containers/honeycomb, /obj/item/disk/plantgene))
-
+	STR.set_holdable(list(
+		/obj/item/reagent_containers/food/snacks/grown,
+		/obj/item/seeds,
+		/obj/item/grown,
+		/obj/item/reagent_containers/honeycomb,
+		/obj/item/disk/plantgene
+		))
 ////////
 
 /obj/item/storage/bag/plants/portaseeder
@@ -231,8 +236,11 @@
 	. = ..()
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
-	STR.can_hold = typecacheof(list(/obj/item/stack/sheet))
-	STR.cant_hold = typecacheof(list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
+	STR.set_holdable(list(/obj/item/stack/sheet),
+		list(
+			/obj/item/stack/sheet/mineral/sandstone,
+			/obj/item/stack/sheet/mineral/wood
+			))
 	STR.max_combined_stack_amount = 300
 
 // -----------------------------
@@ -268,7 +276,11 @@
 	STR.max_combined_w_class = 21
 	STR.max_items = 7
 	STR.display_numerical_stacking = FALSE
-	STR.can_hold = typecacheof(list(/obj/item/book, /obj/item/storage/book, /obj/item/spellbook))
+	STR.set_holdable(list(
+		/obj/item/book,
+		/obj/item/storage/book,
+		/obj/item/spellbook
+		))
 
 /*
  * Trays - Agouri
@@ -345,7 +357,16 @@
 	STR.max_combined_w_class = 200
 	STR.max_items = 50
 	STR.insert_preposition = "in"
-	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/medspray, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/waterbottle))
+	STR.set_holdable(list(
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/glass/waterbottle,
+		/obj/item/reagent_containers/medigel,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/chem_pack
+		))
 
 /*
  *  Biowaste bag (mostly for xenobiologists)
@@ -365,4 +386,16 @@
 	STR.max_combined_w_class = 200
 	STR.max_items = 25
 	STR.insert_preposition = "in"
-	STR.can_hold = typecacheof(list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube))
+	STR.set_holdable(list(
+		/obj/item/slime_extract,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/blood,
+		/obj/item/reagent_containers/hypospray/medipen,
+		/obj/item/reagent_containers/food/snacks/deadmouse,
+		/obj/item/reagent_containers/food/snacks/monkeycube,
+		/obj/item/organ,
+		/obj/item/bodypart
+		))

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -38,7 +38,8 @@
 /obj/item/storage/belt/utility/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	var/static/list/can_hold = typecacheof(list(
+	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.set_holdable(list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -57,7 +58,11 @@
 		/obj/item/holosign_creator/engineering,
 		/obj/item/forcefield_projector,
 		/obj/item/assembly/signaler,
-		/obj/item/lightreplacer
+		/obj/item/lightreplacer,
+		/obj/item/construction/rcd,
+		/obj/item/pipe_dispenser,
+		/obj/item/inducer,
+		/obj/item/plunger
 		))
 	STR.can_hold = can_hold
 
@@ -170,7 +175,10 @@
 		/obj/item/implant,
 		/obj/item/implanter,
 		/obj/item/pinpointer/crew,
-		/obj/item/holosign_creator/medical
+		/obj/item/holosign_creator/medical,
+		/obj/item/pipe_dispenser/plumbing,
+		/obj/item/construction/plumbing,
+		/obj/item/plunger
 		))
 
 /obj/item/storage/belt/security
@@ -445,7 +453,9 @@
 		/obj/item/lighter,
 		/obj/item/multitool,
 		/obj/item/reagent_containers/food/drinks/bottle/molotov,
-		/obj/item/grenade/plastic/c4,
+		/obj/item/grenade/c4,
+		/obj/item/reagent_containers/food/snacks/grown/cherry_bomb,
+		/obj/item/reagent_containers/food/snacks/grown/firelemon
 		))
 
 /obj/item/storage/belt/grenade/full/PopulateContents()
@@ -512,7 +522,8 @@
 		/obj/item/key/janitor,
 		/obj/item/clothing/gloves,
 		/obj/item/melee/flyswatter,
-		/obj/item/assembly/mousetrap
+		/obj/item/assembly/mousetrap,
+		/obj/item/paint/paint_remover
 		))
 
 /obj/item/storage/belt/janitor/full/PopulateContents()

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -3,7 +3,7 @@
 	desc = "You shouldn't see this! Adminhelp and report this as an issue on github!"
 	zone = BODY_ZONE_R_ARM
 	icon_state = "implant-toolkit"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
 
 	var/list/items_list = list()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -5,7 +5,7 @@
 /obj/item/organ/liver
 	name = "liver"
 	icon_state = "liver"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_LIVER
 	desc = "Pairing suggestion: chianti and fava beans."

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -4,7 +4,7 @@
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_LUNGS
 	gender = PLURAL
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 	//Breath damage
 

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -1,7 +1,7 @@
 /obj/item/organ/stomach
 	name = "stomach"
 	icon_state = "stomach"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	zone = BODY_ZONE_CHEST
 	slot = ORGAN_SLOT_STOMACH
 	attack_verb = list("gored", "squished", "slapped", "digested")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
https://github.com/tgstation/tgstation/pull/47318

## About The Pull Request

This PR does a few things which I will list in order.

1. Toolbelts can now also hold RCDs, RPDs, Inducers, and Plungers. The RPD and RCD are important construction and repair tools, and is very(very, very) important to those doing large scale repairs or large scale construction projects, so them fitting in the toolbelt is relatively essential. The Inducer is quite a useful asset to have around in worst case scenarios, and for major repairs or construction a bit aways from the station prior to it being added into the powernet, the Inducer becomes even more essential to have around. The plunger is largely something I threw in because it is creatable via the engineering techlathe, so if they can carry it around more easily, it might give them something to do.
2. For the Medical belt, I have made it so they can now also hold the plunger, the Plumbing Constructor, and the Plumbing RPD(Plumberinator), which would probably be useful to those doing the chem factory in a truly large scale fashion.
3. The Janitorial belt is now also able to hold the cans of Paint Remover.
4. The Grenadier belt, due to being a belt which holds grenades of every variety, is now able to hold both Cherry Bombs and Combustible Lemons. Note, this did not add the cherries and lemons to the belt itself, it is just capable of holding them.
5. Biobags are now capable of holding both organs(yes, this includes implants and the like) and limbs(except the head due to apparent balance reasons). This is so you can more easily refill the organ smartfridges in Medbay with them instead of doing it one at a time, one at a time, per hand.
6. The w_class on various organs were changed to small to fit better with their respective body parts. Like the arm augments were w_class normal, while the arms were small. And the liver, stomach, and lungs were also normal. This was also done so the biobag could pick them up. The alternative would be to just make it able to pick up normal sized items, but I think it is best if it remains like this, since now trash bags can also pick up lungs, stomachs, and livers.


## Why It's Good For The Game

For point 1, it was quite annoying that when doing construction projects or major repairs, that those essential tools could not go into your toolbelt.

For point 2, with the introduction of the chem factory, it seems quite sensible that their own versions of such tools would be in their own belts for ease of access and use.

For point 3, I don’t think I even need to give a reason why it is bad that the janitor can’t put his can of paint remover into his belt of janitorial supplies for some odd reason.

For point 4, It is a belt meant to hold various types of grenades. And cherry bombs and combustible lemons are both grenades(albeit the latter of more of a IED admittedly). So it makes sense that the grenadier belt should be able to hold those two as well.

For point 5, it is honestly just a mess that we couldn’t already pick up organs enmasse to put into smartfridges, whether organic organs or cybernetic organs or even augmentations or implants. But had to do it one by one, by hand, each and every dang time.

For point 6, since the w_class of those body parts themselves were decreased, it didn’t make sense that some implants and some organs still had a larger w_class than the bodypart itself. And, as a bonus, this does make the janitors job easier when people mass suicide via oxygen tanks.

## Changelog
:cl:Firecage
add: Toolbelts can now hold RCDs, RPDs, Inducers, and Plungers.
add: Medical belts can now hold Plumbing Constructors, Plumberinator, and Plungers.
add: Grenadier belts can now hold cherry bombs and combustible lemons.
add: Bio bags can now hold both organs and body parts(except heads).
tweak: Trash bags can now pick up livers, lungs, and stomachs.
/:cl:

Note: organ smartfridge and construction bag aspects from original PR not yet ported.
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
