### PR TITLE
Optional, customisable inventory outline

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -111,11 +111,13 @@
 	if(ismecha(usr.loc)) // stops inventory actions in a mech
 		return TRUE
 
+	//This is where putting stuff into hands is handled
 	if(hud?.mymob && slot_id)
 		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
 		if(inv_item)
 			return inv_item.Click(location, control, params)
 
+	//Putting into something (if its not in us)
 	if(usr.attack_ui(slot_id))
 		usr.update_inv_hands()
 	return TRUE
@@ -123,11 +125,29 @@
 /obj/screen/inventory/MouseEntered()
 	..()
 	add_overlays()
+	//Apply the outline affect
+	add_stored_outline()
 
 /obj/screen/inventory/MouseExited()
 	..()
 	cut_overlay(object_overlays)
 	object_overlays.Cut()
+	remove_stored_outline()
+
+/obj/screen/inventory/proc/add_stored_outline()
+	if(hud?.mymob && slot_id)
+		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
+		if(inv_item)
+			if(hud?.mymob.incapacitated())
+				inv_item.apply_outline(COLOR_RED_GRAY)
+			else
+				inv_item.apply_outline()
+
+/obj/screen/inventory/proc/remove_stored_outline()
+	if(hud?.mymob && slot_id)
+		var/obj/item/inv_item = hud.mymob.get_item_by_slot(slot_id)
+		if(inv_item)
+			inv_item.remove_outline()
 
 /obj/screen/inventory/update_icon_state()
 	if(!icon_empty)
@@ -397,7 +417,7 @@
 	var/mob/living/user = hud?.mymob
 	if(!istype(user))
 		return
-	
+
 	if(!user.resting)
 		icon_state = "act_rest"
 	else
@@ -541,7 +561,7 @@
 	if(choice != selecting)
 		selecting = choice
 		update_icon()
-	
+
 	return TRUE
 
 /obj/screen/zone_sel/update_icon()
@@ -648,7 +668,7 @@
 	icon_state = "slime_health0"
 	screen_loc = ui_slime_health
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	
+
 /obj/screen/healths/lavaland_elite
 	icon = 'icons/mob/screen_elite.dmi'
 	icon_state = "elite_health0"

--- a/code/datums/components/storage/concrete/_concrete.dm
+++ b/code/datums/components/storage/concrete/_concrete.dm
@@ -122,11 +122,13 @@
 	var/list/seeing_mobs = can_see_contents()
 	for(var/mob/M in seeing_mobs)
 		M.client.screen -= AM
-	if(ismob(parent.loc) && isitem(AM))
+	if(isitem(AM))
 		var/obj/item/I = AM
-		var/mob/M = parent.loc
-		I.dropped(M)
 		I.item_flags &= ~IN_STORAGE
+		I.remove_outline()
+		if(ismob(parent.loc))
+			var/mob/M = parent.loc
+			I.dropped(M)
 	if(new_location)
 		//Reset the items values
 		_removal_reset(AM)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -500,6 +500,10 @@
 /datum/component/storage/proc/mousedrop_onto(datum/source, atom/over_object, mob/M)
 	set waitfor = FALSE
 	. = COMPONENT_NO_MOUSEDROP
+	var/atom/A = parent
+	if(istype(A, /obj/item))
+		var/obj/item/I = A
+		I.remove_outline()	//Removes the outline when we drag
 	if(!ismob(M))
 		return
 	if(!over_object)
@@ -508,7 +512,6 @@
 		return
 	if(M.incapacitated() || !M.canUseStorage())
 		return
-	var/atom/A = parent
 	A.add_fingerprint(M)
 	// this must come before the screen objects only block, dunno why it wasn't before
 	if(over_object == M)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -889,11 +889,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/apply_outline(colour = null)
 	if(usr.client)
-		if(!usr.client.prefs.overhead_chat)
+		if(!usr.client.prefs.outline_enabled)
 			return
 	if(!colour)
 		if(usr.client)
-			colour = COLOR_BLUE_GRAY
+			colour = usr.client.prefs.outline_color
+			if(!colour)
+				colour = COLOR_BLUE_GRAY
 		else
 			colour = COLOR_BLUE_GRAY
 	if(outline_filter)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -567,6 +567,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
+	remove_outline()
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -210,6 +210,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(force_string)
 		item_flags |= FORCE_STRING_OVERRIDE
 
+	if(istype(loc, /obj/item/storage))
+		item_flags |= IN_STORAGE
+
+	if(istype(loc, /obj/item/robot_module))
+		item_flags |= IN_INVENTORY
+
 	if(!hitsound)
 		if(damtype == "fire")
 			hitsound = 'sound/items/welder.ogg'
@@ -873,11 +879,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		var/timedelay = usr.client.prefs.tip_delay/100
 		var/user = usr
 		tip_timer = addtimer(CALLBACK(src, .proc/openTip, location, control, params, user), timedelay, TIMER_STOPPABLE)//timer takes delay in deciseconds, but the pref is in milliseconds. dividing by 100 converts it.
-		var/mob/living/L = user
-		if(istype(L) && L.incapacitated())
-			apply_outline(COLOR_RED_GRAY)
-		else
-			apply_outline()
+	var/mob/living/L = usr
+	if(istype(L) && L.incapacitated())
+		apply_outline(COLOR_RED_GRAY)
+	else
+		apply_outline()
 
 /obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	. = ..()
@@ -889,6 +895,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	remove_outline()
 
 /obj/item/proc/apply_outline(colour = null)
+	if(!(item_flags & IN_INVENTORY || item_flags & IN_STORAGE) || QDELETED(src))
+		return
 	if(usr.client)
 		if(!usr.client.prefs.outline_enabled)
 			return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -522,7 +522,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>UI Style:</b> <a href='?_src_=prefs;task=input;preference=ui'>[UI_style]</a><br>"
 			dat += "<b>Overhead Chat:</b> <a href='?_src_=prefs;preference=overheadchat'>[overhead_chat ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Outline:</b> <a href='?_src_=prefs;preference=outline_enabled'>[outline_enabled ? "Enabled" : "Disabled"]</a><br>"
-			dat += "<b>Outline Color:</b> <span style='border:1px solid #161616; background-color: [outline_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=outline_color;task=input'>Change</a><BR>"
+			dat += "<b>Outline Color:</b> <span style='border:1px solid #161616; background-color: [outline_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=outline_color'>Change</a><BR>"
 			dat += "<b>tgui Monitors:</b> <a href='?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary" : "All"]</a><br>"
 			dat += "<b>tgui Style:</b> <a href='?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy" : "No Frills"]</a><br>"
 			dat += "<br>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -27,6 +27,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/UI_style = null
 	var/overhead_chat = TRUE
+	var/outline_enabled = TRUE
+	var/outline_color = COLOR_BLUE_GRAY
 	var/buttons_locked = FALSE
 	var/hotkeys = FALSE
 	var/tgui_fancy = TRUE
@@ -519,6 +521,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<h2>General Settings</h2>"
 			dat += "<b>UI Style:</b> <a href='?_src_=prefs;task=input;preference=ui'>[UI_style]</a><br>"
 			dat += "<b>Overhead Chat:</b> <a href='?_src_=prefs;preference=overheadchat'>[overhead_chat ? "Enabled" : "Disabled"]</a><br>"
+			dat += "<b>Outline:</b> <a href='?_src_=prefs;preference=outline_enabled'>[outline_enabled ? "Enabled" : "Disabled"]</a><br>"
+			dat += "<b>Outline Color:</b> <span style='border:1px solid #161616; background-color: [outline_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=outline_color;task=input'>Change</a><BR>"
 			dat += "<b>tgui Monitors:</b> <a href='?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary" : "All"]</a><br>"
 			dat += "<b>tgui Style:</b> <a href='?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy" : "No Frills"]</a><br>"
 			dat += "<br>"
@@ -1640,6 +1644,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					tgui_fancy = !tgui_fancy
 				if("overheadchat")
 					overhead_chat = !overhead_chat
+				if("outline_enabled")
+					outline_enabled = !outline_enabled
+				if("outline_color")
+					var/pickedOutlineColor = input(user, "Choose your outline color.", "General Preference", outline_color) as color|null
+					if(pickedOutlineColor)
+						outline_color = pickedOutlineColor
 				if("tgui_lock")
 					tgui_lock = !tgui_lock
 				if("winflash")
@@ -1711,7 +1721,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("ghost_pda")
 					chat_toggles ^= CHAT_GHOSTPDA
-				
+
 				if("ghost_laws")
 					chat_toggles ^= CHAT_GHOSTLAWS
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -44,6 +44,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
 	if(current_version < 29)
 		overhead_chat = TRUE
+		outline_enabled = TRUE
+		outline_color = COLOR_BLUE_GRAY
 	return
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
@@ -143,6 +145,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["lastchangelog"]		>> lastchangelog
 	S["UI_style"]			>> UI_style
 	S["overhead_chat"]		>> overhead_chat
+	S["outline_color"]		>> outline_color
+	S["outline_enabled"]	>> outline_enabled
 	S["hotkeys"]			>> hotkeys
 	S["tgui_fancy"]			>> tgui_fancy
 	S["tgui_lock"]			>> tgui_lock
@@ -243,6 +247,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["lastchangelog"], lastchangelog)
 	WRITE_FILE(S["UI_style"], UI_style)
 	WRITE_FILE(S["overhead_chat"], overhead_chat)
+	WRITE_FILE(S["outline_enabled"], outline_enabled)
+	WRITE_FILE(S["outline_color"], outline_color)
 	WRITE_FILE(S["hotkeys"], hotkeys)
 	WRITE_FILE(S["tgui_fancy"], tgui_fancy)
 	WRITE_FILE(S["tgui_lock"], tgui_lock)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	29
+#define SAVEFILE_VERSION_MAX	30
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -44,6 +44,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /datum/preferences/proc/update_preferences(current_version, savefile/S)
 	if(current_version < 29)
 		overhead_chat = TRUE
+	if(current_version < 30)
 		outline_enabled = TRUE
 		outline_color = COLOR_BLUE_GRAY
 	return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -258,11 +258,12 @@
   */
 /mob/proc/attack_ui(slot)
 	var/obj/item/W = get_active_held_item()
-
 	if(istype(W))
+		//IF HELD TRY APPLY TO SLOT
 		if(equip_to_slot_if_possible(W, slot,0,0,0))
+			W.apply_outline()
 			return 1
-
+	//IF NO ITEM IS HELD, APPLY TO SLOT
 	if(!W)
 		// Activate the item
 		var/obj/item/I = get_item_by_slot(slot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Outlines items in your inventory when you hover over them.
Includes options for toggling on and off and changing the colour.

Makes sure the object is only outlined when it should be, so checks for dragging and storage interactions are included, and from testing, it has been robust so far.

Additionally, the effect applies when you hover over the item, or when you hover over the inventory slot.
Especially for smaller items, this provides a lot of visual feedback and makes the game generally more accessable (Not that that is a huge focus of SS13).

## Why It's Good For The Game

Makes it look more modern and provides a nice effect.

![image](https://user-images.githubusercontent.com/26465327/86166026-0d939980-bb0c-11ea-801b-7bf5dfcf7131.png)
![image](https://user-images.githubusercontent.com/26465327/86166042-11bfb700-bb0c-11ea-9433-1977b5f56e38.png)
![image](https://user-images.githubusercontent.com/26465327/86166065-1a17f200-bb0c-11ea-986c-ec3d05a2db6c.png)
![image](https://user-images.githubusercontent.com/26465327/86166105-269c4a80-bb0c-11ea-8aac-bc001b39a253.png)
![image](https://user-images.githubusercontent.com/26465327/86166130-30be4900-bb0c-11ea-8159-348855cebb2b.png)
![image](https://user-images.githubusercontent.com/26465327/86166139-3320a300-bb0c-11ea-8b2e-0d12f983adce.png)

(I have 2 videos that I can supply in discord)

## Changelog
:cl:
add: Optional and customisable outlining on inventory items.
fix: Fixes a bug with storages on the ground not removing IN_STORAGE flag from items taken out of them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
