### PR TITLE
Fixed virodrobe contraband being empty

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -440,9 +440,9 @@
 					/obj/item/clothing/mask/surgical = 2,
 					/obj/item/storage/backpack/virology = 2,
 					/obj/item/storage/backpack/satchel/vir = 2)
-	contraband = list(/obj/item/clothing/suit/bio_suit/plaguedoctorsuit,
-					/obj/item/clothing/head/plaguedoctorhat,
-					/obj/item/clothing/mask/gas/plaguedoctor)
+	contraband = list(/obj/item/clothing/suit/bio_suit/plaguedoctorsuit = 1,
+					/obj/item/clothing/head/plaguedoctorhat = 1,
+					/obj/item/clothing/mask/gas/plaguedoctor = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/viro_wardrobe
 	payment_department = ACCOUNT_MED
 /obj/item/vending_refill/wardrobe/viro_wardrobe


### PR DESCRIPTION
Forgot to set a stock value.

## Changelog
:cl:
fix: Fixed ViroDrobe contraband being empty
/:cl: