### PR TITLE
The return of flypeople 

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -435,7 +435,7 @@ ROUNDSTART_RACES human
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard
-#ROUNDSTART_RACES fly
+ROUNDSTART_RACES fly
 ROUNDSTART_RACES moth
 ROUNDSTART_RACES felinid
 ROUNDSTART_RACES squid

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -432,7 +432,7 @@ ROUNDSTART_RACES human
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard
-#ROUNDSTART_RACES fly
+ROUNDSTART_RACES fly
 ROUNDSTART_RACES moth
 ROUNDSTART_RACES plasmaman
 ROUNDSTART_RACES felinid


### PR DESCRIPTION
This just makes flypeople available at roundstart again.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This basically allows for flypeople to be a selectable race at roundstart once more. Nothing else was changed.

## Why It's Good For The Game

Stemming from the thought that more is more and that it actually had a decent amount of players that used it, I see no reason not to allow a playable race that brings no drawbacks to gameplay whatsoever and whose reintroduction would not interfere with the addition of apids.

## Changelog
:cl:       FleshGordo
config: Made Flypeople a roundstart race once more
/:cl:


