### PR TITLE
You can spraypaint eye coverings to make them flashproof

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -243,5 +243,4 @@
 #define VR_ZONE_TRAIT "vr_zone_trait"
 #define GLUED_ITEM_TRAIT "glued-item"
 #define LEGION_CORE_TRAIT "legion_core_trait"
-#define MIRROR_TRAIT "mirror_trait"
 #define CRAYON_TRAIT "crayon_trait"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -243,4 +243,5 @@
 #define VR_ZONE_TRAIT "vr_zone_trait"
 #define GLUED_ITEM_TRAIT "glued-item"
 #define LEGION_CORE_TRAIT "legion_core_trait"
+#define MIRROR_TRAIT "mirror_trait"
 #define CRAYON_TRAIT "crayon_trait"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -243,8 +243,5 @@
 #define VR_ZONE_TRAIT "vr_zone_trait"
 #define GLUED_ITEM_TRAIT "glued-item"
 #define LEGION_CORE_TRAIT "legion_core_trait"
-<<<<<<< refs/remotes/Upstream/master
 #define MIRROR_TRAIT "mirror_trait"
-=======
 #define CRAYON_TRAIT "crayon_trait"
->>>>>>> adds spraypainting eye-covering items to make them flash protect

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -154,6 +154,7 @@
 
 // item traits
 #define TRAIT_NODROP            "nodrop"
+#define TRAIT_SPRAYPAINTED		"spraypainted"
 #define TRAIT_T_RAY_VISIBLE     "t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1
 #define TRAIT_NO_TELEPORT		"no-teleport" //you just can't
 
@@ -242,4 +243,8 @@
 #define VR_ZONE_TRAIT "vr_zone_trait"
 #define GLUED_ITEM_TRAIT "glued-item"
 #define LEGION_CORE_TRAIT "legion_core_trait"
+<<<<<<< refs/remotes/Upstream/master
 #define MIRROR_TRAIT "mirror_trait"
+=======
+#define CRAYON_TRAIT "crayon_trait"
+>>>>>>> adds spraypainting eye-covering items to make them flash protect

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -805,6 +805,11 @@
 		return
 	if(coloration && atom_colours[colour_priority] != coloration)
 		return //if we don't have the expected color (for a specific priority) to remove, do nothing
+	if(istype(src, /obj/item/clothing) && HAS_TRAIT(src, TRAIT_SPRAYPAINTED))
+		var/obj/item/clothing/C = src
+		C.flash_protect -= 1
+		C.tint -= 2
+		REMOVE_TRAIT(C, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
 	atom_colours[colour_priority] = null
 	update_atom_colour()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -805,11 +805,6 @@
 		return
 	if(coloration && atom_colours[colour_priority] != coloration)
 		return //if we don't have the expected color (for a specific priority) to remove, do nothing
-	if(istype(src, /obj/item/clothing) && HAS_TRAIT(src, TRAIT_SPRAYPAINTED))
-		var/obj/item/clothing/C = src
-		C.flash_protect -= 1
-		C.tint -= 2
-		REMOVE_TRAIT(C, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
 	atom_colours[colour_priority] = null
 	update_atom_colour()
 

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -123,6 +123,13 @@
 		user.visible_message("[user] begins to clean \the [target.name] with [src]...", "<span class='notice'>You begin to clean \the [target.name] with [src]...</span>")
 		if(do_after(user, src.cleanspeed, target = target))
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
+			if(istype(target, /obj/item/clothing) && HAS_TRAIT(target, TRAIT_SPRAYPAINTED))
+				var/obj/item/clothing/C = target
+				var/mob/living/carbon/human/H = user
+				C.flash_protect -= 1
+				C.tint -= 2
+				H.update_tint()
+				REMOVE_TRAIT(target, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
 			for(var/obj/effect/decal/cleanable/C in target)
 				qdel(C)
 			target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -658,8 +658,20 @@
 	if(isobj(target))
 		if(actually_paints)
 			if(color_hex2num(paint_color) < 350 && !istype(target, /obj/structure/window)) //Colors too dark are rejected
-				to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
-				return FALSE
+				if(istype(target, /obj/item/clothing))
+					var/obj/item/clothing/C = target
+					if(((C.flags_cover & HEADCOVERSEYES) || (C.flags_cover & MASKCOVERSEYES) || (C.flags_cover & GLASSESCOVERSEYES)) && !HAS_TRAIT(C, TRAIT_SPRAYPAINTED))
+						C.flash_protect += 1
+						C.tint += 2
+						to_chat(usr, "<span class='warning'>You spray the [C] down, making it harder to see through!</span>")
+						usr.reload_fullscreen()
+						ADD_TRAIT(C, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
+					else
+						to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
+						return FALSE
+				else
+					to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
+					return FALSE
 
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -667,7 +667,7 @@
 						ADD_TRAIT(C, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
 						if(ishuman(usr))
 							var/mob/living/carbon/human/H = usr
-							H.head_update(C, forced = 1)
+							H.update_tint()
 					else
 						to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
 						return FALSE
@@ -676,7 +676,6 @@
 					return FALSE
 
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
-
 			if(istype(target, /obj/structure/window))
 				if(color_hex2num(paint_color) < 255)
 					target.set_opacity(255)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -664,8 +664,10 @@
 						C.flash_protect += 1
 						C.tint += 2
 						to_chat(usr, "<span class='warning'>You spray the [C] down, making it harder to see through!</span>")
-						usr.reload_fullscreen()
 						ADD_TRAIT(C, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)
+						if(ishuman(usr))
+							var/mob/living/carbon/human/H = usr
+							H.head_update(C, forced = 1)
 					else
 						to_chat(usr, "<span class='warning'>A colour that dark on an object like this? Surely not...</span>")
 						return FALSE

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -47,3 +47,11 @@
 		if(do_after(user,30, target = A))
 			user.visible_message("[user] finishes wiping off [A]!", "<span class='notice'>You finish wiping off [A].</span>")
 			SEND_SIGNAL(A, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
+			A.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+			if(istype(A, /obj/item/clothing) && HAS_TRAIT(A, TRAIT_SPRAYPAINTED))
+				var/obj/item/clothing/C = A
+				var/mob/living/carbon/human/H = user
+				C.flash_protect -= 1
+				C.tint -= 2
+				H.update_tint()
+				REMOVE_TRAIT(A, TRAIT_SPRAYPAINTED, CRAYON_TRAIT)


### PR DESCRIPTION

## About The Pull Request

You can use dark spraypaint to make clothing that covers eyes flashproof. This also gives the item heavy tint, obscuring vision like welding helmets do. this tinting can be removed with soap or a damp rag

## Why It's Good For The Game

hardstuns gay

## Changelog
:cl:
add: you can now tint an item that covers the eyes by spraying it with a dark color. This makes it obscure vision and protect against flashes. tint can be cleaned off with soap or a damp rag (damp rags can be made by clicking a sink with a bandage)
/:cl:
