### PR TITLE
Ports Crew Transfer Vote from AuStation

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -234,6 +234,7 @@
 #include "code\controllers\subsystem\assets.dm"
 #include "code\controllers\subsystem\atoms.dm"
 #include "code\controllers\subsystem\augury.dm"
+#include "code\controllers\subsystem\autotransfer.dm"
 #include "code\controllers\subsystem\blackbox.dm"
 #include "code\controllers\subsystem\chat.dm"
 #include "code\controllers\subsystem\communications.dm"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -526,3 +526,15 @@
 
 /datum/config_entry/string/redirect_address
 	config_entry_value = ""
+
+/datum/config_entry/flag/vote_autotransfer_enabled //toggle for autotransfer system
+
+/datum/config_entry/number/vote_autotransfer_initial //length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
+	config_entry_value = 72000
+	integer = FALSE
+	min_val = 0
+
+/datum/config_entry/number/vote_autotransfer_interval //length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)
+	config_entry_value = 18000
+	integer = FALSE
+	min_val = 0

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -7,12 +7,12 @@ SUBSYSTEM_DEF(autotransfer)
 	var/targettime
 
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
+	. = ..()
 	if(!CONFIG_GET(flag/vote_autotransfer_enabled))
 		can_fire = FALSE
 		return
 	starttime = world.time
 	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
-	return ..()
 
 /datum/controller/subsystem/autotransfer/fire()
 	if(world.time > targettime)

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -1,0 +1,20 @@
+SUBSYSTEM_DEF(autotransfer)
+	name = "Autotransfer Vote"
+	flags = SS_KEEP_TIMING | SS_BACKGROUND
+	wait = 1 MINUTES
+
+	var/starttime
+	var/targettime
+
+/datum/controller/subsystem/autotransfer/Initialize(timeofday)
+	if(!CONFIG_GET(flag/vote_autotransfer_enabled))
+		can_fire = FALSE
+		return
+	starttime = world.time
+	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
+	return ..()
+
+/datum/controller/subsystem/autotransfer/fire()
+	if(world.time > targettime)
+		SSvote.initiate_vote("transfer", null)
+		targettime = targettime + CONFIG_GET(number/vote_autotransfer_interval)

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -7,12 +7,13 @@ SUBSYSTEM_DEF(autotransfer)
 	var/targettime
 
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
-	. = ..()
-	if(!CONFIG_GET(flag/vote_autotransfer_enabled))
-		can_fire = FALSE
-		return
 	starttime = world.time
 	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
+
+	if(!CONFIG_GET(flag/vote_autotransfer_enabled))
+		can_fire = FALSE
+
+	. = ..()
 
 /datum/controller/subsystem/autotransfer/fire()
 	if(world.time > targettime)

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -518,3 +518,11 @@ TOPIC_MAX_SIZE 500
 ## Uncomment to enable redirecting to the specified address. If a user attempts to join after EXTREEME_POPCAP has been reached, redirect them to this address.
 ## The given address is a format example. "byond://" is required to function. Create a potential infinite loop at your own risk.
 #REDIRECT_ADDRESS byond://golden.beestation13.com:7777
+
+### Autotransfer Settings
+## Uncomment to enable shuttle autotransfer
+VOTE_AUTOTRANSFER_ENABLED
+## Time (in deciseconds) before the first transfer vote. Default: 2 hours
+VOTE_AUTOTRANSFER_INITIAL 72000
+## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
+VOTE_AUTOTRANSFER_INTERVAL 18000

--- a/config/config.txt
+++ b/config/config.txt
@@ -520,3 +520,11 @@ TOPIC_MAX_SIZE 500
 ## Uncomment to enable redirecting to the specified address. If a user attempts to join after EXTREEME_POPCAP has been reached, redirect them to this address.
 ## The given address is a format example. "byond://" is required to function. Create a potential infinite loop at your own risk.
 #REDIRECT_ADDRESS byond://golden.beestation13.com:7777
+
+### Autotransfer Settings
+## Uncomment to enable shuttle autotransfer
+#VOTE_AUTOTRANSFER_ENABLED
+## Time (in deciseconds) before the first transfer vote. Default: 2 hours
+VOTE_AUTOTRANSFER_INITIAL 72000
+## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
+VOTE_AUTOTRANSFER_INTERVAL 18000


### PR DESCRIPTION
## About The Pull Request
Resolves #864 
Ports the crew transfer vote from AuStation. I tweaked it slightly to allow the system to be enabled or disabled in the config. As per the feature request, the system is enabled by default on sage, and disabled on golden.
If you'd rather any of the messages or text to be changed, let me know.

## Why It's Good For The Game
Idk I just resolved the issue, but it's really handy on austation.

## Changelog
:cl:
add: Automatic Crew Transfer Vote for Sage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
