### PR TITLE
Makes mindshield partially block cult stun

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -139,7 +139,7 @@
 //Cult Blood Spells
 /datum/action/innate/cult/blood_spell/stun
 	name = "Stun"
-	desc = "Empowers your hand to stun and mute a victim on contact."
+	desc = "Empowers your hand to stun and mute a weak-minded victim on contact."
 	button_icon_state = "hand"
 	magic_path = "/obj/item/melee/blood_magic/stun"
 	health_cost = 10
@@ -403,7 +403,7 @@
 //Stun
 /obj/item/melee/blood_magic/stun
 	name = "Forbidden Whispers"
-	desc = "A forgotten word that will drive the target to madness for a short time if their ears are unprotected."
+	desc = "A forgotten word that will drive the target to madness for a short time if their mind is unprotected."
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 
@@ -430,7 +430,17 @@
 			if(istype(anti_magic_source, /obj/item))
 				target.visible_message("<span class='warning'>[L] is utterly unphased by your utterance!</span>", \
 									   "<span class='userdanger'>[user] whispers gibberish into your ear. Was that supposed to do something?</span>")
-		else if(L.get_ear_protection() <= 0)
+		else if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+			var/mob/living/carbon/C = L
+			to_chat(user, "<span class='cultitalic'>Their mind was protected, but you still managed to do some damage!</span>")
+			to_chat(target,"<span class='userdanger'> Your mindshield partially protects you from the heresy of [user]!</span>")
+			C.stuttering += 8
+			C.dizziness += 30
+			C.Jitter(8)
+			C.drop_all_held_items()
+			C.bleed(40)
+			C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+		else
 			to_chat(user, "<span class='cultitalic'>[L] falls to the ground, gibbering madly!</span>")
 			L.Paralyze(160)
 			L.flash_act(1,1)
@@ -443,9 +453,6 @@
 				C.stuttering += 15
 				C.cultslurring += 15
 				C.Jitter(15)
-		else
-			target.visible_message("<span class='warning'>[L] can't seem to hear you!</span>", \
-									   "<span class='userdanger'>[user] whispers something to you, but you can't quite make it out through your hearing protection.</span>")
 		uses--
 	..()
 


### PR DESCRIPTION
## About The Pull Request

Alternative and closes #2036
 
Mindshieled person now takes 60 stamina damage, drops their held items, get's dizzy, jittery and loses about 8% of their blood from a stun attack.
If mindshields become a huge problem to cults mid/late game we can add sechuds to blindfolds.
Also if the whole stun commes out as too weak I'd suggest adding knockdown to it.

## Why It's Good For The Game

Makes it not useless against mindshielded and hearing protection is stupid and a gamble. 

## Changelog
:cl:
balance: Cult stun doesn't get blocked by hearing protection anymore!
balance: Mindshield now partially blocks stun. Mindshielded personnel get dizzy, lose some blood and take some stamina damage instead of full stun.
/:cl: