### PR TITLE
Fixes Hyperspeed Conveyors

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -127,10 +127,6 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		operating = FALSE
 	icon_state = "conveyor[operating * verted]"
 
-/obj/machinery/conveyor/proc/convey(items)
-	for(var/M in items)
-		step(M, movedir)
-
 	// machine process
 	// move items to the target location
 /obj/machinery/conveyor/process()
@@ -159,6 +155,11 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(affected.len)
 		//moving is slightly delayed to prevent moving to a conveyor which has yet to be ticked, creating bluespace-tier conveyor speeds
 		addtimer(CALLBACK(src, .proc/convey, affected), 0)
+
+/obj/machinery/conveyor/proc/convey(items)
+	if(operating) //the problem with slightly delaying movement is that stuff gets confused right after the conveyors are turned off
+		for(var/M in items)
+			step(M, movedir)
 
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(obj/item/I, mob/user, params)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -127,6 +127,10 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		operating = FALSE
 	icon_state = "conveyor[operating * verted]"
 
+/obj/machinery/conveyor/proc/convey(items)
+	for(var/M in items)
+		step(M, movedir)
+
 	// machine process
 	// move items to the target location
 /obj/machinery/conveyor/process()
@@ -138,6 +142,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	use_power(6)
 	//get the first 30 items in contents
 	var/i = 0
+	var/list/affected = list()
 	for(var/atom/movable/M in T)
 		if(M == src)
 			continue
@@ -147,10 +152,13 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 				var/mob/living/L = M
 				if((L.movement_type & FLYING) && !L.stat)
 					continue
-			step(M, movedir)
+			affected.Add(M)
 		if(i >= MAX_CONVEYOR_ITEMS_MOVE)
 			break
 		CHECK_TICK
+	if(affected.len)
+		//moving is slightly delayed to prevent moving to a conveyor which has yet to be ticked, creating bluespace-tier conveyor speeds
+		addtimer(CALLBACK(src, .proc/convey, affected), 0)
 
 // attack with item, place item on conveyor
 /obj/machinery/conveyor/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
## About The Pull Request


Before:
![ut87DubU9v](https://user-images.githubusercontent.com/36010999/86519112-04594400-be0e-11ea-8659-2c93a5eb75be.gif)
After:
![jqKxmYnQPu](https://user-images.githubusercontent.com/36010999/86519118-0ae7bb80-be0e-11ea-8377-fb192b5351c6.gif)


## Why It's Good For The Game

Ludicrous speed is too dangerous

## Changelog
:cl: Trigg
fix: Nanotrasen regrets to inform that the blueprints for bluespace conveyors were NOT intended for use by Space Station 13, and future stations will be equipped with normal-speed conveyor equipment.
/:cl: