### PR TITLE
Stop 'special additional role' from being spawned as an event.

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/Initialize(time, zlevel)
 	for(var/type in typesof(/datum/round_event_control))
 		var/datum/round_event_control/E = new type()
-		if(!E.typepath)
+		if(!E.typepath || !E.auto_add)
 			continue				//don't want this one! leave it for the garbage collector
 		control += E				//add it to the list of all events (controls)
 	reschedule()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -99,6 +99,7 @@
 		var/datum/special_role/new_role = new role_to_init
 		if(!prob(new_role.probability))
 			continue
+		new_role.add_to_pool()
 		active_specials += new_role
 
 	for(var/datum/special_role/special in active_specials)

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -25,8 +25,7 @@
 	//Preferences
 	var/preference_type = ROLE_SPECIAL
 
-/datum/special_role/New()
-	. = ..()
+/datum/special_role/proc/add_to_pool()
 	if(spawn_mode == SPAWNTYPE_ROUNDSTART)
 		return
 	//Create a new event for spawning the antag

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -26,7 +26,7 @@
 	var/list/gamemode_whitelist = list() // Event will happen ONLY in these gamemodes if not empty
 
 	var/triggering	//admin cancellation
-	var/auto_add = TRUE				//Auto add to the event pool, if not you have to do it yourself
+	var/auto_add = TRUE				//Auto add to the event pool, if not you have to do it yourself!
 
 /datum/round_event_control/New()
 	if(config && !wizardevent) // Magic is unaffected by configs

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -26,6 +26,7 @@
 	var/list/gamemode_whitelist = list() // Event will happen ONLY in these gamemodes if not empty
 
 	var/triggering	//admin cancellation
+	var/auto_add = TRUE				//Auto add to the event pool, if not you have to do it yourself
 
 /datum/round_event_control/New()
 	if(config && !wizardevent) // Magic is unaffected by configs

--- a/code/modules/events/special_antag_event.dm
+++ b/code/modules/events/special_antag_event.dm
@@ -1,6 +1,7 @@
 /datum/round_event_control/spawn_special_antagonist
 	name = "Special Antagonist Spawn Event"
 	typepath = /datum/round_event/create_special_antag
+	auto_add = FALSE
 	//Antagonist data
 	var/antagonist_datum = /datum/antagonist/special
 	var/antag_name	//The datum of the antag E.G. /datum/antagonist/special/undercover


### PR DESCRIPTION
…e event pool

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a system to event that allows you to toggle whether or not an event automatically gets added to the event pool, and makes it so the spawn_special_antagonist event isn't automatically added.

## Why It's Good For The Game

Stops blank antags that can't end the round from spawning.

## Changelog
:cl:
fix: Special antagonists no longer randomly spawn mid round.
code: Added code to stop events automatically getting added to the event control
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
