### PR TITLE
Makes secret extended actually exist.

### DIFF
--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -10,6 +10,14 @@
 
 	title_icon = "extended_white"
 
+	var/secret = FALSE
+
+/datum/game_mode/extended/secret
+	name = "secret extended"
+	config_tag ="secret_extended"
+	report_type = "traitor"	//So this won't appear with traitor report
+	secret = TRUE
+
 /datum/game_mode/extended/pre_setup()
 	return 1
 
@@ -17,10 +25,14 @@
 	return "The transmission mostly failed to mention your sector. It is possible that there is nothing in the Syndicate that could threaten your station during this shift."
 
 /datum/game_mode/extended/generate_station_goals()
+	if(secret)
+		return ..()
 	for(var/T in subtypesof(/datum/station_goal))
 		var/datum/station_goal/G = new T
 		station_goals += G
 		G.on_report()
 
 /datum/game_mode/extended/send_intercept(report = 0)
+	if(secret)
+		return ..()
 	priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", 'sound/ai/commandreport.ogg')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Secret extended has been set up in the config for sage, but doesn't actually exist. This adds in extended, except with no announcement and a single station goal, for them calm rounds except everyone is still slightly alert.

## Why It's Good For The Game

Extended with 10% less chaos, because it's secret.
Low chance in config, but was intended for sage seemingly but never implemented. (For reference it is only twice the probablity of wizards so is rare at the moment, but server ops can change this not me.)

## Changelog
:cl:
add: Secret extended re-added
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
