### PR TITLE
Updates actions to only run within our repository

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -9,6 +9,7 @@ jobs:
   compile:
     name: "Compile changelogs"
     runs-on: ubuntu-latest
+    if: github.repository == 'BeeStation/BeeStation-Hornet'
     steps:
       - name: "Setup python"
         uses: actions/setup-python@v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,11 +5,9 @@ on:
     - cron: 0 0 * * *
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
+    if: github.repository == 'BeeStation/BeeStation-Hornet'
     steps:
     - uses: actions/checkout@v2
     - name: Publish to Registry

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -6,9 +6,8 @@ on:
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-
+    if: github.repository == 'BeeStation/BeeStation-Hornet'
     steps:
     - uses: actions/stale@v1
       with:

--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -6,9 +6,8 @@ on:
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-
+    if: github.repository == 'BeeStation/BeeStation-Hornet'
     steps:
     - uses: actions/stale@v1
       with:


### PR DESCRIPTION
This should spare any forks from having to manually disable actions. It'll also stop all those emails about how a scheduled action failed to run due to missing secrets.