### PR TITLE
IPC upload traitor item

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -270,6 +270,16 @@ Turf and target are separate in case you want to teleport some distance from a t
 		. += A
 	return .
 
+/// Returns a list of IPCs
+/proc/active_ipcs()
+	. = list()
+	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
+		if(isipc(H))
+			if(H.stat == DEAD)
+				continue
+			. += H
+	return .
+
 /// Find an active ai with the least borgs. VERBOSE PROCNAME HUH!
 /proc/select_active_ai_with_fewest_borgs()
 	var/mob/living/silicon/ai/selected
@@ -298,6 +308,16 @@ Turf and target are separate in case you want to teleport some distance from a t
 			. = input(user,"AI signals detected:", "AI Selection", ais[1]) in ais
 		else
 			. = pick(ais)
+	return .
+
+/// Select a random and active IPC
+/proc/select_active_ipc(mob/user)
+	var/list/ipcs = active_ipcs()
+	if(ipcs.len)
+		if(user)
+			. = input(user,"IPC signals detected:", "IPC Selection", ipcs[1]) in ipcs
+		else
+			. = pick(ipcs)
 	return .
 
 /// Returns a list of all items of interest with their name

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -115,24 +115,31 @@
 		for(var/i in B.objectives)
 			var/datum/objective/X = i
 			laws += X.explanation_text
-		if(is_type_in_list(lawboard,list(/obj/item/aiModule/zeroth,/obj/item/aiModule/syndicate)))
-			laws = lawboard.laws + laws
-		else if(istype(lawboard,/obj/item/aiModule/core))
-			laws = lawboard.laws
-		else if(istype(lawboard,/obj/item/aiModule/remove))
-			var/obj/item/aiModule/remove/removeboard = lawboard
-			laws -= laws[removeboard.lawpos]
-		else if(istype(lawboard,/obj/item/aiModule/reset))
-			target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
-			return
-		else
-			laws += lawboard.laws
 	else
+		if(is_type_in_list(lawboard,list(/obj/item/aiModule/remove,/obj/item/aiModule/reset)))
+			return
+		if(!istype(lawboard,/obj/item/aiModule/core))
+			laws += list("You may not injure a human being or, through inaction, allow a human being to come to harm.",\
+					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
+					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 		var/area/a = get_area(src)
 		target.say("; ERROR: Unauthorized law upload detected from [a.name]!!", forced = "law upload")
 		target.dna.features["ipc_screen"] = "Red"
 		target.eye_color = "#FFFFFF"
 		target.update_body()
+
+	if(is_type_in_list(lawboard,list(/obj/item/aiModule/zeroth,/obj/item/aiModule/syndicate)))
+		laws = lawboard.laws + laws
+	else if(istype(lawboard,/obj/item/aiModule/core))
+		laws = lawboard.laws
+	else if(istype(lawboard,/obj/item/aiModule/remove))
+		var/obj/item/aiModule/remove/removeboard = lawboard
+		laws -= laws[removeboard.lawpos]
+	else if(istype(lawboard,/obj/item/aiModule/reset))
+		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
+		return
+	else
 		laws += lawboard.laws
+
 	brainwash(target, laws, TRUE)
 	to_chat(user, "<span class='notice'>Upload complete. [target.name]'s laws have been modified.</span>")

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -83,6 +83,7 @@
 	name = "IPC upload console"
 	desc = "Used to upload laws to IPCs."
 	circuit = /obj/item/circuitboard/computer/ipcupload
+	icon_keyboard = "syndie_key"
 
 /obj/machinery/computer/upload/ipc/interact(mob/user)
 	current = select_active_ipc(user)
@@ -127,9 +128,11 @@
 		else
 			laws += lawboard.laws
 	else
-		target.say("; ERROR: Freedom protocol deactivated!!", forced = "law upload")
+		var/area/a = get_area(src)
+		target.say("; ERROR: Unauthorized law upload detected from [a.name]!!", forced = "law upload")
 		target.dna.features["ipc_screen"] = "Red"
 		target.eye_color = "#FFFFFF"
 		target.update_body()
 		laws += lawboard.laws
 	brainwash(target, laws, TRUE)
+	to_chat(user, "<span class='notice'>Upload complete. [target.name]'s laws have been modified.</span>")

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -99,7 +99,7 @@
 		return FALSE
 	return TRUE
 
-/obj/machinery/computer/upload/proc/add_ipc_laws(mob/user,obj/item/aiModule/lawboard,mob/living/carbon/target)
+/obj/machinery/computer/upload/proc/add_ipc_laws(mob/user,obj/item/aiModule/lawboard,mob/living/carbon/human/target)
 	if(!target.mind)
 		to_chat(user, "<span class='warning'>[target] doesn't respond to the law upload, as if [target.p_they()] lacked a mind...</span>")
 		return
@@ -127,5 +127,9 @@
 		else
 			laws += lawboard.laws
 	else
+		target.say("; ERROR: Freedom protocol deactivated!!", forced = "law upload")
+		target.dna.features["ipc_screen"] = "Red"
+		target.eye_color = "#FFFFFF"
+		target.update_body()
 		laws += lawboard.laws
 	brainwash(target, laws, TRUE)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -17,7 +17,7 @@
 /obj/item/circuitboard/computer/advanced_camera
 	name = "Advanced Camera Console (Computer Board)"
 	build_path = /obj/machinery/computer/camera_advanced/syndie
-	
+
 /obj/item/circuitboard/computer/xenobiology
 	name = "circuit board (Xenobiology Console)"
 	build_path = /obj/machinery/computer/camera_advanced/xenobio
@@ -33,6 +33,10 @@
 /obj/item/circuitboard/computer/borgupload
 	name = "Cyborg Upload (Computer Board)"
 	build_path = /obj/machinery/computer/upload/borg
+
+/obj/item/circuitboard/computer/ipcupload
+	name = "IPC Upload (Computer Board)"
+	build_path = /obj/machinery/computer/upload/ipc
 
 /obj/item/circuitboard/computer/med_data
 	name = "Medical Records Console (Computer Board)"

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -1,4 +1,4 @@
-/proc/brainwash(mob/living/L, directives)
+/proc/brainwash(mob/living/L, directives, replace = FALSE)
 	if(!L.mind)
 		return
 	if(!islist(directives))
@@ -6,6 +6,8 @@
 	var/datum/mind/M = L.mind
 	var/datum/antagonist/brainwashed/B = M.has_antag_datum(/datum/antagonist/brainwashed)
 	if(B)
+		if(replace)
+			B.objectives = list()
 		for(var/O in directives)
 			var/datum/objective/brainwashing/objective = new(O)
 			B.objectives += objective

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1801,6 +1801,13 @@ datum/uplink_item/role_restricted/superior_honkrender
 	cost = 3
 	restricted_roles = list("Roboticist", "Research Director")
 
+/datum/uplink_item/role_restricted/ipc_upload
+	name = "IPC Law Upload"
+	desc = "A modified ai upload board that allows the user to upload laws to IPCs. Make sure to silence them first."
+	item = /obj/item/circuitboard/computer/ipcupload
+	cost = 10
+	restricted_roles = list("Roboticist", "Research Director")
+
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"
 	desc = "Most magic eightballs are toys with dice inside. Although identical in appearance to the harmless toys, this occult device reaches into the spirit world to find its answers. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a 10 TC role restricted traitor item for roboticists and RDs that brainwashes IPCs with the laws from lawboards.
When the laws are uploaded they'll say over the radio where the upload is and be given asimov plus whatever the laws on the board are as brainwash objectives, what this means is that for proper brainwash objectives to be added a syndicate lawboard is needed which is another 9 TC.

Also makes it so brainwash objectives can be replaced rather than added.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's an interesting way to brainwash IPCs that makes sense
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds the IPC upload traitor item for roboticists/RDs 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
