### PR TITLE
Xeno Acid Adjust

### DIFF
--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -66,7 +66,7 @@
 
 //xenomorph corrosive acid
 /obj/effect/acid/alien
-	var/target_strength = 30
+	var/target_strength = 80
 
 
 /obj/effect/acid/alien/process()

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -66,7 +66,7 @@
 
 //xenomorph corrosive acid
 /obj/effect/acid/alien
-	var/target_strength = 80
+	var/target_strength = 30
 
 
 /obj/effect/acid/alien/process()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -274,11 +274,6 @@
 /turf/closed/wall/get_dumping_location(obj/item/storage/source, mob/user)
 	return null
 
-/turf/closed/wall/acid_act(acidpwr, acid_volume)
-	if(explosion_block >= 2)
-		acidpwr = min(acidpwr, 50) //we reduce the power so strong walls never get melted.
-	. = ..()
-
 /turf/closed/wall/acid_melt()
 	dismantle_wall(1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull makes it possible for Xenomorph acid to melt through Reinforced Walls.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xenos can now escape R_Wall'ed areas with enough time and effort
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: removed acid power decrease on r_walls
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
