### PR TITLE
Updated Description for IPC Posibrain

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -246,7 +246,7 @@
 	slot = "brain"
 	zone = "chest"
 	status = ORGAN_ROBOTIC
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top."
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top. In order for this Posibrain to be used as a newly built Positronic Brain, it must be coupled with an MMI."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain-occupied"
 	organ_flags = ORGAN_SYNTHETIC


### PR DESCRIPTION
Hopefully clues new roboticists into properly borging IPC's

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updated the description for the IPC Posibrain to include their requirement to be put into a MMI before borging.

## Why It's Good For The Game

Due to the similarities with a Posibrain and a Positronic Brain new roboticists generally fail to borg an IPC. This is frustrating for both the IPC and the Roboticist and this added sentence might make the process a little smoother.

also @zeskorion made this suggestion in #1206.

## Changelog
:cl:

tweak: Changed the description of the IPC's Positronic Brain to highlight the requirement of an MMI before borging.

/:cl:

