### PR TITLE
fixing various language bugs

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -20,4 +20,5 @@
 #define LANGUAGE_MASTER			"master"
 #define LANGUAGE_SOFTWARE		"software"
 #define LANGUAGE_STONER			"stoner"
+#define LANGUAGE_DRUGGY			"druggy"
 #define LANGUAGE_VOICECHANGE	"voicechange"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -20,13 +20,13 @@
 
 /datum/quirk/foreigner/add()
 	var/mob/living/carbon/human/H = quirk_holder
-	if(ishuman(H) && !isipc(H) && !H.job == "Curator")
+	if(ishuman(H) && !isipc(H) && H.job != "Curator")
 		H.add_blocked_language(/datum/language/common)
 		H.grant_language(/datum/language/uncommon)
 
 /datum/quirk/foreigner/remove()
 	var/mob/living/carbon/human/H = quirk_holder
-	if(ishuman(H) && !isipc(H) && !H.job == "Curator")
+	if(ishuman(H) && !isipc(H) && H.job != "Curator")
 		H.remove_blocked_language(/datum/language/common)
 		H.remove_language(/datum/language/uncommon)
 

--- a/code/modules/mob/living/carbon/human/status_procs.dm
+++ b/code/modules/mob/living/carbon/human/status_procs.dm
@@ -42,15 +42,15 @@
 /mob/living/carbon/human/set_drugginess(amount)
 	..()
 	if(!amount)
-		remove_language(/datum/language/beachbum)
+		remove_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_DRUGGY)
 
 /mob/living/carbon/human/adjust_drugginess(amount)
 	..()
 	if(!dna.check_mutation(STONER))
 		if(druggy)
-			grant_language(/datum/language/beachbum)
+			grant_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_DRUGGY)
 		else
-			remove_language(/datum/language/beachbum)
+			remove_language(/datum/language/beachbum, TRUE, TRUE, LANGUAGE_DRUGGY)
 
 /mob/living/carbon/human/proc/adjust_hygiene(amount)
 	hygiene = CLAMP(hygiene+amount, 0, HYGIENE_LEVEL_CLEAN)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -27,8 +27,7 @@
 		/datum/language/shadowtongue,
 		/datum/language/sylvan,
 		/datum/language/terrum,
-		/datum/language/uncommon,
-	))
+		/datum/language/uncommon))
 
 /obj/item/organ/tongue/Initialize(mapload)
 	. = ..()
@@ -185,6 +184,13 @@
 /obj/item/organ/tongue/alien/handle_speech(datum/source, list/speech_args)
 	playsound(owner, "hiss", 25, 1, 1)
 
+/obj/item/organ/tongue/bee
+	name = "proboscis"
+	desc = "A freakish looking meat tube that apparently can take in liquids, this one smells slighlty like flowers."
+	icon_state = "tonguefly"
+	say_mod = "buzzes"
+	taste_sensitivity = 5
+
 /obj/item/organ/tongue/bone
 	name = "bone \"tongue\""
 	desc = "Apparently skeletons alter the sounds they produce through oscillation of their teeth, hence their characteristic rattling."
@@ -226,20 +232,14 @@
 	modifies_speech = TRUE
 	taste_sensitivity = 25 // not as good as an organic tongue
 
-/obj/item/organ/tongue/bee
-	name = "proboscis"
-	desc = "A freakish looking meat tube that apparently can take in liquids, this one smells slighlty like flowers."
-	icon_state = "tonguefly"
-	say_mod = "buzzes"
-	taste_sensitivity = 5
+/obj/item/organ/tongue/robot/Initialize(mapload)
+	. = ..()
+	languages_possible = languages_possible_base += typecacheof(/datum/language/machine) + typecacheof(/datum/language/voltaic)
 
 /obj/item/organ/tongue/robot/emp_act(severity)
 	owner.apply_effect(EFFECT_STUTTER, 120)
 	owner.emote("scream")
 	to_chat(owner, "<span class='warning'>Alert: Vocal cords are malfunctioning.</span>")
-
-/obj/item/organ/tongue/robot/can_speak_language(datum/language/dt)
-	return TRUE // THE MAGIC OF ELECTRONICS
 
 /obj/item/organ/tongue/robot/handle_speech(datum/source, list/speech_args)
 	speech_args[SPEECH_SPANS] |= SPAN_ROBOT
@@ -265,3 +265,7 @@
 	say_mod = "crackles"
 	attack_verb = list("shocked", "jolted", "zapped")
 	taste_sensitivity = 101 // Not a tongue, they can't taste shit
+
+/obj/item/organ/tongue/ethereal/Initialize(mapload)
+	. = ..()
+	languages_possible = languages_possible_base += typecacheof(/datum/language/voltaic)


### PR DESCRIPTION
## About The Pull Request

Due to various reasons (I'm not actually that smart okay?) I might have done quite a few mistakes when I originally refactored languages, this fixes hopefully all of those mistakes.

## Why It's Good For The Game

Closes #2181 

## Changelog
:cl:
fix: beachbum language is no longer lost upon death
fix: voltaic now works
fix: foreigner trait now works
fix: IPCs now actually speak the languages they have
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
