### PR TITLE
Enables viro bottle printing and infection logging

### DIFF
--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -131,6 +131,9 @@ LOG_PRAYER
 ## log lawchanges
 LOG_LAW
 
+## log viruses
+LOG_VIRUS
+
 ## log crew manifest to seperate file
 LOG_MANIFEST
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -128,6 +128,9 @@ LOG_PRAYER
 ## log lawchanges
 LOG_LAW
 
+## log viruses
+LOG_VIRUS
+
 ## log crew manifest to seperate file
 LOG_MANIFEST
 


### PR DESCRIPTION

##About The Pull Request

This **enables** virology logging that was disabled and absent in the configs for some reason. It logs PANDEMIC printing of disease bottles, infection of new infectees and badmin disease spawns. 

This is the first part of additional logging PRs.
@bloons3 paid me for this.
## Why It's Good For The Game

Admins can identify the source of the plague more easily.

## Changelog
:cl:
admin: Important virus events are now logged.
/:cl:
