### PR TITLE
Adds weighting to random rooms, new rooms by gizkafreechman 

### DIFF
--- a/_maps/RandomRooms/10x10/sk_rdm070_pubbybar.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm070_pubbybar.dmm
@@ -26,6 +26,7 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/structure/closet/crate,
+/obj/item/paper/crumpled/beernuke,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},

--- a/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
@@ -1,35 +1,270 @@
-"a" = (/obj/structure/rack,/obj/item/storage/crayons,/obj/item/storage/crayons,/turf/open/floor/plasteel/dark,/area/template_noop)
-"b" = (/obj/structure/rack,/obj/item/storage/toolbox/artistic,/obj/item/storage/toolbox/artistic,/turf/open/floor/plasteel/dark,/area/template_noop)
-"c" = (/obj/structure/closet/crate,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/turf/open/floor/plasteel/dark,/area/template_noop)
-"d" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
-"e" = (/turf/open/floor/plasteel/dark,/area/template_noop)
-"f" = (/obj/structure/mopbucket,/obj/item/mop,/turf/open/floor/plasteel/dark,/area/template_noop)
-"g" = (/obj/structure/reagent_dispensers/watertank,/obj/item/reagent_containers/glass/bucket,/turf/open/floor/plasteel/dark,/area/template_noop)
-"h" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"i" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
-"j" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
-"k" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"l" = (/turf/open/floor/plasteel,/area/template_noop)
-"m" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"n" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
-"o" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
-"q" = (/obj/effect/landmark/blobstart,/turf/open/floor/plasteel,/area/template_noop)
-"r" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"s" = (/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"t" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"u" = (/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/template_noop)
-"v" = (/obj/item/clothing/gloves/fingerless,/turf/open/floor/plasteel,/area/template_noop)
-"w" = (/obj/item/clothing/head/beret,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/rack,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"b" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/artistic,
+/obj/item/storage/toolbox/artistic,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"c" = (
+/obj/structure/closet/crate,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"d" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"e" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"f" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"g" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"h" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"l" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"n" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"q" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"u" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"v" = (
+/obj/item/clothing/gloves/fingerless,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/item/clothing/head/beret,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abcdeedefg
-ehiiiiiije
-ekllllllme
-nkllllllmo
-eklllvllme
-ekllwqllme
-nkllllllmo
-ekllllllme
-ersssssste
-eeeueeueee
+a
+e
+e
+n
+e
+e
+n
+e
+e
+e
+"}
+(2,1,1) = {"
+b
+h
+k
+k
+k
+k
+k
+k
+r
+e
+"}
+(3,1,1) = {"
+c
+i
+l
+l
+l
+l
+l
+l
+s
+e
+"}
+(4,1,1) = {"
+d
+i
+l
+l
+l
+l
+l
+l
+s
+u
+"}
+(5,1,1) = {"
+e
+i
+l
+l
+l
+w
+l
+l
+s
+e
+"}
+(6,1,1) = {"
+e
+i
+l
+l
+v
+q
+l
+l
+s
+e
+"}
+(7,1,1) = {"
+d
+i
+l
+l
+l
+l
+l
+l
+s
+u
+"}
+(8,1,1) = {"
+e
+i
+l
+l
+l
+l
+l
+l
+s
+e
+"}
+(9,1,1) = {"
+f
+j
+m
+m
+m
+m
+m
+m
+t
+e
+"}
+(10,1,1) = {"
+g
+e
+e
+o
+e
+e
+o
+e
+e
+e
 "}

--- a/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
@@ -1,274 +1,35 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/structure/rack,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"b" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/artistic,
-/obj/item/storage/toolbox/artistic,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"c" = (
-/obj/structure/closet/crate,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"d" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"e" = (
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"f" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"g" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"h" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"i" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"j" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"k" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"l" = (
-/turf/open/floor/plasteel,
-/area/template_noop)
-"m" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"n" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"o" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"p" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"q" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"r" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"s" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"t" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"u" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/template_noop)
-"v" = (
-/obj/item/clothing/gloves/fingerless,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"w" = (
-/obj/item/clothing/head/beret,
-/turf/open/floor/plasteel,
-/area/template_noop)
+"a" = (/obj/structure/rack,/obj/item/storage/crayons,/obj/item/storage/crayons,/turf/open/floor/plasteel/dark,/area/template_noop)
+"b" = (/obj/structure/rack,/obj/item/storage/toolbox/artistic,/obj/item/storage/toolbox/artistic,/turf/open/floor/plasteel/dark,/area/template_noop)
+"c" = (/obj/structure/closet/crate,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/turf/open/floor/plasteel/dark,/area/template_noop)
+"d" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
+"e" = (/turf/open/floor/plasteel/dark,/area/template_noop)
+"f" = (/obj/structure/mopbucket,/obj/item/mop,/turf/open/floor/plasteel/dark,/area/template_noop)
+"g" = (/obj/structure/reagent_dispensers/watertank,/obj/item/reagent_containers/glass/bucket,/turf/open/floor/plasteel/dark,/area/template_noop)
+"h" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"i" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
+"j" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
+"k" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"l" = (/turf/open/floor/plasteel,/area/template_noop)
+"m" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"n" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
+"o" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
+"q" = (/obj/effect/landmark/blobstart,/turf/open/floor/plasteel,/area/template_noop)
+"r" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"s" = (/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"t" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"u" = (/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/template_noop)
+"v" = (/obj/item/clothing/gloves/fingerless,/turf/open/floor/plasteel,/area/template_noop)
+"w" = (/obj/item/clothing/head/beret,/turf/open/floor/plasteel,/area/template_noop)
 
 (1,1,1) = {"
-a
-e
-e
-n
-e
-e
-n
-e
-e
-e
-"}
-(2,1,1) = {"
-b
-h
-k
-k
-k
-k
-k
-k
-r
-e
-"}
-(3,1,1) = {"
-c
-i
-l
-l
-l
-l
-l
-l
-s
-e
-"}
-(4,1,1) = {"
-d
-i
-l
-l
-l
-l
-l
-l
-s
-u
-"}
-(5,1,1) = {"
-e
-i
-l
-l
-p
-w
-l
-l
-s
-e
-"}
-(6,1,1) = {"
-e
-i
-l
-l
-v
-q
-l
-l
-s
-e
-"}
-(7,1,1) = {"
-d
-i
-l
-l
-l
-l
-l
-l
-s
-u
-"}
-(8,1,1) = {"
-e
-i
-l
-l
-l
-l
-l
-l
-s
-e
-"}
-(9,1,1) = {"
-f
-j
-m
-m
-m
-m
-m
-m
-t
-e
-"}
-(10,1,1) = {"
-g
-e
-e
-o
-e
-e
-o
-e
-e
-e
+abcdeedefg
+ehiiiiiije
+ekllllllme
+nkllllllmo
+eklllvllme
+ekllwqllme
+nkllllllmo
+ekllllllme
+ersssssste
+eeeueeueee
 "}

--- a/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
@@ -1,36 +1,274 @@
-"a" = (/obj/structure/rack,/obj/item/storage/crayons,/obj/item/storage/crayons,/turf/open/floor/plasteel/dark,/area/template_noop)
-"b" = (/obj/structure/rack,/obj/item/storage/toolbox/artistic,/obj/item/storage/toolbox/artistic,/turf/open/floor/plasteel/dark,/area/template_noop)
-"c" = (/obj/structure/closet/crate,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/turf/open/floor/plasteel/dark,/area/template_noop)
-"d" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
-"e" = (/turf/open/floor/plasteel/dark,/area/template_noop)
-"f" = (/obj/structure/mopbucket,/obj/item/mop,/turf/open/floor/plasteel/dark,/area/template_noop)
-"g" = (/obj/structure/reagent_dispensers/watertank,/obj/item/reagent_containers/glass/bucket,/turf/open/floor/plasteel/dark,/area/template_noop)
-"h" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"i" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
-"j" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
-"k" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"l" = (/turf/open/floor/plasteel,/area/template_noop)
-"m" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"n" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
-"o" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
-"p" = (/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
-"q" = (/obj/effect/landmark/blobstart,/turf/open/floor/plasteel,/area/template_noop)
-"r" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"s" = (/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"t" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
-"u" = (/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/template_noop)
-"v" = (/obj/item/clothing/gloves/fingerless,/turf/open/floor/plasteel,/area/template_noop)
-"w" = (/obj/item/clothing/head/beret,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/rack,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"b" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/artistic,
+/obj/item/storage/toolbox/artistic,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"c" = (
+/obj/structure/closet/crate,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"d" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"e" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"f" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"g" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"h" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"l" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"n" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"p" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"q" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"s" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"u" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"v" = (
+/obj/item/clothing/gloves/fingerless,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"w" = (
+/obj/item/clothing/head/beret,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abcdeedefg
-ehiiiiiije
-ekllllllme
-nkllllllmo
-ekllpvllme
-ekllwqllme
-nkllllllmo
-ekllllllme
-ersssssste
-eeeueeueee
+a
+e
+e
+n
+e
+e
+n
+e
+e
+e
+"}
+(2,1,1) = {"
+b
+h
+k
+k
+k
+k
+k
+k
+r
+e
+"}
+(3,1,1) = {"
+c
+i
+l
+l
+l
+l
+l
+l
+s
+e
+"}
+(4,1,1) = {"
+d
+i
+l
+l
+l
+l
+l
+l
+s
+u
+"}
+(5,1,1) = {"
+e
+i
+l
+l
+p
+w
+l
+l
+s
+e
+"}
+(6,1,1) = {"
+e
+i
+l
+l
+v
+q
+l
+l
+s
+e
+"}
+(7,1,1) = {"
+d
+i
+l
+l
+l
+l
+l
+l
+s
+u
+"}
+(8,1,1) = {"
+e
+i
+l
+l
+l
+l
+l
+l
+s
+e
+"}
+(9,1,1) = {"
+f
+j
+m
+m
+m
+m
+m
+m
+t
+e
+"}
+(10,1,1) = {"
+g
+e
+e
+o
+e
+e
+o
+e
+e
+e
 "}

--- a/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm
@@ -1,0 +1,36 @@
+"a" = (/obj/structure/rack,/obj/item/storage/crayons,/obj/item/storage/crayons,/turf/open/floor/plasteel/dark,/area/template_noop)
+"b" = (/obj/structure/rack,/obj/item/storage/toolbox/artistic,/obj/item/storage/toolbox/artistic,/turf/open/floor/plasteel/dark,/area/template_noop)
+"c" = (/obj/structure/closet/crate,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/obj/item/toy/crayon/spraycan,/turf/open/floor/plasteel/dark,/area/template_noop)
+"d" = (/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
+"e" = (/turf/open/floor/plasteel/dark,/area/template_noop)
+"f" = (/obj/structure/mopbucket,/obj/item/mop,/turf/open/floor/plasteel/dark,/area/template_noop)
+"g" = (/obj/structure/reagent_dispensers/watertank,/obj/item/reagent_containers/glass/bucket,/turf/open/floor/plasteel/dark,/area/template_noop)
+"h" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"i" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
+"j" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/obj/effect/turf_decal/tile/brown{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
+"k" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"l" = (/turf/open/floor/plasteel,/area/template_noop)
+"m" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"n" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
+"o" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
+"p" = (/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
+"q" = (/obj/effect/landmark/blobstart,/turf/open/floor/plasteel,/area/template_noop)
+"r" = (/obj/effect/turf_decal/tile/brown{dir = 1},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"s" = (/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"t" = (/obj/effect/turf_decal/tile/brown{dir = 4},/obj/effect/turf_decal/tile/brown{dir = 8},/obj/effect/turf_decal/tile/brown,/turf/open/floor/plasteel,/area/template_noop)
+"u" = (/obj/machinery/light,/turf/open/floor/plasteel/dark,/area/template_noop)
+"v" = (/obj/item/clothing/gloves/fingerless,/turf/open/floor/plasteel,/area/template_noop)
+"w" = (/obj/item/clothing/head/beret,/turf/open/floor/plasteel,/area/template_noop)
+
+(1,1,1) = {"
+abcdeedefg
+ehiiiiiije
+ekllllllme
+nkllllllmo
+ekllpvllme
+ekllwqllme
+nkllllllmo
+ekllllllme
+ersssssste
+eeeueeueee
+"}

--- a/_maps/RandomRooms/10x10/sk_rdm102_podrepairbay.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm102_podrepairbay.dmm
@@ -1,40 +1,253 @@
-"a" = (/turf/open/floor/plating,/area/template_noop)
-"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating,/area/template_noop)
-"c" = (/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating,/area/template_noop)
-"d" = (/obj/structure/table,/obj/item/storage/toolbox/electrical{step_x = 16; step_y = 9},/obj/item/stack/sheet/iron/five,/turf/open/floor/plating,/area/template_noop)
-"e" = (/obj/structure/table,/obj/item/storage/toolbox/mechanical,/turf/open/floor/plating,/area/template_noop)
-"f" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating,/area/template_noop)
-"g" = (/obj/effect/decal/cleanable/oil,/turf/open/floor/plating,/area/template_noop)
-"h" = (/obj/effect/spawner/lootdrop/maintenance,/turf/open/floor/plating,/area/template_noop)
-"i" = (/obj/structure/shuttle/engine/propulsion{dir = 1},/turf/closed/wall/mineral/titanium,/area/template_noop)
-"j" = (/obj/machinery/door/airlock/titanium{name = "Escape Pod Airlock"},/turf/open/floor/mineral/titanium/blue,/area/template_noop)
-"k" = (/obj/effect/decal/cleanable/oil/streak,/obj/effect/landmark/blobstart,/turf/open/floor/plating,/area/template_noop)
-"l" = (/obj/item/clothing/glasses/welding,/turf/open/floor/plating,/area/template_noop)
-"m" = (/obj/effect/decal/cleanable/robot_debris/old,/turf/open/floor/plating,/area/template_noop)
-"n" = (/turf/closed/wall/mineral/titanium,/area/template_noop)
-"o" = (/obj/structure/chair/comfy/shuttle,/obj/machinery/light/small{dir = 4},/turf/open/floor/mineral/titanium/blue,/area/template_noop)
-"p" = (/obj/item/storage/secure/safe,/turf/closed/wall/mineral/titanium,/area/template_noop)
-"r" = (/obj/structure/chair/comfy/shuttle,/turf/open/floor/mineral/titanium/blue,/area/template_noop)
-"t" = (/obj/effect/spawner/structure/window/shuttle,/turf/open/floor/plating,/area/template_noop)
-"u" = (/obj/item/clothing/gloves/color/fyellow,/turf/open/floor/plating,/area/template_noop)
-"v" = (/obj/effect/decal/cleanable/shreds,/turf/open/floor/plating,/area/template_noop)
-"w" = (/obj/item/weldingtool,/turf/open/floor/plating,/area/template_noop)
-"x" = (/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance,/turf/open/floor/plating,/area/template_noop)
-"y" = (/obj/structure/table,/turf/open/floor/plating,/area/template_noop)
-"z" = (/obj/structure/table,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/turf/open/floor/plating,/area/template_noop)
-"A" = (/obj/structure/table,/obj/item/stack/rods/ten,/obj/effect/spawner/lootdrop/maintenance{step_x = 31},/turf/open/floor/plating,/area/template_noop)
-"B" = (/obj/effect/decal/remains/robot,/turf/open/floor/plating,/area/template_noop)
-"C" = (/obj/effect/landmark/event_spawn,/turf/open/floor/plating,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
+"c" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/plating,
+/area/template_noop)
+"d" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	step_x = 16;
+	step_y = 9
+	},
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/plating,
+/area/template_noop)
+"e" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating,
+/area/template_noop)
+"f" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/template_noop)
+"g" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/template_noop)
+"h" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/template_noop)
+"i" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"j" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/template_noop)
+"k" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/template_noop)
+"l" = (
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plating,
+/area/template_noop)
+"m" = (
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/plating,
+/area/template_noop)
+"n" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"o" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/template_noop)
+"p" = (
+/obj/item/storage/secure/safe,
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"r" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/template_noop)
+"t" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/template_noop)
+"u" = (
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plating,
+/area/template_noop)
+"v" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating,
+/area/template_noop)
+"w" = (
+/obj/item/weldingtool,
+/turf/open/floor/plating,
+/area/template_noop)
+"x" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/template_noop)
+"y" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/template_noop)
+"z" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/titanium,
+/obj/item/stack/sheet/mineral/titanium,
+/obj/item/stack/sheet/mineral/titanium,
+/obj/item/stack/sheet/mineral/titanium,
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/plating,
+/area/template_noop)
+"A" = (
+/obj/structure/table,
+/obj/item/stack/rods/ten,
+/obj/effect/spawner/lootdrop/maintenance{
+	step_x = 31
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"B" = (
+/obj/effect/decal/remains/robot,
+/turf/open/floor/plating,
+/area/template_noop)
+"C" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/template_noop)
 
 (1,1,1) = {"
-aabbbacdef
-ghabbbaabb
-aijiagklmb
-bnopfbbaha
-bnrnbbijia
-bntnubnopb
-avaagwnrnb
-axyzCantna
-aAyxBbbgha
-aaabbbhaab
+a
+g
+a
+b
+b
+b
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+h
+i
+n
+n
+n
+v
+x
+A
+a
+"}
+(3,1,1) = {"
+b
+a
+j
+o
+r
+t
+a
+y
+y
+a
+"}
+(4,1,1) = {"
+b
+b
+i
+p
+n
+n
+a
+z
+x
+b
+"}
+(5,1,1) = {"
+b
+b
+a
+f
+b
+u
+g
+C
+B
+b
+"}
+(6,1,1) = {"
+a
+b
+g
+b
+b
+b
+w
+a
+b
+b
+"}
+(7,1,1) = {"
+c
+a
+k
+b
+i
+n
+n
+n
+b
+h
+"}
+(8,1,1) = {"
+d
+a
+l
+a
+j
+o
+r
+t
+g
+a
+"}
+(9,1,1) = {"
+e
+b
+m
+h
+i
+p
+n
+n
+h
+a
+"}
+(10,1,1) = {"
+f
+b
+b
+a
+a
+b
+b
+a
+a
+b
 "}

--- a/_maps/RandomRooms/10x10/sk_rdm102_podrepairbay.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm102_podrepairbay.dmm
@@ -13,10 +13,7 @@
 /area/template_noop)
 "d" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	step_x = 16;
-	step_y = 9
-	},
+/obj/item/storage/toolbox/electrical,
 /obj/item/stack/sheet/iron/five,
 /turf/open/floor/plating,
 /area/template_noop)
@@ -117,9 +114,7 @@
 "A" = (
 /obj/structure/table,
 /obj/item/stack/rods/ten,
-/obj/effect/spawner/lootdrop/maintenance{
-	step_x = 31
-	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/template_noop)
 "B" = (

--- a/_maps/RandomRooms/10x10/sk_rdm102_podrepairbay.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm102_podrepairbay.dmm
@@ -1,0 +1,40 @@
+"a" = (/turf/open/floor/plating,/area/template_noop)
+"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating,/area/template_noop)
+"c" = (/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance/three,/turf/open/floor/plating,/area/template_noop)
+"d" = (/obj/structure/table,/obj/item/storage/toolbox/electrical{step_x = 16; step_y = 9},/obj/item/stack/sheet/iron/five,/turf/open/floor/plating,/area/template_noop)
+"e" = (/obj/structure/table,/obj/item/storage/toolbox/mechanical,/turf/open/floor/plating,/area/template_noop)
+"f" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating,/area/template_noop)
+"g" = (/obj/effect/decal/cleanable/oil,/turf/open/floor/plating,/area/template_noop)
+"h" = (/obj/effect/spawner/lootdrop/maintenance,/turf/open/floor/plating,/area/template_noop)
+"i" = (/obj/structure/shuttle/engine/propulsion{dir = 1},/turf/closed/wall/mineral/titanium,/area/template_noop)
+"j" = (/obj/machinery/door/airlock/titanium{name = "Escape Pod Airlock"},/turf/open/floor/mineral/titanium/blue,/area/template_noop)
+"k" = (/obj/effect/decal/cleanable/oil/streak,/obj/effect/landmark/blobstart,/turf/open/floor/plating,/area/template_noop)
+"l" = (/obj/item/clothing/glasses/welding,/turf/open/floor/plating,/area/template_noop)
+"m" = (/obj/effect/decal/cleanable/robot_debris/old,/turf/open/floor/plating,/area/template_noop)
+"n" = (/turf/closed/wall/mineral/titanium,/area/template_noop)
+"o" = (/obj/structure/chair/comfy/shuttle,/obj/machinery/light/small{dir = 4},/turf/open/floor/mineral/titanium/blue,/area/template_noop)
+"p" = (/obj/item/storage/secure/safe,/turf/closed/wall/mineral/titanium,/area/template_noop)
+"r" = (/obj/structure/chair/comfy/shuttle,/turf/open/floor/mineral/titanium/blue,/area/template_noop)
+"t" = (/obj/effect/spawner/structure/window/shuttle,/turf/open/floor/plating,/area/template_noop)
+"u" = (/obj/item/clothing/gloves/color/fyellow,/turf/open/floor/plating,/area/template_noop)
+"v" = (/obj/effect/decal/cleanable/shreds,/turf/open/floor/plating,/area/template_noop)
+"w" = (/obj/item/weldingtool,/turf/open/floor/plating,/area/template_noop)
+"x" = (/obj/structure/table,/obj/effect/spawner/lootdrop/maintenance,/turf/open/floor/plating,/area/template_noop)
+"y" = (/obj/structure/table,/turf/open/floor/plating,/area/template_noop)
+"z" = (/obj/structure/table,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/obj/item/stack/sheet/mineral/titanium,/turf/open/floor/plating,/area/template_noop)
+"A" = (/obj/structure/table,/obj/item/stack/rods/ten,/obj/effect/spawner/lootdrop/maintenance{step_x = 31},/turf/open/floor/plating,/area/template_noop)
+"B" = (/obj/effect/decal/remains/robot,/turf/open/floor/plating,/area/template_noop)
+"C" = (/obj/effect/landmark/event_spawn,/turf/open/floor/plating,/area/template_noop)
+
+(1,1,1) = {"
+aabbbacdef
+ghabbbaabb
+aijiagklmb
+bnopfbbaha
+bnrnbbijia
+bntnubnopb
+avaagwnrnb
+axyzCantna
+aAyxBbbgha
+aaabbbhaab
+"}

--- a/_maps/RandomRooms/10x5/sk_rdm046_deltaarcade.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm046_deltaarcade.dmm
@@ -193,6 +193,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/paper/crumpled/beernuke,
 /turf/open/floor/plasteel,
 /area/template_noop)
 "r" = (

--- a/_maps/RandomRooms/10x5/sk_rdm100_meetingroom.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm100_meetingroom.dmm
@@ -1,42 +1,317 @@
-"a" = (/obj/effect/decal/cleanable/cobweb,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
-"b" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
-"c" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
-"d" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
-"e" = (/turf/open/floor/plasteel/dark,/area/template_noop)
-"f" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
-"g" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
-"h" = (/obj/structure/table,/obj/item/paper_bin{step_y = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
-"i" = (/obj/structure/chair/office/light,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"j" = (/turf/open/floor/plating{icon_state = "platingdmg3"},/area/template_noop)
-"k" = (/obj/structure/chair/office/light,/turf/open/floor/plating,/area/template_noop)
-"l" = (/obj/structure/table,/obj/item/pen,/turf/open/floor/plating{icon_state = "platingdmg1"},/area/template_noop)
-"m" = (/obj/structure/chair/office/light{dir = 4},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"n" = (/obj/structure/table,/obj/item/folder/blue,/obj/item/pen,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"o" = (/turf/open/floor/plating,/area/template_noop)
-"p" = (/obj/structure/table,/turf/open/floor/plasteel/dark,/area/template_noop)
-"q" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating{icon_state = "panelscorched"},/area/template_noop)
-"r" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
-"s" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"t" = (/obj/structure/chair/office/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
-"u" = (/obj/structure/chair/office/light{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"v" = (/obj/structure/table,/obj/item/reagent_containers/food/drinks/mug,/turf/open/floor/plasteel/dark,/area/template_noop)
-"w" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
-"x" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
-"y" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/machinery/light/broken{icon_state = "tube-broken"; dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
-"z" = (/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
-"A" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
-"B" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue,/obj/effect/turf_decal/tile/blue{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
-"C" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/obj/machinery/light/broken,/turf/open/floor/plasteel/dark,/area/template_noop)
-"D" = (/obj/structure/table,/turf/open/floor/plating,/area/template_noop)
-"E" = (/obj/structure/chair/office/light{dir = 8},/turf/open/floor/plating{icon_state = "platingdmg3"},/area/template_noop)
-"F" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
-"G" = (/obj/structure/chair/office/light{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating{icon_state = "panelscorched"},/area/template_noop)
-"H" = (/obj/machinery/light/built,/turf/open/floor/plating,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"b" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"c" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"d" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"e" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"f" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"h" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	step_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"i" = (
+/obj/structure/chair/office/light,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"j" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"k" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/plating,
+/area/template_noop)
+"l" = (
+/obj/structure/table,
+/obj/item/pen,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"m" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"n" = (
+/obj/structure/table,
+/obj/item/folder/blue,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"p" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"q" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/template_noop)
+"r" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"s" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"t" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"u" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"v" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"w" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"x" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"y" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	icon_state = "tube-broken";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"z" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"A" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"B" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"C" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"D" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/template_noop)
+"E" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"F" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"G" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/template_noop)
+"H" = (
+/obj/machinery/light/built,
+/turf/open/floor/plating,
+/area/template_noop)
 
 (1,1,1) = {"
-abydeejcbf
-gehiikkloo
-emnqAlDDEs
-jFptGutver
-wFHzesxCxB
+a
+g
+e
+j
+w
+"}
+(2,1,1) = {"
+b
+e
+m
+F
+F
+"}
+(3,1,1) = {"
+y
+h
+n
+p
+H
+"}
+(4,1,1) = {"
+d
+i
+q
+t
+z
+"}
+(5,1,1) = {"
+e
+i
+A
+G
+e
+"}
+(6,1,1) = {"
+e
+k
+l
+u
+s
+"}
+(7,1,1) = {"
+j
+k
+D
+t
+x
+"}
+(8,1,1) = {"
+c
+l
+D
+v
+C
+"}
+(9,1,1) = {"
+b
+o
+E
+e
+x
+"}
+(10,1,1) = {"
+f
+o
+s
+r
+B
 "}

--- a/_maps/RandomRooms/10x5/sk_rdm100_meetingroom.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm100_meetingroom.dmm
@@ -67,9 +67,7 @@
 /area/template_noop)
 "h" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_y = 4
-	},
+/obj/item/paper_bin,
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
 "i" = (

--- a/_maps/RandomRooms/10x5/sk_rdm100_meetingroom.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm100_meetingroom.dmm
@@ -1,0 +1,42 @@
+"a" = (/obj/effect/decal/cleanable/cobweb,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
+"b" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
+"c" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/machinery/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
+"d" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
+"e" = (/turf/open/floor/plasteel/dark,/area/template_noop)
+"f" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
+"g" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
+"h" = (/obj/structure/table,/obj/item/paper_bin{step_y = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
+"i" = (/obj/structure/chair/office/light,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"j" = (/turf/open/floor/plating{icon_state = "platingdmg3"},/area/template_noop)
+"k" = (/obj/structure/chair/office/light,/turf/open/floor/plating,/area/template_noop)
+"l" = (/obj/structure/table,/obj/item/pen,/turf/open/floor/plating{icon_state = "platingdmg1"},/area/template_noop)
+"m" = (/obj/structure/chair/office/light{dir = 4},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"n" = (/obj/structure/table,/obj/item/folder/blue,/obj/item/pen,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"o" = (/turf/open/floor/plating,/area/template_noop)
+"p" = (/obj/structure/table,/turf/open/floor/plasteel/dark,/area/template_noop)
+"q" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating{icon_state = "panelscorched"},/area/template_noop)
+"r" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
+"s" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"t" = (/obj/structure/chair/office/light{dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
+"u" = (/obj/structure/chair/office/light{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"v" = (/obj/structure/table,/obj/item/reagent_containers/food/drinks/mug,/turf/open/floor/plasteel/dark,/area/template_noop)
+"w" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
+"x" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
+"y" = (/obj/effect/turf_decal/tile/blue{dir = 1},/obj/effect/turf_decal/tile/blue{dir = 4},/obj/machinery/light/broken{icon_state = "tube-broken"; dir = 1},/turf/open/floor/plasteel/dark,/area/template_noop)
+"z" = (/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/turf/open/floor/plasteel/dark,/area/template_noop)
+"A" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
+"B" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 4},/obj/effect/turf_decal/tile/blue,/obj/effect/turf_decal/tile/blue{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
+"C" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/blue{dir = 8},/obj/effect/turf_decal/tile/blue,/obj/machinery/light/broken,/turf/open/floor/plasteel/dark,/area/template_noop)
+"D" = (/obj/structure/table,/turf/open/floor/plating,/area/template_noop)
+"E" = (/obj/structure/chair/office/light{dir = 8},/turf/open/floor/plating{icon_state = "platingdmg3"},/area/template_noop)
+"F" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/template_noop)
+"G" = (/obj/structure/chair/office/light{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating{icon_state = "panelscorched"},/area/template_noop)
+"H" = (/obj/machinery/light/built,/turf/open/floor/plating,/area/template_noop)
+
+(1,1,1) = {"
+abydeejcbf
+gehiikkloo
+emnqAlDDEs
+jFptGutver
+wFHzesxCxB
+"}

--- a/_maps/RandomRooms/10x5/sk_rdm105_phage.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm105_phage.dmm
@@ -1,0 +1,211 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"h" = (
+/obj/item/caution{
+	desc = "CAUTION! BIOHAZARD QUARANTINE!";
+	name = "biohazard warning sign"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"i" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"o" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"r" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall,
+/area/template_noop)
+"t" = (
+/turf/closed/wall,
+/area/template_noop)
+"u" = (
+/mob/living/simple_animal/hostile/macrophage/aggro/vector,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plating,
+/area/template_noop)
+"x" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mob_spawn/human/clown/corpse,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/item/caution{
+	desc = "CAUTION! BIOHAZARD QUARANTINE!";
+	name = "biohazard warning sign"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"A" = (
+/obj/item/caution{
+	desc = "CAUTION! BIOHAZARD QUARANTINE!";
+	name = "biohazard warning sign"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"C" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/item/ammo_casing/spent,
+/turf/open/floor/plating,
+/area/template_noop)
+"D" = (
+/obj/effect/mob_spawn/human/corpse/assistant,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"H" = (
+/obj/item/ammo_casing/spent,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"I" = (
+/obj/machinery/power/floodlight,
+/turf/open/floor/plating,
+/area/template_noop)
+"K" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/template_noop)
+"L" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"N" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"O" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Q" = (
+/obj/item/ammo_casing/spent,
+/obj/item/ammo_casing/spent{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"S" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/open/floor/plating,
+/area/template_noop)
+"U" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"W" = (
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"Y" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+Y
+r
+U
+h
+a
+"}
+(2,1,1) = {"
+U
+t
+r
+t
+i
+"}
+(3,1,1) = {"
+a
+t
+u
+t
+a
+"}
+(4,1,1) = {"
+y
+t
+x
+r
+y
+"}
+(5,1,1) = {"
+i
+t
+A
+o
+N
+"}
+(6,1,1) = {"
+U
+t
+b
+t
+U
+"}
+(7,1,1) = {"
+S
+r
+j
+t
+t
+"}
+(8,1,1) = {"
+D
+L
+C
+H
+U
+"}
+(9,1,1) = {"
+i
+W
+K
+I
+U
+"}
+(10,1,1) = {"
+N
+O
+Q
+y
+N
+"}

--- a/_maps/RandomRooms/3x3/sk_rdm093_bubblegumaltar.dmm
+++ b/_maps/RandomRooms/3x3/sk_rdm093_bubblegumaltar.dmm
@@ -1,8 +1,24 @@
-"a" = (/turf/open/floor/fakepit,/area/template_noop)
-"b" = (/obj/item/toy/plush/bubbleplush,/turf/open/floor/grass/fakebasalt,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/fakepit,
+/area/template_noop)
+"b" = (
+/obj/item/toy/plush/bubbleplush,
+/turf/open/floor/grass/fakebasalt,
+/area/template_noop)
 
 (1,1,1) = {"
-aaa
-aba
-aaa
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+b
+a
+"}
+(3,1,1) = {"
+a
+a
+a
 "}

--- a/_maps/RandomRooms/3x3/sk_rdm093_bubblegumaltar.dmm
+++ b/_maps/RandomRooms/3x3/sk_rdm093_bubblegumaltar.dmm
@@ -1,0 +1,8 @@
+"a" = (/turf/open/floor/fakepit,/area/template_noop)
+"b" = (/obj/item/toy/plush/bubbleplush,/turf/open/floor/grass/fakebasalt,/area/template_noop)
+
+(1,1,1) = {"
+aaa
+aba
+aaa
+"}

--- a/_maps/RandomRooms/3x5/sk_rdm085_hank.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm085_hank.dmm
@@ -23,8 +23,7 @@
 /turf/open/floor/plasteel/stairs/old,
 /area/template_noop)
 "f" = (
-/obj/structure/falsewall/bananium,
-/turf/open/space/basic,
+/turf/closed/wall/mineral/bananium,
 /area/template_noop)
 "g" = (
 /turf/open/floor/carpet/orange,

--- a/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
@@ -1,19 +1,82 @@
-"a" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/obj/machinery/portable_atmospherics/canister,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/machinery/portable_atmospherics/canister/air,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/machinery/portable_atmospherics/canister,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/effect/turf_decal/caution,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"h" = (/obj/structure/closet/emcloset,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"i" = (/obj/structure/table,/obj/item/clothing/mask/gas,/obj/machinery/light/small{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
-"j" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plasteel,/area/template_noop)
-"k" = (/obj/structure/table,/obj/item/storage/toolbox/mechanical,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/caution,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abc
-def
-bgb
-hei
-jek
+a
+d
+b
+h
+j
+"}
+(2,1,1) = {"
+b
+e
+g
+e
+e
+"}
+(3,1,1) = {"
+c
+f
+b
+i
+k
 "}

--- a/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
@@ -1,86 +1,19 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"b" = (
-/turf/open/floor/plasteel,
-/area/template_noop)
-"c" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"d" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/window/reinforced/spawner,
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"e" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"f" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/window/reinforced/spawner,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"g" = (
-/obj/effect/turf_decal/caution,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"h" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"i" = (
-/obj/structure/table,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"j" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"k" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	step_x = 0;
-	step_y = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
+"a" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/obj/machinery/portable_atmospherics/canister,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/machinery/portable_atmospherics/canister/air,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/machinery/portable_atmospherics/canister,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/effect/turf_decal/caution,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"h" = (/obj/structure/closet/emcloset,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"i" = (/obj/structure/table,/obj/item/clothing/mask/gas,/obj/machinery/light/small{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
+"j" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plasteel,/area/template_noop)
+"k" = (/obj/structure/table,/obj/item/storage/toolbox/mechanical,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
 
 (1,1,1) = {"
-a
-d
-b
-h
-j
-"}
-(2,1,1) = {"
-b
-e
-g
-e
-e
-"}
-(3,1,1) = {"
-c
-f
-b
-i
-k
+abc
+def
+bgb
+hei
+jek
 "}

--- a/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
@@ -1,0 +1,19 @@
+"a" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/obj/machinery/portable_atmospherics/canister,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/machinery/portable_atmospherics/canister/air,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/machinery/portable_atmospherics/canister,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/effect/turf_decal/caution,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
+"h" = (/obj/structure/closet/emcloset,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"i" = (/obj/structure/table,/obj/item/clothing/mask/gas,/obj/machinery/light/small{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
+"j" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plasteel,/area/template_noop)
+"k" = (/obj/structure/table,/obj/item/storage/toolbox/mechanical{step_x = 0; step_y = 2},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+
+(1,1,1) = {"
+abc
+def
+bgb
+hei
+jek
+"}

--- a/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm
@@ -1,19 +1,86 @@
-"a" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/obj/machinery/portable_atmospherics/canister,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/machinery/portable_atmospherics/canister/air,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/machinery/portable_atmospherics/canister,/obj/structure/window/reinforced/spawner,/obj/effect/turf_decal/box,/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/effect/turf_decal/caution,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
-"h" = (/obj/structure/closet/emcloset,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"i" = (/obj/structure/table,/obj/item/clothing/mask/gas,/obj/machinery/light/small{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
-"j" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plasteel,/area/template_noop)
-"k" = (/obj/structure/table,/obj/item/storage/toolbox/mechanical{step_x = 0; step_y = 2},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/window/reinforced/spawner,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/caution,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	step_x = 0;
+	step_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abc
-def
-bgb
-hei
-jek
+a
+d
+b
+h
+j
+"}
+(2,1,1) = {"
+b
+e
+g
+e
+e
+"}
+(3,1,1) = {"
+c
+f
+b
+i
+k
 "}

--- a/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
@@ -1,22 +1,112 @@
-"a" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/cable_coil/random/five,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/obj/structure/extinguisher_cabinet{dir = 4; pixel_x = 24},/obj/effect/decal/cleanable/dirt,/obj/item/clothing/glasses/welding,/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/effect/turf_decal/bot,/obj/structure/mecha_wreckage/durand,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"h" = (/obj/structure/table,/obj/item/stock_parts/capacitor{step_x = 6; step_y = 5},/obj/item/stock_parts/scanning_module{step_x = -6; step_y = 0},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"i" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"j" = (/obj/structure/reagent_dispensers/fueltank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"k" = (/obj/structure/table,/obj/item/weldingtool,/obj/item/crowbar,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"l" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/four,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"m" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"n" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/random/five,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/mecha_wreckage/durand,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/structure/table,
+/obj/item/stock_parts/capacitor{
+	step_x = 6;
+	step_y = 5
+	},
+/obj/item/stock_parts/scanning_module{
+	step_x = -6;
+	step_y = 0
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"i" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"j" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"k" = (
+/obj/structure/table,
+/obj/item/weldingtool,
+/obj/item/crowbar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"l" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"m" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"n" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abc
-mde
-fng
-hij
-kil
+a
+m
+f
+h
+k
+"}
+(2,1,1) = {"
+b
+d
+n
+i
+i
+"}
+(3,1,1) = {"
+c
+e
+g
+j
+l
 "}

--- a/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
@@ -1,21 +1,105 @@
-"a" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/cable_coil/random/five,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/obj/structure/extinguisher_cabinet{dir = 4; pixel_x = 24},/obj/effect/decal/cleanable/dirt,/obj/item/clothing/glasses/welding,/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/effect/turf_decal/bot,/obj/structure/mecha_wreckage/durand,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"h" = (/obj/structure/table,/obj/item/stock_parts/capacitor{pixel_y = -4},/obj/item/stock_parts/scanning_module{pixel_x = 3; pixel_y = 5},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"i" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"j" = (/obj/structure/reagent_dispensers/fueltank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"k" = (/obj/structure/table,/obj/item/weldingtool,/obj/item/crowbar,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"l" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/four,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
-"m" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/random/five,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/mecha_wreckage/durand,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/structure/table,
+/obj/item/stock_parts/capacitor{
+	pixel_y = -4
+	},
+/obj/item/stock_parts/scanning_module{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"i" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"j" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"k" = (
+/obj/structure/table,
+/obj/item/weldingtool,
+/obj/item/crowbar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"l" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/template_noop)
+"m" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abc
-mde
-fgg
-hij
-kil
+a
+m
+f
+h
+k
+"}
+(2,1,1) = {"
+b
+d
+g
+i
+i
+"}
+(3,1,1) = {"
+c
+e
+g
+j
+l
 "}

--- a/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
@@ -1,112 +1,21 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil/random/five,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"b" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"c" = (
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"d" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/mecha_wreckage/durand,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"e" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"f" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"g" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"h" = (
-/obj/structure/table,
-/obj/item/stock_parts/capacitor{
-	step_x = 6;
-	step_y = 5
-	},
-/obj/item/stock_parts/scanning_module{
-	step_x = -6;
-	step_y = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/template_noop)
-"i" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/template_noop)
-"j" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/template_noop)
-"k" = (
-/obj/structure/table,
-/obj/item/weldingtool,
-/obj/item/crowbar,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/template_noop)
-"l" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/template_noop)
-"m" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/template_noop)
-"n" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
-/area/template_noop)
+"a" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/cable_coil/random/five,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/obj/structure/extinguisher_cabinet{dir = 4; pixel_x = 24},/obj/effect/decal/cleanable/dirt,/obj/item/clothing/glasses/welding,/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/effect/turf_decal/bot,/obj/structure/mecha_wreckage/durand,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"h" = (/obj/structure/table,/obj/item/stock_parts/capacitor{pixel_y = -4},/obj/item/stock_parts/scanning_module{pixel_x = 3; pixel_y = 5},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"i" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"j" = (/obj/structure/reagent_dispensers/fueltank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"k" = (/obj/structure/table,/obj/item/weldingtool,/obj/item/crowbar,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"l" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/four,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"m" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/plasteel,/area/template_noop)
 
 (1,1,1) = {"
-a
-m
-f
-h
-k
-"}
-(2,1,1) = {"
-b
-d
-n
-i
-i
-"}
-(3,1,1) = {"
-c
-e
-g
-j
-l
+abc
+mde
+fgg
+hij
+kil
 "}

--- a/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm
@@ -1,0 +1,22 @@
+"a" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/cable_coil/random/five,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/obj/structure/extinguisher_cabinet{dir = 4; pixel_x = 24},/obj/effect/decal/cleanable/dirt,/obj/item/clothing/glasses/welding,/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/effect/turf_decal/bot,/obj/structure/mecha_wreckage/durand,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/oil,/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"h" = (/obj/structure/table,/obj/item/stock_parts/capacitor{step_x = 6; step_y = 5},/obj/item/stock_parts/scanning_module{step_x = -6; step_y = 0},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"i" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"j" = (/obj/structure/reagent_dispensers/fueltank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"k" = (/obj/structure/table,/obj/item/weldingtool,/obj/item/crowbar,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"l" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/four,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/template_noop)
+"m" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"n" = (/obj/effect/turf_decal/stripes/line,/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
+
+(1,1,1) = {"
+abc
+mde
+fng
+hij
+kil
+"}

--- a/_maps/RandomRooms/5x3/sk_rdm099_incompletefloor.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm099_incompletefloor.dmm
@@ -1,0 +1,21 @@
+"a" = (/obj/effect/turf_decal/stripes/corner,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/obj/item/clothing/head/cone,/turf/open/floor/plating,/area/template_noop)
+"c" = (/obj/item/stack/tile/plasteel,/obj/item/stack/tile/plasteel,/obj/item/stack/tile/plasteel,/obj/item/stack/tile/plasteel,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/effect/turf_decal/stripes/line,/obj/item/stack/cable_coil/random/five{step_x = -3; step_y = -8},/obj/structure/sign/warning{step_y = 31},/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/turf/open/floor/plating{icon_state = "platingdmg1"},/area/template_noop)
+"h" = (/obj/effect/decal/cleanable/oil/slippery,/turf/open/floor/plating,/area/template_noop)
+"i" = (/turf/open/floor/circuit,/area/template_noop)
+"j" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"k" = (/obj/effect/turf_decal/stripes/corner{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
+"l" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/item/stack/tile/circuit{step_x = 6; step_y = 6},/obj/item/stack/tile/circuit{step_x = 6; step_y = 6},/turf/open/floor/plasteel,/area/template_noop)
+"m" = (/obj/item/clothing/head/cone{step_x = -3; step_y = 6},/turf/open/floor/plating,/area/template_noop)
+"n" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/light/broken,/turf/open/floor/plasteel,/area/template_noop)
+"o" = (/obj/effect/turf_decal/stripes/corner{dir = 1},/obj/item/crowbar/large,/turf/open/floor/plasteel,/area/template_noop)
+
+(1,1,1) = {"
+abcde
+fghij
+klmno
+"}

--- a/_maps/RandomRooms/5x3/sk_rdm099_incompletefloor.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm099_incompletefloor.dmm
@@ -1,21 +1,125 @@
-"a" = (/obj/effect/turf_decal/stripes/corner,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/obj/item/clothing/head/cone,/turf/open/floor/plating,/area/template_noop)
-"c" = (/obj/item/stack/tile/plasteel,/obj/item/stack/tile/plasteel,/obj/item/stack/tile/plasteel,/obj/item/stack/tile/plasteel,/obj/effect/turf_decal/stripes/line,/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/effect/turf_decal/stripes/line,/obj/item/stack/cable_coil/random/five{step_x = -3; step_y = -8},/obj/structure/sign/warning{step_y = 31},/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/turf/open/floor/plating{icon_state = "platingdmg1"},/area/template_noop)
-"h" = (/obj/effect/decal/cleanable/oil/slippery,/turf/open/floor/plating,/area/template_noop)
-"i" = (/turf/open/floor/circuit,/area/template_noop)
-"j" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"k" = (/obj/effect/turf_decal/stripes/corner{dir = 4},/turf/open/floor/plasteel,/area/template_noop)
-"l" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/item/stack/tile/circuit{step_x = 6; step_y = 6},/obj/item/stack/tile/circuit{step_x = 6; step_y = 6},/turf/open/floor/plasteel,/area/template_noop)
-"m" = (/obj/item/clothing/head/cone{step_x = -3; step_y = 6},/turf/open/floor/plating,/area/template_noop)
-"n" = (/obj/effect/turf_decal/stripes/line{dir = 1},/obj/machinery/light/broken,/turf/open/floor/plasteel,/area/template_noop)
-"o" = (/obj/effect/turf_decal/stripes/corner{dir = 1},/obj/item/crowbar/large,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/template_noop)
+"c" = (
+/obj/item/stack/tile/plasteel,
+/obj/item/stack/tile/plasteel,
+/obj/item/stack/tile/plasteel,
+/obj/item/stack/tile/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/item/stack/cable_coil/random/five{
+	step_x = -3;
+	step_y = -8
+	},
+/obj/structure/sign/warning{
+	step_y = 31
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"h" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating,
+/area/template_noop)
+"i" = (
+/turf/open/floor/circuit,
+/area/template_noop)
+"j" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"l" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/stack/tile/circuit{
+	step_x = 6;
+	step_y = 6
+	},
+/obj/item/stack/tile/circuit{
+	step_x = 6;
+	step_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/item/clothing/head/cone{
+	step_x = -3;
+	step_y = 6
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"n" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/broken,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/crowbar/large,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abcde
-fghij
-klmno
+a
+f
+k
+"}
+(2,1,1) = {"
+b
+g
+l
+"}
+(3,1,1) = {"
+c
+h
+m
+"}
+(4,1,1) = {"
+d
+i
+n
+"}
+(5,1,1) = {"
+e
+j
+o
 "}

--- a/_maps/RandomRooms/5x3/sk_rdm099_incompletefloor.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm099_incompletefloor.dmm
@@ -17,13 +17,8 @@
 /area/template_noop)
 "d" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/item/stack/cable_coil/random/five{
-	step_x = -3;
-	step_y = -8
-	},
-/obj/structure/sign/warning{
-	step_y = 31
-	},
+/obj/item/stack/cable_coil/random/five,
+/obj/structure/sign/warning,
 /turf/open/floor/plasteel,
 /area/template_noop)
 "e" = (
@@ -66,21 +61,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/item/stack/tile/circuit{
-	step_x = 6;
-	step_y = 6
-	},
-/obj/item/stack/tile/circuit{
-	step_x = 6;
-	step_y = 6
-	},
+/obj/item/stack/tile/circuit,
+/obj/item/stack/tile/circuit,
 /turf/open/floor/plasteel,
 /area/template_noop)
 "m" = (
-/obj/item/clothing/head/cone{
-	step_x = -3;
-	step_y = 6
-	},
+/obj/item/clothing/head/cone,
 /turf/open/floor/plating,
 /area/template_noop)
 "n" = (

--- a/_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm
@@ -33,19 +33,13 @@
 /turf/open/floor/plasteel,
 /area/template_noop)
 "h" = (
-/obj/item/trash/cheesie{
-	step_x = -9;
-	step_y = -7
-	},
+/obj/item/trash/cheesie,
 /turf/open/floor/plasteel,
 /area/template_noop)
 "i" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/mug{
-	step_x = 8;
-	step_y = 3
-	},
+/obj/item/reagent_containers/food/drinks/mug,
 /turf/open/floor/plasteel,
 /area/template_noop)
 "j" = (

--- a/_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm
@@ -1,18 +1,93 @@
-"a" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/vending/cola/random,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/vending/snack/random,/obj/machinery/light/small{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/vending/cigarette,/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/item/trash/can,/turf/open/floor/plasteel,/area/template_noop)
-"h" = (/obj/item/trash/cheesie{step_x = -9; step_y = -7},/turf/open/floor/plasteel,/area/template_noop)
-"i" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table,/obj/item/reagent_containers/food/drinks/mug{step_x = 8; step_y = 3},/turf/open/floor/plasteel,/area/template_noop)
-"j" = (/obj/structure/chair{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
-"k" = (/obj/effect/decal/cleanable/dirt,/obj/structure/mopbucket,/obj/item/mop,/turf/open/floor/plasteel,/area/template_noop)
-"l" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/crate/bin,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/snack/random,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/item/trash/can,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/item/trash/cheesie{
+	step_x = -9;
+	step_y = -7
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"i" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug{
+	step_x = 8;
+	step_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"k" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"l" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abcde
-fgffh
-ijckl
+a
+f
+i
+"}
+(2,1,1) = {"
+b
+g
+j
+"}
+(3,1,1) = {"
+c
+f
+c
+"}
+(4,1,1) = {"
+d
+f
+k
+"}
+(5,1,1) = {"
+e
+h
+l
 "}

--- a/_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm
@@ -1,0 +1,18 @@
+"a" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/vending/cola/random,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/vending/snack/random,/obj/machinery/light/small{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/vending/cigarette,/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/item/trash/can,/turf/open/floor/plasteel,/area/template_noop)
+"h" = (/obj/item/trash/cheesie{step_x = -9; step_y = -7},/turf/open/floor/plasteel,/area/template_noop)
+"i" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table,/obj/item/reagent_containers/food/drinks/mug{step_x = 8; step_y = 3},/turf/open/floor/plasteel,/area/template_noop)
+"j" = (/obj/structure/chair{dir = 8},/turf/open/floor/plasteel,/area/template_noop)
+"k" = (/obj/effect/decal/cleanable/dirt,/obj/structure/mopbucket,/obj/item/mop,/turf/open/floor/plasteel,/area/template_noop)
+"l" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/crate/bin,/turf/open/floor/plasteel,/area/template_noop)
+
+(1,1,1) = {"
+abcde
+fgffh
+ijckl
+"}

--- a/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
@@ -1,67 +1,13 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"b" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"c" = (
-/turf/open/floor/plasteel,
-/area/template_noop)
-"d" = (
-/obj/structure/table,
-/obj/item/stack/sheet/cardboard/fifty,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"e" = (
-/obj/structure/table,
-/obj/item/lightreplacer{
-	step_y = 6
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"f" = (
-/obj/structure/rack,
-/obj/item/extinguisher,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"g" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/template_noop)
-"h" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
-/area/template_noop)
+"a" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/eight,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/structure/table,/obj/item/stack/sheet/cardboard/fifty,/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/structure/table,/obj/item/lightreplacer,/obj/machinery/light/small,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/structure/rack,/obj/item/extinguisher,/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/structure/reagent_dispensers/watertank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
 
 (1,1,1) = {"
-a
-c
-d
-"}
-(2,1,1) = {"
-a
-c
-e
-"}
-(3,1,1) = {"
-b
-h
-c
-"}
-(4,1,1) = {"
-a
-b
-f
-"}
-(5,1,1) = {"
-a
-b
-g
+aabaa
+ccbbb
+decfg
 "}

--- a/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
@@ -1,13 +1,60 @@
-"a" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/eight,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/structure/table,/obj/item/stack/sheet/cardboard/fifty,/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/structure/table,/obj/item/lightreplacer,/obj/machinery/light/small,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/structure/rack,/obj/item/extinguisher,/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/structure/reagent_dispensers/watertank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/fifty,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/structure/table,
+/obj/item/lightreplacer,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/structure/rack,
+/obj/item/extinguisher,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-aabaa
-ccbbb
-decfg
+a
+c
+d
+"}
+(2,1,1) = {"
+a
+c
+e
+"}
+(3,1,1) = {"
+b
+b
+c
+"}
+(4,1,1) = {"
+a
+b
+f
+"}
+(5,1,1) = {"
+a
+b
+g
 "}

--- a/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
@@ -1,14 +1,67 @@
-"a" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/eight,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/structure/table,/obj/item/stack/sheet/cardboard/fifty,/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/structure/table,/obj/item/lightreplacer{step_y = 6},/obj/machinery/light/small,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/obj/structure/rack,/obj/item/extinguisher,/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/structure/reagent_dispensers/watertank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"h" = (/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard/fifty,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/structure/table,
+/obj/item/lightreplacer{
+	step_y = 6
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/obj/structure/rack,
+/obj/item/extinguisher,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"h" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-aabaa
-cchbb
-decfg
+a
+c
+d
+"}
+(2,1,1) = {"
+a
+c
+e
+"}
+(3,1,1) = {"
+b
+h
+c
+"}
+(4,1,1) = {"
+a
+b
+f
+"}
+(5,1,1) = {"
+a
+b
+g
 "}

--- a/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm
@@ -1,0 +1,14 @@
+"a" = (/obj/structure/closet,/obj/effect/spawner/lootdrop/maintenance/eight,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/structure/table,/obj/item/stack/sheet/cardboard/fifty,/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/structure/table,/obj/item/lightreplacer{step_y = 6},/obj/machinery/light/small,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/obj/structure/rack,/obj/item/extinguisher,/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/structure/reagent_dispensers/watertank,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"h" = (/obj/effect/decal/cleanable/dirt,/obj/effect/landmark/xeno_spawn,/turf/open/floor/plasteel,/area/template_noop)
+
+(1,1,1) = {"
+aabaa
+cchbb
+decfg
+"}

--- a/_maps/RandomRooms/5x3/sk_rdm104_pills.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm104_pills.dmm
@@ -1,0 +1,97 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/item/storage/pill_bottle,
+/turf/open/floor/plating,
+/area/template_noop)
+"f" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = -11;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = 13;
+	pixel_y = 13
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"r" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_y = -5
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"C" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"I" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/pill/floorpill,
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = 14;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/pill/floorpill{
+	pixel_x = -7;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"N" = (
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/mob_spawn/human/corpse/assistant,
+/obj/item/storage/pill_bottle,
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+C
+C
+a
+"}
+(2,1,1) = {"
+a
+f
+C
+"}
+(3,1,1) = {"
+C
+r
+N
+"}
+(4,1,1) = {"
+C
+I
+C
+"}
+(5,1,1) = {"
+C
+C
+C
+"}

--- a/_maps/RandomRooms/5x4/sk_rdm096_comproom.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm096_comproom.dmm
@@ -1,0 +1,24 @@
+"a" = (/obj/structure/table,/obj/item/wallframe/camera,/obj/item/stack/cable_coil/random/five{step_x = 1; step_y = 5},/turf/open/floor/plasteel/dark,/area/template_noop)
+"b" = (/obj/machinery/status_display/evac{step_y = 31},/obj/structure/table,/obj/item/paper_bin{step_y = 5},/obj/item/pen{step_y = 6},/turf/open/floor/plasteel/dark,/area/template_noop)
+"c" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"d" = (/obj/machinery/status_display/evac{step_y = 31},/obj/machinery/photocopier,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"e" = (/obj/structure/filingcabinet,/obj/effect/decal/cleanable/cobweb/cobweb2,/turf/open/floor/plasteel/dark,/area/template_noop)
+"f" = (/obj/item/paper/crumpled{step_x = 6; step_y = -6},/turf/open/floor/plasteel/dark,/area/template_noop)
+"g" = (/turf/open/floor/plasteel/dark,/area/template_noop)
+"h" = (/obj/item/wirecutters,/turf/open/floor/plasteel/dark,/area/template_noop)
+"i" = (/obj/structure/frame/computer{anchored = 1; dir = 4; icon_state = "0"},/obj/machinery/light{dir = 8},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"j" = (/obj/structure/chair/office{dir = 8},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"k" = (/obj/structure/chair/office{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
+"l" = (/obj/structure/frame/computer{anchored = 1; dir = 8; icon_state = "0"},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
+"m" = (/obj/structure/frame/computer{anchored = 1; dir = 4; icon_state = "0"},/turf/open/floor/plasteel/dark,/area/template_noop)
+"n" = (/obj/structure/chair/office{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
+"o" = (/obj/item/screwdriver,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"p" = (/obj/structure/chair/office{dir = 4},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
+"q" = (/obj/structure/frame/computer{anchored = 1; dir = 8; icon_state = "0"},/turf/open/floor/plasteel/dark,/area/template_noop)
+
+(1,1,1) = {"
+abcde
+fgchg
+ijckl
+mnopq
+"}

--- a/_maps/RandomRooms/5x4/sk_rdm096_comproom.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm096_comproom.dmm
@@ -1,24 +1,155 @@
-"a" = (/obj/structure/table,/obj/item/wallframe/camera,/obj/item/stack/cable_coil/random/five{step_x = 1; step_y = 5},/turf/open/floor/plasteel/dark,/area/template_noop)
-"b" = (/obj/machinery/status_display/evac{step_y = 31},/obj/structure/table,/obj/item/paper_bin{step_y = 5},/obj/item/pen{step_y = 6},/turf/open/floor/plasteel/dark,/area/template_noop)
-"c" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"d" = (/obj/machinery/status_display/evac{step_y = 31},/obj/machinery/photocopier,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"e" = (/obj/structure/filingcabinet,/obj/effect/decal/cleanable/cobweb/cobweb2,/turf/open/floor/plasteel/dark,/area/template_noop)
-"f" = (/obj/item/paper/crumpled{step_x = 6; step_y = -6},/turf/open/floor/plasteel/dark,/area/template_noop)
-"g" = (/turf/open/floor/plasteel/dark,/area/template_noop)
-"h" = (/obj/item/wirecutters,/turf/open/floor/plasteel/dark,/area/template_noop)
-"i" = (/obj/structure/frame/computer{anchored = 1; dir = 4; icon_state = "0"},/obj/machinery/light{dir = 8},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"j" = (/obj/structure/chair/office{dir = 8},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"k" = (/obj/structure/chair/office{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
-"l" = (/obj/structure/frame/computer{anchored = 1; dir = 8; icon_state = "0"},/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/dark,/area/template_noop)
-"m" = (/obj/structure/frame/computer{anchored = 1; dir = 4; icon_state = "0"},/turf/open/floor/plasteel/dark,/area/template_noop)
-"n" = (/obj/structure/chair/office{dir = 8},/turf/open/floor/plasteel/dark,/area/template_noop)
-"o" = (/obj/item/screwdriver,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"p" = (/obj/structure/chair/office{dir = 4},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plasteel/dark,/area/template_noop)
-"q" = (/obj/structure/frame/computer{anchored = 1; dir = 8; icon_state = "0"},/turf/open/floor/plasteel/dark,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/table,
+/obj/item/wallframe/camera,
+/obj/item/stack/cable_coil/random/five{
+	step_x = 1;
+	step_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"b" = (
+/obj/machinery/status_display/evac{
+	step_y = 31
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	step_y = 5
+	},
+/obj/item/pen{
+	step_y = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"c" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"d" = (
+/obj/machinery/status_display/evac{
+	step_y = 31
+	},
+/obj/machinery/photocopier,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"e" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"f" = (
+/obj/item/paper/crumpled{
+	step_x = 6;
+	step_y = -6
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"g" = (
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"h" = (
+/obj/item/wirecutters,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"i" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4;
+	icon_state = "0"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"j" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"k" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"l" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8;
+	icon_state = "0"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"m" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4;
+	icon_state = "0"
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"n" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"o" = (
+/obj/item/screwdriver,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"p" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
+"q" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8;
+	icon_state = "0"
+	},
+/turf/open/floor/plasteel/dark,
+/area/template_noop)
 
 (1,1,1) = {"
-abcde
-fgchg
-ijckl
-mnopq
+a
+f
+i
+m
+"}
+(2,1,1) = {"
+b
+g
+j
+n
+"}
+(3,1,1) = {"
+c
+c
+c
+o
+"}
+(4,1,1) = {"
+d
+h
+k
+p
+"}
+(5,1,1) = {"
+e
+g
+l
+q
 "}

--- a/_maps/RandomRooms/5x4/sk_rdm096_comproom.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm096_comproom.dmm
@@ -2,23 +2,16 @@
 "a" = (
 /obj/structure/table,
 /obj/item/wallframe/camera,
-/obj/item/stack/cable_coil/random/five{
-	step_x = 1;
-	step_y = 5
-	},
+/obj/item/stack/cable_coil/random/five,
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
 "b" = (
 /obj/machinery/status_display/evac{
-	step_y = 31
+	pixel_y = 25
 	},
 /obj/structure/table,
-/obj/item/paper_bin{
-	step_y = 5
-	},
-/obj/item/pen{
-	step_y = 6
-	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
 "c" = (
@@ -27,7 +20,7 @@
 /area/template_noop)
 "d" = (
 /obj/machinery/status_display/evac{
-	step_y = 31
+	pixel_y = 25
 	},
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39,10 +32,7 @@
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
 "f" = (
-/obj/item/paper/crumpled{
-	step_x = 6;
-	step_y = -6
-	},
+/obj/item/paper/crumpled,
 /turf/open/floor/plasteel/dark,
 /area/template_noop)
 "g" = (

--- a/_maps/RandomRooms/5x4/sk_rdm097_firemanroom.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm097_firemanroom.dmm
@@ -1,20 +1,124 @@
-"a" = (/obj/effect/decal/cleanable/cobweb,/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plasteel,/area/template_noop)
-"b" = (/obj/structure/closet/crate,/obj/item/clothing/head/hardhat/red,/obj/item/clothing/head/hardhat/red,/obj/item/clothing/head/hardhat/red,/obj/item/assembly/prox_sensor,/obj/item/assembly/prox_sensor,/obj/item/assembly/prox_sensor,/obj/item/bodypart/r_arm/robot,/obj/item/bodypart/r_arm/robot,/obj/item/bodypart/r_arm/robot,/obj/item/extinguisher,/obj/item/extinguisher,/obj/item/extinguisher,/obj/effect/turf_decal/bot_red,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"c" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
-"d" = (/obj/structure/closet/firecloset/full,/obj/effect/turf_decal/bot_red/right,/obj/effect/decal/cleanable/dirt,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
-"e" = (/obj/structure/closet/firecloset/full,/obj/effect/turf_decal/bot_red/left,/turf/open/floor/plasteel,/area/template_noop)
-"f" = (/turf/open/floor/plasteel,/area/template_noop)
-"g" = (/obj/structure/table,/obj/machinery/microwave{step_x = 0; step_y = 8},/turf/open/floor/plasteel/cafeteria,/area/template_noop)
-"h" = (/obj/structure/table,/obj/item/storage/box/donkpockets{step_x = 0; step_y = 7},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/cafeteria,/area/template_noop)
-"i" = (/obj/structure/bed,/obj/item/bedsheet/dorms,/obj/item/radio/intercom{step_x = 27},/turf/open/floor/plasteel,/area/template_noop)
-"j" = (/obj/structure/sink{dir = 8; pixel_x = -12; pixel_y = 2},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/cafeteria,/area/template_noop)
-"k" = (/obj/machinery/light,/turf/open/floor/plasteel/cafeteria,/area/template_noop)
-"l" = (/obj/structure/bed,/obj/item/bedsheet/dorms,/turf/open/floor/plasteel,/area/template_noop)
-"m" = (/obj/effect/decal/cleanable/dirt,/obj/structure/festivus,/turf/open/floor/plasteel,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/prox_sensor,
+/obj/item/bodypart/r_arm/robot,
+/obj/item/bodypart/r_arm/robot,
+/obj/item/bodypart/r_arm/robot,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"c" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"d" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/bot_red/right,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"e" = (
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/bot_red/left,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"f" = (
+/turf/open/floor/plasteel,
+/area/template_noop)
+"g" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	step_x = 0;
+	step_y = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"h" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets{
+	step_x = 0;
+	step_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"i" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/item/radio/intercom{
+	step_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"k" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
+/area/template_noop)
+"l" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"m" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/festivus,
+/turf/open/floor/plasteel,
+/area/template_noop)
 
 (1,1,1) = {"
-abcde
-fffcf
-ghmfi
-jkccl
+a
+f
+g
+j
+"}
+(2,1,1) = {"
+b
+f
+h
+k
+"}
+(3,1,1) = {"
+c
+f
+m
+c
+"}
+(4,1,1) = {"
+d
+c
+f
+c
+"}
+(5,1,1) = {"
+e
+f
+i
+l
 "}

--- a/_maps/RandomRooms/5x4/sk_rdm097_firemanroom.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm097_firemanroom.dmm
@@ -1,0 +1,20 @@
+"a" = (/obj/effect/decal/cleanable/cobweb,/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plasteel,/area/template_noop)
+"b" = (/obj/structure/closet/crate,/obj/item/clothing/head/hardhat/red,/obj/item/clothing/head/hardhat/red,/obj/item/clothing/head/hardhat/red,/obj/item/assembly/prox_sensor,/obj/item/assembly/prox_sensor,/obj/item/assembly/prox_sensor,/obj/item/bodypart/r_arm/robot,/obj/item/bodypart/r_arm/robot,/obj/item/bodypart/r_arm/robot,/obj/item/extinguisher,/obj/item/extinguisher,/obj/item/extinguisher,/obj/effect/turf_decal/bot_red,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"c" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/template_noop)
+"d" = (/obj/structure/closet/firecloset/full,/obj/effect/turf_decal/bot_red/right,/obj/effect/decal/cleanable/dirt,/obj/machinery/light{dir = 1},/turf/open/floor/plasteel,/area/template_noop)
+"e" = (/obj/structure/closet/firecloset/full,/obj/effect/turf_decal/bot_red/left,/turf/open/floor/plasteel,/area/template_noop)
+"f" = (/turf/open/floor/plasteel,/area/template_noop)
+"g" = (/obj/structure/table,/obj/machinery/microwave{step_x = 0; step_y = 8},/turf/open/floor/plasteel/cafeteria,/area/template_noop)
+"h" = (/obj/structure/table,/obj/item/storage/box/donkpockets{step_x = 0; step_y = 7},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/cafeteria,/area/template_noop)
+"i" = (/obj/structure/bed,/obj/item/bedsheet/dorms,/obj/item/radio/intercom{step_x = 27},/turf/open/floor/plasteel,/area/template_noop)
+"j" = (/obj/structure/sink{dir = 8; pixel_x = -12; pixel_y = 2},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/cafeteria,/area/template_noop)
+"k" = (/obj/machinery/light,/turf/open/floor/plasteel/cafeteria,/area/template_noop)
+"l" = (/obj/structure/bed,/obj/item/bedsheet/dorms,/turf/open/floor/plasteel,/area/template_noop)
+"m" = (/obj/effect/decal/cleanable/dirt,/obj/structure/festivus,/turf/open/floor/plasteel,/area/template_noop)
+
+(1,1,1) = {"
+abcde
+fffcf
+ghmfi
+jkccl
+"}

--- a/_maps/RandomRooms/5x4/sk_rdm097_firemanroom.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm097_firemanroom.dmm
@@ -46,16 +46,15 @@
 "g" = (
 /obj/structure/table,
 /obj/machinery/microwave{
-	step_x = 0;
-	step_y = 8
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/template_noop)
 "h" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
-	step_x = 0;
-	step_y = 7
+	pixel_y = 8;
+	pixel_x = -3
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
@@ -64,7 +63,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/item/radio/intercom{
-	step_x = 27
+	pixel_x = 25
 	},
 /turf/open/floor/plasteel,
 /area/template_noop)
@@ -87,8 +86,11 @@
 /turf/open/floor/plasteel,
 /area/template_noop)
 "m" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/festivus,
+/obj/structure/festivus{
+	desc = "This fireman's pole serves no purpose, leading nowhere.";
+	name = "fireman pole";
+	pixel_x = -16
+	},
 /turf/open/floor/plasteel,
 /area/template_noop)
 
@@ -107,13 +109,13 @@ k
 (3,1,1) = {"
 c
 f
-m
+c
 c
 "}
 (4,1,1) = {"
 d
 c
-f
+m
 c
 "}
 (5,1,1) = {"

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -19,13 +19,13 @@
 
 /obj/effect/spawner/room/LateInitialize()
 	var/list/possibletemplates = list()
-	var/cantidate = null
+	var/datum/map_template/random_room/cantidate = null
 	shuffle_inplace(SSmapping.random_room_templates)
 	for(var/ID in SSmapping.random_room_templates)
 		cantidate = SSmapping.random_room_templates[ID]
 		if(istype(cantidate, /datum/map_template/random_room) && room_height == cantidate.template_height && room_width == cantidate.template_width)
-			if(!template.spawned)
-				possibletemplates += cantidate
+			if(!cantidate.spawned)
+				possibletemplates[cantidate] = cantidate.weight
 		cantidate = null
 	if(possibletemplates.len)
 		template = pickweight(possibletemplates)

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -49,7 +49,7 @@
 	room_width = 5
 	room_height = 3
 
-/obj/effect/spawner/room/threexfive
+/obj/effect/spawner/room/threexfiveuk
 	name = "3x5 room spawner"
 	room_width = 3
 	room_height = 5

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -18,14 +18,20 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/spawner/room/LateInitialize()
+	var/list/possibletemplates = list()
+	var/cantidate = null
 	shuffle_inplace(SSmapping.random_room_templates)
 	for(var/ID in SSmapping.random_room_templates)
-		template = SSmapping.random_room_templates[ID]
-		if(istype(template, /datum/map_template/random_room) && room_height == template.template_height && room_width == template.template_width)
+		cantidate = SSmapping.random_room_templates[ID]
+		if(istype(cantidate, /datum/map_template/random_room) && room_height == cantidate.template_height && room_width == cantidate.template_width)
 			if(!template.spawned)
-				template.spawned = TRUE
-				addtimer(CALLBACK(src, /obj/effect/spawner/room.proc/LateSpawn), 600)
-				break
+				possibletemplates += cantidate
+		cantidate = null
+	if(possibletemplates.len)
+		template = pickweight(possibletemplates)
+		template.spawned = TRUE
+		addtimer(CALLBACK(src, /obj/effect/spawner/room.proc/LateSpawn), 600)
+	else 
 		template = null
 	if(!template)
 		qdel(src)

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -49,7 +49,7 @@
 	room_width = 5
 	room_height = 3
 
-/obj/effect/spawner/room/threexfiveuk
+/obj/effect/spawner/room/threexfive
 	name = "3x5 room spawner"
 	room_width = 3
 	room_height = 5

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -29,7 +29,10 @@
 		cantidate = null
 	if(possibletemplates.len)
 		template = pickweight(possibletemplates)
-		template.spawned = TRUE
+		template.stock --
+		template.weight = (template.weight / 2)
+		if(template.stock <= 0)
+			template.spawned = TRUE
 		addtimer(CALLBACK(src, /obj/effect/spawner/room.proc/LateSpawn), 600)
 	else 
 		template = null

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -75,7 +75,8 @@
 			else //Already set by admins/something else?
 				nuke_team.memorized_code = nuke.r_code
 			for(var/obj/machinery/nuclearbomb/beer/beernuke in GLOB.nuke_list)
-				beernuke.r_code = nuke_team.memorized_code
+				if(beernuke.r_code == "ADMIN")
+					beernuke.r_code = nuke_team.memorized_code
 		else
 			stack_trace("Syndicate nuke not found during nuke team creation.")
 			nuke_team.memorized_code = null

--- a/code/modules/mapping/random_rooms.dm
+++ b/code/modules/mapping/random_rooms.dm
@@ -269,6 +269,7 @@
 	centerspawner = FALSE
 	template_height = 10
 	template_width = 10
+	weight = 7
 
 /datum/map_template/random_room/sk_rdm034
 	name = "Delta Detective Office"
@@ -501,6 +502,7 @@
 	centerspawner = FALSE
 	template_height = 10
 	template_width = 10
+	weight = 7
 
 /datum/map_template/random_room/sk_rdm063
 	name = "Pubby Clutter 5"
@@ -637,14 +639,16 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	weight = 5
 
-/*/datum/map_template/random_room/sk_rdm080
+/datum/map_template/random_room/sk_rdm080
 	name = "Ancient Cloner"
 	room_id = "sk_rdm080_cloner"
 	mappath = "_maps/RandomRooms/5x3/sk_rdm080_cloner.dmm"
 	centerspawner = FALSE
 	template_height = 3
-	template_width = 5*/
+	template_width = 5
+	weight = 1
 
 /datum/map_template/random_room/sk_rdm081
 	name = "Maint Viro"
@@ -709,6 +713,7 @@
 	centerspawner = FALSE
 	template_height = 10
 	template_width = 10
+	weight = 5
 
 /datum/map_template/random_room/sk_rdm089
 	name = "Nasty Trap"
@@ -742,3 +747,93 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+
+/datum/map_template/random_room/sk_rdm093
+	name = "Bubblegum Altar"
+	room_id = "sk_rdm093_bubblegumaltar"
+	mappath = "_maps/RandomRooms/3x3/sk_rdm093_bubblegumaltar.dmm"
+	centerspawner = FALSE
+	template_height = 3
+	template_width = 3
+	weight = 3
+
+/datum/map_template/random_room/sk_rdm094
+	name = "Canister Room"
+	room_id = "sk_rdm094_canisterroom"
+	mappath = "_maps/RandomRooms/3x5/sk_rdm094_canisterroom.dmm"
+	centerspawner = FALSE
+	template_height = 5
+	template_width = 3
+
+/datum/map_template/random_room/sk_rdm095
+	name = "Durand Wreck"
+	room_id = "sk_rdm095_durandwreck"
+	mappath = "_maps/RandomRooms/3x5/sk_rdm095_durandwreck.dmm"
+	centerspawner = FALSE
+	template_height = 5
+	template_width = 3
+
+/datum/map_template/random_room/sk_rdm096
+	name = "Computer Room"
+	room_id = "sk_rdm096_comproom"
+	mappath = "_maps/RandomRooms/5x4/sk_rdm096_comproom.dmm"
+	centerspawner = FALSE
+	template_height = 4
+	template_width = 5
+
+/datum/map_template/random_room/sk_rdm097
+	name = "Fire Room"
+	room_id = "sk_rdm097_firemanroom"
+	mappath = "_maps/RandomRooms/5x4/sk_rdm097_firemanroom.dmm"
+	centerspawner = FALSE
+	template_height = 4
+	template_width = 5
+
+/datum/map_template/random_room/sk_rdm098
+	name = "Graffiti room"
+	room_id = "sk_rdm098_graffitiroom"
+	mappath = "_maps/RandomRooms/10x10/sk_rdm098_graffitiroom.dmm"
+	centerspawner = FALSE
+	template_height = 10
+	template_width = 10
+	weight = 4
+
+/datum/map_template/random_room/sk_rdm099
+	name = "Broken Floor"
+	room_id = "sk_rdm099_incompletefloor"
+	mappath = "_maps/RandomRooms/5x3/sk_rdm099_incompletefloor.dmm"
+	centerspawner = FALSE
+	template_height = 3
+	template_width = 5
+
+/datum/map_template/random_room/sk_rdm100
+	name = "Meeting Room"
+	room_id = "sk_rdm100_meetingroom"
+	mappath = "_maps/RandomRooms/10x5/sk_rdm100_meetingroom.dmm"
+	centerspawner = FALSE
+	template_height = 5
+	template_width = 10
+
+/datum/map_template/random_room/sk_rdm101
+	name = "Small Break"
+	room_id = "sk_rdm101_minibreakroom"
+	mappath = "_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm"
+	centerspawner = FALSE
+	template_height = 3
+	template_width = 5
+
+/datum/map_template/random_room/sk_rdm102
+	name = "Repair Bay"
+	room_id = "sk_rdm102_podrepairbay"
+	mappath = "_maps/RandomRooms/10x10/sk_rdm102_podrepairbay.dmm"
+	centerspawner = FALSE
+	template_height = 10
+	template_width = 10
+
+/datum/map_template/random_room/sk_rdm103
+	name = "'stroreroom'"
+	room_id = "sk_rdm103_stroreroom"
+	mappath = "_maps/RandomRooms/5x3/sk_rdm103_stroreroom.dmm"
+	centerspawner = FALSE
+	template_height = 3
+	template_width = 5

--- a/code/modules/mapping/random_rooms.dm
+++ b/code/modules/mapping/random_rooms.dm
@@ -4,6 +4,7 @@
 	var/centerspawner = TRUE
 	var/template_height = 0
 	var/template_width = 0
+	var/weight = 10 //weight a room has to appear
 
 /datum/map_template/random_room/sk_rdm001
 	name = "Maintenance Storage"

--- a/code/modules/mapping/random_rooms.dm
+++ b/code/modules/mapping/random_rooms.dm
@@ -21,6 +21,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 2
 
 /datum/map_template/random_room/sk_rdm003
 	name = "Maintenance"
@@ -181,6 +182,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 7
 
 /datum/map_template/random_room/sk_rdm023
 	name = "Box Clutter 7"
@@ -229,6 +231,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 1
 
 /datum/map_template/random_room/sk_rdm029
 	name = "Delta Bar"
@@ -253,6 +256,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 10
+	weight = 5
 
 /datum/map_template/random_room/sk_rdm032
 	name = "Delta EVA"
@@ -261,6 +265,7 @@
 	centerspawner = FALSE
 	template_height = 4
 	template_width = 5
+	weight = 3
 
 /datum/map_template/random_room/sk_rdm033
 	name = "Delta Library"
@@ -294,6 +299,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 7
 
 /datum/map_template/random_room/sk_rdm037
 	name = "Delta Janitor Closet"
@@ -302,6 +308,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 8
 
 /datum/map_template/random_room/sk_rdm038
 	name = "Delta Dressing Room"
@@ -326,6 +333,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 10
+	weight = 9
 
 /datum/map_template/random_room/sk_rdm041
 	name = "Delta Gambling Den"
@@ -366,6 +374,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 10
+	weight = 7
 
 /datum/map_template/random_room/sk_rdm046
 	name = "Delta Arcade"
@@ -382,6 +391,7 @@
 	centerspawner = FALSE
 	template_height = 4
 	template_width = 5
+	weight = 5
 
 /datum/map_template/random_room/sk_rdm048
 	name = "Meta Theatre"
@@ -414,6 +424,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 6
 
 /datum/map_template/random_room/sk_rdm052
 	name = "Meta Clutter 1"
@@ -486,6 +497,7 @@
 	centerspawner = FALSE
 	template_height = 10
 	template_width = 10
+	weight = 6
 
 /datum/map_template/random_room/sk_rdm061
 	name = "Pubby Clutter 4"
@@ -502,7 +514,7 @@
 	centerspawner = FALSE
 	template_height = 10
 	template_width = 10
-	weight = 7
+	weight = 6
 
 /datum/map_template/random_room/sk_rdm063
 	name = "Pubby Clutter 5"
@@ -583,6 +595,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 6
 
 /datum/map_template/random_room/sk_rdm073
 	name = "Kilo Mech Recharger"
@@ -615,6 +628,7 @@
 	centerspawner = FALSE
 	template_height = 4
 	template_width = 5
+	weight = 4
 
 /datum/map_template/random_room/sk_rdm077
 	name = "Kilo Maid Den"
@@ -623,6 +637,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 4
 
 /datum/map_template/random_room/sk_rdm078
 	name = "Kilo Clutter"
@@ -639,7 +654,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
-	weight = 5
+	weight = 3
 
 /datum/map_template/random_room/sk_rdm080
 	name = "Ancient Cloner"
@@ -657,6 +672,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 3
 	
 /datum/map_template/random_room/sk_rdm082
 	name = "Maint Chemistry"
@@ -665,6 +681,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 10
+	weight = 6
 
 /datum/map_template/random_room/sk_rdm083
 	name = "Big Theatre"
@@ -673,6 +690,7 @@
 	centerspawner = FALSE
 	template_height = 10
 	template_width = 10
+	weight = 9
 
 /datum/map_template/random_room/sk_rdm084
 	name = "Monky Paradise"
@@ -681,6 +699,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	weight = 4
 
 /datum/map_template/random_room/sk_rdm085
 	name = "Hank's Room"
@@ -689,6 +708,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	weight = 1
 
 /datum/map_template/random_room/sk_rdm086
 	name = "Max Tide's Last Stand"
@@ -697,6 +717,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	weight = 3
 
 /datum/map_template/random_room/sk_rdm087
 	name = "Junk Closet"
@@ -722,6 +743,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 5
+	weight = 4
 
 /datum/map_template/random_room/sk_rdm090
 	name = "Tiny Barber's Shop"
@@ -730,6 +752,7 @@
 	centerspawner = FALSE
 	template_height = 4
 	template_width = 5
+	weight = 7
 
 
 /datum/map_template/random_room/sk_rdm091
@@ -747,6 +770,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	weight = 8
 
 /datum/map_template/random_room/sk_rdm093
 	name = "Bubblegum Altar"
@@ -772,6 +796,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	weight = 4
 
 /datum/map_template/random_room/sk_rdm096
 	name = "Computer Room"
@@ -813,9 +838,10 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 10
+	weight = 7
 
 /datum/map_template/random_room/sk_rdm101
-	name = "Small Break"
+	name = "Small Breakroom"
 	room_id = "sk_rdm101_minibreakroom"
 	mappath = "_maps/RandomRooms/5x3/sk_rdm101_minibreakroom.dmm"
 	centerspawner = FALSE
@@ -829,6 +855,7 @@
 	centerspawner = FALSE
 	template_height = 10
 	template_width = 10
+	weight = 6
 
 /datum/map_template/random_room/sk_rdm103
 	name = "'stroreroom'"

--- a/code/modules/mapping/random_rooms.dm
+++ b/code/modules/mapping/random_rooms.dm
@@ -881,3 +881,21 @@
 	template_height = 3
 	template_width = 5
 	stock = 2
+
+/datum/map_template/random_room/sk_rdm104
+	name = "pill lottery"
+	room_id = "sk_rdm104_pills"
+	mappath = "_maps/RandomRooms/5x3/sk_rdm104_pills"
+	centerspawner = FALSE
+	template_height = 3
+	template_width = 5
+	weight = 1
+
+/datum/map_template/random_room/sk_rdm105
+	name = "biohazard exclusion zone"
+	room_id = "sk_rdm105_phage"
+	mappath = "_maps/RandomRooms/10x5/sk_rdm105_phage"
+	centerspawner = FALSE
+	template_height = 5
+	template_width = 10
+	weight = 3

--- a/code/modules/mapping/random_rooms.dm
+++ b/code/modules/mapping/random_rooms.dm
@@ -5,6 +5,7 @@
 	var/template_height = 0
 	var/template_width = 0
 	var/weight = 10 //weight a room has to appear
+	var/stock = 1 //how many times this room can appear in a round
 
 /datum/map_template/random_room/sk_rdm001
 	name = "Maintenance Storage"
@@ -13,6 +14,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+
 
 /datum/map_template/random_room/sk_rdm002
 	name = "Maintenance Shrine"
@@ -54,6 +56,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm007
 	name = "Maintenance"
@@ -70,6 +73,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm009
 	name = "Air Refilling Station"
@@ -78,6 +82,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm010
 	name = "Maintenance HAZMAT"
@@ -126,6 +131,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 5
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm016
 	name = "Box Clutter 2"
@@ -134,6 +140,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm017
 	name = "Box Clutter 3"
@@ -191,6 +198,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm024
 	name = "Box Bedroom"
@@ -240,6 +248,7 @@
 	centerspawner = FALSE
 	template_height = 4
 	template_width = 5
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm030
 	name = "Delta Lounge"
@@ -433,6 +442,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 5
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm053
 	name = "Meta Clutter 2"
@@ -539,6 +549,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm066
 	name = "Pubby Bedroom"
@@ -604,6 +615,7 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm074
 	name = "Kilo Theatre"
@@ -620,6 +632,7 @@
 	centerspawner = FALSE
 	template_height = 4
 	template_width = 5
+	stock = 2 //because i hate you
 
 /datum/map_template/random_room/sk_rdm076
 	name = "Kilo Haunted Library"
@@ -655,6 +668,7 @@
 	template_height = 5
 	template_width = 3
 	weight = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm080
 	name = "Ancient Cloner"
@@ -726,6 +740,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm088
 	name = "Construction Zone"
@@ -788,6 +803,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 3
+	stock = 2
 
 /datum/map_template/random_room/sk_rdm095
 	name = "Durand Wreck"
@@ -838,7 +854,7 @@
 	centerspawner = FALSE
 	template_height = 5
 	template_width = 10
-	weight = 7
+	weight = 6
 
 /datum/map_template/random_room/sk_rdm101
 	name = "Small Breakroom"
@@ -864,3 +880,4 @@
 	centerspawner = FALSE
 	template_height = 3
 	template_width = 5
+	stock = 2

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -440,3 +440,16 @@
 
 /obj/item/paper/crumpled/bloody
 	icon_state = "scrap_bloodied"
+
+/obj/item/paper/crumpled/beernuke
+	name = "beer-stained note"
+
+/obj/item/paper/crumpled/beernuke/Initialize()
+	. = ..()
+	var/code = random_nukecode()
+	for(var/obj/machinery/nuclearbomb/beer/beernuke in GLOB.nuke_list)
+		if(beernuke.r_code == "ADMIN")
+			beernuke.r_code = code
+		else 
+			code = beernuke.r_code
+	info = "important party info, DONT FORGET: <b>[code]</b>"


### PR DESCRIPTION
## About The Pull Request

a weight value can now be applied to random rooms, giving them a different likeliness of appearing. this has been applied to existing rooms. 
also adds a system for spawning rooms more than once


## Why It's Good For The Game
now we can add interesting rooms and use weighting instead of volume to balance them. also, new rooms and a few fixes n shit, see changelog

## Changelog
:cl:
add: random room weighting. Some rooms will seem rarer now
add: random room stocking. Some rooms are allowed to spawn more than once
add: 11 new rooms by GizkaFreechman
add: two other new rooms
add: paper that spawns beernuke codes. Fun for the whole family. spawns in randommaint
tweak: the random maint experimental cloner is no longer commented out, as weighting balances it out instead
tweak: weighting has been applied to current room pool
balance: rebalanced something
fix: bananium room now has real bananium walls instead of falsewalls
/:cl:
