### PR TITLE
Corrects the schema version

### DIFF
--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -479,7 +479,7 @@ CREATE TABLE IF NOT EXISTS `SS13_schema_revision` (
   `date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`major`,`minor`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 5);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 6);
 
 
 


### PR DESCRIPTION
The schema version in the `beestation_schema.sql` file wasn't correctly updated before merging #1958 

(Only impacts brand new databases)