### PR TITLE
Edited borg modules

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -372,6 +372,7 @@
 		/obj/item/holosign_creator/cyborg,
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
+		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/borg/projectile_dampen)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	cyborg_base_icon = "peace"
@@ -471,15 +472,14 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/hand_labeler/borg,
 		/obj/item/borg/charger,
-		/obj/item/razor,
 		/obj/item/rsf,
-		/obj/item/instrument/guitar,
 		/obj/item/instrument/piano_synth,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/lighter,
 		/obj/item/storage/bag/tray,
-		/obj/item/reagent_containers/borghypo/borgshaker,
-		/obj/item/borg/lollipop)
+		/obj/item/borg/apparatus/beaker,
+		/obj/item/cookiesynth,
+		/obj/item/reagent_containers/borghypo/borgshaker)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/borgshaker/hacked)
 	moduleselect_icon = "service"
 	special_light_key = "service"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All credit goes to Schneckenhof. Edited the borg modules of the following silicons: Peacekeeper, Serviceborg.
Peacekeeper has been equipped with pepper spray to keep the peace if necessary, servieborg was given cookie synth instead of the lollipop launcher and beaker apparatus

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes service borg more than just a walking keg and a lolipop launcher.
Beaker:
The Beaker allows the service borg to make the full range of drinks in addition to other tasks.
This has been requested multiple times in the forums.

Pepper Spray on Peaceborg:

Firstly, Compensate the Peaceborg for the loss of their cookie exclusivity.

Secondly, Peaceborg needs a mid-range ability. Basically they either sonic blast an entire room, or they have to get in close to stab someone with the hypo.

The current situation is bad in a typical toolbox murderspree situation:

    You get in close to use hypospray. But you misclick, now you are in toolbox range. Ouch. Oh he has armor. Your Hypo doesn't even penetrate. Ouch, you're now dead.

    You use Sonic blast. You have now knocked down the murderer, but you've also knocked down ALL 6 Sec officers who were helping. OOPS, The target has armor, is caffinated, and is on drugs. He recovers faster than everyone else, and proceeds to beat the downed officers to death.

OR:

    You pull out your trusty pepper pray, you catch 2 officers and the target in the blast, but the other 3 officers swoop in to decapitate and throw the target into deep space to arrest the perpetrator and hold a trial -- at least according to officer friendly standing there with bloodstained hands.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Remove: removed modules from service borg: guitar, razor, lollipop launcher.
Add: added modules for peacekeeper borg: pepperspray.
Add: added modules for service borg: cookie synth, beaker apparatus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
