### PR TITLE
[Sage] The return of flypeople

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -435,7 +435,7 @@ ROUNDSTART_RACES human
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
 ROUNDSTART_RACES lizard
-#ROUNDSTART_RACES fly
+ROUNDSTART_RACES fly
 ROUNDSTART_RACES moth
 ROUNDSTART_RACES felinid
 ROUNDSTART_RACES squid


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This basically allows for flypeople to be a selectable race at roundstart once more. Nothing else was changed.

## Why It's Good For The Game

Stemming from the thought that more is more and that it actually had a decent amount of players that used it, I see no reason not to allow a playable race that brings no drawbacks to gameplay whatsoever and whose reintroduction would not interfere with the addition of apids.

## Changelog
:cl: FleshGordo
config: Made Flypeople a roundstart race once more

/:cl: FleshGordo
config: Made Flypeople a roundstart race once more

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
