### PR TITLE
Alternative fix to healing stand

### DIFF
--- a/code/modules/guardian/abilities/major/healing.dm
+++ b/code/modules/guardian/abilities/major/healing.dm
@@ -21,12 +21,13 @@
 		if(target == guardian)
 			to_chat(guardian, "<span class='danger bold'>You can't heal yourself!</span>")
 			return TRUE
+		if(!guardian.is_deployed())
+			to_chat(guardian, "<span class='danger bold'>You must manifest to heal!</span>")
+			return TRUE
 		if(isliving(target))
 			var/mob/living/L = target
 			guardian.do_attack_animation(L)
 			var/heals = -(master_stats.potential * 1.5)
-			if(!guardian.is_deployed())
-				heals = max(heals * 0.5, 2)
 			L.adjustBruteLoss(heals)
 			L.adjustFireLoss(heals)
 			L.adjustOxyLoss(heals)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now healing stand deals damage when trying to heal while not deployed. This will inform the stand that it must be manifested and remove that damage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is an alternative fix to the problem of healing stand damaging the user, in case my guess as to what was intended was wrong.
It is here: https://github.com/BeeStation/BeeStation-Hornet/pull/1965
Either one or the other should be used, depending on what was originally intended.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: instead of damaging the user when not manifested, healing stand will instead do nothing and receive notification it must be manifested instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
