### PR TITLE
Actions: CL Token Adjustment

### DIFF
--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+        with:
+          fetch-depth: 25
       - name: Python setup
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CL_TOKEN }}


### PR DESCRIPTION
I had a misunderstanding of how the snowflake token system works. In order to generate based on merges from forked repositories, I need to supply a special token of my own.

For those tracking these PRs, a [new secret has to be added to your repo](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) called `CL_TOKEN`. This token should be a [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) that you generate, this token will need `repo` access to write the changes.

Below CL is for pr #1747 which wasn't added due to this mistake.

## Changelog
:cl: AyyRobotics and AsphaltEvidence
add: Added Safety Moth(TM), and Safety Pill(TM?) posters.
imageadd: Updated contraband.dmi to add new poster icons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
