### PR TITLE
Telescopic riot shield can be equipped in security belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -214,7 +214,8 @@
 		/obj/item/clothing/gloves,
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/holosign_creator/security,
-		/obj/item/club
+		/obj/item/club,
+		/obj/item/shield/riot/tele
 		))
 
 /obj/item/storage/belt/security/full/PopulateContents()


### PR DESCRIPTION
## About The Pull Request

Makes the telescopic riot shield in its inactive state equippable in a security belt.

## Why It's Good For The Game

Pretty self-explanatory, just gives you another place to put the telescopic riot shield.

## Changelog
:cl:
tweak: telescopic shield can be held in security belt
/:cl:


