### PR TITLE
kelotane now has 3 ingredients

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -231,8 +231,8 @@
 /datum/chemical_reaction/kelotane
 	name = "Kelotane"
 	id = /datum/reagent/medicine/kelotane
-	results = list(/datum/reagent/medicine/kelotane = 2)
-	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/silicon = 1)
+	results = list(/datum/reagent/medicine/kelotane = 3)
+	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/water = 1, /datum/reagent/silicon = 1)
 
 /datum/chemical_reaction/antitoxin
 	name = "Antitoxin"


### PR DESCRIPTION
the other 2 basic healing medicines have 3 ingredients so why doesn't this have 3, annoying as fuk, it needs water now

makes tricordrazine easier to mass produce haHAA

### changelog:

(i was busy doing other shit sorry this shit took a week bruh bruh)

change: kelotane now needs water
change: kelotane now produces 3 units, to account for the 3 chemicals needed

will change the chem wiki once/if this gets merged
