### PR TITLE
Adds plague doctor costume to ViroDrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -440,6 +440,9 @@
 					/obj/item/clothing/mask/surgical = 2,
 					/obj/item/storage/backpack/virology = 2,
 					/obj/item/storage/backpack/satchel/vir = 2)
+	contraband = list(/obj/item/clothing/suit/bio_suit/plaguedoctorsuit,
+					/obj/item/clothing/head/plaguedoctorhat,
+					/obj/item/clothing/mask/gas/plaguedoctor)
 	refill_canister = /obj/item/vending_refill/wardrobe/viro_wardrobe
 	payment_department = ACCOUNT_MED
 /obj/item/vending_refill/wardrobe/viro_wardrobe


### PR DESCRIPTION
## About The Pull Request
Player request in #coding channel.

## Why It's Good For The Game
More reasons to lynch the viro. 

## Changelog
:cl:
add: Plague doctor costume now available as contraband in the ViroDrobe. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
