### PR TITLE
Flashbang nerf port

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -26,11 +26,17 @@
 
 //Flash
 	if(M.flash_act(affect_silicon = 1))
-		M.Paralyze(max(200/max(1,distance), 60))
+		M.Paralyze(max(20/max(1,distance), 5))
+		M.Knockdown(max(200/max(1,distance), 60))
+
 //Bang
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		M.Paralyze(200)
+		M.Paralyze(20)
+		M.Knockdown(200)
 		M.soundbang_act(1, 200, 10, 15)
 
 	else
+		if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
+			M.Paralyze(5)
+			M.Knockdown(30)
 		M.soundbang_act(1, max(200/max(1,distance), 60), rand(0, 5))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -378,7 +378,8 @@
 	var/effect_amount = intensity - ear_safety
 	if(effect_amount > 0)
 		if(stun_pwr)
-			Paralyze(stun_pwr*effect_amount)
+			Paralyze((stun_pwr*effect_amount)*0.1)
+			Knockdown(stun_pwr*effect_amount)
 
 		if(istype(ears) && (deafen_pwr || damage_pwr))
 			var/ear_damage = damage_pwr * effect_amount


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/46221

## About The Pull Request
Flashbangs no longer hard stun, rather do a short stun, followed by a knockdown.

## Why It's Good For The Game
Chain flashbanging no longer a thing, requires more skill to keep criminals down. 

## Changelog
:cl:wesoda25
balance: Flashbangs now stun for 1/10 of their former duration, with a knockdown as long as the old 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
