### PR TITLE
[PLEASE READ THIS PR!!!] RNG REMOVAL PART 1: GENERAL COMBAT

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -156,6 +156,11 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define REFLECT_NORMAL 				(1<<0)
 #define REFLECT_FAKEPROJECTILE		(1<<1)
 
+//blocking flags
+#define ACTIVE_BLOCKING				(1<<0) //does the item need to be in hand to block
+#define PROJECTILE_BLOCKING			(1<<1) //does the item block projectiles
+#define NASTY_BLOCKING				(1<<2) //if it parries a bare hand, will the attacker be hurt?
+
 // Object/Item sharpness
 #define IS_BLUNT			0
 #define IS_SHARP			1

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -157,9 +157,9 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define REFLECT_FAKEPROJECTILE		(1<<1)
 
 //blocking flags
-#define ACTIVE_BLOCKING				(1<<0) //does the item need to be in hand to block
-#define PROJECTILE_BLOCKING			(1<<1) //does the item block projectiles
-#define NASTY_BLOCKING				(1<<2) //if it parries a bare hand, will the attacker be hurt?
+#define BLOCKING_ACTIVE				(1<<0) //does the item need to be in hand to block
+#define BLOCKING_PROJECTILE			(1<<1) //does the item block projectiles
+#define BLOCKING_NASTY				(1<<2) //if it parries a bare hand, will the attacker be hurt?
 
 // Object/Item sharpness
 #define IS_BLUNT			0

--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -51,9 +51,7 @@
 		if(5)
 			if(tendrils)
 				tendril(A)
-			M.dna.species.punchdamagelow = 5
-			M.dna.species.punchdamagehigh = 15
-			M.dna.species.punchstunthreshold = 11
+			M.dna.species.punchdamage = 12
 			M.dna.species.brutemod = 0.6
 			M.dna.species.burnmod = 0.6
 			M.dna.species.heatmod = 0.6
@@ -93,9 +91,7 @@
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	to_chat(M, "<span class='danger'>You feel weak and powerless as the necropolis' blessing leaves your body, leaving you slow and vulnerable.</span>")
-	M.dna.species.punchdamagelow = 1
-	M.dna.species.punchdamagehigh = 5
-	M.dna.species.punchstunthreshold = 10
+	M.dna.species.punchdamage = 3
 	M.dna.species.brutemod = 1.5
 	M.dna.species.burnmod = 1.5
 	M.dna.species.heatmod = 1.5

--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -38,7 +38,7 @@
 
 /datum/martial_art/proc/basic_hit(mob/living/carbon/human/A,mob/living/carbon/human/D)
 
-	var/damage = rand(A.dna.species.punchdamagelow, A.dna.species.punchdamagehigh)
+	var/damage = A.dna.species.punchdamage
 
 	var/atk_verb = A.dna.species.attack_verb
 	if(!(D.mobility_flags & MOBILITY_STAND))
@@ -72,12 +72,7 @@
 
 	log_combat(A, D, "punched")
 
-	if((D.stat != DEAD) && damage >= A.dna.species.punchstunthreshold)
-		D.visible_message("<span class='danger'>[A] knocks [D] down!!</span>", \
-								"<span class='userdanger'>[A] knocks you down!</span>")
-		D.apply_effect(40, EFFECT_KNOCKDOWN, armor_block)
-		D.forcesay(GLOB.hit_appends)
-	else if(!(D.mobility_flags & MOBILITY_STAND))
+	if(!(D.mobility_flags & MOBILITY_STAND))
 		D.forcesay(GLOB.hit_appends)
 	return 1
 

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -16,7 +16,7 @@
 
 	var/atk_verb = pick("left hook","right hook","straight punch")
 
-	var/damage = rand(5, 8) + A.dna.species.punchdamagelow
+	var/damage = 6 + A.dna.species.punchdamage
 	if(!damage)
 		playsound(D.loc, A.dna.species.miss_sound, 25, 1, -1)
 		D.visible_message("<span class='warning'>[A]'s [atk_verb] misses [D]!</span>", \

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -170,6 +170,8 @@
 	slot_flags = ITEM_SLOT_BACK
 	force_unwielded = 10
 	force_wielded = 24
+	block_power_wielded = 50
+	block_power_unwielded = 25
 	throwforce = 20
 	throw_speed = 2
 	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
@@ -177,7 +179,9 @@
 	icon_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
-	block_chance = 50
+	block_level = 1
+	block_upgrade_walk = 1
+	block_power = 25
 
 /obj/item/twohanded/bostaff/update_icon_state()
 	icon_state = "bostaff[wielded]"

--- a/code/game/mecha/mecha_parts.dm
+++ b/code/game/mecha/mecha_parts.dm
@@ -8,6 +8,7 @@
 	icon_state = "blank"
 	w_class = WEIGHT_CLASS_GIGANTIC
 	flags_1 = CONDUCT_1
+	block_upgrade_walk = 1
 
 /obj/item/mecha_parts/proc/try_attach_part(mob/user, obj/mecha/M) //For attaching parts to a finished mech
 	if(!user.transferItemToLoc(src, M))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -141,8 +141,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/block_level = 0
 	//does the item block better if walking?
 	var/block_upgrade_walk = 0
-	//this item won't block if not in the active hand
-	var/active_blocking = TRUE
+	//blocking flags
+	var/block_flags = ACTIVE_BLOCKING
 	//does it block projectiles?
 	var/projectile_blocking = FALSE
 	//reduces stamina damage taken whilst blocking. block power of 0 means it takes the full force of the attacking weapon
@@ -150,7 +150,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	//what sound does blocking make
 	var/block_sound = 'sound/weapons/parry.ogg'
 	//if a mob hits this barehanded, are they in trouble?
-	var/nasty_blocks = FALSE
 	var/hit_reaction_chance = 0 //If you want to have something unrelated to blocking/armour piercing etc. Maybe not needed, but trying to think ahead/allow more freedom
 
 	/// In tiles, how far this weapon can reach; 1 for adjacent, which is default
@@ -454,9 +453,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/final_block_level = block_level
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0
-	if(active_blocking && !owner.get_active_held_item() == src)
+	if((block_flags & ACTIVE_BLOCKING) && !owner.get_active_held_item() == src)
 		return 0
-	if(!projectile_blocking && attack_type == PROJECTILE_ATTACK)
+	if((!block_flags & PROJECTILE_BLOCKING) && attack_type == PROJECTILE_ATTACK)
 		return 0
 	if(owner.m_intent == MOVE_INTENT_WALK)
 		final_block_level += block_upgrade_walk
@@ -511,13 +510,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	else if(attack_type == UNARMED_ATTACK && isliving(hitby))
 		var/mob/living/L = hitby
 		attackforce = damage
-		if(nasty_blocks)
+		if(block_flags & NASTY_BLOCKING)
 			L.attackby(src, owner)
 			owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 	else if(isliving(hitby))
 		var/mob/living/L = hitby
 		attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage
-		if(nasty_blocks)
+		if(block_flags & NASTY_BLOCKING)
 			L.attackby(src, owner)
 			owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 	owner.apply_damage(attackforce, STAMINA, blockhand, block_power) 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -500,7 +500,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			blockhand = BODY_ZONE_L_ARM
 	if(isprojectile(hitby))
 		var/obj/item/projectile/P = hitby
-		attackforce = (P.damage / 2)
+		if(P.damtype != STAMINA)// disablers dont do shit to shields
+			attackforce = (P.damage / 2)
 	else if(isitem(hitby))
 		var/obj/item/I = hitby
 		attackforce = damage

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -142,9 +142,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	//does the item block better if walking?
 	var/block_upgrade_walk = 0
 	//blocking flags
-	var/block_flags = ACTIVE_BLOCKING
-	//does it block projectiles?
-	var/projectile_blocking = FALSE
+	var/block_flags = BLOCKING_ACTIVE
 	//reduces stamina damage taken whilst blocking. block power of 0 means it takes the full force of the attacking weapon
 	var/block_power = 0
 	//what sound does blocking make
@@ -469,9 +467,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return 0
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0
-	if((block_flags & ACTIVE_BLOCKING) && !owner.get_active_held_item() == src)
+	if((block_flags & BLOCKING_ACTIVE) && !owner.get_active_held_item() == src)
 		return 0
-	if((!block_flags & PROJECTILE_BLOCKING) && attack_type == PROJECTILE_ATTACK)
+	if((!block_flags & BLOCKING_PROJECTILE) && attack_type == PROJECTILE_ATTACK)
 		return 0
 	if(owner.m_intent == MOVE_INTENT_WALK)
 		final_block_level += block_upgrade_walk
@@ -526,13 +524,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	else if(attack_type == UNARMED_ATTACK && isliving(hitby))
 		var/mob/living/L = hitby
 		attackforce = damage
-		if(block_flags & NASTY_BLOCKING)
+		if(block_flags & BLOCKING_NASTY)
 			L.attackby(src, owner)
 			owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 	else if(isliving(hitby))
 		var/mob/living/L = hitby
 		attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage
-		if(block_flags & NASTY_BLOCKING)
+		if(block_flags & BLOCKING_NASTY)
 			L.attackby(src, owner)
 			owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 	owner.apply_damage(attackforce, STAMINA, blockhand, block_power) 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -453,7 +453,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/relative_dir = (dir2angle(get_dir(hitby, owner)) - dir2angle(owner.dir)) //shamelessly stolen from mech code
 	var/dir = dir2text(owner.dir)
 	var/relad = get_dir(owner, hitby)
-	owner.visible_message("<span class='danger'>[dir]! [relative_dir]! [relad]!</span>")
 	var/final_block_level = block_level
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -451,6 +451,22 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
 	var/relative_dir = (dir2angle(get_dir(hitby, owner)) - dir2angle(owner.dir)) //shamelessly stolen from mech code
 	var/final_block_level = block_level
+	var/obj/item/bodypart/blockhand = null
+	if(owner.stat) //can't block if you're dead
+		return 0
+	if(owner.get_active_held_item() == src) //copypaste of this code for an edgecase-nodrops
+		if(owner.active_hand_index == 1)
+			blockhand = (locate(/obj/item/bodypart/l_arm) in owner.bodyparts)
+		else
+			blockhand = (locate(/obj/item/bodypart/r_arm) in owner.bodyparts)
+	else
+		if(owner.active_hand_index == 1)
+			blockhand = (locate(/obj/item/bodypart/r_arm) in owner.bodyparts)
+		else
+			blockhand = (locate(/obj/item/bodypart/l_arm) in owner.bodyparts)
+	if(blockhand.is_disabled())
+		to_chat(owner, "<span_class='danger'>You're too exausted to block the attack<!/span>")
+		return 0
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0
 	if((block_flags & ACTIVE_BLOCKING) && !owner.get_active_held_item() == src)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -141,8 +141,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/block_level = 0
 	//does the item block better if walking?
 	var/block_upgrade_walk = 0
-	//this item won't block if not in the active hand
-	var/active_blocking = TRUE
+	//blocking flags
+	var/block_flags = ACTIVE_BLOCKING
 	//does it block projectiles?
 	var/projectile_blocking = FALSE
 	//reduces stamina damage taken whilst blocking. block power of 0 means it takes the full force of the attacking weapon
@@ -150,7 +150,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	//what sound does blocking make
 	var/block_sound = 'sound/weapons/parry.ogg'
 	//if a mob hits this barehanded, are they in trouble?
-	var/nasty_blocks = FALSE
 	var/hit_reaction_chance = 0 //If you want to have something unrelated to blocking/armour piercing etc. Maybe not needed, but trying to think ahead/allow more freedom
 
 	/// In tiles, how far this weapon can reach; 1 for adjacent, which is default
@@ -451,14 +450,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
 	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
 	var/relative_dir = (dir2angle(get_dir(hitby, owner)) - dir2angle(owner.dir)) //shamelessly stolen from mech code
-	var/dir = dir2text(owner.dir)
-	var/relad = get_dir(owner, hitby)
 	var/final_block_level = block_level
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0
-	if(active_blocking && !owner.get_active_held_item() == src)
+	if((block_flags & ACTIVE_BLOCKING) && !owner.get_active_held_item() == src)
 		return 0
-	if(!projectile_blocking && attack_type == PROJECTILE_ATTACK)
+	if((!block_flags & PROJECTILE_BLOCKING) && attack_type == PROJECTILE_ATTACK)
 		return 0
 	if(owner.m_intent == MOVE_INTENT_WALK)
 		final_block_level += block_upgrade_walk
@@ -500,7 +497,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			blockhand = BODY_ZONE_L_ARM
 	if(isprojectile(hitby))
 		var/obj/item/projectile/P = hitby
-		attackforce = (P.damage / 2)
+		if(P.damtype != STAMINA)// disablers dont do shit to shields
+			attackforce = (P.damage / 2)
 	else if(isitem(hitby))
 		var/obj/item/I = hitby
 		attackforce = damage
@@ -509,10 +507,16 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(!I.damtype == BRUTE)
 			attackforce = (attackforce / 2)//as above, burning weapons, or weapons that deal other damage type probably dont get force from physical power
 		attackforce = (attackforce * I.attack_weight)
+	else if(attack_type == UNARMED_ATTACK && isliving(hitby))
+		var/mob/living/L = hitby
+		attackforce = damage
+		if(block_flags & NASTY_BLOCKING)
+			L.attackby(src, owner)
+			owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 	else if(isliving(hitby))
 		var/mob/living/L = hitby
 		attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage
-		if(nasty_blocks)
+		if(block_flags & NASTY_BLOCKING)
 			L.attackby(src, owner)
 			owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 	owner.apply_damage(attackforce, STAMINA, blockhand, block_power) 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -508,6 +508,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(!I.damtype == BRUTE)
 			attackforce = (attackforce / 2)//as above, burning weapons, or weapons that deal other damage type probably dont get force from physical power
 		attackforce = (attackforce * I.attack_weight)
+	else if(attack_type == UNARMED_ATTACK && isliving(hitby))
+		var/mob/living/L = hitby
+		attackforce = damage
+		if(nasty_blocks)
+			L.attackby(src, owner)
+			owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 	else if(isliving(hitby))
 		var/mob/living/L = hitby
 		attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -451,8 +451,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
 	SEND_SIGNAL(src, COMSIG_ITEM_HIT_REACT, args)
 	var/relative_dir = (dir2angle(get_dir(hitby, owner)) - dir2angle(owner.dir)) //shamelessly stolen from mech code
-	var/dir = dir2text(owner.dir)
-	var/relad = get_dir(owner, hitby)
 	var/final_block_level = block_level
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -207,6 +207,7 @@
 	force = 9 // Not as good as a stun baton.
 	brightness_on = 5 // A little better than the standard flashlight.
 	hitsound = 'sound/weapons/genhit1.ogg'
+	block_upgrade_walk = 1
 
 // the desk lamps are a bit special
 /obj/item/flashlight/lamp

--- a/code/game/objects/items/devices/instruments.dm
+++ b/code/game/objects/items/devices/instruments.dm
@@ -10,6 +10,7 @@
 	var/datum/song/handheld/song
 	var/instrumentId = "generic"
 	var/instrumentExt = "mid"
+	block_upgrade_walk = 1
 
 /obj/item/instrument/Initialize()
 	. = ..()

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -11,6 +11,7 @@
 	throw_speed = 2
 	throw_range = 7
 	force = 10
+	block_upgrade_walk = 1
 	materials = list(/datum/material/iron = 90)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 	dog_fashion = /datum/dog_fashion/back
@@ -40,6 +41,7 @@
 	max_water = 30
 	sprite_name = "miniFE"
 	dog_fashion = null
+	block_upgrade_walk = 0
 
 /obj/item/extinguisher/proc/refill()
 	create_reagents(max_water, AMOUNT_VISIBLE)

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -9,6 +9,7 @@
 	flags_1 = CONDUCT_1
 	force = 3
 	throwforce = 10
+	block_upgrade_walk = 1
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -14,6 +14,8 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	w_class = WEIGHT_CLASS_GIGANTIC
 	force = 12
+	block_upgrade_walk = 1
+	block_level = 1
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
 	var/awakened = FALSE

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -271,6 +271,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	block_flags = PROJECTILE_BLOCKING
 	block_level = 2
+	block_power = 20
 	var/shield_icon = "shield-red"
 
 /obj/item/nullrod/staff/worn_overlays(isinhands)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -269,7 +269,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 5
 	slot_flags = ITEM_SLOT_BACK
-	block_flags = PROJECTILE_BLOCKING
+	block_flags = BLOCKING_PROJECTILE
 	block_level = 2
 	block_power = 20
 	var/shield_icon = "shield-red"
@@ -294,7 +294,7 @@
 	desc = "A weapon fit for a crusade!"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
-	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING
+	block_flags = BLOCKING_NASTY | BLOCKING_ACTIVE
 	block_level = 1
 	block_power = 30
 	sharpness = IS_SHARP
@@ -336,7 +336,7 @@
 	desc = "Capable of cutting clean through a holy claymore."
 	icon_state = "katana"
 	item_state = "katana"
-	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	block_power = 0
 
@@ -405,7 +405,7 @@
 	armour_penetration = 35
 	block_level = 1
 	block_power = 15
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = IS_SHARP
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
@@ -535,7 +535,7 @@
 	tool_behaviour = TOOL_SAW
 	toolspeed = 2 //slower than a real saw
 	attack_weight = 2
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 
 
 /obj/item/nullrod/chainsaw/Initialize()

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -192,6 +192,7 @@
 	item_state = "nullrod"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	block_upgrade_walk = 1
 	force = 18
 	throw_speed = 3
 	throw_range = 4
@@ -252,6 +253,7 @@
 	hitsound = 'sound/weapons/sear.ogg'
 	damtype = BURN
 	attack_verb = list("punched", "cross countered", "pummeled")
+	block_upgrade_walk = 0
 
 /obj/item/nullrod/godhand/Initialize()
 	. = ..()
@@ -267,7 +269,8 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 5
 	slot_flags = ITEM_SLOT_BACK
-	block_chance = 50
+	active_blocking = FALSE
+	block_level = 2
 	var/shield_icon = "shield-red"
 
 /obj/item/nullrod/staff/worn_overlays(isinhands)
@@ -290,7 +293,8 @@
 	desc = "A weapon fit for a crusade!"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
-	block_chance = 30
+	block_level = 1
+	block_power = 30
 	sharpness = IS_SHARP
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -336,6 +340,8 @@
 	icon_state = "katana"
 	item_state = "katana"
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+	block_power = 0
+	projectile_blocking = TRUE //memes
 
 /obj/item/nullrod/claymore/multiverse
 	name = "extradimensional blade"
@@ -381,6 +387,15 @@
 	throwforce = 1
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	block_level = 1
+
+/obj/item/nullrod/sord/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
+	if(isitem(hitby))
+		var/obj/item/I = hitby
+		owner.attackby(src)
+		owner.attackby(src, owner)
+		owner.visible_message("<span class='danger'>[owner] can't get a grip, and stabs himself with both the [I] and the[src] while trying to parry the [I]!</span>")
+	return ..()
 
 /obj/item/nullrod/scythe
 	icon_state = "scythe1"
@@ -391,6 +406,9 @@
 	desc = "Ask not for whom the bell tolls..."
 	w_class = WEIGHT_CLASS_BULKY
 	armour_penetration = 35
+	block_level = 1
+	block_power = 15
+	nasty_blocks = TRUE
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = IS_SHARP
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
@@ -503,6 +521,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_HUGE
 	attack_verb = list("smashed", "bashed", "hammered", "crunched")
+	attack_weight = 2
 
 /obj/item/nullrod/chainsaw
 	name = "chainsaw hand"
@@ -518,6 +537,8 @@
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 2 //slower than a real saw
+	attack_weight = 2
+	nasty_blocks = TRUE
 
 
 /obj/item/nullrod/chainsaw/Initialize()
@@ -545,6 +566,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb = list("attacked", "smashed", "crushed", "splattered", "cracked")
 	hitsound = 'sound/weapons/blade1.ogg'
+	attack_weight = 2
 
 /obj/item/nullrod/pride_hammer/afterattack(atom/A as mob|obj|turf|area, mob/user, proximity)
 	. = ..()
@@ -628,7 +650,7 @@
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, it is now used to harass the clown."
 	w_class = WEIGHT_CLASS_BULKY
 	force = 15
-	block_chance = 40
+	block_power = 40
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = IS_BLUNT
 	hitsound = "swing_hit"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -269,7 +269,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 5
 	slot_flags = ITEM_SLOT_BACK
-	active_blocking = FALSE
+	block_flags = PROJECTILE_BLOCKING
 	block_level = 2
 	var/shield_icon = "shield-red"
 
@@ -293,16 +293,12 @@
 	desc = "A weapon fit for a crusade!"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING
 	block_level = 1
 	block_power = 30
 	sharpness = IS_SHARP
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-
-/obj/item/nullrod/claymore/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(attack_type == PROJECTILE_ATTACK)
-		final_block_chance = 0 //Don't bring a sword to a gunfight
-	return ..()
 
 /obj/item/nullrod/claymore/darkblade
 	icon_state = "cultblade"
@@ -339,9 +335,9 @@
 	desc = "Capable of cutting clean through a holy claymore."
 	icon_state = "katana"
 	item_state = "katana"
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	block_power = 0
-	projectile_blocking = TRUE //memes
 
 /obj/item/nullrod/claymore/multiverse
 	name = "extradimensional blade"
@@ -408,7 +404,7 @@
 	armour_penetration = 35
 	block_level = 1
 	block_power = 15
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = IS_SHARP
 	attack_verb = list("chopped", "sliced", "cut", "reaped")
@@ -538,7 +534,7 @@
 	tool_behaviour = TOOL_SAW
 	toolspeed = 2 //slower than a real saw
 	attack_weight = 2
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 
 
 /obj/item/nullrod/chainsaw/Initialize()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -67,7 +67,7 @@
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	throw_speed = 3
 	throw_range = 6
 	materials = list(/datum/material/iron=12000)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -66,6 +66,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	throw_speed = 3
 	throw_range = 6
 	materials = list(/datum/material/iron=12000)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -67,7 +67,7 @@
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	throw_speed = 3
 	throw_range = 6
 	materials = list(/datum/material/iron=12000)

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -104,7 +104,7 @@
 	block_upgrade_walk = 1
 	block_power = 35
 	block_sound = 'sound/weapons/genhit.ogg'
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)
 	. = ..()

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -104,7 +104,7 @@
 	block_upgrade_walk = 1
 	block_power = 35
 	block_sound = 'sound/weapons/genhit.ogg'
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)
 	. = ..()

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -100,7 +100,11 @@
 	sharpness = IS_SHARP
 	embedding = list("embed_chance" = 75, "embedded_impact_pain_multiplier" = 10)
 	armour_penetration = 35
-	block_chance = 50
+	block_level = 1
+	block_upgrade_walk = 1
+	block_power = 35
+	block_sound = 'sound/weapons/genhit.ogg'
+	nasty_blocks = TRUE
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)
 	. = ..()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -39,7 +39,7 @@
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 20
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -63,7 +63,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 50
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	throwforce = 10
 	w_class = WEIGHT_CLASS_BULKY
 	armour_penetration = 75
@@ -384,7 +384,7 @@
 	icon_state = "contractor_baton_0"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	item_state = null
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
@@ -535,7 +535,7 @@
 	var/balanced = 1
 	block_level = 1
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force_string = "INFINITE"
 
 /obj/item/melee/supermatter_sword/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -38,6 +38,8 @@
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	force = 20
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -58,14 +60,18 @@
 	flags_1 = CONDUCT_1
 	obj_flags = UNIQUE_RENAME
 	force = 15
+	block_level = 1
+	block_upgrade_walk = 1
+	block_power = 50
+	nasty_blocks = TRUE
 	throwforce = 10
 	w_class = WEIGHT_CLASS_BULKY
-	block_chance = 50
 	armour_penetration = 75
 	sharpness = IS_SHARP
 	attack_verb = list("slashed", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	materials = list(/datum/material/iron = 1000)
+
 
 /obj/item/melee/sabre/Initialize()
 	. = ..()
@@ -137,6 +143,7 @@
 	item_state = "classic_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+	block_upgrade_walk = 1
 	slot_flags = ITEM_SLOT_BELT
 	force = 12 //9 hit crit
 	w_class = WEIGHT_CLASS_NORMAL
@@ -323,7 +330,12 @@
 	force_off = 0
 	weight_class_on = WEIGHT_CLASS_BULKY
 
-/obj/item/melee/classic_baton/police/telescopic/suicide_act(mob/user)
+/obj/item/melee/classic_baton/telescopic/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(on)
+		return ..()
+	return 0
+
+/obj/item/melee/classic_baton/telescopic/suicide_act(mob/user)
 	var/mob/living/carbon/human/H = user
 	var/obj/item/organ/brain/B = H.getorgan(/obj/item/organ/brain)
 
@@ -372,6 +384,7 @@
 	icon_state = "contractor_baton_0"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	nasty_blocks = TRUE
 	item_state = null
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
@@ -520,7 +533,15 @@
 	armour_penetration = 1000
 	var/obj/machinery/power/supermatter_crystal/shard
 	var/balanced = 1
+	block_level = 1
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	force_string = "INFINITE"
+
+/obj/item/melee/supermatter_sword/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	qdel(hitby)
+	owner.visible_message("<span class='danger'>[hitby] evaporates in midair!</span>")
+	return TRUE
 
 /obj/item/melee/supermatter_sword/Initialize()
 	. = ..()
@@ -671,6 +692,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NONE
 	force = 0
+	block_upgrade_walk = 1
 	attack_verb = list("hit", "poked")
 	var/obj/item/reagent_containers/food/snacks/sausage/held_sausage
 	var/static/list/ovens
@@ -783,6 +805,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 0
 	throwforce = 0
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("repelled")
 	var/cooldown = 0

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -39,7 +39,8 @@
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_level = 1
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 20
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -63,7 +64,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 50
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	throwforce = 10
 	w_class = WEIGHT_CLASS_BULKY
 	armour_penetration = 75
@@ -384,7 +385,7 @@
 	icon_state = "contractor_baton_0"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	item_state = null
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
@@ -535,7 +536,7 @@
 	var/balanced = 1
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	force_string = "INFINITE"
 
 /obj/item/melee/supermatter_sword/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)

--- a/code/game/objects/items/melee/transforming.dm
+++ b/code/game/objects/items/melee/transforming.dm
@@ -14,6 +14,12 @@
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/clumsy_check = TRUE
 
+/obj/item/melee/transforming/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	if(active)
+		return ..()
+	return 0
+	
+
 /obj/item/melee/transforming/Initialize()
 	. = ..()
 	if(active)

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -7,6 +7,9 @@
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	force = 8
 	throwforce = 10
+	block_upgrade_walk = 1 
+	block_level = 1
+	block_power = 20
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
@@ -22,7 +25,6 @@
 /obj/item/mop/Initialize()
 	. = ..()
 	create_reagents(mopcap)
-
 
 /obj/item/mop/proc/clean(turf/A)
 	if(reagents.has_reagent(/datum/reagent/water, 1) || reagents.has_reagent(/datum/reagent/water/holywater, 1) || reagents.has_reagent(/datum/reagent/consumable/ethanol/vodka, 1) || reagents.has_reagent(/datum/reagent/space_cleaner, 1))

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -7,6 +7,7 @@
 	desc = "A gas-powered cannon that can fire any object loaded into it."
 	w_class = WEIGHT_CLASS_BULKY
 	force = 8 //Very heavy
+	block_upgrade_walk = 1
 	attack_verb = list("bludgeoned", "smashed", "beaten")
 	icon = 'icons/obj/pneumaticCannon.dmi'
 	icon_state = "pneumaticCannon"

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -8,6 +8,7 @@
 	flags_1 = CONDUCT_1
 	attack_verb = list("whacked", "fisted", "power-punched")
 	force = 20
+	attack_weight = 1
 	throwforce = 10
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
@@ -40,10 +41,13 @@
 		switch(fisto_setting)
 			if(1)
 				fisto_setting = 2
+				attack_weight = 2
 			if(2)
 				fisto_setting = 3
+				attack_weight = 3
 			if(3)
 				fisto_setting = 1
+				attack_weight = 1
 		W.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You tweak \the [src]'s piston valve to [fisto_setting].</span>")
 	else if(W.tool_behaviour == TOOL_SCREWDRIVER)

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -379,10 +379,13 @@
 /obj/item/claymore/weak
 	desc = "This one is rusted."
 	force = 30
+	block_level = 1
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	armour_penetration = 15
 
 /obj/item/claymore/weak/ceremonial
 	desc = "A rusted claymore, once at the heart of a powerful scottish clan struck down and oppressed by tyrants, it has been passed down the ages as a symbol of defiance."
 	force = 15
-	block_chance = 30
+	block_power = 30
 	armour_penetration = 5

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -381,7 +381,7 @@
 	force = 30
 	block_level = 1
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	armour_penetration = 15
 
 /obj/item/claymore/weak/ceremonial

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -381,7 +381,7 @@
 	force = 30
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	armour_penetration = 15
 
 /obj/item/claymore/weak/ceremonial

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -38,7 +38,7 @@
 			T.visible_message("<span class='warning'>[hitby] destroys [src]!</span>")
 			shatter(owner)
 			return FALSE
-		take_damage(attackforce)
+		take_damage(attackforce * ((100-(block_power))/100))
 		return TRUE
 	else
 		return ..()
@@ -211,7 +211,7 @@
 	force = 3
 	throwforce = 3
 	throw_speed = 3
-	max_integrity = 25
+	max_integrity = 50
 	block_sound = 'sound/weapons/genhit.ogg'
 	var/base_icon_state = "eshield" // [base_icon_state]1 for expanded, [base_icon_state]0 for contracted
 	var/on_force = 10
@@ -221,7 +221,7 @@
 	var/clumsy_check = TRUE
 
 /obj/item/shield/energy/shatter(mob/living/carbon/human/owner)
-	playsound(owner, 'sound/effects/turbolift/turbolift-close.ogg', 50)
+	playsound(owner, 'sound/effects/turbolift/turbolift-close.ogg', 50, 0, -1)
 	src.attack_self(owner)
 	to_chat(owner, "<span class='warning'>The [src] overheats!.</span>")
 	

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -1,12 +1,62 @@
 /obj/item/shield
 	name = "shield"
 	icon = 'icons/obj/shields.dmi'
-	block_chance = 50
-	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 70)
+	block_level = 1
+	block_upgrade_walk = 1
+	active_blocking = FALSE
+	block_power = 50
+	projectile_blocking = TRUE
+	max_integrity =  75
 	var/transparent = FALSE	// makes beam projectiles pass through the shield
+	var/durability = TRUE //the shield uses durability instead of stamina
 
-/obj/item/shield/proc/on_shield_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
-	return TRUE
+/obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(transparent && (hitby.pass_flags & PASSGLASS))
+		return FALSE
+	return ..()
+
+/obj/item/shield/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	if(durability)
+		var/attackforce = 0 
+		if(isitem(hitby))
+			var/obj/item/I = hitby
+			attackforce = damage
+			if(I.sharpness)
+				attackforce = (attackforce * 1.5)//sharp weapons will split shields better
+			if(!I.damtype == BRUTE)
+				attackforce = (attackforce / 2)//as above, burning weapons, or weapons that deal other damage type probably dont get force from physical power
+			attackforce = (attackforce * I.attack_weight)
+		else if(isliving(hitby))
+			var/mob/living/L = hitby
+			attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage
+			if(nasty_blocks)
+				L.attackby(src, owner)
+				owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
+		if (obj_integrity <= attackforce)
+			var/turf/T = get_turf(owner)
+			T.visible_message("<span class='warning'>[hitby] destroys [src]!</span>")
+			shatter(owner)
+			return FALSE
+		take_damage(attackforce)
+		return TRUE
+	else
+		return ..()
+
+/obj/item/shield/examine(mob/user)
+	. = ..()
+	var/healthpercent = round((obj_integrity/max_integrity) * 100, 1)
+	switch(healthpercent)
+		if(50 to 99)
+			. += "<span class='info'>It looks slightly damaged.</span>"
+		if(25 to 50)
+			. += "<span class='info'>It appears heavily damaged.</span>"
+		if(0 to 25)
+			. += "<span class='warning'>It's falling apart!</span>"
+
+/obj/item/shield/proc/shatter(mob/living/carbon/human/owner)
+	playsound(owner, 'sound/effects/glassbr3.ogg', 100)
+	new /obj/item/shard((get_turf(src)))		
+	qdel(src)
 
 /obj/item/shield/riot
 	name = "riot shield"
@@ -15,6 +65,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
+	block_level = 2
 	force = 10
 	throwforce = 5
 	throw_speed = 2
@@ -24,16 +75,6 @@
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	transparent = TRUE
-	max_integrity = 75
-
-/obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(transparent && (hitby.pass_flags & PASSGLASS))
-		return FALSE
-	if(attack_type == THROWN_PROJECTILE_ATTACK)
-		final_block_chance += 30
-	if(attack_type == LEAP_ATTACK)
-		final_block_chance = 100
-	return ..()
 
 /obj/item/shield/riot/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/melee/baton))
@@ -52,31 +93,6 @@
 	else
 		return ..()
 
-/obj/item/shield/riot/examine(mob/user)
-	. = ..()
-	var/healthpercent = round((obj_integrity/max_integrity) * 100, 1)
-	switch(healthpercent)
-		if(50 to 99)
-			. += "<span class='info'>It looks slightly damaged.</span>"
-		if(25 to 50)
-			. += "<span class='info'>It appears heavily damaged.</span>"
-		if(0 to 25)
-			. += "<span class='warning'>It's falling apart!</span>"
-
-/obj/item/shield/riot/proc/shatter(mob/living/carbon/human/owner)
-	playsound(owner, 'sound/effects/glassbr3.ogg', 100)
-	new /obj/item/shard((get_turf(src)))
-
-/obj/item/shield/riot/on_shield_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
-	if (obj_integrity <= damage)
-		var/turf/T = get_turf(owner)
-		T.visible_message("<span class='warning'>[hitby] destroys [src]!</span>")
-		shatter(owner)
-		qdel(src)
-		return FALSE
-	take_damage(damage)
-	return ..()
-
 /obj/item/shield/riot/roman
 	name = "\improper Roman shield"
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
@@ -90,24 +106,27 @@
 
 /obj/item/shield/riot/roman/fake
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>. It appears to be a bit flimsy."
-	block_chance = 0
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	block_level = 1
+	block_upgrade_walk = 1
+	block_power = 0
 	max_integrity = 30
 
 /obj/item/shield/riot/roman/shatter(mob/living/carbon/human/owner)
 	playsound(owner, 'sound/effects/grillehit.ogg', 100)
 	new /obj/item/stack/sheet/iron(get_turf(src))
+	qdel(src)
 
 /obj/item/shield/riot/buckler
 	name = "wooden buckler"
 	desc = "A medieval wooden buckler."
 	icon_state = "buckler"
 	item_state = "buckler"
+	block_level = 1
+	block_upgrade_walk = 1
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	materials = list()
 	resistance_flags = FLAMMABLE
-	block_chance = 30
 	transparent = FALSE
 	max_integrity = 55
 	w_class = WEIGHT_CLASS_NORMAL
@@ -115,6 +134,7 @@
 /obj/item/shield/riot/buckler/shatter(mob/living/carbon/human/owner)
 	playsound(owner, 'sound/effects/bang.ogg', 50)
 	new /obj/item/stack/sheet/mineral/wood(get_turf(src))
+	qdel(src)
 
 /obj/item/shield/riot/flash
 	name = "strobe shield"
@@ -181,7 +201,7 @@
 
 /obj/item/shield/energy
 	name = "energy combat shield"
-	desc = "A shield that reflects almost all energy projectiles, but is useless against physical attacks. It can be retracted, expanded, and stored anywhere."
+	desc = "An advanced hard-light shield. It can be retracted, expanded, and stored anywhere, but can't take much punishment before needing a reset"
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
@@ -190,6 +210,8 @@
 	force = 3
 	throwforce = 3
 	throw_speed = 3
+	max_integrity = 25
+	block_sound = 'sound/weapons/genhit.ogg'
 	var/base_icon_state = "eshield" // [base_icon_state]1 for expanded, [base_icon_state]0 for contracted
 	var/on_force = 10
 	var/on_throwforce = 8
@@ -197,15 +219,26 @@
 	var/active = 0
 	var/clumsy_check = TRUE
 
+/obj/item/shield/energy/shatter(mob/living/carbon/human/owner)
+	playsound(owner, 'sound/effects/turbolift/turbolift-close.ogg', 50)
+	src.attack_self(owner)
+	to_chat(owner, "<span class='warning'>The [src] overheats!.</span>")
+	
+
 /obj/item/shield/energy/Initialize()
 	. = ..()
 	icon_state = "[base_icon_state]0"
 
 /obj/item/shield/energy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(active)
+		if(isprojectile(hitby))
+			var/obj/item/projectile/P = hitby
+			if(P.reflectable)
+				P.firer = src
+				P.setAngle(get_dir(owner, hitby))
+				return 1
+		return ..()
 	return 0
-
-/obj/item/shield/energy/IsReflect()
-	return (active)
 
 /obj/item/shield/energy/attack_self(mob/living/carbon/human/user)
 	if(clumsy_check && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -3,9 +3,8 @@
 	icon = 'icons/obj/shields.dmi'
 	block_level = 1
 	block_upgrade_walk = 1
-	active_blocking = FALSE
+	block_flags = PROJECTILE_BLOCKING
 	block_power = 50
-	projectile_blocking = TRUE
 	max_integrity =  75
 	var/transparent = FALSE	// makes beam projectiles pass through the shield
 	var/durability = TRUE //the shield uses durability instead of stamina
@@ -31,7 +30,7 @@
 		else if(isliving(hitby))
 			var/mob/living/L = hitby
 			attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage
-			if(nasty_blocks)
+			if(block_flags & NASTY_BLOCKING)
 				L.attackby(src, owner)
 				owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 		if (obj_integrity <= attackforce)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -21,10 +21,8 @@
 		if(isitem(hitby))
 			var/obj/item/I = hitby
 			attackforce = damage
-			if(I.sharpness)
-				attackforce = (attackforce * 1.5)//sharp weapons will split shields better
 			if(!I.damtype == BRUTE)
-				attackforce = (attackforce / 2)//as above, burning weapons, or weapons that deal other damage type probably dont get force from physical power
+				attackforce = (attackforce / 2)
 			attackforce = (attackforce * I.attack_weight)
 		else if(isliving(hitby))
 			var/mob/living/L = hitby

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -18,6 +18,10 @@
 /obj/item/shield/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
 	if(durability)
 		var/attackforce = 0 
+		if(isprojectile(hitby))
+			var/obj/item/projectile/P = hitby
+			if(P.damtype != STAMINA)// disablers dont do shit to shields
+				attackforce = P.damage
 		if(isitem(hitby))
 			var/obj/item/I = hitby
 			attackforce = damage

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/shields.dmi'
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = PROJECTILE_BLOCKING
+	block_flags = BLOCKING_PROJECTILE
 	block_power = 50
 	max_integrity =  75
 	var/transparent = FALSE	// makes beam projectiles pass through the shield
@@ -30,7 +30,7 @@
 		else if(isliving(hitby))
 			var/mob/living/L = hitby
 			attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage
-			if(block_flags & NASTY_BLOCKING)
+			if(block_flags & BLOCKING_NASTY)
 				L.attackby(src, owner)
 				owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
 		if (obj_integrity <= attackforce)

--- a/code/game/objects/items/signs.dm
+++ b/code/game/objects/items/signs.dm
@@ -6,6 +6,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed","smacked")
 	resistance_flags = FLAMMABLE
+	
 
 	var/label = ""
 	var/last_wave = 0

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -7,6 +7,8 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
 	force = 5
+	attack_weight = 3
+	block_upgrade_walk = 1
 	force_unwielded = 5
 	force_wielded = 20
 	throwforce = 15
@@ -83,6 +85,8 @@
 	force_wielded = 25
 	throwforce = 30
 	throw_range = 7
+	block_upgrade_walk = 1
+	attack_weight = 3
 	w_class = WEIGHT_CLASS_HUGE
 
 /obj/item/twohanded/mjollnir/proc/shock(mob/living/target)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	attack_verb = list("hit", "bludgeoned", "whacked")
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 	novariants = TRUE
+	block_upgrade_walk = 1
 
 /obj/item/stack/rods/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins to stuff \the [src] down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")//it looks like theyre ur mum

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 	force_string = "holy"
+	block_upgrade_walk = 1
 
 /obj/item/storage/book/bible/Initialize()
 	. = ..()

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -129,6 +129,7 @@
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
+	block_upgrade_walk = 1
 
 /obj/item/storage/secure/briefcase/PopulateContents()
 	new /obj/item/paper(src)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -14,6 +14,7 @@
 	materials = list(/datum/material/iron = 500)
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
+	block_upgrade_walk = 1
 	custom_materials = list(/datum/material/iron = 500) //Toolboxes by default use iron as their core, custom material.
 	var/latches = "single_latch"
 	var/has_latches = TRUE

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -9,7 +9,7 @@
 	force = 5
 	throwforce = 7
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("enforced the law upon")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -9,7 +9,7 @@
 	force = 5
 	throwforce = 7
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("enforced the law upon")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -8,6 +8,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	throwforce = 7
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("enforced the law upon")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -10,6 +10,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	throwforce = 7
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_SMALL
 	materials = list(/datum/material/iron=50)
 

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -9,6 +9,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	throwforce = 7
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/ratchet.ogg'
 	materials = list(/datum/material/iron=150)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -395,7 +395,8 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	block_upgrade_walk = 1
-	projectile_blocking = TRUE
+	block_level = 1
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
 
 /*
  * Snap pops

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -243,6 +243,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("attacked", "struck", "hit")
 	var/hacked = FALSE
+	block_upgrade_walk = 1
+	block_power = -200
 
 /obj/item/toy/sword/attack_self(mob/user)
 	active = !( active )
@@ -306,6 +308,8 @@
 	attack_verb = list("pricked", "absorbed", "gored")
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
+	block_upgrade_walk = 1
+	block_power = -200
 
 
 /obj/item/toy/windupToolbox
@@ -366,6 +370,8 @@
 	force_unwielded = 0
 	force_wielded = 0
 	attack_verb = list("attacked", "struck", "hit")
+	block_upgrade_walk = 1
+	block_power = -100
 
 /obj/item/twohanded/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0
@@ -388,6 +394,8 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	block_upgrade_walk = 1
+	projectile_blocking = TRUE
 
 /*
  * Snap pops

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -396,7 +396,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	block_upgrade_walk = 1
 	block_level = 1
-	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 
 /*
  * Snap pops

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -297,12 +297,11 @@
 	item_color = "green"
 	light_color = "#00ff00"//green
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	projectile_blocking = TRUE
 	block_level = 2
 	block_upgrade_walk = 1
 	block_power = 70
 	block_sound = 'sound/weapons/genhit.ogg'
-	nasty_blocks = TRUE
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
@@ -590,7 +589,7 @@
 	force = 13
 	block_power = 20
 	block_upgrade_walk = 2
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	attack_weight = 2
 	var/force_on = 24
 	w_class = WEIGHT_CLASS_HUGE
@@ -838,8 +837,7 @@
 	block_power_wielded = 40
 	block_level = 1
 	block_upgrade_walk = 2
-	projectile_blocking = TRUE
-	nasty_blocks = TRUE
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
 	block_sound = 'sound/weapons/genhit.ogg'
 	throwforce = 20
 	throw_speed = 4

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -26,6 +26,8 @@
 	var/wielded = 0
 	var/force_unwielded = 0
 	var/force_wielded = 0
+	var/block_power_wielded = 0
+	var/block_power_unwielded = 0
 	var/wieldsound = null
 	var/unwieldsound = null
 
@@ -33,8 +35,13 @@
 	if(!wielded || !user)
 		return
 	wielded = 0
+
 	if(!isnull(force_unwielded))
 		force = force_unwielded
+
+	if(!isnull(block_power_unwielded))
+		block_power = block_power_unwielded
+
 	var/sf = findtext(name," (Wielded)")
 	if(sf)
 		name = copytext(name,1,sf)
@@ -72,6 +79,8 @@
 	wielded = 1
 	if(force_wielded)
 		force = force_wielded
+	if(block_power_wielded)
+		block_power = block_power_wielded
 	name = "[name] (Wielded)"
 	update_icon()
 	if(iscyborg(user))
@@ -221,6 +230,10 @@
 	righthand_file = 'icons/mob/inhands/weapons/axes_righthand.dmi'
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
+	attack_weight = 2
+	block_power_wielded = 25
+	block_level = 1
+	block_upgrade_walk = 1
 	force = 5
 	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY
@@ -284,7 +297,12 @@
 	item_color = "green"
 	light_color = "#00ff00"//green
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 75
+	projectile_blocking = TRUE
+	block_level = 2
+	block_upgrade_walk = 1
+	block_power = 70
+	block_sound = 'sound/weapons/genhit.ogg'
+	nasty_blocks = TRUE
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
@@ -463,6 +481,8 @@
 	slot_flags = ITEM_SLOT_BACK
 	force_unwielded = 10
 	force_wielded = 18
+	block_power_wielded = 25
+	block_upgrade_walk = 1
 	throwforce = 20
 	throw_speed = 4
 	embedding = list("embedded_impact_pain_multiplier" = 3)
@@ -568,6 +588,10 @@
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	flags_1 = CONDUCT_1
 	force = 13
+	block_power = 20
+	block_upgrade_walk = 2
+	nasty_blocks = TRUE
+	attack_weight = 2
 	var/force_on = 24
 	w_class = WEIGHT_CLASS_HUGE
 	throwforce = 13
@@ -618,10 +642,6 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
-/obj/item/twohanded/required/chainsaw/get_dismemberment_chance()
-	if(wielded)
-		. = ..()
-
 /obj/item/twohanded/required/chainsaw/doomslayer
 	name = "THE GREAT COMMUNICATOR"
 	desc = "<span class='warning'>VRRRRRRR!!!</span>"
@@ -647,7 +667,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	attack_verb = list("sawed", "shred", "rended", "gutted", "eviscerated")
 	actions_types = list(/datum/action/item_action/startchainsaw)
-	block_chance = 50
+	block_power = 50
 	armour_penetration = 50
 	light_color = "#ff0000"
 	var/onsound
@@ -684,7 +704,9 @@
 	desc = "The chainsaw you want when you need to kill every damn thing in the room."
 	force_on = 60
 	w_class = WEIGHT_CLASS_NORMAL
-	block_chance = 75
+	block_power = 75
+	block_level = 1
+	attack_weight = 3 //fear him
 	armour_penetration = 75
 	var/knockdown = 1
 	brightness_on = 6
@@ -701,6 +723,7 @@
 	desc = "Recovered from the aftermath of a revolt aboard Defense Outpost Theta Aegis, in which a seemingly endless tide of Assistants caused heavy casualities among Nanotrasen military forces."
 	force_unwielded = 15
 	force_wielded = 25
+	block_level = 1
 	throwforce = 20
 	throw_speed = 4
 	attack_verb = list("gored")
@@ -728,6 +751,9 @@
 	desc = "A simple tool used for moving hay."
 	force = 7
 	throwforce = 15
+	block_power_wielded = 25
+	block_level = 1
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 	force_unwielded = 7
 	force_wielded = 15
@@ -809,7 +835,12 @@
 	force_unwielded = 20
 	force_wielded = 40
 	armour_penetration = 100
-	block_chance = 40
+	block_power_wielded = 40
+	block_level = 1
+	block_upgrade_walk = 2
+	projectile_blocking = TRUE
+	nasty_blocks = TRUE
+	block_sound = 'sound/weapons/genhit.ogg'
 	throwforce = 20
 	throw_speed = 4
 	sharpness = IS_SHARP
@@ -821,20 +852,6 @@
 /obj/item/twohanded/vibro_weapon/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 20, 105)
-
-/obj/item/twohanded/vibro_weapon/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(wielded)
-		final_block_chance *= 2
-	if(wielded || attack_type != PROJECTILE_ATTACK)
-		if(prob(final_block_chance))
-			if(attack_type == PROJECTILE_ATTACK)
-				owner.visible_message("<span class='danger'>[owner] deflects [attack_text] with [src]!</span>")
-				playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 75, 1)
-				return 1
-			else
-				owner.visible_message("<span class='danger'>[owner] parries [attack_text] with [src]!</span>")
-				return 1
-	return 0
 
 /obj/item/twohanded/vibro_weapon/update_icon()
 	icon_state = "hfrequency[wielded]"
@@ -863,6 +880,8 @@
 	force = 11
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
+	block_power_wielded = 25
+	block_upgrade_walk = 1
 	force_unwielded = 11
 	force_wielded = 20					//I have no idea how to balance
 	throwforce = 22
@@ -943,6 +962,8 @@
 	force = 10
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
+	block_power_wielded = 25
+	block_upgrade_walk = 1
 	force_unwielded = 10
 	force_wielded = 18
 	throwforce = 22

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -301,7 +301,7 @@
 	block_upgrade_walk = 1
 	block_power = 70
 	block_sound = 'sound/weapons/genhit.ogg'
-	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF
@@ -589,7 +589,7 @@
 	force = 13
 	block_power = 20
 	block_upgrade_walk = 2
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	attack_weight = 2
 	var/force_on = 24
 	w_class = WEIGHT_CLASS_HUGE
@@ -837,7 +837,7 @@
 	block_power_wielded = 40
 	block_level = 1
 	block_upgrade_walk = 2
-	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	block_sound = 'sound/weapons/genhit.ogg'
 	throwforce = 20
 	throw_speed = 4

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -78,7 +78,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_power = 40
 	block_upgrade_walk = 1
 	block_level = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -233,8 +233,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_power = 50
 	block_level = 1
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
-	projectile_blocking = TRUE //just like one of my japanese animes
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -482,7 +481,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	block_upgrade_walk = 1 //doesnt get as much blocking as a chainsaw cuz there is no limb to disable
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 24
 	attack_weight = TRUE
 	throwforce = 0
@@ -518,7 +517,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "An energy chainsaw that has replaced your arm."
 	force = 40
 	armour_penetration = 50
-	block_chance = 50
 	hitsound = 'sound/weapons/echainsawhit1.ogg'
 
 /obj/item/mounted_chainsaw/energy/Destroy()
@@ -538,7 +536,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A super energy chainsaw that has replaced your arm."
 	force = 60
 	armour_penetration = 75
-	block_chance = 75
 	hitsound = 'sound/weapons/echainsawhit1.ogg'
 
 /obj/item/mounted_chainsaw/super/Destroy()
@@ -698,7 +695,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "This bat is made of highly reflective, highly armored material."
 	icon_state = "baseball_bat_metal"
 	item_state = "baseball_bat_metal"
-	projectile_blocking = TRUE
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
 	block_level = 1
 	force = 12
 	throwforce = 15

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -78,7 +78,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_power = 40
 	block_upgrade_walk = 1
 	block_level = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -233,8 +233,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_power = 50
 	block_level = 1
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
-	projectile_blocking = TRUE //just like one of my japanese animes
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -482,7 +481,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	block_upgrade_walk = 1 //doesnt get as much blocking as a chainsaw cuz there is no limb to disable
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 24
 	attack_weight = TRUE
 	throwforce = 0
@@ -696,7 +695,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "This bat is made of highly reflective, highly armored material."
 	icon_state = "baseball_bat_metal"
 	item_state = "baseball_bat_metal"
-	projectile_blocking = TRUE
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
 	block_level = 1
 	force = 12
 	throwforce = 15

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -518,7 +518,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "An energy chainsaw that has replaced your arm."
 	force = 40
 	armour_penetration = 50
-	block_chance = 50
 	hitsound = 'sound/weapons/echainsawhit1.ogg'
 
 /obj/item/mounted_chainsaw/energy/Destroy()
@@ -538,7 +537,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A super energy chainsaw that has replaced your arm."
 	force = 60
 	armour_penetration = 75
-	block_chance = 75
 	hitsound = 'sound/weapons/echainsawhit1.ogg'
 
 /obj/item/mounted_chainsaw/super/Destroy()

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -41,6 +41,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	slot_flags = ITEM_SLOT_BELT
 	force = 2
 	throwforce = 1
+	block_level = 1
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
@@ -49,6 +51,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	user.visible_message("<span class='suicide'>[user] is trying to impale [user.p_them()]self with [src]! It might be a suicide attempt if it weren't so shitty.</span>", \
 	"<span class='suicide'>You try to impale yourself with [src], but it's USELESS...</span>")
 	return SHAME
+
+/obj/item/sord/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
+	if(isitem(hitby))
+		var/obj/item/I = hitby
+		owner.attackby(src)
+		owner.attackby(src, owner)
+		owner.visible_message("<span class='danger'>[owner] can't get a grip, and stabs himself with both the [I] and the[src] while trying to parry the [I]!</span>")
+	return ..()
 
 /obj/item/claymore
 	name = "claymore"
@@ -63,8 +73,12 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 40
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
+	attack_weight = 1
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 50
+	block_power = 40
+	block_upgrade_walk = 1
+	block_level = 1
+	nasty_blocks = TRUE
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -83,7 +97,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	flags_1 = CONDUCT_1
 	item_flags = DROPDEL
 	slot_flags = null
-	block_chance = 0 //RNG WON'T HELP YOU NOW, PANSY
 	light_range = 3
 	attack_verb = list("brutalized", "eviscerated", "disemboweled", "hacked", "carved", "cleaved") //ONLY THE MOST VISCERAL ATTACK VERBS
 	var/notches = 0 //HOW MANY PEOPLE HAVE BEEN SLAIN WITH THIS BLADE
@@ -217,7 +230,11 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	w_class = WEIGHT_CLASS_HUGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 50
+	block_power = 50
+	block_level = 1
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
+	projectile_blocking = TRUE //just like one of my japanese animes
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -238,6 +255,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	flags_1 = CONDUCT_1
 	force = 9
 	throwforce = 10
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(/datum/material/iron=1150, /datum/material/glass=75)
 	attack_verb = list("hit", "bludgeoned", "whacked", "bonked")
@@ -393,6 +411,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "stick"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	block_upgrade_walk = 1
 	force = 5
 	throwforce = 5
 	w_class = WEIGHT_CLASS_SMALL
@@ -406,6 +425,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "staff"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
+	block_upgrade_walk = 1
 	force = 3
 	throwforce = 5
 	throw_speed = 2
@@ -430,6 +450,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "stick"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	block_upgrade_walk = 1
 	force = 3
 	throwforce = 5
 	throw_speed = 2
@@ -460,7 +481,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
+	block_upgrade_walk = 1 //doesnt get as much blocking as a chainsaw cuz there is no limb to disable
+	nasty_blocks = TRUE
 	force = 24
+	attack_weight = TRUE
 	throwforce = 0
 	throw_range = 0
 	throw_speed = 0
@@ -539,6 +563,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon = 'icons/obj/statue.dmi'
 	icon_state = "bust"
 	force = 15
+	attack_weight = 2
 	throwforce = 10
 	throw_speed = 5
 	throw_range = 2
@@ -553,6 +578,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	name = "tail club"
 	desc = "For the beating to death of lizards with their own tails."
 	icon_state = "tailclub"
+	attack_weight = 2
+	block_upgrade_walk = 1
 	force = 14
 	throwforce = 1 // why are you throwing a club do you even weapon
 	throw_speed = 1
@@ -575,6 +602,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A skateboard. It can be placed on its wheels and ridden, or used as a strong weapon."
 	icon_state = "skateboard"
 	item_state = "skateboard"
+	block_level = 1
+	block_upgrade_walk = 1 //yes, you can use this to fend off attackers
 	force = 12
 	throwforce = 4
 	w_class = WEIGHT_CLASS_NORMAL
@@ -618,6 +647,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "baseball_bat"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
+	block_upgrade_walk = 1
+	attack_weight = 2
 	force = 13
 	throwforce = 6
 	attack_verb = list("beat", "smacked")
@@ -667,6 +698,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "This bat is made of highly reflective, highly armored material."
 	icon_state = "baseball_bat_metal"
 	item_state = "baseball_bat_metal"
+	projectile_blocking = TRUE
+	block_level = 1
 	force = 12
 	throwforce = 15
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -480,7 +480,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
-	block_upgrade_walk = 1 //doesnt get as much blocking as a chainsaw cuz there is no limb to disable
+	block_upgrade_walk = 2
+	block_power = 20
 	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 24
 	attack_weight = TRUE

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -78,7 +78,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_power = 40
 	block_upgrade_walk = 1
 	block_level = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -233,7 +233,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_power = 50
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	sharpness = IS_SHARP
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
@@ -482,7 +482,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	w_class = WEIGHT_CLASS_HUGE
 	block_upgrade_walk = 2
 	block_power = 20
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 24
 	attack_weight = TRUE
 	throwforce = 0
@@ -696,7 +696,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "This bat is made of highly reflective, highly armored material."
 	icon_state = "baseball_bat_metal"
 	item_state = "baseball_bat_metal"
-	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	block_level = 1
 	force = 12
 	throwforce = 15

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -258,9 +258,11 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 8
 	throwforce = 10
+	block_level = 1
+	block_upgrade_walk = 1
+	block_power = 20
 	throw_range = 3
 	hitsound = 'sound/items/trayhit1.ogg'
-	hit_reaction_chance = 50
 	materials = list(/datum/material/iron = 2000)
 	var/break_chance = 5 //Likely hood of smashing the chair.
 	var/obj/structure/chair/origin_type = /obj/structure/chair
@@ -305,15 +307,6 @@
 	else if(materials[/datum/material/iron])
 		new /obj/item/stack/rods(get_turf(loc), 2)
 	qdel(src)
-
-
-
-
-/obj/item/chair/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(attack_type == UNARMED_ATTACK && prob(hit_reaction_chance))
-		owner.visible_message("<span class='danger'>[owner] fends off [attack_text] with [src]!</span>")
-		return 1
-	return 0
 
 /obj/item/chair/afterattack(atom/target, mob/living/carbon/user, proximity)
 	. = ..()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -309,6 +309,7 @@
 	layer = ABOVE_MOB_LAYER
 	w_class = WEIGHT_CLASS_HUGE
 	force = 10
+	attack_weight = 2
 	force_wielded = 10
 	throwforce = 13
 	throw_speed = 2

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -160,7 +160,7 @@
 	throw_range = 0
 	throw_speed = 0
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -396,63 +396,6 @@
 	source = null
 	return ..()
 
-<<<<<<< refs/remotes/origin/master
-=======
-
-/***************************************\
-|****************SHIELD*****************|
-\***************************************/
-/datum/action/changeling/weapon/shield
-	name = "Organic Shield"
-	desc = "We reform one of our arms into a hard shield. Costs 20 chemicals."
-	helptext = "Organic tissue cannot resist damage forever; the shield will break after it is hit too much. The more genomes we absorb, the stronger it is. Cannot be used while in lesser form."
-	button_icon_state = "organic_shield"
-	chemical_cost = 20
-	dna_cost = 1
-	req_human = 1
-
-	weapon_type = /obj/item/shield/changeling
-	weapon_name_simple = "shield"
-
-/datum/action/changeling/weapon/shield/sting_action(mob/user)
-	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling) //So we can read the absorbedcount.
-	if(!changeling)
-		return
-
-	var/obj/item/shield/changeling/S = ..(user)
-	S.remaining_uses = round(changeling.absorbedcount * 3)
-	return TRUE
-
-/obj/item/shield/changeling
-	name = "shield-like mass"
-	desc = "A mass of tough, boney tissue. You can still see the fingers as a twisted pattern in the shield."
-	item_flags = ABSTRACT | DROPDEL
-	icon = 'icons/obj/changeling_items.dmi'
-	icon_state = "ling_shield"
-	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
-
-	var/remaining_uses //Set by the changeling ability.
-
-/obj/item/shield/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
-	if(ismob(loc))
-		loc.visible_message("<span class='warning'>The end of [loc.name]\'s hand inflates rapidly, forming a huge shield-like mass!</span>", "<span class='warning'>We inflate our hand into a strong shield.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
-
-/obj/item/shield/changeling/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(remaining_uses < 1)
-		if(ishuman(loc))
-			var/mob/living/carbon/human/H = loc
-			H.visible_message("<span class='warning'>With a sickening crunch, [H] reforms [H.p_their()] shield into an arm!</span>", "<span class='notice'>We assimilate our shield into our body</span>", "<span class='italics>You hear organic matter ripping and tearing!</span>")
-		qdel(src)
-		return 0
-	else
-		remaining_uses--
-		return ..()
-
-
->>>>>>> 
 /***************************************\
 |*********SPACE SUIT + HELMET***********|
 \***************************************/

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -160,7 +160,7 @@
 	throw_range = 0
 	throw_speed = 0
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP
@@ -396,63 +396,6 @@
 	source = null
 	return ..()
 
-<<<<<<< refs/remotes/origin/master
-=======
-
-/***************************************\
-|****************SHIELD*****************|
-\***************************************/
-/datum/action/changeling/weapon/shield
-	name = "Organic Shield"
-	desc = "We reform one of our arms into a hard shield. Costs 20 chemicals."
-	helptext = "Organic tissue cannot resist damage forever; the shield will break after it is hit too much. The more genomes we absorb, the stronger it is. Cannot be used while in lesser form."
-	button_icon_state = "organic_shield"
-	chemical_cost = 20
-	dna_cost = 1
-	req_human = 1
-
-	weapon_type = /obj/item/shield/changeling
-	weapon_name_simple = "shield"
-
-/datum/action/changeling/weapon/shield/sting_action(mob/user)
-	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling) //So we can read the absorbedcount.
-	if(!changeling)
-		return
-
-	var/obj/item/shield/changeling/S = ..(user)
-	S.remaining_uses = round(changeling.absorbedcount * 3)
-	return TRUE
-
-/obj/item/shield/changeling
-	name = "shield-like mass"
-	desc = "A mass of tough, boney tissue. You can still see the fingers as a twisted pattern in the shield."
-	item_flags = ABSTRACT | DROPDEL
-	icon = 'icons/obj/changeling_items.dmi'
-	icon_state = "ling_shield"
-	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
-
-	var/remaining_uses //Set by the changeling ability.
-
-/obj/item/shield/changeling/Initialize()
-	. = ..()
-	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
-	if(ismob(loc))
-		loc.visible_message("<span class='warning'>The end of [loc.name]\'s hand inflates rapidly, forming a huge shield-like mass!</span>", "<span class='warning'>We inflate our hand into a strong shield.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
-
-/obj/item/shield/changeling/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(remaining_uses < 1)
-		if(ishuman(loc))
-			var/mob/living/carbon/human/H = loc
-			H.visible_message("<span class='warning'>With a sickening crunch, [H] reforms [H.p_their()] shield into an arm!</span>", "<span class='notice'>We assimilate our shield into our body</span>", "<span class='italics>You hear organic matter ripping and tearing!</span>")
-		qdel(src)
-		return 0
-	else
-		remaining_uses--
-		return ..()
-
-
->>>>>>> 
 /***************************************\
 |*********SPACE SUIT + HELMET***********|
 \***************************************/

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -159,6 +159,8 @@
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP
@@ -394,6 +396,63 @@
 	source = null
 	return ..()
 
+<<<<<<< refs/remotes/origin/master
+=======
+
+/***************************************\
+|****************SHIELD*****************|
+\***************************************/
+/datum/action/changeling/weapon/shield
+	name = "Organic Shield"
+	desc = "We reform one of our arms into a hard shield. Costs 20 chemicals."
+	helptext = "Organic tissue cannot resist damage forever; the shield will break after it is hit too much. The more genomes we absorb, the stronger it is. Cannot be used while in lesser form."
+	button_icon_state = "organic_shield"
+	chemical_cost = 20
+	dna_cost = 1
+	req_human = 1
+
+	weapon_type = /obj/item/shield/changeling
+	weapon_name_simple = "shield"
+
+/datum/action/changeling/weapon/shield/sting_action(mob/user)
+	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling) //So we can read the absorbedcount.
+	if(!changeling)
+		return
+
+	var/obj/item/shield/changeling/S = ..(user)
+	S.remaining_uses = round(changeling.absorbedcount * 3)
+	return TRUE
+
+/obj/item/shield/changeling
+	name = "shield-like mass"
+	desc = "A mass of tough, boney tissue. You can still see the fingers as a twisted pattern in the shield."
+	item_flags = ABSTRACT | DROPDEL
+	icon = 'icons/obj/changeling_items.dmi'
+	icon_state = "ling_shield"
+	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
+
+	var/remaining_uses //Set by the changeling ability.
+
+/obj/item/shield/changeling/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
+	if(ismob(loc))
+		loc.visible_message("<span class='warning'>The end of [loc.name]\'s hand inflates rapidly, forming a huge shield-like mass!</span>", "<span class='warning'>We inflate our hand into a strong shield.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
+
+/obj/item/shield/changeling/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(remaining_uses < 1)
+		if(ishuman(loc))
+			var/mob/living/carbon/human/H = loc
+			H.visible_message("<span class='warning'>With a sickening crunch, [H] reforms [H.p_their()] shield into an arm!</span>", "<span class='notice'>We assimilate our shield into our body</span>", "<span class='italics>You hear organic matter ripping and tearing!</span>")
+		qdel(src)
+		return 0
+	else
+		remaining_uses--
+		return ..()
+
+
+>>>>>>> 
 /***************************************\
 |*********SPACE SUIT + HELMET***********|
 \***************************************/

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -162,7 +162,7 @@
 	block_power = 20
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = IS_SHARP

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -159,6 +159,8 @@
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
+	block_power = 20
+	block_level = 1
 	block_upgrade_walk = 1
 	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
@@ -5,6 +5,8 @@
 	clockwork_desc = "A powerful spear of Ratvarian making. It's more effective against enemy cultists and silicons."
 	icon_state = "ratvarian_spear"
 	item_state = "ratvarian_spear"
+	block_upgrade_walk = 1
+	block_level = 1
 	force = 15 //Extra damage is dealt to targets in attack()
 	throwforce = 25
 	armour_penetration = 10

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -18,7 +18,7 @@
 	inhand_y_dimension = 32
 	w_class = WEIGHT_CLASS_SMALL
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 15
 	throwforce = 12 // unlike normal daggers, this one is curved and not designed to be thrown
 	armour_penetration = 35
@@ -43,7 +43,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 30
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 30
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -91,8 +91,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 50
-	nasty_blocks = TRUE
-	projectile_blocking = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
 	throwforce = 20
 	force = 35
 	armour_penetration = 45

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -17,6 +17,8 @@
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
 	w_class = WEIGHT_CLASS_SMALL
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	force = 15
 	throwforce = 12 // unlike normal daggers, this one is curved and not designed to be thrown
 	armour_penetration = 35
@@ -38,6 +40,10 @@
 	flags_1 = CONDUCT_1
 	sharpness = IS_SHARP
 	w_class = WEIGHT_CLASS_BULKY
+	block_level = 1
+	block_upgrade_walk = 1
+	block_power = 30
+	nasty_blocks = TRUE
 	force = 30
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -81,7 +87,12 @@
 	name = "bloody bastard sword"
 	desc = "An enormous sword used by Nar'Sien cultists to rapidly harvest the souls of non-believers."
 	w_class = WEIGHT_CLASS_HUGE
-	block_chance = 50
+	attack_weight = 2
+	block_level = 1
+	block_upgrade_walk = 1
+	block_power = 50
+	nasty_blocks = TRUE
+	projectile_blocking = TRUE
 	throwforce = 20
 	force = 35
 	armour_penetration = 45
@@ -154,13 +165,6 @@
 	linked_action.Remove(user)
 	jaunt.Remove(user)
 	user.update_icons()
-
-/obj/item/twohanded/required/cult_bastard/IsReflect()
-	if(spinning)
-		playsound(src, pick('sound/weapons/effects/ric1.ogg', 'sound/weapons/effects/ric2.ogg', 'sound/weapons/effects/ric3.ogg', 'sound/weapons/effects/ric4.ogg', 'sound/weapons/effects/ric5.ogg'), 100, 1)
-		return TRUE
-	else
-		..()
 
 /obj/item/twohanded/required/cult_bastard/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(prob(final_block_chance))
@@ -237,14 +241,14 @@
 	holder.changeNext_move(50)
 	holder.apply_status_effect(/datum/status_effect/sword_spin)
 	sword.spinning = TRUE
-	sword.block_chance = 100
+	sword.block_level = 4
 	sword.slowdown += 1.5
 	addtimer(CALLBACK(src, .proc/stop_spinning), 50)
 	holder.update_action_buttons_icon()
 
 /datum/action/innate/cult/spin2win/proc/stop_spinning()
 	sword.spinning = FALSE
-	sword.block_chance = 50
+	sword.block_level = 1
 	sword.slowdown -= 1.5
 	sleep(sword.spin_cooldown)
 	holder.update_action_buttons_icon()
@@ -653,7 +657,7 @@
 	throwforce = 40
 	throw_speed = 2
 	armour_penetration = 30
-	block_chance = 30
+	block_upgrade_walk = 1
 	attack_verb = list("attacked", "impaled", "stabbed", "torn", "gored")
 	sharpness = IS_SHARP
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -919,34 +923,8 @@
 
 /obj/item/shield/mirror/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(iscultist(owner))
-		if(istype(hitby, /obj/item/projectile))
-			var/obj/item/projectile/P = hitby
-			if(P.damage_type == BRUTE || P.damage_type == BURN)
-				if(P.damage >= 30)
-					var/turf/T = get_turf(owner)
-					T.visible_message("<span class='warning'>The sheer force from [P] shatters the mirror shield!</span>")
-					new /obj/effect/temp_visual/cult/sparks(T)
-					playsound(T, 'sound/effects/glassbr3.ogg', 100)
-					owner.Paralyze(25)
-					qdel(src)
-					return FALSE
-			if(P.reflectable & REFLECT_NORMAL)
-				return FALSE //To avoid reflection chance double-dipping with block chance
-		if(istype(hitby, /obj/item))
-			var/obj/item/W = hitby
-			if(W.damtype == BRUTE || W.damtype == BURN)
-				if(W.force >= 18) // make it a bit risky to go melee with this, eh?
-					var/turf/T = get_turf(owner)
-					T.visible_message("<span class='warning'>The sheer force from [W] shatters the mirror shield!</span>")
-					new /obj/effect/temp_visual/cult/sparks(T)
-					playsound(T, 'sound/effects/glassbr3.ogg', 100)
-					owner.Paralyze(25)
-					qdel(src)
-					return FALSE
-
 		. = ..()
 		if(.)
-			playsound(src, 'sound/weapons/parry.ogg', 100, 1)
 			if(illusions > 0)
 				illusions--
 				if(prob(60))
@@ -969,11 +947,6 @@
 			H.move_to_delay = owner.movement_delay()
 			to_chat(owner, "<span class='danger'><b>[src] betrays you!</b></span>")
 		return FALSE
-
-/obj/item/shield/mirror/IsReflect()
-	if(prob(block_chance))
-		return TRUE
-	return FALSE
 
 /obj/item/shield/mirror/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	var/turf/T = get_turf(hit_atom)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -18,7 +18,7 @@
 	inhand_y_dimension = 32
 	w_class = WEIGHT_CLASS_SMALL
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 15
 	throwforce = 12 // unlike normal daggers, this one is curved and not designed to be thrown
 	armour_penetration = 35
@@ -43,7 +43,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 30
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 30
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -91,7 +91,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 50
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	throwforce = 20
 	force = 35
 	armour_penetration = 45

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -913,7 +913,6 @@
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 5
 	throwforce = 15
-	block_chance = 70 // higher than normal. This protects against greytiders with improvised weapons, but as soon as real weaponry comes out, the shield's breaking
 	throw_speed = 1
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -18,7 +18,7 @@
 	inhand_y_dimension = 32
 	w_class = WEIGHT_CLASS_SMALL
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 15
 	throwforce = 12 // unlike normal daggers, this one is curved and not designed to be thrown
 	armour_penetration = 35
@@ -43,7 +43,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 30
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	force = 30
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -91,8 +91,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 50
-	nasty_blocks = TRUE
-	projectile_blocking = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
 	throwforce = 20
 	force = 35
 	armour_penetration = 45
@@ -913,7 +912,6 @@
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 5
 	throwforce = 15
-	block_chance = 70 // higher than normal. This protects against greytiders with improvised weapons, but as soon as real weaponry comes out, the shield's breaking
 	throw_speed = 1
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -11,6 +11,7 @@
 	item_state = "knife"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
+	block_upgrade_walk = 1
 	force = 15
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -8,6 +8,7 @@
 	amount_per_transfer_from_this = 10
 	volume = 100
 	throwforce = 15
+	block_upgrade_walk = 1
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
@@ -15,6 +16,14 @@
 	isGlass = TRUE
 	foodtype = ALCOHOL
 
+/obj/item/reagent_containers/food/drinks/bottle/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	if(isliving(hitby))
+		var/mob/living/L = hitby
+		smash(L)
+	else 
+		smash()
+	return TRUE
+	
 
 /obj/item/reagent_containers/food/drinks/bottle/smash(mob/living/target, mob/thrower, ranged = FALSE)
 	//Creates a shattering noise and replaces the bottle with a broken_bottle

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -428,7 +428,10 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/cherryjelly = 5)
 	force = 20
 	throwforce = 10
-	block_chance = 50
+	block_level = 2
+	block_upgrade_walk = 1
+	block_power = 40
+	attack_weight = 2
 	armour_penetration = 75
 	attack_verb = list("slapped", "slathered")
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -36,6 +36,7 @@
 	desc = "It's better than bad, it's good!"
 	icon_state = "logs"
 	force = 5
+	block_upgrade_walk = 1
 	throwforce = 5
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -14,6 +14,7 @@
 	force_unwielded = 20 //It's never not wielded so these are the same
 	force_wielded = 0
 	throwforce = 5
+	block_upgrade_walk = 1
 	throw_speed = 4
 	armour_penetration = 10
 	materials = list(/datum/material/iron=1150, /datum/material/glass=2075)

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -5,6 +5,8 @@
 	icon_state = "pickaxe"
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+	attack_weight = 2
+	block_upgrade_walk = 1
 	force = 15
 	throwforce = 10
 	item_state = "pickaxe"
@@ -99,6 +101,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 8
+	block_upgrade_walk = 1
 	tool_behaviour = TOOL_SHOVEL
 	toolspeed = 1
 	usesound = 'sound/effects/shovel_dig.ogg'

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -156,7 +156,7 @@
 	block_upgrade_walk = 1 
 	block_level = 2
 	block_power = 40 //blocks very well to encourage using it. Just because you're a pacifist doesn't mean you can't defend yourself
-	active_blocking = FALSE
+	block_flags = null //not active, so it's null
 	var/activated = FALSE
 	var/usedHand
 
@@ -796,7 +796,7 @@
 	block_upgrade_walk = 1 
 	block_level = 1
 	block_power = 20
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	hitsound = 'sound/effects/ghost2.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	var/summon_cooldown = 0

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -153,6 +153,10 @@
 	desc = "A wooden rod about the size of your forearm with a snake carved around it, winding its way up the sides of the rod. Something about it seems to inspire in you the responsibilty and duty to help others."
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "asclepius_dormant"
+	block_upgrade_walk = 1 
+	block_level = 2
+	block_power = 40 //blocks very well to encourage using it. Just because you're a pacifist doesn't mean you can't defend yourself
+	active_blocking = FALSE
 	var/activated = FALSE
 	var/usedHand
 
@@ -410,6 +414,7 @@
 	max_charges = 1
 	item_flags = NEEDS_PERMIT | NOBLUDGEON
 	force = 18
+	attack_weight = 2
 
 /obj/item/ammo_casing/magic/hook
 	name = "hook"
@@ -678,6 +683,7 @@
 	attack_verb_on = list("cleaved", "swiped", "slashed", "chopped")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	hitsound_on = 'sound/weapons/bladeslice.ogg'
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = IS_SHARP
 	faction_bonus_force = 30
@@ -787,6 +793,10 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 1
 	throwforce = 1
+	block_upgrade_walk = 1 
+	block_level = 1
+	block_power = 20
+	nasty_blocks = TRUE
 	hitsound = 'sound/effects/ghost2.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	var/summon_cooldown = 0

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -796,7 +796,7 @@
 	block_upgrade_walk = 1 
 	block_level = 1
 	block_power = 20
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	hitsound = 'sound/effects/ghost2.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "rended")
 	var/summon_cooldown = 0

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -122,11 +122,11 @@
 						update_inv_head()
 
 		//dismemberment
-		var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
+		var/dismemberthreshold = (((affecting.max_damage * 2) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 		if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 			dismemberthreshold -= 50
 		if(I.sharpness)
-			dismemberthreshold = min((affecting.max_damage * 2), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
+			dismemberthreshold = min(((affecting.max_damage * 2) - affecting.get_damage()), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
 			if(stat == DEAD)
 				dismemberthreshold = dismemberthreshold / 3 
 		if(I.force >= dismemberthreshold && I.force >= 10)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -122,11 +122,11 @@
 						update_inv_head()
 
 		//dismemberment
-		var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + (I.attack_weight * 15)))
+		var/dismemberthreshold = (((affecting.max_damage * 2) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 		if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 			dismemberthreshold -= 50
 		if(I.sharpness)
-			dismemberthreshold = min((affecting.max_damage * 2), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
+			dismemberthreshold = min(((affecting.max_damage * 2) - affecting.get_damage()), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
 			if(stat == DEAD)
 				dismemberthreshold = dismemberthreshold / 3 
 		if(I.force >= dismemberthreshold && I.force >= 10)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -122,7 +122,7 @@
 						update_inv_head()
 
 		//dismemberment
-		var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + (I.attack_weight * 15)))
+		var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 		if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 			dismemberthreshold -= 50
 		if(I.sharpness)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -102,36 +102,19 @@
 
 /mob/living/carbon/human/proc/check_reflect(def_zone) //Reflection checks for anything in your l_hand, r_hand, or wear_suit based on the reflection chance of the object
 	if(wear_suit)
-		if(wear_suit.IsReflect(def_zone) == 1)
+		if(wear_suit.IsReflect(def_zone, src) == 1)
 			return 1
 	for(var/obj/item/I in held_items)
-		if(I.IsReflect(def_zone) == 1)
+		if(I.IsReflect(def_zone, src) == 1)
 			return 1
 	return 0
 
 /mob/living/carbon/human/proc/check_shields(atom/AM, var/damage, attack_text = "the attack", attack_type = MELEE_ATTACK, armour_penetration = 0)
-	var/block_chance_modifier = round(damage / -3)
-
 	for(var/obj/item/I in held_items)
 		if(!istype(I, /obj/item/clothing))
-			var/final_block_chance = I.block_chance - (CLAMP((armour_penetration-I.armour_penetration)/2,0,100)) + block_chance_modifier //So armour piercing blades can still be parried by other blades, for example
-			if(I.hit_reaction(src, AM, attack_text, final_block_chance, damage, attack_type))
-				if (istype(I, /obj/item/shield))
-					var/obj/item/shield/S = I
-					return S.on_shield_block(src, AM, attack_text, damage, attack_type)
+			if(I.hit_reaction(src, AM, attack_text, damage, attack_type))
+				I.on_block(src, AM, attack_text, damage, attack_type)
 				return 1
-	if(wear_suit)
-		var/final_block_chance = wear_suit.block_chance - (CLAMP((armour_penetration-wear_suit.armour_penetration)/2,0,100)) + block_chance_modifier
-		if(wear_suit.hit_reaction(src, AM, attack_text, final_block_chance, damage, attack_type))
-			return 1
-	if(w_uniform)
-		var/final_block_chance = w_uniform.block_chance - (CLAMP((armour_penetration-w_uniform.armour_penetration)/2,0,100)) + block_chance_modifier
-		if(w_uniform.hit_reaction(src, AM, attack_text, final_block_chance, damage, attack_type))
-			return TRUE
-	if(wear_neck)
-		var/final_block_chance = wear_neck.block_chance - (CLAMP((armour_penetration-wear_neck.armour_penetration)/2,0,100)) + block_chance_modifier
-		if(wear_neck.hit_reaction(src, AM, attack_text, final_block_chance, damage, attack_type))
-			return TRUE
   return FALSE
 
 /mob/living/carbon/human/proc/check_block()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1511,7 +1511,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return 0 //item force is zero
 
 	//dismemberment
-	var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + (I.attack_weight * 15)))
+	var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 		dismemberthreshold -= 50
 	if(I.sharpness)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1534,7 +1534,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		switch(hit_area)
 			if(BODY_ZONE_HEAD)
-				if(!I.sharpness))
+				if(!I.sharpness)
 					if(H.mind && H.stat == CONSCIOUS && H != user && (H.health - (I.force * I.attack_weight)) <= 0) // rev deconversion through blunt trauma.
 						var/datum/antagonist/rev/rev = H.mind.has_antag_datum(/datum/antagonist/rev)
 						if(rev)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1511,11 +1511,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return 0 //item force is zero
 
 	//dismemberment
-	var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
+	var/dismemberthreshold = (((affecting.max_damage * 2) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 		dismemberthreshold -= 50
 	if(I.sharpness)
-		dismemberthreshold = min((affecting.max_damage * 2), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
+		dismemberthreshold = min(((affecting.max_damage * 2  - affecting.get_damage())), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
 		if(H.stat == DEAD)
 			dismemberthreshold = dismemberthreshold / 3 
 	if(I.force >= dismemberthreshold && I.force >= 10)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1328,12 +1328,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			target.apply_damage(damage, attack_type, affecting, armor_block)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
-		switch(affecting)
-			if(BODY_ZONE_PRECISE_MOUTH)
-				if(armor_block <= damage)
-					target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3) //hitting the jaw knocks the brain about a bit
-			if(BODY_ZONE_CHEST)
-				target.adjustOxyLoss(damage) //knocks the air out of them
 
 /datum/species/proc/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	return
@@ -1511,11 +1505,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return 0 //item force is zero
 
 	//dismemberment
-	var/dismemberthreshold = (((affecting.max_damage * 3) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + (I.attack_weight * 15)))
+	var/dismemberthreshold = (((affecting.max_damage * 2) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 		dismemberthreshold -= 50
 	if(I.sharpness)
-		dismemberthreshold = min((affecting.max_damage * 2), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
+		dismemberthreshold = min(((affecting.max_damage * 2  - affecting.get_damage())), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
 		if(H.stat == DEAD)
 			dismemberthreshold = dismemberthreshold / 3 
 	if(I.force >= dismemberthreshold && I.force >= 10)
@@ -1540,13 +1534,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		switch(hit_area)
 			if(BODY_ZONE_HEAD)
-				if(!I.is_sharp())
-					if(I.force >= max(12, armor_block + 10))
-						H.adjustOrganLoss(ORGAN_SLOT_BRAIN, I.attack_weight)
-						if(H.stat == CONSCIOUS)
-							to_chat(H, "you reel from the blow")
-							H.confused = min(H.confused + I.attack_weight, I.force)
-							H.adjust_blurriness(5)
+				if(!I.sharpness)
 					if(H.mind && H.stat == CONSCIOUS && H != user && (H.health - (I.force * I.attack_weight)) <= 0) // rev deconversion through blunt trauma.
 						var/datum/antagonist/rev/rev = H.mind.has_antag_datum(/datum/antagonist/rev)
 						if(rev)
@@ -1564,10 +1552,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 						H.update_inv_glasses()
 
 			if(BODY_ZONE_CHEST)
-				if(H.stat == CONSCIOUS && !I.is_sharp() && armor_block < 50)
-					if(I.force >= max(12, armor_block + 10))
-						H.adjustOxyLoss(I.force / 2) //getting the wind knocked out of ya
-
 				if(bloody)
 					if(H.wear_suit)
 						H.wear_suit.add_mob_blood(H)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1328,12 +1328,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			target.apply_damage(damage, attack_type, affecting, armor_block)
 			target.apply_damage(damage*1.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched")
-		switch(affecting)
-			if(BODY_ZONE_PRECISE_MOUTH)
-				if(armor_block <= damage)
-					target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3) //hitting the jaw knocks the brain about a bit
-			if(BODY_ZONE_CHEST)
-				target.adjustOxyLoss(damage) //knocks the air out of them
 
 /datum/species/proc/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	return
@@ -1540,13 +1534,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 		switch(hit_area)
 			if(BODY_ZONE_HEAD)
-				if(!I.is_sharp())
-					if(I.force >= max(12, armor_block + 10))
-						H.adjustOrganLoss(ORGAN_SLOT_BRAIN, I.attack_weight)
-						if(H.stat == CONSCIOUS)
-							to_chat(H, "you reel from the blow")
-							H.confused = min(H.confused + I.attack_weight, I.force)
-							H.adjust_blurriness(5)
+				if(!I.sharpness))
 					if(H.mind && H.stat == CONSCIOUS && H != user && (H.health - (I.force * I.attack_weight)) <= 0) // rev deconversion through blunt trauma.
 						var/datum/antagonist/rev/rev = H.mind.has_antag_datum(/datum/antagonist/rev)
 						if(rev)
@@ -1564,10 +1552,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 						H.update_inv_glasses()
 
 			if(BODY_ZONE_CHEST)
-				if(H.stat == CONSCIOUS && !I.is_sharp() && armor_block < 50)
-					if(I.force >= max(12, armor_block + 10))
-						H.adjustOxyLoss(I.force / 2) //getting the wind knocked out of ya
-
 				if(bloody)
 					if(H.wear_suit)
 						H.wear_suit.add_mob_blood(H)

--- a/code/modules/mob/living/carbon/human/species_types/corporate.dm
+++ b/code/modules/mob/living/carbon/human/species_types/corporate.dm
@@ -8,9 +8,7 @@
 	burnmod = 0.65//Tough against lasers
 	coldmod = 0
 	heatmod = 0.5//it's a little tough to burn them to death not as hard though.
-	punchdamagelow = 20
-	punchdamagehigh = 30//they are inhumanly strong
-	punchstunthreshold = 25
+	punchdamage = 25//they are inhumanly strong
 	attack_verb = "smash"
 	attack_sound = 'sound/weapons/resonator_blast.ogg'
 	use_skintones = 0

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -9,9 +9,7 @@
 	speedmod = 2
 	armor = 55
 	siemens_coeff = 0
-	punchdamagelow = 5
-	punchdamagehigh = 14
-	punchstunthreshold = 11 //about 40% chance to stun
+	punchdamage = 11
 	no_equip = list(SLOT_WEAR_MASK, SLOT_WEAR_SUIT, SLOT_GLOVES, SLOT_SHOES, SLOT_W_UNIFORM, SLOT_S_STORE)
 	nojumpsuit = 1
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
@@ -166,7 +164,6 @@
 	name = "Silver Golem"
 	id = "silver golem"
 	fixed_mut_color = "ddd"
-	punchstunthreshold = 9 //60% chance, from 40%
 	meat = /obj/item/stack/ore/silver
 	info_text = "As a <span class='danger'>Silver Golem</span>, your attacks have a higher chance of stunning. Being made of silver, your body is immune to most types of magic."
 	prefix = "Silver"
@@ -186,9 +183,7 @@
 	id = "plasteel golem"
 	fixed_mut_color = "bbb"
 	stunmod = 0.4
-	punchdamagelow = 12
-	punchdamagehigh = 21
-	punchstunthreshold = 18 //still 40% stun chance
+	punchdamage = 18
 	speedmod = 4 //pretty fucking slow
 	meat = /obj/item/stack/ore/iron
 	info_text = "As a <span class='danger'>Plasteel Golem</span>, you are slower, but harder to stun, and hit very hard when punching. You also magnetically attach to surfaces and so don't float without gravity and cannot have positions swapped with other beings."
@@ -509,9 +504,7 @@
 	id = "bananium golem"
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NOEYESPRITES)
 	say_mod = "honks"
-	punchdamagelow = 0
-	punchdamagehigh = 1
-	punchstunthreshold = 2 //Harmless and can't stun
+	punchdamage = 0
 	meat = /obj/item/stack/ore/bananium
 	info_text = "As a <span class='danger'>Bananium Golem</span>, you are made for pranking. Your body emits natural honks, and you can barely even hurt people when punching them. Your skin also bleeds banana peels when damaged."
 	attack_verb = "honk"
@@ -702,9 +695,7 @@
 	armor = 15 //feels no pain, but not too resistant
 	burnmod = 2 // don't get burned
 	speedmod = 1 // not as heavy as stone
-	punchdamagelow = 4
-	punchstunthreshold = 7
-	punchdamagehigh = 8 // not as heavy as stone
+	punchdamage = 6
 	prefix = "Cloth"
 	special_names = null
 
@@ -906,9 +897,7 @@
 	burnmod = 1.25
 	heatmod = 2
 	speedmod = 1.5
-	punchdamagelow = 4
-	punchstunthreshold = 7
-	punchdamagehigh = 8
+	punchdamage = 6
 	var/last_creation = 0
 	var/brother_creation_cooldown = 300
 

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -14,9 +14,7 @@
 	inherent_traits = list(TRAIT_NOBREATH)
 	speedmod = 1.5 //faster than golems but not by much
 
-	punchdamagelow = 6
-	punchdamagehigh = 14
-	punchstunthreshold = 14 //about 44% chance to stun
+	punchdamage = 12
 
 	no_equip = list(SLOT_WEAR_MASK, SLOT_WEAR_SUIT, SLOT_GLOVES, SLOT_SHOES, SLOT_W_UNIFORM)
 

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -162,7 +162,7 @@
 	item_state = "arm_blade"
 	force = 25
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -161,6 +161,8 @@
 	icon_state = "arm_blade"
 	item_state = "arm_blade"
 	force = 25
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -162,7 +162,8 @@
 	item_state = "arm_blade"
 	force = 25
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING
+	block_level = 1
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -10,7 +10,7 @@
 	coldmod = 0.5 //snails only come out when its cold and wet
 	burnmod = 1.5
 	speedmod = 2
-	punchdamagehigh = 5 //snails are soft and squishy
+	punchdamage = 3
 	siemens_coeff = 2 //snails are mostly water
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	sexes = FALSE //snails are hermaphrodites

--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -9,7 +9,7 @@
     burnmod = 1.5
     heatmod = 1.4
     coldmod = 1.5
-    punchdamagehigh = 7 // Lower max damage in melee. It's just a tentacle
+    punchdamage = 7 // Lower max damage in melee. It's just a tentacle
     changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | SLIME_EXTRACT
     attack_verb = list("whipped", "lashed", "disciplined")
     attack_sound = 'sound/weapons/whip.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -24,9 +24,7 @@
 	name = "Military Synth"
 	id = "military_synth"
 	armor = 25
-	punchdamagelow = 10
-	punchdamagehigh = 19
-	punchstunthreshold = 14 //about 50% chance to stun
+	punchdamage = 14
 	disguise_fail_health = 50
 	changesource_flags = MIRROR_BADMIN | WABBAJACK
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -182,7 +182,7 @@
 	//anti-riot equipment is also anti-push
 	for(var/obj/item/I in M.held_items)
 		if(!istype(M, /obj/item/clothing))
-			if(prob(I.block_chance*2))
+			if(I.block_power >= 50)
 				return
 
 /mob/living/get_photo_description(obj/item/camera/camera)

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -10,8 +10,7 @@
 	block_power = 50
 	block_level = 1
 	block_upgrade_walk = 1
-	nasty_blocks = TRUE
-	projectile_blocking = TRUE //just like one of my japanese animes
+	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
 	armour_penetration = 50
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -7,12 +7,15 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 40
 	throwforce = 20
-	block_chance = 50
+	block_power = 50
+	block_level = 1
+	block_upgrade_walk = 1
+	nasty_blocks = TRUE
+	projectile_blocking = TRUE //just like one of my japanese animes
 	armour_penetration = 50
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 50
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	sharpness = IS_SHARP
 	max_integrity = 200

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -10,7 +10,7 @@
 	block_power = 50
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = ACTIVE_BLOCKING | NASTY_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	armour_penetration = 50
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -333,7 +333,17 @@
 	mag_display = TRUE
 	automatic = 0
 	fire_rate = 1.5
+<<<<<<< Updated upstream
 	block_upgrade_walk = 1
+=======
+<<<<<<< HEAD
+	block_upgrade_walk = 1
+=======
+=======
+	block_upgrade_walk = 1
+>>>>>>> 
+>>>>>>> rngholocaust
+>>>>>>> Stashed changes
 
 // Laser rifle (rechargeable magazine) //
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -331,12 +331,9 @@
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
-<<<<<<< refs/remotes/origin/master
 	automatic = 0
 	fire_rate = 1.5
-=======
 	block_upgrade_walk = 1
->>>>>>> 
 
 // Laser rifle (rechargeable magazine) //
 
@@ -350,8 +347,6 @@
 	actions_types = list()
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
-<<<<<<< refs/remotes/origin/master
 	fire_rate = 2
-=======
 	block_upgrade_walk = 1
->>>>>>> 
+

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -333,17 +333,7 @@
 	mag_display = TRUE
 	automatic = 0
 	fire_rate = 1.5
-<<<<<<< Updated upstream
 	block_upgrade_walk = 1
-=======
-<<<<<<< HEAD
-	block_upgrade_walk = 1
-=======
-=======
-	block_upgrade_walk = 1
->>>>>>> 
->>>>>>> rngholocaust
->>>>>>> Stashed changes
 
 // Laser rifle (rechargeable magazine) //
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -331,12 +331,9 @@
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
-<<<<<<< refs/remotes/origin/master
 	automatic = 0
 	fire_rate = 1.5
-=======
 	block_upgrade_walk = 1
->>>>>>> 
 
 // Laser rifle (rechargeable magazine) //
 
@@ -350,8 +347,5 @@
 	actions_types = list()
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
-<<<<<<< refs/remotes/origin/master
 	fire_rate = 2
-=======
 	block_upgrade_walk = 1
->>>>>>> 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -331,16 +331,9 @@
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
-<<<<<<< refs/remotes/origin/master
 	automatic = 0
 	fire_rate = 1.5
-<<<<<<< HEAD
 	block_upgrade_walk = 1
-=======
-=======
-	block_upgrade_walk = 1
->>>>>>> 
->>>>>>> rngholocaust
 
 // Laser rifle (rechargeable magazine) //
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -71,6 +71,7 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/c20r/unrestricted
 	pin = /obj/item/firing_pin
@@ -94,6 +95,7 @@
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
 	fire_rate = 3
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/mini_uzi
 	name = "\improper Type U3 Uzi"
@@ -119,6 +121,7 @@
 	pin = /obj/item/firing_pin/implant/pindicate
 	mag_display = TRUE
 	empty_indicator = TRUE
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/m90/Initialize()
 	. = ..()
@@ -190,6 +193,7 @@
 	fire_rate = 5
 	can_suppress = FALSE
 	bolt_type = BOLT_TYPE_OPEN
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/ar
 	name = "\improper NT-ARG 'Boarder'"
@@ -225,6 +229,7 @@
 	tac_reloads = FALSE
 	fire_sound = 'sound/weapons/rifleshot.ogg'
 	rack_sound = 'sound/weapons/chunkyrack.ogg'
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/l6_saw/unrestricted
 	pin = /obj/item/firing_pin
@@ -302,6 +307,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
@@ -325,8 +331,12 @@
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
+<<<<<<< refs/remotes/origin/master
 	automatic = 0
 	fire_rate = 1.5
+=======
+	block_upgrade_walk = 1
+>>>>>>> 
 
 // Laser rifle (rechargeable magazine) //
 
@@ -340,4 +350,8 @@
 	actions_types = list()
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
+<<<<<<< refs/remotes/origin/master
 	fire_rate = 2
+=======
+	block_upgrade_walk = 1
+>>>>>>> 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -13,6 +13,7 @@
 	bolt_type = BOLT_TYPE_NO_BOLT
 	weapon_weight = WEAPON_MEDIUM
 	fire_rate = 2
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -15,6 +15,7 @@
 	bolt_drop_sound = "sound/weapons/mosinboltin.ogg"
 	tac_reloads = FALSE
 	weapon_weight = WEAPON_MEDIUM
+	block_upgrade_walk = 1
 
 obj/item/gun/ballistic/rifle/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -21,6 +21,7 @@
 	cartridge_wording = "shell"
 	tac_reloads = FALSE
 	fire_rate = 1 //reee
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
 	. = 0

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -13,6 +13,7 @@
 	casing_ejector = FALSE
 	fire_rate = 3
 	weapon_weight = WEAPON_LIGHT
+	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/toy/update_icon()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -10,6 +10,8 @@
 	flight_x_offset = 15
 	flight_y_offset = 10
 	weapon_weight = WEAPON_MEDIUM
+	dual_wield_spread = 60
+	block_upgrade_walk = 1
 
 /obj/item/gun/energy/e_gun/mini
 	name = "miniature energy gun"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -19,6 +19,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
+	block_upgrade_walk = 1
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -3,6 +3,7 @@
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
 	item_state = "laser"
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(/datum/material/iron=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -5,6 +5,7 @@
 	item_state = null
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
+	block_upgrade_walk = 1
 	modifystate = TRUE
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -11,6 +11,7 @@
 	ammo_x_offset = 3
 	flight_x_offset = 17
 	flight_y_offset = 9
+	block_upgrade_walk = 1
 
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	return
@@ -80,6 +81,7 @@
 	desc = "A prototype weapon recovered from the ruins of Research-Station Epsilon."
 	icon_state = "xray"
 	item_state = null
+	block_upgrade_walk = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/mindflayer)
 	ammo_x_offset = 2
 
@@ -134,6 +136,7 @@
 	flags_1 = CONDUCT_1
 	attack_verb = list("attacked", "slashed", "cut", "sliced")
 	force = 12
+	block_upgrade_walk = 1
 	sharpness = IS_SHARP
 	can_charge = FALSE
 
@@ -322,11 +325,13 @@
 	automatic = 1
 	fire_rate = 4
 	pin = null
+	block_upgrade_walk = 1
 
 /obj/item/gun/energy/temperature/security
 	name = "security temperature gun"
 	desc = "A weapon that can only be used to its full potential by the truly robust."
 	pin = /obj/item/firing_pin
+	block_upgrade_walk = 1
 
 /obj/item/gun/energy/laser/instakill
 	name = "instakill rifle"
@@ -335,6 +340,7 @@
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit."
 	ammo_type = list(/obj/item/ammo_casing/energy/instakill)
 	force = 60
+	block_upgrade_walk = 1
 
 /obj/item/gun/energy/laser/instakill/red
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a red design."

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -5,6 +5,8 @@
 	item_flags = NEEDS_PERMIT | NO_MAT_REDEMPTION
 	weapon_weight = WEAPON_MEDIUM
 	fire_rate = 1.5
+	block_power = 20 //staffs can block shit if you're walking
+	block_upgrade_walk = 1
 
 /obj/item/gun/magic/staff/change
 	name = "staff of change"
@@ -86,7 +88,9 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	force = 20
 	armour_penetration = 75
-	block_chance = 50
+	block_level = 1
+	nasty_blocks = TRUE
+	projectile_blocking = TRUE //enchanted or some shit
 	sharpness = IS_SHARP
 	max_charges = 4
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -7,6 +7,7 @@
 	fire_rate = 1.5
 	block_power = 20 //staffs can block shit if you're walking
 	block_upgrade_walk = 1
+	block_level = 1
 
 /obj/item/gun/magic/staff/change
 	name = "staff of change"
@@ -88,8 +89,7 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	force = 20
 	armour_penetration = 75
-	block_level = 1
-	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
+	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	sharpness = IS_SHARP
 	max_charges = 4
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -89,8 +89,7 @@
 	force = 20
 	armour_penetration = 75
 	block_level = 1
-	nasty_blocks = TRUE
-	projectile_blocking = TRUE //enchanted or some shit
+	block_flags = NASTY_BLOCKING | ACTIVE_BLOCKING | PROJECTILE_BLOCKING
 	sharpness = IS_SHARP
 	max_charges = 4
 

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -19,6 +19,7 @@
 	fire_sound = 'sound/weapons/beam_sniper.ogg'
 	slot_flags = ITEM_SLOT_BACK
 	force = 15
+	block_upgrade_walk = 1
 	materials = list()
 	recoil = 4
 	ammo_x_offset = 3

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -6,6 +6,7 @@
 	item_state = "blastcannon_empty"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 10
+	block_upgrade_walk = 1
 	fire_sound = 'sound/weapons/blastcannon.ogg'
 	item_flags = NONE
 	clumsy_check = FALSE

--- a/code/modules/projectiles/guns/misc/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/misc/grenade_launcher.dm
@@ -8,6 +8,7 @@
 	throw_speed = 2
 	throw_range = 7
 	force = 5
+	block_upgrade_walk = 1
 	var/list/grenades = new/list()
 	var/max_grenades = 3
 	materials = list(/datum/material/iron=2000)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1633,7 +1633,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		var/mob/living/carbon/human/thehuman = L
 		for(var/obj/item/shield/theshield in thehuman.contents)
 			mighty_shield = theshield
-			mighty_shield.block_chance += 10
+			mighty_shield.block_power += 15
 			to_chat(thehuman, "<span class='notice'>[theshield] appears polished, although you don't recall polishing it.</span>")
 			return TRUE
 
@@ -1644,7 +1644,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/alexander/on_mob_end_metabolize(mob/living/L)
 	if(mighty_shield)
-		mighty_shield.block_chance -= 10
+		mighty_shield.block_power -= 15
 		to_chat(L,"<span class='notice'>You notice [mighty_shield] looks worn again. Weird.</span>")
 	..()
 

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -68,7 +68,7 @@ Slimecrossing Weapons
 	block_power = 75
 	block_level = 3
 	block_upgrade_walk = 1
-	block_flags = PROJECTILE_BLOCKING
+	block_flags = BLOCKING_PROJECTILE
 	throw_range = 1 //How far do you think you're gonna throw a solid crystalline shield...?
 	throw_speed = 2
 	force = 15 //Heavy, but hard to wield.

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -68,7 +68,7 @@ Slimecrossing Weapons
 	block_power = 75
 	block_level = 3
 	block_upgrade_walk = 1
-	projectile_blocking = TRUE 
+	block_flags = PROJECTILE_BLOCKING
 	throw_range = 1 //How far do you think you're gonna throw a solid crystalline shield...?
 	throw_speed = 2
 	force = 15 //Heavy, but hard to wield.

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -16,6 +16,12 @@ Slimecrossing Weapons
 	if(prob(20))
 		user.emote("scream")
 
+/obj/item/melee/arm_blade/slime/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	if(prob(20))
+		owner.emote("scream")
+	return ..()
+	
+
 //Rainbow knife - Burning Rainbow
 /obj/item/kitchen/knife/rainbowknife
 	name = "rainbow knife"
@@ -58,7 +64,11 @@ Slimecrossing Weapons
 	w_class = WEIGHT_CLASS_HUGE
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 50, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 70)
 	slot_flags = ITEM_SLOT_BACK
-	block_chance = 75
+	attack_weight = 2
+	block_power = 75
+	block_level = 3
+	block_upgrade_walk = 1
+	projectile_blocking = TRUE 
 	throw_range = 1 //How far do you think you're gonna throw a solid crystalline shield...?
 	throw_speed = 2
 	force = 15 //Heavy, but hard to wield.

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -167,7 +167,7 @@
 		if(ALIEN_BODYPART,LARVA_BODYPART) //aliens take double burn //nothing can burn with so much snowflake code around
 			burn *= 2
 
-	var/can_inflict = max_damage - get_damage()
+	var/can_inflict = (max_damage * 2) - get_damage()
 	if(can_inflict <= 0)
 		return FALSE
 

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -26,6 +26,8 @@
 	righthand_file = 'icons/mob/inhands/misc/lavaland_righthand.dmi'
 	desc = "Not to be confused with the kind Research hassles you for."
 	force = 12
+	block_level = 1
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 


### PR DESCRIPTION
## About The Pull Request
refactors / reworks the following mechanics to not use rng:
dismemberment
blocking
confusion from being hit
punching
**READ THE DAMN PR AND ALL WILL BE EXPLAINED***
to the best ability of zesko's lazy 3 AM  coedrbrain

**new weapon mechanic**
3/4ths of these changes use a new weapon stat called "attack weight", which represents the weight of a weapon, independent from size or sharpness. most weapons have it at 1, some have it at 2, and a few rare examples have 3

**dismemberment**
dismemberment is calculated using weapon weight, size, sharpness, and force. It's also easier to dismember dead targets if using a sharp weapon. Dismembering targets with blunt objects is possible if the weapon has enough weight

**random confusion, punches, knockdown, etc**
removes all random add effects on normal hits
punching damage is now one flat number

**blocking**
I saved the best for last here

blocking is no longer chance based. Instead, it depends on facing, if the user is walking (walking usually adds a bonus to blocking), if the user is holding the item (most non-shield items must be held for blocking) and if the attack is ranged or not. You also will not block on harm intent.

non-shields don't block projectiles unless they're a double esword or a katana. riot shields are transparent and can't block projectiles that pass through them

there are two kinds of blocking: shield blocking and item blocking. Shields have durability, and break after blocking too many attacks (though energy shields just overheat and must be turned on again), and items cause you to take stamina damage. The calculations behind damage dealt to blocks depends on weight, attacker, sharpness, damage type, etc. 

there are two important numbers for blocking: block Level and block Power. Power is essentially block armor, and determines how hard a block is to break. Block level determines how much a block covers: see shitty diagram below
![image](https://user-images.githubusercontent.com/49600480/80304687-7e18e580-876c-11ea-827b-9b0ecd60238f.png)

block level 1 is mostly seen on common objects you could expect to parry a blow with, only when walking. Block level 2 is seen on more weaponlike objects when walking, and level 3 is mostly reserved for big shields. Level 4 is seldom seen

also, if you hit someone with your bare hands and get parried by a sharp weapon, it's gonna hurt. 


STAY TUNED FOR RNG HOLOCAUST PART 2: SIMPLEMOBS, EMBEDDING, AND THOSE FUCKING MONKEYS


## Why It's Good For The Game

rng is bad and big gay

## Changelog
:cl:
tweak: no more random confusion when hit in the head
tweak: dismemberment now uses a calculation reliant on weapon size, weight, sharpness, and force to determine when a limb is lost, instead of RNG.
tweak: no more RNG on punches! punches now have fixed damage and no stun.
refactor:  totally changes up block chance. blocking now relies on items being held in the active hand or not, if you are walking or not, and the direction you are facing. Shields now use durability and all other items deal stamina damage to the arm holding them when blocking. Read the pr for more in-depth info.

/:cl:

