### PR TITLE
Caltrop effects require standing

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -42,7 +42,7 @@
 		if(!(flags & CALTROP_BYPASS_SHOES) && (H.shoes || feetCover))
 			return
 
-		if((H.movement_type & FLYING) || H.buckled)
+		if((H.movement_type & FLYING) || !(H.mobility_flags & MOBILITY_STAND)|| H.buckled)
 			return
 
 		var/damage = rand(min_damage, max_damage)


### PR DESCRIPTION
## About The Pull Request

Caltrop effects such as stepping on broken glass without shoes now require the person to be standing to take effect.

## Why It's Good For The Game

People can drag someone who isn't wearing shoes over glass shards repeatedly to perma stun them and kill them rather quickly without any way for the person to counteract it, this PR makes it no longer possible to do that.

## Changelog
:cl: Garen
balance: Caltrop effects such as stepping on broken glass without shoes now require the person to be standing to take effect.
/:cl: