### PR TITLE
New chaplain traitor item: Cult Construct Kit

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -137,3 +137,7 @@
 /obj/item/sbeacondrop/clownbomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a silly explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb/badmin/clown
+
+/obj/item/sbeacondrop/constructshell
+	desc = "A label on it reads: <i>Warning: Activating this device will send a Nar'sian construct shell to your location</i>."
+	droptype = /obj/structure/constructshell

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -319,6 +319,10 @@
 	for(var/i in 1 to 6)
 		new /obj/item/soulstone/anybody/chaplain(src)
 
+/obj/item/storage/belt/soulstone/full/purified/PopulateContents()
+	for(var/i in 1 to 6)
+		new /obj/item/soulstone/anybody/purified(src)
+
 /obj/item/storage/belt/champion
 	name = "championship belt"
 	desc = "Proves to the world that you are the strongest!"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -530,3 +530,12 @@
 /obj/item/storage/box/syndie_kit/bee_grenades/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/grenade/spawnergrenade/buzzkill(src)
+
+/obj/item/storage/box/syndie_kit/cultconstructkit
+	name = "cult construct kit"
+	desc = "A sleek, sturdy box with an ominous, dark energy inside. Yikes."
+
+/obj/item/storage/box/syndie_kit/cultconstructkit/PopulateContents()
+	new /obj/item/storage/belt/soulstone/full/purified(src)
+	new /obj/item/sbeacondrop/constructshell(src)
+	new /obj/item/sbeacondrop/constructshell(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1760,6 +1760,13 @@ datum/uplink_item/role_restricted/superior_honkrender
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
 
+/datum/uplink_item/role_restricted/cultconstructkit
+	name = "Cult Construct Kit"
+	desc = "Recovered from an abandoned Nar'sie cult lair two construct shells and a stash of empty soulstones was found. These were purified to prevent occult contamination and have been put in a belt so they may be used as an accessible source of disposable minions. The construct shells have been packaged into two beacons for rapid and portable deployment."
+	item = /obj/item/storage/box/syndie_kit/cultconstructkit
+	cost = 20
+	restricted_roles = list("Chaplain")
+
 /datum/uplink_item/role_restricted/spanish_flu
 	name = "Spanish Flu Culture"
 	desc = "A bottle of cursed blood, full of angry spirits which will burn all the heretics with the fires of hell.\


### PR DESCRIPTION
## About The Pull Request
Adds the Cult Construct Kit so that traitor chaplains can create a horde of purified constructs. 

## Why It's Good For The Game
Purified constructs virtually never happen, let alone potentially an army of them. This adds an alternative to chaplains toolboxing everyone so they can instead raise their own cult. 

## Changelog
:cl:
add: New chaplain traitor item: Cult Construct Kit. Contains two beacons with a construct shell each and a belt full of purified soulstones. Costs 20 TC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
