### PR TITLE
Tasers no longer have stacking confusion

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -22,7 +22,8 @@
 		var/mob/living/carbon/C = target
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "tased", /datum/mood_event/tased)
 		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
-		C.confused +=15
+		if(C.confused < 10)
+			C.confused = 10
 		if(C.dna && C.dna.check_mutation(HULK))
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 		else if((C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE))


### PR DESCRIPTION

## About The Pull Request

no more permaconfusion for being stuck in the ai sat. shortens taser confusion from 15 to 10 seconds as well

## Why It's Good For The Game
permaconfuse gay

## Changelog
:cl:
balance: lower taser confusion to 10 seconds (from 15)
fix: no more stacking confusion for being stuck in ai sat or anywhere else
/:cl:
