### PR TITLE
Lizardpeople get draconic back

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -77,3 +77,4 @@
 	limbs_id = "lizard"
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
 	inherent_traits = list(TRAIT_NOGUNS,TRAIT_NOBREATH)
+	species_language_holder = /datum/language_holder/lizard/ash

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -23,6 +23,7 @@
 	liked_food = GROSS | MEAT
 	inert_mutation = FIREBREATH
 	deathsound = 'sound/voice/lizard/deathsound.ogg'
+	species_language_holder = /datum/language_holder/lizard
 
 /datum/species/lizard/random_name(gender,unique,lastname)
 	if(unique)


### PR DESCRIPTION
## About The Pull Request

Re-adds the species_language_holder to lizardpeople which was removed in #2143 

## Why It's Good For The Game

Lizards should have their language back. Fixes #2231 

## Changelog
:cl:
fix: lizardpeople can speak draconic again
/:cl: