### PR TITLE
buffs slimes, nerfs magicarps

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -36,7 +36,7 @@
 	projectilesound = 'sound/weapons/emitter.ogg'
 	maxHealth = 50
 	health = 50
-	gold_core_spawnable = HOSTILE_SPAWN //NO_SPAWN
+	gold_core_spawnable = NO_SPAWN
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
 	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
@@ -45,11 +45,11 @@
 	projectiletype = pick(allowed_projectile_types)
 	. = ..()
 
-/*/mob/living/simple_animal/hostile/carp/ranged/xenobio
+/mob/living/simple_animal/hostile/carp/ranged/xenobio
 	desc = "45% magic, 50% carp, 5% slime, 100% horrible."
 	allowed_projectile_types = list( /obj/item/projectile/magic/animate, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
-	gold_core_spawnable = HOSTILE_SPAWN*/
+	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos
 	name = "chaos magicarp"

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -211,7 +211,7 @@
 		var/mob/living/simple_animal/SA = M
 
 		var/totaldamage = 0 //total damage done to this unfortunate animal
-		totaldamage += SA.adjustCloneLoss(2)
+		totaldamage += SA.adjustCloneLoss(4)
 		totaldamage += SA.adjustToxLoss(2)
 
 		if(totaldamage <= 0) //if we did no(or negative!) damage to it, stop
@@ -222,7 +222,7 @@
 		Feedstop(0, 0)
 		return
 
-	add_nutrition((11 * CONFIG_GET(number/damage_multiplier)))
+	add_nutrition((18 * CONFIG_GET(number/damage_multiplier)))
 
 	//Heal yourself.
 	adjustBruteLoss(-5)


### PR DESCRIPTION

## About The Pull Request

buffs slime eating speed greatly, xenobio-spawned magicarps can no longer have ressurection, death, or change bolts
## Why It's Good For The Game

This change makes xenobio faster and more palatable, while nerfing the current meta of "spam gold slimes for change bolts to become a ling or dragon". Xenobio is a department with many interesting and awesome uses, yet people who "main" xenobio invariably use it for gold slimes, and sometimes green, whilst ignoring the other available options, and other people usually only care about it because of red slimes, and sometimes blue or yellow. Expect changes to and additions to crossbreeding in particular in the future to make shit more interesting

## Changelog
:cl:
balance: substantially buffs slimes eating rate
balance: xenobio magicarps can no longer have ressurection, death, or change bolts
/:cl:
