### PR TITLE
New engi/atmos traitor item: Crushing Magboots

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -57,3 +57,32 @@
 	name = "blood-red magboots"
 	icon_state = "syndiemag0"
 	magboot_state = "syndiemag"
+
+/obj/item/clothing/shoes/magboots/crushing
+	desc = "Normal looking magboots that are altered to increase magnetic pull to crush anything underfoot."
+
+/obj/item/clothing/shoes/magboots/crushing/proc/crush(mob/living/user)
+	if (!isturf(user.loc) || !magpulse)
+		return
+	var/turf/T = user.loc
+	for (var/mob/living/A in T)
+		if (A != user && A.lying)
+			A.adjustBruteLoss(rand(10,13))
+			to_chat(A,"<span class='userdanger'>[user]'s magboots press down on you, crushing you!</span>")
+			A.emote("scream")
+
+/obj/item/clothing/shoes/magboots/crushing/attack_self(mob/user)
+	. = ..()
+	if (magpulse)
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED,.proc/crush)
+	else
+		UnregisterSignal(user,COMSIG_MOVABLE_MOVED)
+
+/obj/item/clothing/shoes/magboots/crushing/equipped(mob/user,slot)
+	. = ..()
+	if (slot == SLOT_SHOES && magpulse)
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED,.proc/crush)
+
+/obj/item/clothing/shoes/magboots/crushing/dropped(mob/user)
+	. = ..()
+	UnregisterSignal(user,COMSIG_MOVABLE_MOVED)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1648,6 +1648,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 14							//High cost because of the potential for extreme damage in the hands of a skilled scientist.
 	restricted_roles = list("Research Director", "Scientist")
 
+/datum/uplink_item/role_restricted/crushmagboots
+	name = "Crushing Magboots"
+	desc = "A pair of extra-strength magboots that crush anyone you walk over."
+	cost = 2
+	item = /obj/item/clothing/shoes/magboots/crushing
+	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+
 /datum/uplink_item/role_restricted/gorillacubes
 	name = "Box of Gorilla Cubes"
 	desc = "A box with three Waffle Co. brand gorilla cubes. Eat big to get big. \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1651,7 +1651,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/crushmagboots
 	name = "Crushing Magboots"
 	desc = "A pair of extra-strength magboots that crush anyone you walk over."
-	cost = 2
+	cost = 7
 	item = /obj/item/clothing/shoes/magboots/crushing
 	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
 


### PR DESCRIPTION
## About The Pull Request
Crushing Magboots look like normal magboots except they do 10-13 damage every time you step on someone. 

## Why It's Good For The Game
Great utility item which can also do a lot of damage quickly.

## Changelog
:cl:
add: New engi/atmos traitor item: Crushing Magboots. Turn them on and walk over people to crush them. Costs 7 TC.
/:cl:

Ports:
https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10788