### PR TITLE
fixes, parry removal, etc

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -159,10 +159,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_MEDIBOTCOMINGTHROUGH "medbot" //Is a medbot healing you
 #define TRAIT_PASSTABLE			"passtable"
 #define TRAIT_ONEWAYROAD	"one-way road"
-#define TRAIT_JITTERS			"jitters"
-#define TRAIT_PARRY					"parry"
-#define TRAIT_NOPARRY				"noparry"
 #define TRAIT_APPRAISAL			"appraisal"
+#define TRAIT_NOBLOCK			"noblock"
 
 //non-mob traits
 #define TRAIT_PARALYSIS			"paralysis" //Used for limb-based paralysis, where replacing the limb will fix it

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -270,7 +270,7 @@
 	force = 5
 	slot_flags = ITEM_SLOT_BACK
 	block_flags = BLOCKING_PROJECTILE
-	block_level = 2
+	block_level = 1
 	block_power = 20
 	var/shield_icon = "shield-red"
 
@@ -646,7 +646,7 @@
 	name = "monk's staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, it is now used to harass the clown."
 	w_class = WEIGHT_CLASS_BULKY
-	force = 15
+	force = 14
 	block_power = 40
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = IS_BLUNT

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -17,39 +17,21 @@
 /obj/item/shield/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
 	if(durability)
 		var/attackforce = 0 
-		var/obj/item/riposte = src
-		if(owner.get_active_held_item()) //parry with our active item if we have it
-			riposte = owner.get_active_held_item()
 		if(isprojectile(hitby))
 			var/obj/item/projectile/P = hitby
-			if(P.damtype != STAMINA)// disablers dont do shit to shields
+			if(P.damage_type != STAMINA)// disablers dont do shit to shields
 				attackforce = (P.damage / 2)
-				if(HAS_TRAIT(owner, TRAIT_PARRY))
-					owner.visible_message("<span class='danger'>[owner] deflects [P] with the [src]!</span>")
-					playsound(src, 'sound/weapons/effects/ric1.ogg', 75, 0)
-					stoplag(4)
-					playsound(src, 'sound/weapons/bulletremove.ogg', 75, 0)
-					attackforce = 0
 		if(isitem(hitby))
 			var/obj/item/I = hitby
 			attackforce = damage
 			if(!I.damtype == BRUTE)
 				attackforce = (attackforce / 2)
 			attackforce = (attackforce * I.attack_weight)
-			if(isliving(I.loc) && HAS_TRAIT(owner, TRAIT_PARRY))
-				var/mob/living/L = I.loc
-				L.attackby(riposte, owner)
-				owner.visible_message("<span class='danger'>[owner] parries [L]'s [I] with the [src]!</span>")
-				playsound(src, 'sound/weapons/deflect.ogg', 75, 0)
+			if(I.damtype == STAMINA)//pure stamina damage wont affect blocks
 				attackforce = 0
-		else if(isliving(hitby))
+		else if(isliving(hitby)) //not putting an anti stamina clause in here. only stamina damage simplemobs i know of are swarmers, and them eating shields makes sense
 			var/mob/living/L = hitby
 			attackforce = (damage * 2)//simplemobs have an advantage here because of how much these blocking mechanics put them at a disadvantage
-			if(HAS_TRAIT(owner, TRAIT_PARRY))
-				L.attackby(riposte, owner)
-				attackforce = 0
-				owner.visible_message("<span class='danger'>[owner] parries [L] with the [src]!</span>")
-				playsound(src, 'sound/weapons/deflect.ogg', 75, 0)
 			if(block_flags & BLOCKING_NASTY)
 				L.attackby(src, owner)
 				owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -395,7 +395,9 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	block_upgrade_walk = 1
+	block_level = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_PROJECTILE
+	block_power = -500 //not to be used on anything more effective than nerf darts
 
 /*
  * Snap pops

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -115,7 +115,16 @@
 			if(I.hit_reaction(src, AM, attack_text, damage, attack_type))
 				I.on_block(src, AM, attack_text, damage, attack_type)
 				return 1
-  return FALSE
+	if(wear_suit)
+		if(wear_suit.hit_reaction(src, AM, attack_text, damage, attack_type))
+			return TRUE
+	if(w_uniform)
+		if(w_uniform.hit_reaction(src, AM, attack_text, damage, attack_type))
+			return TRUE
+	if(wear_neck)
+		if(wear_neck.hit_reaction(src, AM, attack_text, damage, attack_type))
+			return TRUE
+  return TRUE
 
 /mob/living/carbon/human/proc/check_block()
 	if(mind)
@@ -898,3 +907,9 @@
 
 	for(var/obj/item/I in torn_items)
 		I.take_damage(damage_amount, damage_type, damage_flag, 0)
+	
+/mob/living/carbon/human/proc/blockbreak()
+	to_chat(src, "<span class ='userdanger'>Your block was broken!</span>")
+	ADD_TRAIT(src, TRAIT_NOBLOCK, type)
+	stoplag(50)
+	REMOVE_TRAIT(src, TRAIT_NOBLOCK, type)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -407,19 +407,3 @@
 	..()
 	setMovetype(movement_type & ~FLOATING) // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
 
-
-/mob/living/proc/parry()//A bit janky, but i couldnt think of another way to do the cooldown that worked
-	var/canparry = FALSE
-	for(var/obj/item/I in held_items)
-		if(I.block_level || I.block_upgrade_walk)
-			canparry = TRUE
-			break 
-	if(!HAS_TRAIT(src, TRAIT_NOPARRY) && !stat && canparry)
-		ADD_TRAIT(src, TRAIT_PARRY, PARRY_TRAIT)
-		ADD_TRAIT(src, TRAIT_NOPARRY, PARRY_TRAIT)
-		playsound(src, 'sound/weapons/fwoosh.ogg', 75, 0)
-		new /obj/effect/temp_visual/parry(src.loc)
-		stoplag(5)
-		REMOVE_TRAIT(src, TRAIT_PARRY, PARRY_TRAIT)
-		stoplag(10)
-		REMOVE_TRAIT(src, TRAIT_NOPARRY, PARRY_TRAIT)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -458,9 +458,6 @@
 /mob/proc/toggle_move_intent(mob/user)
 	if(m_intent == MOVE_INTENT_RUN)
 		m_intent = MOVE_INTENT_WALK
-		if(isliving(src))
-			var/mob/living/L = src
-			L.parry()
 	else
 		m_intent = MOVE_INTENT_RUN
 	if(hud_used && hud_used.static_inventory)

--- a/code/modules/projectiles/autofire.dm
+++ b/code/modules/projectiles/autofire.dm
@@ -49,7 +49,7 @@ This system lets you spray and pray with guns when dragging the mouse.
 	var/mob/user = src.loc
 	autofire_target = object //When we start firing, we start firing at whatever you clicked on initially. When the user drags their mouse, this shall change.
 	while(autofire_target)  //While will only run while we have a user (loc) that is a mob, and we are being actively held by this mob, they have a client (as to prevent disconnecting mid-fight causing you to perma-fire) and of course, if we passed the previous check about autofiring.
-		stoplag(max(fire_delay, 0.15 SECONDS)) //Default fire delay to prevent you from instantly dumping an entire mag out.
+		stoplag(max((10 / fire_rate), 1)) //Default fire delay to prevent you from instantly dumping an entire mag out.
 		if(can_fire_at(autofire_target, user))
 			afterattack(autofire_target, user)
 		else

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -620,7 +620,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(!HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		B = new()
 		M.gain_trauma(B, TRAUMA_RESILIENCE_ABSOLUTE)
-	ADD_TRAIT(M, TRAIT_JITTERS, type) //sorry sec, but you dont get a special stam heal to help with blocking
+	ADD_TRAIT(M, TRAIT_NOBLOCK, type) //sorry sec, but you dont get a special stam heal to help with blocking
 	..()
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/carbon/M)
@@ -637,7 +637,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_end_metabolize(mob/living/carbon/M)
 	if(B)
 		QDEL_NULL(B)
-	REMOVE_TRAIT(M, TRAIT_JITTERS, type)
+	REMOVE_TRAIT(M, TRAIT_NOBLOCK, type)
 	return ..()
 
 /datum/reagent/consumable/ethanol/beepsky_smash/overdose_start(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -72,11 +72,11 @@
 	addiction_threshold = 10
 
 /datum/reagent/drug/crank/on_mob_metabolize(mob/living/L)
-	ADD_TRAIT(L, TRAIT_JITTERS, type)
+	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
 	..()
 
 /datum/reagent/drug/crank/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
+	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
 	..()
 
 /datum/reagent/drug/crank/on_mob_life(mob/living/carbon/M)
@@ -185,7 +185,7 @@
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 
 /datum/reagent/drug/methamphetamine/on_mob_metabolize(mob/living/L)
-	ADD_TRAIT(L, TRAIT_JITTERS, type)
+	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
 	..()
 	if (L.client)
 		SSmedals.UnlockMedal(MEDAL_APPLY_REAGENT_METH,L.client)
@@ -193,7 +193,7 @@
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
 
 /datum/reagent/drug/methamphetamine/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
+	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
 	L.remove_movespeed_modifier(type)
 	..()
 
@@ -280,7 +280,7 @@
 	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
-	ADD_TRAIT(L, TRAIT_JITTERS, type)
+	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		rage = new()
@@ -292,7 +292,7 @@
 	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
-	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
+	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
 	if(rage)
 		QDEL_NULL(rage)
 	..()
@@ -377,11 +377,11 @@
 	color = "#78FFF0"
 
 /datum/reagent/drug/aranesp/on_mob_metabolize(mob/living/L)
-	ADD_TRAIT(L, TRAIT_JITTERS, type)
+	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
 	..()
 
 /datum/reagent/drug/aranesp/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_JITTERS, type)
+	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
 	..()
 
 /datum/reagent/drug/aranesp/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
## About The Pull Request

removes parries
changes up the Jitters system a bit
fixes a few bugs

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/49600480/82087176-6e722a00-96a4-11ea-858f-b5f1cad92757.png)

the people have spoken

## Changelog
:cl:
del: parries
tweak: changes up jitters. now, it's noblock, instead of a significant block penalty, but it no longer affects shields
balance: you can't block for a few seconds if you have nolimbdisable or a nodrop item and your block is broken
balance: nerfs toy katana, again
tweak: small changes to some chaplain gear
fix: shielded hardsuits work again
fix: shields dont take damage from blocking disablers anymore
fix: I think this also fixes the bug where blocks randomly stop working
fix: automatic guns now use the fire_rate var again
/:cl:

