### PR TITLE
Stun baton rework

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -12,7 +12,7 @@
 	attack_verb = list("enforced the law upon")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 
-	var/stunforce = 90
+	var/stunforce = 60
 	var/status = 0
 	var/obj/item/stock_parts/cell/cell
 	var/hitcost = 1000

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -142,12 +142,11 @@
 			baton_stun(M, user)
 		..()
 
-// /obj/item/melee/baton/proc/baton_stun(mob/living/L, var/mob/living/carbon/human/K, mob/user)
-/obj/item/melee/baton/proc/baton_stun(mob/living/L, var/mob/living/carbon/human/K, mob/user)
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
+/obj/item/melee/baton/proc/baton_stun(mob/living/target, mob/living/user)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
 		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
-			playsound(L, 'sound/weapons/genhit.ogg', 50, 1)
+			playsound(target, 'sound/weapons/genhit.ogg', 50, 1)
 			return 0
 	if(iscyborg(loc))
 		var/mob/living/silicon/robot/R = loc
@@ -157,23 +156,23 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	var/obj/item/bodypart/affecting = K.get_bodypart(ran_zone(L.zone_selected))
-	var/armor_block = K.run_armor_check(affecting, "energy")
+	var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
+	var/armor_block = target.run_armor_check(affecting, "energy")
 	// L.adjustStaminaLoss(stunforce)
-	L.apply_damage(stunforce, STAMINA, affecting, armor_block)
-	L.apply_effect(EFFECT_STUTTER, stunforce)
-	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
+	target.apply_damage(stunforce, STAMINA, affecting, armor_block)
+	target.apply_effect(EFFECT_STUTTER, stunforce)
+	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)
-		L.lastattacker = user.real_name
-		L.lastattackerckey = user.ckey
-		L.visible_message("<span class='danger'>[user] has electrocuted [L] with [src]!</span>", \
+		target.lastattacker = user.real_name
+		target.lastattackerckey = user.ckey
+		target.visible_message("<span class='danger'>[user] has electrocuted [target] with [src]!</span>", \
 								"<span class='userdanger'>[user] has electrocuted you with [src]!</span>")
-		log_combat(user, L, "stunned")
+		log_combat(user, target, "stunned")
 
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
 
-	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
 		H.forcesay(GLOB.hit_appends)
 
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -142,8 +142,8 @@
 			baton_stun(M, user)
 		..()
 
-
-/obj/item/melee/baton/proc/baton_stun(mob/living/L, mob/user)
+// /obj/item/melee/baton/proc/baton_stun(mob/living/L, var/mob/living/carbon/human/K, mob/user)
+/obj/item/melee/baton/proc/baton_stun(mob/living/L, var/mob/living/carbon/human/K, mob/user)
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
@@ -157,7 +157,10 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	L.adjustStaminaLoss(stunforce)
+	var/obj/item/bodypart/affecting = K.get_bodypart(ran_zone(L.zone_selected))
+	var/armor_block = K.run_armor_check(affecting, "energy")
+	// L.adjustStaminaLoss(stunforce)
+	L.apply_damage(stunforce, STAMINA, affecting, armor_block)
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -12,7 +12,7 @@
 	attack_verb = list("enforced the law upon")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 
-	var/stunforce = 60
+	var/stunforce = 75
 	var/status = 0
 	var/obj/item/stock_parts/cell/cell
 	var/hitcost = 1000

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -24,7 +24,7 @@
 
 	var/disabled = BODYPART_NOT_DISABLED //If disabled, limb is as good as missing
 	var/body_damage_coeff = 1 //Multiplier of the limb's damage that gets applied to the mob
-	var/stam_damage_coeff = 0.5
+	var/stam_damage_coeff = 1
 	var/brutestate = 0
 	var/burnstate = 0
 	var/brute_dam = 0

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -24,7 +24,7 @@
 
 	var/disabled = BODYPART_NOT_DISABLED //If disabled, limb is as good as missing
 	var/body_damage_coeff = 1 //Multiplier of the limb's damage that gets applied to the mob
-	var/stam_damage_coeff = 1
+	var/stam_damage_coeff = 0.7
 	var/brutestate = 0
 	var/burnstate = 0
 	var/brute_dam = 0


### PR DESCRIPTION
## About The Pull Request
First off, stun batons now no longer bypass armor. If you're unarmored it still takes two hits to stamcrit, but if you're wearing an armor vest/helmet then it takes three hits, or if you're wearing the captain's hardsuit then it's four hits.

Next, you can limb target with batons. This allows more tactical play that simply unga dunga with a baton. Limb disabling has also been tweaked so that disabling each limb deals more total stamina damage, so you only have to disable three limbs instead of four to stamcrit. 

Finally it uses apply_damage instead of adjustStaminaLoss. This means that the knockdown may be slightly delayed in some instances (but they won't be able to take any actions except walk during this time) or the knockdown may be shortened, but a final baton hit when they're in either state will make the knockdown instant or lengthen the knockdown.  

## Why It's Good For The Game
Batons now have a counter in the form of good armor. It encourages more tactical play by limb targeting. More counterplay if you're getting batoned. 

## Changelog
:cl:
tweak: Stun batons now do 75 apply_damage instead of 90 adjustStaminaLoss. This means you can do limb targeting, damage is reduced by armor and it may take a moment to knockdown once in stamcrit.
tweak: Limb disabling total damage increased, now only requires disabling three limbs to stamcrit not four. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
