### PR TITLE
Fixes Aspera tea containing no reagents

### DIFF
--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -40,6 +40,7 @@
 /obj/item/reagent_containers/food/snacks/grown/tea/astra
 	seed = /obj/item/seeds/tea/astra
 	name = "Tea Astra tips"
+	desc = "A special blend of tea to sooth the mind."
 	icon_state = "tea_astra_leaves"
 	filling_color = "#4582B4"
 	grind_results = list(/datum/reagent/toxin/teapowder = 0, /datum/reagent/medicine/salglu_solution = 0)

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -14,6 +14,7 @@
 	icon_dead = "tea-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/tea/astra)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/teapowder = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/tea
 	seed = /obj/item/seeds/tea
@@ -21,8 +22,8 @@
 	desc = "These aromatic tips of the tea plant can be dried to make tea."
 	icon_state = "tea_aspera_leaves"
 	filling_color = "#008000"
-	grind_results = list(/datum/reagent/toxin/teapowder = 0)
 	dry_grind = TRUE
+	grind_results = list(/datum/reagent/toxin/teapowder = 0)
 	can_distill = FALSE
 
 // Tea Astra


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Resolves #209 
Aspera tea had no defined reagents in the seed, resulting in nothing when you dried and ground them. This PR gives Aspera tea leaves a reagent list containing 0.04 Vitamins and 0.1 Teapowder.

Also adds a custom description to Astra tea, hinting at its Synaptizine content.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously, the basic tea leaves would grind into nothing. This fixes the intended mechanic, meaning you no longer have to mutate Aspera in Astra tea simply to make a cuppa.

Also makes it easy to distinguish between Aspera and Astra tea, and hints at Astra teas chemical content.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Vitamin and Tea powder reagents to Aspera tea
add: custom description to Astra tea
fix: Aspera tea grinding into nothing 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
