### PR TITLE
Nerfs chem-combat

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -101,6 +101,8 @@
 
 #define STATUS_EFFECT_STASIS /datum/status_effect/incapacitating/stasis //! Halts biological functions like bleeding, chemical processing, blood regeneration, walking, etc
 
+#define STATUS_EFFECT_SYRINGE /datum/status_effect/syringe //used to handle being injected with a syringe
+
 //---------//
 // NEUTRAL //
 //---------//

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -164,6 +164,69 @@
 			to_chat(owner, "<span class='notice'>You succesfuly remove the durathread strand.</span>")
 			L.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 
+/datum/status_effect/syringe
+	id = "syringe"
+	status_type = STATUS_EFFECT_MULTIPLE
+	alert_type = null
+	var/obj/item/reagent_containers/syringe/syringe = null
+	var/injectmult = 1
+	
+/datum/status_effect/syringe/on_creation(mob/living/new_owner, obj/item/reagent_containers/syringe/origin, mult)
+	syringe = origin
+	injectmult = mult
+	return ..()
+
+/datum/status_effect/syringe/on_apply()
+	. = ..()
+	var/amount = syringe.initial_inject
+	syringe.reagents.reaction(owner, INJECT)
+	syringe.reagents.trans_to(owner, max(3.1, amount * injectmult))
+	owner.throw_alert("syringealert", /obj/screen/alert/syringe)
+
+/datum/status_effect/syringe/tick()
+	. = ..()
+	var/amount = syringe.units_per_tick
+	syringe.reagents.reaction(owner, INJECT, amount / 10)//so the slow drip-feed of reagents isn't exploited
+	syringe.reagents.trans_to(owner, amount * injectmult)
+
+
+/obj/screen/alert/syringe
+	name = "Embedded Syringe"
+	desc = "A syringe has embedded itself into your body, injecting its reagents! click this icon to carefully remove the syringe."
+	icon_state = "drugged"
+	alerttooltipstyle = "hisgrace"
+
+/obj/screen/alert/syringe/Click(location, control, params)
+	. = ..()
+	if(usr != owner)
+		return
+	var/list/syringes = list()
+	if(iscarbon(owner))
+		var/mob/living/carbon/C = owner
+		for(var/datum/status_effect/syringe/S in C.status_effects)
+			syringes += S
+		if(!syringes.len)
+			return
+		var/datum/status_effect/syringe/syringestatus = pick_n_take(syringes)
+		if(istype(syringestatus, /datum/status_effect/syringe))
+			var/obj/item/reagent_containers/syringe/syringe = syringestatus.syringe
+			to_chat(owner, "<span class='notice'>You begin carefully yanking the syringe out...</span>")
+			if(do_after(C, 20, null, owner))
+				to_chat(C, "<span class='notice'>You succesfuly remove the syringe.</span>")
+				syringe.forceMove(C.loc)
+				C.put_in_hands(syringe)
+				qdel(syringestatus)
+			else
+				to_chat(C, "<span class='userdanger'>You screw up, and inject yourself with more chemicals by mistake!</span>")
+				var/amount = syringe.initial_inject
+				syringe.reagents.reaction(C, INJECT)
+				syringe.reagents.trans_to(C, amount)
+				syringe.forceMove(C.loc)
+				qdel(syringestatus)
+		if(!C.has_status_effect(STATUS_EFFECT_SYRINGE))	
+			C.clear_alert("syringealert")
+
+
 
 /datum/status_effect/pacify/on_creation(mob/living/new_owner, set_duration)
 	if(isnum_safe(set_duration))

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -89,6 +89,10 @@
 /obj/item/reagent_containers/food/snacks/grown/attack_self(mob/user)
 	if(seed && seed.get_gene(/datum/plant_gene/trait/squash))
 		squash(user)
+		if(seed.get_gene(/datum/plant_gene/trait/noreact))
+			if(iscarbon(user))
+				var/mob/living/carbon/C = user
+				C.throw_mode_on()
 	..()
 
 /obj/item/reagent_containers/food/snacks/grown/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -129,6 +133,7 @@
 /obj/item/reagent_containers/food/snacks/grown/proc/squashreact()
 	for(var/datum/plant_gene/trait/trait in seed.genes)
 		trait.on_squashreact(src)
+		playsound(src, 'sound/effects/fuse.ogg', seed.potency, 0)
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/On_Consume()
@@ -183,3 +188,4 @@
 		qdel(src)
 		user.putItemFromInventoryInHandIfPossible(T, user.active_hand_index, TRUE)
 		to_chat(user, "<span class='notice'>You open [src]\'s shell, revealing \a [T].</span>")
+		

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -414,7 +414,7 @@
 	if(isliving(target) && G.reagents && G.reagents.total_volume)
 		var/mob/living/L = target
 		if(L.reagents && L.can_inject(null, 0))
-			var/injecting_amount = max(1, G.seed.potency*0.2) // Minimum of 1, max of 20
+			var/injecting_amount = max(1, G.seed.potency*0.1) // Minimum of 1, max of 10
 			var/fraction = min(injecting_amount/G.reagents.total_volume, 1)
 			G.reagents.reaction(L, INJECT, fraction)
 			G.reagents.trans_to(L, injecting_amount)

--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -13,13 +13,12 @@
 			return
 
 		var/obj/item/reagent_containers/syringe/S = SG.syringes[1]
-
-		S.reagents.trans_to(BB, S.reagents.total_volume, transfered_by = user)
 		BB.name = S.name
 		var/obj/item/projectile/bullet/dart/D = BB
 		D.piercing = S.proj_piercing
 		SG.syringes.Remove(S)
-		qdel(S)
+		S.forceMove(BB)
+		D.syringe = S
 	..()
 
 /obj/item/ammo_casing/chemgun

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -3,6 +3,7 @@
 	icon_state = "cbbolt"
 	damage = 6
 	var/piercing = FALSE
+	var/obj/item/reagent_containers/syringe/syringe = null
 
 /obj/item/projectile/bullet/dart/Initialize()
 	. = ..()
@@ -14,15 +15,21 @@
 		if(blocked != 100) // not completely blocked
 			if(M.can_inject(null, FALSE, def_zone, piercing)) // Pass the hit zone to see if it can inject by whether it hit the head or the body.
 				..()
-				reagents.reaction(M, INJECT)
-				reagents.trans_to(M, reagents.total_volume)
-				return BULLET_ACT_HIT
+				if(syringe)
+					syringe.embed(M)
+					return BULLET_ACT_HIT
+				else
+					reagents.reaction(M, INJECT)
+					reagents.trans_to(M, reagents.total_volume)
+					return BULLET_ACT_HIT
 			else
 				blocked = 100
 				target.visible_message("<span class='danger'>\The [src] was deflected!</span>", \
 									   "<span class='userdanger'>You were protected against \the [src]!</span>")
 
 	..(target, blocked)
+	if(syringe)
+		syringe.forceMove(loc) //no noreact explosions bypassing piercing protection
 	DISABLE_BITFIELD(reagents.flags, NO_REACT)
 	reagents.handle_reactions()
 	return BULLET_ACT_HIT
@@ -60,8 +67,7 @@
 				var/mob/living/simple_animal/hostile/poison/bees/B = new(src.loc)
 				for(var/datum/reagent/R in reagents.reagent_list)
 					B.assign_reagent(GLOB.chemical_reagents_list[R.type])
-					break
-					
+					break	
 			else
 				playsound(src, 'sound/effects/splat.ogg', 40, 1)
 				new /obj/effect/decal/cleanable/insectguts(src.loc)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -590,7 +590,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
 /datum/reagent/toxin/amanitin/on_mob_end_metabolize(mob/living/M)
-	var/toxdamage = current_cycle*3*REM
+	var/toxdamage = max(165, current_cycle*3*REM) //so it won't instantly kill, but will instantly hardcrit someone.
 	M.log_message("has taken [toxdamage] toxin damage from amanitin toxin", LOG_ATTACK)
 	M.adjustToxLoss(toxdamage)
 	..()

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -3,6 +3,7 @@
 	id = "reagent_explosion"
 	var/strengthdiv = 10
 	var/modifier = 0
+	mob_react = FALSE //noreact explosions are fucky as hell. even a power of 1, being the minimal reaction, will nearly insta-crit and will definitely delimb, depending on armor.
 
 /datum/chemical_reaction/reagent_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/power = modifier + round(created_volume/strengthdiv, 1)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -3,7 +3,6 @@
 	id = "reagent_explosion"
 	var/strengthdiv = 10
 	var/modifier = 0
-	mob_react = FALSE //noreact explosions are fucky as hell. even a power of 1, being the minimal reaction, will nearly insta-crit and will definitely delimb, depending on armor.
 
 /datum/chemical_reaction/reagent_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/power = modifier + round(created_volume/strengthdiv, 1)
@@ -24,7 +23,7 @@
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(power , T, 0, 0)
 		e.start()
-	holder.clear_reagents()
+		holder.clear_reagents()
 
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -15,6 +15,8 @@
 	materials = list(/datum/material/iron=10, /datum/material/glass=20)
 	reagent_flags = TRANSPARENT
 	var/list/syringediseases = list()
+	var/units_per_tick = 1.5
+	var/initial_inject = 5
 
 /obj/item/reagent_containers/syringe/Initialize()
 	. = ..()
@@ -69,6 +71,20 @@
 	var/mob/living/L
 	if(isliving(target))
 		L = target
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			if(!H.can_inject(user, TRUE, penetrate_thick = proj_piercing))
+				return
+		else if(!L.can_inject(user, TRUE))
+			return
+		for(var/datum/disease/D in syringediseases)
+			if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+				continue
+			L.ForceContractDisease(D)
+		for(var/datum/disease/D in L.diseases)
+			if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+				continue
+			syringediseases += D
 
 	// chance of monkey retaliation
 	if(ismonkey(target) && prob(MONKEY_SYRINGE_RETALIATION_PROB))
@@ -98,7 +114,6 @@
 					user.visible_message("[user] takes a blood sample from [L].")
 				else
 					to_chat(user, "<span class='warning'>You are unable to draw any blood from [L]!</span>")
-				transfer_diseases(L)
 
 			else //if not mob
 				if(!target.reagents.total_volume)
@@ -134,7 +149,18 @@
 				return
 
 			if(L) //living mob
-				if(!L.can_inject(user, TRUE))
+				if(ishuman(L))
+					var/mob/living/carbon/human/H = L
+					if(!H.can_inject(user, TRUE, penetrate_thick = proj_piercing))
+						return
+				else if(!L.can_inject(user, TRUE))
+					return
+				if(user.a_intent == INTENT_HARM && iscarbon(L) && do_mob(user, L, 5))
+					var/mob/living/carbon/C = L
+					embed(C, 0.5)
+					log_combat(user, C, "injected (embedding)", src, addition="which had [contained]")
+					L.visible_message("<span class='danger'>[user] stabs [L] with the syringe!", \
+						"<span class='userdanger'>[user] shoves the syringe into your flesh, and it sticks!</span>")
 					return
 				if(L != user)
 					L.visible_message("<span class='danger'>[user] is trying to inject [L]!</span>", \
@@ -152,7 +178,6 @@
 					log_combat(user, L, "injected", src, addition="which had [contained]")
 				else
 					L.log_message("injected themselves ([contained]) with [src.name]", LOG_ATTACK, color="orange")
-				transfer_diseases(L)
 			var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
 			reagents.reaction(L, INJECT, fraction)
 			reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
@@ -185,20 +210,14 @@
 		add_overlay(injoverlay)
 		M.update_inv_hands()
 
-/obj/item/reagent_containers/syringe/proc/transfer_diseases(mob/living/L)
-	for(var/datum/disease/D in syringediseases)
-		if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
-			continue
-		L.ForceContractDisease(D)
-	for(var/datum/disease/D in L.diseases)
-		if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
-			continue
-		syringediseases += D
-
+/obj/item/reagent_containers/syringe/proc/embed(mob/living/carbon/C, injectmult = 1)
+	C.apply_status_effect(STATUS_EFFECT_SYRINGE, src, injectmult)
+	forceMove(C)
+	
 /obj/item/reagent_containers/syringe/used
 	name = "used syringe"
 	desc = "A syringe that can hold up to 15 units. This one is old, and it's probably a bad idea to use it"
-
+	
 
 /obj/item/reagent_containers/syringe/used/Initialize()
 	. = ..()
@@ -225,7 +244,7 @@
 	name = "syringe (diphenhydramine)"
 	desc = "Contains diphenhydramine, an antihistamine agent."
 	list_reagents = list(/datum/reagent/medicine/diphenhydramine = 15)
-
+	
 /obj/item/reagent_containers/syringe/calomel
 	name = "syringe (calomel)"
 	desc = "Contains calomel."
@@ -282,18 +301,22 @@
 	desc = "An advanced syringe that can hold 60 units of chemicals."
 	amount_per_transfer_from_this = 20
 	volume = 60
+	units_per_tick = 2
+	initial_inject = 8
 
 /obj/item/reagent_containers/syringe/noreact
 	name = "cryo syringe"
 	desc = "An advanced syringe that stops reagents inside from reacting. It can hold up to 20 units."
-	volume = 20
+	volume = 15
 	reagent_flags = TRANSPARENT | NO_REACT
 
 /obj/item/reagent_containers/syringe/piercing
 	name = "piercing syringe"
-	desc = "A diamond-tipped syringe that pierces armor when launched at high velocity. It can hold up to 10 units."
+	desc = "A diamond-tipped syringe that pierces armor. It can hold up to 10 units."
 	volume = 10
 	proj_piercing = 1
+	units_per_tick = 1
+	initial_inject = 3
 
 /obj/item/reagent_containers/syringe/crude
 	name = "crude syringe"


### PR DESCRIPTION
## About The Pull Request
chemicals and poisons are no longer quite as lethal, giving players who don't powergame anti-toxins a fighting chance against an average chemist with a syringe gun
**Syringe gun changes:**
syringes shot from a syringe gun (but not shotgun darts or darts from a reagent dartgun) inject reagents over time, as well as an initial injection to get past liver functions.
you can take about two seconds to pull out a syringe and stop the chems. If you fail to stand still, the syringe will inject a decent amount of chems before falling out. Attacking with a syringe on harm intent also embeds it in this way, though it takes about a half second to jab someone, and the chems will inject slower. Noreact chems will no longer react on impact if in a syringe
**Syringe changes:**
piercing syringes are now useful without a syringe gun, being able to normally inject through thick clothing.
cryosyringes now only have 15u capacity, no longer being a direct upgrade over normal syringes
**Reagent changes**
~~reagent explosions will no longer trigger in a human~~
atomized for future pr. instead, these simply no longer purge chems unless an explosion is triggered
amanatin will no longer be able to instakill, instead bringing the target deep into hardcrit. This will kill most unprepared targets, of course, but gives people a chance with some preparation
**Botnis changes**
hypodermic needles inject amount is halved, now capping at 10u
sepchems now plays a sound when beginning to mix


## Why It's Good For The Game
chemcombat is not very fun for anyone but the user, and most darts are a delayed one-shot kill. this is designed to give the victim a fighting chance by lowering reagents injectable per-hit from the more common methods of injection, as well as fucking with explosive noreact memes. Also, large explosive reactions in body is a somewhat niche, but still used, griefing method

## Changelog
:cl:
tweak: sepchems makes a sound when primed
tweak: cryosyringes now only hold 15u
tweak: piercing syringes now inject past thick clothing when not shot from a syringe gun as well
balance: syringe guns no longer instantly inject their reagents, instead injecting them over time
add: syringes can be embedded on harm intent, also injecting reagents over time, but at a slower rate
balance: explosive chem mixes no longer purge chems if an explosion is not triggered
balance: amanatin can no longer instantly kill, instead bringing the target into deep hardcrit
balance: hypodermic needles inject amount is halved, now capping at 10u
/:cl:
