### PR TITLE
Shuttle construction kit with the power of cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -656,7 +656,7 @@
 	name = "Smart Mine Crate"
 	desc = "Contains three nonlethal pressure activated stun mines capable of ignoring mindshieled personnel. Requires Armory access to open."
 	cost = 4000
-	contains = list(/obj/item/deployablemine/smartstun,					
+	contains = list(/obj/item/deployablemine/smartstun,
 					/obj/item/deployablemine/smartstun,
 					/obj/item/deployablemine/smartstun)
 	crate_name = "stun mine create"
@@ -920,6 +920,28 @@
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"
 
+/datum/supply_pack/engineering/shuttle_construction
+	name = "Shuttle Construction Kit"
+	desc = "A DIY kit for building your own shuttle! Comes with all the parts you need to get your people to the stars!"
+	cost = 6000
+	contains = list(
+		/obj/machinery/portable_atmospherics/canister/toxins,
+		/obj/item/construction/rcd/loaded,
+		/obj/item/rcd_ammo/large,
+		/obj/item/rcd_ammo/large,
+		/obj/item/shuttle_creator,
+		/obj/item/pipe_dispenser,
+		/obj/item/storage/toolbox/mechanical,
+		/obj/item/storage/toolbox/electrical,
+		/obj/item/circuitboard/computer/shuttle/docker,
+		/obj/item/circuitboard/computer/shuttle/flight_control,
+		/obj/item/circuitboard/machine/shuttle/engine/plasma,
+		/obj/item/circuitboard/machine/shuttle/engine/plasma,
+		/obj/item/circuitboard/machine/shuttle/heater,
+		/obj/item/circuitboard/machine/shuttle/heater
+		)
+	crate_name = "shuttle construction crate"
+	crate_type = /obj/structure/closet/crate/large
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////// Engine Construction /////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new cargo kit for 6000 credits containing:

/obj/machinery/portable_atmospherics/canister/toxins,
/obj/item/construction/rcd/loaded,
/obj/item/rcd_ammo/large,
/obj/item/rcd_ammo/large,
/obj/item/shuttle_creator,
/obj/item/pipe_dispenser,
/obj/item/storage/toolbox/mechanical,
/obj/item/storage/toolbox/electrical,
/obj/item/circuitboard/computer/shuttle/docker,
/obj/item/circuitboard/computer/shuttle/flight_control,
/obj/item/circuitboard/machine/shuttle/engine/plasma,
/obj/item/circuitboard/machine/shuttle/engine/plasma,
/obj/item/circuitboard/machine/shuttle/heater,
/obj/item/circuitboard/machine/shuttle/heater

(sells back to Centcom for <500)

Please give me your feedback on how you would abuse this, and would should be removed / added.

## Why It's Good For The Game

Makes shuttle construction a lot easier, since building is fun.
Brings the time down from around an hour to build a shuttle, to accommodate for the shorter rounds.

## Changelog
:cl:
add: Cargo shuttle construction kit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
