### PR TITLE
Removes the unused global_ban parameter from the unban panel + fixes page number formatting

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -563,7 +563,7 @@
 			if(roles_to_ban[1] == "Server" && (!is_admin || (is_admin && applies_to_admins)))
 				qdel(i)
 
-/datum/admins/proc/unban_panel(player_key, admin_key, player_ip, player_cid, global_ban, page = 0)
+/datum/admins/proc/unban_panel(player_key, admin_key, player_ip, player_cid, page = 0)
 	if(!check_rights(R_BAN))
 		return
 	if(!SSdbcore.Connect())
@@ -583,7 +583,7 @@
 	</div>
 	<div class='main'>
 	"}
-	if(player_key || admin_key || player_ip || player_cid || global_ban)
+	if(player_key || admin_key || player_ip || player_cid)
 		var/list/searchlist = list()
 		if(player_key)
 			searchlist += "ckey = '[sanitizeSQL(ckey(player_key))]'"
@@ -609,7 +609,7 @@
 			var/pagecount = 1
 			var/list/pagelist = list()
 			while(bancount > 0)
-				pagelist += "<a href='?_src_=holder;[HrefToken()];unbanpagecount=[pagecount - 1];unbankey=[player_key];unbanadminkey=[admin_key];unbanip=[player_ip];unbancid=[player_cid]'>[pagecount == page ? "<b>\[[pagecount]\]</b>" : "\[[pagecount]\]"]</a>"
+				pagelist += "<a href='?_src_=holder;[HrefToken()];unbanpagecount=[pagecount - 1];unbankey=[player_key];unbanadminkey=[admin_key];unbanip=[player_ip];unbancid=[player_cid]'>[pagecount == (page + 1) ? "<b>\[[pagecount]\]</b>" : "\[[pagecount]\]"]</a>"
 				bancount -= bansperpage
 				pagecount++
 			output += pagelist.Join(" | ")


### PR DESCRIPTION
## About The Pull Request

Fixes an error added in #489 which prevents admins from changing pages on the unban panel. 

A parameter was introduced during our rushed implementation of cross-server banning. This item was originally going to be used to help filter searches, but, when that feature was removed the parameter was left in. Preventing admins from viewing more than one page of bans when attempting to edit/remove bans using the unban panel. 

## Changelog
:cl:
admin: Admins can view more than one page on the unban panel again
/:cl:
 