### PR TITLE
fixes a few issues with the flash nerf

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -105,7 +105,7 @@
 		return FALSE
 	return TRUE
 
-/obj/item/assembly/flash/proc/flash_carbon(mob/living/carbon/M, mob/user, power = 20, targeted = TRUE, generic_message = FALSE)
+/obj/item/assembly/flash/proc/flash_carbon(mob/living/carbon/M, mob/user, power = 15, targeted = TRUE, generic_message = FALSE)
 	if(!istype(M))
 		return
 	if(user)
@@ -115,10 +115,11 @@
 	if(generic_message && M != user)
 		to_chat(M, "<span class='disarm'>[src] emits a blinding light!</span>")
 	if(targeted)
-		if(M.flash_act(1, 1, time = 100))
+		if(M.flash_act(1, 1, time = 45))
 			if(M.confused < power)
 				var/diff = power * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
 				M.confused += min(power, diff)
+			M.blind_eyes(10)
 			if(user)
 				terrible_conversion_proc(M, user)
 				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
@@ -134,7 +135,8 @@
 		else
 			to_chat(M, "<span class='danger'>[src] fails to blind you!</span>")
 	else
-		M.flash_act(time = 50)
+		M.flash_act()
+		M.blind_eyes(5)
 
 /obj/item/assembly/flash/attack(mob/living/M, mob/user)
 	if(!try_use_flash(user))
@@ -147,8 +149,6 @@
 		log_combat(user, R, "flashed", src)
 		update_icon(1)
 		R.Paralyze(70)
-		var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
-		R.confused += min(5, diff)
 		R.flash_act(affect_silicon = 1)
 		user.visible_message("<span class='disarm'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
 		return TRUE

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -127,6 +127,6 @@
 	Proj.on_hit(src)
 	return BULLET_ACT_HIT
 
-/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash/static)
+/mob/living/silicon/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, time = 25, type = /obj/screen/fullscreen/flash/static)
 	if(affect_silicon)
 		return ..()


### PR DESCRIPTION
## About The Pull Request

-borgs no longer get blinded forever by flashes
-borgs no longer get confused by flashes
-slightly shorter confusion time
-flashes now no longer give a full blindness overlay for the duration. Instead, they give a blindness overlay for about half, and true blindness for the rest, allowing 1 tile of view range

## Why It's Good For The Game
 fixes and such

## Changelog
:cl:
tweak: makes flash blindness true blindness for half of the duration
fix: fixes borg flash blindness
/:cl:
