### PR TITLE
Some viro QoL stuff

### DIFF
--- a/code/__DEFINES/diseases.dm
+++ b/code/__DEFINES/diseases.dm
@@ -18,6 +18,7 @@
 #define DISEASE_SPREAD_CONTACT_FLUIDS	(1<<3)
 #define DISEASE_SPREAD_CONTACT_SKIN 	(1<<4)
 #define DISEASE_SPREAD_AIRBORNE			(1<<5)
+#define DISEASE_SPREAD_FALTERED			(1<<6)
 
 //! ## Severity Defines
 #define DISEASE_SEVERITY_BENEFICIAL "Beneficial"//! Symptoms that are very beneficial, whose benefits far outweigh downsides

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -34,6 +34,7 @@
 	var/mutable = TRUE //set to FALSE to prevent most in-game methods of altering the disease via virology
 	var/oldres
 	var/sentient = FALSE //used to classify if a disease is sentient
+	var/faltered = FALSE //used if a disease has been made non-contagious
 	// The order goes from easy to cure to hard to cure.
 	var/static/list/advance_cures = 	list(
 																/datum/reagent/consumable/sugar, /datum/reagent/consumable/ethanol, /datum/reagent/consumable/sodiumchloride, 
@@ -239,25 +240,29 @@
 
 // Assign the spread type and give it the correct description.
 /datum/disease/advance/proc/SetSpread(spread_id)
-	switch(spread_id)
-		if(DISEASE_SPREAD_NON_CONTAGIOUS)
-			spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-			spread_text = "None"
-		if(DISEASE_SPREAD_SPECIAL)
-			spread_flags = DISEASE_SPREAD_SPECIAL
-			spread_text = "None"
-		if(DISEASE_SPREAD_BLOOD)
-			spread_flags = DISEASE_SPREAD_BLOOD
-			spread_text = "Blood"
-		if(DISEASE_SPREAD_CONTACT_FLUIDS)
-			spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS
-			spread_text = "Fluids"
-		if(DISEASE_SPREAD_CONTACT_SKIN)
-			spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN
-			spread_text = "On contact"
-		if(DISEASE_SPREAD_AIRBORNE)
-			spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_AIRBORNE
-			spread_text = "Airborne"
+	if(faltered)
+		spread_flags = DISEASE_SPREAD_FALTERED
+		spread_text = "Intentional Injection"
+	else
+		switch(spread_id)
+			if(DISEASE_SPREAD_NON_CONTAGIOUS)
+				spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+				spread_text = "None"
+			if(DISEASE_SPREAD_SPECIAL)
+				spread_flags = DISEASE_SPREAD_SPECIAL
+				spread_text = "None"
+			if(DISEASE_SPREAD_BLOOD)
+				spread_flags = DISEASE_SPREAD_BLOOD
+				spread_text = "Blood"
+			if(DISEASE_SPREAD_CONTACT_FLUIDS)
+				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS
+				spread_text = "Fluids"
+			if(DISEASE_SPREAD_CONTACT_SKIN)
+				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN
+				spread_text = "On contact"
+			if(DISEASE_SPREAD_AIRBORNE)
+				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_AIRBORNE
+				spread_text = "Airborne"
 
 /datum/disease/advance/proc/SetSeverity(level_sev)
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -121,6 +121,7 @@
 	A.properties = properties.Copy()
 	A.id = id
 	A.mutable = mutable
+	A.faltered = faltered
 	//this is a new disease starting over at stage 1, so processing is not copied
 	return A
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -289,7 +289,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	var/bigsweat = FALSE
 	var/toxheal = FALSE
 	threshold_desc = "<b>transmission 6:</b> The sweat production ramps up to the point that it puts out fires in the general vicinity<br>\
-					<b>transmission 8:</b> The EMP affects electronics adjacent to the subject as well."
+					<b>transmission 8:</b> The symptom heals toxin damage and purges chemicals."
 
 /datum/symptom/sweat/severityset(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/lubefeet.dm
+++ b/code/datums/diseases/advance/symptoms/lubefeet.dm
@@ -3,7 +3,7 @@
 	desc = "The host now sweats industrial lubricant from their feet, lubing tiles they walk on. Combine with Pierrot's throat for the penultimate form of torture."
 	stealth = 0
 	resistance = 0
-	stage_speed = 4
+	stage_speed = 5
 	transmittable = -2
 	level = 9
 	severity = 2

--- a/code/datums/diseases/advance/symptoms/spiked.dm
+++ b/code/datums/diseases/advance/symptoms/spiked.dm
@@ -23,7 +23,7 @@ Thresholds
 	level = 0
 	symptom_delay_min = 1
 	symptom_delay_max = 1
-	severity = 2
+	severity = 1
 	base_message_chance = 5
 	var/Power = 1
 	var/get_damage = 0
@@ -37,15 +37,15 @@ Thresholds
 
 /datum/symptom/spiked/severityset(datum/disease/advance/A)
 	. = ..()
-	if(A.properties["transmittable"] >= 6)
+	if(A.properties["resistance"] >= 6)
 		severity -= 1
 
 /datum/symptom/spiked/Start(datum/disease/advance/A)
 	if(!..())
 		return
-	if(A.properties["transmittable"] >= 6) //armor
+	if(A.properties["resistance"] >= 6) //armor
 		armour = TRUE
-	if(A.properties["resistance"] >= 6) //higher damage
+	if(A.properties["transmittable"] >= 6) //higher damage
 		Power = 2
 
 /datum/symptom/spiked/Activate(var/datum/disease/advance/A)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -143,7 +143,7 @@
 				if(blood_data["viruses"])
 					for(var/thing in blood_data["viruses"])
 						var/datum/disease/D = thing
-						if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+						if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS)|| (D.spread_flags & DISEASE_SPREAD_FALTERED))
 							continue
 						C.ForceContractDisease(D)
 				if(!(blood_data["blood_type"] in get_safe_blood(C.dna.blood_type)))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -49,15 +49,21 @@
 			var/list/to_mix = list()
 
 			for(var/datum/disease/advance/AD in mix1)
-				to_mix += AD
+				if(AD.mutable)
+					to_mix += AD
 			for(var/datum/disease/advance/AD in mix2)
-				to_mix += AD
+				if(AD.mutable)
+					to_mix += AD
 
 			var/datum/disease/advance/AD = Advance_Mix(to_mix)
 			if(AD)
 				var/list/preserve = list(AD)
 				for(var/D in data["viruses"])
-					if(!istype(D, /datum/disease/advance))
+					if(istype(D, /datum/disease/advance))
+						var/datum/disease/advance/A = D
+						if(!A.mutable)
+							preserve += A
+					else 
 						preserve += D
 				data["viruses"] = preserve
 	return 1

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -217,19 +217,19 @@
 	name = "Unstable uranium gel"
 	id = "uraniumvirusfood_plasma"
 	results = list(/datum/reagent/uranium/uraniumvirusfood/unstable = 1)
-	required_reagents = list(/datum/reagent/uranium = 5, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
+	required_reagents = list(/datum/reagent/uranium = 2, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
 
 /datum/chemical_reaction/virus_food_uranium_plasma_gold
 	name = "Stable uranium gel"
 	id = "uraniumvirusfood_gold"
 	results = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
-	required_reagents = list(/datum/reagent/uranium = 10, /datum/reagent/gold = 10, /datum/reagent/toxin/plasma = 1)
+	required_reagents = list(/datum/reagent/uranium = 5, /datum/reagent/gold = 5, /datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/virus_food_uranium_plasma_silver
 	name = "Stable uranium gel"
 	id = "uraniumvirusfood_silver"
 	results = list(/datum/reagent/uranium/uraniumvirusfood/stable = 1)
-	required_reagents = list(/datum/reagent/uranium = 10, /datum/reagent/silver = 10, /datum/reagent/toxin/plasma = 1)
+	required_reagents = list(/datum/reagent/uranium = 5, /datum/reagent/silver = 5, /datum/reagent/toxin/plasma = 5)
 
 /datum/chemical_reaction/virus_food_laughter
 	name = "Anomolous virus food"
@@ -395,6 +395,33 @@
 		if(D)
 			D.Neuter()
 
+/datum/chemical_reaction/mix_virus/preserve_virus
+	name = "Preserve Virus"
+	id = "preservevirus"
+	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1)
+	required_catalysts = list(/datum/reagent/blood = 1)
+
+/datum/chemical_reaction/mix_virus/preserve_virus/on_reaction(datum/reagents/holder, created_volume)
+
+	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
+	if(B?.data)
+		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
+		if(D)
+			D.mutable = FALSE
+
+/datum/chemical_reaction/mix_virus/falter_virus
+	name = "Falter Virus"
+	id = "faltervirus"
+	required_reagents = list(/datum/reagent/medicine/spaceacillin = 1)
+	required_catalysts = list(/datum/reagent/blood = 1)
+
+/datum/chemical_reaction/mix_virus/falter_virus/on_reaction(datum/reagents/holder, created_volume)
+
+	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
+	if(B?.data)
+		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
+		if(D)
+			D.faltered = TRUE
 
 
 ////////////////////////////////// foam and foam precursor ///////////////////////////////////////////////////

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -422,6 +422,8 @@
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
 			D.faltered = TRUE
+			D.spread_flags = DISEASE_SPREAD_FALTERED
+			D.spread_text = "Intentional Injection"
 
 
 ////////////////////////////////// foam and foam precursor ///////////////////////////////////////////////////

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -29,7 +29,8 @@
 	contraband = list(/obj/item/reagent_containers/pill/tox = 3,
 		              /obj/item/reagent_containers/pill/morphine = 4,
 		              /obj/item/reagent_containers/pill/charcoal = 6,
-		              /obj/item/storage/box/hug/medical = 1)
+		              /obj/item/storage/box/hug/medical = 1,
+					  /obj/item/reagent_containers/glass/bottle/random_virus = 1)
 	premium = list(/obj/item/reagent_containers/medspray/synthflesh = 2,
 		           /obj/item/storage/pill_bottle/psicodine = 2,
 		           /obj/item/reagent_containers/hypospray/medipen = 3,


### PR DESCRIPTION

## About The Pull Request
includes/requires [#1697]
-2 new virus reactions: Preserve and Falter
**Preserve** makes a disease unmutateable, effectively freezing it as-is. The main intent of this is to allow more than one disease in a bottle. Preserving is done by mixing a disease with cryoaxadone
**Falter** makes a disease non-contagious, and only spread via injection. This allows for a virologist to use diseases with transmission thresholds and make meme diseases without fear of hurting the entire crew. Faltering is done by mixing a disease with spaceacillin
-medivends now have one experimental disease when hacked.
-uranium virus food recipes have been changed to make them more convenient to mix, and make virologists drain less uranium from the autolathe. The current recipes are balanced for old level 7 and 8 symptoms, which have since been changed
**unstable uranium gel** now only needs 2u uranium per 1u virus plasma, or 1 sheet of uranium mixed with 10u virus plasma. This is easy and quick to mix, unlike the akward 4u virus plasma calculation currently used
**stable uranium gel** now uses  5u of each reagent, a simple mix of 1 sheet of each material in the grinder.
-various symptom tweaks
## Why It's Good For The Game
general quality of life shit is always good

## Changelog
:cl:
add: Virus preservation- add cryoxadone to a disease to make it immutable
add: Virus Faltering- add spaceacillin to a disease to make it unable to spread
tweak: some small stat changes to symptoms
tweak: hacked medivends now have one experimental disease bottle
tweak: made uranium virus foods more convenient to mix
/:cl:

