### PR TITLE
meth brain damage is not broken anymore

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -208,7 +208,7 @@
 	M.AdjustImmobilized(-40, FALSE)
 	M.adjustStaminaLoss(-30, 0)
 	M.Jitter(2)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1)
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -208,7 +208,7 @@
 	M.AdjustImmobilized(-40, FALSE)
 	M.adjustStaminaLoss(-30, 0)
 	M.Jitter(2)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1,4))
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25)
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
 	..()


### PR DESCRIPTION
## About The Pull Request

Since a few years back, meth use will deal considerably more brain damage than actually overdosing on meth, the current value of rand(1,4) is enough to hardkill your brain in merely minutes.

## Why It's Good For The Game

Because being addicted to meth is actually a hard griefing tool now which you can not get rid off short of getting a brand new body.
This change reverts the meth use brain damage to something that can be actually managed.
(currently it deals 150% more damage than nanites are able heal)

## Changelog
:cl: yorii
balance: reverted meth damage to a sensible number
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
