### PR TITLE
small riot shield nerf

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -87,7 +87,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/shields_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
-	block_level = 2
+	block_level = 1
 	force = 10
 	throwforce = 5
 	throw_speed = 2


### PR DESCRIPTION

## About The Pull Request

bacon sez riot shield op. it is the best stationside shield atm, and sec alreaaaady has the best melee weapon, so....
nerfs riot shield block level by 1, it now blocks only as good as normal shields

## Why It's Good For The Game
sec already 2 guud melee lol

## Changelog
:cl:
balance: riot shield has a lower block power
/:cl:

