### PR TITLE
flashbang changes

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -26,11 +26,11 @@
 
 //Flash
 	if(M.flash_act(affect_silicon = 1))
-		M.Paralyze(max(200/max(1,distance), 60))
+		M.confused += (max(20/max(1,distance), 6))
 //Bang
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		M.Paralyze(200)
+		var/protection = M.get_ear_protection()
+		M.adjustEarDamage(15/protection, 30/protection)
 		M.soundbang_act(1, 200, 10, 15)
-
 	else
-		M.soundbang_act(1, max(200/max(1,distance), 60), rand(0, 5))
+		M.soundbang_act(1, max(200/max(1,distance), 60), rand(3))

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -93,7 +93,6 @@
 	name = "cat ears"
 	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "kitty"
-	damage_multiplier = 2
 	bang_protect = -2
 
 /obj/item/organ/ears/cat/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)


### PR DESCRIPTION

## About The Pull Request
-instead of a 20 second paralyze on top of flashbang effects on anyone in the tile the flashbang detonates, flashbangs now inflict incredible ear damage and deafness instead. No more flashbang elance stunbatons.
-The flash component of the flashbang causes confusion instead of stunning. The bang effect will still stun
-Felinids will no longer take double ear damage. The -2 hearing protection was enough, Now, there is no excuse to rush ear protection

## Why It's Good For The Game
flashbang elance hardstuns gay.

## Changelog
:cl:
tweak: felinids no longer take double ear damage, just -2 ear protection. No more excuse to rush earmuffs and a helmet
tweak: flashbangs no longer hardstun everyone on their tile, and deal high deafness and ear damage instead. The flash component confuses instead of stunning, but the bang component is unchanged
/:cl:
