### PR TITLE
Headspiders IV: Actually balanced edition

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -517,6 +517,7 @@
 	give_objectives = FALSE
 	show_in_roundend = FALSE //These are here for admin tracking purposes only
 	you_are_greet = FALSE
+	geneticpoints = 3
 
 /datum/antagonist/changeling/roundend_report()
 	var/list/parts = list()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -23,6 +23,8 @@
 	var/datum/mind/origin
 	var/egg_lain = 0
 
+	gold_core_spawnable = HOSTILE_SPAWN
+
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)
 	egg.Insert(victim)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-adds headspiders to the gold slime pool, making xenolings once again obtainable, and also obliterates xenolings with the nerf bat to make them not overpowered. Alongside Zesko's ling nerfs, xenolings now only get three genetics points, and have to find and kill actual lings to get more.

## Why It's Good For The Game

The person who removed them in the first place said he'd be fine with them readded after heavy nerfs. Said heavy nerfs are here, so here we are.

This also prevents people who manage to use the long, hard and unreliable secret methods to become xenolings from taking all the combat skills and demolishing everyone in 1 on 1 combat.

## Changelog
:cl:
add: You can become a xenoling again
balance: Xenolings are no longer stupidly overpowered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
