### PR TITLE
changes to lexorin and sulfonal recipes

### DIFF
--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -54,7 +54,7 @@
 /datum/chemical_reaction/lexorin
 	name = "Lexorin"
 	id = /datum/reagent/toxin/lexorin
-	results = list(/datum/reagent/toxin/lexorin = 3)
+	results = list(/datum/reagent/toxin/lexorin = 4)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/sulfonal = 1)
 
 /datum/chemical_reaction/chloralhydrate

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -37,7 +37,7 @@
 	name = /datum/reagent/toxin/sulfonal
 	id = /datum/reagent/toxin/sulfonal
 	results = list(/datum/reagent/toxin/sulfonal = 3)
-	required_reagents = list(/datum/reagent/acetone = 1, /datum/reagent/diethylamine = 1, /datum/reagent/sulfur = 1)
+	required_reagents = list(/datum/reagent/medicine/perfluorodecalin = 1, /datum/reagent/diethylamine = 1, /datum/reagent/sulfur = 1)
 
 /datum/chemical_reaction/lipolicide
 	name = /datum/reagent/toxin/lipolicide
@@ -55,7 +55,7 @@
 	name = "Lexorin"
 	id = /datum/reagent/toxin/lexorin
 	results = list(/datum/reagent/toxin/lexorin = 3)
-	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1)
+	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/hydrogen = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/sulfonal = 1)
 
 /datum/chemical_reaction/chloralhydrate
 	name = "Chloral Hydrate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lexorin has been talked about as one of the best toxins for a while, and it has a piss-easy recipe, only requiring 3 basic chems. Sulfonal is objectively much worse than lexorin, yet has a much, much harder recipe. After some discussion on the discord, stormcaster has recommended these changes to the recipes. Sulfonal now takes perfluoro instead of acetone, and lexorin takes sulfonal as a 4th ingredient and giving 4u.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
See above, lexorin has been super easy to make and OP, while sulfonal has been pretty bad, with lexorin being basically an upgrade. This balances things a bit, making the recipe for lexorin take sulfonal and making it sort of a step-up from sulfonal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: sulfonal now takes perfluorodecalin instead of acetone
balance: lexorin now takes sulfonal, gives 4u.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
