### PR TITLE
Rust-g SQL Fixes Round 2

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -30,7 +30,6 @@ SUBSYSTEM_DEF(dbcore)
 	for(var/I in active_queries)
 		var/datum/DBQuery/Q = I
 		if(world.time - Q.last_activity_time > (5 MINUTES))
-			message_admins("Found undeleted query, please check the server logs and notify coders.")
 			log_sql("Undeleted query: \"[Q.sql]\" ARGS: \"[list2params(Q.arguments)]\" LA: [Q.last_activity] LAT: [Q.last_activity_time]")
 			qdel(Q)
 		if(MC_TICK_CHECK)

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -35,7 +35,7 @@
 				sql_roles_list += ":role[i]"
 			sql_roles = sql_roles_list.Join(", ")
 		else
-			sql_roles = roles
+			sql_roles = "'[roles]'"
 		var/datum/DBQuery/query_check_ban = SSdbcore.NewQuery({"
 			SELECT 1
 			FROM [format_table_name("ban")]

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -888,13 +888,13 @@
 	var/datum/DBQuery/query_edit_ban = SSdbcore.NewQuery({"
 		UPDATE [format_table_name("ban")]
 		SET
-			expiration_time = IF(:duration IS NULL, NULL, bantime + INTERVAL :duration [interval])
+			expiration_time = IF(:duration IS NULL, NULL, bantime + INTERVAL :duration [interval]),
 			applies_to_admins = :applies_to_admins,
 			reason = :reason,
-			gloabl_ban = :global_ban
+			global_ban = :global_ban,
 			ckey = :ckey,
 			ip = INET_ATON(:ip),
-			computerid = :ci
+			computerid = :cid,
 			edits = CONCAT(IFNULL(edits,''), :change_message)
 		WHERE [where]
 	"}, arguments)

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -136,8 +136,8 @@
 		text = query_find_del_message.item[3]
 	qdel(query_find_del_message)
 	var/datum/DBQuery/query_del_message = SSdbcore.NewQuery(
-		"UPDATE [format_table_name("messages")] SET deleted = 1, deleted_ckey = :deleted_ckey WHERE id = :id",
-		list("deleted_ckey" = deleted_by_ckey, "id" = message_id)
+		"UPDATE [format_table_name("messages")] SET deleted = 1, lasteditor = :last_editor WHERE id = :id",
+		list("last_editor" = deleted_by_ckey, "id" = message_id)
 	)
 	if(!query_del_message.warn_execute())
 		qdel(query_del_message)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed some added errors found with the new SQL system. Also, removed the qdel admin warning since qdel errors no longer matter under this system.

## Why It's Good For The Game

SQL errors bad

## Changelog
:cl:
fix: Bans & Notes can be edited again
fix: Resolves SQL error for Lavaland role ban checks
del: Removes qdel warning for admins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
