### PR TITLE
xenobioling nerf

### DIFF
--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -120,10 +120,12 @@
 
 
 		var/datum/antagonist/changeling/target_ling = target.mind.has_antag_datum(/datum/antagonist/changeling)
+		var/datum/antagonist/changeling/target_xenobioling = target.mind.has_antag_datum(/datum/antagonist/changeling/xenobio)
 		if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
 			to_chat(user, "<span class='boldnotice'>[target] was one of us. We have absorbed their power.</span>")
 			target_ling.remove_changeling_powers()
-			changeling.geneticpoints += 2
+			if(!target_xenobioling)
+				changeling.geneticpoints += 2
 			target_ling.geneticpoints = 0
 			target_ling.canrespec = 0
 			target_ling.chem_charges = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changelings and xenobiolings do not receive genetic points when absorbing xenobiolings.
 
## Why It's Good For The Game

Being able to spawn a bunch of xenobiolings with xenobio then absorbing them all is not balance.

## Changelog
:cl:
balance: changelings do not receive genetic points for absorbing xenobio lings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
