### PR TITLE
Adds tiny fans to arrival shuttles

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -9,6 +9,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -165,6 +165,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plasteel/white,
 /area/shuttle/arrival)
 "o" = (

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -7,15 +7,15 @@
 /area/shuttle/arrival)
 "c" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion"
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "d" = (
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 1
+	dir = 1;
+	icon_state = "heater"
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -40,6 +40,7 @@
 /area/shuttle/arrival)
 "k" = (
 /obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "l" = (
@@ -67,8 +68,8 @@
 /area/shuttle/arrival)
 "p" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 1
+	dir = 1;
+	icon_state = "propulsion"
 	},
 /obj/docking_port/mobile/arrivals{
 	dir = 2;

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -16,6 +16,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "e" = (
@@ -75,8 +76,8 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/arrows{
-	icon_state = "arrows";
-	dir = 1
+	dir = 1;
+	icon_state = "arrows"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -108,8 +109,8 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/arrows{
-	icon_state = "arrows";
-	dir = 1
+	dir = 1;
+	icon_state = "arrows"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -118,8 +119,8 @@
 /area/shuttle/arrival)
 "n" = (
 /obj/structure/shuttle/engine/propulsion/left{
-	icon_state = "propulsion_l";
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion_l"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -130,8 +131,8 @@
 /obj/structure/window/shuttle,
 /obj/structure/grille,
 /obj/structure/shuttle/engine/heater{
-	icon_state = "heater";
-	dir = 8
+	dir = 8;
+	icon_state = "heater"
 	},
 /turf/open/floor/plating,
 /area/shuttle/arrival)
@@ -149,8 +150,8 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/arrows{
-	icon_state = "arrows";
-	dir = 1
+	dir = 1;
+	icon_state = "arrows"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -179,8 +180,8 @@
 	pixel_x = 28
 	},
 /obj/effect/turf_decal/arrows{
-	icon_state = "arrows";
-	dir = 1
+	dir = 1;
+	icon_state = "arrows"
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -201,8 +202,8 @@
 /area/shuttle/arrival)
 "u" = (
 /obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -316,8 +317,8 @@
 /area/shuttle/arrival)
 "G" = (
 /obj/structure/shuttle/engine/propulsion/right{
-	icon_state = "propulsion_r";
-	dir = 8
+	dir = 8;
+	icon_state = "propulsion_r"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -9,6 +9,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tiny fans are now included in arrival shuttles

## Why It's Good For The Game

dumbasses opened the door early and sucked everyone out

## Changelog
:cl:
add: Added tiny fans to arrival shuttles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
