### PR TITLE
Fixes broken botany iconstates

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -308,7 +308,7 @@
 		else
 			plant_overlay.icon_state = myseed.icon_harvest
 	else
-		var/t_growthstate = min(round((age / myseed.maturation) * myseed.growthstages), myseed.growthstages)
+		var/t_growthstate = clamp(round((age / myseed.maturation) * myseed.growthstages), 1, myseed.growthstages)
 		plant_overlay.icon_state = "[myseed.icon_grow][t_growthstate]"
 	add_overlay(plant_overlay)
 


### PR DESCRIPTION
## About The Pull Request

Copied changes from https://github.com/tgstation/tgstation/pull/51340 to fix missing sprite states for certain botany plants.

## Why It's Good For The Game

It's just a bugfix.

## Changelog
:cl: ArcaneMusic
fix: fixed botany plants missing icon states
/:cl:
