### PR TITLE
Gives the abductor helmet flash protection

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -727,10 +727,6 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	blockTracking = TRUE
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 
-/obj/item/clothing/head/helmet/abductor/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
-
 // Operating Table / Beds / Lockers
 
 /obj/structure/bed/abductor

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -723,8 +723,13 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	desc = "Abduct with style - spiky style. Prevents digital tracking."
 	icon_state = "alienhelmet"
 	item_state = "alienhelmet"
+	flash_protect = 1
 	blockTracking = TRUE
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
+
+/obj/item/clothing/head/helmet/abductor/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(SLOT_EARS))
 
 // Operating Table / Beds / Lockers
 


### PR DESCRIPTION
## About The Pull Request

Gives the helmet abductors start with flash protection.

## Why It's Good For The Game

Abductor agents do not start with flash protection, I think most can see why this is a bad thing.

## Changelog
:cl:
tweak: Abductor Helmet now offers flash protection
/:cl: