### PR TITLE
various small tweaks to #1642

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -159,6 +159,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_MEDIBOTCOMINGTHROUGH "medbot" //Is a medbot healing you
 #define TRAIT_PASSTABLE			"passtable"
 #define TRAIT_ONEWAYROAD	"one-way road"
+#define TRAIT_JITTERS			"jitters"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -467,7 +467,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return 0
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0
-	if((block_flags & BLOCKING_ACTIVE) && !owner.get_active_held_item() == src)
+	if(block_flags & BLOCKING_ACTIVE && owner.get_active_held_item() != src)
 		return 0
 	if(isprojectile(hitby)) //fucking bitflags broke this when coded in other ways
 		var/obj/item/projectile/P = hitby

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -476,8 +476,10 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				return 0
 		else
 			return 0 
-	if(owner.m_intent == MOVE_INTENT_WALK)
+	if(owner.m_intent == MOVE_INTENT_WALK && !HAS_TRAIT(owner, TRAIT_JITTERS))
 		final_block_level += block_upgrade_walk
+	if(HAS_TRAIT(owner, TRAIT_JITTERS))
+		final_block_level -= 1
 	switch(relative_dir)
 		if(180, -180)
 			if(final_block_level >= 1)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -462,6 +462,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(blockhand.is_disabled())
 		to_chat(owner, "<span_class='danger'>You're too exausted to block the attack<!/span>")
 		return 0
+	else if(HAS_TRAIT(owner, TRAIT_NOLIMBDISABLE) && owner.getStaminaLoss() >= 30)
+		to_chat(owner, "<span_class='danger'>You're too exausted to block the attack<!/span>")
+		return 0
 	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
 		return 0
 	if((block_flags & BLOCKING_ACTIVE) && !owner.get_active_held_item() == src)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -466,8 +466,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return 0
 	if((block_flags & BLOCKING_ACTIVE) && !owner.get_active_held_item() == src)
 		return 0
-	if((!block_flags & BLOCKING_PROJECTILE) && attack_type == PROJECTILE_ATTACK)
-		return 0
+	if(isprojectile(hitby)) //fucking bitflags broke this when coded in other ways
+		var/obj/item/projectile/P = hitby
+		if(block_flags & BLOCKING_PROJECTILE)
+			if(P.movement_type & UNSTOPPABLE) //you can't block piercing rounds!
+				return 0
+		else
+			return 0 
 	if(owner.m_intent == MOVE_INTENT_WALK)
 		final_block_level += block_upgrade_walk
 	switch(relative_dir)
@@ -509,7 +514,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(isprojectile(hitby))
 		var/obj/item/projectile/P = hitby
 		if(P.damtype != STAMINA)// disablers dont do shit to shields
-			attackforce = (P.damage / 2)
+			attackforce = (P.damage)
 	else if(isitem(hitby))
 		var/obj/item/I = hitby
 		attackforce = damage

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -103,7 +103,7 @@
 	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 35
-	block_sound = 'sound/weapons/genhit.ogg'
+	block_sound = 'sound/weapons/egloves.ogg'
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -107,6 +107,10 @@
 		return ..()
 	force = (baseforce * fisto_setting)
 	attack_weight = fisto_setting
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.check_shields(src, force))
+			return
 	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
 		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
 	new /obj/effect/temp_visual/kinetic_blast(target.loc)
@@ -120,10 +124,5 @@
 	log_combat(user, target, "power fisted", src)
 
 	user.changeNext_move(CLICK_CD_MELEE * click_delay)
-
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
-		if(H.check_shields(src, force))
-			return
 
 	return ..()

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -18,6 +18,7 @@
 	var/fisto_setting = 1
 	var/gasperfist = 3
 	var/obj/item/tank/internals/tank = null //Tank used for the gauntlet's piston-ram.
+	var/baseforce = 20
 
 
 /obj/item/melee/powerfist/examine(mob/user)
@@ -41,13 +42,10 @@
 		switch(fisto_setting)
 			if(1)
 				fisto_setting = 2
-				attack_weight = 2
 			if(2)
 				fisto_setting = 3
-				attack_weight = 3
 			if(3)
 				fisto_setting = 1
-				attack_weight = 1
 		W.play_tool_sound(src)
 		to_chat(user, "<span class='notice'>You tweak \the [src]'s piston valve to [fisto_setting].</span>")
 	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
@@ -74,42 +72,58 @@
 
 
 /obj/item/melee/powerfist/attack(mob/living/target, mob/living/user)
-    if(!tank)
-        to_chat(user, "<span class='warning'>\The [src] can't operate without a source of gas!</span>")
-        return
-    var/datum/gas_mixture/gasused = tank.air_contents.remove(gasperfist * fisto_setting)
-    var/turf/T = get_turf(src)
-    if(!T)
-        return
-    T.assume_air(gasused)
-    T.air_update_turf()
-    if(!gasused)
-        to_chat(user, "<span class='warning'>\The [src]'s tank is empty!</span>")
-        target.apply_damage((force / 5), BRUTE)
-        playsound(loc, 'sound/weapons/punch1.ogg', 50, 1)
-        target.visible_message("<span class='danger'>[user]'s powerfist lets out a dull thunk as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-            "<span class='userdanger'>[user]'s punches you!</span>")
-        return
-    if(gasused.total_moles() < gasperfist * fisto_setting)
-        to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
-        playsound(loc, 'sound/weapons/punch4.ogg', 50, 1)
-        target.apply_damage((force / 2), BRUTE)
-        target.visible_message("<span class='danger'>[user]'s powerfist lets out a weak hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-            "<span class='userdanger'>[user]'s punch strikes with force!</span>")
-        return
-    target.apply_damage(force * fisto_setting, BRUTE)
-    target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
-        "<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
-    new /obj/effect/temp_visual/kinetic_blast(target.loc)
-    playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
-    playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
+	if(!tank)
+		to_chat(user, "<span class='warning'>\The [src] can't operate without a source of gas!</span>")
+		return
+	var/datum/gas_mixture/gasused = tank.air_contents.remove(gasperfist * fisto_setting)
+	var/turf/T = get_turf(src)
+	if(!T)
+		return
+	T.assume_air(gasused)
+	T.air_update_turf()
+	if(!gasused)
+		to_chat(user, "<span class='warning'>\The [src]'s tank is empty!</span>")
+		force = (baseforce / 5)
+		attack_weight = 1
+		playsound(loc, 'sound/weapons/punch1.ogg', 50, 1)
+		target.visible_message("<span class='danger'>[user]'s powerfist lets out a dull thunk as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+			"<span class='userdanger'>[user]'s punches you!</span>")
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			if(H.check_shields(src, force))
+				return
+		return ..()
+	if(gasused.total_moles() < gasperfist * fisto_setting)
+		to_chat(user, "<span class='warning'>\The [src]'s piston-ram lets out a weak hiss, it needs more gas!</span>")
+		playsound(loc, 'sound/weapons/punch4.ogg', 50, 1)
+		force = (baseforce / 2)
+		attack_weight = 1
+		target.visible_message("<span class='danger'>[user]'s powerfist lets out a weak hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+			"<span class='userdanger'>[user]'s punch strikes with force!</span>")
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			if(H.check_shields(src, force))
+				return
+		return ..()
+	force = (baseforce * fisto_setting)
+	attack_weight = fisto_setting
+	target.visible_message("<span class='danger'>[user]'s powerfist lets out a loud hiss as [user.p_they()] punch[user.p_es()] [target.name]!</span>", \
+		"<span class='userdanger'>You cry out in pain as [user]'s punch flings you backwards!</span>")
+	new /obj/effect/temp_visual/kinetic_blast(target.loc)
+	playsound(loc, 'sound/weapons/resonator_blast.ogg', 50, 1)
+	playsound(loc, 'sound/weapons/genhit2.ogg', 50, 1)
 
-    var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 
-    target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
+	target.throw_at(throw_target, 5 * fisto_setting, 0.5 + (fisto_setting / 2))
 
-    log_combat(user, target, "power fisted", src)
+	log_combat(user, target, "power fisted", src)
 
-    user.changeNext_move(CLICK_CD_MELEE * click_delay)
+	user.changeNext_move(CLICK_CD_MELEE * click_delay)
 
-    return
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.check_shields(src, force))
+			return
+
+	return ..()

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -36,6 +36,7 @@
 		if (obj_integrity <= attackforce)
 			var/turf/T = get_turf(owner)
 			T.visible_message("<span class='warning'>[hitby] destroys [src]!</span>")
+			obj_integrity = 1
 			shatter(owner)
 			return FALSE
 		take_damage(attackforce * ((100-(block_power))/100))
@@ -233,12 +234,17 @@
 	var/on_throw_speed = 2
 	var/active = 0
 	var/clumsy_check = TRUE
+	var/cooldown_duration = 100
+	var/cooldown_timer
 
 /obj/item/shield/energy/shatter(mob/living/carbon/human/owner)
-	playsound(owner, 'sound/effects/turbolift/turbolift-close.ogg', 50, 0, -1)
+	playsound(owner, 'sound/effects/turbolift/turbolift-close.ogg', 200, 1)
 	src.attack_self(owner)
 	to_chat(owner, "<span class='warning'>The [src] overheats!.</span>")
-	
+	cooldown_timer = world.time + cooldown_duration
+	sleep(100)
+	playsound(owner, 'sound/effects/beepskyspinsabre.ogg', 35, 1)
+	to_chat(owner, "<span class='warning'>The [src] is ready to use!.</span>")
 
 /obj/item/shield/energy/Initialize()
 	. = ..()
@@ -256,12 +262,13 @@
 	return 0
 
 /obj/item/shield/energy/attack_self(mob/living/carbon/human/user)
+	if(cooldown_timer >= world.time)
+		return
 	if(clumsy_check && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		to_chat(user, "<span class='warning'>You beat yourself in the head with [src].</span>")
 		user.take_bodypart_damage(5)
 	active = !active
 	icon_state = "[base_icon_state][active]"
-
 	if(active)
 		force = on_force
 		throwforce = on_throwforce
@@ -269,7 +276,8 @@
 		w_class = WEIGHT_CLASS_BULKY
 		playsound(user, 'sound/weapons/saberon.ogg', 35, 1)
 		to_chat(user, "<span class='notice'>[src] is now active and back at full power.</span>")
-		obj_integrity = max_integrity
+		if(obj_integrity <= 1)
+			obj_integrity = max_integrity
 	else
 		force = initial(force)
 		throwforce = initial(throwforce)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -45,17 +45,18 @@
 		return ..()
 
 /obj/item/shield/attackby(obj/item/weldingtool/W, mob/living/user, params)
-	if(obj_integrity < max_integrity)
-		if(!W.tool_start_check(user, amount=0))
-			return
-		user.visible_message("[user] is welding the [src].", \
-								"<span class='notice'>You begin repairing the [src]]...</span>")
-		if(W.use_tool(src, user, 40, volume=50))
-			obj_integrity += 10
-			user.visible_message("[user.name] has repaired some dents on [src].", \
-								"<span class='notice'>You finish repairing some of the dents on [src].</span>")
-		else
-			to_chat(user, "<span class='notice'>The [src] doesn't need repairing.</span>")
+	if(istype(W))
+		if(obj_integrity < max_integrity)
+			if(!W.tool_start_check(user, amount=0))
+				return
+			user.visible_message("[user] is welding the [src].", \
+									"<span class='notice'>You begin repairing the [src]]...</span>")
+			if(W.use_tool(src, user, 40, volume=50))
+				obj_integrity += 10
+				user.visible_message("[user.name] has repaired some dents on [src].", \
+									"<span class='notice'>You finish repairing some of the dents on [src].</span>")
+			else
+				to_chat(user, "<span class='notice'>The [src] doesn't need repairing.</span>")
 	return ..()
 
 /obj/item/shield/examine(mob/user)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -228,7 +228,7 @@
 	throwforce = 3
 	throw_speed = 3
 	max_integrity = 50
-	block_sound = 'sound/weapons/genhit.ogg'
+	block_sound = 'sound/weapons/egloves.ogg'
 	var/base_icon_state = "eshield" // [base_icon_state]1 for expanded, [base_icon_state]0 for contracted
 	var/on_force = 10
 	var/on_throwforce = 8
@@ -243,7 +243,9 @@
 	src.attack_self(owner)
 	to_chat(owner, "<span class='warning'>The [src] overheats!.</span>")
 	cooldown_timer = world.time + cooldown_duration
-	sleep(cooldown_duration)
+	addtimer(CALLBACK(src, .proc/recharged, owner), cooldown_duration)
+
+/obj/item/shield/energy/proc/recharged(mob/living/carbon/human/owner)//ree. i hate addtimer. ree.
 	playsound(owner, 'sound/effects/beepskyspinsabre.ogg', 35, 1)
 	to_chat(owner, "<span class='warning'>The [src] is ready to use!.</span>")
 

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -243,7 +243,7 @@
 	src.attack_self(owner)
 	to_chat(owner, "<span class='warning'>The [src] overheats!.</span>")
 	cooldown_timer = world.time + cooldown_duration
-	sleep(100)
+	sleep(cooldown_duration)
 	playsound(owner, 'sound/effects/beepskyspinsabre.ogg', 35, 1)
 	to_chat(owner, "<span class='warning'>The [src] is ready to use!.</span>")
 

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -20,7 +20,7 @@
 		if(isprojectile(hitby))
 			var/obj/item/projectile/P = hitby
 			if(P.damtype != STAMINA)// disablers dont do shit to shields
-				attackforce = P.damage
+				attackforce = (P.damage / 2)
 		if(isitem(hitby))
 			var/obj/item/I = hitby
 			attackforce = damage
@@ -42,6 +42,20 @@
 		return TRUE
 	else
 		return ..()
+
+/obj/item/shield/attackby(obj/item/weldingtool/W, mob/living/user, params)
+	if(obj_integrity < max_integrity)
+		if(!W.tool_start_check(user, amount=0))
+			return
+		user.visible_message("[user] is welding the [src].", \
+								"<span class='notice'>You begin repairing the [src]]...</span>")
+		if(W.use_tool(src, user, 40, volume=50))
+			obj_integrity += 10
+			user.visible_message("[user.name] has repaired some dents on [src].", \
+								"<span class='notice'>You finish repairing some of the dents on [src].</span>")
+		else
+			to_chat(user, "<span class='notice'>The [src] doesn't need repairing.</span>")
+	return ..()
 
 /obj/item/shield/examine(mob/user)
 	. = ..()
@@ -254,7 +268,8 @@
 		throw_speed = on_throw_speed
 		w_class = WEIGHT_CLASS_BULKY
 		playsound(user, 'sound/weapons/saberon.ogg', 35, 1)
-		to_chat(user, "<span class='notice'>[src] is now active.</span>")
+		to_chat(user, "<span class='notice'>[src] is now active and back at full power.</span>")
+		obj_integrity = max_integrity
 	else
 		force = initial(force)
 		throwforce = initial(throwforce)

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -9,6 +9,7 @@
 	hitsound = "swing_hit"
 	throw_speed = 2
 	throw_range = 4
+	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	resistance_flags = FLAMMABLE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -395,8 +395,7 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	block_upgrade_walk = 1
-	block_level = 1
-	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
+	block_flags = BLOCKING_ACTIVE | BLOCKING_PROJECTILE
 
 /*
  * Snap pops

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -289,6 +289,7 @@
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	force_unwielded = 3
 	force_wielded = 34
+	block_power_wielded = 75
 	wieldsound = 'sound/weapons/saberon.ogg'
 	unwieldsound = 'sound/weapons/saberoff.ogg'
 	hitsound = "swing_hit"
@@ -299,7 +300,7 @@
 	block_level = 2
 	block_upgrade_walk = 1
 	block_power = 70
-	block_sound = 'sound/weapons/genhit.ogg'
+	block_sound = 'sound/weapons/egloves.ogg'
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
@@ -382,9 +383,9 @@
 		user.adjustStaminaLoss(25)
 
 /obj/item/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(wielded)
-		return ..()
-	return 0
+	if(!wielded)
+		return 0
+	return ..()
 
 /obj/item/twohanded/dualsaber/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)  //In case thats just so happens that it is still activated on the groud, prevents hulk from picking it up
 	if(wielded)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -373,7 +373,6 @@
 
 /obj/item/twohanded/dualsaber/proc/jedi_spin(mob/living/user) //rip complex code, but this fucked up blocking
 	user.emote("flip")
-	sleep(1)
 
 /obj/item/twohanded/dualsaber/proc/impale(mob/living/user)
 	to_chat(user, "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on [src].</span>")

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -230,9 +230,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/axes_righthand.dmi'
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
-	attack_weight = 2
+	attack_weight = 3
 	block_power_wielded = 25
-	block_level = 1
 	block_upgrade_walk = 1
 	force = 5
 	throwforce = 15
@@ -372,12 +371,9 @@
 	if((wielded) && prob(50))
 		INVOKE_ASYNC(src, .proc/jedi_spin, user)
 
-/obj/item/twohanded/dualsaber/proc/jedi_spin(mob/living/user)
-	for(var/i in list(NORTH,SOUTH,EAST,WEST,EAST,SOUTH,NORTH,SOUTH,EAST,WEST,EAST,SOUTH))
-		user.setDir(i)
-		if(i == WEST)
-			user.emote("flip")
-		sleep(1)
+/obj/item/twohanded/dualsaber/proc/jedi_spin(mob/living/user) //rip complex code, but this fucked up blocking
+	user.emote("flip")
+	sleep(1)
 
 /obj/item/twohanded/dualsaber/proc/impale(mob/living/user)
 	to_chat(user, "<span class='warning'>You twirl around a bit before losing your balance and impaling yourself on [src].</span>")

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -484,7 +484,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_power = 20
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 24
-	attack_weight = TRUE
+	attack_weight = 2
 	throwforce = 0
 	throw_range = 0
 	throw_speed = 0

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -258,7 +258,6 @@
 	w_class = WEIGHT_CLASS_HUGE
 	force = 8
 	throwforce = 10
-	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 20
 	throw_range = 3

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -18,6 +18,8 @@
 	inhand_y_dimension = 32
 	w_class = WEIGHT_CLASS_SMALL
 	block_upgrade_walk = 1
+	block_power = 0
+	block_level = 0
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 15
 	throwforce = 12 // unlike normal daggers, this one is curved and not designed to be thrown
@@ -914,6 +916,7 @@
 	throwforce = 15
 	throw_speed = 1
 	throw_range = 4
+	max_integrity = 50
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bumped", "prodded")
 	hitsound = 'sound/weapons/smash.ogg'

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1510,14 +1510,13 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return 0 //item force is zero
 
 	//dismemberment
-	var/dismemberthreshold = (((affecting.max_damage * 2) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
+	var/dismemberthreshold = ((affecting.max_damage * 2) - affecting.get_damage()) //don't take the current hit into account.
+	var/attackforce = (((I.w_class - 3) * 5) + ((I.attack_weight - 1) * 14) + ((I.sharpness-1) * 20)) //all the variables that go into ripping off a limb in one handy package. Force is absent because it's already been taken into account by the limb being damaged
 	if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
-		dismemberthreshold -= 50
+		dismemberthreshold -= 30
 	if(I.sharpness)
-		dismemberthreshold = min(((affecting.max_damage * 2  - affecting.get_damage())), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
-		if(H.stat == DEAD)
-			dismemberthreshold = dismemberthreshold / 3 
-	if(I.force >= dismemberthreshold && I.force >= 10)
+		attackforce = max(attackforce, I.force)
+	if(attackforce >= dismemberthreshold && I.force >= 10)
 		if(affecting.dismember(I.damtype))
 			I.add_mob_blood(H)
 			playsound(get_turf(H), I.get_dismember_sound(), 80, 1)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -620,6 +620,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(!HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		B = new()
 		M.gain_trauma(B, TRAUMA_RESILIENCE_ABSOLUTE)
+	ADD_TRAIT(M, TRAIT_JITTERS, type) //sorry sec, but you dont get a special stam heal to help with blocking
 	..()
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/M)
@@ -636,6 +637,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_end_metabolize(mob/living/carbon/M)
 	if(B)
 		QDEL_NULL(B)
+	REMOVE_TRAIT(M, TRAIT_JITTERS, type)
 	return ..()
 
 /datum/reagent/consumable/ethanol/beepsky_smash/overdose_start(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -71,6 +71,14 @@
 	overdose_threshold = 20
 	addiction_threshold = 10
 
+/datum/reagent/drug/crank/on_mob_metabolize(mob/living/L)
+	ADD_TRAIT(L, TRAIT_JITTERS, type)
+	..()
+
+/datum/reagent/drug/crank/on_mob_end_metabolize(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
+	..()
+
 /datum/reagent/drug/crank/on_mob_life(mob/living/carbon/M)
 	if(prob(5))
 		var/high_message = pick("You feel jittery.", "You feel like you gotta go fast.", "You feel like you need to step it up.")
@@ -177,6 +185,7 @@
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/methamphetamine/on_mob_metabolize(mob/living/L)
+	ADD_TRAIT(L, TRAIT_JITTERS, type)
 	..()
 	if (L.client)
 		SSmedals.UnlockMedal(MEDAL_APPLY_REAGENT_METH,L.client)
@@ -184,6 +193,7 @@
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
 
 /datum/reagent/drug/methamphetamine/on_mob_end_metabolize(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
 	L.remove_movespeed_modifier(type)
 	..()
 
@@ -270,6 +280,7 @@
 	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
+	ADD_TRAIT(L, TRAIT_JITTERS, type)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		rage = new()
@@ -281,6 +292,7 @@
 	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
+	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
 	if(rage)
 		QDEL_NULL(rage)
 	..()
@@ -363,6 +375,14 @@
 	description = "Amps you up, gets you going, and rapidly restores stamina damage. Side effects include breathlessness and toxicity."
 	reagent_state = LIQUID
 	color = "#78FFF0"
+
+/datum/reagent/drug/aranesp/on_mob_metabolize(mob/living/L)
+	ADD_TRAIT(L, TRAIT_JITTERS, type)
+	..()
+
+/datum/reagent/drug/aranesp/on_mob_end_metabolize(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
+	..()
 
 /datum/reagent/drug/aranesp/on_mob_life(mob/living/carbon/M)
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")


### PR DESCRIPTION
## About The Pull Request
a number of small fixes and balance changes

## Why It's Good For The Game

fixes and balance and shit

## Changelog
:cl:
add: shields can be repaired with a welding tool
tweak: normal briefcases can now block like secure ones can
tweak: fire axe is now worse at blocking, but better at dismemberment and breaking through shields and blocks
tweak: changes up dismemberment calculations to work far better.
tweak: powerfist is no longer snowflake bullshit that fucks the entirety of all melee combat conventions by bypassing shields and armor completely, but it now actually works as a destroyer of shields and the true best melee weapon in the game (not really)(but close)
tweak: penetrating projectiles now bypass shields
balance: projectiles deal full damage to blocks
balance: nerfed toy katana
balance: nerfed chairs
balance: nolimbdisable doesnt let you block forever
balance: stamina healing drugs make you far worse at blocking
balance: cult dagger no longer blocks as if it's a longsword, cult shield is now less durable
fix: energy shield is now repaired when you turn it back on after it breaks. However, after breaking, there is a cooldown before you can use it again
fix: double esword spin is now less theatrical, making it no longer disrupt your blocks.
fix: active blocking now works as intended
fix: projectile blocking now works as intended
/:cl:

