### PR TITLE
Nukie reinforcements work on the station

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -110,9 +110,6 @@
 	if(!user.mind.has_antag_datum(/datum/antagonist/nukeop,TRUE))
 		to_chat(user, "<span class='danger'>AUTHENTICATION FAILURE. ACCESS DENIED.</span>")
 		return FALSE
-	if(!user.onSyndieBase())
-		to_chat(user, "<span class='warning'>[src] is out of range! It can only be used at your base!</span>")
-		return FALSE
 	return TRUE
 
 


### PR DESCRIPTION
so that lone ops can buy syndicate cyborgs etc. Also useful if no ghosts signed up to be reinforcements when the nukies are at their base

:cl:
tweak: Nuke op borg/reinforcement spawners now work on the station.
/:cl: