### PR TITLE
Changes Bee Infestation Thresholds

### DIFF
--- a/code/datums/diseases/advance/symptoms/beesymptom.dm
+++ b/code/datums/diseases/advance/symptoms/beesymptom.dm
@@ -11,8 +11,8 @@
 	symptom_delay_max = 20
 	var/honey = FALSE
 	var/toxic_bees= FALSE
-	threshold_desc = "<b>Resistance 14:</b> The bees become symbiotic with the host, synthesizing honey and no longer stinging the stomach lining, and no longer attacking the host.<br>\
-					  <b>Transmission 10:</b> Bees now contain a completely random toxin, unless resistance exceeds 14"
+	threshold_desc = "<b>Resistance 14:</b> The bees become symbiotic with the host, synthesizing honey and no longer stinging the stomach lining, and no longer attacking the host. Bees will also contain honey, unless transmission exceeds 10.<br>\
+					  <b>Transmission 10:</b> Bees now contain a completely random toxin."
 
 /datum/symptom/beesease/severityset(datum/disease/advance/A)
 	. = ..()
@@ -71,6 +71,9 @@
 								  "<span class='userdanger'>You cough up a bee!</span>")
 				if(toxic_bees)
 					new /mob/living/simple_animal/hostile/poison/bees/toxin(M.loc)
+				else if(honey)
+					var/mob/living/simple_animal/hostile/poison/bees/newbee = new /mob/living/simple_animal/hostile/poison/bees(M.loc) //Heh, newbee
+					newbee.assign_reagent(GLOB.chemical_reagents_list[/datum/reagent/consumable/honey])
 				else
 					new /mob/living/simple_animal/hostile/poison/bees(M.loc)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes what happens when both thresholds are met in the bee infestation symptom. Before, it was supposed to synthesize honey if the resistance threshold was met, overriding the effects of the transmission threshold. Now, the transmission threshold overrides the reagents of the resistance one, but the bees remain friendly and do not sting the infected. Also this makes the resistance threshold make honey bees properly.

"Fixes" https://github.com/BeeStation/BeeStation-Hornet/issues/1753

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Meeting both the transmission and resistance thresholds is a big undertaking. Instead of having one override the good effects of the other, they now both work together to make the infected a toxic bee slinging god. Also there's a bug fix in here (heh, bug). 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: the resistance threshold of bee infestation will no longer override the reagents of the transmission threshold.
fix: meeting the resistance threshold of bee infestation will now properly spawn honey bees, if the transmission threshold is not met
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
