### PR TITLE
Adds the explosive flashbulb (Requires flash rework)

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -939,6 +939,7 @@
 #include "code\game\objects\items\devices\desynchronizer.dm"
 #include "code\game\objects\items\devices\doorCharge.dm"
 #include "code\game\objects\items\devices\electroadaptive_pseudocircuit.dm"
+#include "code\game\objects\items\devices\explosive_flashbulb.dm"
 #include "code\game\objects\items\devices\flashlight.dm"
 #include "code\game\objects\items\devices\forcefieldprojector.dm"
 #include "code\game\objects\items\devices\geiger_counter.dm"

--- a/code/game/objects/items/devices/explosive_flashbulb.dm
+++ b/code/game/objects/items/devices/explosive_flashbulb.dm
@@ -4,7 +4,6 @@
 	charges_left = 15
 
 /obj/item/flashbulb/bomb/use_flashbulb()
-	to_chat(usr, "<span class='userdanger'>You press down firmly on the top flash and hear a violent hiss!</span>")
 	explosion(src, -1, 1, 3, 4)
 	charges_left = 0
 	icon_state = "flashbulbburnt"

--- a/code/game/objects/items/devices/explosive_flashbulb.dm
+++ b/code/game/objects/items/devices/explosive_flashbulb.dm
@@ -1,0 +1,11 @@
+/obj/item/flashbulb/bomb
+	name = "suspicious flashbulb"
+	desc = "A powerful flashbulb that looks slightly off, with strange wires running out the back."
+	charges_left = 15
+
+/obj/item/flashbulb/bomb/use_flashbulb()
+	to_chat(usr, "<span class='userdanger'>You press down on the flashbulb and hear a violent hiss!</span>")
+	explosion(src, -1, 1, 3, 4)
+	charges_left = 0
+	icon_state = "flashbulbburnt"
+	return FLASH_USE_BURNOUT

--- a/code/game/objects/items/devices/explosive_flashbulb.dm
+++ b/code/game/objects/items/devices/explosive_flashbulb.dm
@@ -8,4 +8,4 @@
 	explosion(src, -1, 1, 3, 4)
 	charges_left = 0
 	icon_state = "flashbulbburnt"
-	return FLASH_USE_BURNOUT
+	return 1

--- a/code/game/objects/items/devices/explosive_flashbulb.dm
+++ b/code/game/objects/items/devices/explosive_flashbulb.dm
@@ -4,7 +4,7 @@
 	charges_left = 15
 
 /obj/item/flashbulb/bomb/use_flashbulb()
-	to_chat(usr, "<span class='userdanger'>You press down on the flashbulb and hear a violent hiss!</span>")
+	to_chat(usr, "<span class='userdanger'>You press down firmly on the top flash and hear a violent hiss!</span>")
 	explosion(src, -1, 1, 3, 4)
 	charges_left = 0
 	icon_state = "flashbulbburnt"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1048,6 +1048,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 35
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/explosives/explosive_flashbulbs
+	name = "Explosive Flashbulb"
+	desc = "A flashbulb stuffed with explosives that when used by an oblivious security officers, will cause a violent explosion."
+	item = /obj/item/flashbulb/bomb
+	cost = 1
+	surplus = 8
+
 //Support and Mechs
 /datum/uplink_item/support
 	category = "Support and Exosuits"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Depends on https://github.com/BeeStation/BeeStation-Hornet/pull/1584

## About The Pull Request

Adds in a suspicious flashbulb which, when inserted into a flash, will violently explode when triggered. It costs 1 TC and can be easily identified by wirecutting the bulb out and checking. Be careful who you takes flashes from, kids.

## Why It's Good For The Game

It's a fun traitor item that you can use to blow up powergamers or security who are too lazy to wirecutter the flashbulb out and check it.

## Changelog
:cl:
add: Adds the explosive flashbulb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
