### PR TITLE
Don't generate Cls for commits with the skip tag

### DIFF
--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   MakeCL:
     runs-on: ubuntu-latest
-    if: github.repository == 'BeeStation/BeeStation-Hornet'
+    if: github.repository == 'BeeStation/BeeStation-Hornet' || "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   MakeCL:
     runs-on: ubuntu-latest
-    if: github.repository == 'BeeStation/BeeStation-Hornet' || "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: github.repository == 'BeeStation/BeeStation-Hornet' && "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
Neglected to consider that Github's snowflake token automatically prevents actions from running off of each other. This added conditional should prevent the action from trying to compile commits that have the [ci skip] tag at the end.

Given that actions are a bit trial and error by design, expect more PRs if this doesn't work. (Sorry Terra)

## Changelog
:cl:
tweak: Another CL tweak
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
