### PR TITLE
A change to stand's healing ability

### DIFF
--- a/code/modules/guardian/abilities/major/healing.dm
+++ b/code/modules/guardian/abilities/major/healing.dm
@@ -26,7 +26,7 @@
 			guardian.do_attack_animation(L)
 			var/heals = -(master_stats.potential * 1.5)
 			if(!guardian.is_deployed())
-				heals = max(heals * 0.5, 2)
+				heals = min(heals * 0.5, -2)
 			L.adjustBruteLoss(heals)
 			L.adjustFireLoss(heals)
 			L.adjustOxyLoss(heals)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It seems the intention was to have healing while not deployed to be a third of healing while deployed but no less than two. But because heals variable is negative, max(heals * 0.5, 2) always returns a value of 2 and so healing while not deployed deals 2 damage across the board.

The change will bring this to what I assume was the intention. That is, 1/3 heal from the inside but no less than 2.
EDIT: 1/2 heal compared to when manifest, I am dumb

I will also make another PR in case stand is only supposed to heal while deployed. Because damaging the stand user in healing mode should not be a thing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If my guess to what was intended is correct, this is a bug fix, which is always good. If my guess is not correct then please, take a look at the other PR I intend to make shortly.
https://github.com/BeeStation/BeeStation-Hornet/pull/1966

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed the healing power of healing stand while not deployed so it actually heals, at 1/3 power compared to deployed stand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
