### PR TITLE
Zombie infection chance is lowered by armor port

### DIFF
--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -33,7 +33,10 @@
 		return
 	else if(isliving(target))
 		if(ishuman(target))
-			try_to_zombie_infect(target)
+			var/mob/living/carbon/human/H = target
+			var/flesh_wound = ran_zone(user.zone_selected)
+			if(prob(100-H.getarmor(flesh_wound, "melee")))
+				try_to_zombie_infect(target)
 		else
 			check_feast(target, user)
 


### PR DESCRIPTION
## About The Pull Request
See title.

## Why It's Good For The Game

Makes sense that you'll get instantly zombied if wearing a jumpsuit but less likely if you have an armor vest in the way. 

## Changelog
:cl:
add: Zombie infections are now blocked a % of the time scaling with melee armor
/:cl:

Ports:
https://github.com/yogstation13/Yogstation/pull/6576