### PR TITLE
fixes 3 runtimes

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -340,7 +340,7 @@ SUBSYSTEM_DEF(job)
 				if(player.mind && (job.title in player.mind.restricted_roles))
 					JobDebug("DO incompatible with antagonist role, Player: [player], Job:[job.title]")
 					continue
-				
+
 				// If the player wants that job on this level, then try give it to him.
 				if(player.client.prefs.job_preferences[job.title] == level || (job.gimmick && player.client.prefs.job_preferences["Gimmick"] == level))
 					// If the job isn't filled
@@ -503,6 +503,8 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/LoadJobs()
 	var/jobstext = file2text("[global.config.directory]/jobs.txt")
 	for(var/datum/job/J in occupations)
+		if(J.flag == GIMMICK || J.gimmick) //gimmick job slots are dependant on random maint
+			continue
 		var/regex/jobs = new("[J.title]=(-1|\\d+),(-1|\\d+)")
 		jobs.Find(jobstext)
 		J.total_positions = text2num(jobs.group[1])

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -29,7 +29,7 @@
 		M.confused += (max(20/max(1,distance), 6))
 //Bang
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		var/protection = M.get_ear_protection()
+		var/protection = min(1, M.get_ear_protection())
 		M.adjustEarDamage(15/protection, 30/protection)
 		M.soundbang_act(1, 200, 10, 15)
 	else

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -29,7 +29,7 @@
 		M.confused += (max(20/max(1,distance), 6))
 //Bang
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
-		var/protection = min(1, M.get_ear_protection())
+		var/protection = max(1, M.get_ear_protection())
 		M.adjustEarDamage(15/protection, 30/protection)
 		M.soundbang_act(1, 200, 10, 15)
 	else

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -3,8 +3,8 @@
 	id = "abductor"
 	say_mod = "gibbers"
 	sexes = FALSE
-	species_traits = list(NOBLOOD,NOEYESPRITES)
-	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOGUNS,TRAIT_NOHUNGER,TRAIT_NOBREATH,NOMOUTH)
+	species_traits = list(NOBLOOD,NOEYESPRITES,NOMOUTH)
+	inherent_traits = list(TRAIT_VIRUSIMMUNE,TRAIT_NOGUNS,TRAIT_NOHUNGER,TRAIT_NOBREATH)
 	mutanttongue = /obj/item/organ/tongue/abductor
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 


### PR DESCRIPTION
bug bad

the 1 in max(1, M.get_ear_protection()) was completely arbitrary, let me know if it should be anything else.

## Changelog
:cl: Trigg
fix: That annoying (but harmless?) runtime in jobs.dm literally every initialization is gone.
fix: Abductor species no longer runtime on creation.
fix: Flashbangs no longer runtime when banging completely unprotected targets.
/:cl: