### PR TITLE
Revert gold necklace name in beecoin shop

### DIFF
--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -68,7 +68,7 @@
 	cost = 20000
 
 /datum/gear/accessory/necklace
-	display_name = "dope necklace"
+	display_name = "necklace, gold"
 	path = /obj/item/clothing/neck/necklace/dope
 	cost = 25000
 

--- a/code/modules/client/loadout/loadout_accessories.dm
+++ b/code/modules/client/loadout/loadout_accessories.dm
@@ -1,3 +1,5 @@
+// DO NOT CHANGE DISPLAY NAME
+
 /datum/gear/accessory
 	subtype_path = /datum/gear/accessory
 	slot = SLOT_NECK
@@ -68,6 +70,11 @@
 	cost = 20000
 
 /datum/gear/accessory/necklace
+	display_name = "dope necklace"
+	path = /obj/item/clothing/neck/necklace/dope
+	cost = 25000
+
+/datum/gear/accessory/oldnecklace
 	display_name = "necklace, gold"
 	path = /obj/item/clothing/neck/necklace/dope
 	cost = 25000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After the name of the gold necklace was changed those who bought it before lost access to it (at least i did).
Reverts beecoin shop gold necklace name from 'dope necklace' to 'necklace, gold'.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Those who purchased gold necklace before the name change will have access to it again (hopefully).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: People who bought gold necklace in beecoin shop before its name change should have access to it again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
