### PR TITLE
Brute, burn, and stamina damage wake up target

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -186,11 +186,14 @@
 	stamina_dam += round(CLAMP(stamina, 0, min(max_stamina_damage - stamina_dam, available_damage)), DAMAGE_PRECISION)
 
 
-	if(owner && updating_health)
-		owner.updatehealth()
-		if(stamina > DAMAGE_PRECISION)
-			owner.update_stamina()
-			owner.stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
+	if(owner)
+		if((brute > 0 || burn > 0 || stamina > 0) && owner.IsSleeping())
+			owner.SetSleeping(0)
+		if(updating_health)
+			owner.updatehealth()
+			if(stamina > DAMAGE_PRECISION)
+				owner.update_stamina()
+				owner.stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
 	consider_processing()
 	update_disabled()
 	return update_bodypart_damage_state()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Taking brute, burn, or stamina damage wakes anything with body parts up.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Patients wake up in surgery if saws are used or steps are failed, making anesthetic more useful for keeping them in place and lying down. Being able to wake other people up by hitting them also is a fun mechanic.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Taking brute, burn, or stamina damage wakes anything with body parts up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
