### PR TITLE
Fixes a material dupe bug

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -287,6 +287,8 @@
 	amount -= used
 	if(check)
 		zero_amount()
+	for(var/i in custom_materials)
+		custom_materials[i] = amount * mats_per_stack
 	update_icon()
 	update_weight()
 	return TRUE
@@ -378,6 +380,8 @@
 	if(!use(amount, TRUE, FALSE))
 		return FALSE
 	var/obj/item/stack/F = new type(user? user : drop_location(), amount, FALSE)
+	for(var/i in F.custom_materials)
+		custom_materials[i] -= F.custom_materials[i]
 	. = F
 	F.copy_evidences(src)
 	if(user)


### PR DESCRIPTION
## About The Pull Request

from: https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29398561

## Why It's Good For The Game

Fixes stack-splitting dupe bug as described in https://github.com/tgstation/tgstation/pull/47855

## Changelog
:cl: yorii
fix: fixed stack-splitting dupe bug
/:cl:
