### PR TITLE
cool whip and baton changes

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -504,14 +504,18 @@
 	var/mob/living/carbon/human/U = user
 	if(ishuman(target))
 		if((user.zone_selected == BODY_ZONE_CHEST) || (user.zone_selected == BODY_ZONE_HEAD) || (user.zone_selected == BODY_ZONE_PRECISE_GROIN))
-			if(H.getarmor(type = "melee") < 25)
+			if(H.getarmor(type = "melee") < 16)
 				H.emote("scream")
-				H.Stun(5)
 				H.visible_message("<span class='danger'>[U] whips [H]!</span>", "<span class='userdanger'>[U] whips you! It stings!</span>")
 		if((user.zone_selected == BODY_ZONE_R_LEG) || (user.zone_selected == BODY_ZONE_L_LEG))
-			target.Knockdown((4-get_dist(H, U))*10)
-			log_combat(user, target, "tripped", src)
-			H.visible_message("<span class='danger'>[U] trips [H]!</span>", "<span class='userdanger'>[U] whips your legs out from under you!</span>")
+			var/dist = get_dist(H, U)
+			if(dist < 2)
+				to_chat(user, "<span class='warning'>[H] is too close to trip with the whip!</span>")
+				return
+			else
+				target.Knockdown(30)
+				log_combat(user, target, "tripped", src)
+				H.visible_message("<span class='danger'>[U] trips [H]!</span>", "<span class='userdanger'>[U] whips your legs out from under you!</span>")
 			return
 		if(user.zone_selected == BODY_ZONE_L_ARM)
 			var/obj/item/I = H.get_held_items_for_side("left")


### PR DESCRIPTION
## About The Pull Request
Whips and telescopic/police batons now have more tactical limb-based combat applications, no longer being as much crutch weapons as they were, but still being robust
TL;DR: whips now feel like actual Indiana Jones shit, telebatons now require a bit of tactical thinking and robustness, whilst not being neutered

Whips:
have 3 range
no longer deal damage
when targeting an arm, knock the item out of that hand. If your other hand is empty, you will automatically catch the item and switch hands to it
![image](https://cdn.discordapp.com/attachments/605179594617782302/688254694010912838/whip.gif)
do knockdown when targeting the legs, unless you are adjacent to the target 
do a half-second truestun (without causing item drops) when targeting the chest, head, or groin, and cause the target to scream, unless the target is wearing somewhat decent melee armor

Telebatons:
cooldown is halved
now deal stamina damage when targeting head or torso. now affected by armor.
deal knockdown when targeting legs
when targeting an arm, instantly disables it, depending on target armor. internally, this is 50 stamina damage to the arm, affected by armor.

NOTE: needs https://github.com/BeeStation/BeeStation-Hornet/pull/1292 (knockdowns and truestuns no longer drop items by default). Otherwise, this isn't balanced

## Why It's Good For The Game

telebatons and the whip are less in the vein of fightending unga weapons and now have a degree of tactics and precisions required, but are still quite robust. 

## Changelog
:cl:
tweak: whips now feel like indiana jones and shit man. 
balance: telebatons need a bit more robustness
/:cl:
