### PR TITLE
Corrects the art license

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See tgui/LICENSE.md for the MIT license.
 See tgui/assets/fonts/SIL-OFL-1.1-LICENSE.md for the SIL Open Font License.
 See the footers of code/\_\_DEFINES/server\_tools.dm, code/modules/server\_tools/st\_commands.dm, and code/modules/server\_tools/st\_inteface.dm for the MIT license.
 
-All assets including icons and sound are under a [Creative Commons 3.0 BY-SA license](https://creativecommons.org/licenses/by-sa/3.0/) unless otherwise indicated.
+All assets including icons and sound are under a [Creative Commons 3.0 BY-NC-SA license](https://creativecommons.org/licenses/by-nc-sa/3.0/) unless otherwise indicated.
 
 # Other Codebase Credits
 - /tg/, for the codebase.


### PR DESCRIPTION
Arguments about the code license aside, TG 100% did change the art license from CC BY-NC-SA 3.0 by default to CC BY-SA 3.0 by default even though it contains a lot of artwork (and derivatives of artwork) created under the former license, not the latter.

I am not a lawyer, and any implications regarding sprites properly contributed under CC BY-SA 3.0 should be considered before merging this.