### PR TITLE
Liquid electricity tweaks

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -117,7 +117,9 @@
 		var/mob/living/carbon/human/H = occupant
 		var/datum/species/ethereal/E = H.dna?.species
 		if(E)
-			E.adjust_charge(recharge_speed / 70) //Around 3 per process if unupgraded
+			E.adjust_charge(recharge_speed / 40) //Around 5 per process if unupgraded
+			if(repairs && H.blood_volume < BLOOD_VOLUME_NORMAL)
+				H.reagents.add_reagent(/datum/reagent/consumable/liquidelectricity,repairs*0.2)
 
 /obj/machinery/recharge_station/proc/restock_modules()
 	if(occupant)

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -136,7 +136,7 @@
 	icon_state = "etherealmeat"
 	desc = "So shiny you feel like ingesting it might make you shine too"
 	filling_color = "#97ee63"
-	list_reagents = list(/datum/reagent/consumable/liquidelectricity = 3)
+	list_reagents = list(/datum/reagent/consumable/liquidelectricity = 15)
 	tastes = list("pure electrictiy" = 2, "meat" = 1)
 	foodtype = RAW | MEAT | TOXIC
 

--- a/code/modules/food_and_drinks/food/snacks_burgers.dm
+++ b/code/modules/food_and_drinks/food/snacks_burgers.dm
@@ -286,7 +286,7 @@
 	name = "empowered burger"
 	desc = "It's shockingly good, if you live off of electricity that is."
 	icon_state = "empoweredburger"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/liquidelectricity = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/liquidelectricity = 20)
 	tastes = list("bun" = 2, "pure electricity" = 4)
 	foodtype = GRAIN | TOXIC
 

--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -204,7 +204,7 @@
 	force = 5
 	hitsound = 'sound/weapons/blade1.ogg'
 	slice_path = /obj/item/reagent_containers/food/snacks/cakeslice/birthday/energy
-	list_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/pwr_game = 10, /datum/reagent/consumable/liquidelectricity = 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/pwr_game = 10, /datum/reagent/consumable/liquidelectricity = 30)
 	tastes = list("cake" = 3, "a Vlad's Salad" = 1)
 
 /obj/item/reagent_containers/food/snacks/store/cake/birthday/energy/proc/energy_bite(mob/living/user)
@@ -227,7 +227,7 @@
 	force = 2
 	hitsound = 'sound/weapons/blade1.ogg'
 	filling_color = "#00FF00"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/sprinkles = 2, /datum/reagent/consumable/nutriment/vitamin = 1,  /datum/reagent/consumable/pwr_game = 2, /datum/reagent/consumable/liquidelectricity = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/sprinkles = 2, /datum/reagent/consumable/nutriment/vitamin = 1,  /datum/reagent/consumable/pwr_game = 2, /datum/reagent/consumable/liquidelectricity = 5)
 	tastes = list("cake" = 3, "a Vlad's Salad" = 1)
 
 /obj/item/reagent_containers/food/snacks/cakeslice/birthday/energy/proc/energy_bite(mob/living/user)

--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -98,7 +98,7 @@
 	icon_state = "energybar"
 	desc = "An energy bar with a lot of punch, you probably shouldn't eat this if you're not an Ethereal."
 	trash = /obj/item/trash/energybar
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 3)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity = 10)
 	filling_color = "#97ee63"
 	tastes = list("pure electricity" = 3, "fitness" = 2)
 	foodtype = TOXIC

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -62,6 +62,8 @@
 	blood_type = "L"
 
 /obj/item/reagent_containers/blood/ethereal
+	labelled = 1
+	name = "blood pack - LE"
 	blood_type = "LE"
 	unique_blood = /datum/reagent/consumable/liquidelectricity
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the amount of liquid electricity in foods, adds a name for ethereal blood bags and makes the cyborg recharger restore more charge and gives ethereals a small amount of liquid electricity when upgraded.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Losing blood as an ethereal is basically a death sentence currently as the liquid electricity gained from snacks is incredibly small and the blood bag containing it has the same name as an unfilled blood bag so doctors aren't aware of it's existence.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Cyborg rechargers now slowly restores liquid electricity to ethereals when upgraded
fix: Ethereal blood bag is now properly named
tweak: Cyborg rechargers restore more charge to ethereals
tweak: Amount of liquid electricity in foods increased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
