### PR TITLE
nerfs macrophage

### DIFF
--- a/code/datums/diseases/advance/symptoms/macrophage.dm
+++ b/code/datums/diseases/advance/symptoms/macrophage.dm
@@ -35,7 +35,7 @@
 	if(!..())
 		return
 	var/mob/living/M = A.affected_mob
-	phagecounter -= max(1, A.properties["stage_rate"])
+	phagecounter -= max(2, A.properties["stage_rate"])
 	switch(A.stage)
 		if(1-3)
 			to_chat(M, "<span class='notice'>Your skin crawls.</span>")
@@ -74,3 +74,4 @@
 			phage.infections += D
 	M.visible_message("<span class='danger'>A strange creature bursts out of [M]!</span>", \
 	  "<span class='userdanger'>A slimy creature bursts forth from your flesh!</span>")
+	addtimer(CALLBACK(phage, /mob/living/simple_animal/hostile/macrophage.proc/shrivel), 3000)

--- a/code/datums/diseases/advance/symptoms/macrophage.dm
+++ b/code/datums/diseases/advance/symptoms/macrophage.dm
@@ -45,16 +45,15 @@
 		if(5)
 			if(gigagerms && phagecounter <= 0) //only ever spawn one big germ
 				Burst(A, M, TRUE)
-				phagecounter += 5 //but big germs spawn small ones more frequently
-			while(phagecounter <= 0)
 				phagecounter += 10
+			while(phagecounter <= 0)
+				phagecounter += 5
 				Burst(A, M)
 
 /datum/symptom/macrophage/proc/Burst(datum/disease/advance/A, var/mob/living/M, var/gigagerms = FALSE)
 	var/mob/living/simple_animal/hostile/macrophage/phage
 	if(gigagerms)
 		phage = new /mob/living/simple_animal/hostile/macrophage/aggro(M.loc)
-		phage.melee_damage += max(0, A.properties["resistance"])
 		M.take_overall_damage(brute = rand(10, 20), required_status = BODYPART_ORGANIC)
 		playsound(M, 'sound/effects/splat.ogg', 50, 1)
 		M.emote("scream")

--- a/code/datums/diseases/advance/symptoms/macrophage.dm
+++ b/code/datums/diseases/advance/symptoms/macrophage.dm
@@ -53,7 +53,7 @@
 /datum/symptom/macrophage/proc/Burst(datum/disease/advance/A, var/mob/living/M, var/gigagerms = FALSE)
 	var/mob/living/simple_animal/hostile/macrophage/phage
 	if(gigagerms)
-		phage.melee_damage == max(5, A.properties["resistance"])
+		phage.melee_damage = max(5, A.properties["resistance"])
 		phage = new /mob/living/simple_animal/hostile/macrophage/aggro(M.loc)
 		M.take_overall_damage(brute = rand(10, 20), required_status = BODYPART_ORGANIC)
 		playsound(M, 'sound/effects/splat.ogg', 50, 1)

--- a/code/datums/diseases/advance/symptoms/macrophage.dm
+++ b/code/datums/diseases/advance/symptoms/macrophage.dm
@@ -53,6 +53,7 @@
 /datum/symptom/macrophage/proc/Burst(datum/disease/advance/A, var/mob/living/M, var/gigagerms = FALSE)
 	var/mob/living/simple_animal/hostile/macrophage/phage
 	if(gigagerms)
+		phage.melee_damage == max(5, A.properties["resistance"])
 		phage = new /mob/living/simple_animal/hostile/macrophage/aggro(M.loc)
 		M.take_overall_damage(brute = rand(10, 20), required_status = BODYPART_ORGANIC)
 		playsound(M, 'sound/effects/splat.ogg', 50, 1)
@@ -62,7 +63,6 @@
 		M.take_overall_damage(brute = rand(1, 7), required_status = BODYPART_ORGANIC)
 	phage.health += A.properties["resistance"]
 	phage.maxHealth += A.properties["resistance"]
-	phage.melee_damage += max(0, A.properties["resistance"])
 	phage.infections += A
 	phage.basedisease = A
 	if(A.properties["transmittable"] >= 12)

--- a/code/modules/mob/living/simple_animal/hostile/macrophage.dm
+++ b/code/modules/mob/living/simple_animal/hostile/macrophage.dm
@@ -9,13 +9,12 @@
 	response_help  = "shoos"
 	response_disarm = "swats away"
 	response_harm   = "squashes"
-	maxHealth = 10
-	health = 10
+	maxHealth = 6
+	health = 6
 	spacewalk = TRUE
 	faction = list("hostile")
 	move_to_delay = 0
 	obj_damage = 0
-	harm_intent_damage = 10
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	density = FALSE
@@ -69,8 +68,10 @@
 	desc = "An incredibly huge virus!"
 	icon_state = "macrovirus_large"
 	melee_damage = 5
-	maxHealth = 20
-	health = 20
+	maxHealth = 12
+	health = 12
+	pass_flags = PASSTABLE | PASSGRILLE
+	density = TRUE
 	aggressive = TRUE
 
 /mob/living/simple_animal/hostile/macrophage/aggro/vector

--- a/code/modules/mob/living/simple_animal/hostile/macrophage.dm
+++ b/code/modules/mob/living/simple_animal/hostile/macrophage.dm
@@ -38,7 +38,7 @@
 		for(var/datum/disease/D in M.diseases)
 			if(D.GetDiseaseID() == basedisease.GetDiseaseID())
 				if(aggressive)
-					if(D.stage >= 3)
+					if(D.stage >= 4)
 						alreadyinfected = TRUE
 				else
 					alreadyinfected = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/macrophage.dm
+++ b/code/modules/mob/living/simple_animal/hostile/macrophage.dm
@@ -61,6 +61,10 @@
 					if(M.ForceContractDisease(D))
 						to_chat(src, "<span class ='notice'>You infect [M] with [D]</span>")
 				to_chat(M, "<span class ='userdanger'>[src] pierces your protection, and you feel a sharp stab!</span>")
+
+/mob/living/simple_animal/hostile/macrophage/proc/shrivel()
+	visible_message("<span class='danger'>the [src] shrivels up and dies!</span>")
+	dust()
 		
 
 /mob/living/simple_animal/hostile/macrophage/aggro


### PR DESCRIPTION
## About The Pull Request
after seeing it in action, used by a competent viro, and some thinking, this needs some change
-large phages have less health, small ones die in one punch at 0 resistance
-small phages dont have scaling damage anymore
-large phages can no longer stack multiple phages into a tile
-phage timing values tweaked, but not necessarily nerfed
-large phages are slightly more aggressive
-disease-spawned phages will die after five minutes pass

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/49600480/85199791-146a1300-b2a7-11ea-8c6e-721afaaa0ca8.png)
this disease wasn't intended to be this deadly. The three alive in this image died of chestbursting
## Changelog
:cl:
balance: nerfs macrophage
/:cl:

