### PR TITLE
Makes oddysseus's syringe gun able to synthetise all basic mutation toxins.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -413,7 +413,7 @@
 	var/datum/species/race = /datum/species/human
 	var/mutationtext = "<span class='danger'>The pain subsides. You feel... human.</span>"
 	process_flags = ORGANIC | SYNTHETIC
-	can_synth = FALSE
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/on_mob_life(mob/living/carbon/human/H)
 	..()
@@ -470,6 +470,7 @@
 	race = /datum/species/human/felinid
 	mutationtext = "<span class='danger'>The pain subsides. You feel... like a degenerate.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/lizard
 	name = "Lizard Mutation Toxin"
@@ -478,6 +479,7 @@
 	race = /datum/species/lizard
 	mutationtext = "<span class='danger'>The pain subsides. You feel... scaly.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/fly
 	name = "Fly Mutation Toxin"
@@ -486,6 +488,7 @@
 	race = /datum/species/fly
 	mutationtext = "<span class='danger'>The pain subsides. You feel... buzzy.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/moth
 	name = "Moth Mutation Toxin"
@@ -494,6 +497,7 @@
 	race = /datum/species/moth
 	mutationtext = "<span class='danger'>The pain subsides. You feel... attracted to light.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/pod
 	name = "Podperson Mutation Toxin"
@@ -511,6 +515,7 @@
 	race = /datum/species/jelly
 	mutationtext = "<span class='danger'>The pain subsides. You feel... wobbly.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/golem
 	name = "Golem Mutation Toxin"
@@ -519,6 +524,7 @@
 	race = /datum/species/golem/random
 	mutationtext = "<span class='danger'>The pain subsides. You feel... rocky.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/abductor
 	name = "Abductor Mutation Toxin"
@@ -527,6 +533,7 @@
 	race = /datum/species/abductor
 	mutationtext = "<span class='danger'>The pain subsides. You feel... alien.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/android
 	name = "Android Mutation Toxin"
@@ -535,6 +542,7 @@
 	race = /datum/species/android
 	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/ipc
 	name = "IPC Mutation Toxin"
@@ -543,6 +551,7 @@
 	race = /datum/species/ipc
 	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/squid
 	name = "Squid Mutation Toxin"
@@ -551,6 +560,7 @@
 	race = /datum/species/squid
 	mutationtext = "<span class='danger'>The pain subsides. You feel... salty.</span>"
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = TRUE
 
 //BLACKLISTED RACES
 /datum/reagent/mutationtoxin/skeleton


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Why would oddyseus be able to make unstable and pod mutation toxin but not the rest?
Makes all basic mutation toxins(non-blacklisted and non-dangerous races) able to be produced via oddyseus syringe gun.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency, ~~you can now turn people into cat girls el masse~~.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Balance: makes all basic mutation toxins synthetise-able
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
