### PR TITLE
Researchable Smartmines + Exploding Rubber Duck traitor item

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -10,8 +10,21 @@
 	mine_type = /obj/effect/mine/stun
 
 /obj/item/deployablemine/smartstun
+	name = "deployable smart mine"
 	desc = "An unarmed smart stun mine. It can be planted to arm it."
 	mine_type = /obj/effect/mine/stun/smart
+
+/obj/item/deployablemine/lm6
+	name = "unarmed LM-6 Rapid Deployment Mine"
+	desc = "An unarmed smart stun mine designed to be rapidly placeable."
+	mine_type = /obj/effect/mine/stun/smart/adv
+	arming_time = 10
+
+/obj/item/deployablemine/lm12
+	name = "unarmed LM-12 Sledgehammer Mine"
+	desc = "An unarmed smart heavy stun mine designed to be hard to disarm."
+	mine_type = /obj/effect/mine/stun/smart/heavy
+	arming_time = 50
 
 /obj/item/deployablemine/explosive
 	mine_type = /obj/effect/mine/explosive
@@ -79,6 +92,14 @@
 	icon_state = "uglymine"
 	var/triggered = 0
 	var/smartmine = 0
+	var/disarm_time = 70
+
+/obj/effect/mine/attackby(obj/I, mob/user, params)
+	if(istype(I, /obj/item/multitool))
+		to_chat(user, "You begin to disarm the [src]")
+		if(do_after(user, disarm_time, target = src))
+			to_chat(user, "You disarm the [src]")
+			qdel(src)
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
 	to_chat(victim, "<span class='danger'>*click*</span>")
@@ -145,14 +166,26 @@
 /obj/effect/mine/stun
 	name = "stun mine"
 	var/stun_time = 120
+	var/damage = 0
 
 /obj/effect/mine/stun/smart
 	name = "smart stun mine"
+	desc = "An advanced mine with IFF features, capable of ignoring people with mindshield implants."
 	smartmine = 1
 
+/obj/effect/mine/stun/smart/adv
+	name = "LM-6 Rapid Deployment Mine"
+	disarm_time = 50
+
+/obj/effect/mine/stun/smart/heavy
+	name = "LM-12 Sledgehammer Mine"
+	disarm_time = 120
+	stun_time = 180
+	damage = 40
 /obj/effect/mine/stun/mineEffect(mob/living/victim)
 	if(isliving(victim))
-		victim.Paralyze(stun_time)
+		victim.adjustStaminaLoss(stun_time)
+		victim.adjustBruteLoss(damage)
 
 /obj/effect/mine/kickmine
 	name = "kick mine"

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -3,6 +3,7 @@
 	desc = "An unarmed landmine. It can be planted to arm it."
 	icon_state = "uglymine"
 	var/mine_type = /obj/effect/mine
+	var/arming_time = 30
 
 /obj/item/deployablemine/stun
 	desc = "An unarmed stun mine. It can be planted to arm it."
@@ -32,8 +33,26 @@
 	desc = "A pressure activated explosive disguised as a rubber duck. Plant it to arm. This version is fitted with high yield X4 for a larger blast."
 	mine_type = /obj/effect/mine/explosive/traitor/bigboom
 
+/obj/item/deployablemine/gas
+	name = "oxygen gas mine"
+	desc = "An unarmed mine that releases oxygen into the air when triggered. Pretty pointless huh."
+	mine_type = /obj/effect/mine/gas
+
+/obj/item/deployablemine/plasma
+	name = "incendiary mine"
+	desc = "An unarmed mine that releases plasma into the air when triggered, then ignites it."
+	mine_type = /obj/effect/mine/gas/plasma
+
+/obj/item/deployablemine/sleepy
+	name = "knockout mine"
+	desc = "An unarmed mine that releases N2O into the air when triggered. Nighty Night!"
+	mine_type = /obj/effect/mine/gas/n2o
+
 /obj/item/deployablemine/afterattack(atom/plantspot, mob/user, proximity)
 	if(!proximity)
+		return
+
+	if(!istype(plantspot,/turf/open)) // you can't plant a mine inside a wall or on a mob
 		return
 
 	if(isspaceturf(plantspot))
@@ -43,10 +62,13 @@
 	if((istype(plantspot,/turf/open/lava)) || (istype(plantspot,/turf/open/chasm)))
 		to_chat(user, "<span class='warning'>You can't plant the mine here!</span>")
 		return
-	new mine_type(plantspot)
-	to_chat(user, "You plant and arm the [src].")
-	log_combat(user, src, "planted and armed")
-	qdel(src)
+
+	to_chat(user, "You start arming the [src]...")
+	if(do_after(user, arming_time, target = src))
+		new mine_type(plantspot)
+		to_chat(user, "You plant and arm the [src].")
+		log_combat(user, src, "planted and armed")
+		qdel(src)
 
 /obj/effect/mine
 	name = "dummy mine"
@@ -151,12 +173,12 @@
 
 
 /obj/effect/mine/gas/plasma
-	name = "plasma mine"
+	name = "incendiary mine"
 	gas_type = "plasma"
 
 
 /obj/effect/mine/gas/n2o
-	name = "\improper N2O mine"
+	name = "knockout mine"
 	gas_type = "n2o"
 
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -14,14 +14,15 @@
 	desc = "An unarmed smart stun mine. It can be planted to arm it."
 	mine_type = /obj/effect/mine/stun/smart
 
-/obj/item/deployablemine/lm6
-	name = "unarmed LM-6 Rapid Deployment Mine"
+/obj/item/deployablemine/rapid
+	name = "deployable rapid smart mine"
 	desc = "An unarmed smart stun mine designed to be rapidly placeable."
 	mine_type = /obj/effect/mine/stun/smart/adv
 	arming_time = 10
+	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/deployablemine/lm12
-	name = "unarmed LM-12 Sledgehammer Mine"
+/obj/item/deployablemine/heavy
+	name = "deployable sledgehammer smart mine"
 	desc = "An unarmed smart heavy stun mine designed to be hard to disarm."
 	mine_type = /obj/effect/mine/stun/smart/heavy
 	arming_time = 50
@@ -40,6 +41,7 @@
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "rubberducky"
 	mine_type = /obj/effect/mine/explosive/traitor
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/deployablemine/traitor/bigboom
 	name = "high yield exploding rubber duck"
@@ -100,7 +102,7 @@
 		to_chat(user, "<span class='notice'>You begin to disarm the [src]...</span>")
 		if(do_after(user, disarm_time, target = src))
 			to_chat(user, "<span class='notice'>You disarm the [src].</span>")
-			new disarm_product(user.loc)
+			new disarm_product(src.loc)
 			qdel(src)
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
@@ -182,16 +184,16 @@
 	disarm_product = /obj/item/deployablemine/smartstun
 
 /obj/effect/mine/stun/smart/adv
-	name = "LM-6 Rapid Deployment Mine"
+	name = "rapid smart mine"
 	disarm_time = 120
-	disarm_product = /obj/item/deployablemine/lm6
+	disarm_product = /obj/item/deployablemine/rapid
 
 /obj/effect/mine/stun/smart/heavy
-	name = "LM-12 Sledgehammer Mine"
+	name = "sledgehammer smart mine"
 	disarm_time = 350
 	stun_time = 230
 	damage = 40
-	disarm_product = /obj/item/deployablemine/lm12
+	disarm_product = /obj/item/deployablemine/heavy
 
 
 /obj/effect/mine/stun/mineEffect(mob/living/victim)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -76,10 +76,10 @@
 		to_chat(user, "<span class='warning'>You can't plant the mine here!</span>")
 		return
 
-	to_chat(user, "You start arming the [src]...")
+	to_chat(user, "<span class='notice'>You start arming the [src]...</span>")
 	if(do_after(user, arming_time, target = src))
 		new mine_type(plantspot)
-		to_chat(user, "You plant and arm the [src].")
+		to_chat(user, "<span class='notice'>You plant and arm the [src].</span>")
 		log_combat(user, src, "planted and armed")
 		qdel(src)
 
@@ -92,13 +92,15 @@
 	icon_state = "uglymine"
 	var/triggered = 0
 	var/smartmine = 0
-	var/disarm_time = 70
+	var/disarm_time = 200
+	var/disarm_product = /obj/item/deployablemine // ie what drops when the mine is disarmed
 
 /obj/effect/mine/attackby(obj/I, mob/user, params)
 	if(istype(I, /obj/item/multitool))
-		to_chat(user, "You begin to disarm the [src]")
+		to_chat(user, "<span class='notice'>You begin to disarm the [src]...</span>")
 		if(do_after(user, disarm_time, target = src))
-			to_chat(user, "You disarm the [src]")
+			to_chat(user, "<span class='notice'>You disarm the [src].</span>")
+			new disarm_product(user.loc)
 			qdel(src)
 
 /obj/effect/mine/proc/mineEffect(mob/victim)
@@ -138,6 +140,7 @@
 	var/range_heavy = 1
 	var/range_light = 2
 	var/range_flash = 3
+	disarm_product = /obj/item/deployablemine/explosive
 
 /obj/effect/mine/explosive/traitor
 	name = "rubber ducky"
@@ -148,13 +151,15 @@
 	range_heavy = 2
 	range_light = 3
 	range_flash = 4
+	disarm_time = 400
+	disarm_product = /obj/item/deployablemine/traitor
 
 /obj/effect/mine/explosive/traitor/bigboom
 	range_devastation = 2
 	range_heavy = 4
 	range_light = 8
 	range_flash = 6
-
+	disarm_product = /obj/item/deployablemine/traitor/bigboom
 
 /obj/effect/mine/explosive/mineEffect(mob/victim)
 	explosion(loc, range_devastation, range_heavy, range_light, range_flash)
@@ -165,23 +170,30 @@
 
 /obj/effect/mine/stun
 	name = "stun mine"
-	var/stun_time = 120
+	var/stun_time = 150
 	var/damage = 0
+	disarm_product = /obj/item/deployablemine/stun
 
 /obj/effect/mine/stun/smart
 	name = "smart stun mine"
 	desc = "An advanced mine with IFF features, capable of ignoring people with mindshield implants."
 	smartmine = 1
+	disarm_time = 250
+	disarm_product = /obj/item/deployablemine/smartstun
 
 /obj/effect/mine/stun/smart/adv
 	name = "LM-6 Rapid Deployment Mine"
-	disarm_time = 50
+	disarm_time = 120
+	disarm_product = /obj/item/deployablemine/lm6
 
 /obj/effect/mine/stun/smart/heavy
 	name = "LM-12 Sledgehammer Mine"
-	disarm_time = 120
-	stun_time = 180
+	disarm_time = 350
+	stun_time = 230
 	damage = 40
+	disarm_product = /obj/item/deployablemine/lm12
+
+
 /obj/effect/mine/stun/mineEffect(mob/living/victim)
 	if(isliving(victim))
 		victim.adjustStaminaLoss(stun_time)
@@ -200,6 +212,7 @@
 	name = "oxygen mine"
 	var/gas_amount = 360
 	var/gas_type = "o2"
+	disarm_product = /obj/item/deployablemine/gas
 
 /obj/effect/mine/gas/mineEffect(mob/victim)
 	atmos_spawn_air("[gas_type]=[gas_amount]")
@@ -208,17 +221,20 @@
 /obj/effect/mine/gas/plasma
 	name = "incendiary mine"
 	gas_type = "plasma"
+	disarm_product = /obj/item/deployablemine/plasma
 
 
 /obj/effect/mine/gas/n2o
 	name = "knockout mine"
 	gas_type = "n2o"
-
+	disarm_product = /obj/item/deployablemine/sleepy
 
 /obj/effect/mine/sound
 	name = "honkblaster 1000"
 	var/sound = 'sound/items/bikehorn.ogg'
 	var/volume = 150
+	disarm_time = 1200 // very long disarm time to expand the annoying factor
+	disarm_time = /obj/item/deployablemine/honk
 
 /obj/effect/mine/sound/mineEffect(mob/victim)
 	playsound(loc, sound, volume, 1)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -31,8 +31,8 @@
 	mine_type = /obj/effect/mine/explosive
 
 /obj/item/deployablemine/honk
-	name = "unarmed honkblaster 1000"
-	desc = "An advanced pranking landmine for clowns, honk! Delivers a harmless extra loud HONK to the head when triggered. It can be planted to arm it."
+	name = "deployable honkblaster 1000"
+	desc = "An advanced pranking landmine for clowns, honk! Delivers an extra loud HONK to the head when triggered. It can be planted to arm it, or have its sound customised with a sound synthesiser."	
 	mine_type = /obj/effect/mine/sound
 
 /obj/item/deployablemine/traitor
@@ -234,18 +234,22 @@
 /obj/effect/mine/sound
 	name = "honkblaster 1000"
 	var/sound = 'sound/items/bikehorn.ogg'
-	var/volume = 150
+	var/volume = 100
 	disarm_time = 1200 // very long disarm time to expand the annoying factor
-	disarm_time = /obj/item/deployablemine/honk
+	disarm_product = /obj/item/deployablemine/honk
 
 /obj/effect/mine/sound/mineEffect(mob/victim)
 	playsound(loc, sound, volume, 1)
 
+/obj/effect/mine/sound/attackby(obj/item/soundsynth/J, mob/user, params)
+	if(istype(J, /obj/item/soundsynth))
+		to_chat(user, "<span class='notice'>You change the sound settings of the [src].</span>")
+		sound = J.selected_sound
+		
 
 /obj/effect/mine/sound/bwoink
 	name = "bwoink mine"
 	sound = 'sound/effects/adminhelp.ogg'
-	volume = 100
 
 /obj/effect/mine/pickup
 	name = "pickup"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -666,7 +666,25 @@
 	for(var/i in 1 to 10)
 		var/item = pick(contains)
 		new item(C)
+/datum/supply_pack/security/armory/smartmine
+	name = "Smart Mine Crate"
+	desc = "Contains three nonlethal pressure activated stun mines capable of ignoring mindshieled personnel. Requires Armory access to open."
+	cost = 4000
+	contains = list(/obj/item/deployablemine/smartstun,					
+					/obj/item/deployablemine/smartstun,
+					/obj/item/deployablemine/smartstun)
+	crate_name = "stun mine create"
 
+/datum/supply_pack/security/armory/stunmine
+	name = "Stun Mine Crate"
+	desc = "Contains five nonlethal pressure activated stun mines. Requires Armory access to open."
+	cost = 2500
+	contains = list(/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun,
+					/obj/item/deployablemine/stun)
+	crate_name = "stun mine create"
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -134,22 +134,22 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/lm6_stunmine/sec
-	name = "LM-6 Rapid Deployment Smartmine"
+	name = "Rapid Deployment Smartmine"
 	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant. Can be rapidly placed and disarmed."
 	id = "stunmine_rapid"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/copper = 1000, /datum/material/silver = 500, /datum/material/uranium = 200)
-	build_path = /obj/item/deployablemine/lm6
+	build_path = /obj/item/deployablemine/rapid
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/lm12_stunmine/sec
-	name = "LM-12 Sledgehammer Smartmine"
+	name = "Sledgehammer Smartmine"
 	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant. Very powerful and hard to disarm."
 	id = "stunmine_heavy"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/copper = 1000, /datum/material/silver = 500, /datum/material/uranium = 200)
-	build_path = /obj/item/deployablemine/lm12
+	build_path = /obj/item/deployablemine/heavy
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -156,7 +156,7 @@
 /datum/design/honkmine
 	name = "Honkblaster 1000"
 	desc = "An advanced pressure activated pranking mine, honk!"
-	id = "Honkmine"
+	id = "clown_mine"
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 400)
 	build_path = /obj/item/deployablemine/honk
 	category = list("Ammo")

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -157,6 +157,7 @@
 	name = "Honkblaster 1000"
 	desc = "An advanced pressure activated pranking mine, honk!"
 	id = "clown_mine"
+	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 400)
 	build_path = /obj/item/deployablemine/honk
 	category = list("Ammo")

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -133,6 +133,26 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/lm6_stunmine/sec
+	name = "LM-6 Rapid Deployment Smartmine"
+	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant. Can be rapidly placed and disarmed."
+	id = "stunmine_rapid"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/copper = 1000, /datum/material/silver = 500, /datum/material/uranium = 200)
+	build_path = /obj/item/deployablemine/lm6
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/lm12_stunmine/sec
+	name = "LM-12 Sledgehammer Smartmine"
+	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant. Very powerful and hard to disarm."
+	id = "stunmine_heavy"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 10000, /datum/material/glass = 4000, /datum/material/copper = 1000, /datum/material/silver = 500, /datum/material/uranium = 200)
+	build_path = /obj/item/deployablemine/lm12
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/honkmine
 	name = "Honkblaster 1000"
 	desc = "An advanced pressure activated pranking mine, honk!"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -128,7 +128,7 @@
 	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant."
 	id = "stunmine_adv"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 8000, /datum/material/glass = 3000, /datum/material/copper = 1000, /datum/material/uranium = 200)
+	materials = list(/datum/material/iron = 8000, /datum/material/glass = 3000, /datum/material/copper = 1000, /datum/material/silver = 200)
 	build_path = /obj/item/deployablemine/smartstun
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -136,12 +136,12 @@
 /datum/design/honkmine
 	name = "Honkblaster 1000"
 	desc = "An advanced pressure activated pranking mine, honk!"
-	id = "serv_Honkmine"
+	id = "Honkmine"
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 400)
 	build_path = /obj/item/deployablemine/honk
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-	
+
 /datum/design/stunrevolver
 	name = "Tesla Revolver"
 	desc = "A high-tech revolver that fires internal, reusable shock cartridges in a revolving cylinder. The cartridges can be recharged using conventional rechargers."

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -113,6 +113,35 @@
 	category = list("Firing Pins")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/stunmine/sec/
+	name = "Stun Mine"
+	desc = "A basic nonlethal stunning mine. Does very heavy stamina damage to anyone who walks over it."
+	id = "stunmine"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 400)
+	build_path = /obj/item/deployablemine/stun
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/adv_stunmine/sec
+	name = "Smart Stun Mine"
+	desc = "A advanced nonlethal stunning mine. Uses advanced detection software to only trigger when activated by someone without a mindshield implant."
+	id = "stunmine_adv"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 8000, /datum/material/glass = 3000, /datum/material/copper = 1000, /datum/material/uranium = 200)
+	build_path = /obj/item/deployablemine/smartstun
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/honkmine
+	name = "Honkblaster 1000"
+	desc = "An advanced pressure activated pranking mine, honk!"
+	id = "serv_Honkmine"
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 400)
+	build_path = /obj/item/deployablemine/honk
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+	
 /datum/design/stunrevolver
 	name = "Tesla Revolver"
 	desc = "A high-tech revolver that fires internal, reusable shock cartridges in a revolving cylinder. The cartridges can be recharged using conventional rechargers."

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -158,7 +158,7 @@
 	desc = "An advanced pressure activated pranking mine, honk!"
 	id = "clown_mine"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 400)
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/bananium = 500)
 	build_path = /obj/item/deployablemine/honk
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -413,7 +413,7 @@
 	description = "Honk?!"
 	prereq_ids = list("base")
 	design_ids = list("air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
-	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "Honkmine")
+	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "clown_mine")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -688,7 +688,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 
-/datum/techweb_node/smartmine
+/datum/techweb_node/advmine
 	id = "adv_mines"
 	display_name = "Advanced Landmine Technology"
 	description = "We can develop some extremely capable landmines."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -671,9 +671,9 @@
 	export_price = 5000
 
 /datum/techweb_node/smartmine
-	id = "nonlethal_mines"
+	id = "smart_mines"
 	display_name = "Smart Landmine Technology"
-	description = "Using IFF technolgy, we could develop smartmines that are only triggered by enemies."
+	description = "Using IFF technology, we could develop smartmines that are only triggered by enemies."
 	prereq_ids = list("weaponry", "nonlethal_mines", "adv_engi")
 	design_ids = list("stunmine_adv")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
@@ -686,6 +686,15 @@
 	prereq_ids = list("adv_engi", "weaponry")
 	design_ids = list("pin_loyalty")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	export_price = 5000
+
+/datum/techweb_node/smartmine
+	id = "adv_mines"
+	display_name = "Advanced Landmine Technology"
+	description = "We can develop some extremely capable landmines."
+	prereq_ids = list("weaponry", "smart_mines", "adv_engi")
+	design_ids = list("stunmine_rapid", "stunmine_heavy")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/electric_weapons

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -413,7 +413,7 @@
 	description = "Honk?!"
 	prereq_ids = list("base")
 	design_ids = list("air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
-	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown")
+	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "Honkmine")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -651,6 +651,16 @@
 
 
 /////////////////////////weaponry tech/////////////////////////
+
+/datum/techweb_node/landmine
+	id = "nonlethal_mines"
+	display_name = "Nonlethal Landmine Technology"
+	description = "Our weapons technicians could perhaps work out methods for the creation of nonlethal landmines for security teams."
+	prereq_ids = list("engineering", "sec_basic")
+	design_ids = list("stunmine")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
+	export_price = 5000
+
 /datum/techweb_node/weaponry
 	id = "weaponry"
 	display_name = "Weapon Development Technology"
@@ -658,6 +668,15 @@
 	prereq_ids = list("engineering")
 	design_ids = list("pin_testing", "tele_shield", "sleepy")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	export_price = 5000
+
+/datum/techweb_node/smartmine
+	id = "nonlethal_mines"
+	display_name = "Smart Landmine Technology"
+	description = "Using IFF technolgy, we could develop smartmines that are only triggered by enemies."
+	prereq_ids = list("weaponry", "nonlethal_mines", "adv_engi")
+	design_ids = list("stunmine_adv")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
 /datum/techweb_node/adv_weaponry

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -656,7 +656,7 @@
 	id = "nonlethal_mines"
 	display_name = "Nonlethal Landmine Technology"
 	description = "Our weapons technicians could perhaps work out methods for the creation of nonlethal landmines for security teams."
-	prereq_ids = list("engineering", "sec_basic")
+	prereq_ids = list("sec_basic")
 	design_ids = list("stunmine")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
@@ -673,8 +673,8 @@
 /datum/techweb_node/smartmine
 	id = "smart_mines"
 	display_name = "Smart Landmine Technology"
-	description = "Using IFF technology, we could develop smartmines that are only triggered by enemies."
-	prereq_ids = list("weaponry", "nonlethal_mines", "adv_engi")
+	description = "Using IFF technology, we could develop smartmines that do not trigger for those who are mindshielded."
+	prereq_ids = list("weaponry", "nonlethal_mines", "engineering")
 	design_ids = list("stunmine_adv")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
@@ -691,7 +691,7 @@
 /datum/techweb_node/advmine
 	id = "adv_mines"
 	display_name = "Advanced Landmine Technology"
-	description = "We can develop some extremely capable landmines."
+	description = "We can further develop our smartmines to build some extremely capable designs."
 	prereq_ids = list("weaponry", "smart_mines", "adv_engi")
 	design_ids = list("stunmine_rapid", "stunmine_heavy")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1026,7 +1026,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A seemingly innocent rubber duck. When placed, it arms, and will violently explode when stepped on. \
 			This variant has been fitted with high yield X4 charges for a larger explosion."
 	item = /obj/item/deployablemine/traitor/bigboom
-	cost = 9
+	cost = 10
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/explosives/pizza_bomb

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -995,6 +995,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/emp
 	cost = 4
 
+/datum/uplink_item/explosives/ducky
+	name = "Exploding Rubber Duck"
+	desc = "A seemingly innocent rubber duck. When placed, it arms, and will violently explode when stepped on."
+	item = /obj/item/deployablemine/traitor
+	cost = 4
+	include_modes = list(/datum/game_mode/nuclear/clown_ops)
+	
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"
 	desc = "A primed bio-grenade packed into a compact box. Comes with five Bio Virus Antidote Kit (BVAK) \
@@ -1013,6 +1020,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	include_modes = list(/datum/game_mode/nuclear)
 	cost = 24
 	surplus = 0
+
+/datum/uplink_item/explosives/bigducky
+	name = "High Yield Exploding Rubber Duck"
+	desc = "A seemingly innocent rubber duck. When placed, it arms, and will violently explode when stepped on. \
+			This variant has been fitted with high yield X4 charges for a larger explosion."
+	item = /obj/item/deployablemine/traitor/bigboom
+	cost = 9
+	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/explosives/pizza_bomb
 	name = "Pizza Bomb"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR significantly changes how landmines work in game, and can be summarised in three parts:

**1: Landmines can now be planted, moved and disarmed.**
Adds disarmed versions of most mines, which can be safely picked up and carried around, and walking over one does nothing. Using a disarmed mine on a valid (ie not space, a wall or lava/chasms)  turf will plant and arm the mine after a short windup (3 seconds for most mines), after which it functions normally. Mines can be disarmed with a multitool, which takes 20 seconds by default, and drops the appropriate disarmed mine (or the base dummy mine if it's a mine type you shouldn't have like a bwoink mine). Clown mines take 6 times as long to disarm to make them more annoying,  and are now louder when set off. Stun mines now do stamina damage instead of hardstunning.

**2: New mines and mine tech.**
Adds three new tech nodes, three new mines for security, and allows you to build both the new mines as well as stun and clown mines. Nonlethal Landmine Technology allows sec to build stun mines, and requires basic security equipment as a prerequisite, as well as costing 1000 points.

Once you have researched industrial engineering, weapons development and nonlethal mines, you can research Smart Landmine Technology for 2500 points, which allows you to build smart stun mines. These mines are more expensive but are harder to disarm (25s) and do not trigger if the person walking over them is mindshielded, opening up interesting tactical possibilities for security.


Once you have smartmines you can research Advanced Landmine Technology for 2500, which gives you two more advanced smartmines, the rapid deployment and the  Sledgehammer. The RD is easier to disarm (12s) but has a very short arm time (1s), allowing for mid combat placement if you play it right, allowing sec to, say, enter through a door and deploy one behind them to block escape via that route. It also fits in pockets and boxes, unlike the other mines.

The sledgehammer is slower to arm (5s) but is very hard to disarm (35s), does extra stamina damage as well as 40 brute, making it more suited to defensive use such as blocking off the armoury.

The lower tier mines can be ordered from cargo at a reasonably high cost.

**3: Exploding Rubber Duck:**
Adds two further new mine types, the regular and high yield exploding rubber duck. Both are explosive, take a very long time to disarm (40s) and look like a rubber duck when armed. The high yield version is far more powerful but costs more (10TC vs 4TC). Both make the same sound effect as a rubber duck before detonation, d'aww!

## Why It's Good For The Game
Mines are basically nonexistant currently, and their new abilities to be moved, disarmed and discriminate between friend and foe open up interesting oppertunities for area denial or other tactics  (such as blocking retreat as mentioned above).


Printable clown mines give clowns a clown tech item to play with that does not require 8 million bananium.

The exploding rubber ducks are just plain funny and fun to use.
## Changelog
:cl:
add: Added ability to move and plant mines, as well as disarm them with a multitool
add: Added ability for mines to be "smart" and detect mindshield implants if a particular mine type
add: Clown and stun mines can now be printed in the service and security protolathes respectively
add: three new mine related tech nodes, and three new printable smart mine types for security
add: Added the exploding rubber duck as a 4TC traitor and clownops item, with a more powerful version available for 10TC.
add: Some mines can be ordered from cargo
tweak: stun mines now do stamina damage instead of a hardstun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
