### PR TITLE
Revert "Increased reagent cap"

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -3,7 +3,7 @@
 
 /mob/living/carbon/Initialize()
 	. = ..()
-	create_reagents(5000)
+	create_reagents(1000)
 	update_body_parts() //to update the carbon's new bodyparts appearance
 	GLOB.carbon_list += src
 


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#1388

## About The Pull Request
Decreases reagent cap for carbon mobs from 5000 to 1000.


## Why It's Good For The Game
Was griefcode, only used for self antag by the original coder

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: decreased reagent cap on carbon mobs to 1000
/:cl: