### PR TITLE
Felinids are now actually weak to loud noises

### DIFF
--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -94,6 +94,7 @@
 	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "kitty"
 	damage_multiplier = 2
+	bang_protect = -2
 
 /obj/item/organ/ears/cat/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
 	..()


### PR DESCRIPTION

## About The Pull Request

Felinids now have a similar noise weakness to moth's flash weakness, needing earmuffs and a helmet to fully protect from flashbangs

## Why It's Good For The Game

felinids are meant to be weak to sound, but due to code limitations, were unable to have anything greater than an ear damage multiplier up until a recent PR. this fixes that

## Changelog
:cl:
tweak: felinids are weak to loud noises now, not just to ear damage
/:cl: