### PR TITLE
Failing self surgery no longer forces you to eat organs you try to insert

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -128,13 +128,20 @@
 	if(M == user && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(status == ORGAN_ORGANIC)
-			var/obj/item/reagent_containers/food/snacks/S = prepare_eat(H)
-			if(S)
-				qdel(src)
-				if(H.put_in_active_hand(S))
-					S.attack(H, H)
+			if(!check_for_surgery(H))
+				var/obj/item/reagent_containers/food/snacks/S = prepare_eat(H)
+				if(S)
+					qdel(src)
+					if(H.put_in_active_hand(S))
+						S.attack(H, H)
 	else
 		..()
+
+/obj/item/organ/proc/check_for_surgery(mob/living/carbon/human/H)
+	for(var/datum/surgery/S in H.surgeries)
+		if(S.location == H.zone_selected)
+			return	TRUE			//no snacks mid surgery
+	return FALSE
 
 /obj/item/organ/item_action_slot_check(slot,mob/user)
 	return //so we don't grant the organ's action to mobs who pick up the organ.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds proc check to see if you are currently doing surgery on yourself and if your target is the same as surgery target.

## Why It's Good For The Game
Focus on your job instead of eating snacks

## Changelog
:cl:
tweak: You no longer bite organs if you fail self surgery while targeting mouth
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
