### PR TITLE
Modify Canister Gas verb

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -122,7 +122,7 @@
 
 // misc
 #define VV_HK_SPACEVINE_PURGE "spacevine_purge"
-
+#define VV_HK_MODIFY_CANISTER_GAS "modify_canister_gas"
 
 
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -174,6 +174,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/cmd_display_overlay_log,
 	/client/proc/reload_configuration,
 	/datum/admins/proc/create_or_modify_area,
+	/client/proc/modify_canister_gas
 	)
 
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -173,8 +173,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/cmd_display_init_log,
 	/client/proc/cmd_display_overlay_log,
 	/client/proc/reload_configuration,
-	/datum/admins/proc/create_or_modify_area,
-	/client/proc/modify_canister_gas
+	/datum/admins/proc/create_or_modify_area
 	)
 
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -884,7 +884,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if(alert(usr, "Are you absolutely sure you want to reload the configuration from the default path on the disk, wiping any in-round modificatoins?", "Really reset?", "No", "Yes") == "Yes")
 		config.admin_reload()
 
-/client/proc/modify_canister_gas(obj/machinery/portable_atmospherics/canister/C in world)
+/client/proc/modify_canister_gas(obj/machinery/portable_atmospherics/canister/C)
 	set category = "Debug"
 	set name = "Modify Canister Gas"
 	set desc = "Add/modify a gas in a canister"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -885,14 +885,10 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		config.admin_reload()
 
 /client/proc/modify_canister_gas(obj/machinery/portable_atmospherics/canister/C)
-	set category = "Debug"
-	set name = "Modify Canister Gas"
-	set desc = "Add/modify a gas in a canister"
-
 	if(!check_rights(R_DEBUG) || !C)
 		return
 
-	var/gas_to_add = input(usr, "Choose a gas to modify.", "Choose a gas.") as null|anything in (subtypesof(/datum/gas) - /datum/gas/unobtanium)
+	var/gas_to_add = input(usr, "Choose a gas to modify.", "Choose a gas.") as null|anything in (subtypesof(/datum/gas) - /datum/gas/unobtanium) //nice try
 	var/amount = input(usr, "Choose the amount of moles.", "Choose the amount.", 0) as num
 	var/temp = input(usr, "Choose the temperature (Kelvin).", "Choose the temp (K).", 0) as num
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -883,3 +883,24 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		return
 	if(alert(usr, "Are you absolutely sure you want to reload the configuration from the default path on the disk, wiping any in-round modificatoins?", "Really reset?", "No", "Yes") == "Yes")
 		config.admin_reload()
+
+/client/proc/modify_canister_gas(obj/machinery/portable_atmospherics/canister/C in world)
+	set category = "Debug"
+	set name = "Modify Canister Gas"
+	set desc = "Add/modify a gas in a canister"
+
+	if(!check_rights(R_DEBUG) || !C)
+		return
+
+	var/gas_to_add = input(usr, "Choose a gas to modify.", "Choose a gas.") as null|anything in (subtypesof(/datum/gas) - /datum/gas/unobtanium)
+	var/amount = input(usr, "Choose the amount of moles.", "Choose the amount.", 0) as num
+	var/temp = input(usr, "Choose the temperature (Kelvin).", "Choose the temp (K).", 0) as num
+
+
+	C.air_contents.set_moles(gas_to_add, amount)
+	C.air_contents.set_temperature(temp)
+	C.update_icon()
+
+	message_admins("<span class='adminnotice'>[key_name_admin(src)] modified \the [C.name] at [AREACOORD(C)] - Gas: [gas_to_add], Moles: [amount], Temp: [temp].</span>")
+	log_admin("[key_name_admin(src)] modified \the [C.name] at [AREACOORD(C)] - Gas: [gas_to_add], Moles: [amount], Temp: [temp].")
+

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -185,7 +185,14 @@
 	filled = 1
 	release_pressure = ONE_ATMOSPHERE*2
 
+/obj/machinery/portable_atmospherics/canister/vv_get_dropdown()
+	. = ..()
+	VV_DROPDOWN_OPTION(VV_HK_MODIFY_CANISTER_GAS, "Modify Canister Gas")
 
+/obj/machinery/portable_atmospherics/canister/vv_do_topic(href_list)
+	. = ..()
+	if(href_list[VV_HK_MODIFY_CANISTER_GAS])
+		usr.client.modify_canister_gas(src)
 
 /obj/machinery/portable_atmospherics/canister/New(loc, datum/gas_mixture/existing_mixture)
 	. = ..()


### PR DESCRIPTION
Adds a VV dropdown verb to canisters (requires DEBUG) to modify gasses in it. 

The way that gas contents work is that you don't actually *add* or *remove* a gas. You directly set the amount of a gas type in the mixture. In layman's terms this effectively means that everything has 0 moles of every gas unless set to a higher amount. So we set the moles of a chosen gas, then set the temperature for the mixture.

Demo: https://streamable.com/9m4ljh (Verb has since been moved from right click to VV dropdown)

## Changelog
:cl:
add: Admins can now easily modify a gas in a canister using VV dropdown.
/:cl:

