### PR TITLE
buffs relic water bottle

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -331,8 +331,17 @@
 
 // Relic water bottle
 /obj/item/reagent_containers/glass/waterbottle/relic
-	desc = "A bottle of water filled at an old Earth bottling facility. It seems to be radiating some kind of energy."
+	desc = "A bottle of water filled with unknown liquids. It seems to be radiating some kind of energy."
 	flip_chance = 100 // FLIPP
+	list_reagents = list()
+
+/obj/item/reagent_containers/glass/waterbottle/relic/Initialize()
+	var/reagents = volume
+	while(reagents)
+		var/newreagent = rand(1, min(reagents, 30))
+		list_reagents += list(get_unrestricted_random_reagent_id() = newreagent)
+		reagents -= newreagent
+	. = ..()
 
 //Red/Blue Cubes
 /obj/item/warp_cube


### PR DESCRIPTION

## About The Pull Request
relic waterbottle is no longer just a meme. it is now a super-floorpill that contains 50 units of a random number of random reagents.

## Why It's Good For The Game
no useless bloat in necrochest
![image](https://user-images.githubusercontent.com/49600480/80925896-692dea80-8d48-11ea-961d-444d3cf84912.png)

## Changelog
:cl:
balance: buffs relic water bottle. don't drink it.
/:cl:
