### PR TITLE
CentCom Galatic Ban DB

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -317,6 +317,7 @@
 #include "code\datums\explosion.dm"
 #include "code\datums\forced_movement.dm"
 #include "code\datums\holocall.dm"
+#include "code\datums\http.dm"
 #include "code\datums\hud.dm"
 #include "code\datums\map_config.dm"
 #include "code\datums\mind.dm"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -522,6 +522,8 @@
 
 /datum/config_entry/flag/auto_profile
 
+/datum/config_entry/string/centcom_ban_db	// URL for the CentCom Galactic Ban DB API
+
 /datum/config_entry/flag/ic_filter_enabled
 
 /datum/config_entry/flag/ooc_filter_enabled

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -1,0 +1,74 @@
+/datum/http_request
+	var/id
+	var/in_progress = FALSE
+
+	var/method
+	var/body
+	var/headers
+	var/url
+
+	var/_raw_response
+
+/datum/http_request/proc/prepare(method, url, body = "", list/headers)
+	if (!length(headers))
+		headers = ""
+	else
+		headers = json_encode(headers)
+
+	src.method = method
+	src.url = url
+	src.body = body
+	src.headers = headers
+
+/datum/http_request/proc/execute_blocking()
+	_raw_response = rustg_http_request_blocking(method, url, body, headers)
+
+/datum/http_request/proc/begin_async()
+	if (in_progress)
+		CRASH("Attempted to re-use a request object.")
+
+	id = rustg_http_request_async(method, url, body, headers)
+
+	if (isnull(text2num(id)))
+		stack_trace("Proc error: [id]")
+		_raw_response = "Proc error: [id]"
+	else
+		in_progress = TRUE
+
+/datum/http_request/proc/is_complete()
+	if (isnull(id))
+		return TRUE
+
+	if (!in_progress)
+		return TRUE
+
+	var/r = rustg_http_check_request(id)
+
+	if (r == RUSTG_JOB_NO_RESULTS_YET)
+		return FALSE
+	else
+		_raw_response = r
+		in_progress = FALSE
+		return TRUE
+
+/datum/http_request/proc/into_response()
+	var/datum/http_response/R = new()
+
+	try
+		var/list/L = json_decode(_raw_response)
+		R.status_code = L["status_code"]
+		R.headers = L["headers"]
+		R.body = L["body"]
+	catch
+		R.errored = TRUE
+		R.error = _raw_response
+
+	return R
+
+/datum/http_response
+	var/status_code
+	var/body
+	var/list/headers
+
+	var/errored = FALSE
+	var/error

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -39,8 +39,11 @@
 
 	if(M.client)
 		body += "<br><br><b>First Seen:</b> [M.client.player_join_date]<br><b>Byond account registered on:</b> [M.client.account_join_date]"
-		body += "<br><br><b>CentCom Galactic Ban DB:</b> "
-		body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a> "
+		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
+		if(CONFIG_GET(string/centcom_ban_db))
+			body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
+		else
+			body += "<i>Disabled</i>"
 		body += "<br><br><b>Show related accounts by:</b> "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -39,6 +39,8 @@
 
 	if(M.client)
 		body += "<br><br><b>First Seen:</b> [M.client.player_join_date]<br><b>Byond account registered on:</b> [M.client.account_join_date]"
+		body += "<br><br><b>CentCom Galactic Ban DB:</b> "
+		body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a> "
 		body += "<br><br><b>Show related accounts by:</b> "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2003,7 +2003,6 @@
 				dat += "<center><b>[bans.len] bans detected for [ckey]</b></center>"
 
 				for(var/ban in bans)
-					to_chat(usr, "Ban: [ban]")
 					var/list/bandata = json_decode(ban)
 					dat += "<b>Server: </b> [bandata["sourceName"]]<br>"
 					dat += "<b>Type: </b> [bandata["type"]]<br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1980,9 +1980,13 @@
 		if(!check_rights(R_ADMIN))
 			return
 
+		if(!CONFIG_GET(string/centcom_ban_db))
+			to_chat(usr, "<span class='warning'>Centcom Galactic Ban DB is disabled!</span>")
+			return
+
 		var/ckey = href_list["centcomlookup"]
 
-		var/list/query = json_decode(rustg_http_request_blocking(RUSTG_HTTP_METHOD_GET, "https://centcom.melonmesa.com/ban/search/[ckey]", null, null))
+		var/list/query = json_decode(rustg_http_request_blocking(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)][ckey]", null, null))
 
 		var/list/bans
 
@@ -2004,17 +2008,17 @@
 					//But now we need to readd } so it's valid json.
 					//But not if it's the final entry because that retained its }
 					var/list/bandata = json_decode("[ban][ban == bans.len ? "" : "}"]")
-					dat += "<b>Server: </b> [bandata["sourceName"]]<br>"
-					dat += "<b>Type: </b> [bandata["type"]]<br>"
-					dat += "<b>Banned By: </b> [bandata["bannedBy"]]<br>"
-					dat += "<b>Reason: </b> [bandata["reason"]]<br>"
-					dat += "<b>Datetime: </b> [bandata["bannedOn"]]<br>"
+					dat += "<b>Server: </b> [sanitize(bandata["sourceName"])]<br>"
+					dat += "<b>Type: </b> [sanitize(bandata["type"])]<br>"
+					dat += "<b>Banned By: </b> [sanitize(bandata["bannedBy"])]<br>"
+					dat += "<b>Reason: </b> [sanitize(bandata["reason"])]<br>"
+					dat += "<b>Datetime: </b> [sanitize(bandata["bannedOn"])]<br>"
 					var/expiration = bandata["expires"]
-					dat += "<b>Expires: </b> [expiration ? "[expiration]" : "Permanent"]<br>"
+					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
 					if(bandata["type"] == "job")
 						dat += "<b>Jobs: </b> "
 						for(var/job in bandata["jobs"])
-							dat += "[job], "
+							dat += "[sanitize(job)], "
 						dat += "<br>"
 					dat += "<hr>"
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2000,7 +2000,7 @@
 				query["body"] = replacetext(query["body"], "},", "}},") //splittext strips the char you split so let's double it up
 				bans = splittext(query["body"], "},")
 
-				dat += "<center><b>[bans.len] bans detected for [ckey]</b></center>"
+				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
 
 				for(var/ban in bans)
 					var/list/bandata = json_decode(ban)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1996,14 +1996,14 @@
 			if(query["body"] == "[]")
 				dat += "<center><b>0 bans detected for [ckey]</b></center>"
 			else
-				query["body"] = copytext(query["body"], 2, -1) //strip [ and ]
-				query["body"] = replacetext(query["body"], "},", "}},") //splittext strips the char you split so let's double it up
-				bans = splittext(query["body"], "},")
-
+				bans = splittext(query["body"], "},", 2, length(query["body"])-1) //We don't want the [] that wraps the query
 				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
 
 				for(var/ban in bans)
-					var/list/bandata = json_decode(ban)
+					//Okay so what's going on here is we intentionally removed }, in splittext so each ban entry wouldn't have a trailing comma (invalid json)
+					//But now we need to readd } so it's valid json.
+					//But not if it's the final entry because that retained its }
+					var/list/bandata = json_decode("[ban][ban == bans.len ? "" : "}"]")
 					dat += "<b>Server: </b> [bandata["sourceName"]]<br>"
 					dat += "<b>Type: </b> [bandata["type"]]<br>"
 					dat += "<b>Banned By: </b> [bandata["bannedBy"]]<br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2011,6 +2011,7 @@
 				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
 				for(var/list/ban in bans)
 					dat += "<b>Server: </b> [sanitize(ban["sourceName"])]<br>"
+					dat += "<b>RP Level: </b> [sanitize(ban["sourceRoleplayLevel"])]<br>"
 					dat += "<b>Type: </b> [sanitize(ban["type"])]<br>"
 					dat += "<b>Banned By: </b> [sanitize(ban["bannedBy"])]<br>"
 					dat += "<b>Reason: </b> [sanitize(ban["reason"])]<br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1988,7 +1988,7 @@
 
 		// Make the request
 		var/datum/http_request/request = new()
-		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)][ckey]", "", "")
+		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)]/[ckey]", "", "")
 		request.begin_async()
 		UNTIL(request.is_complete())
 		var/datum/http_response/response = request.into_response()
@@ -2022,8 +2022,8 @@
 					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
 					if(bandata["type"] == "job")
 						dat += "<b>Jobs: </b> "
-						for(var/job in bandata["jobs"])
-							dat += "[sanitize(job)], "
+						var/list/jobs = bandata["jobs"]
+						dat += sanitize(jobs.Join(", "))
 						dat += "<br>"
 					dat += "<hr>"
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1996,7 +1996,7 @@
 			if(query["body"] == "[]")
 				dat += "<center><b>0 bans detected for [ckey]</b></center>"
 			else
