### PR TITLE
EMERGENCY FIX can_interact logic issues

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -234,24 +234,39 @@ Class Procs:
 	return !(stat & (NOPOWER|BROKEN|MAINT))
 
 /obj/machinery/can_interact(mob/user)
-	var/silicon = issiliconoradminghost(user)
-	if((stat & (NOPOWER|BROKEN)) && !(interaction_flags_machine & INTERACT_MACHINE_OFFLINE))
+	var/silicon = issilicon(user)
+	var/admin_ghost = IsAdminGhost(user)
+	var/living = isliving(user)
+
+	if((stat & (NOPOWER|BROKEN)) && !(interaction_flags_machine & INTERACT_MACHINE_OFFLINE)) // Check if the machine is broken, and if we can still interact with it if so
 		return FALSE
-	if(panel_open && !(interaction_flags_machine & INTERACT_MACHINE_OPEN))
+
+	if(panel_open && !(interaction_flags_machine & INTERACT_MACHINE_OPEN)) // Check if we can interact with an open panel machine, if the panel is open
 		if(!silicon || !(interaction_flags_machine & INTERACT_MACHINE_OPEN_SILICON))
 			return FALSE
 
-	if(silicon)
+	if(silicon || admin_ghost) // If we are an AI or adminghsot, make sure the machine allows silicons to interact
 		if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON))
 			return FALSE
-	else
-		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON)
+
+	else if(living) // If we are a living human
+		var/mob/living/L = user
+
+		if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON) // First make sure the machine doesn't require silicon interaction
 			return FALSE
-		if(!Adjacent(user))
-			var/mob/living/carbon/H = user
+
+		if(!Adjacent(user)) // Next make sure we are next to the machine unless we have telekinesis
+			var/mob/living/carbon/H = L
 			if(!(istype(H) && H.has_dna() && H.dna.check_mutation(TK)))
 				return FALSE
-	return TRUE
+
+		if(L.incapacitated()) // Finally make sure we aren't incapacitated
+			return FALSE
+
+	else // If we aren't a silicon, living, or admin ghost, bad!
+		return FALSE
+
+	return TRUE // If we pass all these checks, woohoo! We can interact
 
 /obj/machinery/proc/check_nap_violations()
 	if(!SSeconomy.full_ancap)


### PR DESCRIPTION
## About The Pull Request

Incapacitated people and ghosts may no longer control/alt-click to interact with machines.

This proc was just riddled with logic issues and it has been this way for years. Commented the hell out of it in order to try and prevent things like this from happening in the future.

## Why It's Good For The Game

Bug Bad

## Changelog
:cl:
fix: Ghosts and incapacitated users can no longer interact with machines using control/alt-click
/:cl: