### PR TITLE
Actions: Another Make CL edge case fix

### DIFF
--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           fetch-depth: 25
+          persist-credentials: false
       - name: Python setup
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
Fixes another edge-case with the checkout token overriding the push token.

## Changelog
:cl:
tweak: CL generation adjustment 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
