### PR TITLE
Adds lethal autoturrets to nuke operative uplink

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -675,6 +675,8 @@
 	desc = "An energy blaster auto-turret."
 
 /obj/machinery/porta_turret/syndicate/energy/heavy
+	name = "syndicate heavy laser turret"
+	desc = "A heavy laser auto-turret."
 	icon_state = "standard_lethal"
 	base_icon_state = "standard"
 	stun_projectile = /obj/item/projectile/energy/electrode
@@ -683,6 +685,9 @@
 	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 	desc = "An energy blaster auto-turret."
 
+/obj/machinery/porta_turret/syndicate/energy/heavy/traitor
+	faction = list(ROLE_TRAITOR)
+
 /obj/machinery/porta_turret/syndicate/energy/raven
 	stun_projectile =  /obj/item/projectile/beam/laser
 	stun_projectile_sound = 'sound/weapons/laser.ogg'
@@ -690,12 +695,19 @@
 
 
 /obj/machinery/porta_turret/syndicate/pod
+	name = "syndicate semi-auto turret"
+	desc = "A ballistic semi-automatic auto-turret."
 	integrity_failure = 20
 	max_integrity = 40
 	stun_projectile = /obj/item/projectile/bullet/syndicate_turret
 	lethal_projectile = /obj/item/projectile/bullet/syndicate_turret
 
+/obj/machinery/porta_turret/syndicate/pod/traitor
+	faction = list(ROLE_TRAITOR)
+
 /obj/machinery/porta_turret/syndicate/shuttle
+	name = "syndicate penetrator turret"
+	desc = "A ballistic penetrator auto-turret."
 	scan_range = 9
 	shot_delay = 3
 	stun_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -685,9 +685,6 @@
 	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 	desc = "An energy blaster auto-turret."
 
-/obj/machinery/porta_turret/syndicate/energy/heavy/traitor
-	faction = list(ROLE_TRAITOR)
-
 /obj/machinery/porta_turret/syndicate/energy/raven
 	stun_projectile =  /obj/item/projectile/beam/laser
 	stun_projectile_sound = 'sound/weapons/laser.ogg'
@@ -701,9 +698,6 @@
 	max_integrity = 40
 	stun_projectile = /obj/item/projectile/bullet/syndicate_turret
 	lethal_projectile = /obj/item/projectile/bullet/syndicate_turret
-
-/obj/machinery/porta_turret/syndicate/pod/traitor
-	faction = list(ROLE_TRAITOR)
 
 /obj/machinery/porta_turret/syndicate/shuttle
 	name = "syndicate penetrator turret"

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -144,7 +144,7 @@
 
 /obj/item/sbeacondrop/semiautoturret
 	desc = "A label on it reads: <i>Warning: Activating this device will send a semi-auto turret to your location</i>."
-	droptype = /obj/machinery/porta_turret/syndicate/pod/nuke
+	droptype = /obj/machinery/porta_turret/syndicate/pod
 
 /obj/item/sbeacondrop/heavylaserturret
 	desc = "A label on it reads: <i>Warning: Activating this device will send a heavy laser turret to your location</i>."

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -141,3 +141,23 @@
 /obj/item/sbeacondrop/constructshell
 	desc = "A label on it reads: <i>Warning: Activating this device will send a Nar'sian construct shell to your location</i>."
 	droptype = /obj/structure/constructshell
+
+/obj/item/sbeacondrop/semiautoturret
+	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/pod
+
+/obj/item/sbeacondrop/semiautoturrettraitor
+	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/pod/traitor
+
+/obj/item/sbeacondrop/heavylaserturret
+	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/energy/heavy
+
+/obj/item/sbeacondrop/heavylaserturrettraitor
+	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/energy/heavy/traitor
+
+/obj/item/sbeacondrop/penetratorturret
+	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/shuttle

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -143,21 +143,13 @@
 	droptype = /obj/structure/constructshell
 
 /obj/item/sbeacondrop/semiautoturret
-	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
-	droptype = /obj/machinery/porta_turret/syndicate/pod
-
-/obj/item/sbeacondrop/semiautoturrettraitor
-	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
-	droptype = /obj/machinery/porta_turret/syndicate/pod/traitor
+	desc = "A label on it reads: <i>Warning: Activating this device will send a semi-auto turret to your location</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/pod/nuke
 
 /obj/item/sbeacondrop/heavylaserturret
-	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
+	desc = "A label on it reads: <i>Warning: Activating this device will send a heavy laser turret to your location</i>."
 	droptype = /obj/machinery/porta_turret/syndicate/energy/heavy
 
-/obj/item/sbeacondrop/heavylaserturrettraitor
-	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
-	droptype = /obj/machinery/porta_turret/syndicate/energy/heavy/traitor
-
 /obj/item/sbeacondrop/penetratorturret
-	desc = "A label on it reads: <i>Warning: Activating this device will send a turret to your location</i>."
+	desc = "A label on it reads: <i>Warning: Activating this device will send a penetrator turret to your location</i>."
 	droptype = /obj/machinery/porta_turret/syndicate/shuttle

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -547,6 +547,45 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 2
 	surplus = 10
 
+/datum/uplink_item/dangerous/semiautoturret
+	name = "Semi-Auto Turret - nukie"
+	desc = "A non-portabl.The turret is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+			transported to you that will teleport the actual turret to it upon activation. "
+	item = /obj/item/sbeacondrop/semiautoturret
+	cost = 4
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/semiautoturret/traitor
+	name = "Semi-Auto Turret - traitor"
+	item = /obj/item/sbeacondrop/semiautoturrettraitor
+	cost = 4
+	include_modes = list()
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/dangerous/heavylaserturret
+	name = "Heavy Laser Turret - nukie"
+	desc = "A non-portabl.The turret is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+			transported to you that will teleport the actual turret to it upon activation. "
+	item = /obj/item/sbeacondrop/heavylaserturret
+	cost = 7
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/dangerous/heavylaserturret/traitor
+	name = "Heavy Laser Turret - traitor"
+	item = /obj/item/sbeacondrop/heavylaserturrettraitor
+	cost = 11
+	include_modes = list()
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/dangerous/penetratorturret
+	name = "Penetrator Turret"
+	desc = "A non-portabl.The turret is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
+			transported to you that will teleport the actual turret to it upon activation. "
+	item = /obj/item/sbeacondrop/penetratorturret
+	cost = 22
+	include_modes = list(/datum/game_mode/nuclear)
+
+
 // Stealthy Weapons
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy Weapons"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -553,7 +553,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			and cannot be moved; upon ordering this item, a smaller beacon will be transported to you \
 			that will teleport the actual turret to it upon activation."
 	item = /obj/item/sbeacondrop/semiautoturret
-	cost = 4
+	cost = 8
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/heavylaserturret
@@ -562,16 +562,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			and cannot be moved; upon ordering this item, a smaller beacon will be transported to you \
 			that will teleport the actual turret to it upon activation."
 	item = /obj/item/sbeacondrop/heavylaserturret
-	cost = 7
-	include_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/dangerous/penetratorturret
-	name = "Penetrator Turret"
-	desc = "An autoturret which shoots penetrator rounds over an extended range. The turret is bulky \
-			and cannot be moved; upon ordering this item, a smaller beacon will be transported to you \
-			that will teleport the actual turret to it upon activation."
-	item = /obj/item/sbeacondrop/penetratorturret
-	cost = 22
+	cost = 12
 	include_modes = list(/datum/game_mode/nuclear)
 
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -548,39 +548,28 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 10
 
 /datum/uplink_item/dangerous/semiautoturret
-	name = "Semi-Auto Turret - nukie"
-	desc = "A non-portabl.The turret is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-			transported to you that will teleport the actual turret to it upon activation. "
+	name = "Semi-Auto Turret"
+	desc = "An autoturret which shoots semi-automatic ballistic rounds. The turret is bulky \
+			and cannot be moved; upon ordering this item, a smaller beacon will be transported to you \
+			that will teleport the actual turret to it upon activation."
 	item = /obj/item/sbeacondrop/semiautoturret
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/dangerous/semiautoturret/traitor
-	name = "Semi-Auto Turret - traitor"
-	item = /obj/item/sbeacondrop/semiautoturrettraitor
-	cost = 4
-	include_modes = list()
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-
 /datum/uplink_item/dangerous/heavylaserturret
-	name = "Heavy Laser Turret - nukie"
-	desc = "A non-portabl.The turret is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-			transported to you that will teleport the actual turret to it upon activation. "
+	name = "Heavy Laser Turret"
+	desc = "An autoturret which shoots heavy lasers. The turret is bulky \
+			and cannot be moved; upon ordering this item, a smaller beacon will be transported to you \
+			that will teleport the actual turret to it upon activation."
 	item = /obj/item/sbeacondrop/heavylaserturret
 	cost = 7
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/dangerous/heavylaserturret/traitor
-	name = "Heavy Laser Turret - traitor"
-	item = /obj/item/sbeacondrop/heavylaserturrettraitor
-	cost = 11
-	include_modes = list()
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-
 /datum/uplink_item/dangerous/penetratorturret
 	name = "Penetrator Turret"
-	desc = "A non-portabl.The turret is bulky and cannot be moved; upon ordering this item, a smaller beacon will be \
-			transported to you that will teleport the actual turret to it upon activation. "
+	desc = "An autoturret which shoots penetrator rounds over an extended range. The turret is bulky \
+			and cannot be moved; upon ordering this item, a smaller beacon will be transported to you \
+			that will teleport the actual turret to it upon activation."
 	item = /obj/item/sbeacondrop/penetratorturret
 	cost = 22
 	include_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds semi-automatic rounds (assault pod) and heavy laser autoturrets to nuke operative uplink. Mainly added for custom shuttles in the upcoming operative event but also would be useful weapons in many nuke operative rounds. May add semi-auto turrets to traitor uplink at a later date for traitors building their own shuttles. 

## Why It's Good For The Game
Custom shuttles are easy to attack without robust autoturrets defending it. Normal nuke operatives can also use these for suppressing fire or making parts of the station more hazardous in the same way they might otherwise use explosives, flamethrowers or assault cyborgs. 

## Changelog
:cl:
add: Semi-auto rounds and heavy laser autoturrets added to nuke operative uplink for 8 and 12 TC respectively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
