### PR TITLE
Removes the "To Kill" wish option from the wishgranter (#47084)

### DIFF
--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -88,7 +88,7 @@
 	else
 		chargesa--
 		insistinga = 0
-		var/wish = input("You want...","Wish") as null|anything in list("Power","Wealth","Immortality","To Kill","Peace")
+		var/wish = input("You want...","Wish") as null|anything in list("Power","Wealth","Immortality","Peace")
 		switch(wish)
 			if("Power")
 				to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
@@ -106,11 +106,6 @@
 				to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
 				to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
 				user.verbs += /mob/living/carbon/proc/immortality
-				user.set_species(/datum/species/shadow)
-			if("To Kill")
-				to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
-				to_chat(user, "The Wish Granter punishes you for your wickedness, claiming your soul and warping your body to match the darkness in your heart.")
-				user.mind.add_antag_datum(/datum/antagonist/wishgranter)
 				user.set_species(/datum/species/shadow)
 			if("Peace")
 				to_chat(user, "<B>Whatever alien sentience that the Wish Granter possesses is satisfied with your wish. There is a distant wailing as the last of the Faithless begin to die, then silence.</B>")


### PR DESCRIPTION
Wishgranter exists for miners, assistants or robo to get a free hijack antag and is honestly pretty awful. People are tired of having an assistant run into the gateway when it opens and coming back with gamer loot and a free excuse to kill everyone on the station, or robos rushing phazon to noclip into the wishgranter cube, or miners using bluespace crystals or launchpads to get into the wishgranter cube.

:cl: ATHATH
del: Your wish that the wishgranter grants you can no longer be "To Kill".
/:cl: