### PR TITLE
More surgical supplies, plumbing gear, stasis beds and synthflesh

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5896,7 +5896,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "amu" = (
-/obj/machinery/sleeper,
+/obj/machinery/sleeper{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "amv" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5896,9 +5896,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "amu" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "amv" = (
@@ -5946,9 +5944,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "amB" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /obj/machinery/camera/autoname{
 	icon_state = "camera";
 	dir = 9

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -306,7 +306,10 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/obj/machinery/sleeper,
+/obj/machinery/sleeper{
+	icon_state = "sleeper";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "aaJ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -306,10 +306,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/obj/machinery/sleeper{
-	icon_state = "sleeper";
-	dir = 4
-	},
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "aaJ" = (
@@ -319,9 +316,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "aaK" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -17975,6 +17975,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"aQh" = (
+/obj/machinery/camera{
+	c_tag = "Medical - Sleeper Bay";
+	dir = 1;
+	network = list("ss13","Medical")
+	},
+/obj/machinery/stasis,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "aQi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -19432,6 +19441,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"aTD" = (
+/obj/machinery/stasis,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "aTE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -21887,7 +21900,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/sleeper,
+/obj/machinery/stasis,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "aYp" = (
@@ -56929,7 +56942,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wMM" = (
-/obj/machinery/sleeper,
+/obj/machinery/stasis,
 /obj/machinery/airalarm{
 	pixel_y = 25
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3862,9 +3862,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/machinery/sleeper,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -3905,9 +3903,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3862,7 +3862,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/sleeper,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -54,7 +54,10 @@
 	network = list("ss13","medbay");
 	dir = 4
 	},
-/obj/machinery/sleeper,
+/obj/machinery/sleeper{
+	icon_state = "sleeper";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "aag" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -54,17 +54,11 @@
 	network = list("ss13","medbay");
 	dir = 4
 	},
-/obj/machinery/sleeper{
-	icon_state = "sleeper";
-	dir = 4
-	},
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "aag" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper";
-	dir = 4
-	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "aah" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1118,10 +1118,7 @@
 /obj/structure/window{
 	dir = 8
 	},
-/obj/machinery/sleeper{
-	icon_state = "sleeper";
-	dir = 1
-	},
+/obj/machinery/stasis,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -1133,10 +1130,7 @@
 	},
 /area/holodeck/rec_center/medical)
 "dd" = (
-/obj/machinery/sleeper{
-	icon_state = "sleeper";
-	dir = 1
-	},
+/obj/machinery/stasis,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -371,9 +371,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bz" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bC" = (
@@ -450,6 +448,13 @@
 /area/shuttle/escape)
 "Jx" = (
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"JM" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -837,7 +842,7 @@ aP
 ac
 bq
 ad
-ac
+JM
 ac
 ac
 ac

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -417,9 +417,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "br" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bs" = (
@@ -659,13 +657,18 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "cb" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Yn" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -829,7 +832,7 @@ aN
 aN
 aE
 ca
-ae
+Yn
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -112,6 +112,13 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"w" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
 "x" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -284,9 +291,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "X" = (
-/obj/machinery/sleeper{
-	dir = 1
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Y" = (
@@ -496,7 +501,7 @@ b
 h
 C
 C
-h
+w
 b
 A
 c

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -269,9 +269,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bd" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "be" = (
@@ -306,6 +304,10 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "bj" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "bk" = (

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1128,9 +1128,6 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cu" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -1141,6 +1138,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cv" = (
@@ -1243,13 +1241,11 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cD" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cE" = (
@@ -1388,16 +1384,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
-"cL" = (
-/obj/machinery/sleeper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "cM" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -1410,9 +1396,6 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cN" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -1420,6 +1403,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cO" = (
@@ -1746,6 +1730,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
+/area/shuttle/escape)
+"pf" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -2485,7 +2476,7 @@ cs
 cp
 cp
 cp
-cL
+cw
 ab
 cR
 cY
@@ -2568,7 +2559,7 @@ ac
 ac
 ab
 ab
-ad
+pf
 cu
 cy
 cD

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -155,6 +155,10 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aF" = (
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0
+	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aG" = (
@@ -273,9 +277,7 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aX" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aY" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -497,30 +497,16 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aQ" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "aR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
-"aS" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -1907,7 +1893,7 @@ aB
 aG
 aJ
 aN
-aS
+aQ
 aP
 aZ
 bd

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -330,7 +330,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bf" = (
-/obj/machinery/sleeper,
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bg" = (
@@ -485,6 +485,13 @@
 "bt" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"bS" = (
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/structure/table/optable,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -660,7 +667,7 @@ aW
 aX
 aY
 ab
-bf
+bS
 bj
 bn
 ab

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -67,9 +67,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "q" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "r" = (
@@ -291,7 +289,7 @@ d
 T
 J
 H
-d
+l
 d
 "}
 (5,1,1) = {"
@@ -300,7 +298,7 @@ d
 d
 w
 f
-d
+l
 f
 K
 d

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -1341,9 +1341,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cv" = (
@@ -1390,9 +1388,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cz" = (

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -301,9 +301,7 @@
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape/luxury)
 "bf" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape/luxury)
 "bg" = (
@@ -351,6 +349,25 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape/luxury)
+"hA" = (
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape/luxury)
+"zg" = (
+/obj/machinery/vending/wallmed,
+/turf/closed/indestructible/riveted/uranium,
+/area/shuttle/escape/luxury)
+"OL" = (
+/obj/item/surgicaldrill,
+/obj/item/scalpel,
+/obj/item/retractor,
+/obj/item/cautery,
+/obj/item/hemostat,
+/obj/item/circular_saw,
+/obj/structure/table/wood/fancy,
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape/luxury)
 
 (1,1,1) = {"
 aa
@@ -380,7 +397,7 @@ as
 as
 ab
 bf
-bf
+hA
 ab
 ab
 "}
@@ -394,10 +411,10 @@ ab
 ab
 ab
 ab
-ab
+zg
 aj
 aj
-ab
+zg
 ab
 "}
 (4,1,1) = {"
@@ -413,7 +430,7 @@ aj
 bj
 aj
 aj
-ak
+OL
 ab
 "}
 (5,1,1) = {"

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -400,9 +400,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bl" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bm" = (

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -34,9 +34,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "g" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "h" = (
@@ -173,6 +171,10 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"G" = (
+/obj/structure/table/optable,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "H" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
@@ -252,6 +254,12 @@
 /obj/item/crowbar,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"W" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "X" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -305,7 +313,7 @@ b
 (3,1,1) = {"
 c
 d
-X
+W
 X
 X
 n
@@ -328,7 +336,7 @@ n
 (4,1,1) = {"
 c
 d
-g
+G
 l
 g
 n

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -609,9 +609,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "ba" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = -26;
@@ -623,6 +620,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bb" = (
@@ -635,9 +633,6 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bc" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = 26
@@ -648,6 +643,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bd" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -419,13 +419,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/escape)
 "aX" = (
-/obj/machinery/sleeper,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "aY" = (
@@ -454,6 +454,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/vending/wallmed/pubby{
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -461,9 +461,7 @@
 /area/shuttle/escape)
 "bh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -586,9 +584,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 28
 	},
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/machinery/stasis,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -487,17 +487,8 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bD" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bE" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/stasis,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bF" = (
@@ -583,6 +574,18 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"iJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/clothing/gloves/fingerless,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"wq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/optable,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -796,7 +799,7 @@ ax
 ax
 ad
 bA
-bE
+bD
 bA
 bK
 bL
@@ -845,7 +848,7 @@ ax
 bw
 bB
 bB
-bB
+bF
 bK
 bL
 "}
@@ -892,7 +895,7 @@ ax
 ax
 ad
 bC
-bF
+iJ
 ad
 ad
 aa
@@ -915,7 +918,7 @@ bk
 bP
 bt
 ab
-bD
+wq
 ab
 ad
 aa

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -244,9 +244,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aK" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "aL" = (

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -219,7 +219,7 @@
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 "J" = (
-/obj/machinery/sleeper/survival_pod,
+/obj/machinery/stasis,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 "K" = (

--- a/_maps/templates/shelter_1.dmm
+++ b/_maps/templates/shelter_1.dmm
@@ -27,7 +27,7 @@
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/survivalpod)
 "g" = (
-/obj/machinery/sleeper/survival_pod,
+/obj/machinery/stasis/survival_pod,
 /obj/machinery/vending/wallmed/survival_pod{
 	pixel_x = -24
 	},

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -50,7 +50,7 @@
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/survivalpod)
 "k" = (
-/obj/machinery/sleeper/survival_pod,
+/obj/machinery/stasis/survival_pod,
 /obj/machinery/vending/wallmed/survival_pod{
 	pixel_x = -24
 	},

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -27,8 +27,11 @@
 	var/enter_message = "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.</b></span>"
 	payment_department = ACCOUNT_MED
 	fair_market_price = 5
-/obj/machinery/sleeper/Initialize()
+/obj/machinery/sleeper/Initialize(mapload)
 	. = ..()
+	if(mapload)
+		component_parts -= circuit
+		QDEL_NULL(circuit)
 	occupant_typecache = GLOB.typecache_living
 	update_icon()
 	reset_chem_buttons()
@@ -261,7 +264,6 @@
 /obj/machinery/sleeper/syndie/fullupgrade/Initialize()
 	. = ..()
 	component_parts = list()
-	component_parts += new /obj/item/circuitboard/machine/sleeper(null)
 	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
 	component_parts += new /obj/item/stock_parts/manipulator/femto(null)
 	component_parts += new /obj/item/stack/sheet/glass(null)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -371,6 +371,7 @@
 	new /obj/item/surgical_drapes(src)
 	new /obj/item/clothing/mask/surgical(src)
 	new /obj/item/razor(src)
+	new /obj/item/reagent_containers/medspray/sterilizine(src)
 
 /obj/item/storage/backpack/duffelbag/sec
 	name = "security duffel bag"
@@ -391,6 +392,7 @@
 	new /obj/item/cautery(src)
 	new /obj/item/surgical_drapes(src)
 	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/reagent_containers/medspray/sterilizine(src)
 
 /obj/item/storage/backpack/duffelbag/engineering
 	name = "industrial duffel bag"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -78,6 +78,7 @@
 	new /obj/item/wallframe/defib_mount(src)
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/CMO(src)
+	new /obj/item/reagent_containers/food/drinks/bottle/synthflesh(src)
 	new /obj/item/card/id/departmental_budget/med(src)
 
 /obj/structure/closet/secure_closet/animal

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -15,7 +15,9 @@
 		/obj/item/reagent_containers/glass/bottle/morphine = 2,
 		/obj/item/reagent_containers/glass/bottle/epinephrine= 3,
 		/obj/item/reagent_containers/glass/bottle/charcoal = 3,
-		/obj/item/storage/box/rxglasses = 1)
+		/obj/item/storage/box/rxglasses = 1,
+		/obj/item/stack/ducts/fifty = 4,			
+		/obj/item/construction/plumbing = 2)
 	generate_items_inside(items_inside,src)
 
 /obj/structure/closet/secure_closet/medical2
@@ -117,3 +119,9 @@
 	new /obj/item/storage/box/syringes/variety(src)
 	new /obj/item/storage/box/beakers/variety(src)
 	new /obj/item/clothing/glasses/science(src)
+	new /obj/item/stack/ducts/fifty(src)
+	new /obj/item/stack/ducts/fifty(src)
+	new /obj/item/stack/ducts/fifty(src)
+	new /obj/item/stack/ducts/fifty(src)			
+	new /obj/item/construction/plumbing(src)
+	new /obj/item/construction/plumbing(src)

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -23,7 +23,7 @@
 					/obj/item/reagent_containers/syringe/antiviral = 6,
 					/obj/item/reagent_containers/medspray/styptic = 2,
 					/obj/item/reagent_containers/medspray/silver_sulf = 2,
-					/obj/item/reagent_containers/medspray/sterilizine = 1,
+					/obj/item/reagent_containers/medspray/sterilizine = 3,
 					/obj/item/sensor_device = 2,
 					/obj/item/pinpointer/crew = 2)
 	contraband = list(/obj/item/reagent_containers/pill/tox = 3,

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -11,7 +11,7 @@
 					/obj/item/reagent_containers/pill/charcoal = 2,
 					/obj/item/reagent_containers/medspray/styptic = 2,
 					/obj/item/reagent_containers/medspray/silver_sulf = 2,
-					/obj/item/reagent_containers/medspray/sterilizine = 1)
+					/obj/item/reagent_containers/medspray/sterilizine = 3)
 	contraband = list(/obj/item/reagent_containers/pill/tox = 2,
 	                  /obj/item/reagent_containers/pill/morphine = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)


### PR DESCRIPTION
## About The Pull Request
Steriliser spray or anaesthetic gas is now needed to ensure 100% success rate for surgery, so two more sprays have been added to nanomed vendors and one spray to surgical bags.

Some stations had different types of chemical lockers which didn't have plumbing equipment automatically added into them, this has been rectified.

In medbay one of the two sleepers have been swapped with a stasis bed. This means there's both a source of unlimited meds as well as a source of stasis, which means more people can be defibbed rather than having to go to overloaded cloning (as their bodies don't decay in stasis). This is especially needed now that synthflesh is required for cloning, and an additional bonus is that it makes it much easier for tend wounds healing surgery to take place so it can be comboed with sleeper meds.

The amount of roundstart synthflesh cloning is a bit low so an extra carton has been added to the CMOs locker. 

## Why It's Good For The Game
Medbay is a bit overworked now especially in early game due to the necessity of synthflesh for cloning. These additions all help ensure people continue to get revived in a timely manner. 

## Changelog
:cl:
add: More steriliser spray in med vendors and one spray in surgical bags also.
add: Plumbing constructors and fluid ducts added into chem lockers missed in the earlier PR. 
add: Medbay now has a sleeper and a stasis bed. Everywhere else stasis beds are also replacing sleepers. 
add: An extra carton of synthflesh to the CMOs locker for emergencies.
/:cl: