### PR TITLE
Adds a sugar sack option to the biogenerator

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -68,7 +68,7 @@
 	category = list("initial","Food")
 	
 /datum/design/sugar_sack
-	name = "Sugar sack"
+	name = "Sugar Sack"
 	id = "sugar_sack"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass= 200)

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -66,6 +66,14 @@
 	materials = list(/datum/material/biomass= 150)
 	build_path = /obj/item/reagent_containers/food/condiment/flour
 	category = list("initial","Food")
+	
+/datum/design/sugar_sack
+	name = "Sugar sack"
+	id = "sugar_sack"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 200)
+	build_path = /obj/item/reagent_containers/food/condiment/sugar
+	category = list("initial","Food")
 
 /datum/design/monkey_cube
 	name = "Monkey Cube"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It adds the option to print a sack of sugar for 200 biomass

## Why It's Good For The Game

If the Chef runs out of sugar you don't have to spend 10 minutes making an ungodly amount of sugar
More importantly, it lets prisoners in perma make cakes and other pastries, as well as letting them grow more weeds for more plants.

So far in perma, the best you can really do is grow some carrots to eat and grow ambrosia to get high despite the microwave and chef gear. The main barrier to making food perma is sugar since you can't make it and a lot of recipes demand it. Now, prisoners can stick around and have fun making food instead of instantly disconnecting or cryosleeping.

![Sugar Option](https://user-images.githubusercontent.com/60122079/87897822-0e6e7a00-ca7f-11ea-91ee-8bc78ab76dc4.PNG)
![Sugar Printed](https://user-images.githubusercontent.com/60122079/87897831-15958800-ca7f-11ea-8dfe-68a1b24d9722.PNG)

## Changelog
:cl:
add: Sugar sack option to the Biogenerator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
