### PR TITLE
Fixes spammy comms consoles destroying the ears of the playerbase

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -135,13 +135,13 @@
 				var/input = stripped_multiline_input(usr, "Please choose a message to transmit to allied stations.  Please be aware that this process is very expensive, and abuse will lead to... termination.", "Send a message to an allied station.", "")
 				if(!input || !(usr in view(1,src)) || !checkCCcooldown())
 					return
+				CM.lastTimeUsed = world.time
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 				send2otherserver("[station_name()]", input,"Comms_Console")
 				minor_announce(input, title = "Outgoing message to allied station")
 				usr.log_talk(input, LOG_SAY, tag="message to the other server")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] has sent a message to the other server.")
 				deadchat_broadcast("<span class='deadsay bold'>[usr.real_name] has sent an outgoing message to the other station(s).</span>", usr)
-				CM.lastTimeUsed = world.time
 
 		if("purchase_menu")
 			state = STATE_PURCHASE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was a delay in send2otherserver(), but for some reason the code that added the cooldown was after the send2otherserver() proc, meaning if there was a large delay you could use the console again and again and again, and the second the delay ended every single minor_announcement would play at once resulting in the blown eardrums of everyone online and a large amount of OOC spam.
It was pretty funny though.

## Why It's Good For The Game

You can no longer queue hundreds of messages to the other station resulting in the bombardment of everyone onlines ears as 100 simultaneous sounds play.

## Changelog
:cl:
fix: You can no longer queue hundreds of messages to the other station resulting in the bombardment of everyone onlines ears as 100 simultaneous sounds play.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
