### PR TITLE
Adds support for defining preset tags for issues reported mid-game

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -210,6 +210,8 @@
 /datum/config_entry/string/githuburl
 	config_entry_value = "https://www.github.com/tgstation/-tg-station"
 
+/datum/config_entry/string/issue_label
+
 /datum/config_entry/string/donateurl
 	config_entry_value = "https://www.patreon.com/user?u=10639001"
 

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -245,6 +245,10 @@ RULESURL https://beestation13.com/rules?server=bs_sage
 ## Github address
 GITHUBURL https://www.github.com/beestation/beestation-hornet
 
+## Label to tag ingame-registered issues with.
+## Uncomment this to enable them.
+#ISSUE_LABEL Ingame Issue Report
+
 ## Donation URL
 DONATEURL https://www.patreon.com/user?u=10639001
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -242,6 +242,10 @@ RULESURL http://beestation13.com/rules?server=bs_golden
 ## Github address
 GITHUBURL https://www.github.com/beestation/beestation-hornet
 
+## Label to tag ingame-registered issues with.
+## Uncomment this to enable them.
+#ISSUE_LABEL Ingame Issue Report
+
 ## Donation URL
 DONATEURL https://www.patreon.com/user?u=10639001
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -242,6 +242,9 @@ RULESURL http://beestation13.com/rules?server=bs_golden
 ## Github address
 GITHUBURL https://www.github.com/beestation/beestation-hornet
 
+## Label to tag ingame-registered issues with.
+ISSUE_LABEL Ingame Issue Report
+
 ## Donation URL
 DONATEURL https://www.patreon.com/user?u=10639001
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -70,7 +70,8 @@
 		var/url_params = "Reporting client version: [byond_version].[byond_build]\n\n[issue_template]"
 		if(GLOB.round_id || servername)
 			url_params = "Issue reported from [GLOB.round_id ? " Round ID: [GLOB.round_id][servername ? " ([servername])" : ""]" : servername]\n\n[url_params]"
-		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[url_encode(url_params)]"))
+		var/issue_label = CONFIG_GET(string/issue_label)
+		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[url_encode(url_params)][issue_label ? "&labels=[url_encode(issue_label)]" : ""]"))
 	else
 		to_chat(src, "<span class='danger'>The Github URL is not set in the server configuration.</span>")
 	return


### PR DESCRIPTION
Downstream PR Merged: https://github.com/BeeStation/NSV13/pull/507

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game

Adds a github issue label to reports made with the ingame tracker, as they can be missing information such as testmerges.

## Changelog
:cl:
code: Issues reported with the ingame tracker are now labeled automatically.
config: Config flag string/issue_label contains the setting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