-				query["body"] = copytext_char(query["body"], 2, -1) //strip [ and ]
+				query["body"] = copytext(query["body"], 2, -1) //strip [ and ]
 				query["body"] = replacetext(query["body"], "},", "}},") //splittext strips the char you split so let's double it up
 				bans = splittext(query["body"], "},")
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1990,7 +1990,9 @@
 		var/datum/http_request/request = new()
 		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)]/[ckey]", "", "")
 		request.begin_async()
-		UNTIL(request.is_complete())
+		UNTIL(request.is_complete() || !usr)
+		if (!usr)
+			return
 		var/datum/http_response/response = request.into_response()
 
 		var/list/bans

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1986,21 +1986,26 @@
 
 		var/ckey = href_list["centcomlookup"]
 
-		var/list/query = json_decode(rustg_http_request_blocking(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)][ckey]", null, null))
+		// Make the request
+		var/datum/http_request/request = new()
+		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)][ckey]", "", "")
+		request.begin_async()
+		UNTIL(request.is_complete())
+		var/datum/http_response/response = request.into_response()
 
 		var/list/bans
 
 		var/dat = "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>"
 
-		if(!query)
+		if(response.errored)
 			dat += "<br>Failed to connect to CentCom."
-		else if(query["status_code"] != 200)
-			dat += "<br>Failed to connect to CentCom. Status code: [query["status_code"]]"
+		else if(response.status_code != 200)
+			dat += "<br>Failed to connect to CentCom. Status code: [response.status_code]"
 		else
-			if(query["body"] == "[]")
+			if(response.body == "[]")
 				dat += "<center><b>0 bans detected for [ckey]</b></center>"
 			else
-				bans = splittext(query["body"], "},", 2, length(query["body"])-1) //We don't want the [] that wraps the query
+				bans = splittext(response.body, "},", 2, length(response.body)-1) //We don't want the [] that wraps the query
 				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
 
 				for(var/ban in bans)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2008,6 +2008,7 @@
 				dat += "<center><b>0 bans detected for [ckey]</b></center>"
 			else
 				bans = json_decode(response["body"])
+				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
 				for(var/list/ban in bans)
 					dat += "<b>Server: </b> [sanitize(ban["sourceName"])]<br>"
 					dat += "<b>Type: </b> [sanitize(ban["type"])]<br>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2007,24 +2007,18 @@
 			if(response.body == "[]")
 				dat += "<center><b>0 bans detected for [ckey]</b></center>"
 			else
-				bans = splittext(response.body, "},", 2, length(response.body)-1) //We don't want the [] that wraps the query
-				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
-
-				for(var/ban in bans)
-					//Okay so what's going on here is we intentionally removed }, in splittext so each ban entry wouldn't have a trailing comma (invalid json)
-					//But now we need to readd } so it's valid json.
-					//But not if it's the final entry because that retained its }
-					var/list/bandata = json_decode("[ban][ban == bans.len ? "" : "}"]")
-					dat += "<b>Server: </b> [sanitize(bandata["sourceName"])]<br>"
-					dat += "<b>Type: </b> [sanitize(bandata["type"])]<br>"
-					dat += "<b>Banned By: </b> [sanitize(bandata["bannedBy"])]<br>"
-					dat += "<b>Reason: </b> [sanitize(bandata["reason"])]<br>"
-					dat += "<b>Datetime: </b> [sanitize(bandata["bannedOn"])]<br>"
-					var/expiration = bandata["expires"]
+				bans = json_decode(response["body"])
+				for(var/list/ban in bans)
+					dat += "<b>Server: </b> [sanitize(ban["sourceName"])]<br>"
+					dat += "<b>Type: </b> [sanitize(ban["type"])]<br>"
+					dat += "<b>Banned By: </b> [sanitize(ban["bannedBy"])]<br>"
+					dat += "<b>Reason: </b> [sanitize(ban["reason"])]<br>"
+					dat += "<b>Datetime: </b> [sanitize(ban["bannedOn"])]<br>"
+					var/expiration = ban["expires"]
 					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
-					if(bandata["type"] == "job")
+					if(ban["type"] == "job")
 						dat += "<b>Jobs: </b> "
-						var/list/jobs = bandata["jobs"]
+						var/list/jobs = ban["jobs"]
 						dat += sanitize(jobs.Join(", "))
 						dat += "<br>"
 					dat += "<hr>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1988,8 +1988,10 @@
 
 		var/dat = "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>"
 
-		if(!query || query["status_code"] != 200)
-			dat += "Failed to connect to CentCom. Status code: [query["status_code"]]"
+		if(!query)
+			dat += "<br>Failed to connect to CentCom."
+		else if(query["status_code"] != 200)
+			dat += "<br>Failed to connect to CentCom. Status code: [query["status_code"]]"
 		else
 			if(query["body"] == "[]")
 				dat += "<center><b>0 bans detected for [ckey]</b></center>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1997,7 +1997,7 @@
 
 		var/list/bans
 
-		var/dat = "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>"
+		var/list/dat = list("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>")
 
 		if(response.errored)
 			dat += "<br>Failed to connect to CentCom."
@@ -2026,7 +2026,7 @@
 
 		dat += "<br></body>"
 		var/datum/browser/popup = new(usr, "centcomlookup-[ckey]", "<div align='center'>Central Command Galactic Ban Database</div>", 700, 600)
-		popup.set_content(dat)
+		popup.set_content(dat.Join())
 		popup.open(0)
 
 	else if(href_list["modantagrep"])

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -502,7 +502,6 @@ RESPECT_GLOBAL_BANS
 MAX_SHUTTLE_COUNT 6
 MAX_SHUTTLE_SIZE 300
 
-
 ### Fail2Topic settings
 ### fail2topic is a system for automating IP bans for abusers of the world/Topic API.
 ### Note that this subsystem respects the IPs listed in topic_rate_limit_whitelist.txt. They will not be considered for a ban.
@@ -516,6 +515,9 @@ TOPIC_RULE_NAME "_DD_Fail2topic"
 TOPIC_MAX_SIZE 500
 ## Uncomment to enable Fail2Topic, comment-out to disable
 #TOPIC_ENABLED
+
+## Uncomment to enable CentCom Galactic Ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -518,7 +518,7 @@ TOPIC_MAX_SIZE 500
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
 ## More API details can be found here: https://centcom.melonmesa.com
-#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
+CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -517,7 +517,7 @@ TOPIC_MAX_SIZE 500
 #TOPIC_ENABLED
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
-## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
+## More API details can be found here: https://centcom.melonmesa.com
 #CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -516,7 +516,8 @@ TOPIC_MAX_SIZE 500
 ## Uncomment to enable Fail2Topic, comment-out to disable
 #TOPIC_ENABLED
 
-## Uncomment to enable CentCom Galactic Ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
 #CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -518,7 +518,7 @@ TOPIC_MAX_SIZE 500
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
 ## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
-#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
+#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED

--- a/config/config.txt
+++ b/config/config.txt
@@ -519,6 +519,9 @@ TOPIC_MAX_SIZE 500
 ## Enable automatic profiling - Byond 513.1506 and newer only.
 #AUTO_PROFILE
 
+## Uncomment to enable CentCom Galactic Ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
+
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED
 #OOC_FILTER_ENABLED

--- a/config/config.txt
+++ b/config/config.txt
@@ -521,7 +521,7 @@ TOPIC_MAX_SIZE 500
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
 ## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
-#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
+#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED

--- a/config/config.txt
+++ b/config/config.txt
@@ -521,7 +521,7 @@ TOPIC_MAX_SIZE 500
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
 ## More API details can be found here: https://centcom.melonmesa.com
-#CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
+CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them
 #IC_FILTER_ENABLED

--- a/config/config.txt
+++ b/config/config.txt
@@ -519,7 +519,8 @@ TOPIC_MAX_SIZE 500
 ## Enable automatic profiling - Byond 513.1506 and newer only.
 #AUTO_PROFILE
 
-## Uncomment to enable CentCom Galactic Ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
 #CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search/
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them

--- a/config/config.txt
+++ b/config/config.txt
@@ -520,7 +520,7 @@ TOPIC_MAX_SIZE 500
 #AUTO_PROFILE
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
-## More API details can be found here: https://centcom.melonmesa.com/swagger/index.html
+## More API details can be found here: https://centcom.melonmesa.com
 #CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search
 
 ## Enable IC/OOC Hard Filtering. Comment to disable one or both of them


### PR DESCRIPTION
Admins will now be able to look up a player's bans from several other servers via the player panel. 

Supported servers: 
* BeeStation 
* /vg/station
* OracleStation
* FTL13
* Fulpstation
* TGMC

Planned support that bobbah is working on:
* Yogstation
* World Server
* Any other server willing to make their bans publicly visible.

API: https://centcom.melonmesa.com
Source: https://github.com/bobbahbrown/CentCom

## Changelog
:cl: ike709 and bobbahbrown
add: Admins can now see your bans on (some) other servers.
/:cl:
