### PR TITLE
Fixes push brooms breaking things

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -1006,7 +1006,10 @@
 	. = ..()
 	if(!proximity)
 		return
-	sweep(user, A, FALSE)
+	if(wielded)
+		sweep(user, A, FALSE)
+	else
+		to_chat(user, "<span class='warning'>You need to wield \the [src] in both hands to sweep!</span>")
 
 /obj/item/twohanded/pushbroom/proc/sweep(mob/user, atom/A, moving = TRUE)
 	var/turf/target
@@ -1014,9 +1017,9 @@
 		if (isturf(A))
 			target = A
 		else
-			target = A.loc
+			target = get_turf(A)
 	else
-		target = user.loc
+		target = get_turf(user)
 	if (locate(/obj/structure/table) in target.contents)
 		return
 	var/i = 0


### PR DESCRIPTION
Fixes #2060

## Changelog
:cl:
tweak: Push broom must be wielded in both hands to sweep.
fix: Push broom no longer causes really bad things to happen if you try to put it in a full backpack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
