### PR TITLE
Makes mindshield block cult stuns instead

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -430,7 +430,7 @@
 			if(istype(anti_magic_source, /obj/item))
 				target.visible_message("<span class='warning'>[L] is utterly unphased by your utterance!</span>", \
 									   "<span class='userdanger'>[user] whispers gibberish into your ear. Was that supposed to do something?</span>")
-		else if(L.get_ear_protection() <= 0)
+		else if(!HAS_TRAIT(target, TRAIT_MINDSHIELD))
 			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
 			L.Paralyze(160)
 			L.flash_act(1,1)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -414,7 +414,7 @@
 	if(iscultist(target))
 		return
 	if(iscultist(user))
-		user.visible_message("<span class='warning'>[user] whispers an unintelligable phrase into [L]'s ear.</span>", \
+		user.visible_message("<span class='warning'>[user] floods [L]'s mind with an eldritch energy!</span>", \
 							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
 
 		user.mob_light(_color = LIGHT_COLOR_BLOOD_MAGIC, _range = 3, _duration = 2)
@@ -429,7 +429,7 @@
 
 			if(istype(anti_magic_source, /obj/item))
 				target.visible_message("<span class='warning'>[L] is utterly unphased by your utterance!</span>", \
-									   "<span class='userdanger'>[user] whispers gibberish into your ear. Was that supposed to do something?</span>")
+									   "<span class='userdanger'>[GLOB.deity] protects you from the heresy of [user]!</span>")
 		else if(!HAS_TRAIT(target, TRAIT_MINDSHIELD))
 			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
 			L.Paralyze(160)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -444,8 +444,8 @@
 				C.cultslurring += 15
 				C.Jitter(15)
 		else
-			target.visible_message("<span class='warning'>[L] can't seem to hear you!</span>", \
-									   "<span class='userdanger'>[user] whispers something to you, but you can't quite make it out through your hearing protection.</span>")
+			target.visible_message("<span class='warning'>You fail to corrupt [L]'s mind!</span>", \
+									   "<span class='userdanger'>Your mindshield protects you from the heresy of [user]!</span>")
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -403,7 +403,7 @@
 //Stun
 /obj/item/melee/blood_magic/stun
 	name = "Forbidden Whispers"
-	desc = "A forgotten word that will drive the target to madness for a short time if their ears are unprotected."
+	desc = "A coil of death wrapped around your hand, anyone inflicted with this will have their mind flooded with the forbidden whispers of Nar'Sie, causing them to collapse in to a frenzy if they lack protection for their mind."
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -430,7 +430,7 @@
 			if(istype(anti_magic_source, /obj/item))
 				target.visible_message("<span class='warning'>[L] is utterly unphased by your utterance!</span>", \
 									   "<span class='userdanger'>[GLOB.deity] protects you from the heresy of [user]!</span>")
-		else if(!HAS_TRAIT(target, TRAIT_MINDSHIELD))
+		else if(!HAS_TRAIT(target, TRAIT_MINDSHIELD) && !istype(L.get_item_by_slot(SLOT_HEAD), /obj/item/clothing/head/foilhat))
 			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
 			L.Paralyze(160)
 			L.flash_act(1,1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes mindshield block cult stuns instead

## Why It's Good For The Game

Cult stuns based on hearing protection is stupid.
1. It's hard to tell if someone has hearing protection and will be affected (they can wear stuff over their ears too)
2. Anyone with a hardsuit or space suit is not convertible

It was intended to counter stun combat, however made the stun an unreliable tool that gets cult cucked way too easily.

having it based on the mindshield instead of the hearing protection is better for these reasons
 - Stealing sec glasses allows you to instantly see who can be affected
 - Combat stuns don't work, as anyone fighting cult *should* have a mindshield
 - Mindshields are a tool for security but aren't powergamed withing 5 minutes by assistants

Some other parts of cult may be overpowered, however, fucking up their only means of early game stealth completely destroys the flow of cult rounds and makes it either 50/50 cult vs sec in an epic battle/cult gets cucked early round and has no chance of winning (discovering cult early on almost guarantees their destruction)

Additionally, out of all the cult rounds I have seen, they only win around 15% of the time, so something that improves the gameplay experience for cultists significantly can't be too bad in terms of making cult literally unstoppable.

## Changelog
:cl:
tweak: Cult stun now works on mindshield instead of hearing protection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
