### PR TITLE
Reduces the space ruin budget

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -517,7 +517,7 @@ BOMBCAP 24
 ## a less lootfilled or smaller or less round effecting ruin costs less to
 ## spawn, while the converse is true. Alter this number to affect the amount
 ## of ruins.
-LAVALAND_BUDGET 75
+LAVALAND_BUDGET 60
 
 ## Space Ruin Budged
 Space_Budget 8

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -520,7 +520,7 @@ BOMBCAP 24
 LAVALAND_BUDGET 75
 
 ## Space Ruin Budged
-Space_Budget 20
+Space_Budget 8
 
 ## Time in ds from when a player latejoins till the arrival shuttle docks at the station
 ## Must be at least 30. At least 55 recommended to be visually/aurally appropriate

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -516,7 +516,7 @@ BOMBCAP 24
 LAVALAND_BUDGET 60
 
 ## Space Ruin Budged
-Space_Budget 16
+Space_Budget 8
 
 ## Time in ds from when a player latejoins till the arrival shuttle docks at the station
 ## Must be at least 30. At least 55 recommended to be visually/aurally appropriate


### PR DESCRIPTION
## Changelog
:cl:
tweak: The default number of space ruins to load in has been reduced.
/:cl:
