### PR TITLE
Allows custom shuttles to land on some forms of plating, but not the …

### DIFF
--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -229,7 +229,12 @@
 	name = "Shuttle Navigation Computer"
 	desc = "Used to designate a precise transit location for private ships."
 	lock_override = NONE
-	whitelist_turfs = list(/turf/open/space, /turf/open/lava)
+	whitelist_turfs = list(/turf/open/space,
+		/turf/open/lava,
+		/turf/open/floor/plating/beach,
+		/turf/open/floor/plating/ashplanet,
+		/turf/open/floor/plating/asteroid,
+		/turf/open/floor/plating/lavaland_baseturf)
 	jumpto_ports = list("whiteship_home" = 1)
 	view_range = 12
 	designate_time = 100


### PR DESCRIPTION
…station plating

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows custom shuttle to land on:
 - Beach turfs
 - Ash planet turfs
 - Asteroid Turfs
 - Lavaland Base Turf

Should make it so shuttles can go down to lavaland, since they use asteroid turfs.

## Why It's Good For The Game

Shuttles cannot currently land on lavaland which is a little sad and cringe.

## Changelog
:cl:
tweak: Custom shuttles can land on non-station plating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
