### PR TITLE
IPCs can no longer be bloodcult sacrifice

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -348,6 +348,12 @@
 	var/sacced = FALSE
 	var/sac_image
 
+/datum/objective/sacrifice/is_valid_target(possible_target)
+	. = ..()
+	var/datum/mind/M = possible_target
+	if(istype(M) && isIPC(M.current))
+		return FALSE
+
 /datum/objective/sacrifice/check_completion()
 	return sacced || completed
 


### PR DESCRIPTION
Doesn't work. Also IPCs don't have blood so it doesn't make sense.

## Changelog
:cl:
fix: IPCs can no longer be selected as a bloodcult sacrifice target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
