### PR TITLE
makes spacevines threatening

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -22,7 +22,7 @@
 
 	if(turfs.len) //Pick a turf to spawn at if we can
 		var/turf/T = pick(turfs)
-		new /datum/spacevine_controller(T, event = src) //spawn a controller at turf
+		new /datum/spacevine_controller(T, list(pick(subtypesof(/datum/spacevine_mutation))), rand(10,100), rand(1,6), src) //spawn a controller at turf with randomized stats and a single random mutation
 
 
 /datum/spacevine_mutation
@@ -377,11 +377,9 @@
 	init_subtypes(/datum/spacevine_mutation/, vine_mutations_list)
 	if(potency != null)
 		mutativeness = potency / 10
-	else
-		mutativeness = rand(1, 6)
-	if(production != null)
-		spread_cap *= production / 5
-		spread_multiplier /= production / 5
+	if(production != null && production <= 10) //Prevents runtime in case production is set to 11.
+		spread_cap *= (11 - production) / 5 //Best production speed of 1 doubles spread_cap to 60 while worst speed of 10 lowers it to 6. Even distribution.
+		spread_multiplier /= (11 - production) / 5
 
 /datum/spacevine_controller/vv_get_dropdown()
 	. = ..()
@@ -430,7 +428,7 @@
 		var/obj/item/seeds/kudzu/KZ = new(S.loc)
 		KZ.mutations |= S.mutations
 		KZ.set_potency(mutativeness * 10)
-		KZ.set_production((spread_cap / initial(spread_cap)) * 5)
+		KZ.set_production(11 - (spread_cap / initial(spread_cap)) * 5) //Reverts spread_cap formula so resulting seed gets original production stat or equivalent back.
 		qdel(src)
 
 /datum/spacevine_controller/process()


### PR DESCRIPTION
## About The Pull Request
-spacevines now spawn in maint, not in exposed hallways
-spacevines now slowly break structures in their way. They won't break fuel tanks, external airlocks, firelocks, or SMES units, however, as to avoid hullbreaches.
-spacevines now start with random mutability between 1 and 6%, instead of a fixed 1% chance per spread
-ports https://github.com/tgstation/tgstation/pull/52116

## Why It's Good For The Game
spacevines is boring and kudzu is super easy to contain

## Changelog 
:cl: Zeskorion, Angustmeta
tweak: spacevines now spawn in maint, not halls
tweak: spacevines now break shit that's in their way
tweak: spacevines spawn with random stats and a single mutation
fix: fixed space vines / kudzu growing slower from better (lower) production speed
balance: random event space vines buffed to have 1-6 production instead of 5-10 to compensate
/:cl:

