### PR TITLE
Ashwalkers can no longer use shuttle consoles

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -11,6 +11,10 @@
 	var/no_destination_swap = 0
 
 /obj/machinery/computer/shuttle/ui_interact(mob/user)
+	//Ash walkers cannot use the console because they are unga bungas
+	if(user.mind?.has_antag_datum(/datum/antagonist/ashwalker))
+		to_chat(user, "<span class='warning'>This computer has been designed to keep the natives like you from meddling with it, you have no hope of using it.</span>")
+		return
 	. = ..()
 	var/list/options = params2list(possible_destinations)
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ash walkers can no longer send themselves to the station, meaning they aren't a free grief pass for the station.
Instead, you can only grief the miners, or hide on the shuttle and hitch a ride up.

## Why It's Good For The Game

The mining shuttle console has been designed to keep the pesky ash walkers out.
![image](https://user-images.githubusercontent.com/26465327/83252256-d8112e80-a1a2-11ea-9f1f-d7ef9253a21a.png)

## Changelog
:cl:
tweak: Ash walkers can no longer use shuttle consoles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
