### PR TITLE
Right to be hidden

### DIFF
--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -472,6 +472,7 @@ CREATE TABLE IF NOT EXISTS `SS13_schema_revision` (
   `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`major`,`minor`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 5);
 
 
 

--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS `SS13_ban` (
   `unbanned_computerid` varchar(32) DEFAULT NULL,
   `unbanned_round_id` int(11) unsigned DEFAULT NULL,
   `global_ban` tinyint(1) unsigned NOT NULL DEFAULT '1',
+  `hidden` tinyint(1) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `idx_ban_isbanned` (`ckey`,`role`,`unbanned_datetime`,`expiration_time`),
   KEY `idx_ban_isbanned_details` (`ckey`,`ip`,`computerid`,`role`,`unbanned_datetime`,`expiration_time`),

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,9 +2,9 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 5.4; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 4);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 5);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 4);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 5);
 
 In any query remember to add a prefix to the table names if you use one.
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -9,6 +9,13 @@ INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 4);
 In any query remember to add a prefix to the table names if you use one.
 
 ----------------------------------------------------
+Version 5.5 21 May 2020, by Crossedfall
+Adds a new `hidden` column in the `ban` table that allows for server maintainers to hide specific ban entries if needed (e.g. in cases where the GDPR is invoked)
+
+ALTER TABLE `ban`
+ADD `hidden` tinyint(1) unsigned NOT NULL DEFAULT '0';
+
+----------------------------------------------------
 Version 5.4 2 Jan 2020, by ike709
 Adds the ability to specify a minimum playtime requirement (in hours) to vote in a server poll.
 

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
   *
   * make sure you add an update to the schema_version stable in the db changelog
   */
-#define DB_MINOR_VERSION 4
+#define DB_MINOR_VERSION 5
 
 
 //! ## Timing subsystem

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -597,7 +597,7 @@
 		var/bancount = 0
 		var/bansperpage = 10
 		page = text2num(page)
-		var/datum/DBQuery/query_unban_count_bans = SSdbcore.NewQuery("SELECT COUNT(id) FROM [format_table_name("ban")] WHERE [search]")
+		var/datum/DBQuery/query_unban_count_bans = SSdbcore.NewQuery("SELECT COUNT(id) FROM [format_table_name("ban")] WHERE [search] AND hidden=0")
 		if(!query_unban_count_bans.warn_execute())
 			qdel(query_unban_count_bans)
 			return
@@ -614,7 +614,7 @@
 				pagecount++
 			output += pagelist.Join(" | ")
 		var/limit = " LIMIT [bansperpage * page], [bansperpage]"
-		var/datum/DBQuery/query_unban_search_bans = SSdbcore.NewQuery({"SELECT id, bantime, round_id, role, expiration_time, TIMESTAMPDIFF(MINUTE, bantime, expiration_time), IF(expiration_time < NOW(), 1, NULL), applies_to_admins, reason, IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].ckey), ckey), INET_NTOA(ip), computerid, IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].a_ckey), a_ckey), IF(edits IS NOT NULL, 1, NULL), unbanned_datetime, IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].unbanned_ckey), unbanned_ckey), unbanned_round_id FROM [format_table_name("ban")] WHERE [search] ORDER BY id DESC[limit]"})
+		var/datum/DBQuery/query_unban_search_bans = SSdbcore.NewQuery({"SELECT id, bantime, round_id, role, expiration_time, TIMESTAMPDIFF(MINUTE, bantime, expiration_time), IF(expiration_time < NOW(), 1, NULL), applies_to_admins, reason, IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].ckey), ckey), INET_NTOA(ip), computerid, IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].a_ckey), a_ckey), IF(edits IS NOT NULL, 1, NULL), unbanned_datetime, IFNULL((SELECT byond_key FROM [format_table_name("player")] WHERE [format_table_name("player")].ckey = [format_table_name("ban")].unbanned_ckey), unbanned_ckey), unbanned_round_id FROM [format_table_name("ban")] WHERE [search] AND hidden=0 ORDER BY id DESC[limit]"})
 		if(!query_unban_search_bans.warn_execute())
 			qdel(query_unban_search_bans)
 			return


### PR DESCRIPTION
Adds a hidden flag in the bans table within the database that allows system maintainers to hide bans if needed. Like if a user invokes their right to be forgotten under GDPR, for example.

Once the flag is set, attempting to search for the ban via the unbanning panel should yield no results.

I've also updated our SQL setup file to automatically insert a schema version entry during initial setup. That'll prevent the game from warning admins that the version isn't set when linking to a fresh database.

-----

_**Note**_: This requires a database change to be made __BEFORE__ merging.