### PR TITLE
No more subsystem initialization messages

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -161,7 +161,9 @@
 	initialized = TRUE
 	var/time = (REALTIMEOFDAY - start_timeofday) / 10
 	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!"
+#ifndef TESTING
 	to_chat(world, "<span class='boldannounce'>[msg]</span>")
+#endif
 	log_world(msg)
 	return time
 

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -161,9 +161,7 @@
 	initialized = TRUE
 	var/time = (REALTIMEOFDAY - start_timeofday) / 10
 	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!"
-#ifndef TESTING
-	to_chat(world, "<span class='boldannounce'>[msg]</span>")
-#endif
+	testing("[msg]")
 	log_world(msg)
 	return time
 


### PR DESCRIPTION
These serve no purpose on the production servers aside from giving an indication that something is happening, which it does a poor job of.
## Changelog
:cl:
del: Removed subsystem initialization messages from roundstart.
/:cl:

