### PR TITLE
Two new clown ERTs

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -80,3 +80,22 @@
 	rename_team = "The Juggernaut"
 	mission = "Send them straight back to Hell."
 	polldesc = "an elite Nanotrasen enhanced supersoldier"
+
+/datum/ert/clown
+	roles = list(/datum/antagonist/ert/clown)
+	leader_role = /datum/antagonist/ert/clown
+	teamsize = 7
+	opendoors = FALSE
+	rename_team = "The Circus"
+	mission = "Provide vital morale support to the station in this time of crisis."
+	code = "Banana"
+
+/datum/ert/honk
+	roles = list(/datum/antagonist/ert/clown/honk)
+	leader_role = /datum/antagonist/ert/clown/honk
+	teamsize = 5
+	opendoors = TRUE
+	rename_team = "HONK Squad"
+	mission = "HONK them into submission"
+	polldesc = "an elite Nanotrasen tactical pranking squad"
+	code = "HOOOOOOOOOONK"

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -87,7 +87,7 @@
 	teamsize = 7
 	opendoors = FALSE
 	rename_team = "The Circus"
-	mission = "Provide vital morale support to the station in this time of crisis."
+	mission = "Provide vital morale support to the station in this time of crisis"
 	code = "Banana"
 
 /datum/ert/honk

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -288,6 +288,12 @@
 	charge_type = /obj/item/reagent_containers/food/snacks/pie/cream
 	maxWeightClass = 60	//20 pies.
 
+/obj/item/pneumatic_cannon/pie/selfcharge/compact
+	name = "honkinator-4 compact pie cannon"
+	desc = "A compact, self loading pie cannon for tactical pranking action."
+	w_class = WEIGHT_CLASS_NORMAL
+	maxWeightClass = 30	//10 pies.
+
 /obj/item/pneumatic_cannon/pie/selfcharge/cyborg
 	name = "low velocity pie cannon"
 	automatic = FALSE

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -292,7 +292,6 @@
 	name = "honkinator-4 compact pie cannon"
 	desc = "A compact, self loading pie cannon for tactical pranking action."
 	w_class = WEIGHT_CLASS_NORMAL
-	maxWeightClass = 30	//10 pies.
 
 /obj/item/pneumatic_cannon/pie/selfcharge/cyborg
 	name = "low velocity pie cannon"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -47,6 +47,12 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 50)
 	component_type = /datum/component/storage/concrete/bluespace/bag_of_holding
 
+/obj/item/storage/backpack/holding/clown
+	name = "bag of honking"
+	desc = "An advanced clowning backpack for holding large quantities of pranking gear"
+	icon_state = "clownpack"
+	item_state = "clownpack"
+
 /obj/item/storage/backpack/holding/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -36,6 +36,10 @@
 	. = ..()
 	name_source = GLOB.commando_names
 
+/datum/antagonist/ert/clown/New()
+	. = ..()
+	name_source = GLOB.clown_names
+
 /datum/antagonist/ert/deathsquad/apply_innate_effects(mob/living/mob_override)
 	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, DEATHSQUAD_TRAIT)
 
@@ -127,6 +131,16 @@
 	random_names = FALSE
 	role = "The Juggernaut"
 
+/datum/antagonist/ert/clown
+	name = "Comedy Response Officer"
+	outfit = /datum/outfit/centcom_clown
+	role = "Prankster"
+
+/datum/antagonist/ert/clown/honk
+	name = "HONK Squad Trooper"
+	outfit = /datum/outfit/centcom_clown/honk_squad
+	role = "HONKER"
+
 /datum/antagonist/ert/create_team(datum/team/ert/new_team)
 	if(istype(new_team))
 		ert_team = new_team
@@ -184,6 +198,23 @@
 		missiondesc += " Take stock of your equipment and teammates (if any) and board the transit shuttle when you are ready."
 	else
 		missiondesc += " Rip and tear."
+
+	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
+	to_chat(owner,missiondesc)
+
+/datum/antagonist/ert/clown/greet()
+	if(!ert_team)
+		return
+
+	to_chat(owner, "<B><font size=3 color=red>You are the [name].</font></B>")
+
+	var/missiondesc = "Your squad is being sent on a mission to [station_name()] by Nanotrasen's Comedy Division."
+	if(leader) //If Squad Leader
+		missiondesc += " You are the worst clown here. As such, you were able to stop slipping the admiral for long enough to be given command. Good luck, honk!"
+	else
+		missiondesc += " Follow orders given to you by your squad leader, or ignore them if it's funnier."
+
+		missiondesc += " Slip as many civilians as possible."
 
 	missiondesc += "<BR><B>Your Mission</B> : [ert_team.mission.explanation_text]"
 	to_chat(owner,missiondesc)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -370,7 +370,6 @@
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
 	W.update_label(W.registered_name, W.assignment)
-	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
 	H.dna.add_mutation(CLOWNMUT)
 
 /datum/outfit/centcom_clown/honk_squad

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -369,6 +369,7 @@
 
 	var/obj/item/card/id/W = H.wear_id
 	W.registered_name = H.real_name
+	W.access += ACCESS_THEATRE
 	W.update_label(W.registered_name, W.assignment)
 	H.dna.add_mutation(CLOWNMUT)
 

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -334,3 +334,41 @@
 	suit_store = /obj/item/gun/ballistic/rifle/boltaction
 	r_hand = /obj/item/megaphone
 	head = /obj/item/clothing/head/intern
+
+/datum/outfit/centcom_clown
+	name = "Code Banana ERT"
+	id = /obj/item/card/id/centcom
+	belt = /obj/item/pda/clown
+	ears = /obj/item/radio/headset/headset_cent
+	uniform = /obj/item/clothing/under/rank/civilian/clown
+	back = /obj/item/storage/backpack/clown
+	shoes = /obj/item/clothing/shoes/clown_shoes
+	mask = /obj/item/clothing/mask/gas/clown_hat
+	l_pocket = /obj/item/bikehorn
+	backpack_contents = list(
+		/obj/item/stamp/clown = 1,
+		/obj/item/reagent_containers/spray/waterflower/lube = 1,
+		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
+		/obj/item/instrument/bikehorn = 1,
+		/obj/item/megaphone/clown = 1,
+		)
+
+	implants = list(/obj/item/implant/sad_trombone)
+
+/datum/outfit/centcom_clown/honk_squad
+	name = "HONK Squad Trooper"
+	back = /obj/item/storage/backpack/holding/clown
+	shoes = /obj/item/clothing/shoes/clown_shoes/taeclowndo
+	suit = /obj/item/clothing/suit/space/hardsuit/shielded/swat/honk
+	suit_store = /obj/item/tank/internals/emergency_oxygen/double
+	l_pocket = /obj/item/bikehorn/golden
+	r_pocket = /obj/item/shield/energy/bananium
+	l_hand = /obj/item/pneumatic_cannon/pie/selfcharge
+	backpack_contents = list(
+		/obj/item/stamp/clown = 1,
+		/obj/item/reagent_containers/spray/waterflower/lube = 1,
+		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
+		/obj/item/instrument/bikehorn = 1,
+		/obj/item/megaphone/clown = 1,
+		/obj/item/reagent_containers/spray/chemsprayer/janitor/clown = 1,
+		)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -355,6 +355,24 @@
 
 	implants = list(/obj/item/implant/sad_trombone)
 
+
+/datum/outfit/centcom_clown/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
+	var/obj/item/implant/mindshield/L = new/obj/item/implant/mindshield(H)
+	L.implant(H, null, 1)
+
+	var/obj/item/radio/R = H.ears
+	R.set_frequency(FREQ_CENTCOM)
+	R.freqlock = TRUE
+
+	var/obj/item/card/id/W = H.wear_id
+	W.registered_name = H.real_name
+	W.update_label(W.registered_name, W.assignment)
+	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
+	H.dna.add_mutation(CLOWNMUT)
+
 /datum/outfit/centcom_clown/honk_squad
 	name = "HONK Squad Trooper"
 	back = /obj/item/storage/backpack/holding/clown

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -860,6 +860,22 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	actions_types = list()
 
+/obj/item/clothing/suit/space/hardsuit/shielded/swat/honk
+	name = "honk squad spacesuit"
+	desc = "A hilarious hardsuit favored by HONK squad troopers for use in special pranks."
+	icon_state = "hardsuit-clown"
+	item_state = "clown_hardsuit"
+	item_color = "clown"
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/shielded/swat/honk
+
+/obj/item/clothing/head/helmet/space/hardsuit/shielded/swat/honk
+	name = "honk squad helmet"
+	desc = "A hilarious helmet with built in anti-mime propaganda shielding."
+	icon_state = "hardsuit0-clown"
+	item_state = "hardsuit0-clown"
+	item_color = "clown"
+	
+
 // Doomguy ERT version
 /obj/item/clothing/suit/space/hardsuit/shielded/doomguy
 	name = "juggernaut armor"

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -123,6 +123,10 @@
 			return get_ert_access("med")
 		if("CentCom Bartender")
 			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_BAR)
+		if("Comedy Response Officer")
+			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING)
+		if("HONK Squad Trooper")
+			return list(ACCESS_CENT_GENERAL, ACCESS_CENT_SPECOPS, ACCESS_CENT_LIVING, ACCESS_CENT_STORAGE)
 
 /proc/get_all_accesses()
 	return list(ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_BRIG, ACCESS_ARMORY, ACCESS_FORENSICS_LOCKERS, ACCESS_COURT,
@@ -360,7 +364,7 @@
 	return get_all_jobs() + list("Prisoner")
 
 /proc/get_all_centcom_jobs()
-	return list("VIP Guest","Custodian","Thunderdome Overseer","CentCom Official","Medical Officer","Death Commando","Research Officer","Special Ops Officer","Admiral","CentCom Commander","Emergency Response Team Commander","Security Response Officer","Engineer Response Officer", "Medical Response Officer","CentCom Bartender")
+	return list("VIP Guest","Custodian","Thunderdome Overseer","CentCom Official","Medical Officer","Death Commando","Research Officer","Special Ops Officer","Admiral","CentCom Commander","Emergency Response Team Commander","Security Response Officer","Engineer Response Officer", "Medical Response Officer","CentCom Bartender","Comedy Response Officer", "HONK Squad Trooper")
 
 /obj/item/proc/GetJobName() //Used in secHUD icon generation
 	var/obj/item/card/id/I = GetID()

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -341,6 +341,8 @@
 /obj/item/reagent_containers/spray/chemsprayer/janitor/clown
 	name = "lubinator 8000"
 	desc = "A modified industrial cleaning sprayer, capable of coating entire hallways in high performance lubricant, honk!"
+	icon_state = "chemsprayer"
+	item_state = "chemsprayer"
 	list_reagents = list(/datum/reagent/lube = 1000)
 	generate_type = /datum/reagent/lube
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -338,6 +338,12 @@
 	last_generate = world.time
 	reagents.add_reagent(generate_type, generate_amount)
 
+/obj/item/reagent_containers/spray/chemsprayer/janitor/clown
+	name = "lubinator 8000"
+	desc = "A modified industrial cleaning sprayer, capable of coating entire hallways in high performance lubricant, honk!"
+	list_reagents = list(/datum/reagent/lube = 1000)
+	generate_type = /datum/reagent/lube
+
 // Plant-B-Gone
 /obj/item/reagent_containers/spray/plantbgone // -- Skie
 	name = "Plant-B-Gone"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two new ERTs: the Code Banana ERT and the HONK Squad.

Code Banana ERTs are just clowns with centcomm access, megaphones and lube flowers, making them even weaker than interns.

The HONK Squad is much stronger. They get a special clown version of the death commando hardsuit, a new clown BoH, golden bikehorn, bananium eshield, taeclowndo shoes, a pie cannon and a self refilling lube sprayer.

## Why It's Good For The Game
Honk.

Code Banana ERTs offer an even weaker ERT to get ghosts back in the game without screwing over antags too much.

HONK Squads are roughly on par with a Code Red ERT, but offer a funny alternative to make the round more goofy.

## Changelog
:cl:
add: Added two new clown ERTs, code banana and the HONK squad
add: Added some clown themed ERT items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
