### PR TITLE
[S] Patch for admins being able to view a system's file-tree

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -4,6 +4,11 @@
 		src << browse_rsc(file)
 
 /client/proc/browse_files(root="data/logs/", max_iterations=10, list/valid_extensions=list("txt","log","htm", "html"))
+	if(IsAdminAdvancedProcCall())
+		log_admin_private("BROWSEFILES: Admin proc call blocked")
+		message_admins("BROWSEFILES: Admin proc call blocked")
+		return null
+
 	var/path = root
 
 	for(var/i=0, i<max_iterations, i++)

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -14,6 +14,11 @@
 	browseserverlogs("[GLOB.log_directory]/")
 
 /client/proc/browseserverlogs(path = "data/logs/")
+	if(IsAdminAdvancedProcCall())
+		log_admin_private("BROWSEFILES: Admin proc call blocked")
+		message_admins("BROWSEFILES: Admin proc call blocked")
+		return null
+
 	path = browse_files(path)
 	if(!path)
 		return


### PR DESCRIPTION
Port of the Yog commit: https://github.com/yogstation13/Yogstation/commit/7b604a042d8f489360cbbd627660120980cdd784

Adds extra checks to prevent someone with admin perms from being able to browse the host system's file-tree using proccall. 
