### PR TITLE
Reverts contractor baton knockdown to cause item drop again

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -480,6 +480,7 @@
 
 			playsound(get_turf(src), on_stun_sound, 75, 1, -1)
 			target.Knockdown(knockdown_time_carbon)
+			target.drop_all_held_items()
 			target.adjustStaminaLoss(stamina_damage)
 			additional_effects_carbon(target, user)
 


### PR DESCRIPTION
## About The Pull Request
A weapon which was affected by https://github.com/BeeStation/BeeStation-Hornet/pull/1365, this changes the baton so that it causes item drop again.

## Why It's Good For The Game
This is the only tool contractors get to capture people with so it should be a robust item. Without causing item drop however your target can just keep sliding on the floor and shoot/baton/whatever you. 

## Changelog
:cl:
tweak: Contractor baton knockdown causes item drop again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
