### PR TITLE
Nerfs legion core transformation disease

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -440,7 +440,7 @@
 	name = "Necropolis Infestation"
 	cure_text = "The healing Vitrium Froth of some Lavaland flora"
 	cures = list(/datum/reagent/consumable/vitfro)
-	cure_chance = 5 //about 20 seconds/5 units of Froth to heal. Takes a decent gathering period but just shy of the amount that'll fatten you
+	cure_chance = 10 //about 10 seconds/5 units of Froth to heal. Takes a decent gathering period but just shy of the amount that'll fatten you
 	stage_prob = 5
 	agent = "Legion droppings"
 	desc = "Who knew that spreading the primordial goop of a vile entity would take a toll on the body?"


### PR DESCRIPTION
Makes legion core transformation disease a little easier to cure with lavaland froth. It takes too long to cure yourself from it.

:cl:
balance: It's easier to cure the legion core disease.
/:cl: