### PR TITLE
Hepatectomy Surgery

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2900,6 +2900,7 @@
 #include "code\modules\surgery\eye_surgery.dm"
 #include "code\modules\surgery\healing.dm"
 #include "code\modules\surgery\helpers.dm"
+#include "code\modules\surgery\hepatectomy.dm"
 #include "code\modules\surgery\implant_removal.dm"
 #include "code\modules\surgery\limb_augmentation.dm"
 #include "code\modules\surgery\lipoplasty.dm"

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -1,0 +1,46 @@
+/datum/surgery/hepatectomy
+	name = "Hepatectomy"
+	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	possible_locs = list(BODY_ZONE_CHEST)
+	requires_real_bodypart = TRUE
+	steps = list(/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/saw,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/incise,
+		/datum/surgery_step/hepatectomy,
+		/datum/surgery_step/close
+		)
+
+/datum/surgery/hepatectomy/can_start(mob/user, mob/living/carbon/target)
+	var/obj/item/organ/liver/L = target.getorganslot(ORGAN_SLOT_LIVER)
+	if(L?.damage > 50 && !(L.organ_flags & ORGAN_FAILING))
+		return TRUE
+
+////hepatectomy, removes damaged parts of the liver so that the liver may regenerate properly
+//95% chance of success, not 100 because organs are delicate
+/datum/surgery_step/hepatectomy
+	name = "remove damaged liver section"
+	implements = list(/obj/item/scalpel = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
+		/obj/item/shard = 35)
+	time = 52
+
+/datum/surgery_step/hepatectomy/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You begin to cut out a damaged peice of [target]'s liver...</span>",
+		"<span class='notice'>[user] begins to make an incision in [target].</span>",
+		"<span class='notice'>[user] begins to make an incision in [target].</span>")
+
+/datum/surgery_step/hepatectomy/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	var/mob/living/carbon/human/H = target
+	H.setOrganLoss(ORGAN_SLOT_LIVER, 10) //not bad, not great
+	display_results(user, target, "<span class='notice'>You successfully remove the damaged part of [target]'s liver.</span>",
+		"<span class='notice'>[user] successfullly removes the damaged part of [target]'s liver.",
+		"<span class='notice'>[user] successfullly removes the damaged part of [target]'s liver.")
+	return TRUE
+
+/datum/surgery_step/hepatectomy/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery)
+	var/mob/living/carbon/human/H = target
+	H.adjustOrganLoss(ORGAN_SLOT_LIVER, 15)
+	display_results(user, target, "<span class='warning'>You cut the wrong part of [target]'s liver!</span>",
+		"<span class='warning'>[user] cuts the wrong part of [target]'s liver!",
+		"<span class='warning'>[user] cuts the wrong part of [target]'s liver!")

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -26,7 +26,7 @@
 	time = 52
 
 /datum/surgery_step/hepatectomy/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	display_results(user, target, "<span class='notice'>You begin to cut out a damaged peice of [target]'s liver...</span>",
+	display_results(user, target, "<span class='notice'>You begin to cut out a damaged piece of [target]'s liver...</span>",
 		"<span class='notice'>[user] begins to make an incision in [target].</span>",
 		"<span class='notice'>[user] begins to make an incision in [target].</span>")
 

--- a/code/modules/surgery/hepatectomy.dm
+++ b/code/modules/surgery/hepatectomy.dm
@@ -21,7 +21,7 @@
 //95% chance of success, not 100 because organs are delicate
 /datum/surgery_step/hepatectomy
 	name = "remove damaged liver section"
-	implements = list(/obj/item/scalpel = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
+	implements = list(TOOL_SCALPEL = 95, /obj/item/melee/transforming/energy/sword = 65, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 35)
 	time = 52
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/46397

followup to the organ PR because doctors need more ways to heal livers

:cl: aarontheidiot
add: Added Hepatectomy surgery, used to heal livers without needing to replace them when they get damaged. Only appears when a liver is damaged to a certain degree, and doesn't work on failed livers.
/:cl: