### PR TITLE
Wallslams rework

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -63,8 +63,8 @@
 		if((confused || is_blind()) && stat == CONSCIOUS && m_intent=="run")
 			playsound(get_turf(src), "punch", 25, 1, -1)
 			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
-			apply_damage(5, BRUTE)
-			Paralyze(40)
+			adjustStaminaLoss(30)
+			Knockdown(40)
 
 	if(ismob(A))
 		var/mob/M = A

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -64,7 +64,7 @@
 			playsound(get_turf(src), "punch", 25, 1, -1)
 			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
 			adjustStaminaLoss(30)
-			Knockdown(40)
+			Knockdown(30)
 
 	if(ismob(A))
 		var/mob/M = A


### PR DESCRIPTION
## About The Pull Request
Changes wallslams in two ways:
- Instead of brute damage it deals stamina damage
- Instead of stun it does a knockdown

## Why It's Good For The Game
Now there's some counterplay once you wallslam instead of it being a fight-ender, whilst keeping flashes still strong equipment for sec who can effectively follow-up on knockdowns.  

Prevents hulks getting confused and critting themselves in a second by walking into a wall.
It also stops the lame stunlock murder tactic of shove spamming someone against a wall once they're confused.

## Changelog
:cl:
balance: Wallslams now deal stamina damage and a knockdown instead of brute damage and a stun.
/:cl: