### PR TITLE
weekly cat surgeon buff [hopefully the last one]

### DIFF
--- a/code/modules/mapping/random_rooms.dm
+++ b/code/modules/mapping/random_rooms.dm
@@ -632,6 +632,7 @@
 	centerspawner = FALSE
 	template_height = 4
 	template_width = 5
+	weight = 6
 	stock = 2 //because i hate you
 
 /datum/map_template/random_room/sk_rdm076

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -34,6 +34,7 @@
 	status_flags = CANPUSH
 	del_on_death = 1
 	var/impatience = 0
+	rapid_melee = 2 //this lets him attack nearly as fast as a normal player, instead of half as fast as one. Without this, due to mood differences, a greytider in melee can actually facetank and beat him to death with only fists
 	hardattacks = TRUE
 
 /mob/living/simple_animal/hostile/cat_butcherer/Life()
@@ -86,7 +87,7 @@
 			say("I'm a genius!!")
 			if(L.mind && maxHealth <= 300) //if he robusts a tider, he becomes stronger
 				maxHealth += 20
-			L.health = maxHealth //he heals whenever he finishes
+				adjustHealth(-(maxHealth)) //he heals whenever he finishes
 		else if(L.stat) //quickly heal them up and move on to our next target! 
 			visible_message("[src] injects [L] with an unknown medicine!", "<span class='notice'>You inject [L] with medicine.</span>")
 			L.SetSleeping(0, FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -87,7 +87,7 @@
 			say("I'm a genius!!")
 			if(L.mind && maxHealth <= 300) //if he robusts a tider, he becomes stronger
 				maxHealth += 20
-				adjustHealth(-(maxHealth)) //he heals whenever he finishes
+			adjustHealth(-(maxHealth)) //he heals whenever he finishes
 		else if(L.stat) //quickly heal them up and move on to our next target! 
 			visible_message("[src] injects [L] with an unknown medicine!", "<span class='notice'>You inject [L] with medicine.</span>")
 			L.SetSleeping(0, FALSE)


### PR DESCRIPTION

## About The Pull Request
-cat surgeon now properly heals when robusting tiders, instead of not healing at all
-cat surgeon now attacks *almost* as fast as players do, so now he won't be beat by a tider who stands still and facetanks him while punching (yes, you can actually kill him this way, reliably, right now.)
-cat surgeon is now significantly rarer (IMO this is a buff, because people will not expect him as much)

## Why It's Good For The Game
I observe for the sole purpose of watching this fuck robust assistants in maints. he deserves a fighting chance.

## Changelog
:cl:
balance: you can no longer beat cat surgeon by standing still and facetanking his saw whilst punching
fix: cat surgeon properly heals when finishing operations 
tweak: cat surgeon is rarer
/:cl:
