### PR TITLE
bag of holding fix

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -6,7 +6,7 @@
 	matching -= A
 	if(istype(W, /obj/item/storage/backpack/holding) || matching.len)
 		var/safety = alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [A.name]?", "Abort", "Proceed")
-		if(safety != "Proceed" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)))
+		if(safety != "Proceed" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)) || !(W in user.contents)) // need to be holding the bag you're "inserting"
 			return
 		var/turf/loccheck = get_turf(A)
 		to_chat(user, "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>")


### PR DESCRIPTION
## About The Pull Request
I was informed last night that the reason for the stealth removal of BoH bombing that nobody was told about and that introduced an exploit allowing infinite storage was actually to fix another exploit that allowed boh bombing while holding only one of the bags.
Basically, you get two bags, stick one in the other but don't close the dialog. Then you can get rid of the bag you tried to insert, and just carry the other bag. When you get arrested or attacked, you can press the proceed button and the bag explodes, even though the other bag is nowhere nearby.

Basically you now have to be holding or wearing the bag you tried to insert else nothing will happen. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
exploit fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: can no longer bomb with just a single BoH in the vicinity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
