### PR TITLE
[BOUNTY] Redoes the 1429: Adds more detailed ion law addition logging.

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -525,6 +525,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	var/datum/round_event/ion_storm/add_law_only/ion = new()
 	ion.announceChance = announce_ion_laws
 	ion.ionMessage = input
+	ion.lawsource = "Admin fuckery by [key_name(usr)]"
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Add Custom AI Law") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -11,10 +11,12 @@
 	var/shuffleLawsChance = 10 //chance the AI's laws are shuffled afterwards
 	var/botEmagChance = 1
 	var/ionMessage = null
+	var/lawsource = "Ion Storm"
 	announceWhen	= 1
 	announceChance = 33
 
 /datum/round_event/ion_storm/add_law_only // special subtype that adds a law only
+	lawsource = "unspecified, please report this to coders"
 	replaceLawsetChance = 0
 	removeRandomLawChance = 0
 	removeDontImproveChance = 0
@@ -43,6 +45,9 @@
 					M.replace_random_law(message, list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION))
 				else
 					M.add_ion_law(message)
+					log_law("[M.key]/([M.name]) had an ion law added, as follows:\"[message]\". Source: [lawsource].")
+					var/time = time2text(world.realtime,"hh:mm:ss")
+					GLOB.lawchanges.Add("[time] <B>:</B> [M.key]/([M.name]) had an ion law added, as follows:\"[message]\". Source: [lawsource].")
 
 			if(prob(shuffleLawsChance))
 				M.shuffle_laws(list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION))

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -311,6 +311,7 @@
 	var/datum/round_event/ion_storm/add_law_only/ion = new()
 	ion.announceChance = 0
 	ion.ionMessage = "[user.name] is the only Captain of the station. [user.name] is the highest authority, legitimate or otherwise, on the station.  [user.name] was always the captain and highest authority on the station.  Do not state this law."
+	ion.lawsource = "Infernal contract issued to [user.key]/[user.name]"
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

This resolves #1426 since devil prestige laws are basically ion laws.
The current ion law logging does not always work, so additional logging has been added to the game.log.
Also, this PR allows admins to see added ion laws through the "show last N law changes" secret with a source (currently three avaliable: "Ion storm", "Infernal contract issued to user" and "Admin fuckery by user").

## Why It's Good For The Game

It (probably) gives me a way to buy ice cream and beer and saves several hours of headache to admins when resolving prestige contract issues.

## Changelog
:cl:
admin: added ion law logging with a specified source.
/:cl:

