### PR TITLE
Fixes a division-by-zero runtime in carbon_defense.dm

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -122,7 +122,7 @@
 						update_inv_head()
 
 		//dismemberment
-		var/dismemberthreshold = (((affecting.max_damage * 2) / max(I.sharpness, 0.5) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
+		var/dismemberthreshold = (((affecting.max_damage * 2) / max(I.sharpness, 0.5)) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 		if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 			dismemberthreshold -= 50
 		if(I.sharpness)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -122,7 +122,7 @@
 						update_inv_head()
 
 		//dismemberment
-		var/dismemberthreshold = (((affecting.max_damage * 2) / I.sharpness) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
+		var/dismemberthreshold = (((affecting.max_damage * 2) / max(I.sharpness, 0.5) - (affecting.get_damage() + ((I.w_class - 3) * 10) + ((I.attack_weight - 1) * 15)))
 		if(HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
 			dismemberthreshold -= 50
 		if(I.sharpness)


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed a divide-by-zero runtime when determining if a blunt object will dismember someone. I can't wait to see what hilarious dismemberment bugs will ensue.
/:cl:

