### PR TITLE
Fixes the beeshop female executive suit item

### DIFF
--- a/code/modules/client/loadout/loadout_uniform.dm
+++ b/code/modules/client/loadout/loadout_uniform.dm
@@ -181,7 +181,7 @@
 
 /datum/gear/uniform/suit/suit_jacket/female
 	display_name = "executive suit (female)"
-	path = /obj/item/clothing/under/suit/black/skirt
+	path = /obj/item/clothing/under/suit/black/female
 
 /datum/gear/uniform/suit/suit_jacket/green
 	display_name = "green suit"

--- a/code/modules/clothing/under/suits.dm
+++ b/code/modules/clothing/under/suits.dm
@@ -55,23 +55,15 @@
 	item_state = "bl_suit"
 	item_color = "really_black_suit"
 
-/obj/item/clothing/under/suit/black_really/skirt
-	name = "executive suitskirt"
-	desc = "A formal black suitskirt and red tie, intended for the station's finest."
-	icon_state = "really_black_suit_skirt"
-	item_state = "bl_suit"
-	item_color = "really_black_suit_skirt"
-	body_parts_covered = CHEST|GROIN|ARMS
-	can_adjust = FALSE
-	fitted = FEMALE_UNIFORM_TOP
-
-
 /obj/item/clothing/under/suit/black/female
 	name = "executive suit"
 	desc = "A formal trouser suit for women, intended for the station's finest."
 	icon_state = "black_suit_fem"
 	item_state = "black_suit_fem"
 	item_color = "black_suit_fem"
+	body_parts_covered = CHEST|GROIN|ARMS
+	can_adjust = FALSE
+	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/suit/green
 	name = "green suit"

--- a/tools/mapmerge2/map_scripts/clothingunderrepath.txt
+++ b/tools/mapmerge2/map_scripts/clothingunderrepath.txt
@@ -119,7 +119,7 @@
 /obj/item/clothing/under/lawyer/blacksuit : /obj/item/clothing/under/suit/black
 /obj/item/clothing/under/lawyer/blacksuit/skirt : /obj/item/clothing/under/suit/black/skirt
 /obj/item/clothing/under/lawyer/really_black : /obj/item/clothing/under/suit/black_really
-/obj/item/clothing/under/lawyer/really_black/skirt : /obj/item/clothing/under/suit/black/female
+/obj/item/clothing/under/lawyer/black/female : /obj/item/clothing/under/suit/black/female
 /obj/item/clothing/under/rank/head_of_personnel : /obj/item/clothing/under/rank/civilian/head_of_personnel
 /obj/item/clothing/under/rank/head_of_personnel/skirt : /obj/item/clothing/under/rank/civilian/head_of_personnel/skirt
 /obj/item/clothing/under/gimmick/rank/head_of_personnel/suit : /obj/item/clothing/under/rank/civilian/head_of_personnel/suit

--- a/tools/mapmerge2/map_scripts/clothingunderrepath.txt
+++ b/tools/mapmerge2/map_scripts/clothingunderrepath.txt
@@ -119,7 +119,7 @@
 /obj/item/clothing/under/lawyer/blacksuit : /obj/item/clothing/under/suit/black
 /obj/item/clothing/under/lawyer/blacksuit/skirt : /obj/item/clothing/under/suit/black/skirt
 /obj/item/clothing/under/lawyer/really_black : /obj/item/clothing/under/suit/black_really
-/obj/item/clothing/under/lawyer/really_black/skirt : /obj/item/clothing/under/suit/black_really/skirt
+/obj/item/clothing/under/lawyer/really_black/skirt : /obj/item/clothing/under/suit/black/female
 /obj/item/clothing/under/rank/head_of_personnel : /obj/item/clothing/under/rank/civilian/head_of_personnel
 /obj/item/clothing/under/rank/head_of_personnel/skirt : /obj/item/clothing/under/rank/civilian/head_of_personnel/skirt
 /obj/item/clothing/under/gimmick/rank/head_of_personnel/suit : /obj/item/clothing/under/rank/civilian/head_of_personnel/suit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The executive suit is set to use an item that doesn't actually have an icon. This removes the iconless item and sets it to the correct executive suit object which was previously unused. (also fixes the female lawyer to use the correct suit)

## Why It's Good For The Game

Getting what you paid for is always nice

## Changelog
:cl:
fix: The female executive suit uses the correct object now
del: Removed the unused "really black" female skirt suit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
