### PR TITLE
Traitor uplink items rework

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -607,7 +607,7 @@
 	new /obj/item/ammo_box/magazine/pistolm9mm(src)
 	new /obj/item/ammo_box/magazine/pistolm9mm(src)
 	new /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka(src)
-	new /obj/item/reagent_containers/hypospray/medipen/stimulants(src)
+	new /obj/item/reagent_containers/hypospray/medipen/pumpup(src)
 	new /obj/item/grenade/syndieminibomb(src)
 
 // For ClownOps.

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -133,7 +133,7 @@
 			new /obj/item/ammo_box/magazine/m10mm/hp(src)
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/card/id/syndicate(src)
-			new /obj/item/reagent_containers/hypospray/medipen/stimulants(src)
+			new /obj/item/reagent_containers/hypospray/medipen/pumpup(src)
 			new /obj/item/reagent_containers/glass/rag(src)
 			new /obj/item/encryptionkey/syndicate(src)
 			
@@ -290,7 +290,7 @@
 		/obj/item/storage/box/syndie_kit/imp_radio,
 		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
 		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
-		/obj/item/reagent_containers/hypospray/medipen/stimulants,
+		/obj/item/reagent_containers/hypospray/medipen/pumpup,
 		/obj/item/compressionkit,
 		/obj/item/book/granter/martial/karate,
 		/obj/item/storage/box/syndie_kit/imp_freedom

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -12,6 +12,7 @@
 			new /obj/item/grenade/syndieminibomb/concussion/frag(src) // ~2 tc each?
 			new /obj/item/grenade/syndieminibomb/concussion/frag(src) 
 			new /obj/item/flashlight/emp(src)
+			new /obj/item/book/granter/martial/karate(src)
 
 		if("bloodyspai") 
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
@@ -54,6 +55,7 @@
 			new /obj/item/clothing/suit/space/syndicate/black/red(src)
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
 			new /obj/item/encryptionkey/syndicate(src)
+			new /obj/item/pen/edagger(src)
 
 		if("murder") 
 			new /obj/item/melee/transforming/energy/sword/saber(src)
@@ -81,6 +83,7 @@
 			new /obj/item/camera_bug(src)
 			new /obj/item/clothing/glasses/thermal/syndi(src)
 			new /obj/item/card/id/syndicate(src)
+			new /obj/item/pen/edagger(src)
 
 		if("lordsingulo") 
 			new /obj/item/sbeacondrop(src)
@@ -88,6 +91,7 @@
 			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
 			new /obj/item/card/emag(src)
 			new /obj/item/storage/toolbox/syndicate(src)
+			new /obj/item/pen/edagger(src)
 
 		if("sabotage") 
 			new /obj/item/grenade/plastic/c4 (src)
@@ -125,11 +129,13 @@
 			new /obj/item/gun/ballistic/automatic/pistol(src)
 			new /obj/item/suppressor(src)
 			new /obj/item/ammo_box/magazine/m10mm(src)
-			new /obj/item/ammo_box/magazine/m10mm(src)
+			new /obj/item/ammo_box/magazine/m10mm/ap(src)
+			new /obj/item/ammo_box/magazine/m10mm/hp(src)
 			new /obj/item/clothing/under/chameleon(src)
 			new /obj/item/card/id/syndicate(src)
 			new /obj/item/reagent_containers/hypospray/medipen/stimulants(src)
 			new /obj/item/reagent_containers/glass/rag(src)
+			new /obj/item/encryptionkey/syndicate(src)
 			
 		if("ninja") 
 			new /obj/item/katana(src) // Unique , hard to tell how much tc this is worth. 8 tc?
@@ -273,23 +279,21 @@
 	var/list/item_list = list(
 		/obj/item/storage/backpack/duffelbag/syndie/x4,
 		/obj/item/storage/box/syndie_kit/throwing_weapons,
-		/obj/item/gun/syringe/syndicate,
 		/obj/item/pen/edagger,
 		/obj/item/pen/sleepy,
-		/obj/item/flashlight/emp,
-		/obj/item/reagent_containers/syringe/mulligan,
+		/obj/item/storage/box/syndie_kit/emp,
 		/obj/item/clothing/shoes/chameleon/noslip,
 		/obj/item/storage/firstaid/tactical,
-		/obj/item/encryptionkey/syndicate,
+		/obj/item/encryptionkey/binary,
 		/obj/item/clothing/glasses/thermal/syndi,
 		/obj/item/slimepotion/slime/sentience/nuclear,
 		/obj/item/storage/box/syndie_kit/imp_radio,
-		/obj/item/storage/box/syndie_kit/imp_uplink,
 		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
 		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 		/obj/item/reagent_containers/hypospray/medipen/stimulants,
-		/obj/item/storage/box/syndie_kit/imp_freedom,
-		/obj/item/toy/eightball/haunted
+		/obj/item/compressionkit,
+		/obj/item/book/granter/martial/karate,
+		/obj/item/storage/box/syndie_kit/imp_freedom
 	)
 
 	var/obj/item1 = pick_n_take(item_list)

--- a/code/modules/clothing/shoes/taeclowndo.dm
+++ b/code/modules/clothing/shoes/taeclowndo.dm
@@ -13,8 +13,6 @@
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/H = user
-	if(!(HAS_TRAIT(src, TRAIT_CLUMSY)) && !(H.mind && H.mind.assigned_role == "Clown"))
-		return
 	if(slot == SLOT_SHOES)
 		spells = new
 		for(var/spell in spelltypes)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -934,6 +934,7 @@
 	..()
 	. = 1
 
+//Stimulants. Used in Adrenal Implant
 /datum/reagent/medicine/stimulants
 	name = "Stimulants"
 	description = "Increases stun resistance and movement speed in addition to restoring minor damage and weakness. Overdose causes weakness and toxin damage."
@@ -967,6 +968,43 @@
 		M.losebreath++
 		. = 1
 	..()
+
+
+//Pump-Up for Stimpack
+/datum/reagent/medicine/pumpup
+	name = "Pump-Up"
+	description = "Makes you immune to damage slowdown, resistant to all other kinds of slowdown and gives a minor speed boost. Overdose causes weakness and toxin damage."
+	color = "#78008C"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 60
+
+/datum/reagent/medicine/pumpup/on_mob_life(mob/living/carbon/M as mob)
+	M.AdjustAllImmobility(-80, FALSE)
+	M.adjustStaminaLoss(-80, 0)
+	M.Jitter(300)
+	..()
+	return TRUE
+
+/datum/reagent/medicine/pumpup/on_mob_metabolize(mob/living/L)
+	..()
+	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	ADD_TRAIT(L, TRAIT_STUNRESISTANCE, type)
+	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
+
+/datum/reagent/medicine/pumpup/on_mob_end_metabolize(mob/living/L)
+	..()
+	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
+	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
+
+/datum/reagent/medicine/pumpup/overdose_process(mob/living/M)
+	if(prob(33))
+		M.adjustStaminaLoss(2.5*REM, 0)
+		M.adjustToxLoss(1*REM, 0)
+		M.losebreath++
+		. = 1
+	..()
+
 
 /datum/reagent/medicine/insulin
 	name = "Insulin"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -175,14 +175,14 @@
 	desc = "A modified stimulants autoinjector for use in combat situations. Has a mild healing effect."
 	list_reagents = list(/datum/reagent/medicine/stimulants = 10, /datum/reagent/medicine/omnizine = 10)
 
-/obj/item/reagent_containers/hypospray/medipen/stimulants
-	name = "stimulant medipen"
-	desc = "Contains a very large amount of an incredibly powerful stimulant, vastly increasing your movement speed and reducing stuns by a very large amount for around five minutes. Do not take if pregnant."
+/obj/item/reagent_containers/hypospray/medipen/pumpup
+	name = "pumpup medipen"
+	desc = "Contains a very large amount of an incredibly powerful stimulant, vastly increasing your immunity and recovery from slowdowns for around five minutes. Do not take if pregnant."
 	icon_state = "syndipen"
 	item_state = "tbpen"
 	volume = 50
 	amount_per_transfer_from_this = 50
-	list_reagents = list(/datum/reagent/medicine/stimulants = 50)
+	list_reagents = list(/datum/reagent/medicine/pumpup = 50)
 
 /obj/item/reagent_containers/hypospray/medipen/morphine
 	name = "morphine medipen"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -425,7 +425,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be \
 			pocketed when inactive. Activating it produces a loud, distinctive noise."
 	item = /obj/item/melee/transforming/energy/sword/saber
-	cost = 10
+	cost = 8
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/dangerous/shield

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -592,7 +592,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A miniaturized version of a normal syringe gun. It is very quiet when fired and can fit into any \
 			space a small item can."
 	item = /obj/item/gun/syringe/syndicate
-	cost = 4
+	cost = 3
 	surplus = 50
 
 /datum/uplink_item/stealthy_weapons/dehy_carp
@@ -613,7 +613,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This scroll contains the secrets of the ancient martial arts technique of Karate. You will learn \
 			various ways to incapacitate and defeat downed foes."
 	item = /obj/item/book/granter/martial/karate
-	cost = 6
+	cost = 4
 	surplus = 40
 
 /datum/uplink_item/stealthy_weapons/martialarts
@@ -658,7 +658,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This box contains a guide on how to craft masterful works of origami, allowing you to transform normal pieces of paper into \
 			perfectly aerodynamic (and potentially lethal) paper airplanes."
 	item = /obj/item/storage/box/syndie_kit/origami_bundle
-	cost = 8
+	cost = 6
 	surplus = 20
 	exclude_modes = list(/datum/game_mode/nuclear) //clown ops intentionally left in, because that seems like some s-tier shenanigans.
 
@@ -666,7 +666,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Poison Kit"
 	desc = "An assortment of deadly chemicals packed into a compact box. Comes with a syringe for more precise application."
 	item = /obj/item/storage/box/syndie_kit/chemical
-	cost = 6
+	cost = 7
 	surplus = 50
 
 /datum/uplink_item/stealthy_weapons/romerol_kit
@@ -685,7 +685,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The pen holds one dose of the mixture, and can be refilled with any chemicals. Note that before the target \
 			falls asleep, they will be able to move and act."
 	item = /obj/item/pen/sleepy
-	cost = 4
+	cost = 5
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_weapons/suppressor
@@ -1019,7 +1019,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A pizza box with a bomb cunningly attached to the lid. The timer needs to be set by opening the box; afterwards, \
 			opening the box again will trigger the detonation after the timer has elapsed. Comes with free pizza, for you or your target!"
 	item = /obj/item/pizzabox/bomb
-	cost = 5
+	cost = 3
 	surplus = 8
 
 /datum/uplink_item/explosives/soap_clusterbang
@@ -1037,7 +1037,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			be defused, and some crew may attempt to do so. \
 			The bomb core can be pried out and manually detonated with other explosives."
 	item = /obj/item/sbeacondrop/bomb
-	cost = 11
+	cost = 12
 
 /datum/uplink_item/explosives/syndicate_detonator
 	name = "Syndicate Detonator"
@@ -1046,7 +1046,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Useful for when speed matters or you wish to synchronize multiple bomb blasts. Be sure to stand clear of \
 			the blast radius before using the detonator."
 	item = /obj/item/syndicatedetonator
-	cost = 3
+	cost = 1
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/explosives/syndicate_minibomb
@@ -1199,7 +1199,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Syndicate agents can be trained to use a series of codewords to convey complex information, which sounds like random concepts and drinks to anyone listening. \
 			This manual teaches you this Codespeak. You can also hit someone else with the manual in order to teach them. This is the deluxe edition, which has unlimited uses."
 	item = /obj/item/codespeak_manual/unlimited
-	cost = 3
+	cost = 2
 
 /datum/uplink_item/stealthy_tools/combatbananashoes
 	name = "Combat Banana Shoes"
@@ -1243,7 +1243,6 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	item = /obj/item/clothing/shoes/chameleon/noslip
 	cost = 3
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-	player_minimum = 15
 
 /datum/uplink_item/stealthy_tools/syndigaloshes/nuke
 	item = /obj/item/clothing/shoes/chameleon/noslip
@@ -1489,7 +1488,7 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \
 			5 minutes after injection."
 	item = /obj/item/reagent_containers/hypospray/medipen/stimulants
-	cost = 5
+	cost = 7
 	surplus = 90
 
 /datum/uplink_item/device_tools/medkit
@@ -1514,7 +1513,7 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	desc = "The Syndicate surgery duffel bag is a toolkit containing all surgery tools, surgical drapes, \
 			a Syndicate brand MMI, a straitjacket, and a muzzle."
 	item = /obj/item/storage/backpack/duffelbag/syndie/surgery
-	cost = 3
+	cost = 2
 
 /datum/uplink_item/device_tools/encryptionkey
 	name = "Syndicate Encryption Key"
@@ -1532,7 +1531,7 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 			of the originals, these inferior copies are still quite useful, being able to provide \
 			both weal and woe on the battlefield, even if they do occasionally bite off a finger."
 	item = /obj/item/storage/book/bible/syndicate
-	cost = 5
+	cost = 3
 
 /datum/uplink_item/device_tools/thermal
 	name = "Thermal Imaging Glasses"
@@ -1805,7 +1804,7 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 /datum/uplink_item/role_restricted/taeclowndo_shoes
 	name = "Tae-clown-do Shoes"
 	desc = "A pair of shoes for the most elite agents of the honkmotherland. They grant the mastery of taeclowndo with some honk-fu moves as long as they're worn."
-	cost = 14
+	cost = 12
 	item = /obj/item/clothing/shoes/clown_shoes/taeclowndo
 	restricted_roles = list("Clown")
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1485,10 +1485,10 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 
 /datum/uplink_item/device_tools/stimpack
 	name = "Stimpack"
-	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \
-			5 minutes after injection."
-	item = /obj/item/reagent_containers/hypospray/medipen/stimulants
-	cost = 7
+	desc = "Stimpacks, the tool for many great heroes, make you mostly immune to any form of slowdown (including damage slowdown) \
+			or stamina damage for about 5 minutes after injection."
+	item = /obj/item/reagent_containers/hypospray/medipen/pumpup
+	cost = 5
 	surplus = 90
 
 /datum/uplink_item/device_tools/medkit


### PR DESCRIPTION
## About The Pull Request
Lots of changes intended to spice up the meta and increase the diversity of traitor items bought again.

Full list of changes:
- Taeclowndo shoes can be used by anyone now, but still only bought by the Clown if not discounted.
- Taeclowndo shoes decreased from 14 to 12 TC
- Dart Gun decreased from 4 to 3 TC
- Boxed Origami Kit decreased from 8 to 6 TC
- Karate Scroll decreased from 6 to 4 TC
- Pizza Box Bomb decreased from 5 to 3 TC
- Codespeak Manual decreased from 3 to 2 TC
- Syndicate Tome decreased from 5 to 2 TC
- Syndicate Surgery Duffel Bag decreased from 3 to 2 TC
- Energy Sword decreased from 10 to 8 TC
- Syndicate Bomb increased from 11 to 12 TC
- Poison Kit increased from 6 to 7 TC
- Sleepy Pen increased from 4 to 5 TC
- Contract Kit random starting items list changes:
  - Removed: Magic eightball, EMP flashlight, uplink implant, syndicate encryption key (radio implant still kepy in), Mulligan, dart pistol
  - Added: Bluespace compression kit, Karate scroll, EMP kit, binary key
- Syndi-Kit Tactical (A) changes:
  - "Screwed" (syndibomb/powersink), "Lord Singulo" and "Hacker" kits get an energy dagger as they were lacky in any personal self-defence options. 
  - Recon kit gets a Karate scroll.
- Syndi-Kit Special (B) changes:
  - Bond kit gets 1 hollowpoint mag, 1 armor-piercing, and 1 standard 10mm instead of 2x standard 10mm. Also gets a Syndi encryption key
- Also for nukies Syndicate Detonator decreased from 3 to 1 TC since they already get one for free so it's never bought at 3 TC
- Stimpack now uses Pump-Up instead of Stimulants. This makes you immune to damage slowdown, recover 80% faster from stuns/slips/knockdowns and gain 80 stamina regen. Also makes you jitter quite a bit.

## Why It's Good For The Game
Encourages a greater variety of traitor loadouts, which keeps rounds from feeling repetitive.

## Changelog
:cl:
balance: Lots of traitor item costs rebalanced.
balance: Taeclowndo shoes now usable by anyone, but still can only be bought by Clown if not discounted.
balance: Stimpack now uses Pump-Up instead of Stimulants. This makes you immune to damage slowdown, recover 80% faster from stuns/slips/knockdowns and gain 80 stamina regen. Also makes you jitter quite a bit. 
balance: Player minimum requirement for No-Slips removed. 
balance: Contract Kit has it's set of random items tweaked. 
baalnce: Syndi-Kit Tactical also gets an energy dagger or Karate scroll in several of their kits.
balance: Syndi-Kit Special "Bond" kit gets a diversity of magazines and a syndi encryption key.
/:cl: