### PR TITLE
Directional Airlock Cycle Controllers

### DIFF
--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -76,7 +76,7 @@
 	var/scan_on_late_init = FALSE
 	var/depressurization_margin = 10 // use a lower value to reduce cross-contamination
 	var/overlays_hash = null
-	var/skip_delay = 300
+	var/skip_delay = 150
 	var/skip_timer = 0
 	var/is_skipping = FALSE
 

--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -76,7 +76,7 @@
 	var/scan_on_late_init = FALSE
 	var/depressurization_margin = 10 // use a lower value to reduce cross-contamination
 	var/overlays_hash = null
-	var/skip_delay = 150
+	var/skip_delay = 300
 	var/skip_timer = 0
 	var/is_skipping = FALSE
 
@@ -91,6 +91,20 @@
 
 /obj/machinery/advanced_airlock_controller/mix_chamber
 	depressurization_margin = 0.15 // The minimum - We really don't want contamination.
+
+/obj/machinery/advanced_airlock_controller/directional //NSV13 makes directinal versions of advanced airlock controllers mapping QOL
+
+/obj/machinery/advanced_airlock_controller/directional/north
+	pixel_y = 24
+
+/obj/machinery/advanced_airlock_controller/directional/south
+	pixel_y = -24
+
+/obj/machinery/advanced_airlock_controller/directional/east
+	pixel_x = 24
+
+/obj/machinery/advanced_airlock_controller/directional/west
+	pixel_x = -24
 
 /obj/machinery/advanced_airlock_controller/New(loc, ndir, nbuild)
 	..()


### PR DESCRIPTION
## About The Pull Request

This PR is intended for mapper Quality of Life (QOL) and adds pixel shifted variants of the airlock cycle controllers required by monstermos.

## Why It's Good For The Game

making mapper's lives easier is good because mappers already often want to kill themselves for having the hobby of mapping in the first place. (Please help us, we have problems)

## Changelog
:cl:
add: Pixel shift presets of airlock controllers (significant to mappers)
/:cl:

