### PR TITLE
disables mood, again. (dammit qwert)

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -551,7 +551,7 @@ IC_PRINTING
 ROUNDSTART_TRAITS
 
 ## Uncomment to disable human moods.
-#DISABLE_HUMAN_MOOD
+DISABLE_HUMAN_MOOD
 
 ## Enable night shifts ##
 ENABLE_NIGHT_SHIFTS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -547,7 +547,7 @@ IC_PRINTING
 ROUNDSTART_TRAITS
 
 ## Uncomment to disable human moods.
-#DISABLE_HUMAN_MOOD
+DISABLE_HUMAN_MOOD
 
 ## Enable night shifts ##
 #ENABLE_NIGHT_SHIFTS


### PR DESCRIPTION
## About The Pull Request
passed multiple votes, but qwerty put in a rework option even though nobody wants to rework this fucking shit. disables mood.

## Why It's Good For The Game

AIGHT LEMME LAY IT DOWN FOR YA:
-MOOD IS BAD FOR ROLEPLAY. NOT GOOD FOR ROLEPLAY. I DECIDE HOW MY CHARACTER IS. HUMAN MOOD IS TOO FUCKING NUANCED TO EMULATE IN A GAME, ESPECIALLY A GAME THAT ISN'T ABOUT AUTISTIC MANAGEMENT. IF I WANTED TO PLAY RIMWORLD, I'D PLAY RIMWORLD (which i dont cuz it is boring and because it has a shitty mood system)
-ALL MOOD IS IS A WAY FOR CODERS TO LAZILY PUNISH PLAYERS FOR RANDOM SHIT. THAT IS HOW IT'S USED, AT LEAST.
-WHY THE FUCK CAN BEING A BIT HUNGRY FOR ABOUT A HALF HOUR DRIVE YOU INSANE?
-HOW CAN FEELING SLIGHTLY SHITTY AT ALL DRIVE YOU INSANE
-WHO THE FUCK THOUGHT MAKING A QUIRK THAT ALLOWS MOOD TO BE CHECKED, AND GIVING ANTAGS A MOODLET AT THE SAME TIME WAS A GOOD IDEA? 
-im too lazy to add moodlets to shit i code and everyone else is too
-MECHANICAL MOOD IN A GAME WHERE YOU PLAY A SINGLE CHARACTER, ESPECIALLY A ROLE-PLAYING GAME, IS GENERALLY A BAD IDEA. 
-MOOD IS VERY POORLY DONE. I DONT WANNA FIX IT BECAUSE, EVEN THOUGH I COULD DO BETTER, I WOULD NOT BE SATISFIED AND IT WOULD BE A LOT OF WORK FOR SOMETHING THIS GAME DOESNT NEED
-MOOD MAKES GAMEPLAY INCONSISTENT. 100 HP TO CRIT, DAMMIT. DONT MAKE IT ALL FANCY N SHIT
-MOOD BROKE MY CAPSLOCK KEY

## Changelog
:cl:
config: MOOD IS GONE 
/:cl:
