### PR TITLE
Here we go again (Fixes all necropolis seed issues)

### DIFF
--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -1,8 +1,8 @@
 /datum/symptom/necroseed
 	name = "Necropolis Seed"
 	desc = "An infantile form of the root of Lavaland's tendrils. Forms a symbiotic bond with the host, making them stronger and hardier, at the cost of speed. Should the disease be cured, the host will be severely weakened"
-	stealth = 8
-	resistance = 20
+	stealth = 0
+	resistance = 3
 	stage_speed = -10
 	transmittable = -3
 	level = 9


### PR DESCRIPTION

## About The Pull Request

my bounties are cursed to always be in some way broken on the first merge, eh?

anyways, this pr:
-adds a mind check to the stealth 8 threshold, meaning farming empty clones for tendril chests is now impossible
-makes ALL disease effects relegated to stage 5
-halves the range of the tendrils
-tendrils now stun for 4 seconds instead of doing nothing, and are no longer persistent

## Why It's Good For The Game
fuck

## Changelog
:cl:
fix: both esoteric necropolis seed thresholds
/:cl:
