### PR TITLE
Replaces ED-209's dragnet with a disabler

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -163,7 +163,7 @@
 					if(!istype(W, /obj/item/gun/energy/laser/redtag))
 						return
 				if("")
-					if(!istype(W, /obj/item/gun/energy/e_gun/dragnet))
+					if(!istype(W, /obj/item/gun/energy/disabler))
 						return
 				else
 					return

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -16,7 +16,7 @@
 	radio_channel = RADIO_CHANNEL_SECURITY
 	bot_type = SEC_BOT
 	model = "ED-209"
-	bot_core = /obj/machinery/bot_core/secbot
+	bot_core_type = /obj/machinery/bot_core/secbot
 	window_id = "autoed209"
 	window_name = "Automatic Security Unit v2.6"
 	allow_pai = 0
@@ -40,12 +40,11 @@
 	var/check_records = TRUE //Does it check security records?
 	var/arrest_type = FALSE //If true, don't handcuff
 	var/projectile = /obj/item/projectile/energy/electrode //Holder for projectile type
-	var/shoot_sound = 'sound/weapons/taser.ogg'
+	var/shoot_sound = 'sound/weapons/taser2.ogg'
 	var/cell_type = /obj/item/stock_parts/cell
 	var/vest_type = /obj/item/clothing/suit/armor/vest
 
 	do_footstep = TRUE
-
 
 /mob/living/simple_animal/bot/ed209/Initialize(mapload,created_name,created_lasercolor)
 	. = ..()
@@ -119,7 +118,6 @@ Maintenance panel panel is [open ? "opened" : "closed"]<BR>"},
 Arrest Unidentifiable Persons: []<BR>
 Arrest for Unauthorized Weapons: []<BR>
 Arrest for Warrant: []<BR>
-<BR>
 Operating Mode: []<BR>
 Report Arrests[]<BR>
 Auto Patrol[]"},
@@ -389,7 +387,7 @@ Auto Patrol[]"},
 	drop_part(cell_type, Tsec)
 
 	if(!lasercolor)
-		var/obj/item/gun/energy/e_gun/dragnet/G = new (Tsec)
+		var/obj/item/gun/energy/disabler/G = new (Tsec)
 		G.cell.charge = 0
 		G.update_icon()
 	else if(lasercolor == "b")
@@ -431,7 +429,7 @@ Auto Patrol[]"},
 	else
 		if(!lasercolor)
 			shoot_sound = 'sound/weapons/laser.ogg'
-			projectile = /obj/item/projectile/energy/net
+			projectile = /obj/item/projectile/beam/disabler
 		else if(lasercolor == "b")
 			projectile = /obj/item/projectile/beam/lasertag/bluetag
 		else if(lasercolor == "r")


### PR DESCRIPTION
## About The Pull Request
Provides the ED-209s with a disabler to make them a little more useful at catching criminals. Also fixes a bug that let anyone access its controls without the appropriate access on their ID card.

## Why It's Good For The Game
ED-209s previously used to roam the halls with a taser, because they were designed to be a more powerful version of Beepsky units / securitrons with ranged capability. When tasers were removed from security, the ED-209 received the very underwhelming DragNET which has the nasty habit of teleporting criminals away from security, either randomly killing the suspect via spacing or allowing them to escape. Since then the ED has been very rarely made, and never been much more useful than making a standard Beepsky.

## Changelog
:cl:
tweak: ED-209s now instead use a disabler.
fix: Fixed a bug that let anyone unlock the ED-209s controls regardless of their access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
