### PR TITLE
Dedicated action for stale issue handling

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,20 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: "This issue has been inactive for long enough to be automatically marked as stale. If this was a bug report and hasn't been addressed yet, and is still a probelm, please don't hesitate to notify a maintainer."
+        stale-issue-label: 'Stale'
+        exempt-issue-label: 'Exempt'
+        days-before-stale: 30
+        days-before-close: 180

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -15,6 +15,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: "This issue has been inactive for long enough to be automatically marked as stale. If this was a bug report and hasn't been addressed yet, and is still a probelm, please don't hesitate to notify a maintainer."
         stale-issue-label: 'Stale'
-        exempt-issue-label: 'Exempt'
+        exempt-issue-label: 'Triaged'
         days-before-stale: 30
         days-before-close: 180

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,4 +1,4 @@
-name: Mark stale issues and pull requests
+name: Mark issues as stale
 
 on:
   schedule:

--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -1,4 +1,4 @@
-name: Mark stale issues and pull requests
+name: Mark pull requests as stale
 
 on:
   schedule:

--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -13,11 +13,8 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: "This issue has been inactive for long enough to be automatically marked as stale. If this was a bug report and hasn't been addressed yet, and is still a probelm, please don't hesitate to notify a maintainer."
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being closed by a maintainer if it is not updated or reviews are not addressed. If your PR is closed as stale, feel free to open a new one after dealing with the issues. This may also be an indication that the maintainers do not have interest in this change, you can try to convince them otherwise, or persist in the doomed world you have created."
-        stale-issue-label: 'Stale'
         stale-pr-label: 'Stale'
         exempt-pr-label: 'Needs Review'
-        exempt-issue-label: 'Exempt'
         days-before-stale: 30
         days-before-close: 5


### PR DESCRIPTION
Splits the stale PR and Issue handling actions so that issues can be maintained for a longer period of time before they're auto closed.

Closes #1263 