### PR TITLE
[BOUNTY] Adds a mini-chem dispenser to botany

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -15033,9 +15033,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aJN" = (
-/obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/paper/guides/jobs/hydroponics,
+/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aJO" = (
@@ -15563,6 +15561,8 @@
 	pixel_y = 5
 	},
 /obj/item/watertank,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/item/book/manual/hydroponics_pod_people,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aLe" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32561,6 +32561,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beT" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54000,13 +54000,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccu" = (
-/obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccv" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -19039,6 +19039,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aSD" = (

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -689,6 +689,18 @@
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
 	needs_anchored = FALSE
 
+/obj/item/circuitboard/machine/chem_dispenser/botany
+	name = "Minor Botanical Chem Dispenser (Machine Board)"
+	build_path = /obj/machinery/chem_dispenser/mutagensaltpeter
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 2,
+		/obj/item/stock_parts/capacitor = 1,
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/cell = 1)
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
+	needs_anchored = FALSE
+
 /obj/item/circuitboard/machine/chem_dispenser/drinks
 	name = "Soda Dispenser (Machine Board)"
 	build_path = /obj/machinery/chem_dispenser/drinks

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -691,7 +691,7 @@
 
 /obj/item/circuitboard/machine/chem_dispenser/botany
 	name = "Minor Botanical Chem Dispenser (Machine Board)"
-	build_path = /obj/machinery/chem_dispenser/mutagensaltpeter
+	build_path = /obj/machinery/chem_dispenser/mutagensaltpetersmall
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/stock_parts/capacitor = 1,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -592,10 +592,10 @@
 /obj/machinery/chem_dispenser/mutagensaltpetersmall
 	name = "minor botanical chemical dispenser"
 	desc = "A botanical chemical dispenser on a budget."
-	flags_1 = NODECONSTRUCT_1
 	icon_state = "minidispenser"
 	working_state = "minidispenser_working"
 	nopower_state = "minidispenser_nopower"
+	circuit = /obj/item/circuitboard/machine/chem_dispenser/botany
 	dispensable_reagents = list(
 		/datum/reagent/toxin/mutagen,
 		/datum/reagent/saltpetre,
@@ -612,17 +612,7 @@
 	b_o.pixel_x = -4
 	return b_o
 
-/obj/machinery/chem_dispenser/mutagensaltpetersmall/Initialize() //Ugly.
-	. = ..()
-	component_parts = list()
-	component_parts += new /obj/item/circuitboard/machine/chem_dispenser(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
-	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
-	component_parts += new /obj/item/stock_parts/manipulator(null)
-	component_parts += new /obj/item/stack/sheet/glass(null)
-	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
-	RefreshParts()
+
 
 /obj/machinery/chem_dispenser/fullupgrade //fully ugpraded stock parts, emagged
 	desc = "Creates and dispenses chemicals. This model has had its safeties shorted out."

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -589,6 +589,34 @@
 	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
 	RefreshParts()
 
+/obj/machinery/chem_dispenser/mutagensaltpetersmall
+	name = "minor botanical chemical dispenser"
+	desc = "A botanical chemical dispenser on a budget."
+	flags_1 = NODECONSTRUCT_1
+	icon_state = "minidispenser"
+
+	dispensable_reagents = list(
+		/datum/reagent/toxin/mutagen,
+		/datum/reagent/saltpetre,
+		/datum/reagent/water)
+	upgrade_reagents = list(
+		/datum/reagent/toxin/plantbgone,
+		/datum/reagent/toxin/plantbgone/weedkiller,
+		/datum/reagent/toxin/pestkiller,
+		/datum/reagent/diethylamine)
+
+/obj/machinery/chem_dispenser/mutagensaltpetersmall/Initialize() //Ugly.
+	. = ..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/machine/chem_dispenser(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/bluespace(null)
+	component_parts += new /obj/item/stock_parts/capacitor/quadratic(null)
+	component_parts += new /obj/item/stock_parts/manipulator(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
+	RefreshParts()
+
 /obj/machinery/chem_dispenser/fullupgrade //fully ugpraded stock parts, emagged
 	desc = "Creates and dispenses chemicals. This model has had its safeties shorted out."
 	obj_flags = CAN_BE_HIT | EMAGGED

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -594,7 +594,8 @@
 	desc = "A botanical chemical dispenser on a budget."
 	flags_1 = NODECONSTRUCT_1
 	icon_state = "minidispenser"
-
+	working_state = "minidispenser_working"
+	nopower_state = "minidispenser_nopower"
 	dispensable_reagents = list(
 		/datum/reagent/toxin/mutagen,
 		/datum/reagent/saltpetre,
@@ -604,6 +605,12 @@
 		/datum/reagent/toxin/plantbgone/weedkiller,
 		/datum/reagent/toxin/pestkiller,
 		/datum/reagent/diethylamine)
+
+/obj/machinery/chem_dispenser/mutagensaltpetersmall/display_beaker()
+	var/mutable_appearance/b_o = beaker_overlay || mutable_appearance(icon, "disp_beaker")
+	b_o.pixel_y = -4
+	b_o.pixel_x = -4
+	return b_o
 
 /obj/machinery/chem_dispenser/mutagensaltpetersmall/Initialize() //Ugly.
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This resolves #1559 

Adds a lesser version of the lifebringers chem dispenser to botany. Roundstart it can dispense only unstable mutagen, saltpetre and water. After t4 manipulators it can also dispense diethylamine, plantbgone, weedkiller and pestkiller.
~~Despite the small assortment, it can dispense a ton of these reagents.~~ 
~~It is also undeconstructable to prevent other bad people from getting cool parts.~~ Not anymore. Upgrade it now.

## Why It's Good For The Game

Quoting the bounty: 

> The problem: Beestation rounds are SHORT. Like, 25 minutes short at times. An effective Botanist has to speed run tech storage or chemistry to steal a dispenser (optimally) in order to get chemicals needed to mutate plants and increase yield.

In addition from myself:
We get to use one of those unused sprites.
Botanists greytide much less now.
Chemists can be left in peace.
I get money. ^^_^^

## Changelog
:cl:
add: Nanotrasen has provided the on-board botanists with their own minor botanical chemical dispenser for advanced botanical duties.
/:cl:
