### PR TITLE
Door security increase

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -1,9 +1,34 @@
 /datum/wires/airlock
 	holder_type = /obj/machinery/door/airlock
 	proper_name = "Airlock"
+	var/wiretype
 
 /datum/wires/airlock/secure
 	randomize = TRUE
+
+/datum/wires/airlock/command
+	proper_name = "Command Airlock"
+	wiretype = "commandairlock"
+
+/datum/wires/airlock/security
+	proper_name = "Security Airlock"
+	wiretype = "securityairlock"
+
+/datum/wires/airlock/engineering
+	proper_name = "Engineering Airlock"
+	wiretype = "engineeringairlock"
+
+/datum/wires/airlock/science
+	proper_name = "Science Airlock"
+	wiretype = "scienceairlock"
+
+/datum/wires/airlock/medical
+	proper_name = "Medical Airlock"
+	wiretype = "medicalairlock"
+
+/datum/wires/airlock/cargo
+	proper_name = "Cargo Airlock"
+	wiretype = "cargoairlock"
 
 /datum/wires/airlock/New(atom/holder)
 	wires = list(
@@ -14,7 +39,16 @@
 		WIRE_ZAP1, WIRE_ZAP2
 	)
 	add_duds(2)
-	..()
+	. = ..()
+	if(randomize || !wiretype)
+		return
+	if(!GLOB.wire_color_directory[wiretype])
+		colors = list()
+		randomize()
+		GLOB.wire_color_directory[wiretype] = colors
+		GLOB.wire_name_directory[wiretype] = proper_name
+	else
+		colors = GLOB.wire_color_directory[wiretype]
 
 /datum/wires/airlock/interactable(mob/user)
 	var/obj/machinery/door/airlock/A = holder

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -83,6 +83,7 @@
 	var/boltDown = 'sound/machines/boltsdown.ogg'
 	var/noPower = 'sound/machines/doorclick.ogg'
 	var/previous_airlock = /obj/structure/door_assembly //what airlock assembly mineral plating was applied to
+	var/wiretypepath = /datum/wires/airlock
 	var/airlock_material //material of inner filling; if its an airlock with glass, this should be set to "glass"
 	var/overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 	var/note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi' //Used for papers and photos pinned to the airlock
@@ -102,7 +103,7 @@
 
 /obj/machinery/door/airlock/Initialize()
 	. = ..()
-	wires = new /datum/wires/airlock(src)
+	wires = new wiretypepath(src)
 	if(frequency)
 		set_frequency(frequency)
 

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -5,20 +5,25 @@
 /obj/machinery/door/airlock/command
 	icon = 'icons/obj/doors/airlocks/station/command.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
+	wiretypepath = /datum/wires/airlock/command
 	normal_integrity = 450
+	security_level = 3
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_sec
+	wiretypepath = /datum/wires/airlock/security
 	normal_integrity = 450
 
 /obj/machinery/door/airlock/engineering
 	icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_eng
+	wiretypepath = /datum/wires/airlock/engineering
 
 /obj/machinery/door/airlock/medical
 	icon = 'icons/obj/doors/airlocks/station/medical.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_med
+	wiretypepath = /datum/wires/airlock/medical
 
 /obj/machinery/door/airlock/maintenance
 	name = "maintenance access"
@@ -35,15 +40,18 @@
 	name = "mining airlock"
 	icon = 'icons/obj/doors/airlocks/station/mining.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_min
+	wiretypepath = /datum/wires/airlock/cargo
 
 /obj/machinery/door/airlock/atmos
 	name = "atmospherics airlock"
 	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_atmo
+	wiretypepath = /datum/wires/airlock/engineering
 
 /obj/machinery/door/airlock/research
 	icon = 'icons/obj/doors/airlocks/station/research.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_research
+	wiretypepath = /datum/wires/airlock/science
 
 /obj/machinery/door/airlock/freezer
 	name = "freezer airlock"
@@ -53,10 +61,12 @@
 /obj/machinery/door/airlock/science
 	icon = 'icons/obj/doors/airlocks/station/science.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_science
+	wiretypepath = /datum/wires/airlock/science
 
 /obj/machinery/door/airlock/virology
 	icon = 'icons/obj/doors/airlocks/station/virology.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_viro
+	wiretypepath = /datum/wires/airlock/medical
 
 //////////////////////////////////
 /*

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -7,7 +7,7 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_com
 	wiretypepath = /datum/wires/airlock/command
 	normal_integrity = 450
-	security_level = 3
+	security_level = 1
 
 /obj/machinery/door/airlock/security
 	icon = 'icons/obj/doors/airlocks/station/security.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Space OSHA have done a review of centcoms wiring practices and found them sorely lacking and requiring an update.

Airlocks for command, security, engineering, science, medical, cargo will now have randomized wiring that will only be common to that department.

Increased the security of command level doors now requiring a weld before gaining access to the wires.

Port of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/5574

## Why It's Good For The Game
No more speedrunning captains spare in 2 minutes because you learned the test wire from a public door.

Also makes hacking less of a skeleton key and more of an involved practice in remembering each test wire 

## Changelog
:cl:
add: Adds code allowing for the randomizing the wires of individual door types
balance: Increased command door security level from 0 to 1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
