### PR TITLE
fixes maint lootdrops not having real sunglasses

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -27,7 +27,7 @@
 GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/bodybag = 1,
 	/obj/item/clothing/glasses/meson = 2,
-	/obj/item/clothing/glasses/sunglasses = 1,
+	/obj/item/clothing/glasses/sunglasses/advanced = 1,
 	/obj/item/clothing/gloves/color/fyellow = 1,
 	/obj/item/clothing/head/hardhat = 1,
 	/obj/item/clothing/head/hardhat/red = 1,


### PR DESCRIPTION

## About The Pull Request
victor took out even nonfixed sunglass spawns with a somewhat deceptive pr

## Why It's Good For The Game
flashes still hardstun, making flash protection harder to get is gay
## Changelog
:cl:
add: nonfixed maint sunglasses have flash protection again! rejoice!
/:cl:

