### PR TITLE
Revert "Headspiders IV: Actually balanced edition"

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -528,7 +528,6 @@
 	give_objectives = FALSE
 	show_in_roundend = FALSE //These are here for admin tracking purposes only
 	you_are_greet = FALSE
-	geneticpoints = 3
 
 /datum/antagonist/changeling/roundend_report()
 	var/list/parts = list()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -23,8 +23,6 @@
 	var/datum/mind/origin
 	var/egg_lain = 0
 
-	gold_core_spawnable = HOSTILE_SPAWN
-
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)
 	egg.Insert(victim)


### PR DESCRIPTION

## About The Pull Request
qwert speedmerged this pr just before he resigned without any other input

## Why It's Good For The Game
reliably getting antag powers as long as you can make rainbow slimes is super mega triple gay, especially if that antag is the one with being unkillable by normal means as a base ability

xenobiology is already full of insane powercreep and doesnt need this too.

## Changelog
:cl:
del: Removed xenolings, again. dammit qwert
/:cl:



