### PR TITLE
[REPULL- QWERT IF YOU PUT THIS UP TO VOTE OR LET IT SIT A MONTH AGAIN I SWEAR] monkey gorilla leaders

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -112,7 +112,7 @@
 	stage_prob = 4
 	visibility_flags = 0
 	agent = "Kongey Vibrion M-909"
-	new_form = /mob/living/carbon/monkey
+	new_form = null
 	bantype = ROLE_MONKEY
 
 

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -127,9 +127,11 @@
 	if(affected_mob.mind && !is_monkey(affected_mob.mind))
 		add_monkey(affected_mob.mind)
 	if(ishuman(affected_mob))
-		var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSE)
-		M.ventcrawler = VENTCRAWLER_ALWAYS
-
+		if(affected_mob && !is_monkey_leader(affected_mob.mind))
+			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSE)
+			M.ventcrawler = VENTCRAWLER_ALWAYS
+		else
+			affected_mob.junglegorillize()
 
 /datum/disease/transformation/jungle_fever/stage_act()
 	..()

--- a/code/modules/antagonists/monkey/monkey.dm
+++ b/code/modules/antagonists/monkey/monkey.dm
@@ -164,6 +164,17 @@
 			return TRUE
 	return FALSE
 
+/datum/team/monkey/proc/infected_gorillas_alive()
+	for(var/mob/living/simple_animal/hostile/gorilla/rabid/M in GLOB.alive_mob_list)
+		return TRUE
+	return FALSE
+
+/datum/team/monkey/proc/infected_gorillas_escaped()
+	for(var/mob/living/simple_animal/hostile/gorilla/rabid/M in GLOB.alive_mob_list)
+		if(M.onCentCom() || M.onSyndieBase())
+			return TRUE
+	return FALSE
+
 /datum/team/monkey/proc/infected_humans_escaped()
 	var/datum/disease/D = new /datum/disease/transformation/jungle_fever()
 	for(var/mob/living/carbon/human/M in GLOB.alive_mob_list)
@@ -179,9 +190,9 @@
 	return FALSE
 
 /datum/team/monkey/proc/get_result()
-	if(infected_monkeys_escaped())
+	if(infected_monkeys_escaped() || infected_gorillas_escaped())
 		return MONKEYS_ESCAPED
-	if(infected_monkeys_alive())
+	if(infected_monkeys_alive() || infected_gorillas_alive())
 		return MONKEYS_LIVED
 	if(infected_humans_alive() || infected_humans_escaped())
 		return DISEASE_LIVED

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -37,6 +37,7 @@
 	unique_name = TRUE
 	var/list/gorilla_overlays[GORILLA_TOTAL_LAYERS]
 	var/oogas = 0
+	var/diseased = FALSE
 
 	do_footstep = TRUE
 
@@ -70,9 +71,13 @@
 		if(prob(80))
 			var/atom/throw_target = get_edge_target_turf(L, dir)
 			L.throw_at(throw_target, rand(1,2), 7, src)
+			if(diseased)
+				var/flesh_wound = ran_zone(CHEST, 40)
+				if(prob(100-L.getarmor(flesh_wound, "melee")))
+					L.ForceContractDisease(new /datum/disease/transformation/jungle_fever())
 		else
-			L.Paralyze(20)
-			visible_message("<span class='danger'>[src] knocks [L] down!</span>")
+			L.Unconscious(20)
+			visible_message("<span class='danger'>[src] knocks [L] out!</span>")
 
 /mob/living/simple_animal/hostile/gorilla/CanAttack(atom/the_target)
 	var/list/parts = target_bodyparts(target)
@@ -108,3 +113,22 @@
 		playsound(src, 'sound/creatures/gorilla.ogg', 50)
 		oogas = 0
 
+/mob/living/simple_animal/hostile/gorilla/rabid
+	name = "Rabid Gorilla"
+	desc = "A mangy looking gorilla."
+	icon_state = "crawling"
+	icon_state = "crawling"
+	icon_living = "crawling"
+	icon_dead = "dead"
+	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
+	speak_chance = 80
+	maxHealth = 220
+	health = 220
+	loot = list(/obj/effect/gibspawner/generic/animal)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/gorilla = 4)
+	melee_damage_lower = 15
+	melee_damage_upper = 25
+	damage_coeff = list(BRUTE = 0.8, BURN = 1, TOX = 1, CLONE = 0, STAMINA = 0, OXY = 1)
+	obj_damage = 50
+	environment_smash = ENVIRONMENT_SMASH_RWALLS
+	diseased = TRUE

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -523,6 +523,32 @@
 	. = new_gorilla
 	qdel(src)
 
+/mob/living/carbon/proc/junglegorillize()
+	if(notransform)
+		return
+	notransform = TRUE
+	Paralyze(1, ignore_canstun = TRUE)
+
+	SSblackbox.record_feedback("amount", "gorillas_created", 1)
+
+	var/Itemlist = get_equipped_items(TRUE)
+	Itemlist += held_items
+	for(var/obj/item/W in Itemlist)
+		dropItemToGround(W, TRUE)
+
+	regenerate_icons()
+	icon = null
+	invisibility = INVISIBILITY_MAXIMUM
+	var/mob/living/simple_animal/hostile/gorilla/rabid/new_gorilla = new (get_turf(src))
+	new_gorilla.a_intent = INTENT_HARM
+	if(mind)
+		mind.transfer_to(new_gorilla)
+	else
+		new_gorilla.key = key
+	to_chat(new_gorilla, "<B>You are now a gorilla. Ooga ooga!</B>")
+	. = new_gorilla
+	qdel(src)
+
 /mob/living/carbon/human/Animalize()
 
 	var/list/mobtypes = typesof(/mob/living/simple_animal)


### PR DESCRIPTION
## About The Pull Request
Leader monkeys now become rabid gorillas
Rabid gorillas apply jungle fever on punch, affected by melee armor. They do higher damage, and are tankier than normal gorillas, lacking the weakness to fire normal gorillas have, and having 20% brute resistance
gorillas have been buffed so that their punches have a chance to knock out for 2 seconds, instead of paralyze. 
## Why It's Good For The Game

Monkeys are now intimidating, instead of being little fucking bitches

## Changelog
:cl:
add: Rabid gorillas
tweak: monkey leaders now become gorillas instead of normal monkeys
balance: buffed gorillas slightly
fix: fixed jungle fever so the code within it that gives antag monkeys the ability to ventcrawl universally works
/:cl: