### PR TITLE
Fixes unrecyclability of circuit components

### DIFF
--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -80,23 +80,21 @@ a creative player the means to solve many problems.  Circuits are held inside an
 		return user.canUseTopic(src, BE_CLOSE)
 
 /obj/item/integrated_circuit/Initialize()
-	. = ..()
 	displayed_name = name
 	setup_io(inputs, /datum/integrated_io, inputs_default, IC_INPUT)
 	setup_io(outputs, /datum/integrated_io, outputs_default, IC_OUTPUT)
 	setup_io(activators, /datum/integrated_io/activate, null, IC_ACTIVATOR)
-	materials[/datum/material/iron] = w_class * SScircuit.cost_multiplier
-
+	materials[MAT_METAL] = w_class * SScircuit.cost_multiplier
+	. = ..()
 
 /obj/item/integrated_circuit/proc/on_data_written() //Override this for special behaviour when new data gets pushed to the circuit.
 	return
 
 /obj/item/integrated_circuit/Destroy()
-	. = ..()
 	QDEL_LIST(inputs)
 	QDEL_LIST(outputs)
 	QDEL_LIST(activators)
-
+	. = ..()
 
 /obj/item/integrated_circuit/emp_act(severity)
 	for(var/k in inputs)
@@ -123,9 +121,6 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	if(check_interactivity(M))
 		if(!input)
 			input = name
-		if(CHAT_FILTER_CHECK(input))
-			to_chat(M, "<span class='warning'>The circuit name contains prohibited words!</span>")
-			return
 		to_chat(M, "<span class='notice'>The circuit '[name]' is now labeled '[input]'.</span>")
 		displayed_name = input
 
@@ -145,7 +140,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	var/table_middle_width = "40%"
 
 	var/datum/browser/popup = new(user, "scannernew", name, 800, 630) // Set up the popup browser window
-	popup.add_stylesheet("scannernew", 'html/browser/assembly_ui.css')
+	popup.add_stylesheet("scannernew", 'html/browser/circuits.css')
 
 	var/HTML = "<html><head><title>[src.displayed_name]</title></head><body> \
 		<div align='center'> \
@@ -181,7 +176,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 					io = get_pin_ref(IC_INPUT, i)
 					if(io)
 						words += "<b><a href='?src=[REF(src)];act=wire;pin=[REF(io)]'>[io.display_pin_type()] [io.name]</a> \
-							<a href='?src=[REF(src)];act=data;pin=[REF(io)]'>[io.display_data(io.data)]</a></b><br>"
+							[io.display_data(io.data)]</b><br>"
 						if(io.linked.len)
 							words += "<ul>"
 							for(var/k in io.linked)
@@ -202,7 +197,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 					io = get_pin_ref(IC_OUTPUT, i)
 					if(io)
 						words += "<b><a href='?src=[REF(src)];act=wire;pin=[REF(io)]'>[io.display_pin_type()] [io.name]</a> \
-							<a href='?src=[REF(src)];act=data;pin=[REF(io)]'>[io.display_data(io.data)]</a></b><br>"
+							[io.display_data(io.data)]</b><br>"
 						if(io.linked.len)
 							words += "<ul>"
 							for(var/k in io.linked)

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -84,7 +84,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	setup_io(inputs, /datum/integrated_io, inputs_default, IC_INPUT)
 	setup_io(outputs, /datum/integrated_io, outputs_default, IC_OUTPUT)
 	setup_io(activators, /datum/integrated_io/activate, null, IC_ACTIVATOR)
-	materials[MAT_METAL] = w_class * SScircuit.cost_multiplier
+	materials[/datum/material/iron] = w_class * SScircuit.cost_multiplier
 	. = ..()
 
 /obj/item/integrated_circuit/proc/on_data_written() //Override this for special behaviour when new data gets pushed to the circuit.
@@ -121,6 +121,9 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	if(check_interactivity(M))
 		if(!input)
 			input = name
+		if(CHAT_FILTER_CHECK(input))
+			to_chat(M, "<span class='warning'>The circuit name contains prohibited words!</span>")
+			return
 		to_chat(M, "<span class='notice'>The circuit '[name]' is now labeled '[input]'.</span>")
 		displayed_name = input
 

--- a/html/browser/circuits.css
+++ b/html/browser/circuits.css
@@ -1,0 +1,31 @@
+div.scrollleft
+{
+	bottom: 0;
+	margin: 0;
+	overflow: scroll;
+	overflow-x: auto;
+	position: absolute;
+	text-indent: 15px;
+	top: 120px;
+	width: 200px;
+	overflow: auto;
+}
+
+div.scrollright
+{
+	bottom: 0;
+	left: 210px;
+	margin: 0;
+	right: 0;
+	overflow: scroll;
+	overflow-x: auto;
+	position: absolute;
+	text-indent: 15px;
+	top: 120px;
+	overflow: auto;
+}
+
+font.lowtext
+{
+	bottom: 0;
+}


### PR DESCRIPTION

## About The Pull Request
 For a long time, circuit parts have been unrecyclable, so I just rewinded the code a little bit to a time where stuff was still possible to be recycled. This also brings back the frame-based UI I coded initially for circuits when I was overhauling the whole thing, keeping better track of the whole thing. It seems like the one who brought modularization of circuits on bee didn't notice that he was missing my css file and just went and tried to fix the UI himself, so there ya go.

## Why It's Good For The Game

Bugfixes are always good

## Changelog
:cl:
tweak: circuit's frame-UI is back
fix: Circuit components can finally be recycled again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
