### PR TITLE
Biogenerator update

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -194,3 +194,11 @@
 	materials = list(/datum/material/biomass= 300)
 	build_path = /obj/item/clothing/head/rice_hat
 	category = list("initial","Organic Materials")
+
+/datum/design/paper
+	name = "Sheet of Paper"
+	id = "paper"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 10)
+	build_path = /obj/item/stack/sheet/paper
+	category = list("initial","Organic Materials")


### PR DESCRIPTION
Biogenerators now can create sheets of paper for 10 biomass per sheet.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The biogenerator can now produce new item: sheet of paper for 10 biomass.

## Why It's Good For The Game

This minor change lets botany help all departments with paperwork, especially to cargo since paper can only be found and bought in supply console. It also makes sense for biogenerator to create paper since paper is generally made out of wood.

## Changelog
:cl:
add: Added ability for Biogenerators to create paper.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
