### PR TITLE
Fixes pressure tanks being empty

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -12,7 +12,7 @@
 	pipe_flags = PIPING_ONE_PER_TURF
 
 	var/volume = 10000 //in liters
-	var/gas_type = 0
+	var/gas_type = null
 
 /obj/machinery/atmospherics/components/unary/tank/New()
 	..()
@@ -20,7 +20,7 @@
 	air_contents.set_volume(volume)
 	air_contents.set_temperature(T20C)
 	if(gas_type)
-		air_contents.set_moles(AIR_CONTENTS)
+		air_contents.set_moles(gas_type, AIR_CONTENTS)
 		name = "[name] ([GLOB.meta_gas_info[gas_type][META_GAS_NAME]])"
 	setPipingLayer(piping_layer)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pressure tanks (the 10,000 mols ones) are empty currently for some reason, this has been fixed. 

## Why It's Good For The Game
It's a fix.

## Changelog
:cl:
fix: Pressure tanks are not empty anymore. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
