### PR TITLE
Adds checks to reject book author/title entries longer than 45 characters

### DIFF
--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -264,6 +264,8 @@
 				if(!newauthor)
 					to_chat(user, "The name is invalid.")
 					return
+				else if(length(newauthor) > 45)
+					to_chat(user, "That name is too long!")
 				else
 					author = newauthor
 			else

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -401,7 +401,10 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 	if(href_list["setauthor"])
 		var/newauthor = stripped_input(usr, "Enter the author's name: ")
 		if(newauthor)
-			scanner.cache.author = newauthor
+			if(length(newauthor) <= 45)
+				scanner.cache.author = newauthor
+			else
+				alert("Unable to set author. The field must be fewer than 45 characters.")
 	if(href_list["setcategory"])
 		var/newcategory = input("Choose a category: ") in list("Fiction", "Non-Fiction", "Adult", "Reference", "Religion","Technical")
 		if(newcategory)
@@ -413,6 +416,9 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 				if(choice == "Confirm")
 					if (!SSdbcore.Connect())
 						alert("Connection to Archive has been severed. Aborting.")
+					else if((length(scanner.cache.name) > 45) || (length(scanner.cache.author) > 45))
+						alert("The title and author fields must be fewer than 45 characters each. Check your entry and try again")
+						return
 					else
 						var/msg = "[key_name(usr)] has uploaded the book titled [scanner.cache.name], [length(scanner.cache.dat)] signs"
 						var/datum/DBQuery/query_library_upload = SSdbcore.NewQuery({"

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -417,7 +417,7 @@ GLOBAL_LIST(cachedbooks) // List of our cached book datums
 					if (!SSdbcore.Connect())
 						alert("Connection to Archive has been severed. Aborting.")
 					else if((length(scanner.cache.name) > 45) || (length(scanner.cache.author) > 45))
-						alert("The title and author fields must be fewer than 45 characters each. Check your entry and try again")
+						alert("The title and author fields must each be 45 characters or fewer. Check your entry and try again.")
 						return
 					else
 						var/msg = "[key_name(usr)] has uploaded the book titled [scanner.cache.name], [length(scanner.cache.dat)] signs"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added checks to make sure that book authors and titles remain under 45 characters, since the database has a hard limit set on both.

## Why It's Good For The Game

This gives a clearer indication as to why a book isn't able to be uploaded to the database. 

## Changelog
:cl:
add: Added new warnings to prevent books from having titles/authors longer than 45 characters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
