### PR TITLE
Antagonists can now be set to not prevent round end

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -290,9 +290,11 @@
 		if(!continuous_sanity_checked) //make sure we have antags to be checking in the first place
 			for(var/mob/Player in GLOB.mob_list)
 				if(Player.mind)
-					if(Player.mind.special_role || LAZYLEN(Player.mind.antag_datums))
-						continuous_sanity_checked = 1
-						return 0
+					if(Player.mind.special_role)
+						for(var/datum/antagonist/A in Player.mind.antag_datums)
+							if(A.delay_roundend)
+								continuous_sanity_checked = 1
+								return 0
 			if(!continuous_sanity_checked)
 				message_admins("The roundtype ([config_tag]) has no antagonists, continuous round has been defaulted to on and midround_antag has been defaulted to off.")
 				continuous[config_tag] = TRUE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -289,12 +289,11 @@
 	if(!round_converted && (!continuous[config_tag] || (continuous[config_tag] && midround_antag[config_tag]))) //Non-continuous or continous with replacement antags
 		if(!continuous_sanity_checked) //make sure we have antags to be checking in the first place
 			for(var/mob/Player in GLOB.mob_list)
-				if(Player.mind)
-					if(Player.mind.special_role)
-						for(var/datum/antagonist/A in Player.mind.antag_datums)
-							if(A.delay_roundend)
-								continuous_sanity_checked = 1
-								return 0
+				if(Player.mind?.special_role)
+					for(var/datum/antagonist/A in Player.mind.antag_datums)
+						if(A.delay_roundend)
+							continuous_sanity_checked = TRUE
+							return FALSE
 			if(!continuous_sanity_checked)
 				message_admins("The roundtype ([config_tag]) has no antagonists, continuous round has been defaulted to on and midround_antag has been defaulted to off.")
 				continuous[config_tag] = TRUE

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST(admin_antag_list)
 	var/antag_memory = ""//These will be removed with antag datum
 	var/antag_moodlet //typepath of moodlet that the mob will gain with their status
 	var/can_hijack = HIJACK_NEUTRAL //If these antags are alone on shuttle hijack happens.
+	var/delay_roundend = TRUE
 
 	//Antag panel properties
 	var/show_in_antagpanel = TRUE	//This will hide adding this antag type in antag panel, use only for internal subtypes that shouldn't be added directly but still show if possessed by mind

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -65,6 +65,8 @@
 	job_rank = ROLE_SPECIAL
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = FALSE
+	prevent_roundtype_conversion = FALSE
+	delay_roundend = FALSE
 
 /datum/antagonist/special/proc/equip()
 	return

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -107,6 +107,9 @@
 		if(objectives)
 			if(!A)
 				A = MM.add_antag_datum(/datum/antagonist/custom)
+				//Don't delay roundend with ghost role created antags
+				A.delay_roundend = FALSE
+				A.prevent_roundtype_conversion = FALSE
 			for(var/objective in objectives)
 				var/datum/objective/O = new/datum/objective(objective)
 				O.owner = MM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a variable to let you choose whether or not the antagonist type should delay the round end.
Instead of checking if you have an antag datum, the system now loops through your antag datums and checks if that antag datum delays the round end.

## Why It's Good For The Game

Hotel staff delay the round end and prevent the roundtype from being converted.

## Changelog
:cl:
code: Antags can now have the ability to not delay the end of the round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
