### PR TITLE
Revert "Remakes Cyanide"

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -444,59 +444,20 @@
 
 /datum/reagent/toxin/cyanide
 	name = "Cyanide"
-	description = "An infamous poison known for its use in assassination. Causes headaches and sickness at first,followed by failure of cellular respiration leading to cardiac arrest"
+	description = "An infamous poison known for its use in assassination. Causes small amounts of toxin damage with a small chance of oxygen damage or a stun."
 	reagent_state = LIQUID
 	color = "#00B4FF"
-	metabolization_rate = 0.1 * REAGENTS_METABOLISM
-	toxpwr = 0
+	metabolization_rate = 0.125 * REAGENTS_METABOLISM
+	toxpwr = 1.25
 
 /datum/reagent/toxin/cyanide/on_mob_life(mob/living/carbon/M)
-	switch(current_cycle)
-		if(3 to 16)
-			if(prob(13))
-				M.losebreath += 1
-				to_chat(M, "<font size=3 color=red><b>Your chest is thumping like a jackhammer!</b></font>")
-				M.eye_blurry = max(M.eye_blurry, 4)
-				M.adjustOxyLoss(rand(1,3))
-				. = 1
-			if(prob(8))
-				M.losebreath += 1
-				to_chat(M, "<font size=3 color=red><b>You feel horribly sick!</b></font>")
-				M.adjustOxyLoss(rand(1,3))
-				if(iscarbon(M))
-					var/mob/living/carbon/C = M
-					C.vomit(20, stun = FALSE)
-				M.eye_blurry = max(M.eye_blurry, 4)
-				. = 1
-			if(prob(13))
-				M.losebreath += 1
-				to_chat(M, "<font size=3 color=red><b>Your head feels like it's going to explode!</b></font>")
-				M.adjustOxyLoss(rand(1,3))
-				M.Stun(30,0)
-				M.eye_blurry = max(M.eye_blurry, 4)
-				. = 1
-		if (16 to 35)
-			if(prob(20))
-				to_chat(M, "<font size=3 color=red><b>You feel incredibly weak!</b></font>")
-				M.losebreath += 2
-				M.confused += 2
-				M.Dizzy(5)
-				M.adjustStaminaLoss(14)
-				M.Stun(20,0)
-			if(prob(20))
-				M.adjustOxyLoss(rand(6,8))
-				. = 1
-		if (35 to 36)
-			to_chat(M, "<font size=2 color=red>Weakness overtakes you as your consciousness begins to  slip away...</font>")
-			M.adjustStaminaLoss(40)
-			M.losebreath += 1
-			. = 1
-		if (36 to INFINITY)
-			M.Sleeping(100,0)
-			if(!M.undergoing_cardiac_arrest() && M.can_heartattack())
-				M.set_heartattack(TRUE)
-			. = 1
-	..()
+	if(prob(5))
+		M.losebreath += 1
+	if(prob(8))
+		to_chat(M, "You feel horrendously weak!")
+		M.Stun(40, 0)
+		M.adjustToxLoss(2*REM, 0)
+	return ..()
 
 /datum/reagent/toxin/bad_food
 	name = "Bad Food"


### PR DESCRIPTION
Reverts #1207

Reverts a change that made cyanide vastly overpowered for a chemical that is accessible without a syndicate poison kit or emag. Even 5u of this stuff can kill you in no time at all and it's easy to make.