### PR TITLE
Dissable the space wizard academy from gateway missions untill its fixed

### DIFF
--- a/config/Sage/awaymissionconfig.txt
+++ b/config/Sage/awaymissionconfig.txt
@@ -10,7 +10,7 @@
 _maps/RandomZLevels/blackmarketpackers.dmm
 _maps/RandomZLevels/spacebattle.dmm
 _maps/RandomZLevels/beach.dmm
-_maps/RandomZLevels/Academy.dmm
+#_maps/RandomZLevels/Academy.dmm
 _maps/RandomZLevels/wildwest.dmm
 _maps/RandomZLevels/challenge.dmm
 _maps/RandomZLevels/centcomAway.dmm

--- a/config/awaymissionconfig.txt
+++ b/config/awaymissionconfig.txt
@@ -10,7 +10,7 @@
 _maps/RandomZLevels/blackmarketpackers.dmm
 _maps/RandomZLevels/spacebattle.dmm
 _maps/RandomZLevels/TheBeach.dmm
-_maps/RandomZLevels/Academy.dmm
+#_maps/RandomZLevels/Academy.dmm until its fixed this is just smack-a-window
 _maps/RandomZLevels/wildwest.dmm
 _maps/RandomZLevels/challenge.dmm
 _maps/RandomZLevels/centcomAway.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Temporarily comment out  the space wizard academy from available gateway missions until it gets redone by some one(or myself)

## Why It's Good For The Game

As it stands now, it's trivial to depressure the entire academy and grab all the loot without any sort of struggle. Even player spawned wizard head masters die at the whole no air.

## Changelog
:cl:
del: Wizard academy has been dissabeld from gateway missions for now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
