### PR TITLE
Should fix the revolution issue

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -292,11 +292,14 @@
 	if(!round_converted && (!continuous[config_tag] || (continuous[config_tag] && midround_antag[config_tag]))) //Non-continuous or continous with replacement antags
 		if(!continuous_sanity_checked) //make sure we have antags to be checking in the first place
 			for(var/mob/Player in GLOB.mob_list)
-				if(Player.mind?.special_role)
-					for(var/datum/antagonist/A in Player.mind.antag_datums)
-						if(A.delay_roundend)
-							continuous_sanity_checked = TRUE
-							return FALSE
+				//Gamemodes like revs do not give antag status, but special roles instead.
+				if(Player.mind?.special_role && !LAZYLEN(Player.mind.antag_datums))
+					continuous_sanity_checked = TRUE
+					return FALSE
+				for(var/datum/antagonist/A in Player.mind.antag_datums)
+					if(A.delay_roundend)
+						continuous_sanity_checked = TRUE
+						return FALSE
 			if(!continuous_sanity_checked)
 				message_admins("The roundtype ([config_tag]) has no antagonists, continuous round has been defaulted to on and midround_antag has been defaulted to off.")
 				continuous[config_tag] = TRUE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -292,6 +292,8 @@
 	if(!round_converted && (!continuous[config_tag] || (continuous[config_tag] && midround_antag[config_tag]))) //Non-continuous or continous with replacement antags
 		if(!continuous_sanity_checked) //make sure we have antags to be checking in the first place
 			for(var/mob/Player in GLOB.mob_list)
+				if(!Player.mind)
+					continue
 				//Gamemodes like revs do not give antag status, but special roles instead.
 				if(Player.mind?.special_role && !LAZYLEN(Player.mind.antag_datums))
 					continuous_sanity_checked = TRUE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -295,7 +295,7 @@
 				if(!Player.mind)
 					continue
 				//Gamemodes like revs do not give antag status, but special roles instead.
-				if(Player.mind?.special_role && !LAZYLEN(Player.mind.antag_datums))
+				if(Player.mind.special_role && !LAZYLEN(Player.mind.antag_datums))
 					continuous_sanity_checked = TRUE
 					return FALSE
 				for(var/datum/antagonist/A in Player.mind.antag_datums)

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -8,6 +8,7 @@
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
 	antagpanel_category = "Ash Walkers"
+	delay_roundend = FALSE
 	var/datum/team/ashwalkers/ashie_team
 
 /datum/antagonist/ashwalker/create_team(datum/team/team)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Revolution no longer defaults to continuous

## Why It's Good For The Game

Revolution no longer defaults to continuous

## Changelog
:cl:
fix: Revolution no longer defaults to continuous
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
