### PR TITLE
Better gauze + medical patch crafting

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -747,6 +747,30 @@
 	category = CAT_MISC
 	tools = list(TOOL_WELDER)
 
+/datum/crafting_recipe/upgraded_gauze
+	name = "Improved Gauze"
+	result = /obj/item/stack/medical/gauze/adv
+	time = 1
+	reqs = list(/obj/item/stack/medical/gauze = 1,
+				/datum/reagent/space_cleaner/sterilizine = 10)
+	category = CAT_MISC
+
+/datum/crafting_recipe/bruise_pack
+	name = "Bruise Pack"
+	result = /obj/item/stack/medical/bruise_pack
+	time = 1
+	reqs = list(/obj/item/stack/medical/gauze = 1,
+				/datum/reagent/medicine/styptic_powder = 10)
+	category = CAT_MISC
+
+/datum/crafting_recipe/burn_pack
+	name = "Brun Ointment"
+	result = /obj/item/stack/medical/ointment
+	time = 1
+	reqs = list(/obj/item/stack/medical/gauze = 1,
+				/datum/reagent/medicine/silver_sulfadiazine = 10)
+	category = CAT_MISC
+
 // Shank - Makeshift weapon that can embed on throw
 /datum/crafting_recipe/shank
 	name = "Shank"

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -764,7 +764,7 @@
 	category = CAT_MISC
 
 /datum/crafting_recipe/burn_pack
-	name = "Brun Ointment"
+	name = "Burn Ointment"
 	result = /obj/item/stack/medical/ointment
 	time = 1
 	reqs = list(/obj/item/stack/medical/gauze = 1,

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -749,7 +749,7 @@
 
 /datum/crafting_recipe/upgraded_gauze
 	name = "Improved Gauze"
-	result = /obj/item/stack/medical/gauze/adv
+	result = /obj/item/stack/medical/gauze/adv/one
 	time = 1
 	reqs = list(/obj/item/stack/medical/gauze = 1,
 				/datum/reagent/space_cleaner/sterilizine = 10)
@@ -757,7 +757,7 @@
 
 /datum/crafting_recipe/bruise_pack
 	name = "Bruise Pack"
-	result = /obj/item/stack/medical/bruise_pack
+	result = /obj/item/stack/medical/bruise_pack/one
 	time = 1
 	reqs = list(/obj/item/stack/medical/gauze = 1,
 				/datum/reagent/medicine/styptic_powder = 10)
@@ -765,7 +765,7 @@
 
 /datum/crafting_recipe/burn_pack
 	name = "Burn Ointment"
-	result = /obj/item/stack/medical/ointment
+	result = /obj/item/stack/medical/ointment/one
 	time = 1
 	reqs = list(/obj/item/stack/medical/gauze = 1,
 				/datum/reagent/medicine/silver_sulfadiazine = 10)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -100,8 +100,6 @@
 
 	use(1)
 
-
-
 /obj/item/stack/medical/bruise_pack
 	name = "bruise pack"
 	singular_name = "bruise pack"
@@ -119,14 +117,14 @@
 
 /obj/item/stack/medical/gauze
 	name = "medical gauze"
-	desc = "A roll of elastic cloth that is extremely effective at stopping bleeding, but does not heal wounds."
+	desc = "A roll of elastic cloth that is extremely effective at stopping bleeding, heals minor bruising."
 	gender = PLURAL
 	singular_name = "medical gauze"
 	icon_state = "gauze"
 	stop_bleeding = 1800
+	heal_brute = 5 //Reminder that you can not stack healing thus you wait out the 1800 timer.
 	self_delay = 20
 	max_amount = 12
-
 
 /obj/item/stack/medical/gauze/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_WIRECUTTER || I.is_sharp())
@@ -150,6 +148,13 @@
 	singular_name = "improvised gauze"
 	desc = "A roll of cloth roughly cut from something that can stop bleeding, but does not heal wounds."
 	stop_bleeding = 900
+	heal_brute = 0
+
+/obj/item/stack/medical/gauze/adv
+	name = "sterilized medical gauze"
+	desc = "A roll of elastic sterilized cloth that is extremely effective at stopping bleeding, heals minor wounds and cleans them."
+	singular_name = "sterilized medical gauze"
+	self_delay = 5
 
 /obj/item/stack/medical/gauze/cyborg
 	materials = list()

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -111,6 +111,9 @@
 	self_delay = 20
 	grind_results = list(/datum/reagent/medicine/styptic_powder = 10)
 
+/obj/item/stack/medical/bruise_pack/one
+	amount = 1
+
 /obj/item/stack/medical/bruise_pack/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is bludgeoning [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (BRUTELOSS)
@@ -156,6 +159,9 @@
 	singular_name = "sterilized medical gauze"
 	self_delay = 5
 
+/obj/item/stack/medical/gauze/adv/one
+	amount = 1
+
 /obj/item/stack/medical/gauze/cyborg
 	materials = list()
 	is_cyborg = 1
@@ -172,6 +178,9 @@
 	heal_burn = 40
 	self_delay = 20
 	grind_results = list(/datum/reagent/medicine/silver_sulfadiazine = 10)
+
+/obj/item/stack/medical/ointment/one
+	amount = 1
 
 /obj/item/stack/medical/ointment/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is squeezing \the [src] into [user.p_their()] mouth! [user.p_do(TRUE)]n't [user.p_they()] know that stuff is toxic?</span>")


### PR DESCRIPTION

## About The Pull Request
Basic medical gauze will now heal just 5 brute damage, this isn't a lot meaning your likely still going to need to get to medical, this also is self-regulated as it will prevent you from laying gauze
You can now craft using gauze and chems new bruise packs / burn ointment 

## Why It's Good For The Game
Gauze as it is has only 2 main uses, one is to make damp rags for fire bombs or getting clothing. Its hard to not want to as soon as you craft your medical pack as an EMT or medical person just flat out not bother to keep a stack on you. Why is that? Well you have no real reason to ever use the Gauze as its a item that does not heal, just delays blood loss the only time you use it is if you are dragging a body if that, as a body bag prevents blood trails as well and is the same size.
Crafting allows people to get the chems used back into the burn/bruise packs for better healing if needed, as well as helps restock some peoples healing kits when needed rather then needing to run to cargo/venders.

Adv gauze just gives a sad chem that has little use outside surgery some love, and rewords players that think to upgrade their gear rather then just work with what they get round start.
Does NOT heal more nor do anything to fancy other then be faster to use on-self 

## Changelog
:cl:
add: New crafting for Medical patches such as bruise packs and burn ointment. As well as new type of Gauze!
add: Gauze now heal 5 brute, thats it. Makeshift heals 0
/:cl:
