### PR TITLE
adds needlessly complex finger gun emote

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -537,7 +537,6 @@
 		qdel(N)
 		to_chat(user, "<span class='warning'>You don't have any free hands to high-five with.</span>")
 
-
 /datum/emote/living/snap
 	key = "snap"
 	key_third_person = "snaps"
@@ -547,3 +546,18 @@
 
 /datum/emote/living/snap/get_sound(mob/living/user)
 	return pick('sound/misc/fingersnap1.ogg', 'sound/misc/fingersnap2.ogg')
+
+/datum/emote/living/fingergun
+	key = "fingergun"
+	key_third_person = "fingerguns"
+	message = "forms their fingers into the shape of a crude gun"
+	restraint_check = TRUE
+
+/datum/emote/living/fingergun/run_emote(mob/user, params)
+	. = ..()
+	var/obj/item/gun/ballistic/revolver/mime/N = new(user)
+	if(user.put_in_hands(N))
+		to_chat(user, "<span class='notice'>You form your fingers into a gun.</span>")
+	else
+		qdel(N)
+		to_chat(user, "<span class='warning'>You don't have any free hands to make fingerguns with.</span>")

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -46,3 +46,10 @@
 	caliber = "mime"
 	projectile_type = /obj/item/projectile/bullet/c38/mime
 
+/obj/item/ammo_casing/mime/lethals
+	name = "odd .38 bullet casing"
+	icon_state = "s-casing"
+	desc = "A .38 bullet chambered to be fired from your fingers."
+	caliber = "mime"
+	projectile_type = /obj/item/projectile/bullet/c38
+

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -47,8 +47,5 @@
 	projectile_type = /obj/item/projectile/bullet/c38/mime
 
 /obj/item/ammo_casing/caseless/mime/lethals
-	name = "odd .38 bullet casing"
-	desc = "A .38 bullet chambered to be fired from your fingers."
-	caliber = "mime"
 	projectile_type = /obj/item/projectile/bullet/c38
 

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -38,3 +38,11 @@
 	desc = "A .38 Iceblox bullet casing."
 	caliber = "38"
 	projectile_type = /obj/item/projectile/bullet/c38/iceblox
+
+/obj/item/ammo_casing/caseless/mime
+	name = "invisible .38 bullet casing"
+	icon_state = null
+	desc = "You shouldnt be seeing this."
+	caliber = "mime"
+	projectile_type = /obj/item/projectile/bullet/c38/mime
+

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -46,9 +46,8 @@
 	caliber = "mime"
 	projectile_type = /obj/item/projectile/bullet/c38/mime
 
-/obj/item/ammo_casing/mime/lethals
+/obj/item/ammo_casing/caseless/mime/lethals
 	name = "odd .38 bullet casing"
-	icon_state = "s-casing"
 	desc = "A .38 bullet chambered to be fired from your fingers."
 	caliber = "mime"
 	projectile_type = /obj/item/projectile/bullet/c38

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -35,7 +35,7 @@
 	max_ammo = 6
 	desc = "Designed to quickly reload your fingers with lethal rounds."
 	item_flags = DROPDEL
-	ammo_type = /obj/item/ammo_casing/mime/lethals
+	ammo_type = /obj/item/ammo_casing/caseless/mime/lethals
 
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -30,6 +30,13 @@
 	desc = "Designed to quickly reload revolvers. Iceblox bullets contain a cryogenic payload."
 	ammo_type = /obj/item/ammo_casing/c38/iceblox
 
+/obj/item/ammo_box/c38/mime
+	name = "speed loader (.38 finger)"
+	max_ammo = 6
+	desc = "Designed to quickly reload your fingers with lethal rounds."
+	item_flags = DROPDEL
+	ammo_type = /obj/item/ammo_casing/mime/lethals
+
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"
 	icon_state = "9mmbox"

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -47,3 +47,9 @@
 			return TRUE
 
 	return FALSE
+
+/obj/item/ammo_box/magazine/internal/cylinder/mime
+	name = "fingergun cylinder"
+	ammo_type = /obj/item/ammo_casing/caseless/mime
+	caliber = "mime"
+	max_ammo = 6

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -257,3 +257,26 @@
 		user.emote("scream")
 		user.drop_all_held_items()
 		user.Paralyze(80)
+
+/obj/item/gun/ballistic/revolver/mime
+	name = "finger gun"
+	desc = "Your hand, pointed into the shape of a gun."
+	fire_sound = null
+	dry_fire_sound = 'sound/misc/fingersnap1.ogg'
+	icon_state = "detective"
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/mime
+	lefthand_file = null
+	righthand_file = null
+	item_flags = DROPDEL | ABSTRACT
+	w_class = WEIGHT_CLASS_HUGE
+	force = 0
+	throwforce = 0
+	throw_range = 0
+	throw_speed = 0
+
+/obj/item/gun/ballistic/revolver/mime/shoot_with_empty_chamber(mob/living/user as mob|obj)
+	to_chat(user, "<span class='warning'>Your fingergun is out of ammo!</span>")
+	qdel(src)
+
+/obj/item/gun/ballistic/revolver/mime/attack_self(mob/user)
+	qdel(src)

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -53,6 +53,23 @@
 		var/mob/living/M = target
 		M.adjust_bodytemperature(((100-blocked)/100)*(temperature - M.bodytemperature))
 
+/obj/item/projectile/bullet/c38/mime
+	name = "invisible .38 bullet"
+	icon_state = null
+	damage = 0
+	nodamage = TRUE
+
+/obj/item/projectile/bullet/c38/mime/on_hit(atom/target, blocked = FALSE)
+	if(isliving(target))
+		var/mob/living/carbon/human/M = target
+		if(M.job == "Mime")
+			var/defense = M.getarmor(CHEST, "bullet")
+			M.apply_damage(5, BRUTE, CHEST, defense)
+			M.visible_message("<span class='danger'>A bullet wound appears in [M]'s chest!</span>", \
+							"<span class='userdanger'>You get hit with a .38 bullet from a finger gun! Those hurt!...</span>")
+		else 
+			to_chat(M, "<span class='userdanger'>You get shot with the finger gun!</span>")
+
 // .357 (Syndie Revolver)
 
 /obj/item/projectile/bullet/a357


### PR DESCRIPTION
## About The Pull Request

you can *fingergun to get a finger gun to shoot people with invisible bullets that dont do anything. unless the target is a mime, in which it deals 5 damage

## Why It's Good For The Game

It's funny i guess
## Changelog
:cl:
add: fingergun emote
add: admin only lethal fingergun speedloader
/:cl:
