### PR TITLE
Ex security now spawns on traitor based gamemodes.

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
-	allowed_special = list(/datum/antagonist/special/undercover)
+	allowed_special = list(/datum/special_role/undercover)
 
 	announce_span = "green"
 	announce_text = "Alien changelings have infiltrated the crew!\n\

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -16,6 +16,7 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
+	allowed_special = list(/datum/antagonist/special/undercover)
 
 	announce_span = "green"
 	announce_text = "Alien changelings have infiltrated the crew!\n\

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -4,7 +4,7 @@
 	report_type = "extended"
 	false_report_weight = 0
 	required_players = 0
-	allowed_special = list(/datum/antagonist/special/undercover)
+	allowed_special = list(/datum/special_role/undercover)
 
 	announce_span = "notice"
 	announce_text = "Just have fun and enjoy the game!"

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -4,6 +4,7 @@
 	report_type = "extended"
 	false_report_weight = 0
 	required_players = 0
+	allowed_special = list(/datum/antagonist/special/undercover)
 
 	announce_span = "notice"
 	announce_text = "Just have fun and enjoy the game!"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -34,7 +34,7 @@
 	var/reroll_friendly 	//During mode conversion only these are in the running
 	var/continuous_sanity_checked	//Catches some cases where config options could be used to suggest that modes without antagonists should end when all antagonists die
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
-	var/list/allowed_special = list()	//Special roles that can spawn (Add things like /datum/antagonist/special/undercover for them to be able to spawn during this gamemode)
+	var/list/allowed_special = list()	//Special roles that can spawn (Add things like /datum/special_role/undercover for them to be able to spawn during this gamemode)
 	var/list/active_specials = list()	//Special roles that have spawned, and can now spawn late
 
 	var/announce_span = "warning" //The gamemode's name will be in this span during announcement.

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -13,6 +13,7 @@
 	reroll_friendly = 0
 	traitor_name = "Nanotrasen Internal Affairs Agent"
 	antag_flag = ROLE_INTERNAL_AFFAIRS
+	allowed_special = list(/datum/antagonist/special/undercover)
 
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 4 // Four additional traitors

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -13,7 +13,7 @@
 	reroll_friendly = 0
 	traitor_name = "Nanotrasen Internal Affairs Agent"
 	antag_flag = ROLE_INTERNAL_AFFAIRS
-	allowed_special = list(/datum/antagonist/special/undercover)
+	allowed_special = list(/datum/special_role/undercover)
 
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 4 // Four additional traitors

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -13,6 +13,7 @@
 	false_report_weight = 20 //Reports of traitors are pretty common.
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician")
+	allowed_special = list(/datum/antagonist/special/undercover)
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -13,7 +13,7 @@
 	false_report_weight = 20 //Reports of traitors are pretty common.
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician")
-	allowed_special = list(/datum/antagonist/special/undercover)
+	allowed_special = list(/datum/special_role/undercover)
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/modules/antagonists/roundstart_special/undercover/undercover.dm
+++ b/code/modules/antagonists/roundstart_special/undercover/undercover.dm
@@ -74,6 +74,11 @@
 	if(ID)
 		ID.access += ACCESS_WEAPONS
 
+	//Mindshield
+	var/obj/item/implant/mindshield/P = new
+	if(!P.implant(H))
+		to_chat(owner, "<span class='warning'Through countless generations your mindshield has finally started to break, you are free!</span>")
+
 ////////////////////////////////
 //////     Objectives    ///////
 ////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A little solution to help with murderboning (I don't expect this to make much difference, but at least it will make it so there isn't someone boning on a fully defenceless crew). Uses the new round start special roles system.

## Why It's Good For The Game

Murderboning has always been an issue, mainly because the people doing it would be fighting unarmed defenceless crew. Now some of the crew may have disablers, so you better pick your fights carefully.
They can never be antagonist, spawn with weapon passes, spawn with a windshield, a disabler and will never be the target of an antagonist (You won't be assassinating armed crew).
The objectives they get is
- Secure the emergency shuttle ensuring [x] people make it out alive.

Engineers additionally get an objective to keep the supermatter above a certain integrity.

## Changelog
:cl:
add: Ex-security agents now spawn on traitors, extended, changelings, and other gamemodes that derive these types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
