### PR TITLE
Allow AI and IPC to start their name with a number or special char

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -157,8 +157,8 @@
 					continue
 				last_char_group = SYMBOLS_DETECTED
 
-			// ~   |   @  :  #  $  %  &  *  +
-			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
+			// ~   |   @  :  #  $  %  &  *  + / \
+			if(126,124,64,58,35,36,37,38,42,43,47,92)			//Other symbols that we'll allow (mainly for AI)
 				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers)
 					continue
 				last_char_group = SYMBOLS_DETECTED

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -146,7 +146,7 @@
 
 			// 0  .. 9
 			if(48 to 57)			//Numbers
-				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //do not suppress at start of string
+				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers)
 					continue
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED
@@ -159,7 +159,7 @@
 
 			// ~   |   @  :  #  $  %  &  *  +
 			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
-				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //do not suppress at start of string
+				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers)
 					continue
 				last_char_group = SYMBOLS_DETECTED
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -157,8 +157,8 @@
 					continue
 				last_char_group = SYMBOLS_DETECTED
 
-			// ~   |   @  :  #  $  %  &  *  + / \
-			if(126,124,64,58,35,36,37,38,42,43,47,92)			//Other symbols that we'll allow (mainly for AI)
+			// ~   |   @  :  #  $  %  &  *  +
+			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
 				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers)
 					continue
 				last_char_group = SYMBOLS_DETECTED

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -121,7 +121,7 @@
 		return //Rejects the input if it is null
 
 	var/number_of_alphanumeric = 0
-	var/last_char_group = NO_CHARS_DETECTED
+	var/last_char_group = ""
 	var/t_out = ""
 	var/t_len = length(t_in)
 	var/charcount = 0
@@ -146,7 +146,7 @@
 
 			// 0  .. 9
 			if(48 to 57)			//Numbers
-				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //suppress at start of string
+				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //do not suppress at start of string
 					continue
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED
@@ -159,7 +159,7 @@
 
 			// ~   |   @  :  #  $  %  &  *  +
 			if(126,124,64,58,35,36,37,38,42,43)			//Other symbols that we'll allow (mainly for AI)
-				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //suppress at start of string
+				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //do not suppress at start of string
 					continue
 				last_char_group = SYMBOLS_DETECTED
 


### PR DESCRIPTION
## About The Pull Request

Just a simple fix to allow AI and IPC to start their names with a number or the short list of allowed special chars, instead of arbitrarily enforcing a letter for the first character.

## Why It's Good For The Game

Roleplaying a serial number.

## Changelog
:cl: yorii
tweak: AI and IPC can begin their name with a number or certain allowed special characters.
/:cl:

