### PR TITLE
Don't you love conflicting documentation?

### DIFF
--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   MakeCL:
     runs-on: ubuntu-latest
-    if: github.repository == 'BeeStation/BeeStation-Hornet' && "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: github.repository == 'BeeStation/BeeStation-Hornet' && !contains(github.event.head_commit.message, '[ci skip]')
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
I guess the documentation I was looking at is outdated, since it doesn't like double quotes. Removed them and trying again. (Isn't this system amazing? I love how it's impossible to test without doing a bunch of trial and error PRs)

## Changelog
:cl:
tweak: Yet another CLs tweak
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
