### PR TITLE
makes disposals loop detainment no longer viable

### DIFF
--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -118,6 +118,8 @@
 		return
 	for(var/mob/M in range(5, get_turf(src)))
 		M.show_message("<FONT size=[max(0, 5 - get_dist(src, M))]>CLONG, clong!</FONT>", 2)
+	var/obj/structure/disposalpipe/pipe = loc
+	pipe.take_damage(10)
 	playsound(src.loc, 'sound/effects/clang.ogg', 50, 0, 0)
 
 // called to vent all gas in holder to a location


### PR DESCRIPTION
## About The Pull Request

Struggling in disposals now deals minor damage to pipes, making escaping loops possible
![image](https://user-images.githubusercontent.com/49600480/79495875-1b8c5080-7fda-11ea-986a-57fcac10e50f.png)

## Why It's Good For The Game

infinite disposals loops are cancerous as fuck.

## Changelog
:cl:
tweak: disposals loops are no longer inescapable if you dont have explosives
/:cl:

