### PR TITLE
Gives atmos techs access to the Pubby Engine Room/engi protolathe

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -44709,7 +44709,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
-	req_access_txt = "10"
+	req_one_access_txt = "10;24"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"


### PR DESCRIPTION
## About The Pull Request
Simple tweak, changes door access on Pubby Engine Room so that atmos techs can use the engineering protolathe which they don't currently have access to on this station.

## Why It's Good For The Game
Atmos Techs can't otherwise access the engi protolathe, and with the TEG soon to replace the SM as well it fits that they would have access to this room. 

## Changelog
:cl:
tweak: Atmos techs now have access to the Pubby Engine Room (and thus the engi protolathe).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
