### PR TITLE
Cult stun protected against by mindshields instead, and it only offers partial immunity

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -402,8 +402,8 @@
 
 //Stun
 /obj/item/melee/blood_magic/stun
-	name = "Forbidden Whispers"
-	desc = "A forgotten word that will drive the target to madness for a short time if their ears are unprotected."
+	name = "Stunning Aura"
+	desc = "Will stun and mute a weak-minded victim on contact."
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 
@@ -414,7 +414,7 @@
 	if(iscultist(target))
 		return
 	if(iscultist(user))
-		user.visible_message("<span class='warning'>[user] whispers an unintelligable phrase into [L]'s ear.</span>", \
+		user.visible_message("<span class='warning'>[user] holds up [user.p_their()] hand, which explodes in a flash of red light!</span>", \
 							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
 
 		user.mob_light(_color = LIGHT_COLOR_BLOOD_MAGIC, _range = 3, _duration = 2)
@@ -429,29 +429,35 @@
 
 			if(istype(anti_magic_source, /obj/item))
 				var/obj/item/ams_object = anti_magic_source
-				target.visible_message("<span class='warning'>[L] seems too distracted to hear you!</span>", \
-									   "<span class='userdanger'>Your [ams_object.name] throbs, and you can't quite make out what [user] says!</span>")
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
 			else
-				target.visible_message("<span class='warning'>[L] is utterly unphased by your utterance!</span>", \
-									   "<span class='userdanger'>[user] whispers gibberish into your ear. Was that supposed to do something?</span>")
-		else if(L.get_ear_protection() <= 0)
-			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
-			L.Paralyze(160)
-			L.flash_act(1,1)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
-				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(15)
-			if(is_servant_of_ratvar(L))
-				L.adjustBruteLoss(15)
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
+
 		else
-			target.visible_message("<span class='warning'>[L] can't seem to hear you!</span>", \
-									   "<span class='userdanger'>[user] whispers something to you, but you can't quite make it out through your hearing protection.</span>")
+			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+				var/mob/living/carbon/C = L
+				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				C.stuttering += 8
+				C.dizziness += 30
+				C.Jitter(8)
+				C.drop_all_held_items()
+				C.bleed(40)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -445,6 +445,7 @@
 				C.drop_all_held_items()
 				C.bleed(40)
 				C.apply_damage(45, STAMINA, BODY_ZONE_CHEST)
+				C.Knockdown(10)
 			else
 				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
 				L.Paralyze(160)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -444,7 +444,7 @@
 				C.Jitter(8)
 				C.drop_all_held_items()
 				C.bleed(40)
-				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+				C.apply_damage(45, STAMINA, BODY_ZONE_CHEST)
 			else
 				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
 				L.Paralyze(160)


### PR DESCRIPTION
## About The Pull Request
Cult stun is unaffected by ear protection again, but is protected against by mindshields instead. If you have a mindshield the stun does moderate stamina damage, applies a long dizzying affect, a brief knockdown and makes the target drop items. 

## Why It's Good For The Game
### On changing immunity from full to partial
Cultists are known for being deadly in melee but also they don't want to stick around too long in melee range with a seccie lest they get batoned. This enables a team of cultists or perhaps one very robust cultist to stun a seccie. The values for stamina damage or other effects can also be tweaked further after playtesting if it's necessary. 

It also has the benefit of making random people in hardsuits stunnable once more, instead of making hardsuits even more premiere gamer gear for being flashproof, spaceproof and previously cult-stunproof also. 

### On changing protection from bang protection to mindshield
Currently if you hear about a cult you're incentivised to rush hearing protection whether it be the nearest sec locker, hardsuit, public autolathe earmuffs or whatever else. It's pretty easy to get the entire crew unstunnable as soon as it's cult presence is first noticed. 

Instead by relying on mindshields you can still *eventually* get the whole crew unstunnable but it takes time and effort. Competent cultists can strategically focus on taking out Security and preventing Cargo from ordering mindshields, which allows them to much more easily dominate the rest of the crew like they could before the stun nerf. With so many current options for stun protection currently cultists would end up needing to crit most of the crew, which just encourages murderbone.

Furthermore it incentivises crew actually coming to the Brig to get mindshielded. Before they might not want to do it because it just means they'll be a construct if they get converted, whereas now they'll also get some actual protection from cultists because of it. 

## Changelog
:cl:
balance: Mindshields instead of ear protection now protect from cult stun. If they're mindshielded instead it makes them drop items they are currently holding, applies a dizziness effect, a brief knockdown and does some stamina damage.
/:cl:

Ports: https://github.com/tgstation/tgstation/pull/50522 mostly