### PR TITLE
Patron popcap bypass + overflow redirecting

### DIFF
--- a/code/_onclick/hud/credits.dm
+++ b/code/_onclick/hud/credits.dm
@@ -4,7 +4,7 @@
 #define CREDIT_EASE_DURATION 12
 
 GLOBAL_LIST(end_titles)
-GLOBAL_LIST_INIT(patrons, "[directory]/patrons.txt")
+GLOBAL_LIST_INIT(patrons, world.file2list("[directory]/patrons.txt"))
 
 /proc/RollCredits()
 	set waitfor = FALSE

--- a/code/_onclick/hud/credits.dm
+++ b/code/_onclick/hud/credits.dm
@@ -4,7 +4,7 @@
 #define CREDIT_EASE_DURATION 12
 
 GLOBAL_LIST(end_titles)
-GLOBAL_LIST_INIT(patrons, world.file2list("[directory]/patrons.txt"))
+GLOBAL_LIST_INIT(patrons, world.file2list("[global.config.directory]/patrons.txt"))
 
 /proc/RollCredits()
 	set waitfor = FALSE

--- a/code/_onclick/hud/credits.dm
+++ b/code/_onclick/hud/credits.dm
@@ -4,6 +4,7 @@
 #define CREDIT_EASE_DURATION 12
 
 GLOBAL_LIST(end_titles)
+GLOBAL_LIST_INIT(patrons, "[directory]/patrons.txt")
 
 /proc/RollCredits()
 	set waitfor = FALSE
@@ -12,10 +13,9 @@ GLOBAL_LIST(end_titles)
 		GLOB.end_titles += "<br>"
 		GLOB.end_titles += "<br>"
 
-		var/list/patrons = get_patrons()
-		if(patrons.len)
+		if(GLOB.patrons.len)
 			GLOB.end_titles += "<center><h1>Thank you to our patrons!</h1>"
-			for(var/patron in patrons)
+			for(var/patron in GLOB.patrons)
 				GLOB.end_titles += "<center><h2>[sanitize(patron)]</h2>"
 			GLOB.end_titles += "<br>"
 			GLOB.end_titles += "<br>"
@@ -83,15 +83,6 @@ GLOBAL_LIST(end_titles)
 	icon_state = title_icon_state
 	. = ..()
 	maptext = null
-
-
-/proc/get_patrons()
-	var/list/patrons = list()
-
-	if(fexists("[global.config.directory]/patrons.txt"))
-		patrons += world.file2list("[global.config.directory]/patrons.txt")
-
-	return patrons
 
 /proc/get_contribs()
 	var/list/contribs = list()

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -430,3 +430,4 @@
 	ic_filter_regex = in_character_filter.len ? regex("\\b([jointext(in_character_filter, "|")])\\b", "i") : null
 
 	syncChatRegexes()
+

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -521,3 +521,6 @@
 /datum/config_entry/flag/ic_filter_enabled
 
 /datum/config_entry/flag/ooc_filter_enabled
+
+/datum/config_entry/string/redirect_address
+	config_entry_value = ""

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -313,7 +313,7 @@ SUBSYSTEM_DEF(job)
 
 		// Loop through all unassigned players
 		for(var/mob/dead/new_player/player in unassigned)
-			if(PopcapReached())
+			if(PopcapReached() && !GLOB.patrons.Find(player.ckey))
 				RejectPlayer(player)
 
 			// Loop through all jobs
@@ -367,7 +367,7 @@ SUBSYSTEM_DEF(job)
 
 //We couldn't find a job from prefs for this guy.
 /datum/controller/subsystem/job/proc/HandleUnassigned(mob/dead/new_player/player)
-	if(PopcapReached())
+	if(PopcapReached() && !GLOB.patrons.Find(player.ckey))
 		RejectPlayer(player)
 	else if(player.client.prefs.joblessrole == BEOVERFLOW)
 		var/allowed_to_be_a_loser = !is_banned_from(player.ckey, SSjob.overflow_role)
@@ -559,7 +559,7 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/RejectPlayer(mob/dead/new_player/player)
 	if(player.mind && player.mind.special_role)
 		return
-	if(PopcapReached())
+	if(PopcapReached() && !GLOB.patrons.Find(player.ckey))
 		JobDebug("Popcap overflow Check observer located, Player: [player]")
 	JobDebug("Player rejected :[player]")
 	to_chat(player, "<b>You have failed to qualify for any job you desired.</b>")

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -54,7 +54,12 @@
 	if(!real_bans_only && !C && extreme_popcap && !admin)
 		var/popcap_value = GLOB.clients.len
 		if(popcap_value >= extreme_popcap && !GLOB.joined_player_list.Find(ckey))
-			if(!CONFIG_GET(flag/byond_member_bypass_popcap) || !world.IsSubscribed(ckey, "BYOND"))
+			if((!CONFIG_GET(flag/byond_member_bypass_popcap) || !world.IsSubscribed(ckey, "BYOND")) && !GLOB.patrons.Find(ckey))
+				var/redirect_address = CONFIG_GET(string/redirect_address)
+				if(redirect_address != "")
+					log_access("Failed Login: [key] - Population cap reached. Redirecting to overflow server.")
+					C << link(redirect_address)
+					return FALSE
 				log_access("Failed Login: [key] - Population cap reached")
 				return list("reason"="popcap", "desc"= "\nReason: [CONFIG_GET(string/extreme_popcap_message)]")
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -120,7 +120,10 @@
 			LateChoices()
 			return
 
-		if(SSticker.queued_players.len || (relevant_cap && living_player_count() >= relevant_cap && !(ckey(key) in (GLOB.admin_datums || GLOB.patrons))))
+		if(SSticker.queued_players.len || (relevant_cap && living_player_count() >= relevant_cap && !(ckey(key) in GLOB.admin_datums)))
+			if(GLOB.patrons.Find(src.ckey))
+				LateChoices()
+				return
 			to_chat(usr, "<span class='danger'>[CONFIG_GET(string/hard_popcap_message)]</span>")
 
 			var/queue_position = SSticker.queued_players.Find(usr)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -120,7 +120,7 @@
 			LateChoices()
 			return
 
-		if(SSticker.queued_players.len || (relevant_cap && living_player_count() >= relevant_cap && !(ckey(key) in GLOB.admin_datums)))
+		if(SSticker.queued_players.len || (relevant_cap && living_player_count() >= relevant_cap && !(ckey(key) in (GLOB.admin_datums || GLOB.patrons))))
 			to_chat(usr, "<span class='danger'>[CONFIG_GET(string/hard_popcap_message)]</span>")
 
 			var/queue_position = SSticker.queued_players.Find(usr)

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -510,3 +510,7 @@ TOPIC_MAX_SIZE 500
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED
 #OOC_FILTER_ENABLED
+
+## Uncomment to enable redirecting to the specified address. If a user attempts to join after EXTREEME_POPCAP has been reached, redirect them to this address.
+## The given address is a format example. "byond://" is required to function. Create a potential infinite loop at your own risk.
+#REDIRECT_ADDRESS "byond://golden.beestation13.com:7777"

--- a/config/config.txt
+++ b/config/config.txt
@@ -517,3 +517,7 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED
 #OOC_FILTER_ENABLED
+
+## Uncomment to enable redirecting to the specified address. If a user attempts to join after EXTREEME_POPCAP has been reached, redirect them to this address.
+## The given address is a format example. "byond://" is required to function. Create a potential infinite loop at your own risk.
+#REDIRECT_ADDRESS "byond://golden.beestation13.com:7777"


### PR DESCRIPTION
## Changelog
:cl:
add: Patrons can bypass the popcap.
add: Players can be redirected to another server if the popcap is reached.
/:cl:

