### PR TITLE
Updates Rust-g, sets the dependencies to use our fork, and enables builtin overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y --no-install-recommends \
     gcc-multilib \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host i686-unknown-linux-gnu \
     && git init \
-    && git remote add origin https://github.com/tgstation/rust-g
+    && git remote add origin https://github.com/BeeStation/rust-g
 
 COPY dependencies.sh .
 
@@ -29,7 +29,7 @@ RUN dos2unix dependencies.sh \
 	&& /bin/bash -c "source dependencies.sh \
     && git fetch --depth 1 origin \$RUST_G_VERSION" \
     && git checkout FETCH_HEAD \
-    && ~/.cargo/bin/cargo build --release --features log,dmi,git,http,sql,noise,url,file,hash \
+    && ~/.cargo/bin/cargo build --release --all-features \
 	&& apt-get --purge remove -y dos2unix
 
 FROM base as dm_base

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -7,7 +7,7 @@
 // Override the .dll/.so detection logic with a fixed path or with detection
 // logic of your own.
 //
-// #define RUSTG_OVERRIDE_BUILTINS
+#define RUSTG_OVERRIDE_BUILTINS
 // Enable replacement rust-g functions for certain builtins. Off by default.
 
 #ifndef RUST_G
@@ -52,8 +52,8 @@
 #define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
-#define file2text(fname) rustg_file_read(fname)
-#define text2file(text, fname) rustg_file_append(text, fname)
+#define file2text(fname) rustg_file_read("[fname]")
+#define text2file(text, fname) rustg_file_append(text, "[fname]")
 #endif
 
 #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -162,7 +162,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 		NEWSCASTER.update_icon()
 
 /datum/newscaster/feed_network/proc/save_photo(icon/photo)
-	var/photo_file = copytext_char(md5("\icon[photo]"), 1, 6)
+	var/photo_file = copytext_char(md5("/icon[photo]"), 1, 6)
 	if(!fexists("[GLOB.log_directory]/photos/[photo_file].png"))
 		//Clean up repeated frames
 		var/icon/clean = new /icon()

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -173,7 +173,7 @@ GLOBAL_PROTECT(protected_ranks)
 	//load ranks from backup file
 	if(dbfail)
 		var/backup_file = file2text("data/admins_backup.json")
-		if(backup_file == null)
+		if(!backup_file)
 			log_world("Unable to locate admins backup file.")
 			return FALSE
 		var/list/json = json_decode(backup_file)
@@ -252,7 +252,7 @@ GLOBAL_PROTECT(protected_ranks)
 				//already tried
 				return
 			var/backup_file = file2text("data/admins_backup.json")
-			if(backup_file == null)
+			if(!backup_file)
 				log_world("Unable to locate admins backup file.")
 				return
 			backup_file_json = json_decode(backup_file)

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -13,7 +13,7 @@ if [[ -f "Dockerfile" ]]; then
 fi
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.5.1
+export RUST_G_VERSION=0.4.5.2
 
 #node version
 export NODE_VERSION=12

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -13,7 +13,7 @@ if [[ -f "Dockerfile" ]]; then
 fi
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.5
+export RUST_G_VERSION=0.4.5.1
 
 #node version
 export NODE_VERSION=12

--- a/tools/travis/install_rust_g.sh
+++ b/tools/travis/install_rust_g.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 source dependencies.sh
 
 mkdir -p ~/.byond/bin
-wget -O ~/.byond/bin/librust_g.so "https://github.com/BeeStation/rust-g/releases/download/$RUST_G_VERSION/librust_g_full.so"
+wget -O ~/.byond/bin/librust_g.so "https://github.com/BeeStation/rust-g/releases/download/$RUST_G_VERSION/full_librust_g.so"
 chmod +x ~/.byond/bin/librust_g.so
 ldd ~/.byond/bin/librust_g.so

--- a/tools/travis/install_rust_g.sh
+++ b/tools/travis/install_rust_g.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 source dependencies.sh
 
 mkdir -p ~/.byond/bin
-wget -O ~/.byond/bin/librust_g.so "https://github.com/tgstation/rust-g/releases/download/$RUST_G_VERSION/librust_g.so"
+wget -O ~/.byond/bin/librust_g.so "https://github.com/BeeStation/rust-g/releases/download/$RUST_G_VERSION/librust_g_full.so"
 chmod +x ~/.byond/bin/librust_g.so
 ldd ~/.byond/bin/librust_g.so


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pretty much the same deal as https://github.com/BeeStation/BeeStation-Hornet/pull/2190. 

TG has accepted my changes for rust_g which makes overrides actually viable. We will be moving forward with our own fork from here to ensure that we can always build using the full version of rust_g, and so that we can evolve it as needed. https://github.com/BeeStation/rust-g

## Why It's Good For The Game

It's `f a s t`

## Notice for downstreams: 
This will require that you either use our version of rust-g (the one included in the repo), the latest `full` [release version](https://github.com/BeeStation/rust-g/releases/latest), or that you compile your own version with all of the required additional features (url & file): https://github.com/BeeStation/rust-g#compiling

----

Depends on https://github.com/BeeStation/BeeStation-Hornet/pull/2274