### PR TITLE
[TG PORT] [s] fixes a href exploit on shuttle computer code

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -62,8 +62,8 @@
 				to_chat(usr, "<span class='warning'>Shuttle already in transit.</span>")
 				return
 		if(!(href_list["move"] in params2list(possible_destinations)))
-			log_admin("[usr] attempted to href dock exploit on [src] with target location \"[href_list["move"]]\"")
-			message_admins("[usr] just attempted to href dock exploit on [src] with target location \"[href_list["move"]]\"")
+			log_admin("[usr] attempted to forge a target location through a href exploit on [src] with target location \"[href_list["move"]]\"")
+			message_admins("[ADMIN_FULLMONTY(usr)] attempted to forge a target location through a href exploit on [src]")
 			return
 		switch(SSshuttle.moveShuttle(shuttleId, href_list["move"], 1))
 			if(0)

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -62,7 +62,7 @@
 				to_chat(usr, "<span class='warning'>Shuttle already in transit.</span>")
 				return
 		if(!(href_list["move"] in params2list(possible_destinations)))
-			log_admin("[usr] attempted to forge a target location through a href exploit on [src] with target location \"[href_list["move"]]\"")
+			log_admin("[usr] attempted to forge a target location through a href exploit on [src]")
 			message_admins("[ADMIN_FULLMONTY(usr)] attempted to forge a target location through a href exploit on [src]")
 			return
 		switch(SSshuttle.moveShuttle(shuttleId, href_list["move"], 1))

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -169,8 +169,8 @@
 
 /obj/machinery/computer/custom_shuttle/proc/SetTargetLocation(var/newTarget)
 	if(!(newTarget in params2list(possible_destinations)))
-		log_admin("[usr] attempted to href dock exploit on [src] with target location \"[newTarget]\"")
-		message_admins("[usr] just attempted to href dock exploit on [src] with target location \"[newTarget]\"")
+		log_admin("[usr] attempted to forge a target location through a href exploit on [src]")
+		message_admins("[ADMIN_FULLMONTY(usr)] attempted to forge a target location through a href exploit on [src]")
 		return
 	targetLocation = newTarget
 	say("Shuttle route calculated.")


### PR DESCRIPTION
"User can crash the admins chat, or send them evil memes."
Ports the [fix](https://github.com/tgstation/tgstation/pull/51657) to a href exploit from TG as requested by @ike709.