### PR TITLE
Reduces autotransfer vote time to 90 minutes

### DIFF
--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -522,7 +522,7 @@ TOPIC_MAX_SIZE 500
 ### Autotransfer Settings
 ## Uncomment to enable shuttle autotransfer
 VOTE_AUTOTRANSFER_ENABLED
-## Time (in deciseconds) before the first transfer vote. Default: 2 hours
-VOTE_AUTOTRANSFER_INITIAL 72000
+## Time (in deciseconds) before the first transfer vote. Default: 90 minutes
+VOTE_AUTOTRANSFER_INITIAL 54000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000

--- a/config/config.txt
+++ b/config/config.txt
@@ -523,8 +523,8 @@ TOPIC_MAX_SIZE 500
 
 ### Autotransfer Settings
 ## Uncomment to enable shuttle autotransfer
-#VOTE_AUTOTRANSFER_ENABLED
-## Time (in deciseconds) before the first transfer vote. Default: 2 hours
-VOTE_AUTOTRANSFER_INITIAL 72000
+VOTE_AUTOTRANSFER_ENABLED
+## Time (in deciseconds) before the first transfer vote. Default: 90 minutes
+VOTE_AUTOTRANSFER_INITIAL 54000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000


### PR DESCRIPTION
The server is liable to crash after 2 hours of highpop, so let's give the crew a chance to end the round before then. Also enables it on Golden.

## Changelog
:cl:
tweak: Crew transfer vote will occur at the 90 minute mark, and every 30 minutes thereafter.
/:cl:
