### PR TITLE
Ports "Edited Gygax diamond cost to be silver and gold but the same values #46385" from /tg/

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -206,7 +206,7 @@
 	id = "gygax_torso"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_torso
-	materials = list(/datum/material/iron=20000,/datum/material/glass = 10000,/datum/material/diamond=2000)
+	materials = list(/datum/material/iron=20000,/datum/material/glass = 10000,/datum/material/gold=2000, /datum/material/silver=2000)
 	construction_time = 300
 	category = list("Gygax")
 
@@ -215,8 +215,7 @@
 	id = "gygax_head"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_head
-	materials = list(/datum/material/iron=10000,/datum/material/glass = 5000, /datum/material/diamond=2000)
-	construction_time = 200
+	materials = list(/datum/material/iron=10000,/datum/material/glass = 5000, /datum/material/gold=2000, /datum/material/silver=2000)
 	category = list("Gygax")
 
 /datum/design/gygax_left_arm
@@ -224,7 +223,7 @@
 	id = "gygax_left_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_left_arm
-	materials = list(/datum/material/iron=15000, /datum/material/diamond=1000)
+	materials = list(/datum/material/iron=15000, /datum/material/gold=1000, /datum/material/silver=1000)
 	construction_time = 200
 	category = list("Gygax")
 
@@ -233,7 +232,7 @@
 	id = "gygax_right_arm"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_right_arm
-	materials = list(/datum/material/iron=15000, /datum/material/diamond=1000)
+	materials = list(/datum/material/iron=15000, /datum/material/gold=1000, /datum/material/silver=1000)
 	construction_time = 200
 	category = list("Gygax")
 
@@ -242,7 +241,7 @@
 	id = "gygax_left_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_left_leg
-	materials = list(/datum/material/iron=15000, /datum/material/diamond=2000)
+	materials = list(/datum/material/iron=15000, /datum/material/gold=2000, /datum/material/silver=2000)
 	construction_time = 200
 	category = list("Gygax")
 
@@ -251,7 +250,7 @@
 	id = "gygax_right_leg"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_right_leg
-	materials = list(/datum/material/iron=15000, /datum/material/diamond=2000)
+	materials = list(/datum/material/iron=15000, /datum/material/gold=2000, /datum/material/silver=2000)
 	construction_time = 200
 	category = list("Gygax")
 
@@ -260,7 +259,7 @@
 	id = "gygax_armor"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/part/gygax_armor
-	materials = list(/datum/material/iron=15000,/datum/material/diamond=10000,/datum/material/titanium=10000)
+	materials = list(/datum/material/iron=15000,/datum/material/gold=10000, /datum/material/silver=10000, /datum/material/titanium=10000)
 	construction_time = 600
 	category = list("Gygax")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TO BE MERGED WITH #1684 ONLY.

>Gygax diamond values changed to their equivalents in silver and gold, therefore if a part costs 2k diamonds, it will now cost 2k gold and 2k silver. This PR is a favor for Arathian Spider RD main man on Discord and the servers who wanted to change the costs but didn't know how to make multiple 1 lines fixes. Seeing as I can make just over 1 line fixes, I did this as a favor.

## Why It's Good For The Game

>Gygax has been heavily nerfed due to autopunch removal? No longer sleeps target and does less damage?? ((Im not a fucking science main) This brings the Gygax cost for parts into line with its abilities, as it is no longer a fucking death mobile running around chain stunning and unlocking people to death, it is now a weaker Durand. This PR hopes to make it so it is not so outrageously priced for what you get.

https://github.com/tgstation/tgstation/pull/46385

All of the arguments for this change have likely already been made.

## Changelog
:cl:
balance: Gygax mech costs gold and silver instead of diamond.
/:cl: