### PR TITLE
Fixes energy chainsaws reverting to normal chainsaws when implanted

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -452,7 +452,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "angelplasm"
 
 /obj/item/mounted_chainsaw
-	name = "mounted chainsaw"
+	name = "mounted chainsaw template"
 	desc = "A chainsaw that has replaced your arm."
 	icon_state = "chainsaw_on"
 	item_state = "mounted_chainsaw"
@@ -474,7 +474,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 
-/obj/item/mounted_chainsaw/Destroy()
+/obj/item/mounted_chainsaw/normal
+	name = "mounted chainsaw"
+
+/obj/item/mounted_chainsaw/normal/Destroy()
 	var/obj/item/bodypart/part
 	new /obj/item/twohanded/required/chainsaw(get_turf(src))
 	if(iscarbon(loc))
@@ -485,6 +488,50 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	if(part)
 		part.drop_limb()
+
+/obj/item/mounted_chainsaw/energy
+	name = "mounted energy chainsaw"
+	desc = "An energy chainsaw that has replaced your arm."
+	force = 40
+	armour_penetration = 50
+	block_chance = 50
+	hitsound = 'sound/weapons/echainsawhit1.ogg'
+
+/obj/item/mounted_chainsaw/energy/Destroy()
+	var/obj/item/bodypart/part
+	new /obj/item/twohanded/required/chainsaw/energy(get_turf(src))
+	if(iscarbon(loc))
+		var/mob/living/carbon/holder = loc
+		var/index = holder.get_held_index_of_item(src)
+		if(index)
+			part = holder.hand_bodyparts[index]
+	. = ..()
+	if(part)
+		part.drop_limb()
+
+/obj/item/mounted_chainsaw/super
+	name = "mounted super energy chainsaw"
+	desc = "A super energy chainsaw that has replaced your arm."
+	force = 60
+	armour_penetration = 75
+	block_chance = 75
+	hitsound = 'sound/weapons/echainsawhit1.ogg'
+
+/obj/item/mounted_chainsaw/super/Destroy()
+	var/obj/item/bodypart/part
+	new /obj/item/twohanded/required/chainsaw/energy/doom(get_turf(src))
+	if(iscarbon(loc))
+		var/mob/living/carbon/holder = loc
+		var/index = holder.get_held_index_of_item(src)
+		if(index)
+			part = holder.hand_bodyparts[index]
+	. = ..()
+	if(part)
+		part.drop_limb()
+
+/obj/item/mounted_chainsaw/super/attack(mob/living/target)
+	..()
+	target.Knockdown(4)
 
 /obj/item/statuebust
 	name = "bust"

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -87,8 +87,16 @@
 			"[user] finishes attaching [tool]!",
 			"[user] finishes the attachment procedure!")
 		qdel(tool)
-		if(istype(tool, /obj/item/twohanded/required/chainsaw))
-			var/obj/item/mounted_chainsaw/new_arm = new(target)
+		if(istype(tool, /obj/item/twohanded/required/chainsaw/energy/doom))
+			var/obj/item/mounted_chainsaw/super/new_arm = new(target)
+			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
+			return 1
+		else if(istype(tool, /obj/item/twohanded/required/chainsaw/energy))
+			var/obj/item/mounted_chainsaw/energy/new_arm = new(target)
+			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
+			return 1
+		else if(istype(tool, /obj/item/twohanded/required/chainsaw))
+			var/obj/item/mounted_chainsaw/normal/new_arm = new(target)
 			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
 			return 1
 		else if(istype(tool, /obj/item/melee/synthetic_arm_blade))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title

## Why It's Good For The Game
It's a bugfix

## Changelog
:cl:
fix: Energy chainsaws no longer revert to normal chainsaws when implanted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
