### PR TITLE
Defib Rework port

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -79,6 +79,8 @@
 
 #define STATUS_EFFECT_NECKSLICE /datum/status_effect/neck_slice //Creates the flavor messages for the neck-slice
 
+#define STATUS_EFFECT_CONVULSING /datum/status_effect/convulsing
+
 #define STATUS_EFFECT_NECROPOLIS_CURSE /datum/status_effect/necropolis_curse
 #define CURSE_BLINDING	1 //! makes the edges of the target's screen obscured
 #define CURSE_SPAWNING	2 //! spawns creatures that attack the target only

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -752,6 +752,29 @@
 					owner.log_message("threw [I] due to a Muscle Spasm", LOG_ATTACK)
 					owner.throw_item(pick(targets))
 
+/datum/status_effect/convulsing
+	id = "convulsing"
+	duration = 	150
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /obj/screen/alert/status_effect/convulsing
+
+/datum/status_effect/convulsing/on_creation(mob/living/zappy_boy)
+	. = ..()
+	to_chat(zappy_boy, "<span class='boldwarning'>You feel a shock moving through your body! Your hands start shaking!</span>")
+
+/datum/status_effect/convulsing/tick()
+	var/mob/living/carbon/H = owner
+	if(prob(40))
+		var/obj/item/I = H.get_active_held_item()
+		if(I && H.dropItemToGround(I))
+			H.visible_message("<span class='notice'>[H]'s hand convulses, and they drop their [I.name]!</span>","<span class='userdanger'>Your hand convulses violently, and you drop what you were holding!</span>")
+			H.jitteriness += 5
+
+/obj/screen/alert/status_effect/convulsing
+	name = "Shaky Hands"
+	desc = "You've been zapped with something and your hands can't stop shaking! You can't seem to hold on to anything."
+	icon_state = "convulsing"
+
 /datum/status_effect/dna_melt
 	id = "dna_melt"
 	duration = 600

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -234,7 +234,7 @@
 
 
 /obj/item/defibrillator/proc/cooldowncheck(mob/user)
-	addtimer(CALLBACK(src, .proc/finish_charging), 5 SECONDS)
+	addtimer(CALLBACK(src, .proc/finish_charging), cooldown_duration)
 
 /obj/item/defibrillator/proc/finish_charging()
 	if(cell)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -488,7 +488,7 @@
 	busy = TRUE
 	M.visible_message("<span class='danger'>[user] has touched [M] with [src]!</span>", \
 			"<span class='userdanger'>[user] has touched [M] with [src]!</span>")
-	M.adjustStaminaLoss(60)
+	M.adjustStaminaLoss(80)
 	M.Knockdown(75)
 	M.Jitter(50)
 	M.apply_status_effect(STATUS_EFFECT_CONVULSING)

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -3,8 +3,6 @@
 //The effects include: stun, knockdown, unconscious, sleeping, resting, jitteriness, dizziness, ear damage,
 // eye damage, eye_blind, eye_blurry, druggy, TRAIT_BLIND trait, and TRAIT_NEARSIGHT trait.
 
-
-
 ///Set the jitter of a mob
 /mob/proc/Jitter(amount)
 	jitteriness = max(jitteriness,amount,0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Combat defibrillator cooldown and harm intent heart attack takes half as much time. This allows it to both zap people more often, and reasonably be used to cause a heart attack with harm intent whilst the target is downed.

Adds a new status effect, 'convulsing'. Convulsion makes you drop your inhand item with a 40% chance every tick.

EMP'd and emagged defibs now knocks down for 7.5 seconds, deal 80 stamina damage, and convulse for 15 seconds. Stamina damage was boosted from 55 in the original PRs to an amount that would stamcrit in two zaps. 

## Why It's Good For The Game

Combat defibs can now be used in combat and buffs them appropiately so a nuclear operative could reasonably use it, at the cost of sacrificing their belt slot and their offhand.

EMP'd and emagged defibs are a legacy hardstun and it's easy to get one in the first few mins of roundstart with the maint EMP or if you have one of the various antag options for doing this. They still remain the superior choice over the stun baton, as they take up a belt slot or back slot, two hands, and preparation. Simply making them a shitty stun baton would mean that everyone would just make a stunprod or stunbaton without bothering to emp/emag the defib whatsoever, ruining the point of their existence.

## Changelog
:cl:carlarctg
balance: Halved syndicate combat defibrillator recharge time (now 2.5 seconds)
balance: Harm intent defibrillator heart attack takes half as much time.
add: New status effect: Convulsions. 40% chance to drop your inhand item every tick.
balance: EMP'd/emagged defibs now knock people down for 7.5 seconds, deal 80 stamina damage, and convulse for 15 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
