### PR TITLE
Antagonist Token Improvements

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -71,6 +71,8 @@
 	var/list/learned_recipes //List of learned recipe TYPES.
 	var/list/crew_objectives = list()
 
+	var/requesting_antag_token_usage = FALSE	//If the client wants to use an antagonist token
+
 /datum/mind/New(var/key)
 	src.key = key
 	soulOwner = src

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -418,7 +418,7 @@
 
 		if(mind.requesting_antag_token_usage && mind.current?.client?.get_antag_token_count() >= 1)
 			if(mind.current?.client?.inc_antag_token_count(-1))
-				to_chat(mind, "<font color='green'>You have successfully used an antagonist token!</span>")
+				to_chat(mind, "<font color='green'>You have successfully used an antagonist token!</font>")
 				mind.requesting_antag_token_usage = FALSE
 				return mind
 			else

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -416,13 +416,13 @@
 		var/spend = min(((role in player.client.prefs.be_special) ? p_rep : 0) + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
 		current += spend
 
-		if(mind?.client?.requesting_antag_token_usage && mind?.client?.get_antag_token_count() >= 1)
-			if(mind.client.inc_antag_token_count(-1))
+		if(mind.requesting_antag_token_usage && mind.current?.client?.get_antag_token_count() >= 1)
+			if(mind.current?.client?.inc_antag_token_count(-1))
 				to_chat(mind, "<font color='green'>You have successfully used an antagonist token!</span>")
-				mind.client.requesting_antag_token_usage = FALSE
+				mind.requesting_antag_token_usage = FALSE
 				return mind
 			else
-				to_chat(mind, "<span class='warning'></span>")
+				to_chat(mind, "<span class='warning'>Failed to use antagonist token.</span>")
 
 		if(antag_select >= previous && antag_select <= (current-1))
 			SSpersistence.antag_rep_change[p_ckey] = -(spend - DEFAULT_ANTAG_TICKETS)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -416,6 +416,14 @@
 		var/spend = min(((role in player.client.prefs.be_special) ? p_rep : 0) + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
 		current += spend
 
+		if(mind?.client?.requesting_antag_token_usage && mind?.client?.get_antag_token_count() >= 1)
+			if(mind.client.inc_antag_token_count(-1))
+				to_chat(mind, "<font color='green'>You have successfully used an antagonist token!</span>")
+				mind.client.requesting_antag_token_usage = FALSE
+				return mind
+			else
+				to_chat(mind, "<span class='warning'></span>")
+
 		if(antag_select >= previous && antag_select <= (current-1))
 			SSpersistence.antag_rep_change[p_ckey] = -(spend - DEFAULT_ANTAG_TICKETS)
 //			WARNING("AR_DEBUG: Player [mind.key] won spending [spend] tickets from starting value [SSpersistence.antag_rep[p_ckey]]")

--- a/code/modules/client/antag_tokens.dm
+++ b/code/modules/client/antag_tokens.dm
@@ -16,12 +16,14 @@
 	var/datum/DBQuery/query_set_antag_tokens = SSdbcore.NewQuery("UPDATE [format_table_name("player")] SET antag_tokens = '[token_count]' WHERE ckey = '[ckey]'")
 	if(!query_set_antag_tokens.warn_execute())
 		qdel(query_set_antag_tokens)
-		return
+		return FALSE
 	qdel(query_set_antag_tokens)
+	return TRUE
 
 /client/proc/inc_antag_token_count(token_count)
 	var/datum/DBQuery/query_inc_antag_tokens = SSdbcore.NewQuery("UPDATE [format_table_name("player")] SET antag_tokens = antag_tokens + [token_count] WHERE ckey = '[ckey]'")
 	if(!query_inc_antag_tokens.warn_execute())
 		qdel(query_inc_antag_tokens)
-		return
+		return FALSE
 	qdel(query_inc_antag_tokens)
+	return TRUE

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -107,5 +107,3 @@
 	var/next_keysend_reset = 0
 	var/next_keysend_trip_reset = 0
 	var/keysend_tripped = FALSE
-
-	var/requesting_antag_token_usage = FALSE	//If the client wants to use an antagonist token

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -107,3 +107,5 @@
 	var/next_keysend_reset = 0
 	var/next_keysend_trip_reset = 0
 	var/keysend_tripped = FALSE
+
+	var/requesting_antag_token_usage = FALSE	//If the client wants to use an antagonist token

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -386,17 +386,29 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 /client/verb/use_antag_token()
 	set name = "Use Antagonist Token"
-	set desc = "Use an antagonist token to become an antagonist in the next round."
+	set desc = "Toggle whether or not you want to use an antagonist token to become an antagonist in the next round."
 	set category = "OOC"
+
+	if(!(SSticker.current_state == GAME_STATE_PREGAME || SSticker.current_state == GAME_STATE_STARTUP))
+		usr.mind.requesting_antag_token_usage = FALSE
+		to_chat(usr, "<span class='warning'>You cannot use an antagonist token after the round has started.</span>")
+		return
+
+	if(usr.mind.requesting_antag_token_usage)
+		usr.mind.requesting_antag_token_usage = FALSE
+		to_chat(usr, "<span class='warning'>You are no longer using an antagonist token.</span>")
+		return
 
 	var/antag_token_count = get_antag_token_count()
 	if(!antag_token_count)
 		to_chat(usr, "<span class='warning'>You have no antag tokens!</span>")
 		return
 
-	var/confimation = input(usr, "Are you sure you want to use an antag token if possible (You have [antag_token_count] remaining)?", "Antag Token", "Yes", "No")
+	var/confimation = alert(usr, "Are you sure you want to use an antag token if possible (You have [antag_token_count] remaining)? (You may be given antagonists that you have disabled in your preferences)", "Antag Token", "Yes", "No")
 
 	if(confimation != "Yes")
 		return
 
 	usr.mind.requesting_antag_token_usage = TRUE
+	to_chat(usr, "<font color='green'>You are now requesting to use an antagonist token. Your chance of becoming antagonist has been greatly increased!</font>")
+	to_chat(usr, "<font color='green'>Your antagonist token will only be used if you qualify for an antagonist role (This includes antagonist roles you have disabled in your preferences).</font>")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -134,6 +134,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set OOC Color") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
+
 /client/verb/resetcolorooc()
 	set name = "Reset Your OOC Color"
 	set desc = "Returns your OOC Color to default"
@@ -254,7 +255,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	chatOutput.start()
 	chatOutput.load()
 	alert(src, "Your chat has been force recreated. If this still hasnt fixed issues, please make an issue report, with your BYOND version, Windows version, and IE Version.", "Done", "Ok")
-				
+
 /client/verb/motd()
 	set name = "MOTD"
 	set category = "OOC"
@@ -382,3 +383,20 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 		pct += delta
 		winset(src, "mainwindow.split", "splitter=[pct]")
+
+/client/verb/use_antag_token()
+	set name = "Use Antagonist Token"
+	set desc = "Use an antagonist token to become an antagonist in the next round."
+	set category = "OOC"
+
+	var/antag_token_count = get_antag_token_count()
+	if(!antag_token_count)
+		to_chat(usr, "<span class='warning'>You have no antag tokens!</span>")
+		return
+
+	var/confimation = input(usr, "Are you sure you want to use an antag token if possible (You have [antag_token_count] remaining)?", "Antag Token", "Yes", "No")
+
+	if(confimation != "Yes")
+		return
+
+	usr.mind.requesting_antag_token_usage = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Forever now, antagonist tokens have destroyed the balance of the game, infuriating players and completely disrupting the flow of the round, but I have nerfed that.

Just kidding, this just makes them more useable.

## About The Pull Request

Antagonist tokens can now be used in the OOC tab by the client and will give the user forced antagonist for that round (if available) at the cost of 1 token, however they will not know what antagonist they are going to be and cannot pick (Antagonist tokens now force you to be antag, rather than let you pick what antag you want to be).

Tests ran:
 - Attempting to use an antagonist token with no tokens [Success]
 - Attempting to use an antagonist token with a token [Success]
 - Attempting to use an antagonist token but not readying up [Success]
 - Attempting to use an antagonist token, but subtracting the token away before used [Success]
 - Attempting to use the antagonist token on extended [Success]
 - No database access [Success]

## Why It's Good For The Game

Less work for admins, a better system in general. Slightly nerfed antag tokens so they could be given out for other things (maybe).

## Changelog
:cl:
refactor: refactored antagonist tokens to be useable without admin intervention.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
