### PR TITLE
Reduces riot suit slowdown

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -122,7 +122,7 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
-	slowdown = 0.2
+	slowdown = 0.05
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -122,6 +122,7 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
+	slowdown = 0.2
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -122,7 +122,6 @@
 	blocks_shove_knockdown = TRUE
 	strip_delay = 80
 	equip_delay_other = 60
-	slowdown = 0.5
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"


### PR DESCRIPTION
## Why It's Good For The Game
Several months ago I reduced riot suit slowdown from 50% to 20% riot suits when I actually wanted to remove it completely, but I was talked down from that change because it'd be "too OP". 

Let's look at riot suits now: still garbage-tier items that no-one uses ever because the slowdown just makes you a victim. So slowdown has been reduced further to hopefully bring it to a place where it might actually be used. It also still has only got 10 energy/laser/bullet resist, which is the main weakness of the gear. 

## Changelog
:cl:
balance: Reduced riot suit slowdown from 20% to 5%.
/:cl: