### PR TITLE
Replace Peacekeeper borg Dizzying Solution with Inabizine

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -593,7 +593,7 @@
 	mutationtext = "<span class='danger'>The pain subsides. You feel... like you can take on anything.</span>"
 	process_flags = ORGANIC | SYNTHETIC
 	can_synth = FALSE
-	random_unrestricted = FALSE 
+	random_unrestricted = FALSE
 
 
 //DANGEROUS RACES
@@ -1945,6 +1945,24 @@
 		M.dizziness = CLAMP(M.dizziness + 3, 0, 5)
 	if(prob(20))
 		to_chat(M, "You feel confused and disorientated.")
+	..()
+
+/datum/reagent/peaceborg/inabizine
+	name = "Inabizine"
+	description = "Induces muscle relaxation causing the target to drop items and fall on the ground"
+	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	taste_description = "relaxing"
+	can_synth = TRUE
+	random_unrestricted = TRUE
+
+/datum/reagent/peaceborg/inabizine/on_mob_life(mob/living/carbon/M)
+	if(prob(33))
+		M.Stun(20, 0)
+		M.blur_eyes(5)
+	if(prob(33))
+		M.Knockdown(2 SECONDS)
+	if(prob(20))
+		to_chat(M, "Your muscles relax...")
 	..()
 
 /datum/reagent/peaceborg/tire

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1952,8 +1952,6 @@
 	description = "Induces muscle relaxation causing the target to drop items and fall on the ground"
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	taste_description = "relaxing"
-	can_synth = TRUE
-	random_unrestricted = TRUE
 
 /datum/reagent/peaceborg/inabizine/on_mob_life(mob/living/carbon/M)
 	if(prob(33))

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -266,13 +266,13 @@ Borg Shaker
 /obj/item/reagent_containers/borghypo/peace
 	name = "Peace Hypospray"
 
-	reagent_ids = list(/datum/reagent/peaceborg/confuse,/datum/reagent/peaceborg/tire,/datum/reagent/pax/peaceborg)
+	reagent_ids = list(/datum/reagent/peaceborg/inabizine,/datum/reagent/peaceborg/tire,/datum/reagent/pax/peaceborg)
 	accepts_reagent_upgrades = FALSE
 
 /obj/item/reagent_containers/borghypo/peace/hacked
 	desc = "Everything's peaceful in death!"
 	icon_state = "borghypo_s"
-	reagent_ids = list(/datum/reagent/peaceborg/confuse,/datum/reagent/peaceborg/tire,/datum/reagent/pax/peaceborg,/datum/reagent/toxin/staminatoxin,/datum/reagent/toxin/sulfonal,/datum/reagent/toxin/sodium_thiopental,/datum/reagent/toxin/cyanide,/datum/reagent/toxin/fentanyl)
+	reagent_ids = list(/datum/reagent/peaceborg/inabizine,/datum/reagent/peaceborg/tire,/datum/reagent/pax/peaceborg,/datum/reagent/toxin/staminatoxin,/datum/reagent/toxin/sulfonal,/datum/reagent/toxin/sodium_thiopental,/datum/reagent/toxin/cyanide,/datum/reagent/toxin/fentanyl)
 	accepts_reagent_upgrades = FALSE
 
 /obj/item/reagent_containers/borghypo/epi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Peacekeeper dizzying solution is making people run into walls and causes human harm (which is against the whole point of Peacekeeper borg).
Peacekeeper hypospray dizzying solution is replaced with inabizine.
Inabizine has a chance to stun you, blur your vision or/and knock your down for a short period of time.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Peacekeeper borgs do not cause human harm when using their hypospray anymore.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Inabizine
tweak: Peacekeeper hypospray now has inabizine instead of dizzying solution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
