### PR TITLE
Bags of Holding can now bomb again and can't be used for infinite storage

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -45,6 +45,7 @@
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 50)
+	component_type = /datum/component/storage/concrete/bluespace/bag_of_holding
 
 /obj/item/storage/backpack/holding/ComponentInitialize()
 	. = ..()
@@ -418,8 +419,8 @@
 	custom_premium_price = 500
 
 /obj/item/storage/backpack/duffelbag/sec/deputy/PopulateContents()
-	new /obj/item/clothing/head/soft/sec(src) 
-	new /obj/item/radio/headset/headset_sec(src) 
+	new /obj/item/clothing/head/soft/sec(src)
+	new /obj/item/radio/headset/headset_sec(src)
 	new /obj/item/clothing/glasses/hud/security/deputy(src)
 	new /obj/item/clothing/under/rank/security/mallcop(src)
 	new /obj/item/clothing/shoes/sneakers/black(src)


### PR DESCRIPTION
## About The Pull Request
Review your goddamn code, people! Jesus.
The component type was literally stealth removed in #1328 . Whether on purpose or by accident I do not know. Surprised nobody noticed or cared, but basically you can put bags of holding into each other infinitely right now, for virtually unlimited storage, and the bombing mechanic is completely gone.

## Why It's Good For The Game
Shouldn't have had to make this PR.

## Changelog
:cl:
fix: bags of holding function as intended again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
