### PR TITLE
Allow robots to have serial number names

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -121,7 +121,7 @@
 		return //Rejects the input if it is null
 
 	var/number_of_alphanumeric = 0
-	var/last_char_group = NO_CHARS_DETECTED
+	var/last_char_group = ""
 	var/t_out = ""
 	var/t_len = length(t_in)
 	var/charcount = 0

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -146,7 +146,7 @@
 
 			// 0  .. 9
 			if(48 to 57)			//Numbers
-				if(!allow_numbers) //suppress at start of string
+				if(!allow_numbers)
 					continue
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -121,7 +121,7 @@
 		return //Rejects the input if it is null
 
 	var/number_of_alphanumeric = 0
-	var/last_char_group = ""
+	var/last_char_group = NO_CHARS_DETECTED
 	var/t_out = ""
 	var/t_len = length(t_in)
 	var/charcount = 0
@@ -146,7 +146,7 @@
 
 			// 0  .. 9
 			if(48 to 57)			//Numbers
-				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //suppress at start of string
+				if(!allow_numbers) //suppress at start of string
 					continue
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED


### PR DESCRIPTION
## About The Pull Request

This PR is needed so that robots can comply with MRP naming policy. And I made a better, less significant change this time.

## Why It's Good For The Game

Now robots can be named like a model ID in order to comply with MRP naming policy.

## Changelog
:cl:
fix: now robots can actually roleplay as a serial number.
/:cl:

