### PR TITLE
adds upgrade wand, magicman balance changes

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -255,6 +255,16 @@ effective or pretty fucking useless.
 	equipslot = SLOT_NECK
 	attack_verb = null
 
+/obj/item/shadowcloak/magician/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	if(istype(W, /obj/item/upgradewand))
+		var/obj/item/upgradewand/wand = W
+		wand.used = TRUE
+		charge = 450
+		max_charge = 450
+		to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+		playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
+
 /obj/item/jammer
 	name = "radio jammer"
 	desc = "Device used to disrupt nearby radio communication."

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -259,11 +259,12 @@ effective or pretty fucking useless.
 	. = ..()
 	if(istype(W, /obj/item/upgradewand))
 		var/obj/item/upgradewand/wand = W
-		wand.used = TRUE
-		charge = 450
-		max_charge = 450
-		to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
-		playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
+		if(!wand.used && max_charge == initial(max_charge))
+			wand.used = TRUE
+			charge = 450
+			max_charge = 450
+			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 
 /obj/item/jammer
 	name = "radio jammer"

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -263,7 +263,7 @@ effective or pretty fucking useless.
 			wand.used = TRUE
 			charge = 450
 			max_charge = 450
-			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand].</span>")
 			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 
 /obj/item/jammer

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -191,7 +191,7 @@
 			kidnappingcoefficient = 0.5
 			capacity = 4
 			maximum_size = 4
-			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand].</span>")
 			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 	
 /obj/item/clothing/head/that/bluespace/afterattack(atom/target, mob/user, proximity_flag, click_parameters)

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -297,7 +297,7 @@
 	return ouija_spaghetti_list
 
 /obj/item/upgradewand
-	desc = "A wand laced with nanotech calibration devices."
+	desc = "A wand laced with nanotech calibration devices, used to enhance gear commonly used by modern stage magicians."
 	name = "Upgrade Wand"
 	icon = 'icons/obj/guns/magic.dmi'
 	icon_state = "nothingwand"

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -186,12 +186,13 @@
 	. = ..()
 	if(istype(W, /obj/item/upgradewand))
 		var/obj/item/upgradewand/wand = W
-		wand.used = TRUE
-		kidnappingcoefficient = 0.5
-		capacity = 4
-		maximum_size = 4
-		to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
-		playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
+		if(!wand.used && kidnappingcoefficient == initial(kidnappingcoefficient))
+			wand.used = TRUE
+			kidnappingcoefficient = 0.5
+			capacity = 4
+			maximum_size = 4
+			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 	
 /obj/item/clothing/head/that/bluespace/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -88,7 +88,16 @@
 	icon_state = "white"
 	item_state = "wgloves"
 	item_color="white"
-	var/range = 4
+	var/range = 3
+
+/obj/item/clothing/gloves/color/white/magic/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	if(istype(W, /obj/item/upgradewand))
+		var/obj/item/upgradewand/wand = W
+		wand.used = TRUE
+		range = 6
+		to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+		playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 
 /obj/item/clothing/gloves/color/white/magic/Touch(atom/A, proximity)
 	var/mob/living/M = loc

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -94,10 +94,11 @@
 	. = ..()
 	if(istype(W, /obj/item/upgradewand))
 		var/obj/item/upgradewand/wand = W
-		wand.used = TRUE
-		range = 6
-		to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
-		playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
+		if(!wand.used && range == initial(range))
+			wand.used = TRUE
+			range = 6
+			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 
 /obj/item/clothing/gloves/color/white/magic/Touch(atom/A, proximity)
 	var/mob/living/M = loc

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -97,7 +97,7 @@
 		if(!wand.used && range == initial(range))
 			wand.used = TRUE
 			range = 6
-			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand]</span>")
+			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand].</span>")
 			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 
 /obj/item/clothing/gloves/color/white/magic/Touch(atom/A, proximity)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1750,6 +1750,13 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	restricted_roles = list("Medical Doctor", "Chief Medical Officer", "Roboticist")
 	cost = 3
 
+/datum/uplink_item/role_restricted/upgrade_wand
+	name = "Upgrade Wand"
+	desc = "A powerful, single-use wand containing nanomachines that will calibrate the high-tech gadgets commonly employed by magicians to nearly double their potential."
+	item = /obj/item/upgradewand
+	restricted_roles = list("Stage Magician")
+	cost = 5
+
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"
 	desc = "The Clown bomb is a hilarious device capable of massive pranks. It has an adjustable timer, \


### PR DESCRIPTION
## About The Pull Request
adds the upgrade wand, a 5 tc traitor item for magicians. you can use it on any magician item to upgrade its stats. 
lowers teleglove range by 1
changes tophat calcs a bit, it's a bit faster on non-carbons now, and is very fast when you use it on yourself
## Why It's Good For The Game
fun magicman shit

## Changelog
:cl:
add: the upgrade wand, a magician only traitor item that upgrades his gear
balance: lowers teleglove range by 1
balance: bottomless top hat now kidnaps non-carbons faster, and works better on the user
/:cl:
