### PR TITLE
adds plasmaman chameleon envirosuit, some blasmasuit refactors

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -468,6 +468,23 @@
 	new /obj/item/stamp/chameleon(src)
 	new /obj/item/pda/chameleon(src)
 
+/obj/item/storage/box/syndie_kit/plasmachameleon
+	name = "plasmaman chameleon kit"
+
+/obj/item/storage/box/syndie_kit/plasmachameleon/PopulateContents()
+	new /obj/item/clothing/under/chameleon/envirosuit(src)
+	new /obj/item/clothing/suit/chameleon(src)
+	new /obj/item/clothing/gloves/chameleon(src)
+	new /obj/item/clothing/shoes/chameleon(src)
+	new /obj/item/clothing/glasses/chameleon(src)
+	new /obj/item/clothing/head/chameleon/envirohelm(src)
+	new /obj/item/clothing/mask/chameleon(src)
+	new /obj/item/clothing/neck/cloak/chameleon(src)
+	new /obj/item/storage/backpack/chameleon(src)
+	new /obj/item/radio/headset/chameleon(src)
+	new /obj/item/stamp/chameleon(src)
+	new /obj/item/pda/chameleon(src)
+
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
 /obj/item/storage/box/syndie_kit/throwing_weapons/PopulateContents()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -262,6 +262,15 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
+/obj/item/clothing/under/chameleon/envirosuit
+	name = "plasma envirosuit"
+	desc = "A special containment suit that allows plasma-based lifeforms to exist safely in an oxygenated environment, and automatically extinguishes them in a crisis. Despite being airtight, it's not spaceworthy. It has a small dial on the wrist."
+	icon_state = "plasmaman"
+	item_state = "plasmaman"
+	item_color = "plasmaman"
+	resistance_flags = FIRE_PROOF
+	envirosealed = TRUE
+
 /obj/item/clothing/under/chameleon/ratvar
 	name = "ratvarian engineer's jumpsuit"
 	desc = "A tough jumpsuit woven from alloy threads. It can take on the appearance of other jumpsuits."
@@ -401,6 +410,23 @@
 /obj/item/clothing/head/chameleon/broken/Initialize()
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/clothing/head/chameleon/envirohelm
+	name = "plasma envirosuit helmet"
+	desc = "A special containment helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment. It is space-worthy, and may be worn in tandem with other EVA gear."
+	icon_state = "plasmaman-helm"
+	item_state = "plasmaman-helm"
+	resistance_flags = FIRE_PROOF
+	strip_delay = 80
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SHOWEROKAY
+	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	heat_protection = HEAD
+	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	flash_protect = 2
+	bang_protect = 1
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 
 /obj/item/clothing/head/chameleon/drone
 	// The camohat, I mean, holographic hat projection, is part of the

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -22,6 +22,7 @@
 	var/toggle_cooldown = null
 	var/cooldown = 0
 	var/scan_reagents = 0 //Can the wearer see reagents while it's equipped?
+	var/envirosealed = FALSE //is it safe for plasmamen
 
 	var/blocks_shove_knockdown = FALSE //Whether wearing the clothing item blocks the ability for shove to knock down.
 
@@ -262,12 +263,14 @@ BLIND     // can't see anything
 		return
 	adjusted = !adjusted
 	if(adjusted)
+		envirosealed = FALSE
 		if(fitted != FEMALE_UNIFORM_TOP)
 			fitted = NO_FEMALE_UNIFORM
 		if(!alt_covers_chest) // for the special snowflake suits that expose the chest when adjusted
 			body_parts_covered &= ~CHEST
 	else
 		fitted = initial(fitted)
+		envirosealed = initial(envirosealed)
 		if(!alt_covers_chest)
 			body_parts_covered |= CHEST
 	return adjusted

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -642,9 +642,11 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	can_adjust = FALSE
 	strip_delay = 80
+	resistance_flags = FIRE_PROOF
 	var/next_extinguish = 0
 	var/extinguish_cooldown = 100
 	var/extinguishes_left = 5
+	envirosealed = TRUE
 
 
 /obj/item/clothing/under/plasmaman/examine(mob/user)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -30,15 +30,19 @@
 		var/obj/item/clothing/CH = H.head
 		if (CS.clothing_flags & CH.clothing_flags & STOPSPRESSUREDAMAGE)
 			atmos_sealed = TRUE
-	if((!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/foilhat/plasmaman) && !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman)) && !atmos_sealed)
-		if(environment)
-			if(environment.total_moles())
-				if(environment.gases[/datum/gas/oxygen] && (environment.gases[/datum/gas/oxygen][MOLES]) >= 1) //Same threshhold that extinguishes fire
-					H.adjust_fire_stacks(0.5)
-					if(!H.on_fire && H.fire_stacks > 0)
-						H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
-					H.IgniteMob()
-					internal_fire = TRUE
+	if(H.w_uniform && H.head)
+		var/obj/item/clothing/CU = H.w_uniform
+		var/obj/item/clothing/CH = H.head
+		if (CU.envirosealed && (CH.clothing_flags & STOPSPRESSUREDAMAGE))
+			atmos_sealed = TRUE
+	if(environment && !atmos_sealed)
+		if(environment.total_moles())
+			if(environment.gases[/datum/gas/oxygen] && (environment.gases[/datum/gas/oxygen][MOLES]) >= 1) //Same threshhold that extinguishes fire
+				H.adjust_fire_stacks(0.5)
+				if(!H.on_fire && H.fire_stacks > 0)
+					H.visible_message("<span class='danger'>[H]'s body reacts with the atmosphere and bursts into flames!</span>","<span class='userdanger'>Your body reacts with the atmosphere and bursts into flame!</span>")
+				H.IgniteMob()
+				internal_fire = TRUE
 	else
 		if(H.fire_stacks)
 			var/obj/item/clothing/under/plasmaman/P = H.w_uniform

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1685,6 +1685,14 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	item = /obj/item/grenade/discogrenade
 	restricted_species = list("ethereal")
 
+/datum/uplink_item/race_restricted/plasmachameleon
+	name = "Plasmaman Chameleon Kit"
+	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more! \
+			Due to budget cuts, the shoes don't provide protection against slipping. The normal bells and whistles of a plasmaman's jumpsuit and helmet are gutted to make room for the chameleon machinery."
+	item = /obj/item/storage/box/syndie_kit/plasmachameleon
+	cost = 2
+	restricted_species = list("plasmaman")
+
 // Role-specific items
 /datum/uplink_item/role_restricted
 	category = "Role-Restricted"


### PR DESCRIPTION
## About The Pull Request
-adds a plasmaman chameleon kit, a race restricted item for plasmaman that can be worn without worry. The helmet has no light, and the envirosuit has no extinguisher, however.
-refactors plasmaman jumpsuits to use a single variable instead of snowflake code to work
-any spaceworthy item can now work as an envirohelm
-adds necessary code to alt-wear plasmaman jumpsuits
-plasmaman jumpsuits no longer burn off

## Why It's Good For The Game
I've been wanting to add this for awhile. And plasmaman envirohelmets are fireproof, so why shouldnt the suits be

## Changelog
:cl:
add: plasmaman chameleon kit
tweak: plasmaman suits no longer burn off
code: refactored plasmaman fire code a bit. any spaceworthy helmet will function as an envirohelm now.
/:cl:
