### PR TITLE
Ayyliens: Abductor Frequency Increase

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -28,7 +28,7 @@
 	landmark_type = /obj/effect/landmark/abductor/scientist
 	greet_text = "Use your experimental console and surgical equipment to monitor your agent and experiment upon abducted humans."
 	show_in_antagpanel = TRUE
-	
+
 /datum/antagonist/abductor/scientist/onemanteam
 	name = "Abductor Solo"
 	outfit = /datum/outfit/abductor/scientist/onemanteam
@@ -61,6 +61,8 @@
 /datum/antagonist/abductor/greet()
 	to_chat(owner.current, "<span class='notice'>You are the [owner.special_role]!</span>")
 	to_chat(owner.current, "<span class='notice'>With the help of your teammate, kidnap and experiment on station crew members!</span>")
+	to_chat(owner.current, "<span class='notice'>There are two of you! One can monitor cameras while the other infiltrates the station.</span>")
+	to_chat(owner.current, "<span class='notice'>Choose a worthy disguise and plan your targets carefully! Humans will kill you on sight.</span>")
 	to_chat(owner.current, "<span class='notice'>[greet_text]</span>")
 	owner.announce_objectives()
 

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -1,11 +1,11 @@
 /datum/round_event_control/abductor
 	name = "Abductors"
 	typepath = /datum/round_event/ghost_role/abductor
-	weight = 10
+	weight = 12
 	max_occurrences = 1
 	min_players = 20
-	earliest_start = 10 MINUTES //not particularly dangerous, gives abductors time to do their objective
-	gamemode_blacklist = list("nuclear","wizard","revolution")
+	earliest_start = 8 MINUTES //not particularly dangerous, gives abductors time to do their objective
+	gamemode_blacklist = list("nuclear","wizard")
 
 /datum/round_event/ghost_role/abductor
 	minimum_required = 2

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 	min_players = 20
 	earliest_start = 8 MINUTES //not particularly dangerous, gives abductors time to do their objective
-	gamemode_blacklist = list("nuclear","wizard")
+	gamemode_blacklist = list("nuclear","wizard","revolution")
 
 /datum/round_event/ghost_role/abductor
 	minimum_required = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the rate at which abductor spawns are randomly chosen as ghost role by 20%, gives the players a little more flavor text at the beginning.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Frankly, I like abductors. It's a fun ghost event that rarely spawns, or when it does spawn, evac is ready to depart and you're left hunting for marooned survivors. Abductors are rare and non lethal, which makes it not particularly unfair or unbalanced to increase the rate of, considering few people have or will ever get experience playing their two man team.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: More descriptive text for abductor teams
tweak: Increased frequency of ayyliens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
