### PR TITLE
Brings back pages to the unban panel

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -641,8 +641,8 @@
 		"}, list(
 			"player_key" = ckey(player_key),
 			"admin_key" = ckey(admin_key),
-			"player_ip" = player_ip,
-			"player_cid" = player_cid,
+			"player_ip" = player_ip || null,
+			"player_cid" = player_cid || null,
 		))
 		if(!query_unban_count_bans.warn_execute())
 			qdel(query_unban_count_bans)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One of the ported queries didn't correctly null out variables that could be unused, which would almost always result in a false result for the bancount query.

## Why It's Good For The Game

Admins can see all the bans again

## Changelog
:cl:
fix: The unban panel will correctly pagify bans again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
