### PR TITLE
TGUI Tutorial fix and BYOND cache locator ports

### DIFF
--- a/tgui/docs/tutorial-and-examples.md
+++ b/tgui/docs/tutorial-and-examples.md
@@ -142,7 +142,7 @@ export const SampleInterface = (props, context) => {
             <LabeledList.Item label="Button">
               <Button
                 content="Dispatch a 'test' action"
-                onClick={() => act('test')}>
+                onClick={() => act('test')} />
             </LabeledList.Item>
           </LabeledList>
         </Section>
@@ -345,7 +345,7 @@ export const SampleInterface = (props, context) => {
             <LabeledList.Item label="Button">
               <Button
                 content="Dispatch a 'test' action"
-                onClick={() => act('test')}>
+                onClick={() => act('test')} />
             </LabeledList.Item>
           </LabeledList>
         </Section>

--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -4,6 +4,7 @@ import os from 'os';
 import { basename } from 'path';
 import { promisify } from 'util';
 import { resolveGlob, resolvePath } from './util.js';
+import { regQuery } from './winreg.js';
 
 const logger = createLogger('reloader');
 
@@ -36,6 +37,21 @@ export const findCacheRoot = async () => {
     const paths = await resolveGlob(pattern);
     if (paths.length > 0) {
       cacheRoot = paths[0];
+      logger.log(`found cache at '${cacheRoot}'`);
+      return cacheRoot;
+    }
+  }
+  // Query the Windows Registry
+  if (process.platform === 'win32') {
+    logger.log('querying windows registry');
+    let userpath = await regQuery(
+      'HKCU\\Software\\Dantom\\BYOND',
+      'userpath');
+    if (userpath) {
+      cacheRoot = userpath
+        .replace(/\\$/, '')
+        .replace(/\\/g, '/')
+        + '/cache';
       logger.log(`found cache at '${cacheRoot}'`);
       return cacheRoot;
     }

--- a/tgui/packages/tgui-dev-server/winreg.js
+++ b/tgui/packages/tgui-dev-server/winreg.js
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Tools for dealing with Windows Registry bullshit.
+ */
+import { exec } from 'child_process';
+import { createLogger } from 'common/logging.js';
+import { promisify } from 'util';
+
+const logger = createLogger('winreg');
+
+export const regQuery = async (path, key) => {
+  if (process.platform !== 'win32') {
+    return null;
+  }
+  try {
+    const command = `reg query "${path}" /v ${key}`;
+    const { stdout } = await promisify(exec)(command);
+    const keyPattern = `    ${key}    `;
+    const indexOfKey = stdout.indexOf(keyPattern);
+    if (indexOfKey === -1) {
+      logger.error('could not find the registry key');
+      return null;
+    }
+    const indexOfEol = stdout.indexOf('\r\n', indexOfKey);
+    if (indexOfEol === -1) {
+      logger.error('could not find the end of the line');
+      return null;
+    }
+    const indexOfValue = stdout.indexOf(
+      '    ',
+      indexOfKey + keyPattern.length);
+    if (indexOfValue === -1) {
+      logger.error('could not find the start of the key value');
+      return null;
+    }
+    const value = stdout.substring(indexOfValue + 4, indexOfEol);
+    return value;
+  }
+  catch (err) {
+    logger.error(err);
+    return null;
+  }
+};


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/issues/50766 and https://github.com/tgstation/tgstation/issues/50769

----

50766:

> Web edit kung-fu for a really dumb mistake in documentation, which makes copypasta not work, and confuses the hell out of newbs.

50769:
> This finally makes tgui-dev-server aware of custom BYOND cache locations by querying BYOND settings in Windows Registry in `HKCU\Software\Dantom\BYOND`,
> 
> There were too many weird chaps with their BYOND folder located in something liek:
> 
>     * `~/OneDrive/Documents/BYOND`
> 
>     * `E:/Libraries/Documents/BYOND`
> 
> 
> It runs `reg query` in a child process, so has a chance of breaking, so here's a usual disclaimer:
> 
> ![image](https://camo.githubusercontent.com/3cf0cbcfd7a6a418258a94656251db7c1a17d612/68747470733a2f2f666f7274686562616467652e636f6d2f696d616765732f6261646765732f36302d70657263656e742d6f662d7468652d74696d652d776f726b732d65766572792d74696d652e737667)