### PR TITLE
Revival is not Repair

### DIFF
--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -26,7 +26,7 @@
 	return TRUE
 
 /datum/surgery_step/revive
-	name = "repair body"
+	name = "revive body"
 	implements = list(/obj/item/twohanded/shockpaddles = 100, /obj/item/melee/baton = 75, /obj/item/gun/energy = 60)
 	time = 120
 


### PR DESCRIPTION


## About The Pull Request
Changes "Repair body" to "Revive body" to avoid confusion.

## Why It's Good For The Game

Confusion is bad.

## Changelog
:cl:
fix: fixed the last step of revival surgery saying "repair body"
/:cl:
