### PR TITLE
[Port] Non temp workaround for admins matching stickybans because of a byond bug.

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -159,6 +159,7 @@
 #include "code\_globalvars\logging.dm"
 #include "code\_globalvars\misc.dm"
 #include "code\_globalvars\regexes.dm"
+#include "code\_globalvars\lists\admin.dm"
 #include "code\_globalvars\lists\client.dm"
 #include "code\_globalvars\lists\flavor_misc.dm"
 #include "code\_globalvars\lists\maintenance_loot.dm"

--- a/code/_globalvars/lists/admin.dm
+++ b/code/_globalvars/lists/admin.dm
@@ -1,0 +1,3 @@
+GLOBAL_LIST_EMPTY(stickybanadminexemptions)	//stores a list of ckeys exempted from a stickyban (workaround for a bug)
+GLOBAL_LIST_EMPTY(stickybanadmintexts) //stores the entire stickyban list temporarily
+GLOBAL_VAR(stickbanadminexemptiontimerid) //stores the timerid of the callback that restores all stickybans after an admin joins

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -10,11 +10,15 @@ SUBSYSTEM_DEF(stickyban)
 
 
 /datum/controller/subsystem/stickyban/Initialize(timeofday)
+	if (length(GLOB.stickybanadminexemptions))
+		restore_stickybans()
 	var/list/bannedkeys = sticky_banned_ckeys()
 	//sanitize the sticky ban list
 
 	//delete db bans that no longer exist in the database and add new legacy bans to the database
 	if (SSdbcore.Connect() || length(SSstickyban.dbcache))
+		if (length(GLOB.stickybanadminexemptions))
+			restore_stickybans()
 		for (var/oldban in (world.GetConfig("ban") - bannedkeys))
 			var/ckey = ckey(oldban)
 			if (ckey != oldban && (ckey in bannedkeys))
@@ -29,6 +33,8 @@ SUBSYSTEM_DEF(stickyban)
 				bannedkeys += ckey
 			world.SetConfig("ban", oldban, null)
 
+	if (length(GLOB.stickybanadminexemptions)) //the previous loop can sleep
+		restore_stickybans()
 
 	for (var/bannedkey in bannedkeys)
 		var/ckey = ckey(bannedkey)

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -105,7 +105,23 @@ GLOBAL_LIST_EMPTY(ckey_redirects)
 				[expires]"}
 				log_access("Failed Login: [key] [computer_id] [address] - Banned (#[i["id"]]) [text2num(i["global_ban"]) ? "globally" : "locally"]")
 				return list("reason"="Banned","desc"="[desc]")
+	if (admin)
+		if (GLOB.directory[ckey])
+			return
 
+		//oh boy, so basically, because of a bug in byond, sometimes stickyban matches don't trigger here, so we can't exempt admins.
+		//	Whitelisting the ckey with the byond whitelist field doesn't work.
+		//	So we instead have to remove every stickyban than later re-add them.
+		if (!length(GLOB.stickybanadminexemptions))
+			for (var/banned_ckey in world.GetConfig("ban"))
+				GLOB.stickybanadmintexts[banned_ckey] = world.GetConfig("ban", banned_ckey)
+				world.SetConfig("ban", banned_ckey, null)
+		if (!SSstickyban.initialized)
+			return
+		GLOB.stickybanadminexemptions[ckey] = world.time
+		stoplag() // sleep a byond tick
+		GLOB.stickbanadminexemptiontimerid = addtimer(CALLBACK(GLOBAL_PROC, /proc/restore_stickybans), 5 SECONDS, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE)
+		return
 	var/list/ban = ..()	//default pager ban stuff
 
 	if (ban)
@@ -224,6 +240,14 @@ GLOBAL_LIST_EMPTY(ckey_redirects)
 
 	return .
 
+/proc/restore_stickybans()
+	for (var/banned_ckey in GLOB.stickybanadmintexts)
+		world.SetConfig("ban", banned_ckey, GLOB.stickybanadmintexts[banned_ckey])
+	GLOB.stickybanadminexemptions = list()
+	GLOB.stickybanadmintexts = list()
+	if (GLOB.stickbanadminexemptiontimerid)
+		deltimer(GLOB.stickbanadminexemptiontimerid)
+	GLOB.stickbanadminexemptiontimerid = null
 
 #undef STICKYBAN_MAX_MATCHES
 #undef STICKYBAN_MAX_EXISTING_USER_MATCHES

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -298,6 +298,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 
 
 	. = ..()	//calls mob.Login()
+	if (length(GLOB.stickybanadminexemptions))
+		GLOB.stickybanadminexemptions -= ckey
+		if (!length(GLOB.stickybanadminexemptions))
+			restore_stickybans()
 
 	if (byond_version >= 512)
 		if (!byond_build || byond_build < 1386)


### PR DESCRIPTION
From https://github.com/tgstation/tgstation/pull/46462

Workaround for the byond bug with stickybans causing the admin whitelist code to not get called.

How does it work? when an admin is connecting, just before byond asks the hub about the current stickybans, we remove all of the stickybans from byond's database. later, when either 5 seconds have passed, or the admin's client/New is called, we restore the stickybans we deleted earlier.