### PR TITLE
Makes toxin treatment kits not just boxes of charcoal

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -95,7 +95,7 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/syringe/carthatoline = 2,
+		/obj/item/reagent_containers/syringe/antitoxin = 2,
 		/obj/item/reagent_containers/syringe/calomel = 1,
 		/obj/item/reagent_containers/syringe/diphenhydramine = 1,
 		/obj/item/storage/pill_bottle/charcoal = 2,

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -95,7 +95,9 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/syringe/charcoal = 4,
+		/obj/item/reagent_containers/syringe/carthatoline = 2,
+		/obj/item/reagent_containers/syringe/calomel = 1,
+		/obj/item/reagent_containers/syringe/diphenhydramine = 1,
 		/obj/item/storage/pill_bottle/charcoal = 2,
 		/obj/item/healthanalyzer = 1)
 	generate_items_inside(items_inside,src)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -400,12 +400,12 @@
 	description = "Heals mild toxin damage as well as slowly removing any other chemicals the patient has in their bloodstream."
 	reagent_state = LIQUID
 	color = "#000000"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	metabolization_rate = REAGENTS_METABOLISM
 	taste_description = "ash"
 	process_flags = ORGANIC
 
 /datum/reagent/medicine/charcoal/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(-0.25*REM, 0)
+	M.adjustToxLoss(-1*REM, 0)
 	. = 1
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -397,7 +397,7 @@
 
 /datum/reagent/medicine/charcoal
 	name = "Charcoal"
-	description = "Heals toxin damage as well as slowly removing any other chemicals the patient has in their bloodstream."
+	description = "Heals mild toxin damage as well as slowly removing any other chemicals the patient has in their bloodstream."
 	reagent_state = LIQUID
 	color = "#000000"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -405,11 +405,11 @@
 	process_flags = ORGANIC
 
 /datum/reagent/medicine/charcoal/on_mob_life(mob/living/carbon/M)
-	M.adjustToxLoss(-2*REM, 0)
+	M.adjustToxLoss(-0.25*REM, 0)
 	. = 1
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
-			M.reagents.remove_reagent(R.type,1)
+			M.reagents.remove_reagent(R.type,0.75)
 	..()
 
 /datum/reagent/medicine/system_cleaner

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -186,10 +186,10 @@
 	desc = "Contains charcoal."
 	list_reagents = list(/datum/reagent/medicine/charcoal = 15)
 
-/obj/item/reagent_containers/syringe/carthatoline
-	name = "syringe (carthatoline)"
-	desc = "Contains carthatoline."
-	list_reagents = list(/datum/reagent/medicine/carthatoline = 15)
+/obj/item/reagent_containers/syringe/antitoxin
+	name = "syringe (antitoxin)"
+	desc = "Contains antitoxin."
+	list_reagents = list(/datum/reagent/medicine/antitoxin = 15)
 
 /obj/item/reagent_containers/syringe/diphenhydramine
 	name = "syringe (diphenhydramine)"

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -186,6 +186,21 @@
 	desc = "Contains charcoal."
 	list_reagents = list(/datum/reagent/medicine/charcoal = 15)
 
+/obj/item/reagent_containers/syringe/carthatoline
+	name = "syringe (carthatoline)"
+	desc = "Contains carthatoline."
+	list_reagents = list(/datum/reagent/medicine/carthatoline = 15)
+
+/obj/item/reagent_containers/syringe/diphenhydramine
+	name = "syringe (diphenhydramine)"
+	desc = "Contains diphenhydramine, an antihistamine agent."
+	list_reagents = list(/datum/reagent/medicine/diphenhydramine = 15)
+	
+/obj/item/reagent_containers/syringe/calomel
+	name = "syringe (calomel)"
+	desc = "Contains calomel."
+	list_reagents = list(/datum/reagent/medicine/calomel = 15)
+
 /obj/item/reagent_containers/syringe/antiviral
 	name = "syringe (spaceacillin)"
 	desc = "Contains antiviral agents."


### PR DESCRIPTION
## About The Pull Request

The primary goal of this PR is to make toxin treatment first aid kits something else rather than just being boxes of charcoal.

The toxin treatment kit now contains:
2 pill bottles of charcoal.
2 syringes of anti-toxin.
1 syringe of calomel, a reagent purging drug with a side-effect of dealing toxin damage down to 20 health.
1 syringe of diphenhydramine to fight those rare cases when you have histamine poisoning.
1 health analyzer.

Also charcoal has been a bit nerfed because it was basically the universal answer to all toxin-related poisoning.

Charcoal now heals just 0.25 of toxin damage instead of 2 per tick which was basically antitoxin+, since it was much more available and purged chemicals in addition to healing. Also the purging of chemicals has been decreased by a quarter to encourage the usage of more specialized drugs.


## Why It's Good For The Game

In my opinion, there should not be a universal answer to all poisoning. Also this change will actually buff the toxin treatment kit. The charcoal pills are still a cheap, affordable alternative for assistants that want to survive that suspicious syringe that has hit them.

## Changelog
:cl:
tweak: The toxin treatment kit is no longer a box of charcoal and has some more powerful drugs.
tweak: Charcoal is no longer a universal answer to poisoning, but still very viable against poisoning being in progress.
/:cl:
