### PR TITLE
Adds in support for additional roundstart special roles

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1763,6 +1763,7 @@
 #include "code\modules\events\shuttle_loan.dm"
 #include "code\modules\events\space_dragon.dm"
 #include "code\modules\events\spacevine.dm"
+#include "code\modules\events\special_antag_event.dm"
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"
 #include "code\modules\events\vent_clog.dm"

--- a/beestation.dme
+++ b/beestation.dme
@@ -1433,6 +1433,8 @@
 #include "code\modules\antagonists\revenant\revenant_blight.dm"
 #include "code\modules\antagonists\revenant\revenant_spawn_event.dm"
 #include "code\modules\antagonists\revolution\revolution.dm"
+#include "code\modules\antagonists\roundstart_special\special_antagonist.dm"
+#include "code\modules\antagonists\roundstart_special\undercover\undercover.dm"
 #include "code\modules\antagonists\santa\santa.dm"
 #include "code\modules\antagonists\separatist\separatist.dm"
 #include "code\modules\antagonists\slaughter\slaughter.dm"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -66,3 +66,8 @@
 
 #define CONTRACT_UPLINK_PAGE_CONTRACTS "CONTRACTS"
 #define CONTRACT_UPLINK_PAGE_HUB "HUB"
+
+//Special Antagonists
+#define SPAWNTYPE_ROUNDSTART "roundstart"
+#define SPAWNTYPE_MIDROUND "midround"
+#define SPAWNTYPE_EITHER "either"

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -37,7 +37,7 @@
 #define ROLE_LAVALAND			"Lavaland"
 #define ROLE_INTERNAL_AFFAIRS	"Internal Affairs Agent"
 #define ROLE_GANG				"Gangster"
-#define ROLE_SPECIAL			"Other Additional Roles"
+#define ROLE_SPECIAL			"Special Antagonists"
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -37,7 +37,7 @@
 #define ROLE_LAVALAND			"Lavaland"
 #define ROLE_INTERNAL_AFFAIRS	"Internal Affairs Agent"
 #define ROLE_GANG				"Gangster"
-#define ROLE_EXSEC				"Ex-security"
+#define ROLE_SPECIAL			"Special"
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough
@@ -65,7 +65,8 @@ GLOBAL_LIST_INIT(special_roles, list(
 	ROLE_HIVE = /datum/game_mode/hivemind,
 	ROLE_INTERNAL_AFFAIRS = /datum/game_mode/traitor/internal_affairs,
 	ROLE_SENTIENCE,
-	ROLE_GANG = /datum/game_mode/gang
+	ROLE_GANG = /datum/game_mode/gang,
+	ROLE_SPECIAL
 ))
 
 //Job defines for what happens when you fail to qualify for any job during job selection

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -37,6 +37,7 @@
 #define ROLE_LAVALAND			"Lavaland"
 #define ROLE_INTERNAL_AFFAIRS	"Internal Affairs Agent"
 #define ROLE_GANG				"Gangster"
+#define ROLE_EXSEC				"Ex-security"
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -37,7 +37,7 @@
 #define ROLE_LAVALAND			"Lavaland"
 #define ROLE_INTERNAL_AFFAIRS	"Internal Affairs Agent"
 #define ROLE_GANG				"Gangster"
-#define ROLE_SPECIAL			"Special"
+#define ROLE_SPECIAL			"Other Additional Roles"
 
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -486,3 +486,15 @@ GLOBAL_LIST_EMPTY(species_list)
 		chosen = pick(mob_spawn_meancritters)
 	var/mob/living/simple_animal/C = new chosen(spawn_location)
 	return C
+
+/proc/get_living_mobs()
+	. = list()
+	for(var/mob/living in GLOB.mob_list)
+		if(player.stat != DEAD && player.mind && is_station_level(player.z) && !isnewplayer(Player) && !isbrain(Player))
+			. |= player.mind
+
+/proc/get_living_crew()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.mob_list)
+		if(player.stat != DEAD && player.mind && is_station_level(player.z))
+			. |= player.mind

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -487,14 +487,20 @@ GLOBAL_LIST_EMPTY(species_list)
 	var/mob/living/simple_animal/C = new chosen(spawn_location)
 	return C
 
-/proc/get_living_mobs()
+/proc/get_sentient_mobs()
 	. = list()
-	for(var/mob/living/player in GLOB.mob_list)
-		if(player.stat != DEAD && player.mind && is_station_level(player.z) && !isnewplayer(player) && !isbrain(player))
-			. |= player.mind
+	for(var/mob/living/player in GLOB.mob_living_list)
+		if(player.stat != DEAD && player.mind && !is_centcom_level(player.z) && !isnewplayer(player) && !isbrain(player))
+			. |= player
 
-/proc/get_living_crew()
+/proc/get_living_station_crew()
 	. = list()
-	for(var/mob/living/carbon/human/player in GLOB.mob_list)
+	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)
+		if(player.stat != DEAD && player.mind && is_station_level(player.z))
+			. |= player
+
+/proc/get_living_station_minds()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)
 		if(player.stat != DEAD && player.mind && is_station_level(player.z))
 			. |= player.mind

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -490,7 +490,7 @@ GLOBAL_LIST_EMPTY(species_list)
 /proc/get_living_mobs()
 	. = list()
 	for(var/mob/living/player in GLOB.mob_list)
-		if(player.stat != DEAD && player.mind && is_station_level(player.z) && !isnewplayer(Player) && !isbrain(Player))
+		if(player.stat != DEAD && player.mind && is_station_level(player.z) && !isnewplayer(player) && !isbrain(player))
 			. |= player.mind
 
 /proc/get_living_crew()

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -489,7 +489,7 @@ GLOBAL_LIST_EMPTY(species_list)
 
 /proc/get_living_mobs()
 	. = list()
-	for(var/mob/living in GLOB.mob_list)
+	for(var/mob/living/player in GLOB.mob_list)
 		if(player.stat != DEAD && player.mind && is_station_level(player.z) && !isnewplayer(Player) && !isbrain(Player))
 			. |= player.mind
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -487,18 +487,28 @@ GLOBAL_LIST_EMPTY(species_list)
 	var/mob/living/simple_animal/C = new chosen(spawn_location)
 	return C
 
+//Gets the sentient mobs that are not on centcom and are alive
 /proc/get_sentient_mobs()
 	. = list()
 	for(var/mob/living/player in GLOB.mob_living_list)
 		if(player.stat != DEAD && player.mind && !is_centcom_level(player.z) && !isnewplayer(player) && !isbrain(player))
 			. |= player
 
+//Gets all sentient humans that are alive
+/proc/get_living_crew()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)
+		if(player.stat != DEAD && player.mind)
+			. |= player
+
+//Gets all sentient humans that are on the station
 /proc/get_living_station_crew()
 	. = list()
 	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)
 		if(player.stat != DEAD && player.mind && is_station_level(player.z))
 			. |= player
 
+//Gets all the minds of humans that are on station
 /proc/get_living_station_minds()
 	. = list()
 	for(var/mob/living/carbon/human/player in GLOB.mob_living_list)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -56,6 +56,7 @@
 	var/datum/mind/soulOwner //who owns the soul.  Under normal circumstances, this will point to src
 	var/hasSoul = TRUE // If false, renders the character unable to sell their soul.
 	var/isholy = FALSE //is this person a chaplain or admin role allowed to use bibles
+	var/isAntagTarget = FALSE
 
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
 	var/datum/language_holder/language_holder

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -94,6 +94,11 @@
 	mood_change = 10 //maybe being a cultist isnt that bad after all
 	hidden = TRUE
 
+/datum/mood_event/determined
+	description = "<span class='nicegreen'>I am determined to keep my friends safe.</span>\n"
+	mood_change = 2
+	hidden = TRUE
+
 /datum/mood_event/family_heirloom
 	description = "<span class='nicegreen'>My family heirloom is safe with me.</span>\n"
 	mood_change = 1
@@ -149,11 +154,11 @@
 	description = "<span class='nicegreen'>The bottle landing like that was satisfying.</span>\n"
 	mood_change = 2
 	timeout = 3 MINUTES
-  
+
 /datum/mood_event/hope_lavaland
 	description = "<span class='nicegreen'>What a peculiar emblem.  It makes me feel hopeful for my future.</span>\n"
 	mood_change = 5
-  
+
 /datum/mood_event/nanite_happiness
 	description = "<span class='nicegreen robot'>+++++++HAPPINESS ENHANCEMENT+++++++</span>\n"
 	mood_change = 7

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -4,7 +4,8 @@
 	report_type = "extended"
 	false_report_weight = 0
 	required_players = 0
-
+	//DEBUG VALUE: PLEASE REMOVE
+	allowed_special = list(/datum/special_role/undercover)
 	announce_span = "notice"
 	announce_text = "Just have fun and enjoy the game!"
 

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -5,8 +5,6 @@
 	false_report_weight = 0
 	required_players = 0
 
-	allowed_special = list(/datum/special_role/undercover)
-
 	announce_span = "notice"
 	announce_text = "Just have fun and enjoy the game!"
 

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -5,6 +5,8 @@
 	false_report_weight = 0
 	required_players = 0
 
+	allowed_special = list(/datum/special_role/undercover)
+
 	announce_span = "notice"
 	announce_text = "Just have fun and enjoy the game!"
 

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -4,8 +4,7 @@
 	report_type = "extended"
 	false_report_weight = 0
 	required_players = 0
-	//DEBUG VALUE: PLEASE REMOVE
-	allowed_special = list(/datum/special_role/undercover)
+
 	announce_span = "notice"
 	announce_text = "Just have fun and enjoy the game!"
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -504,16 +504,6 @@
 			. ++
 
 ////////////////////////////
-//Keeps track of all living//
-////////////////////////////
-
-/datum/game_mode/proc/get_living_crew()
-	. = list()
-	for(var/mob/living/carbon/human/player in GLOB.mob_list)
-		if(player.stat != DEAD && player.mind && is_station_level(player.z))
-			. |= player.mind
-
-////////////////////////////
 //Keeps track of all heads//
 ////////////////////////////
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -34,7 +34,7 @@
 	var/reroll_friendly 	//During mode conversion only these are in the running
 	var/continuous_sanity_checked	//Catches some cases where config options could be used to suggest that modes without antagonists should end when all antagonists die
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
-	var/list/allowed_special = list()	//Special roles that can spawn (undercover etc.)
+	var/list/allowed_special = list()	//Special roles that can spawn (Add things like /datum/antagonist/special/undercover for them to be able to spawn during this gamemode)
 	var/list/active_specials = list()	//Special roles that have spawned, and can now spawn late
 
 	var/announce_span = "warning" //The gamemode's name will be in this span during announcement.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -100,7 +100,6 @@
 	for(var/role_to_init in allowed_special)
 		var/datum/special_role/new_role = new role_to_init
 		if(!prob(new_role.probability) || new_role.spawn_mode == 2)
-			qdel(new_role)
 			continue
 		active_specials += new_role
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -85,13 +85,11 @@
 
 /datum/game_mode/proc/create_special_antags()
 	var/list/living_crew = list()
-	for(var/mob/Player in GLOB.mob_list)
-		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client)
-			living_crew += Player
+	living_crew = get_living_crew()
 
 	var/list/candidates = list()
 	for(var/mob/living/carbon/human/H in living_crew)
-		if(!(H.client && !is_centcom_level(H.z)))
+		if((!H.client) || (is_centcom_level(H.z)))
 			continue
 		if(is_banned_from(H.ckey, list(ROLE_SPECIAL)))
 			continue
@@ -112,7 +110,7 @@
 		for(var/i in 1 to amount)
 			var/mob/person = pick(candidates)
 			if(!person)
-				break
+				continue
 			var/datum/mind/selected_mind = person.mind
 			candidates.Remove(person)
 			if(selected_mind.special_role)
@@ -196,10 +194,8 @@
 /datum/game_mode/proc/convert_roundtype()
 	set waitfor = FALSE
 	var/list/living_crew = list()
+	living_crew = get_living_crew()
 
-	for(var/mob/Player in GLOB.mob_list)
-		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client)
-			living_crew += Player
 	var/malc = CONFIG_GET(number/midround_antag_life_check)
 	if(living_crew.len / GLOB.joined_player_list.len <= malc) //If a lot of the player base died, we start fresh
 		message_admins("Convert_roundtype failed due to too many dead people. Limit is [malc * 100]% living crew")
@@ -506,6 +502,16 @@
 	for(var/mob/dead/new_player/P in GLOB.player_list)
 		if(P.client && P.ready == PLAYER_READY_TO_PLAY)
 			. ++
+
+////////////////////////////
+//Keeps track of all living//
+////////////////////////////
+
+/datum/game_mode/proc/get_living_crew()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.mob_list)
+		if(player.stat != DEAD && player.mind && is_station_level(player.z))
+			. |= player.mind
 
 ////////////////////////////
 //Keeps track of all heads//

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -107,7 +107,7 @@
 		var/datum/special_role/special = active_special
 		if(!istype(special))
 			continue
-		if(special.spawn_mode == SPAWNTYPE_MIDROUND)
+		if(special.spawn_mode == "midround")
 			continue
 		//To make it feel a little more random, and for efficiency reasons we just pick the person, then check their job and if they cannot be antag, we will just remove the slot
 		var/amount = round(living_crew.len * special.proportion)
@@ -178,7 +178,7 @@
 	for(var/datum/special_role/subantag in active_specials)
 		if(!subantag.latejoin_allowed)
 			continue
-		if(subantag.spawn_mode == SPAWNTYPE_MIDROUND)
+		if(subantag.spawn_mode == "midround")
 			continue
 		var/count = 0
 		for(var/mob/living/M in GLOB.mob_list)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -179,7 +179,7 @@
 		for(var/mob/living/M in GLOB.mob_living_list)
 			if(!M.mind)
 				continue
-			if(!is_special_type(M, subantag.attatched_antag_datum))
+			if(!is_special_type(M, subantag.attached_antag_datum))
 				continue
 			count++
 		if(count >= subantag.max_amount)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -91,7 +91,7 @@
 
 	var/list/candidates = list()
 	for(var/mob/living/carbon/human/H in living_crew)
-		if(!(H.client && H.client.prefs.allow_midround_antag && !is_centcom_level(H.z)))	//TODO CHANGE ALLOW MIDROUND TO SOMETHING SPECIAL
+		if(!(H.client && !is_centcom_level(H.z)))
 			continue
 		if(is_banned_from(H.ckey, list(ROLE_SPECIAL)))
 			continue

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -99,13 +99,15 @@
 
 	for(var/role_to_init in allowed_special)
 		var/datum/special_role/new_role = new role_to_init
-		if(!prob(new_role.probability) || new_role.spawn_mode == 2)
+		if(!prob(new_role.probability))
 			continue
 		active_specials += new_role
 
 	for(var/active_special in active_specials)
 		var/datum/special_role/special = active_special
 		if(!istype(special))
+			continue
+		if(special.spawn_mode == SPAWNTYPE_MIDROUND)
 			continue
 		//To make it feel a little more random, and for efficiency reasons we just pick the person, then check their job and if they cannot be antag, we will just remove the slot
 		var/amount = round(living_crew.len * special.proportion)
@@ -124,10 +126,6 @@
 			if(selected_mind.isAntagTarget)
 				continue
 			var/datum/antagonist/special/A = special.add_antag_status_to(selected_mind)
-			/*selected_mind.special_role = special.role_name
-			var/datum/antagonist/special/A = selected_mind.add_antag_datum(created_datum)
-			A.forge_objectives(selected_mind)
-			A.equip()*/
 			log_game("[key_name(selected_mind)] has been selected as a [A.name]")
 
 ///Everyone should now be on the station and have their normal gear.  This is the place to give the special roles extra things
@@ -179,6 +177,8 @@
 		return
 	for(var/datum/special_role/subantag in active_specials)
 		if(!subantag.latejoin_allowed)
+			continue
+		if(subantag.spawn_mode == SPAWNTYPE_MIDROUND)
 			continue
 		var/count = 0
 		for(var/mob/living/M in GLOB.mob_list)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -93,6 +93,8 @@
 	for(var/mob/living/carbon/human/H in living_crew)
 		if(!(H.client && H.client.prefs.allow_midround_antag && !is_centcom_level(H.z)))	//TODO CHANGE ALLOW MIDROUND TO SOMETHING SPECIAL
 			continue
+		if(is_banned_from(H.ckey, list(ROLE_SPECIAL)))
+			continue
 		candidates += H
 
 	message_admins("There are [candidates.len] candidates available for a total of [allowed_special.len] special roles.")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -103,10 +103,7 @@
 			continue
 		active_specials += new_role
 
-	for(var/active_special in active_specials)
-		var/datum/special_role/special = active_special
-		if(!istype(special))
-			continue
+	for(var/datum/special_role/special in active_specials)
 		if(special.spawn_mode == "midround")
 			continue
 		//To make it feel a little more random, and for efficiency reasons we just pick the person, then check their job and if they cannot be antag, we will just remove the slot
@@ -123,7 +120,7 @@
 			if(person.job in special.protected_jobs)
 				continue
 			//Would be annoying trying to assasinate someone with special statuses
-			if(selected_mind.isAntagTarget)
+			if(selected_mind.isAntagTarget && !special.allowAntagTargets)
 				continue
 			var/datum/antagonist/special/A = special.add_antag_status_to(selected_mind)
 			log_game("[key_name(selected_mind)] has been selected as a [A.name]")
@@ -191,10 +188,8 @@
 			continue
 		//Lower chance for midrounds than round starts
 		if(prob(subantag.proportion * 100))
-			character.mind.special_role = subantag.role_name
-			var/datum/antagonist/special/A = character.mind.add_antag_datum(subantag)
-			A.forge_objectives(character.mind)
-			A.equip()
+			var/datum/antagonist/special/A = subantag.add_antag_status_to(character.mind)
+			log_game("[key_name(character.mind)] has been selected as a [A.name]")
 			return
 
 ///Allows rounds to basically be "rerolled" should the initial premise fall through. Also known as mulligan antags.

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -179,7 +179,7 @@
 		for(var/mob/living/M in GLOB.mob_living_list)
 			if(!M.mind)
 				continue
-			if(!is_special_type(M, subantag.attached_antag_datum))
+			if(!is_special_type(M, subantag.attatched_antag_datum))
 				continue
 			count++
 		if(count >= subantag.max_amount)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -98,6 +98,7 @@
 		candidates += H
 
 	for(var/special in allowed_special)
+		//Create the role with default values from the datum, for comparisons
 		var/datum/antagonist/special/special_antag = new special()
 		if(!special_antag)
 			message_admins("Warning, incorrect antag datum input into the allowed_special variable of the current gamemode.")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -175,6 +175,9 @@
 	if(character.mind.antag_datums)
 		if(character.mind.antag_datums.len > 0)
 			return
+	//Check if they are banned
+	if(is_banned_from(character.ckey, list(ROLE_SPECIAL)) || QDELETED(character))
+		return
 	for(var/subantag in active_specials)
 		var/datum/antagonist/special/newAntag = new subantag
 		if(!newAntag.latejoin_allowed)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -165,9 +165,8 @@
 	return
 
 /datum/game_mode/proc/make_special_antag_chance(mob/living/character)
-	if(character.mind.antag_datums)
-		if(character.mind.antag_datums.len > 0)
-			return
+	if(!character.mind.antag_datums)
+		return
 	//Check if they are banned
 	if(is_banned_from(character.ckey, list(ROLE_SPECIAL)) || QDELETED(character))
 		return

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -97,8 +97,6 @@
 			continue
 		candidates += H
 
-	message_admins("There are [candidates.len] candidates available for a total of [allowed_special.len] special roles.")
-
 	for(var/special in allowed_special)
 		var/datum/antagonist/special/special_antag = new special()
 		if(!special_antag)
@@ -129,6 +127,7 @@
 			var/datum/antagonist/special/A = selected_mind.add_antag_datum(special_antag)
 			A.forge_objectives(selected_mind)
 			A.equip()
+			log_game("[key_name(selected_mind)] has been selected as a [A.name]")
 			special_antag = new special()
 		//Remove the final one, because otherwise we will have antags with no owner lying around which will break shit
 		qdel(special_antag)

--- a/code/game/gamemodes/gangs/gangtool.dm
+++ b/code/game/gamemodes/gangs/gangtool.dm
@@ -188,9 +188,7 @@
 	if(!recallchecks(user))
 		return
 	var/list/living_crew = list()//shamelessly copied from mulligan code, there should be a helper for this
-	for(var/mob/Player in GLOB.mob_list)
-		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client)
-			living_crew += Player
+	living_crew = get_living_mobs()
 	var/malc = CONFIG_GET(number/midround_antag_life_check)
 	if(living_crew.len / GLOB.joined_player_list.len <= malc) //Shuttle cannot be recalled if too many people died
 		to_chat(user, "<span class='warning'>[icon2html(src, user)]Error: Station communication systems compromised. Unable to establish connection.</span>")

--- a/code/game/gamemodes/gangs/gangtool.dm
+++ b/code/game/gamemodes/gangs/gangtool.dm
@@ -188,7 +188,7 @@
 	if(!recallchecks(user))
 		return
 	var/list/living_crew = list()//shamelessly copied from mulligan code, there should be a helper for this
-	living_crew = get_living_mobs()
+	living_crew = get_living_station_crew()
 	var/malc = CONFIG_GET(number/midround_antag_life_check)
 	if(living_crew.len / GLOB.joined_player_list.len <= malc) //Shuttle cannot be recalled if too many people died
 		to_chat(user, "<span class='warning'>[icon2html(src, user)]Error: Station communication systems compromised. Unable to establish connection.</span>")

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -124,6 +124,7 @@ GLOBAL_LIST_EMPTY(objectives)
 			possible_targets = all_possible_targets
 	if(possible_targets.len > 0)
 		target = pick(possible_targets)
+		target.isAntagTarget = TRUE
 	update_explanation_text()
 	return target
 
@@ -146,6 +147,7 @@ GLOBAL_LIST_EMPTY(objectives)
 				possible_targets += possible_target
 	if(length(possible_targets))
 		target = pick(possible_targets)
+		target.isAntagTarget = TRUE
 	update_explanation_text()
 	return target
 

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -293,7 +293,7 @@
 									ROLE_MONKEY, ROLE_NINJA, ROLE_OPERATIVE,
 									ROLE_OVERTHROW, ROLE_REV, ROLE_REVENANT,
 									ROLE_REV_HEAD, ROLE_SERVANT_OF_RATVAR, ROLE_SYNDICATE,
-									ROLE_TRAITOR, ROLE_WIZARD, ROLE_HIVE, ROLE_GANG)) //ROLE_REV_HEAD is excluded from this because rev jobbans are handled by ROLE_REV
+									ROLE_TRAITOR, ROLE_WIZARD, ROLE_HIVE, ROLE_GANG, ROLE_SPECIAL)) //ROLE_REV_HEAD is excluded from this because rev jobbans are handled by ROLE_REV
 		for(var/department in long_job_lists)
 			output += "<div class='column'><label class='rolegroup long [ckey(department)]'><input type='checkbox' name='[department]' class='hidden' [usr.client.prefs.tgui_fancy ? " onClick='toggle_checkboxes(this, \"_com\")'" : ""]>[department]</label><div class='content'>"
 			break_counter = 0

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -1,0 +1,20 @@
+/datum/antagonist/special
+	var/probability = 100			//The probability of any spawning
+	var/proportion = 1				//The prbability per person of rolling it
+	var/max_amount = 5				//The maximum amount
+	var/latejoin_allowed = TRUE		//Can latejoins be assigned to this?
+	var/allowAntagTargets = FALSE
+	var/role_name = "special role"
+	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
+
+/datum/antagonist/special/proc/equip()
+	return
+
+/datum/antagonist/special/proc/forge_objectives(var/datum/mind/undercovermind)
+	return
+
+/proc/is_special_type(var/datum/mind/M, var/datum/antagonist/special/A)
+	for(var/i in M.antag_datums)
+		if(istype(i, A))
+			return TRUE
+	return FALSE

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -52,7 +52,7 @@
 	var/datum/antagonist/special/A = M.add_antag_datum(new attached_antag_datum())
 	A.forge_objectives(M)
 	A.equip()
-	return(A)
+	return A
 
 ////////////////////////////////
 //////    Round event    ///////
@@ -74,22 +74,16 @@
 /datum/round_event/create_special_antag/start()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 		if(!H.client || !(preference_type in H.client.prefs.be_special) || !(H.client.prefs.allow_midround_antag))
-			message_admins("1")
 			continue
 		if(is_banned_from(H, list(preference_type)))
-			message_admins("2")
 			continue
 		if(H.stat == DEAD)
-			message_admins("3")
 			continue
 		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions)) //only station jobs sans nonhuman roles, prevents ashwalkers trying to stalk with crewmembers they never met
-			message_admins("4")
 			continue
 		if(H.mind.assigned_role in protected_jobs)
-			message_admins("5")
 			continue
 		if(H.mind.has_antag_datum(antag_datum))
-			message_admins("6")
 			continue
 		var/datum/mind/M = H.mind
 		M.special_role = role_name

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -1,8 +1,10 @@
-/datum/antagonist/special
-	name = "Special Additional Role"
-	job_rank = ROLE_SPECIAL
-	show_in_antagpanel = FALSE
-	show_name_in_check_antagonists = FALSE
+#define SPAWNTYPE_ROUNDSTART 1
+#define SPAWNTYPE_MIDROUND 2
+#define SPAWNTYPE_EITHER 3
+
+/datum/special_role
+	var/attached_antag_datum = /datum/antagonist/special
+	var/spawn_mode = SPAWNTYPE_ROUNDSTART
 	var/probability = 0				//The probability of any spawning
 	var/proportion = 0				//The prbability per person of rolling it
 	var/max_amount = 0				//The maximum amount
@@ -10,6 +12,19 @@
 	var/allowAntagTargets = FALSE
 	var/role_name = "special role"
 	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
+
+/datum/special_role/proc/add_antag_status_to(var/datum/mind/M)
+	M.special_role = role_name
+	var/datum/antagonist/special/A = M.add_antag_datum(new attached_antag_datum())
+	A.forge_objectives(M)
+	A.equip()
+	return(A)
+
+/datum/antagonist/special
+	name = "Special Additional Role"
+	job_rank = ROLE_SPECIAL
+	show_in_antagpanel = FALSE
+	show_name_in_check_antagonists = FALSE
 
 /datum/antagonist/special/proc/equip()
 	return

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -13,6 +13,11 @@
 	var/role_name = "special role"
 	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
 
+/datum/special_role/New()
+	. = ..()
+	if(spawn_mode != SPAWNTYPE_ROUNDSTART)
+
+
 /datum/special_role/proc/add_antag_status_to(var/datum/mind/M)
 	M.special_role = role_name
 	var/datum/antagonist/special/A = M.add_antag_datum(new attached_antag_datum())

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -5,6 +5,7 @@
 	var/latejoin_allowed = TRUE		//Can latejoins be assigned to this?
 	var/allowAntagTargets = FALSE
 	var/role_name = "special role"
+	job_rank = ROLE_SPECIAL
 	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
 
 /datum/antagonist/special/proc/equip()

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -1,7 +1,3 @@
-#define SPAWNTYPE_ROUNDSTART "roundstart"
-#define SPAWNTYPE_MIDROUND "midround"
-#define SPAWNTYPE_EITHER "either"
-
 ////////////////////////////////
 //////Special Role 'Controller'///////
 ////////////////////////////////
@@ -67,7 +63,7 @@
 /datum/round_event/create_special_antag
 	fakeable = FALSE
 	var/role_name
-	var/antag_datum
+	var/antag_datum	//The datum of the antag E.G. /datum/antagonist/special/undercover
 	var/preference_type = ROLE_SPECIAL
 	var/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
 

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -6,17 +6,36 @@
 	var/attached_antag_datum = /datum/antagonist/special
 	var/spawn_mode = SPAWNTYPE_ROUNDSTART
 	var/probability = 0				//The probability of any spawning
+	var/min_players = 0				//Min player count (Forgot about this, might be important)
+	var/max_players = -1			//Max player count (-1 for no max count)
 	var/proportion = 0				//The prbability per person of rolling it
 	var/max_amount = 0				//The maximum amount
 	var/latejoin_allowed = TRUE		//Can latejoins be assigned to this?
 	var/allowAntagTargets = FALSE
 	var/role_name = "special role"
 	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
+	//Midround event vars
+	var/weight = 10
+	var/earliest_start = 20 MINUTES
+	var/max_occurrences = 1
+	var/holidayID = ""
 
 /datum/special_role/New()
 	. = ..()
-	if(spawn_mode != SPAWNTYPE_ROUNDSTART)
-
+	if(spawn_mode == SPAWNTYPE_ROUNDSTART)
+		return
+	//Create a new event for spawning the antag
+	var/datum/round_event_control/E = new()
+	E.weight = weight
+	E.holidayID = holidayID
+	if(config)
+		E.earliest_start = CEILING(earliest_start * CONFIG_GET(number/events_min_time_mul), 1)
+		E.min_players = CEILING(min_players * CONFIG_GET(number/events_min_players_mul), 1)
+	else
+		E.earliest_start = earliest_start
+		E.min_players = min_players
+	//Shove our event into the subsystem pool :)
+	SSevents.control += E
 
 /datum/special_role/proc/add_antag_status_to(var/datum/mind/M)
 	M.special_role = role_name

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -1,6 +1,6 @@
-#define SPAWNTYPE_ROUNDSTART 1
-#define SPAWNTYPE_MIDROUND 2
-#define SPAWNTYPE_EITHER 3
+#define SPAWNTYPE_ROUNDSTART "roundstart"
+#define SPAWNTYPE_MIDROUND "midround"
+#define SPAWNTYPE_EITHER "either"
 
 /datum/special_role
 	var/attached_antag_datum = /datum/antagonist/special

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -5,7 +5,7 @@
 //and setup the antag datum. See the undercover.dm file for help
 
 /datum/special_role
-	var/attatched_antag_datum = /datum/antagonist/special
+	var/attached_antag_datum = /datum/antagonist/special
 	var/spawn_mode = SPAWNTYPE_ROUNDSTART
 	var/probability = 0				//The probability of any spawning
 	var/min_players = 0				//Min player count (Forgot about this, might be important)
@@ -32,7 +32,7 @@
 	//Create a new event for spawning the antag
 	var/datum/round_event_control/spawn_special_antagonist/E = new()
 	E.name = role_name
-	E.antagonist_datum = attatched_antag_datum
+	E.antagonist_datum = attached_antag_datum
 	E.antag_name = role_name
 	E.preference_type = preference_type
 	E.protected_jobs = protected_jobs
@@ -50,7 +50,7 @@
 
 /datum/special_role/proc/add_antag_status_to(var/datum/mind/M)
 	M.special_role = role_name
-	var/datum/antagonist/special/A = M.add_antag_datum(new attatched_antag_datum())
+	var/datum/antagonist/special/A = M.add_antag_datum(new attached_antag_datum())
 	A.forge_objectives(M)
 	A.equip()
 	return A

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -1,9 +1,11 @@
 ////////////////////////////////
 //////Special Role 'Controller'///////
 ////////////////////////////////
+//To make your own special antagonist, simple setup the variables
+//and setup the antag datum. See the undercover.dm file for help
 
 /datum/special_role
-	var/attached_antag_datum = /datum/antagonist/special
+	var/attatched_antag_datum = /datum/antagonist/special
 	var/spawn_mode = SPAWNTYPE_ROUNDSTART
 	var/probability = 0				//The probability of any spawning
 	var/min_players = 0				//Min player count (Forgot about this, might be important)
@@ -16,7 +18,6 @@
 	var/latejoin_allowed = TRUE		//Can latejoins be assigned to this? If you want this to be a midround spawn, put these in the round_event
 	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
 	//----Required for midround----
-	var/event_typepath = /datum/round_event/create_special_antag
 	var/weight = 10
 	var/earliest_start = 20 MINUTES
 	var/max_occurrences = 1
@@ -29,9 +30,13 @@
 	if(spawn_mode == SPAWNTYPE_ROUNDSTART)
 		return
 	//Create a new event for spawning the antag
-	var/datum/round_event_control/E = new()
+	var/datum/round_event_control/spawn_special_antagonist/E = new()
 	E.name = role_name
-	E.typepath = event_typepath
+	E.antagonist_datum = attatched_antag_datum
+	E.antag_name = role_name
+	E.preference_type = preference_type
+	E.protected_jobs = protected_jobs
+	E.typepath = /datum/round_event/create_special_antag
 	E.weight = weight
 	E.holidayID = holidayID
 	if(config)
@@ -45,55 +50,10 @@
 
 /datum/special_role/proc/add_antag_status_to(var/datum/mind/M)
 	M.special_role = role_name
-	var/datum/antagonist/special/A = M.add_antag_datum(new attached_antag_datum())
+	var/datum/antagonist/special/A = M.add_antag_datum(new attatched_antag_datum())
 	A.forge_objectives(M)
 	A.equip()
 	return A
-
-////////////////////////////////
-//////    Round event    ///////
-////////////////////////////////
-//The event that is associated with the special antag
-//If you are making a midround event that uses this system
-//Create a datum that implements /datum/round_event/create_special_antag
-//and put that datum as the event_typepath variable in
-//The controller.
-//If your role cannot spawn midround, don't bother making it.
-
-/datum/round_event/create_special_antag
-	fakeable = FALSE
-	var/role_name
-	var/antag_datum	//The datum of the antag E.G. /datum/antagonist/special/undercover
-	var/preference_type = ROLE_SPECIAL
-	var/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
-
-/datum/round_event/create_special_antag/start()
-	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.client || !(preference_type in H.client.prefs.be_special) || !(H.client.prefs.allow_midround_antag))
-			continue
-		if(is_banned_from(H, list(preference_type)))
-			continue
-		if(H.stat == DEAD)
-			continue
-		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions)) //only station jobs sans nonhuman roles, prevents ashwalkers trying to stalk with crewmembers they never met
-			continue
-		if(H.mind.assigned_role in protected_jobs)
-			continue
-		if(H.mind.has_antag_datum(antag_datum))
-			continue
-		var/datum/mind/M = H.mind
-		M.special_role = role_name
-		var/datum/antagonist/special/A = M.add_antag_datum(antag_datum)
-		if(!A)
-			message_admins("[key_name(H.mind)] failed to become a [role_name]")
-			log_game("[key_name(H.mind)] failed to become a [role_name]")
-			return
-		A.forge_objectives(M)
-		A.equip()
-		message_admins("[key_name(H.mind)] was randomly selected as [A.name]")
-		log_game("[key_name(H.mind)] was randomly selected as [A.name]")
-		announce_to_ghosts(H)
-		break
 
 ////////////////////////////////
 //////  Antagonist Datum ///////

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -1,4 +1,5 @@
 /datum/antagonist/special
+	name = "Special Additional Role"
 	var/probability = 100			//The probability of any spawning
 	var/proportion = 1				//The prbability per person of rolling it
 	var/max_amount = 5				//The maximum amount

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -57,6 +57,13 @@
 ////////////////////////////////
 //////    Round event    ///////
 ////////////////////////////////
+//The event that is associated with the special antag
+//If you are making a midround event that uses this system
+//Create a datum that implements /datum/round_event/create_special_antag
+//and put that datum as the event_typepath variable in
+//The controller.
+//If your role cannot spawn midround, don't bother making it.
+
 /datum/round_event/create_special_antag
 	fakeable = FALSE
 	var/role_name
@@ -101,6 +108,7 @@
 ////////////////////////////////
 //////  Antagonist Datum ///////
 ////////////////////////////////
+//The datum associated with the role
 
 /datum/antagonist/special
 	name = "Special Additional Role"

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -1,12 +1,14 @@
 /datum/antagonist/special
 	name = "Special Additional Role"
-	var/probability = 100			//The probability of any spawning
-	var/proportion = 1				//The prbability per person of rolling it
-	var/max_amount = 5				//The maximum amount
+	job_rank = ROLE_SPECIAL
+	show_in_antagpanel = FALSE
+	show_name_in_check_antagonists = FALSE
+	var/probability = 0				//The probability of any spawning
+	var/proportion = 0				//The prbability per person of rolling it
+	var/max_amount = 0				//The maximum amount
 	var/latejoin_allowed = TRUE		//Can latejoins be assigned to this?
 	var/allowAntagTargets = FALSE
 	var/role_name = "special role"
-	job_rank = ROLE_SPECIAL
 	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
 
 /datum/antagonist/special/proc/equip()

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -1,7 +1,6 @@
 /datum/antagonist/special/undercover
 	name = "Ex-security agent"
 	show_in_antagpanel = FALSE
-	job_rank = ROLE_EXSEC
 	show_name_in_check_antagonists = FALSE
 	antag_moodlet = /datum/mood_event/determined
 	role_name = "Undercover Agent"

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -1,0 +1,83 @@
+/datum/antagonist/special/undercover
+	name = "Ex-security agent"
+	show_in_antagpanel = FALSE
+	job_rank = ROLE_EXSEC
+	show_name_in_check_antagonists = FALSE
+	antag_moodlet = /datum/mood_event/determined
+	role_name = "Undercover Agent"
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician", "Clown")
+
+/datum/antagonist/special/undercover/greet()
+	to_chat(owner, "<span class='userdanger'>You are an ex-security agent.</span>")
+	to_chat(owner, "<b>Due to your loyality to nanotrasen in the past, you have been granted with a weapon permit.</b>")
+	to_chat(owner, "<b>Additionally nanotrasen has authorised you to have a disabler for personal defense.</b>")
+	to_chat(owner, "<b>You are not a member of security, and shouldn't hunt criminals, but may use your weapon for self defense.</b>")
+	to_chat(owner, "<span class='boldannounce'>Do NOT commit traitorous acts in persuit of your objectives.</span>")
+
+/datum/antagonist/special/undercover/admin_add(datum/mind/new_owner, mob/admin)
+	. = ..()
+	var/mob/living/carbon/C = new_owner.current
+	if(!istype(C))
+		to_chat(admin, "You can only turn carbons into an ex-security agent.")
+		return
+	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] into an ex-security agent.")
+	log_admin("[key_name(admin)] made [key_name(new_owner)] into [name].")
+
+/datum/antagonist/special/undercover/forge_objectives(var/datum/mind/undercovermind)
+	var/datum/objective/saveshuttle/chosen_objective = new
+	chosen_objective.generate_people_goal()
+	objectives += chosen_objective
+	owner.announce_objectives()
+
+/datum/antagonist/special/undercover/equip()
+	if(!owner)
+		return
+
+	var/mob/living/carbon/H = owner.current
+	if(!ishuman(H) && !ismonkey(H))
+		return
+
+	var/obj/item/gun/energy/disabler/T = new(H)
+	var/obj/item/restraints/handcuffs/cable/zipties/T2 = new(H)
+	var/list/slots = list (
+		"backpack" = SLOT_IN_BACKPACK,
+		"left pocket" = SLOT_L_STORE,
+		"right pocket" = SLOT_R_STORE
+	)
+	var/where = H.equip_in_one_of_slots(T, slots)
+	H.equip_in_one_of_slots(T2, slots)
+	if (!where)
+		to_chat(owner, "<span class='warning'>You lost your weapon on the way here! You should be more careful next time.</span>")
+
+	//Update ID
+	var/obj/item/card/id/ID = H.get_idcard()
+	ID.access += ACCESS_WEAPONS
+
+////////////////////////////////
+//////     Objectives    ///////
+////////////////////////////////
+
+/datum/objective/saveshuttle
+	name = "protect shuttle"
+
+/datum/objective/saveshuttle/check_completion()
+	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
+		return FALSE
+	var/count = 0
+	for(var/place in SSshuttle.emergency.shuttle_areas)
+		for(var/mob/living/carbon/human/person in place)
+			if(!person.mind)
+				continue
+			if(!considered_alive(person.mind))
+				continue
+			count ++
+	return count >= target_amount
+
+/datum/objective/saveshuttle/update_explanation_text()
+	. = ..()
+	explanation_text = "Protect the emergency shuttle from harm, ensuring that at least [target_amount] people make it on the shuttle alive."
+
+/datum/objective/saveshuttle/proc/generate_people_goal()
+	target_amount = rand(2, 8)			//This should really be made to scale with the population
+	update_explanation_text()
+	return target_amount

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -1,12 +1,23 @@
+////////////////////////////////
+////// Special Role Datum///////
+////////////////////////////////
+
+/datum/special_role/undercover
+	probability = 100//65			//The probability of any spawning at all
+	proportion = 1//0.05			//The prbability per person of rolling it (5% is (5 in 100) (1 in 20))
+	max_amount = 4				//The maximum amount
+	role_name = "Undercover Agent"
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician", "Clown")
+	attached_antag_datum = /datum/antagonist/special/undercover
+
+////////////////////////////////
+//////  Antagonist Datum ///////
+////////////////////////////////
+
 /datum/antagonist/special/undercover
 	name = "Ex-security agent"
 	roundend_category = "Special Roles"
-	probability = 65			//The probability of any spawning at all
-	proportion = 0.05			//The prbability per person of rolling it (5% is (5 in 100) (1 in 20))
-	max_amount = 4				//The maximum amount
 	antag_moodlet = /datum/mood_event/determined
-	role_name = "Undercover Agent"
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician", "Clown")
 
 /datum/antagonist/special/undercover/greet()
 	to_chat(owner, "<span class='userdanger'>You are an ex-security agent.</span>")

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -41,7 +41,6 @@
 	objectives += chosen_objective
 
 	if(owner.assigned_role in list("Chief Engineer", "Station Engineer", "Atmospheric Technician"))
-		message_admins("hell yea")
 		var/datum/objective/protect_sm/objective = new
 		if(objective.get_target())
 			objective.update_explanation_text()

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -85,13 +85,9 @@
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return FALSE
 	var/count = 0
-	for(var/place in SSshuttle.emergency.shuttle_areas)
-		for(var/mob/living/carbon/human/person in place)
-			if(!person.mind)
-				continue
-			if(!considered_alive(person.mind))
-				continue
-			count++
+	for(var/mob/living/carbon/human/person in get_living_crew())
+		if(get_area(person) in SSshuttle.emergency.shuttle_areas)
+			count ++
 	return count >= target_amount
 
 /datum/objective/saveshuttle/update_explanation_text()

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -24,7 +24,7 @@
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] into an ex-security agent.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] into [name].")
 
-/datum/antagonist/special/undercover/forge_objectives(var/datum/mind/undercovermind)
+/datum/antagonist/special/undercover/forge_objectives()
 	var/datum/objective/saveshuttle/chosen_objective = new
 	chosen_objective.generate_people_goal()
 	objectives += chosen_objective

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -40,7 +40,7 @@
 	chosen_objective.generate_people_goal()
 	objectives += chosen_objective
 
-	if(owner.assigned_role in list("Chief Engineer", "Station Engineer", "Atmospheric Technician"))
+	if(owner.assigned_role in GLOB.engineering_positions)
 		var/datum/objective/protect_sm/objective = new
 		if(objective.get_target())
 			objective.update_explanation_text()

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -39,6 +39,14 @@
 	var/datum/objective/saveshuttle/chosen_objective = new
 	chosen_objective.generate_people_goal()
 	objectives += chosen_objective
+
+	if(owner.assigned_role in list("Chief Engineer", "Station Engineer", "Atmospheric Technician"))
+		message_admins("hell yea")
+		var/datum/objective/protect_sm/objective = new
+		if(objective.get_target())
+			objective.update_explanation_text()
+			objectives += objective
+
 	owner.announce_objectives()
 
 /datum/antagonist/special/undercover/equip()
@@ -100,3 +108,24 @@
 	target_amount = rand(1, round(potential_escapees * 0.2))			//This should really be made to scale with the population
 	update_explanation_text()
 	return target_amount
+
+/datum/objective/protect_sm
+	name = "protect supermatter"
+	var/target_integrity = 20
+	var/target_sm
+
+/datum/objective/protect_sm/get_target()
+	for(var/obj/machinery/power/supermatter_crystal/S in GLOB.machines)
+		target_sm = S
+		return TRUE
+	log_runtime("Failed to find a supermatter crystal for the supermatter objective.")
+	return FALSE
+
+/datum/objective/protect_sm/update_explanation_text()
+	explanation_text = "Ensure the Supermatter crystal in [get_area(target_sm).name] remains stable and has above [target_integrity]% integrity at the end of the shift."
+
+/datum/objective/protect_sm/check_completion()
+	if(!target_sm)
+		return FALSE
+	var/obj/machinery/power/supermatter_crystal/S = target_sm
+	return S.get_integrity() > target_amount

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -8,7 +8,7 @@
 	max_amount = 4				//The maximum amount
 	role_name = "Undercover Agent"
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician", "Clown")
-	attached_antag_datum = /datum/antagonist/special/undercover
+	attatched_antag_datum = /datum/antagonist/special/undercover
 
 ////////////////////////////////
 //////  Antagonist Datum ///////

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -90,6 +90,13 @@
 	explanation_text = "Protect the emergency shuttle from harm, ensuring that at least [target_amount] people make it on the shuttle alive."
 
 /datum/objective/saveshuttle/proc/generate_people_goal()
-	target_amount = rand(2, 8)			//This should really be made to scale with the population
+	var/potential_escapees = 0
+	for(var/mob/M in GLOB.mob_list)
+		if(M.mind)
+			potential_escapees ++
+	if(potential_escapees == 0)
+		explanation_text = "Free Objective"
+		return 0
+	target_amount = rand(1, round(potential_escapees * 0.2))			//This should really be made to scale with the population
 	update_explanation_text()
 	return target_amount

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -3,8 +3,8 @@
 ////////////////////////////////
 
 /datum/special_role/undercover
-	probability = 100//65			//The probability of any spawning at all
-	proportion = 1//0.05			//The prbability per person of rolling it (5% is (5 in 100) (1 in 20))
+	probability = 65			//The probability of any spawning at all
+	proportion = 0.05			//The prbability per person of rolling it (5% is (5 in 100) (1 in 20))
 	max_amount = 4				//The maximum amount
 	role_name = "Undercover Agent"
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician", "Clown")

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -1,7 +1,8 @@
 /datum/antagonist/special/undercover
 	name = "Ex-security agent"
-	show_in_antagpanel = FALSE
-	show_name_in_check_antagonists = FALSE
+	probability = 65			//The probability of any spawning at all
+	proportion = 0.05			//The prbability per person of rolling it (5% is (5 in 100) (1 in 20))
+	max_amount = 4				//The maximum amount
 	antag_moodlet = /datum/mood_event/determined
 	role_name = "Undercover Agent"
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician", "Clown")

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -8,7 +8,7 @@
 	max_amount = 4				//The maximum amount
 	role_name = "Undercover Agent"
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician", "Clown")
-	attatched_antag_datum = /datum/antagonist/special/undercover
+	attached_antag_datum = /datum/antagonist/special/undercover
 
 ////////////////////////////////
 //////  Antagonist Datum ///////

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/special/undercover
 	name = "Ex-security agent"
+	roundend_category = "Special Roles"
 	probability = 65			//The probability of any spawning at all
 	proportion = 0.05			//The prbability per person of rolling it (5% is (5 in 100) (1 in 20))
 	max_amount = 4				//The maximum amount

--- a/code/modules/events/special_antag_event.dm
+++ b/code/modules/events/special_antag_event.dm
@@ -1,0 +1,66 @@
+/datum/round_event_control/spawn_special_antagonist
+	name = "Special Antagonist Spawn Event"
+	typepath = /datum/round_event/create_special_antag
+	//Antagonist data
+	var/antagonist_datum = /datum/antagonist/special
+	var/antag_name	//The datum of the antag E.G. /datum/antagonist/special/undercover
+	var/preference_type = ROLE_SPECIAL
+	var/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
+
+/datum/round_event_control/spawn_special_antagonist/runEvent()
+	var/datum/round_event/create_special_antag/E = new /datum/round_event/create_special_antag
+	E.antag_datum = antagonist_datum
+	E.role_name = antag_name
+	E.preference_type = preference_type
+	E.protected_jobs = protected_jobs
+	E.current_players = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
+	E.control = src
+	SSblackbox.record_feedback("tally", "event_ran", 1, "[E]")
+	occurrences++
+
+	testing("[time2text(world.time, "hh:mm:ss")] [E.type]")
+	if(random)
+		log_game("Random Event triggering: [name] ([typepath])")
+	if (alert_observers)
+		deadchat_broadcast("<span class='deadsay'><b>[name]</b> has just been[random ? " randomly" : ""] triggered!</span>") //STOP ASSUMING IT'S BADMINS!
+	return E
+
+////////////////////////////////
+//////    Round event    ///////
+////////////////////////////////
+//The event that is associated with the special antag
+
+/datum/round_event/create_special_antag
+	fakeable = FALSE
+	var/role_name
+	var/antag_datum	//The datum of the antag E.G. /datum/antagonist/special/undercover
+	var/preference_type = ROLE_SPECIAL
+	var/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
+
+/datum/round_event/create_special_antag/start()
+	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
+		if(!H.client || !(preference_type in H.client.prefs.be_special) || !(H.client.prefs.allow_midround_antag))
+			continue
+		if(is_banned_from(H, list(preference_type)))
+			continue
+		if(H.stat == DEAD)
+			continue
+		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions)) //only station jobs sans nonhuman roles, prevents ashwalkers trying to stalk with crewmembers they never met
+			continue
+		if(H.mind.assigned_role in protected_jobs)
+			continue
+		if(H.mind.has_antag_datum(antag_datum))
+			continue
+		var/datum/mind/M = H.mind
+		M.special_role = role_name
+		var/datum/antagonist/special/A = M.add_antag_datum(antag_datum)
+		if(!A)
+			message_admins("[key_name(H.mind)] failed to become a [role_name]")
+			log_game("[key_name(H.mind)] failed to become a [role_name]")
+			return
+		A.forge_objectives(M)
+		A.equip()
+		message_admins("[key_name(H.mind)] was randomly selected as [A.name]")
+		log_game("[key_name(H.mind)] was randomly selected as [A.name]")
+		announce_to_ghosts(H)
+		break

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -400,9 +400,11 @@
 			switch(SSshuttle.emergency.mode)
 				if(SHUTTLE_RECALL, SHUTTLE_IDLE)
 					SSticker.mode.make_antag_chance(humanc)
+					SSticker.mode.make_special_antag_chance(humanc)
 				if(SHUTTLE_CALL)
 					if(SSshuttle.emergency.timeLeft(1) > initial(SSshuttle.emergencyCallTime)*0.5)
 						SSticker.mode.make_antag_chance(humanc)
+						SSticker.mode.make_special_antag_chance(humanc)
 
 	if(humanc && CONFIG_GET(flag/roundstart_traits))
 		SSquirks.AssignQuirks(humanc, humanc.client, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the framework for creating minor special roles to the game. This PR doesn't add any roles and only adds the baseline for them.

This is a good PR as it enables developers to add in special roles that will spice up the gameplay for people every few rounds a little without making entirely new gamemodes.

## Why It's Good For The Game

This gives people the ability to make their own roles, as well as 1 example role is included (**THIS DOES NOT ADD ANY ROLES, I will do that in another PR**).

Minor special roles are chosen after the normal gamemode antags have been chosen.

Options for new roles
 - Probability (The probability that these roles will exist at all)
 - Proportion (This individual probability that you will be selected for the role, if it is selected to spawn)
 - Max Amount (The maximum amount of this special role that can exist)
 - Late Join Allowed (Can players that arrive late be selected for this role)
 - Allow Antag Targets (Can players that are the target of an antag be selected for this role)
 - Protected Jobs (Jobs that cannot be this role)

Included is an example special role, the Ex-Security agent.
The ex-security agent is an example of what this is used for. It is a very very minor special role that some players will have and will spawn with the objective to ensure X amount of people escape on the shuttle alive. They spawn with a disabler, zipties and weapon auth and are informed they are not a sec officers and shouldn't go round making arrests.
The reason for them is to help prevent low-population murderboning, as most low-pop rounds have almost no security and it's not fun for anyone <s>except the guy murdering everyone</s> if someone is going round against an unarmed, defenceless crew; since it is good that people going around murdering everyone because they can have some competition, sure killing defenceless people is fun for you, but it can get frustrating when it happens 3 times in a row.

**This PR doesn't add them, just the code for adding antags like them**

This system is pretty flexible and can be made to support whatever you can think of that doesn't deserve it's own game mode (think roles like obsessed)

Additionally, gamemodes have an 'allowed_special' list, where all of the allowed special roles for that game mode can be added, allowing for roles like the ex-security to be spawned on traitors, lings and extended but not on gamemodes like nuclear ops where they could interfere or not function.

## Changelog
:cl:
code: Implements the code for roundstart special roles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
