### PR TITLE
I'm taking a break from actions after this

### DIFF
--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -1,20 +1,18 @@
 name: Make changelogs
 
 on:
-  pull_request:
+  push:
     branches: [master]
-    types: [closed]
 
 jobs:
   MakeCL:
-    if: ${{ github.event.pull_request.merged }}
     runs-on: ubuntu-latest
+    if: github.repository == 'BeeStation/BeeStation-Hornet'
     steps:
       - name: Checkout
         uses: actions/checkout@v1
         with:
           fetch-depth: 25
-          persist-credentials: false
       - name: Python setup
         uses: actions/setup-python@v1
         with:
@@ -22,13 +20,9 @@ jobs:
       - name: Install depends
         run: |
           python -m pip install --upgrade pip
-          pip install ruamel.yaml
+          pip install ruamel.yaml PyGithub
       - name: Make CL
-        env:
-          PR_BODY: ${{ toJson(github.event.pull_request.body) }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: python tools/changelog/generate_cl.py "$PR_BODY" $PR_NUMBER "$PR_AUTHOR"
+        run: python tools/changelog/generate_cl.py $GITHUB_REPOSITORY ${{ secrets.GITHUB_TOKEN }} $GITHUB_SHA
       - name: Commit
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -41,4 +35,4 @@ jobs:
       - name: Push
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.CL_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -31,7 +31,7 @@ if not pr_list.totalCount:
 
 pr = pr_list[0]
 
-pr_body = pr._body.value
+pr_body = pr.body
 pr_number = pr.number
 pr_author = pr.user.login
 

--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -3,7 +3,6 @@ DO NOT MANUALLY RUN THIS SCRIPT.
 """
 import sys
 import re
-import json
 from pathlib import Path
 from ruamel import yaml
 from github import Github

--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -6,6 +6,7 @@ import re
 import json
 from pathlib import Path
 from ruamel import yaml
+from github import Github
 
 CL_BODY = re.compile(r":cl:(.+)?\r\n((.|\n|\r)+?)\r\n\/:cl:", re.MULTILINE)
 CL_SPLIT = re.compile(r"(^\w+):\s+(\w.+)", re.MULTILINE)
@@ -14,9 +15,25 @@ if len(sys.argv) < 4:
     print("Missing arguments")
     exit(1)
 
-pr_body = bytes(sys.argv[1], "utf-8").decode("unicode_escape")
-pr_number = sys.argv[2]
-pr_author = sys.argv[3]
+# Blessed is the GoOnStAtIoN birb ZeWaKa for thinking of this first
+repo = sys.argv[1]
+token = sys.argv[2]
+sha = sys.argv[3]
+
+git = Github(token)
+repo = git.get_repo(repo)
+commit = repo.get_commit(sha)
+pr_list = commit.get_pulls()
+
+if not pr_list.totalCount:
+    print("Direct commit detected")
+    exit(1)
+
+pr = pr_list[0]
+
+pr_body = pr._body.value
+pr_number = pr.number
+pr_author = pr.user.login
 
 write_cl = {}
 try:
@@ -54,4 +71,4 @@ if write_cl['changes']:
     print("Done!")
 else:
     print("No CL changes detected!")
-    exit(1)
+    exit(0)


### PR DESCRIPTION
Alright. This should be the last change I need to make to this thing. I've spoken with GitHub's support.. They have clarified with me that despite prior indications that this would work, they have restricted actions triggered by PRs to the point where they can't push anything if it originated outside of the original repository (or if it isn't directly linked in some way). 

So! What does this mean? It means I'm just going to trigger based on events and have the script check if the commit was from a pull request or not. Easy as that. The idea originally comes from the Goons with how they handle their CL generation. 

Expect at least one more PR after this

## Changelog
:cl:
fix: CLs are properly generated when a PR comes from an external fork.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
