### PR TITLE
Emergency shuttles now with actual air

### DIFF
--- a/_maps/shuttles/emergency_arena.dmm
+++ b/_maps/shuttles/emergency_arena.dmm
@@ -50,23 +50,25 @@
 /obj/structure/fluff/drake_statue,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
-"n" = (
-/obj/effect/forcefield/arena_shuttle_entrance,
-/turf/open/indestructible/necropolis/air,
-/area/shuttle/escape/arena)
-"o" = (
-/obj/effect/forcefield/arena_shuttle_entrance,
-/obj/docking_port/mobile/emergency{
-	name = "The Arena"
-	},
-/turf/open/indestructible/necropolis/air,
-/area/shuttle/escape/arena)
 "p" = (
 /obj/structure/healingfountain,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
 "z" = (
 /obj/effect/landmark/shuttle_arena_safe,
+/turf/open/indestructible/necropolis/air,
+/area/shuttle/escape/arena)
+"L" = (
+/obj/effect/forcefield/arena_shuttle_entrance,
+/obj/docking_port/mobile/emergency{
+	name = "The Arena"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/indestructible/necropolis/air,
+/area/shuttle/escape/arena)
+"N" = (
+/obj/effect/forcefield/arena_shuttle_entrance,
+/obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/necropolis/air,
 /area/shuttle/escape/arena)
 
@@ -106,17 +108,17 @@ g
 g
 g
 g
-n
+N
 g
-o
-g
-g
+L
 g
 g
 g
-n
 g
-n
+g
+N
+g
+N
 g
 g
 g

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -10,41 +10,9 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"ae" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
 "ah" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"ai" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aj" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dir = 2;
-	dwidth = 10;
-	height = 13;
-	name = "Asteroid emergency shuttle";
-	width = 28
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"al" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "am" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -108,12 +76,6 @@
 /obj/machinery/suit_storage_unit,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"aG" = (
-/obj/machinery/door/airlock/mining{
-	name = "Emergency Shuttle Storage"
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
 "aH" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -155,13 +117,6 @@
 "aN" = (
 /obj/structure/bed/roller,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aP" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "aQ" = (
 /obj/structure/bed,
@@ -256,13 +211,6 @@
 /obj/machinery/ai_slipper,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"bg" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "bi" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
@@ -306,19 +254,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"bq" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "5"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"br" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "bs" = (
 /obj/structure/bed,
 /turf/open/floor/mineral/titanium/white,
@@ -331,12 +266,6 @@
 	},
 /obj/structure/mirror{
 	pixel_x = -30
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bu" = (
-/obj/machinery/door/airlock{
-	name = "Emergency Shuttle Restroom"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -416,11 +345,6 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"bI" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "bJ" = (
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium/yellow,
@@ -446,8 +370,90 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"jj" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"qg" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"qO" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"rp" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"xE" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"ED" = (
+/obj/machinery/door/airlock/mining{
+	name = "Emergency Shuttle Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Gw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"IJ" = (
+/obj/machinery/door/airlock{
+	name = "Emergency Shuttle Restroom"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "Jx" = (
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"JJ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "JM" = (
 /obj/machinery/vending/wallmed{
@@ -456,6 +462,69 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
+"QG" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"RT" = (
+/obj/machinery/door/airlock{
+	name = "Emergency Shuttle Restroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"RU" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	dwidth = 10;
+	height = 13;
+	name = "Asteroid emergency shuttle";
+	width = 28
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"VO" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"YJ" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Zz" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -463,9 +532,9 @@ aa
 ac
 am
 ac
-ad
-ad
-bI
+qO
+qO
+qg
 ac
 am
 ac
@@ -518,7 +587,7 @@ ac
 ac
 "}
 (5,1,1) = {"
-ad
+qO
 ap
 aq
 bJ
@@ -528,12 +597,12 @@ bd
 bl
 ac
 bN
-bu
+IJ
 bE
-ad
+qO
 "}
 (6,1,1) = {"
-ae
+xE
 aq
 aq
 aq
@@ -548,7 +617,7 @@ ac
 ac
 "}
 (7,1,1) = {"
-ad
+qO
 ar
 aq
 aq
@@ -558,21 +627,21 @@ bf
 bn
 ac
 Jx
-bu
+IJ
 bE
-ad
+qO
 "}
 (8,1,1) = {"
 ac
 ac
 ac
-aG
+ED
 ac
 aX
-bg
+YJ
 bi
 az
-bu
+RT
 az
 ac
 ac
@@ -608,8 +677,8 @@ aa
 aa
 "}
 (11,1,1) = {"
-ah
-ah
+VO
+VO
 aB
 aJ
 at
@@ -623,9 +692,9 @@ aa
 aa
 "}
 (12,1,1) = {"
-ai
+QG
 at
-at
+Gw
 at
 at
 aZ
@@ -638,8 +707,8 @@ aa
 aa
 "}
 (13,1,1) = {"
-ah
-ah
+VO
+VO
 aB
 bK
 at
@@ -655,7 +724,7 @@ aa
 (14,1,1) = {"
 aa
 aa
-ad
+qO
 aK
 at
 aZ
@@ -663,14 +732,14 @@ ah
 aK
 at
 aZ
-ad
+qO
 aa
 aa
 "}
 (15,1,1) = {"
 aa
 aa
-ad
+qO
 aK
 at
 at
@@ -678,14 +747,14 @@ at
 at
 at
 aZ
-ad
+qO
 aa
 aa
 "}
 (16,1,1) = {"
 aa
 aa
-ad
+qO
 aK
 at
 aZ
@@ -693,13 +762,13 @@ ah
 aK
 at
 aZ
-ad
+qO
 aa
 aa
 "}
 (17,1,1) = {"
-ah
-ah
+VO
+VO
 aB
 bK
 at
@@ -713,9 +782,9 @@ aa
 aa
 "}
 (18,1,1) = {"
-aj
+RU
 at
-at
+Gw
 at
 at
 aZ
@@ -728,8 +797,8 @@ aa
 aa
 "}
 (19,1,1) = {"
-ah
-ah
+VO
+VO
 aB
 aL
 at
@@ -777,11 +846,11 @@ ac
 ac
 ac
 ad
-aP
+JJ
 ad
 bi
 ad
-br
+Zz
 ad
 ac
 ac
@@ -803,7 +872,7 @@ bF
 ac
 "}
 (24,1,1) = {"
-al
+jj
 aw
 aw
 aw
@@ -815,7 +884,7 @@ Jx
 Jx
 Jx
 bG
-ad
+qO
 "}
 (25,1,1) = {"
 ac
@@ -838,9 +907,9 @@ ac
 ac
 ac
 ad
-aP
+JJ
 ac
-bq
+rp
 ad
 JM
 ac
@@ -868,9 +937,9 @@ aa
 aa
 ac
 ac
-ad
+qO
 ac
-ad
+qO
 ac
 ac
 aa

--- a/_maps/shuttles/emergency_backup.dmm
+++ b/_maps/shuttles/emergency_backup.dmm
@@ -5,11 +5,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
-"c" = (
-/obj/machinery/door/airlock/titanium,
-/obj/docking_port/mobile/emergency/backup,
-/turf/open/floor/plating,
-/area/shuttle/escape/backup)
 "f" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/random,
@@ -17,6 +12,12 @@
 /area/shuttle/escape/backup)
 "g" = (
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"i" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/mobile/emergency/backup,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/escape/backup)
 "m" = (
 /turf/closed/wall/mineral/titanium,
@@ -55,7 +56,7 @@
 (1,1,1) = {"
 m
 m
-c
+i
 m
 m
 m

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -134,13 +134,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
-"az" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/escape)
 "aA" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
@@ -208,24 +201,6 @@
 "aI" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"aK" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aL" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -284,19 +259,6 @@
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/lizardwine,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"aT" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "The Emergency Escape Bar"
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -369,16 +331,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bg" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "bi" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -390,53 +342,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bm" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
 "bn" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"bo" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
 "bp" = (
 /turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"bq" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay"
-	},
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "br" = (
 /obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"bs" = (
-/obj/machinery/door/airlock{
-	name = "Unit 1"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"bu" = (
-/obj/machinery/door/airlock{
-	name = "Unit 2"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"bv" = (
-/obj/machinery/door/airlock{
-	name = "Unit B"
-	},
-/turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "bw" = (
 /obj/structure/table/optable,
@@ -663,12 +579,135 @@
 /obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"hb" = (
+/obj/machinery/door/airlock{
+	name = "Unit B"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"kK" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"pT" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"rb" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"CM" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"FR" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"GY" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"LQ" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"PE" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "The Emergency Escape Bar"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"QE" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"UQ" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
 "Yn" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	use_power = 0
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"YJ" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -679,17 +718,17 @@ aa
 ab
 ab
 ab
-aK
+LQ
 ab
-aT
+PE
 ab
-ac
-ac
-ac
+CM
+CM
+CM
 ab
-bg
+pT
 ab
-bo
+kK
 ab
 ab
 ab
@@ -714,7 +753,7 @@ bH
 bZ
 ab
 bp
-bs
+YJ
 bx
 ab
 ab
@@ -744,7 +783,7 @@ bC
 bE
 "}
 (4,1,1) = {"
-ac
+CM
 af
 am
 ar
@@ -762,19 +801,19 @@ bQ
 aE
 ab
 ak
-bu
+rb
 bx
 bC
 bE
 "}
 (5,1,1) = {"
-ac
+CM
 ag
 an
 as
 ab
 ac
-aJ
+UQ
 ac
 ae
 aE
@@ -792,7 +831,7 @@ bC
 bE
 "}
 (6,1,1) = {"
-ac
+CM
 ah
 an
 at
@@ -808,19 +847,19 @@ aE
 aE
 aE
 aE
-bm
+QE
 bp
-bv
+hb
 by
 bC
 bE
 "}
 (7,1,1) = {"
-ac
+CM
 ag
 an
 an
-az
+GY
 aE
 aE
 aN
@@ -840,7 +879,7 @@ bC
 bE
 "}
 (8,1,1) = {"
-ac
+CM
 ai
 ao
 ao
@@ -880,7 +919,7 @@ aE
 be
 aE
 aE
-bq
+FR
 bi
 bi
 bS
@@ -917,21 +956,21 @@ aa
 aa
 aa
 ab
-ac
+CM
 ab
-ac
-ab
-ab
-ab
-ac
-ac
-ac
+CM
 ab
 ab
 ab
-ac
+CM
+CM
+CM
 ab
-ac
+ab
+ab
+CM
+ab
+CM
 ab
 aa
 "}

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -1,15 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aa" = (
 /turf/template_noop,
 /area/template_noop)
-"b" = (
+"ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"c" = (
+"ac" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"d" = (
+"ad" = (
 /obj/structure/table,
 /obj/item/scalpel,
 /obj/item/retractor{
@@ -18,7 +18,7 @@
 /obj/item/hemostat,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"e" = (
+"ae" = (
 /obj/structure/table,
 /obj/item/cautery,
 /obj/item/surgicaldrill,
@@ -27,99 +27,92 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"f" = (
+"af" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"g" = (
+"ag" = (
 /obj/structure/shuttle/engine/propulsion/right{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"h" = (
+"ah" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"i" = (
+"ai" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"j" = (
+"aj" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"k" = (
+"ak" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"l" = (
+"al" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"m" = (
+"am" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"n" = (
+"an" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"o" = (
+"ao" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"p" = (
+"ap" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"q" = (
+"aq" = (
 /obj/machinery/computer/communications{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"r" = (
+"ar" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"s" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "bridge door";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"t" = (
+"at" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"u" = (
+"au" = (
 /obj/structure/shuttle/engine/propulsion/left{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"v" = (
+"av" = (
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"w" = (
+"aw" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	use_power = 0
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"x" = (
+"ax" = (
 /obj/structure/table,
 /obj/machinery/recharger{
 	active_power_usage = 0;
@@ -129,58 +122,43 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"y" = (
+"ay" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"z" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "security airlock";
-	req_access_txt = "63"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"A" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"B" = (
+"aB" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"C" = (
+"aC" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"D" = (
+"aD" = (
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"E" = (
+"aE" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"F" = (
+"aF" = (
 /obj/structure/table,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"G" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"H" = (
+"aH" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"I" = (
+"aI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/spaghetti/boiledspaghetti{
 	name = "pasghetti";
@@ -189,40 +167,27 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"J" = (
+"aJ" = (
 /obj/machinery/light/small,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"K" = (
-/obj/machinery/door/airlock/titanium,
-/obj/docking_port/mobile/emergency{
-	dheight = 0;
-	dir = 8;
-	dwidth = 6;
-	height = 18;
-	port_direction = 4;
-	width = 14;
-	name = "Birdboat emergency escape shuttle"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"L" = (
+"aL" = (
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"M" = (
+"aM" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/chocolatebar,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"N" = (
+"aN" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"O" = (
+"aO" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
@@ -232,7 +197,7 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"P" = (
+"aP" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -240,13 +205,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"Q" = (
+"aQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"R" = (
+"aR" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/fire{
 	pixel_x = 5;
@@ -255,20 +220,20 @@
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"S" = (
+"aS" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"T" = (
+"aT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"U" = (
+"aU" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/brute{
 	pixel_x = 5;
@@ -280,311 +245,398 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"V" = (
+"aV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"W" = (
+"aW" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"X" = (
+"aX" = (
 /obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Y" = (
+"aY" = (
 /obj/structure/table/glass,
 /obj/item/defibrillator/loaded,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"mv" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "bridge door";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"xJ" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "bridge door";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Cf" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Hy" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Mg" = (
+/obj/machinery/door/airlock/titanium,
+/obj/docking_port/mobile/emergency{
+	dheight = 0;
+	dir = 8;
+	dwidth = 6;
+	height = 18;
+	name = "Birdboat emergency escape shuttle";
+	port_direction = 4;
+	width = 14
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"MN" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ti" = (
+/obj/machinery/door/airlock/titanium,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Wn" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "security airlock";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
 
 (1,1,1) = {"
-a
-a
-b
-b
-c
-b
-c
-c
-c
-c
-c
-b
-a
-a
+aa
+aa
+ab
+ab
+MN
+ab
+MN
+MN
+MN
+MN
+MN
+ab
+aa
+aa
 "}
 (2,1,1) = {"
-a
-b
-h
-q
-k
-c
-B
-H
-H
-H
-B
-h
-b
-a
+aa
+ab
+ah
+aq
+ak
+ac
+aB
+aH
+aH
+aH
+aB
+ah
+ab
+aa
 "}
 (3,1,1) = {"
-a
-b
-i
-r
-C
-s
-C
-C
-C
-C
-C
-S
-b
-a
+aa
+ab
+ai
+ar
+aC
+mv
+aC
+aC
+aC
+aC
+aC
+aS
+ab
+aa
 "}
 (4,1,1) = {"
-a
-c
-j
-C
-v
-b
-D
-D
-L
-C
-C
-S
-b
-a
+aa
+MN
+aj
+aC
+av
+ab
+aD
+aD
+aL
+aC
+aC
+aS
+ab
+aa
 "}
 (5,1,1) = {"
-a
-c
-j
-C
-V
-b
-E
-E
-M
-C
-C
-S
-b
-a
+aa
+MN
+aj
+aC
+aV
+ab
+aE
+aE
+aM
+aC
+aC
+aS
+ab
+aa
 "}
 (6,1,1) = {"
-a
-b
-k
-C
-k
-b
-F
-I
-L
-C
-C
-T
-h
-b
+aa
+ab
+ak
+aC
+ak
+ab
+aF
+aI
+aL
+aC
+aC
+aT
+ah
+ab
 "}
 (7,1,1) = {"
-a
-b
-b
-s
-c
-b
-C
-C
-C
-C
-C
-C
-B
-b
+aa
+ab
+ab
+xJ
+ac
+ab
+aC
+aC
+aC
+aC
+aC
+aC
+aB
+ab
 "}
 (8,1,1) = {"
-a
-b
-l
-t
-t
-c
-B
-C
-C
-C
-C
-C
-V
-b
+aa
+ab
+al
+at
+at
+ac
+aB
+aC
+aC
+aC
+aC
+aC
+aV
+ab
 "}
 (9,1,1) = {"
-a
-b
-l
-t
-t
-z
-C
-C
-N
-P
-C
-C
-W
-c
+aa
+ab
+al
+at
+at
+Wn
+aC
+aC
+aN
+aP
+aC
+aC
+aW
+MN
 "}
 (10,1,1) = {"
-a
-b
-m
-t
-t
-c
-C
-C
-N
-P
-C
-C
-W
-c
+aa
+ab
+am
+at
+at
+ac
+aC
+aC
+aN
+aP
+aC
+aC
+aW
+MN
 "}
 (11,1,1) = {"
-a
-b
-l
-t
-x
-b
-C
-C
-N
-P
-C
-C
-W
-c
+aa
+ab
+al
+at
+ax
+ab
+aC
+aC
+aN
+aP
+aC
+aC
+aW
+MN
 "}
 (12,1,1) = {"
-a
-b
-l
-t
-y
-b
-C
-C
-O
-P
-C
-C
-B
-b
+aa
+ab
+al
+at
+ay
+ab
+aC
+aC
+aO
+aP
+aC
+aC
+aB
+ab
 "}
 (13,1,1) = {"
-b
-b
-b
-b
-b
-h
-C
-C
-w
-b
-A
-c
-b
-b
+ab
+ab
+ab
+ab
+ab
+ah
+aC
+aC
+aw
+ab
+Cf
+ac
+ab
+ab
 "}
 (14,1,1) = {"
-b
-d
-n
-f
-f
-A
-C
-C
-A
-Q
-f
-f
-X
-b
+ab
+ad
+an
+af
+af
+Hy
+aC
+aC
+Hy
+aQ
+af
+af
+aX
+ab
 "}
 (15,1,1) = {"
-b
-e
-f
-f
-f
-A
-C
-C
-A
-f
-f
-f
-f
-b
+ab
+ae
+af
+af
+af
+Hy
+aC
+aC
+Hy
+af
+af
+af
+af
+ab
 "}
 (16,1,1) = {"
-b
-f
-o
-f
-b
-b
-G
-G
-b
-b
-R
-U
-Y
-b
+ab
+af
+ao
+af
+ab
+ab
+Ti
+Ti
+ab
+ab
+aR
+aU
+aY
+ab
 "}
 (17,1,1) = {"
-b
-b
-b
-b
-b
-b
-C
-J
-b
-b
-b
-b
-b
-b
+ab
+ab
+ab
+ab
+ab
+ab
+aC
+aJ
+ab
+ab
+ab
+ab
+ab
+ab
 "}
 (18,1,1) = {"
-b
-g
-p
-u
-b
-b
-G
-K
-b
-b
-g
-p
-u
-b
+ab
+ag
+ap
+au
+ab
+ab
+Ti
+Mg
+ab
+ab
+ag
+ap
+au
+ab
 "}

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -101,13 +101,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"ay" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "az" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
@@ -164,20 +157,6 @@
 "aG" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aH" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aI" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aJ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -191,15 +170,6 @@
 "aM" = (
 /obj/structure/table,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aP" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Box emergency shuttle"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aQ" = (
 /obj/structure/extinguisher_cabinet{
@@ -235,29 +205,11 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"aV" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aX" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Cargo"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aZ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bb" = (
 /turf/open/floor/mineral/titanium/yellow,
@@ -364,6 +316,80 @@
 "ga" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"mA" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Dd" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Cargo"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Gx" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"JW" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Km" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Box emergency shuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Lm" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"RE" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ta" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 "XC" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/white,
@@ -377,17 +403,17 @@ aa
 ad
 ad
 ad
-aI
+Gx
 ad
-aP
+Km
 ad
-ac
-ac
-ac
+JW
+JW
+JW
 ad
-aV
+mA
 ad
-aV
+mA
 ad
 ad
 ad
@@ -442,7 +468,7 @@ bi
 bk
 "}
 (4,1,1) = {"
-ac
+JW
 af
 am
 ar
@@ -458,7 +484,7 @@ aS
 aS
 aS
 aC
-aX
+Dd
 bb
 bb
 bg
@@ -466,13 +492,13 @@ bi
 bk
 "}
 (5,1,1) = {"
-ac
+JW
 ag
 aC
 as
 ad
 ac
-aH
+RE
 ac
 bj
 aC
@@ -490,7 +516,7 @@ bi
 bk
 "}
 (6,1,1) = {"
-ac
+JW
 ah
 aC
 at
@@ -514,11 +540,11 @@ bi
 bk
 "}
 (7,1,1) = {"
-ac
+JW
 ag
 aC
 aC
-ay
+Ta
 aC
 aC
 ao
@@ -538,7 +564,7 @@ bi
 bk
 "}
 (8,1,1) = {"
-ac
+JW
 ai
 ao
 ao
@@ -554,7 +580,7 @@ aT
 aT
 aT
 aC
-aZ
+Lm
 ga
 ga
 ga
@@ -615,21 +641,21 @@ aa
 aa
 aa
 ad
-ac
+JW
 ad
-ac
-ad
-ad
-ad
-ac
-ac
-ac
+JW
 ad
 ad
 ad
-ac
+JW
+JW
+JW
 ad
-ac
+ad
+ad
+JW
+ad
+JW
 ad
 aa
 "}

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -476,13 +476,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"aR" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "aS" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
@@ -571,13 +564,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"bn" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "bo" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/plasteel,
@@ -590,13 +576,6 @@
 	id = "shuttle_flasher";
 	pixel_x = -24;
 	pixel_y = 6
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"bq" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
@@ -639,13 +618,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bv" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "bw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -657,22 +629,6 @@
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/zipties,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"bA" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Cargo"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "bB" = (
 /obj/effect/turf_decal/tile/brown{
@@ -695,19 +651,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bE" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dheight = 0;
-	dwidth = 15;
-	height = 20;
-	name = "Cere emergency shuttle";
-	width = 42
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "bF" = (
 /obj/structure/closet/crate/bin,
@@ -936,12 +879,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"bY" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "bZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -979,22 +916,6 @@
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"ce" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Emergency Shuttle Medbay"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cf" = (
 /obj/machinery/light{
@@ -1418,23 +1339,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"cP" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engine Room";
-	req_one_access_txt = "10;24"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "cQ" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -1679,10 +1583,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"dq" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "dr" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -1731,12 +1631,190 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"eb" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ez" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"jG" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"mR" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"oS" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
 "pf" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	use_power = 0
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"pz" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Cargo"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"uv" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dheight = 0;
+	dwidth = 15;
+	height = 20;
+	name = "Cere emergency shuttle";
+	width = 42
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Du" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Emergency Shuttle Medbay"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Ed" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"Ev" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"GI" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Emergency Shuttle Medbay"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"LM" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"YO" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -1753,27 +1831,27 @@ ab
 ab
 ab
 ab
-bv
+jG
 ab
-bE
-ab
-aa
-aa
-aa
-ab
-bY
-ab
-bY
+uv
 ab
 aa
 aa
+aa
+ab
+mR
+ab
+mR
+ab
+aa
+aa
 ab
 ab
-ac
-ac
-ac
-ac
-ac
+Ev
+Ev
+Ev
+Ev
+Ev
 ab
 ab
 ab
@@ -1801,9 +1879,9 @@ be
 ab
 bc
 ad
-ac
-ac
-ac
+Ev
+Ev
+Ev
 ad
 bc
 bZ
@@ -1928,7 +2006,7 @@ ab
 ab
 ab
 ac
-bq
+YO
 ac
 ab
 bF
@@ -2006,7 +2084,7 @@ dz
 (7,1,1) = {"
 aa
 aa
-ac
+Ev
 af
 aq
 ap
@@ -2038,7 +2116,7 @@ bT
 bT
 bT
 bR
-cP
+ez
 cU
 bc
 bc
@@ -2050,7 +2128,7 @@ dz
 (8,1,1) = {"
 aa
 aa
-ac
+Ev
 ag
 ar
 aA
@@ -2094,7 +2172,7 @@ dz
 (9,1,1) = {"
 aa
 aa
-ac
+Ev
 ah
 as
 aB
@@ -2138,7 +2216,7 @@ dz
 (10,1,1) = {"
 aa
 aa
-ac
+Ev
 ai
 at
 aC
@@ -2182,7 +2260,7 @@ ad
 (11,1,1) = {"
 aa
 aa
-ac
+Ev
 aj
 at
 aC
@@ -2191,8 +2269,8 @@ aO
 ab
 ab
 ac
-bn
-bn
+LM
+LM
 ac
 ad
 aZ
@@ -2226,13 +2304,13 @@ ad
 (12,1,1) = {"
 aa
 aa
-ac
+Ev
 ak
 au
 aD
 aC
 aC
-aR
+oS
 aZ
 aZ
 aZ
@@ -2252,17 +2330,17 @@ bW
 bR
 ad
 ab
-ce
+Du
 ab
 ab
 ab
 ab
 ab
-cQ
+Ed
 ab
 ab
 ab
-dq
+eb
 ad
 dy
 dz
@@ -2270,13 +2348,13 @@ dz
 (13,1,1) = {"
 aa
 aa
-ac
+Ev
 al
 av
 aE
 aC
 aC
-aR
+oS
 ba
 ba
 ba
@@ -2314,7 +2392,7 @@ dz
 (14,1,1) = {"
 aa
 aa
-ac
+Ev
 am
 aw
 ax
@@ -2325,8 +2403,8 @@ ab
 ab
 ab
 ab
-bA
-bA
+pz
+pz
 ab
 ad
 bT
@@ -2338,7 +2416,7 @@ bT
 bT
 bT
 bR
-ce
+GI
 ci
 cp
 cw
@@ -2550,13 +2628,13 @@ bD
 bP
 ab
 ab
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+Ev
+Ev
+Ev
+Ev
+Ev
+Ev
+Ev
 ab
 ab
 pf
@@ -2605,9 +2683,9 @@ aa
 aa
 ab
 ab
-ac
-ac
-ac
+Ev
+Ev
+Ev
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -174,15 +174,6 @@
 /obj/item/toy/sword,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
-"aI" = (
-/obj/machinery/door/airlock/bananium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Snappop(tm)!"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aJ" = (
 /obj/item/toy/snappop/phoenix,
 /obj/machinery/light/small{
@@ -237,12 +228,6 @@
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
-"aQ" = (
-/obj/machinery/door/airlock/bananium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aR" = (
 /obj/item/toy/snappop/phoenix,
 /obj/machinery/light/small,
@@ -253,18 +238,6 @@
 	pixel_y = -30
 	},
 /obj/item/toy/snappop/phoenix,
-/turf/open/floor/bluespace,
-/area/shuttle/escape)
-"aT" = (
-/obj/machinery/door/airlock/bananium{
-	name = "Emergency Shuttle Cargo"
-	},
-/turf/open/floor/bluespace,
-/area/shuttle/escape)
-"aU" = (
-/obj/machinery/door/airlock/bananium/glass{
-	name = "Emergency Shuttle Infirmary"
-	},
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aV" = (
@@ -340,6 +313,48 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"eU" = (
+/obj/machinery/door/airlock/bananium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"oM" = (
+/obj/machinery/door/airlock/bananium/glass{
+	name = "Emergency Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/bluespace,
+/area/shuttle/escape)
+"KO" = (
+/obj/machinery/door/airlock/bananium{
+	name = "Emergency Shuttle Cargo"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/bluespace,
+/area/shuttle/escape)
+"LN" = (
+/obj/machinery/door/airlock/bananium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Snappop(tm)!"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Nn" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Zf" = (
 /obj/structure/closet/emcloset,
 /obj/item/toy/sword,
@@ -356,15 +371,15 @@ ab
 ab
 ab
 ab
-aI
+LN
 ab
-ac
-ac
-ac
+Nn
+Nn
+Nn
 ab
-aQ
+eU
 ab
-aQ
+eU
 ab
 ab
 ab
@@ -419,7 +434,7 @@ bf
 bg
 "}
 (4,1,1) = {"
-ac
+Nn
 ae
 aj
 ao
@@ -435,7 +450,7 @@ aN
 aN
 aN
 ak
-aT
+KO
 aV
 aV
 bd
@@ -443,7 +458,7 @@ bf
 bg
 "}
 (5,1,1) = {"
-ac
+Nn
 af
 ak
 ap
@@ -467,7 +482,7 @@ bf
 bg
 "}
 (6,1,1) = {"
-ac
+Nn
 ag
 ak
 aq
@@ -491,7 +506,7 @@ bf
 bg
 "}
 (7,1,1) = {"
-ac
+Nn
 af
 ak
 ak
@@ -515,7 +530,7 @@ bf
 bg
 "}
 (8,1,1) = {"
-ac
+Nn
 ah
 al
 al
@@ -531,7 +546,7 @@ aO
 aO
 aO
 ak
-aU
+oM
 aV
 aV
 aV
@@ -592,21 +607,21 @@ aa
 aa
 aa
 ab
-ac
+Nn
 ab
-ac
-ab
-ab
-ab
-ac
-ac
-ac
+Nn
 ab
 ab
 ab
-ac
+Nn
+Nn
+Nn
 ab
-ac
+ab
+ab
+Nn
+ab
+Nn
 ab
 aa
 "}

--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -30,30 +30,6 @@
 "f" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"g" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"h" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"i" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency/shuttle_build{
-	dwidth = 6;
-	height = 15;
-	name = "Shuttle Under Construction";
-	port_direction = 4;
-	preferred_direction = 2;
-	width = 23
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "j" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -175,23 +151,50 @@
 "p" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
+"B" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"J" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency/shuttle_build{
+	dwidth = 6;
+	height = 15;
+	name = "Shuttle Under Construction";
+	port_direction = 4;
+	preferred_direction = 2;
+	width = 23
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"U" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
 c
 e
 e
-g
+B
 e
-i
-e
-e
+J
 e
 e
 e
-g
 e
-g
+e
+B
+e
+B
 e
 p
 a
@@ -271,9 +274,9 @@ f
 f
 e
 e
-h
-h
-h
+U
+U
+U
 a
 "}
 (5,1,1) = {"
@@ -298,8 +301,8 @@ f
 f
 f
 f
-h
-h
+U
+U
 "}
 (6,1,1) = {"
 b
@@ -324,7 +327,7 @@ f
 f
 f
 f
-h
+U
 "}
 (7,1,1) = {"
 b
@@ -349,7 +352,7 @@ f
 f
 f
 f
-h
+U
 "}
 (8,1,1) = {"
 c
@@ -374,7 +377,7 @@ f
 f
 f
 f
-h
+U
 "}
 (9,1,1) = {"
 b
@@ -399,7 +402,7 @@ f
 f
 f
 f
-h
+U
 "}
 (10,1,1) = {"
 b
@@ -424,7 +427,7 @@ f
 f
 f
 f
-h
+U
 "}
 (11,1,1) = {"
 b
@@ -448,8 +451,8 @@ f
 f
 f
 f
-h
-h
+U
+U
 "}
 (12,1,1) = {"
 c
@@ -471,9 +474,9 @@ f
 f
 e
 e
-h
-h
-h
+U
+U
+U
 a
 "}
 (13,1,1) = {"
@@ -531,17 +534,17 @@ a
 c
 e
 e
-h
+U
 e
 e
 e
 e
-h
+U
 e
 e
 e
 e
-h
+U
 e
 p
 a

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -2,17 +2,6 @@
 "a" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"b" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"c" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "d" = (
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -54,18 +43,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"k" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dwidth = 3;
-	height = 5;
-	name = "Secure Transport Vessel 5";
-	width = 14
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "l" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -92,12 +69,6 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"q" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "r" = (
 /obj/structure/closet/crate/secure/weapon,
@@ -141,25 +112,58 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"B" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"C" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"E" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dwidth = 3;
+	height = 5;
+	name = "Secure Transport Vessel 5";
+	width = 14
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Q" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
-c
+B
 a
-k
+E
 a
-b
-b
-b
+Q
+Q
+Q
 a
-q
+C
 a
-q
+C
 a
 a
 "}
 (2,1,1) = {"
-b
+Q
 d
 g
 l
@@ -175,7 +179,7 @@ t
 u
 "}
 (3,1,1) = {"
-b
+Q
 e
 h
 l
@@ -191,7 +195,7 @@ t
 u
 "}
 (4,1,1) = {"
-b
+Q
 f
 i
 v
@@ -212,9 +216,9 @@ a
 j
 a
 a
-b
-b
-b
+Q
+Q
+Q
 a
 a
 a

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -393,15 +393,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"aF" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "aG" = (
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/regular{
@@ -483,15 +474,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
-"aO" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "aP" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
@@ -525,30 +507,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"aV" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"aW" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dheight = 0;
-	dwidth = 11;
-	height = 18;
-	name = "Delta emergency shuttle";
-	width = 30;
-	preferred_direction = 2;
-	port_direction = 4
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aX" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -684,15 +642,6 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"bk" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Cargo"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "bl" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -756,33 +705,6 @@
 /obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bt" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"bu" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bv" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "bw" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
@@ -979,16 +901,6 @@
 "bX" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bY" = (
-/obj/machinery/door/airlock/command{
-	name = "Emergency Recovery Airlock";
-	req_access_txt = "19"
-	},
-/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1382,9 +1294,148 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"eY" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
 "hB" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"uQ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"zd" = (
+/obj/machinery/door/airlock/command{
+	name = "Emergency Recovery Airlock";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Ay" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Ej" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Ey" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Cargo"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Hh" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Ky" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"KD" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"TQ" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dheight = 0;
+	dwidth = 11;
+	height = 18;
+	name = "Delta emergency shuttle";
+	port_direction = 4;
+	preferred_direction = 2;
+	width = 30
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Yt" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -1393,21 +1444,21 @@ ac
 ae
 af
 af
-hB
-hB
+Ky
+Ky
 af
 af
-aO
+Ay
 aT
-aW
+TQ
 af
-hB
-hB
-hB
+Ky
+Ky
+Ky
 af
-aO
+Ay
 af
-bv
+KD
 af
 af
 af
@@ -1452,7 +1503,7 @@ aa
 (3,1,1) = {"
 ab
 ad
-hB
+Ky
 ai
 ao
 ao
@@ -1468,12 +1519,12 @@ ao
 ao
 ao
 bo
-bt
+uQ
 bw
 bw
 bw
 bU
-hB
+Ky
 aa
 aa
 aa
@@ -1483,7 +1534,7 @@ aa
 (4,1,1) = {"
 ab
 ad
-hB
+Ky
 ai
 ao
 aw
@@ -1538,7 +1589,7 @@ bU
 af
 af
 aT
-hB
+Ky
 af
 af
 "}
@@ -1576,7 +1627,7 @@ af
 (7,1,1) = {"
 ab
 ad
-hB
+Ky
 ai
 ao
 ao
@@ -1594,7 +1645,7 @@ ao
 bp
 af
 af
-bt
+Ej
 hB
 aT
 af
@@ -1602,7 +1653,7 @@ cb
 cf
 cf
 cr
-hB
+Ky
 "}
 (8,1,1) = {"
 ac
@@ -1633,12 +1684,12 @@ cc
 cc
 cl
 cs
-hB
+Ky
 "}
 (9,1,1) = {"
 ab
 ad
-hB
+Ky
 ai
 ao
 ax
@@ -1654,22 +1705,22 @@ bj
 aX
 ao
 bo
-bu
+Hh
 ai
 ao
 ao
 bX
-bu
+Hh
 cc
 cc
 cm
 ct
-hB
+Ky
 "}
 (10,1,1) = {"
 ab
 ad
-hB
+Ky
 ai
 ao
 av
@@ -1685,17 +1736,17 @@ av
 av
 ao
 bo
-bu
+Hh
 ai
 ao
 ao
 bX
-bu
+Hh
 cc
 cc
 cn
 cu
-hB
+Ky
 "}
 (11,1,1) = {"
 ac
@@ -1726,12 +1777,12 @@ cc
 cg
 cl
 cv
-hB
+Ky
 "}
 (12,1,1) = {"
 ab
 ad
-hB
+Ky
 ah
 ap
 aw
@@ -1751,13 +1802,13 @@ af
 aT
 af
 af
-bY
+zd
 af
 cb
 ch
 ch
 cw
-hB
+Ky
 "}
 (13,1,1) = {"
 ab
@@ -1766,16 +1817,16 @@ af
 af
 aq
 ag
-aF
-aF
+eY
+eY
 ag
 aP
 af
 af
 af
 af
-bk
-bk
+Ey
+Ey
 af
 af
 af
@@ -1817,14 +1868,14 @@ af
 af
 af
 aT
-hB
+Ky
 af
 af
 "}
 (15,1,1) = {"
 ab
 ad
-hB
+Ky
 ak
 as
 az
@@ -1832,7 +1883,7 @@ ao
 ao
 aM
 aR
-aV
+Yt
 aE
 bb
 bg
@@ -1855,7 +1906,7 @@ aa
 (16,1,1) = {"
 ab
 ad
-hB
+Ky
 al
 at
 aA
@@ -1863,7 +1914,7 @@ ao
 ao
 aM
 aR
-aV
+Yt
 aE
 bc
 bh
@@ -1876,7 +1927,7 @@ bC
 bJ
 ai
 bZ
-hB
+Ky
 aa
 aa
 aa
@@ -1919,25 +1970,25 @@ aa
 ac
 ae
 af
-hB
-hB
-hB
-hB
+Ky
+Ky
+Ky
+Ky
 af
 af
 aT
 af
-hB
-hB
-hB
-hB
-hB
+Ky
+Ky
+Ky
+Ky
+Ky
 af
 af
-hB
+Ky
 bL
 bL
-hB
+Ky
 af
 aa
 aa

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -7,6 +7,7 @@
 /area/shuttle/escape)
 "c" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/shuttle/escape)
 "d" = (
@@ -79,12 +80,6 @@
 	},
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape)
-"p" = (
-/obj/machinery/door/airlock/gold{
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/gold,
-/area/shuttle/escape)
 "q" = (
 /obj/structure/statue/plasma/scientist{
 	anchored = 1;
@@ -101,24 +96,9 @@
 "t" = (
 /turf/open/floor/light/colour_cycle,
 /area/shuttle/escape)
-"u" = (
-/obj/docking_port/mobile/emergency{
-	name = "Disco Inferno"
-	},
-/obj/machinery/door/airlock/gold{
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100);
-	heat_proof = 1;
-	resistance_flags = 2
-	},
-/turf/open/floor/mineral/plasma,
-/area/shuttle/escape)
 "v" = (
 /obj/machinery/jukebox/disco/indestructible,
 /turf/open/floor/light/colour_cycle,
-/area/shuttle/escape)
-"w" = (
-/obj/machinery/door/airlock/gold,
-/turf/open/floor/wood,
 /area/shuttle/escape)
 "x" = (
 /turf/open/floor/wood,
@@ -220,6 +200,33 @@
 "O" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
+"P" = (
+/obj/docking_port/mobile/emergency{
+	name = "Disco Inferno"
+	},
+/obj/machinery/door/airlock/gold{
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100);
+	heat_proof = 1;
+	resistance_flags = 2
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plasma,
+/area/shuttle/escape)
+"V" = (
+/obj/machinery/door/airlock/gold{
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/gold,
+/area/shuttle/escape)
+"Y" = (
+/obj/machinery/door/airlock/gold,
+/obj/structure/fans/tiny,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
@@ -231,7 +238,7 @@ b
 b
 c
 b
-u
+P
 b
 c
 c
@@ -239,7 +246,7 @@ c
 b
 O
 b
-w
+Y
 b
 c
 b
@@ -370,7 +377,7 @@ c
 e
 j
 j
-p
+V
 r
 r
 s

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -105,13 +105,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"au" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "av" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
@@ -158,13 +151,6 @@
 "aC" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aD" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Containment Cell";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aE" = (
 /obj/machinery/light{
 	dir = 4
@@ -209,13 +195,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aL" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "aM" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -235,34 +214,11 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"aP" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aQ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aR" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"aS" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Donut emergency shuttle";
-	width = 34
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aT" = (
 /obj/structure/extinguisher_cabinet,
@@ -312,12 +268,6 @@
 /area/shuttle/escape)
 "bb" = (
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"bc" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bd" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -493,6 +443,84 @@
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"fg" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"hl" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"pk" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"uu" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Dr" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"FX" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Donut emergency shuttle";
+	width = 34
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ia" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Containment Cell";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"JF" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -508,17 +536,17 @@ aa
 aa
 ab
 ab
-aP
+pk
 ab
-aS
+FX
 ab
 aa
 aa
 aa
 ab
-aR
-ac
-aR
+uu
+Dr
+uu
 ab
 aa
 ab
@@ -548,9 +576,9 @@ aC
 ab
 ak
 ab
-ac
-ac
-ac
+Dr
+Dr
+Dr
 ad
 ak
 ak
@@ -569,8 +597,8 @@ ab
 (3,1,1) = {"
 aa
 ab
-ac
-ac
+Dr
+Dr
 ab
 ab
 ab
@@ -647,7 +675,7 @@ am
 aq
 av
 ac
-aD
+Ia
 ac
 ad
 aI
@@ -675,7 +703,7 @@ bs
 bt
 "}
 (6,1,1) = {"
-ac
+Dr
 af
 al
 am
@@ -687,7 +715,7 @@ aC
 aF
 ab
 ac
-aL
+JF
 ac
 aH
 ak
@@ -702,7 +730,7 @@ am
 aW
 aX
 am
-bc
+fg
 bg
 bg
 bg
@@ -711,7 +739,7 @@ bs
 bt
 "}
 (7,1,1) = {"
-ac
+Dr
 ag
 al
 am
@@ -747,7 +775,7 @@ bs
 bt
 "}
 (8,1,1) = {"
-ac
+Dr
 ah
 al
 am
@@ -783,7 +811,7 @@ bs
 bt
 "}
 (9,1,1) = {"
-ac
+Dr
 ai
 al
 am
@@ -810,7 +838,7 @@ am
 aW
 aX
 am
-bc
+fg
 bg
 bg
 bg
@@ -860,7 +888,7 @@ ad
 ak
 ak
 ak
-au
+hl
 am
 am
 am
@@ -893,8 +921,8 @@ bt
 (12,1,1) = {"
 aa
 ab
-ac
-ac
+Dr
+Dr
 ab
 ad
 ax
@@ -944,9 +972,9 @@ ak
 ak
 ak
 ad
-ac
-ac
-ac
+Dr
+Dr
+Dr
 ad
 ak
 ak
@@ -976,17 +1004,17 @@ aa
 aa
 ab
 ab
-aR
-ac
-aR
+uu
+Dr
+uu
 ab
 aa
 aa
 aa
 ab
-aR
-ac
-aR
+uu
+Dr
+uu
 ab
 aa
 ab

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -24,24 +24,30 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"g" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+"j" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"h" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+"k" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Infirmary"
 	},
-/obj/docking_port/mobile/emergency{
-	dheight = 0;
-	dir = 2;
-	dwidth = 9;
-	name = "NES Port";
-	width = 19
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "l" = (
 /obj/machinery/vending/wallmed,
@@ -96,12 +102,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"w" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "y" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
@@ -127,6 +127,11 @@
 /obj/item/radio,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"C" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "D" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -135,11 +140,18 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "E" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
 	},
-/turf/open/floor/mineral/titanium/yellow,
+/obj/docking_port/mobile/emergency{
+	dheight = 0;
+	dir = 2;
+	dwidth = 9;
+	name = "NES Port";
+	width = 19
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "F" = (
 /turf/open/floor/mineral/titanium/yellow,
@@ -171,18 +183,31 @@
 "J" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"K" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "L" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"M" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"P" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Q" = (
 /obj/machinery/light,
@@ -296,11 +321,11 @@ d
 d
 d
 d
-w
+k
 f
 l
 f
-K
+j
 d
 d
 d
@@ -320,7 +345,7 @@ a
 "}
 (7,1,1) = {"
 a
-m
+C
 s
 r
 s
@@ -328,7 +353,7 @@ s
 s
 r
 s
-m
+C
 a
 "}
 (8,1,1) = {"
@@ -345,7 +370,7 @@ d
 d
 "}
 (9,1,1) = {"
-g
+P
 r
 r
 r
@@ -355,10 +380,10 @@ r
 r
 r
 r
-g
+P
 "}
 (10,1,1) = {"
-h
+E
 r
 r
 r
@@ -368,7 +393,7 @@ r
 r
 r
 r
-g
+P
 "}
 (11,1,1) = {"
 d
@@ -385,7 +410,7 @@ d
 "}
 (12,1,1) = {"
 a
-m
+C
 s
 s
 s
@@ -393,12 +418,12 @@ r
 s
 s
 s
-m
+C
 a
 "}
 (13,1,1) = {"
 a
-m
+C
 s
 s
 s
@@ -406,7 +431,7 @@ r
 s
 s
 s
-m
+C
 a
 "}
 (14,1,1) = {"
@@ -428,7 +453,7 @@ d
 d
 m
 d
-E
+M
 f
 m
 d
@@ -438,13 +463,13 @@ a
 (16,1,1) = {"
 a
 a
-m
+C
 y
 A
 F
 A
 L
-m
+C
 a
 a
 "}
@@ -465,11 +490,11 @@ a
 a
 a
 a
-m
+C
 B
 G
 I
-m
+C
 a
 a
 a
@@ -479,9 +504,9 @@ a
 a
 a
 d
-m
-m
-m
+C
+C
+C
 d
 a
 a

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -76,8 +76,8 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/box/corners{
-	icon_state = "box_corners";
-	dir = 8
+	dir = 8;
+	icon_state = "box_corners"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -92,17 +92,6 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/assembly/flash/handheld,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"ao" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/airlock/shuttle{
-	name = "External Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "ap" = (
@@ -337,14 +326,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aJ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_one_access_txt = "19"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "aK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -353,8 +334,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box/corners{
-	icon_state = "box_corners";
-	dir = 4
+	dir = 4;
+	icon_state = "box_corners"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -378,20 +359,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box/corners{
-	icon_state = "box_corners";
-	dir = 1
+	dir = 1;
+	icon_state = "box_corners"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"aN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/command{
-	name = "Shuttle Control";
-	req_one_access_txt = "19"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -564,19 +537,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bb" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_one_access_txt = "63"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "bc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -673,14 +633,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bm" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "bn" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
@@ -699,27 +651,6 @@
 	pixel_y = 4
 	},
 /obj/item/clothing/mask/breath,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bp" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bq" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Kilo emergency shuttle"
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "br" = (
@@ -824,8 +755,7 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21";
-	
+	icon_state = "plant-21"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -902,8 +832,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32;
-	
+	pixel_x = 32
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -1073,18 +1002,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"bX" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "bY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -1158,20 +1075,9 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21";
-	
+	icon_state = "plant-21"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cf" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cg" = (
 /obj/structure/table,
@@ -1236,13 +1142,6 @@
 "cm" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"cn" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "co" = (
 /obj/structure/rack,
@@ -1682,16 +1581,55 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"eM" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "gX" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"hS" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"jK" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_one_access_txt = "63"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "nB" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/shuttle/engine/large,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"uL" = (
+"uF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/command{
 	name = "Shuttle Control";
@@ -1700,11 +1638,106 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "uO" = (
 /obj/structure/shuttle/engine/heater,
 /turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"zw" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/command{
+	name = "Shuttle Control";
+	req_one_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"zT" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_one_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Bo" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/shuttle{
+	name = "External Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Bu" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Kilo emergency shuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Mw" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Oa" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Tp" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Vz" = (
 /obj/effect/turf_decal/caution/stand_clear,
@@ -1719,17 +1752,17 @@ ac
 ab
 ac
 ai
-bb
+jK
 ab
-bq
+Bu
 ab
 ac
 ac
 ac
 ab
-bX
+eM
 ab
-bX
+eM
 ai
 ab
 as
@@ -1774,7 +1807,7 @@ aA
 aA
 aA
 bd
-bm
+hS
 bs
 bC
 bJ
@@ -1782,7 +1815,7 @@ bM
 bJ
 bS
 bY
-cf
+Tp
 ck
 cs
 cD
@@ -1852,7 +1885,7 @@ ad
 aj
 as
 aD
-aJ
+zT
 ac
 as
 as
@@ -1891,7 +1924,7 @@ bu
 bT
 ca
 bC
-cn
+Mw
 cv
 cF
 cO
@@ -1908,7 +1941,7 @@ au
 aF
 aL
 aV
-uL
+uF
 Vz
 bx
 bF
@@ -1945,7 +1978,7 @@ bu
 bV
 cc
 bG
-cn
+Mw
 cx
 cH
 cP
@@ -1960,7 +1993,7 @@ ah
 an
 as
 as
-aN
+zw
 ab
 as
 as
@@ -2038,13 +2071,13 @@ cS
 (13,1,1) = {"
 aa
 aa
-ao
+Bo
 ax
 aH
 aQ
 aZ
 bk
-bp
+Oa
 bz
 bG
 bJ
@@ -2052,7 +2085,7 @@ bR
 bJ
 bW
 cd
-cf
+Tp
 cp
 cA
 cJ

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -9,28 +9,9 @@
 "ad" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"af" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "ag" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"ah" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dir = 2;
-	dwidth = 5;
-	height = 14;
-	name = "Meta emergency shuttle";
-	width = 25
-	},
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "al" = (
 /obj/structure/table,
@@ -237,13 +218,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"aH" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "aI" = (
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
@@ -330,37 +304,9 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"aW" = (
-/obj/machinery/door/airlock/command{
-	name = "Emergency Recovery Airlock";
-	req_access_txt = "19"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"aY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aZ" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "ba" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"bb" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Cargo Bay Airlock"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bd" = (
 /obj/structure/chair/comfy/shuttle{
@@ -521,11 +467,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"bC" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "bD" = (
@@ -713,9 +654,6 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"bT" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "bU" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
@@ -836,13 +774,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"cc" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "cd" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -852,11 +783,152 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"cO" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ef" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"fr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"hJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"pq" = (
+/obj/machinery/door/airlock/command{
+	name = "Emergency Recovery Airlock";
+	req_access_txt = "19"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"BN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Ce" = (
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 10
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"CQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"DK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Gk" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"GG" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Li" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "LY" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"Ml" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	dwidth = 5;
+	height = 14;
+	name = "Meta emergency shuttle";
+	width = 25
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"PE" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
 "Vs" = (
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Xm" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Cargo Bay Airlock"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Yo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden,
+/turf/open/floor/plasteel,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -908,7 +980,7 @@ ad
 ad
 "}
 (4,1,1) = {"
-ac
+Li
 al
 aw
 aB
@@ -920,11 +992,11 @@ aJ
 bd
 bd
 bd
-bC
-ac
+DK
+Li
 "}
 (5,1,1) = {"
-ac
+Li
 am
 aq
 aC
@@ -934,13 +1006,13 @@ aq
 aQ
 ad
 be
-cc
-be
-be
+hJ
+BN
+Yo
 bf
 "}
 (6,1,1) = {"
-ac
+Li
 an
 ax
 LY
@@ -950,13 +1022,13 @@ aC
 aR
 ad
 bf
-bT
-be
-be
+Ce
+CQ
+fr
 bf
 "}
 (7,1,1) = {"
-ac
+Li
 ao
 ay
 LY
@@ -964,19 +1036,19 @@ LY
 LY
 bY
 aq
-aW
+pq
 cb
 ad
 by
 by
-ac
+Li
 "}
 (8,1,1) = {"
 ad
 ad
 az
 ad
-aH
+Gk
 ad
 az
 ad
@@ -1004,7 +1076,7 @@ bD
 ad
 "}
 (10,1,1) = {"
-ac
+Li
 LY
 LY
 LY
@@ -1012,12 +1084,12 @@ LY
 LY
 LY
 LY
-aY
+ef
 bU
 bU
 bU
 bE
-ac
+Li
 "}
 (11,1,1) = {"
 ad
@@ -1033,10 +1105,10 @@ bi
 bU
 bU
 bF
-ac
+Li
 "}
 (12,1,1) = {"
-af
+cO
 LY
 LY
 aE
@@ -1068,7 +1140,7 @@ ad
 ad
 "}
 (14,1,1) = {"
-af
+cO
 LY
 LY
 aE
@@ -1097,10 +1169,10 @@ bk
 Vs
 Vs
 bI
-ac
+Li
 "}
 (16,1,1) = {"
-ac
+Li
 ar
 LY
 LY
@@ -1108,15 +1180,15 @@ LY
 LY
 LY
 LY
-aZ
+PE
 Vs
 Vs
 Vs
 bJ
-ac
+Li
 "}
 (17,1,1) = {"
-ac
+Li
 ar
 LY
 aE
@@ -1132,7 +1204,7 @@ bK
 ad
 "}
 (18,1,1) = {"
-ac
+Li
 ar
 LY
 aE
@@ -1143,7 +1215,7 @@ aE
 ba
 ad
 ac
-aZ
+GG
 ba
 ad
 "}
@@ -1164,7 +1236,7 @@ bM
 ad
 "}
 (20,1,1) = {"
-ah
+Ml
 LY
 LY
 aE
@@ -1193,10 +1265,10 @@ bo
 be
 be
 bO
-ac
+Li
 "}
 (22,1,1) = {"
-af
+cO
 LY
 LY
 LY
@@ -1204,12 +1276,12 @@ LY
 LY
 LY
 LY
-bb
+Xm
 bp
 be
 bw
 bP
-ac
+Li
 "}
 (23,1,1) = {"
 ad
@@ -1220,7 +1292,7 @@ LY
 LY
 LY
 LY
-bb
+Xm
 bp
 be
 be
@@ -1246,16 +1318,16 @@ ad
 (25,1,1) = {"
 ad
 ad
-ac
+Li
 ad
-ac
+Li
 ad
-ac
+Li
 ad
 ad
 ad
-ac
-ac
+Li
+Li
 ad
 ad
 "}

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -78,19 +78,6 @@
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"o" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Cell";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"p" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "q" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
@@ -111,6 +98,21 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
 	},
+/obj/docking_port/mobile/emergency{
+	dir = 8;
+	dwidth = 8;
+	height = 9;
+	name = "Mini emergency shuttle";
+	width = 21
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"w" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "x" = (
@@ -144,17 +146,14 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "B" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
 	},
-/obj/docking_port/mobile/emergency{
-	dir = 8;
-	dwidth = 8;
-	height = 9;
-	name = "Mini emergency shuttle";
-	width = 21
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "D" = (
 /obj/structure/table,
@@ -178,13 +177,6 @@
 "H" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"I" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Escape Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "J" = (
 /obj/machinery/computer/atmos_alert{
@@ -254,6 +246,11 @@
 /obj/item/crowbar,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"U" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "W" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/surgical,
@@ -262,6 +259,28 @@
 /area/shuttle/escape)
 "X" = (
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Y" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Escape Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Z" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Cell";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -273,9 +292,9 @@ b
 b
 b
 b
-n
-n
-n
+U
+U
+U
 b
 b
 b
@@ -293,7 +312,7 @@ b
 e
 k
 X
-p
+B
 f
 M
 M
@@ -331,7 +350,7 @@ b
 K
 K
 Q
-n
+U
 "}
 (4,1,1) = {"
 c
@@ -354,7 +373,7 @@ H
 t
 f
 R
-n
+U
 "}
 (5,1,1) = {"
 c
@@ -373,11 +392,11 @@ n
 R
 f
 f
-I
+Y
 f
 f
 S
-n
+U
 "}
 (6,1,1) = {"
 c
@@ -400,14 +419,14 @@ b
 L
 f
 R
-n
+U
 "}
 (7,1,1) = {"
 c
 d
 i
 i
-o
+Z
 f
 f
 f
@@ -423,7 +442,7 @@ b
 M
 M
 T
-n
+U
 "}
 (8,1,1) = {"
 b
@@ -455,13 +474,13 @@ b
 b
 b
 b
+w
+b
+b
+U
+b
+b
 u
-b
-b
-n
-b
-b
-B
 b
 b
 b

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -113,19 +113,6 @@
 "al" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"am" = (
-/obj/machinery/door/airlock/command{
-	name = "Emergency Recovery Airlock";
-	req_access_txt = "19"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "an" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -173,19 +160,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"aq" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "ar" = (
 /obj/structure/table/reinforced,
@@ -246,48 +220,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"av" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
 "aw" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"ax" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
-"ay" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	dheight = 0;
-	dwidth = 5;
-	height = 11;
-	name = "Omega emergency shuttle";
-	width = 19
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "az" = (
 /obj/effect/turf_decal/delivery,
@@ -499,18 +434,6 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/shuttle/escape)
-"aP" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "aQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -538,33 +461,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"aT" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Emergency Shuttle Cargo"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "aU" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"aV" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/shuttle/escape)
 "aW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -867,22 +766,154 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"fg" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"sC" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"wN" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Dr" = (
+/obj/structure/window/shuttle,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Eg" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Ls" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Mg" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dheight = 0;
+	dwidth = 5;
+	height = 11;
+	name = "Omega emergency shuttle";
+	width = 19
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Rm" = (
+/obj/machinery/door/airlock/command{
+	name = "Emergency Recovery Airlock";
+	req_access_txt = "19"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Ui" = (
+/obj/machinery/door/airlock/shuttle{
+	name = "Emergency Shuttle Cargo"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
 aa
 aa
-aq
+Ls
 ac
-ay
+Mg
 aa
-ab
-ab
-ab
+Dr
+Dr
+Dr
 aa
-aP
+wN
 ac
-aP
+wN
 aa
 aa
 aZ
@@ -911,11 +942,11 @@ br
 bv
 "}
 (3,1,1) = {"
-ab
+Dr
 ae
 al
 al
-av
+fg
 aA
 aE
 aE
@@ -923,16 +954,16 @@ aE
 aE
 aE
 aQ
-aT
+Ui
 aW
 be
 bk
-ab
+Dr
 bs
 bv
 "}
 (4,1,1) = {"
-ab
+Dr
 ae
 al
 al
@@ -944,11 +975,11 @@ aF
 aF
 aF
 aQ
-aT
+Ui
 aX
 bf
 bl
-ab
+Dr
 bt
 bv
 "}
@@ -976,7 +1007,7 @@ bv
 (6,1,1) = {"
 ac
 ab
-am
+Rm
 ab
 aw
 aB
@@ -1016,11 +1047,11 @@ bt
 bv
 "}
 (8,1,1) = {"
-ab
+Dr
 ah
 ao
 an
-ax
+sC
 aA
 aJ
 aN
@@ -1028,16 +1059,16 @@ aJ
 aJ
 aJ
 aQ
-aV
+Eg
 bb
 bb
 bo
-ab
+Dr
 bt
 bv
 "}
 (9,1,1) = {"
-ab
+Dr
 ai
 an
 at
@@ -1049,16 +1080,16 @@ aE
 aE
 aE
 aQ
-aV
+Eg
 bb
 bb
 bp
-ab
+Dr
 bt
 bv
 "}
 (10,1,1) = {"
-ab
+Dr
 aj
 ap
 au
@@ -1080,16 +1111,16 @@ bv
 "}
 (11,1,1) = {"
 aa
-ab
-ab
+Dr
+Dr
 aa
 ac
 aa
-ab
-ab
-ab
-ab
-ab
+Dr
+Dr
+Dr
+Dr
+Dr
 aa
 ac
 aa

--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -1,8 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion"
 	},
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -17,12 +17,6 @@
 "d" = (
 /turf/open/space/basic,
 /area/space)
-"e" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Shuttle Airlock"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "f" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
@@ -32,8 +26,8 @@
 /area/shuttle/escape)
 "i" = (
 /obj/machinery/light{
-	icon_state = "tube";
-	dir = 8
+	dir = 8;
+	icon_state = "tube"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -48,12 +42,19 @@
 	dir = 8
 	},
 /obj/machinery/light/small{
-	icon_state = "bulb";
-	dir = 4
+	dir = 4;
+	icon_state = "bulb"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"m" = (
+"K" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"T" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Shuttle Airlock"
 	},
@@ -61,22 +62,23 @@
 	port_direction = 2;
 	preferred_direction = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 
 (1,1,1) = {"
 a
-e
+K
 b
-m
+T
 a
 d
 d
 d
 a
-e
+K
 b
-e
+K
 a
 "}
 (2,1,1) = {"

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -5,10 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ac" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ad" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -133,12 +129,6 @@
 "ax" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"ay" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "az" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -255,12 +245,6 @@
 /area/shuttle/escape)
 "aH" = (
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aI" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "First Class"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aJ" = (
 /obj/structure/chair/comfy/shuttle,
@@ -598,11 +582,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"bv" = (
-/obj/structure/window/plastitanium,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "bw" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -624,12 +603,6 @@
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
 /obj/item/melee/baton,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"bA" = (
-/obj/machinery/door/airlock/public/glass{
-	req_access_txt = "2"
-	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "bB" = (
@@ -672,13 +645,72 @@
 /obj/machinery/light,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"bK" = (
+"kK" = (
+/obj/structure/window/plastitanium,
+/obj/structure/grille,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lf" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Economy Class"
+	name = "First Class"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"bL" = (
+"lO" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Service"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ub" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"wl" = (
+/obj/machinery/door/airlock/public/glass{
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"xt" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"yT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Service"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"IC" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Kg" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
 	},
@@ -691,33 +723,7 @@
 	preferred_direction = 1;
 	width = 46
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"bO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"bQ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Service"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"bT" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"xt" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Uu" = (
@@ -726,52 +732,84 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"UT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"XN" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Zi" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Economy Class"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
 ab
-ac
-ac
+ub
+ub
 ab
 aa
 ab
 ab
-ac
+ub
 ab
-ac
+ub
 ab
-ac
-ab
-ab
-aa
-ab
-ab
-ac
-ab
-ac
-ab
-ac
+ub
 ab
 ab
 aa
 ab
 ab
-ac
+ub
 ab
-ac
+ub
 ab
-ac
+ub
+ab
+ab
+aa
+ab
+ab
+ub
+ab
+ub
+ab
+ub
 ab
 ab
 aa
 bs
 bs
-bv
-bv
+kK
+kK
 bs
 bs
-bv
-bv
+kK
+kK
 bs
 bs
 "}
@@ -824,7 +862,7 @@ bE
 bc
 "}
 (3,1,1) = {"
-ac
+ub
 ad
 al
 br
@@ -865,20 +903,20 @@ bH
 ax
 ax
 ax
-bA
+wl
 ax
 bI
 bE
 bc
 "}
 (4,1,1) = {"
-ac
+ub
 ae
 ah
 aH
-bO
+XN
 xt
-aI
+lf
 ar
 ar
 ar
@@ -886,9 +924,9 @@ ar
 ar
 ar
 ar
-aI
+lf
 xt
-bK
+Zi
 ar
 ar
 ar
@@ -896,9 +934,9 @@ ar
 ar
 ar
 ar
-bK
+Zi
 xt
-bQ
+lO
 au
 au
 au
@@ -906,9 +944,9 @@ au
 au
 au
 au
-bQ
+yT
 xt
-bT
+UT
 ax
 ax
 by
@@ -920,13 +958,13 @@ bE
 bc
 "}
 (5,1,1) = {"
-ac
+ub
 af
 ah
 aH
-bO
+XN
 Uu
-aI
+lf
 ar
 ar
 ar
@@ -934,9 +972,9 @@ ar
 ar
 ar
 ar
-aI
+lf
 Uu
-bK
+Zi
 ar
 ar
 ar
@@ -944,9 +982,9 @@ ar
 ar
 ar
 ar
-bK
+Zi
 Uu
-bQ
+lO
 au
 au
 au
@@ -954,9 +992,9 @@ au
 au
 au
 au
-bQ
+yT
 Uu
-bT
+UT
 ax
 ax
 bz
@@ -968,7 +1006,7 @@ bE
 bc
 "}
 (6,1,1) = {"
-ac
+ub
 ad
 aq
 bt
@@ -1009,7 +1047,7 @@ bH
 ax
 ax
 ax
-bA
+wl
 ax
 bI
 bE
@@ -1066,48 +1104,48 @@ bc
 (8,1,1) = {"
 aa
 ab
-ac
-ac
+ub
+ub
 ab
 aa
 ab
 ab
 ab
 ab
-ay
+IC
 ab
-ay
-ab
-ab
-aa
-ab
-ab
-bL
-ab
-ay
-ab
-ac
+IC
 ab
 ab
 aa
 ab
 ab
-ac
+Kg
 ab
-ac
+IC
 ab
-ac
+ub
+ab
+ab
+aa
+ab
+ab
+ub
+ab
+ub
+ab
+ub
 ab
 ab
 aa
 bs
 bs
-bv
-bv
+kK
+kK
 bs
 bs
-bv
-bv
+kK
+kK
 bs
 bs
 "}

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -2,15 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ab" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/obj/machinery/door/poddoor/preopen{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Blast Door"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ac" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/bot_white,
@@ -329,13 +320,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aS" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "aT" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white/side{
@@ -487,23 +471,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"bk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "bl" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -554,24 +521,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"bo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary";
-	req_one_access_txt = "2;19"
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "bp" = (
@@ -628,23 +577,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"bx" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/airlock/command/glass{
-	name = "Cockpit";
-	req_one_access_txt = "2;19"
-	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "by" = (
 /obj/machinery/iv_drip,
@@ -868,12 +800,6 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
-"bT" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/turf/open/floor/plasteel,
-/area/shuttle/escape)
 "bU" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
@@ -972,18 +898,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"ce" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "cg" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -1050,13 +964,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"cm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "cn" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
@@ -1066,21 +973,6 @@
 	dir = 8
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/escape)
-"cp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "cr" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -1098,60 +990,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"cs" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"ct" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "cw" = (
 /obj/machinery/porta_turret/syndicate/energy/raven{
 	dir = 4
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/escape)
-"cx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"cy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "cz" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -1215,12 +1058,6 @@
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"cD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "cE" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -1527,22 +1364,6 @@
 /obj/item/clothing/head/hardhat/red,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"da" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Seating"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "db" = (
 /obj/structure/closet/crate/medical{
 	name = "medical crate"
@@ -1577,33 +1398,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"de" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Seating"
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"df" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "dg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -1617,22 +1411,6 @@
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"dh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -1676,40 +1454,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"dn" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"do" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "dp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -1744,22 +1488,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"dr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/airlock/grunge{
-	name = "Emergency Shuttle Cargo Bay"
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ds" = (
@@ -1868,12 +1596,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"dA" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Emergency Shutle Engineering"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "dB" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
@@ -1890,20 +1612,6 @@
 "dD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dE" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/item/radio/intercom{
-	dir = 2;
-	name = "Station Intercom (General)";
-	pixel_y = 22
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -1940,44 +1648,19 @@
 "dJ" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"dK" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "dL" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dM" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dN" = (
-/obj/item/cigbutt,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"dP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -2188,6 +1871,643 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"fn" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"iS" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"jH" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"kr" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"ks" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"kI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ld" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Emergency Shutle Engineering"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lz" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"on" = (
+/obj/machinery/door/airlock/external{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qd" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"rD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"vr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"vD" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/item/radio/intercom{
+	dir = 2;
+	name = "Station Intercom (General)";
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"vG" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"xF" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ye" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"yl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"zx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"AX" = (
+/obj/item/cigbutt,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Bo" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Dl" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"DU" = (
+/obj/structure/grille,
+/obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Et" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"ED" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ic" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ie" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Jn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Jx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ka" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Emergency Shuttle Cargo Bay"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Mk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Nk" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"NQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 10
+	},
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"OW" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Seating"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"PE" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"PJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Qg" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit";
+	req_one_access_txt = "2;19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"QD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"QI" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"RC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ul" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Vm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Xn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Xx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Yc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Yx" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Shuttle Infirmary";
+	req_one_access_txt = "2;19"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"YG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/general/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"ZE" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Seating"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -2233,21 +2553,21 @@ aa
 aa
 aa
 aH
-br
+DU
 ax
 ax
 bU
-ce
-cp
-cx
+Ic
+Mk
+kI
 cE
 ax
-br
+DU
 ax
 cT
-ce
-df
-cx
+Ic
+Jx
+kI
 bU
 ax
 ax
@@ -2271,17 +2591,17 @@ bs
 ax
 ax
 bV
-cf
-cq
-cy
+Xx
+zx
+rD
 ax
 ax
 aj
 ax
 ax
-cf
-cq
-cD
+NQ
+zx
+ED
 du
 ax
 ax
@@ -2306,7 +2626,7 @@ bC
 ax
 ax
 cg
-cd
+on
 ax
 ax
 cH
@@ -2314,7 +2634,7 @@ cJ
 cO
 ax
 ax
-cd
+on
 cg
 ax
 ax
@@ -2340,7 +2660,7 @@ bD
 br
 bW
 ch
-cr
+Dl
 cz
 cF
 bP
@@ -2348,7 +2668,7 @@ bP
 bP
 cU
 br
-dg
+fn
 dp
 dv
 ax
@@ -2361,9 +2681,9 @@ en
 "}
 (6,1,1) = {"
 aa
-ab
-ab
-ab
+dL
+dL
+dL
 ax
 ax
 aQ
@@ -2371,22 +2691,22 @@ aY
 aY
 aY
 bE
-bk
+jH
 bX
 ci
-ci
-ci
-ci
-ci
-bP
-bP
-bP
-da
-dh
-bP
-bP
-dA
-dJ
+yl
+qz
+qz
+qz
+ks
+ks
+ks
+ZE
+Yc
+ks
+ks
+ld
+PE
 dJ
 dZ
 ek
@@ -2394,8 +2714,8 @@ el
 el
 "}
 (7,1,1) = {"
-ab
-ab
+dL
+dL
 aj
 ap
 ay
@@ -2420,7 +2740,7 @@ di
 dq
 dw
 dB
-dK
+Xn
 dJ
 ea
 ek
@@ -2428,7 +2748,7 @@ em
 aa
 "}
 (8,1,1) = {"
-ab
+dL
 ac
 ak
 aq
@@ -2451,10 +2771,10 @@ cP
 ax
 ax
 ax
-dr
+Ka
 ax
 ax
-dL
+Nk
 dT
 eb
 ek
@@ -2462,7 +2782,7 @@ em
 aa
 "}
 (9,1,1) = {"
-ab
+dL
 ad
 al
 ar
@@ -2470,7 +2790,7 @@ aA
 aI
 ax
 ax
-bk
+Bo
 ax
 ax
 bO
@@ -2488,7 +2808,7 @@ dj
 bP
 ax
 dC
-dM
+lz
 dU
 ec
 ek
@@ -2496,16 +2816,16 @@ el
 en
 "}
 (10,1,1) = {"
-ab
+dL
 ae
 am
 as
 aB
 aJ
-aS
+kr
 bb
 bl
-bx
+Qg
 bG
 bP
 bP
@@ -2522,7 +2842,7 @@ dk
 bP
 ax
 dD
-dN
+AX
 dJ
 ax
 ax
@@ -2530,7 +2850,7 @@ el
 el
 "}
 (11,1,1) = {"
-ab
+dL
 af
 al
 at
@@ -2555,8 +2875,8 @@ bP
 bP
 ds
 ax
-dE
-dO
+vD
+RC
 dO
 ed
 ax
@@ -2564,16 +2884,16 @@ ax
 aa
 "}
 (12,1,1) = {"
-ab
+dL
 ag
 ep
 au
 aD
 aL
-aS
+kr
 bc
 bn
-bx
+Qg
 bI
 bQ
 bP
@@ -2590,7 +2910,7 @@ cX
 bP
 ax
 dF
-dJ
+ye
 dJ
 ax
 ax
@@ -2598,7 +2918,7 @@ el
 en
 "}
 (13,1,1) = {"
-ab
+dL
 ah
 al
 ar
@@ -2606,7 +2926,7 @@ aE
 aM
 ax
 ax
-bo
+Yx
 ax
 ax
 bR
@@ -2624,7 +2944,7 @@ dm
 bQ
 ax
 dG
-dP
+Ie
 dU
 ec
 ek
@@ -2632,7 +2952,7 @@ el
 el
 "}
 (14,1,1) = {"
-ab
+dL
 ai
 an
 av
@@ -2655,10 +2975,10 @@ cP
 ax
 ax
 ax
-dr
+Ka
 ax
 ax
-dL
+Nk
 dJ
 ee
 ek
@@ -2666,8 +2986,8 @@ em
 aa
 "}
 (15,1,1) = {"
-ab
-ab
+dL
+dL
 ao
 aw
 aG
@@ -2692,7 +3012,7 @@ dg
 cr
 dx
 dB
-dK
+Xn
 dJ
 ef
 ek
@@ -2701,9 +3021,9 @@ aa
 "}
 (16,1,1) = {"
 aa
-ab
-ab
-ab
+dL
+dL
+dL
 ax
 ax
 aU
@@ -2711,22 +3031,22 @@ bf
 bf
 bf
 bK
-bT
+vG
 ca
 cj
-cj
-cj
-cj
-cj
-bP
-bP
-bP
-de
-dn
-bP
-bP
-dA
-dJ
+QI
+Et
+Et
+Et
+ks
+ks
+ks
+OW
+YG
+ks
+ks
+ld
+qd
 dJ
 eg
 ek
@@ -2748,7 +3068,7 @@ bL
 br
 ca
 cl
-cs
+Ul
 cC
 cG
 bP
@@ -2756,7 +3076,7 @@ bP
 bP
 cU
 br
-do
+iS
 dt
 dy
 ax
@@ -2782,7 +3102,7 @@ bM
 ax
 ax
 cg
-ct
+xF
 ax
 ax
 cI
@@ -2790,7 +3110,7 @@ cN
 cN
 ax
 ax
-cd
+on
 cg
 ax
 ax
@@ -2815,17 +3135,17 @@ aj
 ax
 ax
 cb
-cm
-cu
-cx
+Jn
+Vm
+vr
 ax
 ax
 ao
 ax
 ax
-ce
-cu
-cx
+tP
+Vm
+kI
 dz
 ax
 ax
@@ -2845,21 +3165,21 @@ aa
 aa
 aa
 aN
-br
+DU
 ax
 ax
 cc
-cf
-cv
-cD
+Xx
+PJ
+ED
 cE
 ax
-br
+DU
 ax
 cE
-cf
-cv
-cy
+Xx
+PJ
+QD
 cc
 ax
 ax

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -116,13 +116,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/rust,
 /area/shuttle/escape)
-"at" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Glorious Leaders";
-	req_access_txt = "19"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "au" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -196,13 +189,6 @@
 "aH" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"aI" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "aJ" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -229,13 +215,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /mob/living/simple_animal/hostile/bear/fightpit,
 /turf/open/floor/engine,
-/area/shuttle/escape)
-"aO" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aP" = (
 /obj/structure/chair/comfy/shuttle{
@@ -273,16 +252,6 @@
 /obj/item/kitchen/fork,
 /mob/living/simple_animal/hostile/bear/fightpit,
 /turf/open/floor/engine,
-/area/shuttle/escape)
-"aW" = (
-/obj/docking_port/mobile/emergency{
-	height = 15;
-	name = "Box emergency shuttle"
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aX" = (
 /obj/structure/extinguisher_cabinet{
@@ -416,12 +385,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
-"br" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "bs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -436,21 +399,9 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"bu" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Cargo"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "bv" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
-/area/shuttle/escape)
-"bw" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Infirmary"
-	},
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "bx" = (
 /turf/open/floor/plating,
@@ -575,6 +526,14 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"hP" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "iJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -582,10 +541,84 @@
 /obj/item/clothing/gloves/fingerless,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
+"sP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "wq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/optable,
 /turf/open/floor/plasteel,
+/area/shuttle/escape)
+"Dd" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Cargo"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Ge" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"OL" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Infirmary"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"OT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Glorious Leaders";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"SF" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Vh" = (
+/obj/docking_port/mobile/emergency{
+	height = 15;
+	name = "Box emergency shuttle"
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Xw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -596,17 +629,17 @@ aa
 ad
 ab
 ad
-aO
+hP
 ab
-aW
+Vh
 ad
-ac
-ac
-ac
+sP
+sP
+sP
 ad
-br
+Ge
 ad
-br
+Ge
 ad
 aa
 aa
@@ -677,7 +710,7 @@ bc
 bc
 bc
 aR
-bu
+Dd
 bx
 bx
 bG
@@ -691,7 +724,7 @@ ai
 an
 ad
 ac
-aI
+SF
 ac
 ad
 bN
@@ -709,7 +742,7 @@ bK
 bL
 "}
 (6,1,1) = {"
-ac
+sP
 ae
 aj
 ao
@@ -733,11 +766,11 @@ bK
 bL
 "}
 (7,1,1) = {"
-ac
+sP
 af
 ak
 ak
-at
+OT
 ax
 aJ
 aJ
@@ -757,7 +790,7 @@ bK
 bL
 "}
 (8,1,1) = {"
-ac
+sP
 ag
 ak
 ap
@@ -781,7 +814,7 @@ bK
 bL
 "}
 (9,1,1) = {"
-ac
+sP
 af
 al
 aq
@@ -791,7 +824,7 @@ aK
 aQ
 aA
 aZ
-ax
+Xw
 ax
 bl
 ax
@@ -805,7 +838,7 @@ bK
 bL
 "}
 (10,1,1) = {"
-ac
+sP
 ah
 ak
 aq
@@ -845,7 +878,7 @@ bm
 bo
 ax
 ax
-bw
+OL
 bB
 bB
 bF
@@ -936,13 +969,13 @@ aE
 aE
 aE
 ad
-ac
-ac
-ac
+sP
+sP
+sP
 ad
 ad
 ad
-ac
+sP
 ad
 aa
 aa

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -87,20 +87,6 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
-"aq" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"ar" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Cockpit";
-	req_access_txt = "19"
-	},
-/turf/open/floor/carpet,
-/area/shuttle/escape)
 "as" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock";
@@ -169,13 +155,6 @@
 "aB" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/escape)
-"aC" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -219,15 +198,6 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aK" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Scrapheap Challenge"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aL" = (
 /obj/structure/chair/comfy/shuttle{
@@ -305,12 +275,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/shuttle/escape)
-"aZ" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ba" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -337,12 +301,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"bd" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
 "be" = (
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
@@ -352,24 +310,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"bg" = (
-/obj/machinery/door/airlock{
-	name = "Unit 1"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"bh" = (
-/obj/machinery/door/airlock{
-	name = "Unit 2"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"bi" = (
-/obj/machinery/door/airlock{
-	name = "Unit B"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
@@ -426,6 +366,123 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"bL" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"cq" = (
+/obj/structure/grille/broken,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/shuttle/escape)
+"gl" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"jr" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Scrapheap Challenge"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ly" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"mJ" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"mN" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Dc" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Gw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"KJ" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"NP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Cockpit";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/shuttle/escape)
+"Ow" = (
+/obj/machinery/door/airlock{
+	name = "Unit B"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"Uc" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -435,17 +492,17 @@ aa
 ab
 ab
 ab
-aC
+gl
 ab
-aK
+jr
 ab
-ac
-ac
-ac
+Uc
+Uc
+Uc
 ab
-aZ
+mN
 ab
-aZ
+mN
 ab
 ab
 ab
@@ -462,7 +519,7 @@ ax
 aD
 ab
 bp
-aA
+cq
 aG
 aw
 aR
@@ -470,7 +527,7 @@ aX
 av
 ab
 be
-bg
+KJ
 bj
 ab
 ab
@@ -480,7 +537,7 @@ ab
 ad
 ai
 am
-aq
+Dc
 at
 ay
 aE
@@ -518,7 +575,7 @@ aY
 av
 ab
 bf
-bh
+bL
 bj
 bl
 bn
@@ -558,15 +615,15 @@ aA
 aF
 aw
 aw
-aw
+Gw
 aw
 aw
 aL
 ac
 av
-bd
+mJ
 be
-bi
+Ow
 bk
 bl
 bn
@@ -576,7 +633,7 @@ ac
 af
 ak
 ap
-ar
+NP
 av
 ac
 aG
@@ -600,7 +657,7 @@ ac
 ah
 al
 aa
-ac
+Uc
 ac
 aB
 bo
@@ -626,7 +683,7 @@ aa
 aa
 as
 aw
-aw
+Gw
 aw
 aw
 aL
@@ -648,8 +705,8 @@ aa
 aa
 aa
 aa
-ac
-ac
+Uc
+Uc
 aB
 aH
 aw
@@ -678,7 +735,7 @@ ab
 aI
 aJ
 aM
-aM
+ly
 aM
 aJ
 aW

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -97,12 +97,6 @@
 "aw" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"aA" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aB" = (
 /obj/machinery/power/supermatter_crystal/shard/hugbox/fakecrystal,
 /turf/open/floor/plating,
@@ -121,25 +115,9 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"aF" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Hyperfractal Gigashuttle"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "aI" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"aL" = (
-/obj/machinery/door/airlock/external{
-	name = "Emergency Launch Catwalk";
-	req_access_txt = "10;13"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aM" = (
 /turf/open/floor/plating/airless,
@@ -307,6 +285,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/shuttle/escape)
+"lT" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"my" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "pb" = (
 /obj/structure/closet/radiation{
 	anchored = 1
@@ -317,6 +307,16 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"yn" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Hyperfractal Gigashuttle"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Bi" = (
 /obj/structure/closet/radiation{
 	anchored = 1
@@ -326,6 +326,14 @@
 	pixel_x = -32
 	},
 /turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Jo" = (
+/obj/machinery/door/airlock/external{
+	name = "Emergency Launch Catwalk";
+	req_access_txt = "10;13"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "UA" = (
 /obj/machinery/status_display/evac{
@@ -342,9 +350,9 @@ aa
 aa
 aa
 aw
-aA
+my
 ac
-aF
+yn
 aw
 aa
 aa
@@ -361,10 +369,10 @@ aa
 (2,1,1) = {"
 aw
 ae
-ad
+lT
 ac
 ae
-ad
+lT
 aw
 ai
 aD
@@ -407,7 +415,7 @@ bc
 be
 "}
 (4,1,1) = {"
-ad
+lT
 ah
 ai
 al
@@ -431,7 +439,7 @@ aa
 aa
 "}
 (5,1,1) = {"
-ad
+lT
 ag
 aj
 am
@@ -455,7 +463,7 @@ aU
 aX
 "}
 (6,1,1) = {"
-ad
+lT
 ag
 aj
 an
@@ -466,7 +474,7 @@ aB
 bf
 at
 at
-aL
+Jo
 aM
 aM
 hD
@@ -479,7 +487,7 @@ bd
 aY
 "}
 (7,1,1) = {"
-ad
+lT
 ag
 aj
 ao
@@ -503,7 +511,7 @@ aW
 aZ
 "}
 (8,1,1) = {"
-ad
+lT
 ah
 ai
 ap
@@ -553,10 +561,10 @@ be
 (10,1,1) = {"
 aw
 ae
-ad
+lT
 ac
 ae
-ad
+lT
 aw
 ai
 aE
@@ -582,9 +590,9 @@ aa
 aa
 aa
 aw
-aA
+my
 ac
-aA
+my
 aw
 aa
 aa

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -5,11 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ac" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle/tinted,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ad" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -81,11 +76,6 @@
 "ai" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"aj" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "ak" = (
 /obj/structure/chair/comfy/shuttle{
@@ -161,13 +151,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"ax" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ay" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -187,26 +170,6 @@
 /obj/structure/table,
 /obj/item/coin/mythril,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"aC" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aD" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "NT Lepton Violet"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aF" = (
 /obj/machinery/door/window/eastleft,
@@ -297,16 +260,6 @@
 	},
 /obj/item/reagent_containers/glass/bottle/charcoal,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"aU" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aV" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "aW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -515,11 +468,60 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"bK" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"el" = (
+/obj/machinery/door/airlock/titanium,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ft" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle/tinted,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "ji" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"oh" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"uR" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/titanium,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cult,
+/area/shuttle/escape)
+"AO" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	req_access_txt = "2"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Ec" = (
 /obj/structure/chair/comfy/shuttle{
@@ -530,9 +532,32 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"JM" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "NT Lepton Violet"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "MK" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Re" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"RB" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -543,17 +568,17 @@ aa
 ab
 ab
 ab
-ax
+AO
 ab
-aD
+JM
 ab
-as
-as
-as
+RB
+RB
+RB
 ab
-aV
+oh
 ab
-aV
+oh
 ab
 ab
 ab
@@ -592,7 +617,7 @@ ab
 bj
 al
 al
-aB
+bK
 aq
 aq
 aq
@@ -608,7 +633,7 @@ bf
 bg
 "}
 (4,1,1) = {"
-ac
+ft
 ad
 ae
 ad
@@ -622,7 +647,7 @@ aJ
 aJ
 aJ
 aq
-aU
+Re
 aq
 aq
 aq
@@ -632,7 +657,7 @@ bf
 bg
 "}
 (5,1,1) = {"
-ac
+ft
 ae
 ad
 ae
@@ -656,7 +681,7 @@ bf
 bg
 "}
 (6,1,1) = {"
-ac
+ft
 af
 ad
 bi
@@ -680,11 +705,11 @@ bf
 bg
 "}
 (7,1,1) = {"
-ac
+ft
 ae
 ad
 ae
-aj
+uR
 ao
 au
 az
@@ -704,7 +729,7 @@ bf
 bg
 "}
 (8,1,1) = {"
-ac
+ft
 ad
 ae
 ad
@@ -718,7 +743,7 @@ aL
 aO
 aL
 aq
-aU
+Re
 aq
 aq
 aq
@@ -736,7 +761,7 @@ aH
 aq
 aq
 aq
-aC
+el
 aq
 aq
 aP
@@ -781,19 +806,19 @@ aa
 aa
 aa
 ab
-as
+RB
 ab
-as
-ab
-ab
-ab
-as
-as
-as
+RB
 ab
 ab
 ab
-as
+RB
+RB
+RB
+ab
+ab
+ab
+RB
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -98,13 +98,6 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"at" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Command Center";
-	req_access_txt = "19"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
 "au" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -119,24 +112,11 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"ax" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Holding Facility";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
 "ay" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"az" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Repair Bay"
-	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 "aB" = (
@@ -166,12 +146,6 @@
 	pixel_x = -13
 	},
 /obj/item/multitool/abductor,
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"aF" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Experimentation Lab"
-	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
 "aG" = (
@@ -302,12 +276,41 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"hm" = (
+"cD" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Repair Bay"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"qB" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"yI" = (
+"tG" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Transport Ship Theta"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"yL" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Experimentation Lab"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"zQ" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Command Center";
+	req_access_txt = "19"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"BU" = (
 /obj/machinery/door/airlock/abductor{
 	name = "Transport Ship Theta"
 	},
@@ -317,16 +320,13 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"yL" = (
+"Mw" = (
 /obj/machinery/door/airlock/abductor{
-	name = "Transport Ship Theta"
+	name = "Holding Facility";
+	req_access_txt = "2"
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"Ul" = (
-/obj/structure/fans/tiny/invisible,
-/turf/closed/wall/mineral/abductor,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -335,17 +335,17 @@ aa
 aa
 aa
 aa
-Ul
-Ul
-yI
-hm
-Ul
-hm
-Ul
-hm
-yL
-Ul
-Ul
+ab
+ab
+BU
+qB
+ab
+qB
+ab
+qB
+tG
+ab
+ab
 aa
 aa
 aa
@@ -357,8 +357,8 @@ aa
 aa
 aa
 aa
-Ul
-Ul
+ab
+ab
 al
 al
 al
@@ -368,8 +368,8 @@ ay
 al
 al
 al
-Ul
-Ul
+ab
+ab
 aa
 aa
 aa
@@ -379,8 +379,8 @@ aa
 aa
 aa
 aa
-Ul
-Ul
+ab
+ab
 ao
 al
 al
@@ -392,8 +392,8 @@ al
 al
 al
 am
-Ul
-Ul
+ab
+ab
 aa
 aa
 aa
@@ -401,8 +401,8 @@ aa
 (4,1,1) = {"
 aa
 aa
-Ul
-Ul
+ab
+ab
 ao
 al
 al
@@ -416,15 +416,15 @@ al
 al
 al
 am
-Ul
-Ul
+ab
+ab
 aa
 aa
 "}
 (5,1,1) = {"
 aa
-Ul
-Ul
+ab
+ab
 ao
 al
 al
@@ -440,13 +440,13 @@ al
 al
 al
 am
-Ul
-Ul
+ab
+ab
 aa
 "}
 (6,1,1) = {"
-Ul
-Ul
+ab
+ab
 aj
 al
 ar
@@ -464,11 +464,11 @@ ar
 ar
 al
 aQ
-Ul
-Ul
+ab
+ab
 "}
 (7,1,1) = {"
-Ul
+ab
 ab
 ab
 ab
@@ -488,10 +488,10 @@ ab
 ab
 ab
 ab
-Ul
+ab
 "}
 (8,1,1) = {"
-Ul
+ab
 ad
 ak
 ap
@@ -511,10 +511,10 @@ aJ
 aJ
 aR
 aU
-Ul
+ab
 "}
 (9,1,1) = {"
-hm
+qB
 ae
 al
 al
@@ -529,15 +529,15 @@ ao
 al
 al
 al
-ac
+qB
 al
 al
 al
 aV
-hm
+qB
 "}
 (10,1,1) = {"
-hm
+qB
 af
 ak
 al
@@ -552,20 +552,20 @@ ao
 al
 al
 al
-ac
+qB
 al
 al
 al
 aW
-hm
+qB
 "}
 (11,1,1) = {"
-hm
+qB
 ag
 am
 al
 al
-at
+zQ
 al
 al
 al
@@ -575,15 +575,15 @@ ao
 al
 al
 al
-aF
+yL
 al
 al
 al
 aX
-hm
+qB
 "}
 (12,1,1) = {"
-hm
+qB
 af
 ak
 al
@@ -598,15 +598,15 @@ ao
 al
 al
 al
-ac
+qB
 aK
 al
 al
 aY
-hm
+qB
 "}
 (13,1,1) = {"
-hm
+qB
 ah
 al
 al
@@ -621,15 +621,15 @@ ao
 al
 al
 al
-ac
+qB
 aL
 al
 al
 al
-hm
+qB
 "}
 (14,1,1) = {"
-Ul
+ab
 ai
 ak
 aq
@@ -649,10 +649,10 @@ aM
 aO
 aS
 aZ
-Ul
+ab
 "}
 (15,1,1) = {"
-Ul
+ab
 ab
 ab
 ab
@@ -672,74 +672,74 @@ ab
 ab
 ab
 ab
-Ul
+ab
 "}
 (16,1,1) = {"
-Ul
-Ul
+ab
+ab
 an
 al
 ap
 au
 au
 au
-ac
+qB
 al
 al
 al
-ac
+qB
 aB
 al
 aG
 ap
 al
 aT
-Ul
-Ul
+ab
+ab
 "}
 (17,1,1) = {"
 aa
-Ul
-Ul
+ab
+ab
 ao
 al
 al
 al
 al
-ac
+qB
 al
 al
 al
-ac
+qB
 al
 al
 al
 al
 aP
-Ul
-Ul
+ab
+ab
 aa
 "}
 (18,1,1) = {"
 aa
 aa
-Ul
-Ul
+ab
+ab
 ao
 al
 al
 al
-ax
+Mw
 al
 al
 al
-az
+cD
 al
 al
 aH
 aN
-Ul
-Ul
+ab
+ab
 aa
 aa
 "}
@@ -747,21 +747,21 @@ aa
 aa
 aa
 aa
-Ul
-Ul
+ab
+ab
 ar
 al
 al
-ac
+qB
 al
 al
 al
-ac
+qB
 al
 aD
 aI
-Ul
-Ul
+ab
+ab
 aa
 aa
 aa
@@ -771,19 +771,19 @@ aa
 aa
 aa
 aa
-Ul
-Ul
+ab
+ab
 ar
 aw
-ac
+qB
 ar
 ar
 ar
-ac
+qB
 aC
 aE
-Ul
-Ul
+ab
+ab
 aa
 aa
 aa
@@ -795,17 +795,17 @@ aa
 aa
 aa
 aa
-Ul
-Ul
-Ul
-Ul
-hm
-hm
-hm
-Ul
-Ul
-Ul
-Ul
+ab
+ab
+ab
+ab
+qB
+qB
+qB
+ab
+ab
+ab
+ab
 aa
 aa
 aa

--- a/_maps/shuttles/emergency_zeta.dmm
+++ b/_maps/shuttles/emergency_zeta.dmm
@@ -1,22 +1,22 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aa" = (
 /turf/template_noop,
 /area/space)
-"b" = (
+"ab" = (
 /turf/closed/wall/mineral/abductor,
 /area/shuttle/escape)
-"c" = (
+"ac" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"d" = (
+"ad" = (
 /obj/structure/table/abductor,
 /obj/item/abductor/mind_device{
 	desc = "Just holding this makes your head ache."
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"e" = (
+"ae" = (
 /obj/structure/table/abductor,
 /obj/item/anomaly_neutralizer{
 	pixel_x = -15
@@ -24,47 +24,47 @@
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"f" = (
+"af" = (
 /obj/machinery/abductor/console,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"g" = (
+"ag" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"h" = (
+"ah" = (
 /obj/structure/table/abductor,
 /obj/machinery/recharger,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"i" = (
+"ai" = (
 /obj/structure/table/abductor,
 /obj/item/gun/energy/alien,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"j" = (
+"aj" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"k" = (
+"ak" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"l" = (
+"al" = (
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"m" = (
+"am" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"n" = (
+"an" = (
 /obj/structure/table/abductor,
 /obj/machinery/recharger,
 /obj/item/abductor/baton{
@@ -72,55 +72,46 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"o" = (
+"ao" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"p" = (
+"ap" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"q" = (
+"aq" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"r" = (
+"ar" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"s" = (
+"as" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"t" = (
+"at" = (
 /obj/machinery/door/airlock/abductor{
 	name = "Command Center";
 	req_access_txt = "19"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"u" = (
+"au" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"v" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Transport Ship Theta"
-	},
-/obj/docking_port/mobile/emergency{
-	name = "Zeta emergency shuttle"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"w" = (
+"aw" = (
 /obj/structure/table/abductor,
 /obj/item/storage/box/alienhandcuffs,
 /obj/machinery/light{
@@ -128,44 +119,38 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"x" = (
+"ax" = (
 /obj/machinery/door/airlock/abductor{
 	name = "Holding Facility";
 	req_access_txt = "2"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"y" = (
+"ay" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"z" = (
+"az" = (
 /obj/machinery/door/airlock/abductor{
 	name = "Repair Bay"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"A" = (
-/obj/machinery/door/airlock/abductor{
-	name = "Transport Ship Theta"
-	},
-/turf/open/floor/plating/abductor,
-/area/shuttle/escape)
-"B" = (
+"aB" = (
 /obj/machinery/abductor/experiment,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"C" = (
+"aC" = (
 /obj/structure/chair/office,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"D" = (
+"aD" = (
 /obj/structure/table/abductor,
 /obj/item/screwdriver/abductor{
 	pixel_y = -5
@@ -175,22 +160,21 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"E" = (
+"aE" = (
 /obj/structure/table/abductor,
 /obj/item/crowbar/abductor{
-	pixel_x = -13;
-	
+	pixel_x = -13
 	},
 /obj/item/multitool/abductor,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"F" = (
+"aF" = (
 /obj/machinery/door/airlock/abductor{
 	name = "Experimentation Lab"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"G" = (
+"aG" = (
 /obj/structure/table/abductor,
 /obj/item/stock_parts/subspace/crystal{
 	pixel_x = -8
@@ -204,13 +188,13 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"H" = (
+"aH" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"I" = (
+"aI" = (
 /obj/structure/table/abductor,
 /obj/item/abductor/gizmo,
 /obj/item/wirecutters/abductor{
@@ -218,48 +202,48 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"J" = (
+"aJ" = (
 /obj/machinery/stasis,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"K" = (
+"aK" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"L" = (
+"aL" = (
 /obj/machinery/computer/prototype_cloning,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"M" = (
+"aM" = (
 /obj/machinery/clonepod/experimental,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"N" = (
+"aN" = (
 /obj/machinery/abductor/pad{
 	desc = "A funky looking disc, built into the floor."
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"O" = (
+"aO" = (
 /obj/machinery/shower{
 	dir = 8;
 	name = "emergency shower"
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"P" = (
+"aP" = (
 /obj/structure/closet/abductor,
 /obj/item/stack/sheet/mineral/abductor{
 	amount = 50
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"Q" = (
+"aQ" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic,
 /obj/machinery/light,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"R" = (
+"aR" = (
 /obj/machinery/light{
 	dir = 8
 	},
@@ -271,7 +255,7 @@
 /obj/item/clothing/glasses/eyepatch,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"S" = (
+"aS" = (
 /obj/item/lazarus_injector,
 /obj/structure/table/abductor,
 /obj/machinery/light{
@@ -279,22 +263,22 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"T" = (
+"aT" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"U" = (
+"aU" = (
 /obj/machinery/abductor/gland_dispenser{
 	desc = "A tank filled with grotesque bits of flesh."
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"V" = (
+"aV" = (
 /obj/structure/table/optable/abductor,
 /obj/item/surgical_drapes,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"W" = (
+"aW" = (
 /obj/structure/table/abductor,
 /obj/item/scalpel/alien,
 /obj/item/cautery/alien,
@@ -304,501 +288,527 @@
 /obj/item/surgicaldrill/alien,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"X" = (
+"aX" = (
 /obj/structure/table/abductor,
 /obj/item/organ/heart/gland/egg,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"Y" = (
+"aY" = (
 /obj/machinery/fat_sucker,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
-"Z" = (
+"aZ" = (
 /obj/structure/bed/abductor,
 /obj/machinery/iv_drip,
 /turf/open/floor/plating/abductor,
 /area/shuttle/escape)
+"hm" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"yI" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Transport Ship Theta"
+	},
+/obj/docking_port/mobile/emergency{
+	name = "Zeta emergency shuttle"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"yL" = (
+/obj/machinery/door/airlock/abductor{
+	name = "Transport Ship Theta"
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating/abductor,
+/area/shuttle/escape)
+"Ul" = (
+/obj/structure/fans/tiny/invisible,
+/turf/closed/wall/mineral/abductor,
+/area/shuttle/escape)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-b
-b
-v
-c
-b
-c
-b
-c
-A
-b
-b
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+Ul
+Ul
+yI
+hm
+Ul
+hm
+Ul
+hm
+yL
+Ul
+Ul
+aa
+aa
+aa
+aa
+aa
 "}
 (2,1,1) = {"
-a
-a
-a
-a
-b
-b
-l
-l
-l
-y
-l
-y
-l
-l
-l
-b
-b
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+Ul
+Ul
+al
+al
+al
+ay
+al
+ay
+al
+al
+al
+Ul
+Ul
+aa
+aa
+aa
+aa
 "}
 (3,1,1) = {"
-a
-a
-a
-b
-b
-o
-l
-l
-l
-l
-l
-l
-l
-l
-l
-m
-b
-b
-a
-a
-a
+aa
+aa
+aa
+Ul
+Ul
+ao
+al
+al
+al
+al
+al
+al
+al
+al
+al
+am
+Ul
+Ul
+aa
+aa
+aa
 "}
 (4,1,1) = {"
-a
-a
-b
-b
-o
-l
-l
-l
-r
-r
-r
-r
-r
-l
-l
-l
-m
-b
-b
-a
-a
+aa
+aa
+Ul
+Ul
+ao
+al
+al
+al
+ar
+ar
+ar
+ar
+ar
+al
+al
+al
+am
+Ul
+Ul
+aa
+aa
 "}
 (5,1,1) = {"
-a
-b
-b
-o
-l
-l
-l
-l
-b
-b
-c
-b
-b
-l
-l
-l
-l
-m
-b
-b
-a
+aa
+Ul
+Ul
+ao
+al
+al
+al
+al
+ab
+ab
+ac
+ab
+ab
+al
+al
+al
+al
+am
+Ul
+Ul
+aa
 "}
 (6,1,1) = {"
-b
-b
-j
-l
-r
-r
-r
-l
-u
-u
-u
-u
-u
-l
-r
-r
-r
-l
-Q
-b
-b
+Ul
+Ul
+aj
+al
+ar
+ar
+ar
+al
+au
+au
+au
+au
+au
+al
+ar
+ar
+ar
+al
+aQ
+Ul
+Ul
 "}
 (7,1,1) = {"
-b
-b
-b
-b
-b
-b
-b
-l
-l
-l
-l
-l
-l
-l
-b
-b
-b
-b
-b
-b
-b
+Ul
+ab
+ab
+ab
+ab
+ab
+ab
+al
+al
+al
+al
+al
+al
+al
+ab
+ab
+ab
+ab
+ab
+ab
+Ul
 "}
 (8,1,1) = {"
-b
-d
-k
-p
-s
-b
-s
-l
-l
-l
-q
-l
-l
-l
-s
-b
-J
-J
-R
-U
-b
+Ul
+ad
+ak
+ap
+as
+ab
+as
+al
+al
+al
+aq
+al
+al
+al
+as
+ab
+aJ
+aJ
+aR
+aU
+Ul
 "}
 (9,1,1) = {"
-c
-e
-l
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-l
-l
-l
-V
-c
+hm
+ae
+al
+al
+al
+ab
+al
+al
+al
+am
+ab
+ao
+al
+al
+al
+ac
+al
+al
+al
+aV
+hm
 "}
 (10,1,1) = {"
-c
-f
-k
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-l
-l
-l
-W
-c
+hm
+af
+ak
+al
+al
+ab
+al
+al
+al
+am
+ab
+ao
+al
+al
+al
+ac
+al
+al
+al
+aW
+hm
 "}
 (11,1,1) = {"
-c
-g
-m
-l
-l
-t
-l
-l
-l
-m
-c
-o
-l
-l
-l
-F
-l
-l
-l
-X
-c
+hm
+ag
+am
+al
+al
+at
+al
+al
+al
+am
+ac
+ao
+al
+al
+al
+aF
+al
+al
+al
+aX
+hm
 "}
 (12,1,1) = {"
-c
-f
-k
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-K
-l
-l
-Y
-c
+hm
+af
+ak
+al
+al
+ab
+al
+al
+al
+am
+ab
+ao
+al
+al
+al
+ac
+aK
+al
+al
+aY
+hm
 "}
 (13,1,1) = {"
-c
-h
-l
-l
-l
-b
-l
-l
-l
-m
-b
-o
-l
-l
-l
-c
-L
-l
-l
-l
-c
+hm
+ah
+al
+al
+al
+ab
+al
+al
+al
+am
+ab
+ao
+al
+al
+al
+ac
+aL
+al
+al
+al
+hm
 "}
 (14,1,1) = {"
-b
-i
-k
-q
-s
-b
-s
-l
-l
-l
-p
-l
-l
-q
-s
-b
-M
-O
-S
-Z
-b
+Ul
+ai
+ak
+aq
+as
+ab
+as
+al
+al
+al
+ap
+al
+al
+aq
+as
+ab
+aM
+aO
+aS
+aZ
+Ul
 "}
 (15,1,1) = {"
-b
-b
-b
-b
-b
-b
-b
-b
-b
-l
-l
-l
-b
-b
-b
-b
-b
-b
-b
-b
-b
+Ul
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+al
+al
+al
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+Ul
 "}
 (16,1,1) = {"
-b
-b
-n
-l
-p
-u
-u
-u
-c
-l
-l
-l
-c
-B
-l
-G
-p
-l
-T
-b
-b
+Ul
+Ul
+an
+al
+ap
+au
+au
+au
+ac
+al
+al
+al
+ac
+aB
+al
+aG
+ap
+al
+aT
+Ul
+Ul
 "}
 (17,1,1) = {"
-a
-b
-b
-o
-l
-l
-l
-l
-c
-l
-l
-l
-c
-l
-l
-l
-l
-P
-b
-b
-a
+aa
+Ul
+Ul
+ao
+al
+al
+al
+al
+ac
+al
+al
+al
+ac
+al
+al
+al
+al
+aP
+Ul
+Ul
+aa
 "}
 (18,1,1) = {"
-a
-a
-b
-b
-o
-l
-l
-l
-x
-l
-l
-l
-z
-l
-l
-H
-N
-b
-b
-a
-a
+aa
+aa
+Ul
+Ul
+ao
+al
+al
+al
+ax
+al
+al
+al
+az
+al
+al
+aH
+aN
+Ul
+Ul
+aa
+aa
 "}
 (19,1,1) = {"
-a
-a
-a
-b
-b
-r
-l
-l
-c
-l
-l
-l
-c
-l
-D
-I
-b
-b
-a
-a
-a
+aa
+aa
+aa
+Ul
+Ul
+ar
+al
+al
+ac
+al
+al
+al
+ac
+al
+aD
+aI
+Ul
+Ul
+aa
+aa
+aa
 "}
 (20,1,1) = {"
-a
-a
-a
-a
-b
-b
-r
-w
-c
-r
-r
-r
-c
-C
-E
-b
-b
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+Ul
+Ul
+ar
+aw
+ac
+ar
+ar
+ar
+ac
+aC
+aE
+Ul
+Ul
+aa
+aa
+aa
+aa
 "}
 (21,1,1) = {"
-a
-a
-a
-a
-a
-b
-b
-b
-b
-c
-c
-c
-b
-b
-b
-b
-a
-a
-a
-a
-a
+aa
+aa
+aa
+aa
+aa
+Ul
+Ul
+Ul
+Ul
+hm
+hm
+hm
+Ul
+Ul
+Ul
+Ul
+aa
+aa
+aa
+aa
+aa
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds fire windows to exterior shuttle windows
Adds interior firelocks
Adds tiny fans to the main doors (so people don't get slowed down by a 1x1 airlock when boarding)

Special Exceptions:
Zeta Shuttle (Alien) uses invisible tiny fans instead of firelocks beacuse alien magic.
The raven shuttle has an airlock system with actual pressurisation.
Meta shuttle airlock room uses an advanced airlock controller.

## Why It's Good For The Game

Literally everyone dies every single round because shuttle.

## Changelog
:cl:
tweak: Improves shuttles atmospherics system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
