### PR TITLE
Blood-tier transmission is no longer contagious

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -143,7 +143,7 @@
 				if(blood_data["viruses"])
 					for(var/thing in blood_data["viruses"])
 						var/datum/disease/D = thing
-						if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+						if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS) || (D.spread_flags & DISEASE_SPREAD_BLOOD))
 							continue
 						C.ForceContractDisease(D)
 				if(!(blood_data["blood_type"] in get_safe_blood(C.dna.blood_type)))


### PR DESCRIPTION

## About The Pull Request
blood splatters no longer transmit diseases with blood transmission when  you get covered in blood

## Why It's Good For The Game
makes single target diseases less worrisome when dealing with collateral, makes fluid transmission actually mean something other than working for spray bottles

## Changelog
:cl:
balance: nerfs blood transmission
/:cl:
