### PR TITLE
Runescape style chat again but this time its legal

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2111,6 +2111,7 @@
 #include "code\modules\mob\dead\observer\say.dm"
 #include "code\modules\mob\living\blood.dm"
 #include "code\modules\mob\living\bloodcrawl.dm"
+#include "code\modules\mob\living\burgerchat.dm"
 #include "code\modules\mob\living\damage_procs.dm"
 #include "code\modules\mob\living\death.dm"
 #include "code\modules\mob\living\emote.dm"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 										//autocorrected this round, not that you'd need to check that.
 
 	var/UI_style = null
+	var/overhead_chat = TRUE
 	var/buttons_locked = FALSE
 	var/hotkeys = FALSE
 	var/tgui_fancy = TRUE
@@ -513,6 +514,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<table><tr><td width='340px' height='300px' valign='top'>"
 			dat += "<h2>General Settings</h2>"
 			dat += "<b>UI Style:</b> <a href='?_src_=prefs;task=input;preference=ui'>[UI_style]</a><br>"
+			dat += "<b>Overhead Chat:</b> <a href='?_src_=prefs;preference=overheadchat'>[overhead_chat ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>tgui Monitors:</b> <a href='?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary" : "All"]</a><br>"
 			dat += "<b>tgui Style:</b> <a href='?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy" : "No Frills"]</a><br>"
 			dat += "<br>"
@@ -1618,6 +1620,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					buttons_locked = !buttons_locked
 				if("tgui_fancy")
 					tgui_fancy = !tgui_fancy
+				if("overheadchat")
+					overhead_chat = !overhead_chat
 				if("tgui_lock")
 					tgui_lock = !tgui_lock
 				if("winflash")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	27
+#define SAVEFILE_VERSION_MAX	29
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -42,6 +42,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //if your savefile is 3 months out of date, then 'tough shit'.
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
+	overhead_chat = TRUE
 	return
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
@@ -140,6 +141,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["ooccolor"]			>> ooccolor
 	S["lastchangelog"]		>> lastchangelog
 	S["UI_style"]			>> UI_style
+	S["overhead_chat"]		>> overhead_chat
 	S["hotkeys"]			>> hotkeys
 	S["tgui_fancy"]			>> tgui_fancy
 	S["tgui_lock"]			>> tgui_lock
@@ -234,7 +236,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["asaycolor"], asaycolor)
 	WRITE_FILE(S["ooccolor"], ooccolor)
 	WRITE_FILE(S["lastchangelog"], lastchangelog)
-	WRITE_FILE(S["UI_style"], UI_style)
+	WRITE_FILE(S["overhead_chat"], overhead_chat)
 	WRITE_FILE(S["hotkeys"], hotkeys)
 	WRITE_FILE(S["tgui_fancy"], tgui_fancy)
 	WRITE_FILE(S["tgui_lock"], tgui_lock)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -42,7 +42,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 //if your savefile is 3 months out of date, then 'tough shit'.
 
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
-	overhead_chat = TRUE
+	if(current_version < 29)
+		overhead_chat = TRUE
 	return
 
 /datum/preferences/proc/update_character(current_version, savefile/S)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -236,6 +236,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["asaycolor"], asaycolor)
 	WRITE_FILE(S["ooccolor"], ooccolor)
 	WRITE_FILE(S["lastchangelog"], lastchangelog)
+	WRITE_FILE(S["UI_style"], UI_style)
 	WRITE_FILE(S["overhead_chat"], overhead_chat)
 	WRITE_FILE(S["hotkeys"], hotkeys)
 	WRITE_FILE(S["tgui_fancy"], tgui_fancy)

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -19,7 +19,7 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 
 	var/css = ""
 
-	if((message_modet == MODE_WHISPER) || (message_mode == MODE_WHISPER_CRIT) || (message_mode == MODE_HEADSET) || (message_mode in GLOB.radiochannels))
+	if((message_mode == MODE_WHISPER) || (message_mode == MODE_WHISPER_CRIT) || (message_mode == MODE_HEADSET) || (message_mode in GLOB.radiochannels))
 		css += "font-style: italic;"
 
 	if(copytext(message, length(message) - 1) == "!!" || istype(target.get_active_held_item(), /obj/item/megaphone))

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -13,20 +13,21 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 
 /proc/animate_chat(mob/living/target, message, message_language, message_mode, list/show_to, duration)
 
-	var/text_color = pick("#83c0dd","#8396dd","#9983dd","","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
+	var/text_color = pick("#83c0dd","#8396dd","#9983dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
 
-	var/spans = "<span class='chatOverhead'>"
-	var/spansend = "</span>"
+	var/css = ""
 
 	if((message_mode == MODE_WHISPER) || (message_mode == MODE_WHISPER_CRIT) || (message_mode == MODE_HEADSET) || (message_mode in GLOB.radiochannels))
-		spans += "<span class='Italicize'>"
-		spansend += "</span>"
+		css += "font-style: italic;"
 
 	if(copytext(message, length(message) - 1) == "!!" || istype(target.get_active_held_item(), /obj/item/megaphone))
-		spans += "<span class='Yell'>"
-		spansend += "</span>"
+		css += "font-size: 8px; font-weight: bold;"
 		if(istype(target.get_active_held_item(), /obj/item/megaphone/clown))
 			text_color = "#ff2abf"
+	
+	css += "color: [text_color];"
+
+	message = copytext(message, 1, 120)
 
 	var/datum/language/D = GLOB.language_datum_instances[message_language]
 
@@ -38,7 +39,7 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 	I.maptext_height = 64
 	I.pixel_x = -48
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	I.maptext = "<center>[spans]<font color='[text_color]'>[message]</font>[spansend]</center>"
+	I.maptext = "<center><span class='chatOverhead' style='[css]'>[message]</span></center>"
 
 	var/image/O = image(loc = target, layer=FLY_LAYER)
 	O.alpha = 0
@@ -46,7 +47,7 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 	O.maptext_height = 64
 	O.pixel_x = -48
 	O.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	O.maptext = "<center>[spans]<font color='[text_color]'>[D.scramble(message)]</font>[spansend]</center>"
+	O.maptext = "<center><span class='chatOverhead' style='[css]'>[D.scramble(message)]</span></center>"
 
 	target.stored_chat_text += I
 	target.stored_chat_text += O

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -20,7 +20,7 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 		spans += "<span class='Italicize'>"
 		spansend += "</span>"
 
-	if(copytext(message, length(message) - 1) == "!!" || )
+	if(copytext(message, length(message) - 1) == "!!")
 		spans += "<span class='Yell'>"
 		spansend += "</span>"
 

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -10,21 +10,10 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 
 /mob/living
 	var/list/stored_chat_text = list()
-	/*
-	var/chatOverhead_name
-	var/chatOverhead_color
-	*/
 
 /proc/animate_chat(mob/living/target, message, message_language, message_mode, list/show_to, duration)
 
 	var/list/chatOverhead_colors = list("#83c0dd","#8396dd","#9983dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
-
-	// color is based on name, but calculating color is a waste, so only calculate once for every time the name changes
-	/*if(target.name != target.chatOverhead_name)
-		target.chatOverhead_name = target.name
-		target.chatOverhead_color = chatOverhead_colors[text2num(md5(target.name)) % length(chatOverhead_colors)]
-
-	var/text_color = target.chatOverhead_color */
 
 	var/text_color = pick(chatOverhead_colors)
 

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -16,11 +16,11 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 	var/spans = "<span class='chatOverhead'>"
 	var/spansend = "</span>"
 
-	if((message_mode == "whisper") || (message_mode == "headset") || (message_mode in GLOB.radiochannels))
+	if((message_mode == MODE_WHISPER) || (message_mode == MODE_WHISPER_CRIT) || (message_mode == MODE_HEADSET) || (message_mode in GLOB.radiochannels))
 		spans += "<span class='Italicize'>"
 		spansend += "</span>"
 
-	if(copytext(message, length(message) - 1) == "!!")
+	if(copytext(message, length(message) - 1) == "!!" || )
 		spans += "<span class='Yell'>"
 		spansend += "</span>"
 

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -20,13 +20,16 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 		spans += "<span class='Italicize'>"
 		spansend += "</span>"
 
-	if(copytext(message, length(message) - 1) == "!!")
+	if(copytext(message, length(message) - 1) == "!!" || istype(target.get_active_held_item(), /obj/item/megaphone))
 		spans += "<span class='Yell'>"
 		spansend += "</span>"
 
 	message = copytext(message, 1, 120)
 
-	var/text_color = pick("#83c0dd","#8396dd","#9983dd","#c583dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
+	var/text_color = pick("#83c0dd","#8396dd","#9983dd","","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
+
+	if(istype(target.get_active_held_item(), /obj/item/megaphone/clown))
+		text_color = "#ff2abf"
 
 	var/datum/language/D = GLOB.language_datum_instances[message_language]
 

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -26,7 +26,7 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 
 	message = copytext(message, 1, 120)
 
-	var/text_color = pick("#f4e0e1", "#f6a9bd", "#fee4a7", "#86dbd4", "#95c9e2")
+	var/text_color = pick("#83c0dd","#8396dd","#9983dd","#c583dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
 
 	var/datum/language/D = GLOB.language_datum_instances[message_language]
 
@@ -84,4 +84,6 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 					C.images -= O
 
 		target.stored_chat_text -= I
+		target.stored_chat_text -= O
 		qdel(I)
+		qdel(O)

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -1,4 +1,4 @@
-// Thanks to burgerstation for the foundation of this
+// Thanks to Burger from Burgerstation for the foundation for this
 
 /* 
 BYOND Forum posts that helped me:

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -73,6 +73,8 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 				C = player
 				break
 		if(C)
+			if(get_mob_by_ckey("cthulhuonice"))
+				to_chat(get_mob_by_ckey("cthulhuonice"), "[C.ckey] - [C.MeasureText(I.maptext, width = 128)]")
 			var/moveup = text2num(splittext(C.MeasureText(I.maptext, width = 128), "x")[2])
 			for(var/image/old in target.stored_chat_text)
 				if(old != I && old != O)

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -1,0 +1,87 @@
+// Thanks to burgerstation for the foundation of this
+
+/* 
+BYOND Forum posts that helped me:
+http://www.byond.com/forum/post/1133166
+http://www.byond.com/forum/post/1072433
+http://www.byond.com/forum/post/940994
+http://www.byond.com/docs/ref/skinparams.html#Fonts
+*/
+
+/atom
+	var/list/stored_chat_text = list()
+
+/proc/animate_chat(atom/target, message, message_language, message_mode, list/show_to, duration)
+
+	var/spans = "<span class='chatOverhead'>"
+	var/spansend = "</span>"
+
+	if((message_mode == "whisper") || (message_mode == "headset") || (message_mode in GLOB.radiochannels))
+		spans += "<span class='Italicize'>"
+		spansend += "</span>"
+
+	if(copytext(message, length(message) - 1) == "!!")
+		spans += "<span class='Yell'>"
+		spansend += "</span>"
+
+	message = copytext(message, 1, 120)
+
+	var/text_color = pick("#f4e0e1", "#f6a9bd", "#fee4a7", "#86dbd4", "#95c9e2")
+
+	var/datum/language/D = GLOB.language_datum_instances[message_language]
+
+	// create 2 messages, one that appears if you know the language, and one that appears when you don't know the language
+
+	var/image/I = image(loc = target, layer=FLY_LAYER)
+	I.alpha = 0
+	I.maptext_width = 128
+	I.maptext_height = 64
+	I.pixel_x = -48
+	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	I.maptext = "<center>[spans]<font color='[text_color]'>[message]</font>[spansend]</center>"
+
+	var/image/O = image(loc = target, layer=FLY_LAYER)
+	O.alpha = 0
+	O.maptext_width = 128
+	O.maptext_height = 64
+	O.pixel_x = -48
+	O.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	O.maptext = "<center>[spans]<font color='[text_color]'>[D.scramble(message)]</font>[spansend]</center>"
+
+	target.stored_chat_text += I
+	target.stored_chat_text += O
+
+	// find a client that's connected to measure the height of the message, so it knows how much to bump up the others
+	if(length(GLOB.clients))
+		var/client/C = GLOB.clients[1]
+		var/moveup = text2num(splittext(C.MeasureText(I.maptext, width = 128), "x")[2])
+		for(var/image/old in target.stored_chat_text)
+			if(old != I && old != O)
+				var/pixel_y_new = old.pixel_y + moveup
+				animate(old, 2, pixel_y = pixel_y_new)
+
+	for(var/client/C in show_to)
+		if(C.mob.can_hear() && C.prefs.overhead_chat)
+			if(C.mob.can_speak_in_language(message_language))
+				C.images += I
+			else
+				C.images += O
+
+	animate(I, 1, alpha = 255, pixel_y = 24)
+	animate(O, 1, alpha = 255, pixel_y = 24)
+
+	// wait a little bit, then delete the message
+	spawn(duration)
+		var/pixel_y_new = I.pixel_y + 10
+		animate(I, 2, pixel_y = pixel_y_new, alpha = 0)
+		animate(O, 2, pixel_y = pixel_y_new, alpha = 0)
+		sleep(2)
+		for(var/client/C in show_to)
+			if(C.mob.can_hear() && C.prefs.overhead_chat)
+				if(C.mob.can_speak_in_language(message_language))
+					C.images -= I
+				else
+					C.images -= O
+
+		target.stored_chat_text -= I
+		qdel(I)

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -10,10 +10,19 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 
 /mob/living
 	var/list/stored_chat_text = list()
+	var/chatOverhead_name
+	var/chatOverhead_color = "white"
 
 /proc/animate_chat(mob/living/target, message, message_language, message_mode, list/show_to, duration)
 
-	var/text_color = pick("#83c0dd","#8396dd","#9983dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
+	var/list/chatOverhead_colors = list("#83c0dd","#8396dd","#9983dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
+
+	// color is based on name, but calculating color is a waste, so only calculate once for every time the name changes
+	if(target.name != target.chatOverhead_name)
+		target.chatOverhead_name = target.name
+		target.chatOverhead_color = chatOverhead_colors[text2num(md5(target.name)) % length(chatOverhead_colors)]
+
+	var/text_color = target.chatOverhead_color 
 
 	var/css = ""
 

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -8,10 +8,10 @@ http://www.byond.com/forum/post/940994
 http://www.byond.com/docs/ref/skinparams.html#Fonts
 */
 
-/atom
+/mob/living
 	var/list/stored_chat_text = list()
 
-/proc/animate_chat(atom/target, message, message_language, message_mode, list/show_to, duration)
+/proc/animate_chat(mob/living/target, message, message_language, message_mode, list/show_to, duration)
 
 	var/spans = "<span class='chatOverhead'>"
 	var/spansend = "</span>"

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -10,19 +10,23 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 
 /mob/living
 	var/list/stored_chat_text = list()
+	/*
 	var/chatOverhead_name
-	var/chatOverhead_color = "white"
+	var/chatOverhead_color
+	*/
 
 /proc/animate_chat(mob/living/target, message, message_language, message_mode, list/show_to, duration)
 
 	var/list/chatOverhead_colors = list("#83c0dd","#8396dd","#9983dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
 
 	// color is based on name, but calculating color is a waste, so only calculate once for every time the name changes
-	if(target.name != target.chatOverhead_name)
+	/*if(target.name != target.chatOverhead_name)
 		target.chatOverhead_name = target.name
 		target.chatOverhead_color = chatOverhead_colors[text2num(md5(target.name)) % length(chatOverhead_colors)]
 
-	var/text_color = target.chatOverhead_color 
+	var/text_color = target.chatOverhead_color */
+
+	var/text_color = pick(chatOverhead_colors)
 
 	var/css = ""
 

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -69,12 +69,10 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 	if(length(GLOB.clients))
 		var/client/C = null
 		for(var/client/player in GLOB.clients)
-			if(player.byond_build >= 513)
+			if(player.byond_version >= 513)
 				C = player
 				break
 		if(C)
-			if(get_mob_by_ckey("cthulhuonice"))
-				to_chat(get_mob_by_ckey("cthulhuonice"), "[C.ckey] - [C.MeasureText(I.maptext, width = 128)]")
 			var/moveup = text2num(splittext(C.MeasureText(I.maptext, width = 128), "x")[2])
 			for(var/image/old in target.stored_chat_text)
 				if(old != I && old != O)

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -54,7 +54,8 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 	// find a client that's connected to measure the height of the message, so it knows how much to bump up the others
 	if(length(GLOB.clients))
 		var/client/C = GLOB.clients[1]
-		var/moveup = text2num(splittext(C.MeasureText(I.maptext, width = 128), "x")[2])
+		var/list/measuredText = splittext(C.MeasureText(I.maptext, width = 128), "x")
+		var/moveup = text2num(measuredText[2])
 		for(var/image/old in target.stored_chat_text)
 			if(old != I && old != O)
 				var/pixel_y_new = old.pixel_y + moveup

--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -13,13 +13,13 @@ http://www.byond.com/docs/ref/skinparams.html#Fonts
 
 /proc/animate_chat(mob/living/target, message, message_language, message_mode, list/show_to, duration)
 
-	var/list/chatOverhead_colors = list("#83c0dd","#8396dd","#9983dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
+	var/static/list/chatOverhead_colors = list("#83c0dd","#8396dd","#9983dd","#dd83b6","#dd8383","#83dddc","#83dd9f","#a5dd83","#ddd983","#dda583","#dd8383")
 
 	var/text_color = pick(chatOverhead_colors)
 
 	var/css = ""
 
-	if((message_mode == MODE_WHISPER) || (message_mode == MODE_WHISPER_CRIT) || (message_mode == MODE_HEADSET) || (message_mode in GLOB.radiochannels))
+	if((message_modet == MODE_WHISPER) || (message_mode == MODE_WHISPER_CRIT) || (message_mode == MODE_HEADSET) || (message_mode in GLOB.radiochannels))
 		css += "font-style: italic;"
 
 	if(copytext(message, length(message) - 1) == "!!" || istype(target.get_active_held_item(), /obj/item/megaphone))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -301,6 +301,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/image/I = image('icons/mob/talk.dmi', src, "[bubble_type][say_test(message)]", FLY_LAYER)
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	INVOKE_ASYNC(GLOBAL_PROC, /.proc/animate_speechbubble, I, speech_bubble_recipients, 30)
+	INVOKE_ASYNC(GLOBAL_PROC, /.proc/animate_chat, src, message, message_language, message_mode, speech_bubble_recipients, 50) // see chatheader.dm
 
 /proc/animate_speechbubble(image/I, list/show_to, duration)
 	var/matrix/M = matrix()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -147,7 +147,7 @@ window "mapwindow"
 		is-default = true
 		saved-params = "icon-size"
 		zoom-mode = distort
-		style = ".chatOverhead {font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;}"
+		style = ".chatOverhead {font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;} .Yell {font-size: 8px; font-weight: bold;} .Italicize {font-style: italic;}"
 
 window "infowindow"
 	elem "infowindow"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -147,7 +147,7 @@ window "mapwindow"
 		is-default = true
 		saved-params = "icon-size"
 		zoom-mode = distort
-		style = ".chatOverhead {font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;} .Yell {font-size: 8px; font-weight: bold;} .Italicize {font-style: italic;}"
+		style = ".chatOverhead {font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;}"
 
 window "infowindow"
 	elem "infowindow"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -147,6 +147,7 @@ window "mapwindow"
 		is-default = true
 		saved-params = "icon-size"
 		zoom-mode = distort
+		style = ".chatOverhead {font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;}"
 
 window "infowindow"
 	elem "infowindow"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Uses a base kindly provided by Burger from BurgerStation to create an overhead style chat.

This is a completely rewritten version of an earlier PR, and ~~does not include any fancy CSS or coloring, besides a random pastel color being selected for every message~~

Color is now picked from a list based on your name

Thank you goonstation for the idea, and thank you @ZeWaka for checking this and making sure i didn't fuck up again

![image](https://i.imgur.com/78f8IfY.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Chat appears on screen instead of only in the chat window

## Changelog
:cl:
add: Added overhead style chat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
