### PR TITLE
Adds fluid ducts and plumbing constructors to chem lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -100,6 +100,12 @@
 	new /obj/item/storage/box/pillbottles(src)
 	new /obj/item/storage/box/medsprays(src)
 	new /obj/item/storage/box/medsprays(src)
+	new /obj/item/stack/ducts/fifty(src)
+	new /obj/item/stack/ducts/fifty(src)
+	new /obj/item/stack/ducts/fifty(src)
+	new /obj/item/stack/ducts/fifty(src)			
+	new /obj/item/construction/plumbing(src)
+	new /obj/item/construction/plumbing(src)
 
 /obj/structure/closet/secure_closet/chemical/heisenberg //contains one of each beaker, syringe etc.
 	name = "advanced chemical closet"


### PR DESCRIPTION
## About The Pull Request

Adds four stacks of fluid ducts and two plumbing constructors to chemistry lockers.

## Why It's Good For The Game

We may not have a dedicated plumbing room (yet) but sometimes you just want to get started wherever you can find space. This PR adds the necessary items so you can start plumbing from roundstart.

## Changelog
:cl:
add: Adds stacks of fluid ducts and two plumbing constructors to chemistry lockers. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
