### PR TITLE
Lavaland shuttle fix + Some other fix

### DIFF
--- a/code/game/objects/items/shuttle_creator.dm
+++ b/code/game/objects/items/shuttle_creator.dm
@@ -217,7 +217,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	port.linkup(new_shuttle, stationary_port)
 
 	port.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
-	port.initiate_docking(stationary_port, old_area_override = overwritten_area)
+	port.initiate_docking(stationary_port)
 
 	port.mode = SHUTTLE_IDLE
 	port.timer = 0

--- a/code/game/objects/items/shuttle_creator.dm
+++ b/code/game/objects/items/shuttle_creator.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	resistance_flags = FIRE_PROOF
 	var/ready = TRUE
 	var/recorded_shuttle_area
+	var/overwritten_area = /area/space
 	var/list/loggedTurfs = list()
 	var/loggedOldArea
 	var/linkedShuttleId
@@ -177,6 +178,8 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	port.preferred_direction = 4
 	port.area_type = recorded_shuttle_area
 
+	stationary_port.area_type = overwritten_area
+
 	var/portDirection = getNonShuttleDirection(get_turf(port))
 	var/invertedDir = invertDir(portDirection)
 	if(!portDirection || !invertedDir)
@@ -214,7 +217,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 	port.linkup(new_shuttle, stationary_port)
 
 	port.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
-	port.initiate_docking(stationary_port, old_area_override = loggedOldArea)
+	port.initiate_docking(stationary_port, old_area_override = overwritten_area)
 
 	port.mode = SHUTTLE_IDLE
 	port.timer = 0
@@ -301,7 +304,11 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 		if(!place)
 			to_chat(usr, "<span class='warning'>You can't seem to overpower the bluespace harmonics in this location, try somewhere else.</span>")
 			return FALSE
-		if(!istype(place, /area/space) && !istype(place, /area/lavaland))
+		if(istype(place, /area/space))
+			overwritten_area = /area/space
+		else if(istype(place, /area/lavaland/surface/outdoors))
+			overwritten_area = /area/lavaland/surface/outdoors
+		else
 			to_chat(usr, "<span class='warning'>Caution, shuttle must not use any material connected to the station. Your shuttle is currenly overlapping with [place.name]</span>")
 			return FALSE
 	return TRUE

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -1,5 +1,5 @@
 /// This is the main proc. It instantly moves our mobile port to stationary port `new_dock`.
-/obj/docking_port/mobile/proc/initiate_docking(obj/docking_port/stationary/new_dock, movement_direction, force=FALSE, old_area_override=SHUTTLE_DEFAULT_UNDERLYING_AREA)
+/obj/docking_port/mobile/proc/initiate_docking(obj/docking_port/stationary/new_dock, movement_direction, force=FALSE)
 	// Crashing this ship with NO SURVIVORS
 	if(new_dock.get_docked() == src)
 		remove_ripples()
@@ -16,7 +16,7 @@
 	var/obj/docking_port/stationary/old_dock = get_docked()
 
 	// The area that gets placed under where the shuttle moved from
-	var/underlying_area_type = old_area_override
+	var/underlying_area_type = SHUTTLE_DEFAULT_UNDERLYING_AREA
 
 	if(old_dock) //Dock overwrites
 		underlying_area_type = old_dock.area_type

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -1,5 +1,5 @@
 /// This is the main proc. It instantly moves our mobile port to stationary port `new_dock`.
-/obj/docking_port/mobile/proc/initiate_docking(obj/docking_port/stationary/new_dock, movement_direction, force=FALSE)
+/obj/docking_port/mobile/proc/initiate_docking(obj/docking_port/stationary/new_dock, movement_direction, force=FALSE, old_area_override=SHUTTLE_DEFAULT_UNDERLYING_AREA)
 	// Crashing this ship with NO SURVIVORS
 	if(new_dock.get_docked() == src)
 		remove_ripples()
@@ -16,7 +16,7 @@
 	var/obj/docking_port/stationary/old_dock = get_docked()
 
 	// The area that gets placed under where the shuttle moved from
-	var/underlying_area_type = SHUTTLE_DEFAULT_UNDERLYING_AREA
+	var/underlying_area_type = old_area_override
 
 	if(old_dock) //Dock overwrites
 		underlying_area_type = old_dock.area_type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/1514


## About The Pull Request

Shuttles can now be created on lavaland, and on take off the area will be restored to lavaland wastes (meaning you can make shuttles and not delete the ash storm effect there).

There is now a second check after you choose an area to make sure the area doesn't change while you were choosing an airlock. (You made the shuttle in a docking area and another shuttle docked with the area). This will now force you to re-select the area

## Why It's Good For The Game

bug man bad.

## Changelog
:cl:
tweak: Shuttles can now be built on lavaland
fix: You cannot define other shuttles as a custom shuttle if they fly into the shuttle area before you define it as a shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
