### PR TITLE
Couple tiny fixes

### DIFF
--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(title)
 	fdel("data/previous_title.dat")
 
 	var/list/provisional_title_screens = flist("[global.config.directory]/title_screens/images/")
-
+	LAZYREMOVE(provisional_title_screens, "exclude")
 	if(length(provisional_title_screens))
 		file_path = "[global.config.directory]/title_screens/images/[pick(provisional_title_screens)]"
 	else

--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -11,8 +11,8 @@
 	// var/damage_multiplier = 0.2 Not in use yet.
 
 /obj/item/compressionkit/examine(mob/user)
-	..()
-	to_chat(user, "<span class='notice'>It has [charges] charges left. Recharge with bluespace crystals.</span>")
+	. = ..()
+	. += ("<span class='notice'>It has [charges] charges left. Recharge with bluespace crystals.</span>")
 
 /obj/item/compressionkit/proc/sparks()
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -417,7 +417,7 @@
 
 /obj/item/paper/construction/Initialize()
 	. = ..()
-	color = pick("FF0000", "#33cc33", "#ffb366", "#551A8B", "#ff80d5", "#4d94ff")
+	color = pick("#FF0000", "#33cc33", "#ffb366", "#551A8B", "#ff80d5", "#4d94ff")
 
 /*
  * Natural paper

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -64,6 +64,7 @@
 /obj/machinery/rnd/server/update_icon()
 	if (panel_open)
 		icon_state = "RD-server-on_t"
+		return
 	if (stat & EMPED || stat & NOPOWER)
 		icon_state = "RD-server-off"
 		return


### PR DESCRIPTION
bug bad, fix good

gonna be honest, I couldn't figure out what happens to that "exclude" file, but the title screen was sometimes picking it as an icon which was no bueno.

other fixes shouldn't need further explaining.

## Changelog
:cl: Trigg
fix: The title screen no longer occasionally fails to load.
fix: R&D Servers no longer look active when their panels are open.
fix: The Bluespace Compression Kit can now be properly examined.
fix: Construction paper now also comes in red colors, as originally intended.
fix: ...What do you mean, "you have no idea what construction paper is"?
/:cl:
