### PR TITLE
Classic EMP grenades break lights

### DIFF
--- a/code/game/objects/items/grenades/emgrenade.dm
+++ b/code/game/objects/items/grenades/emgrenade.dm
@@ -6,5 +6,8 @@
 
 /obj/item/grenade/empgrenade/prime()
 	update_mob()
+	for(var/obj/machinery/light/L in range(10, src))
+		L.on = 1
+		L.break_light_tube()
 	empulse(src, 4, 10)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
Traitor EMP grenades now break lights instead of just EMPing the area and turning on emergency lighting only. 

## Why It's Good For The Game
EMP Kit is pretty expensive now (4 TC) and the grenades aren't *that* good. Currently it's simple to use the APC and just revert from emergency lighting back to normal. By additionally breaking lights it makes EMP grenades have a longer lasting utility and the additional darkness pairs well with a well-prepared traitor comboing them with NVGs, thermals or another tactic.

## Changelog
:cl:
add: Classic EMP grenades now break lights also. 
/:cl: