### PR TITLE
fixes id console blacklist of gimmick jobs

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -36,11 +36,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		"Research Director",
 		"Chief Medical Officer",
 		"Brig Physician", 
-		"Deputy",
-		"Brig Physician",
-		"Gimmick",
-		"Barber",
-		"Stage Magician")
+		"Deputy")
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players
@@ -59,6 +55,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 /obj/machinery/computer/card/Initialize()
 	. = ..()
 	change_position_cooldown = CONFIG_GET(number/id_console_jobslot_delay)
+	for(var/G in typesof(/datum/job/gimmick))
+		var/datum/job/gimmick/J = new G
+		blacklisted += J.title
 
 /obj/machinery/computer/card/attackby(obj/O, mob/user, params)//TODO:SANITY
 	if(istype(O, /obj/item/card/id))

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -37,7 +37,10 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		"Chief Medical Officer",
 		"Brig Physician", 
 		"Deputy",
-		"Brig Physician")
+		"Brig Physician",
+		"Gimmick",
+		"Barber",
+		"Stage Magician")
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players
@@ -56,8 +59,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 /obj/machinery/computer/card/Initialize()
 	. = ..()
 	change_position_cooldown = CONFIG_GET(number/id_console_jobslot_delay)
-	for(var/datum/job/gimmick/J in typesof(/datum/job/gimmick))
-		blacklisted += J.title
 
 /obj/machinery/computer/card/attackby(obj/O, mob/user, params)//TODO:SANITY
 	if(istype(O, /obj/item/card/id))

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -17,7 +17,7 @@
 
 /datum/job/gimmick/New()
 	. = ..()
-	GLOB.civilian_positions += title
+	GLOB.civilian_positions |= title
 
 /datum/job/gimmick/barber
 	title = "Barber"


### PR DESCRIPTION

## About The Pull Request

HOP can no longer open gimmick jobs

## Why It's Good For The Game

ike asking for gimmicks not to be hardcoded here aint feasible it seems

## Changelog
:cl:
fix: HOP cant open gimmick jobs anymore
/:cl:
