### PR TITLE
clown car can no longer be cheesed

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -207,8 +207,11 @@
 // this could be made more general, but for now just handle mulebot
 /mob/living/carbon/human/Crossed(atom/movable/AM)
 	var/mob/living/simple_animal/bot/mulebot/MB = AM
+	var/obj/vehicle/sealed/car/C = AM
 	if(istype(MB))
 		MB.RunOver(src)
+	if(istype(C))
+		C.RunOver(src)
 
 	. = ..()
 	spreadFire(AM)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -210,7 +210,7 @@
 	var/obj/vehicle/sealed/car/C = AM
 	if(istype(MB))
 		MB.RunOver(src)
-	if(istype(C))
+	else if(istype(C))
 		C.RunOver(src)
 
 	. = ..()

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -32,6 +32,23 @@
 	playsound(src, engine_sound, 100, TRUE)
 	return TRUE
 
+/obj/vehicle/sealed/car/proc/RunOver(mob/living/carbon/human/H) //pasted right out of mulebot code
+	log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
+	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
+					"<span class='userdanger'>[src] drives over you!</span>")
+	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+
+	var/damage = 10
+	H.apply_damage(2*damage, BRUTE, BODY_ZONE_HEAD)
+	H.apply_damage(2*damage, BRUTE, BODY_ZONE_CHEST)
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_LEG)
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_LEG)
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_ARM)
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_ARM)
+
+	var/turf/T = get_turf(src)
+	T.add_mob_blood(H)
+
 /obj/vehicle/sealed/car/MouseDrop_T(atom/dropping, mob/M)
 	if(M.stat || M.restrained())
 		return FALSE

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -64,6 +64,12 @@
 		to_chat(user, "<span class='danger'>You use the [banana] to repair the [src]!</span>")
 		qdel(banana)
 
+/obj/vehicle/sealed/car/clowncar/remove_occupant(mob/M)
+	. = ..()
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M 
+		C.uncuff()
+
 /obj/vehicle/sealed/car/clowncar/Bump(atom/movable/M)
 	. = ..()
 	if(isliving(M))
@@ -73,6 +79,7 @@
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
 			C.Paralyze(40) //I play to make sprites go horizontal
+			restraintarget(C)
 		L.visible_message("<span class='warning'>[src] rams into [L] and sucks him up!</span>") //fuck off shezza this isn't ERP.
 		mob_forced_enter(L)
 		playsound(src, pick('sound/vehicles/clowncar_ram1.ogg', 'sound/vehicles/clowncar_ram2.ogg', 'sound/vehicles/clowncar_ram3.ogg'), 75)
@@ -81,6 +88,23 @@
 		playsound(src, pick('sound/vehicles/clowncar_crash1.ogg', 'sound/vehicles/clowncar_crash2.ogg'), 75)
 		playsound(src, 'sound/vehicles/clowncar_crashpins.ogg', 75)
 		DumpMobs(TRUE)
+
+/obj/vehicle/sealed/car/clowncar/RunOver(mob/living/carbon/human/H)
+	mob_forced_enter(H)
+	H.visible_message("<span class='warning'>[src] drives over [H] and sucks him up!</span>")
+	restraintarget(H)
+
+/obj/vehicle/sealed/car/clowncar/proc/restraintarget(mob/living/carbon/C)
+	if(istype(C))
+		if(!C.handcuffed)
+			if(C.get_num_arms(FALSE) >= 2 || C.get_arm_ignore())
+				C.handcuffed = new /obj/item/restraints/handcuffs/energy/used(C)
+				C.update_handcuffed()
+				to_chat(C, "<span class = 'danger'> Your hands are restrained by the sheer volume of occupants in the car!</span>")
+
+/obj/item/restraints/handcuffs/energy/used/clown
+	name = "tangle of limbs"
+	desc = "You are restrained in a tangle of bodies!"
 
 /obj/vehicle/sealed/car/clowncar/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -100,6 +100,7 @@
 		if(iscarbon(i))
 			var/mob/living/carbon/Carbon = i
 			Carbon.Paralyze(40)
+			Carbon.uncuff()
 
 /obj/vehicle/sealed/proc/DumpSpecificMobs(flag, randomstep = TRUE)
 	for(var/i in occupants)
@@ -108,6 +109,7 @@
 			if(iscarbon(i))
 				var/mob/living/carbon/C = i
 				C.Paralyze(40)
+				C.uncuff()
 
 
 /obj/vehicle/sealed/AllowDrop()


### PR DESCRIPTION

## About The Pull Request
-clown car sucks people up if it runs them over whilst they are laying down
-clown car occupants are restrained, so they cant shoot the car from inside

## Why It's Good For The Game
spending 20 tc for something people can beat just by pressing the r"rest" button everyone gets is a real shame

## Changelog
:cl:
balance: clown car occupants are now restrained
balance: clown car can no longer be cheesed by laying down
/:cl:
