### PR TITLE
Fixes stasis beds not having a surgery success probability 

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -87,7 +87,7 @@
 	if(locate(/obj/structure/table/optable/abductor, T))
 		propability = 1.2
 	if(locate(/obj/machinery/stasis, T))
-		propability = 0.8
+		propability = 0.9
 	if(locate(/obj/structure/table/optable, T))
 		propability = 0.8
 	else if(locate(/obj/structure/table, T))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -86,6 +86,8 @@
 		sleepbonus = 0.5
 	if(locate(/obj/structure/table/optable/abductor, T))
 		propability = 1.2
+	if(locate(/obj/machinery/stasis, T))
+		propability = 0.8
 	if(locate(/obj/structure/table/optable, T))
 		propability = 0.8
 	else if(locate(/obj/structure/table, T))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -87,7 +87,7 @@
 	if(locate(/obj/structure/table/optable/abductor, T))
 		propability = 1.2
 	if(locate(/obj/machinery/stasis, T))
-		propability = 0.9
+		propability = 0.8
 	if(locate(/obj/structure/table/optable, T))
 		propability = 0.8
 	else if(locate(/obj/structure/table, T))


### PR DESCRIPTION
## About The Pull Request
They now have the same surgery success probability, which is 90% (10% higher than that of a surgical table).

## Why It's Good For The Game
Right now trying to do surgery on one of these fails much more than it should. 

## Changelog
:cl:
fix: Stasis beds now have a surgery success probability of 90%, 10% higher than that of an operating table.
/:cl: