### PR TITLE
Cakehat

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -48,10 +48,9 @@
 	hitsound = 'sound/weapons/tap.ogg'
 	var/hitsound_on = 'sound/weapons/sear.ogg' //so we can differentiate between cakehat and energyhat
 	var/hitsound_off = 'sound/weapons/tap.ogg'
-	var/force_on = 15
-	var/throwforce_on = 15
+	var/force_on = 12
+	var/throwforce_on = 12
 	var/damtype_on = BURN
-	var/single_use = TRUE
 	flags_inv = HIDEEARS|HIDEHAIR
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	brightness_on = 2 //luminosity when on
@@ -88,32 +87,6 @@
 
 /obj/item/clothing/head/hardhat/cakehat/is_hot()
 	return on * heat
-
-/obj/item/clothing/head/hardhat/cakehat/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
-	. = ..()
-	if(ishuman(hit_atom) && single_use)
-		splat(hit_atom)
-
-/obj/item/clothing/head/hardhat/cakehat/attack(mob/M, mob/user, def_zone)
-	. = ..()
-	if(single_use)
-		splat(M)
-
-/obj/item/clothing/head/hardhat/cakehat/proc/splat(mob/M)
-	if(ishuman(M))
-		var/mob/living/carbon/human/C = M
-		var/mutable_appearance/overlay = mutable_appearance('icons/effects/creampie.dmi')
-		if(C.dna.species.limbs_id == "lizard")
-			overlay.icon_state = "creampie_lizard"
-		else
-			overlay.icon_state = "creampie_human"
-		if(!C.creamed)
-			C.add_overlay(overlay)
-			C.creamed = TRUE
-		C.Paralyze(20) //splat!
-	M.adjust_blurriness(1)
-	M.visible_message("<span class='warning'>[M] is smashed in the face by [src]!</span>", "<span class='userdanger'>You've been cake'd by [src]!</span>")
-	qdel(src)
 
 /obj/item/clothing/head/hardhat/cakehat/energycake
 	name = "energy cake"

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -91,12 +91,12 @@
 
 /obj/item/clothing/head/hardhat/cakehat/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
 	. = ..()
-	if(ishuman(hit_atom) && . && single_use)
+	if(ishuman(hit_atom) && single_use)
 		splat(hit_atom)
 
 /obj/item/clothing/head/hardhat/cakehat/attack(mob/M, mob/user, def_zone)
 	. = ..()
-	if(. && single_use)
+	if(single_use)
 		splat(M)
 
 /obj/item/clothing/head/hardhat/cakehat/proc/splat(mob/M)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -101,7 +101,6 @@
 	force_on = 18 //same as epen (but much more obvious)
 	brightness_on = 3
 	heat = 0
-	single_use = FALSE
 
 /obj/item/clothing/head/hardhat/cakehat/energycake/turn_on(mob/living/user)
 	playsound(user, 'sound/weapons/saberon.ogg', 5, TRUE)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -51,6 +51,7 @@
 	var/force_on = 15
 	var/throwforce_on = 15
 	var/damtype_on = BURN
+	var/single_use = TRUE
 	flags_inv = HIDEEARS|HIDEHAIR
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	brightness_on = 2 //luminosity when on
@@ -88,6 +89,25 @@
 /obj/item/clothing/head/hardhat/cakehat/is_hot()
 	return on * heat
 
+/obj/item/clothing/head/hardhat/cakehat/attack(mob/M, mob/user, def_zone)
+	. = ..()
+	if(!. || single_use)
+		return
+	if(ishuman(M))
+		var/mob/living/carbon/human/C = M
+		var/mutable_appearance/overlay = mutable_appearance('icons/effects/creampie.dmi')
+		if(C.dna.species.limbs_id == "lizard")
+			overlay.icon_state = "creampie_lizard"
+		else
+			overlay.icon_state = "creampie_human"
+		if(!C.creamed)
+			C.add_overlay(overlay)
+			C.creamed = TRUE
+		C.Paralyze(20) //splat!
+	M.adjust_blurriness(1)
+	M.visible_message("<span class='warning'>[M] is smashed in the face by [src]!</span>", "<span class='userdanger'>You've been cake'd by [src]!</span>")
+	qdel(src)
+
 /obj/item/clothing/head/hardhat/cakehat/energycake
 	name = "energy cake"
 	desc = "You put the energy sword on your cake. Brilliant."
@@ -101,6 +121,7 @@
 	force_on = 18 //same as epen (but much more obvious)
 	brightness_on = 3
 	heat = 0
+	single_use = FALSE
 
 /obj/item/clothing/head/hardhat/cakehat/energycake/turn_on(mob/living/user)
 	playsound(user, 'sound/weapons/saberon.ogg', 5, TRUE)

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -89,10 +89,17 @@
 /obj/item/clothing/head/hardhat/cakehat/is_hot()
 	return on * heat
 
+/obj/item/clothing/head/hardhat/cakehat/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
+	. = ..()
+	if(ishuman(hit_atom) && . && single_use)
+		splat(hit_atom)
+
 /obj/item/clothing/head/hardhat/cakehat/attack(mob/M, mob/user, def_zone)
 	. = ..()
-	if(!. || single_use)
-		return
+	if(. && single_use)
+		splat(M)
+
+/obj/item/clothing/head/hardhat/cakehat/proc/splat(mob/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/C = M
 		var/mutable_appearance/overlay = mutable_appearance('icons/effects/creampie.dmi')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the cake hat's damage from 15 to 12, a minor decrease to make it less powergaming for people to rush so I don't have to care about it anymore.

## Why It's Good For The Game

if u disagre ban 4 powergaym 

## Changelog
:cl:
balance: nerfs the cake hat to have the equivalent amount of damage as the toolbox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
