### PR TITLE
Patch and bottle dispensers no longer cause lag.

### DIFF
--- a/code/modules/plumbing/plumbers/bottle_dispenser.dm
+++ b/code/modules/plumbing/plumbers/bottle_dispenser.dm
@@ -25,8 +25,7 @@
 	if(stat & NOPOWER)
 		return
 	if(reagents.total_volume >= bottle_size)
-		var/obj/item/reagent_containers/glass/bottle/P
-		P = new/obj/item/reagent_containers/glass/bottle(drop_location())
+		var/obj/item/reagent_containers/glass/bottle/P = new(src)
 		reagents.trans_to(P, bottle_size)
 		P.name = bottle_name
 		stored_bottles += P

--- a/code/modules/plumbing/plumbers/bottle_dispenser.dm
+++ b/code/modules/plumbing/plumbers/bottle_dispenser.dm
@@ -7,6 +7,7 @@
 	var/bottle_size = 30
 	///the icon_state number for the bottle.
 	var/list/stored_bottles = list()
+	var/max_stored_bottles = 3
 	///max amount of bottles allowed on our tile before we start storing them instead
 	var/max_floor_bottles = 10
 
@@ -24,7 +25,7 @@
 /obj/machinery/plumbing/bottle_dispenser/process()
 	if(stat & NOPOWER)
 		return
-	if(reagents.total_volume >= bottle_size)
+	if((reagents.total_volume >= bottle_size) && (stored_bottles.len < max_stored_bottles))
 		var/obj/item/reagent_containers/glass/bottle/P = new(src)
 		reagents.trans_to(P, bottle_size)
 		P.name = bottle_name

--- a/code/modules/plumbing/plumbers/patch_dispenser.dm
+++ b/code/modules/plumbing/plumbers/patch_dispenser.dm
@@ -7,6 +7,7 @@
 	var/patch_size = 40
 	///the icon_state number for the patch.
 	var/list/stored_patches = list()
+	var/max_stored_patches = 3
 	///max amount of patches allowed on our tile before we start storing them instead
 	var/max_floor_patches = 10
 
@@ -24,7 +25,7 @@
 /obj/machinery/plumbing/patch_dispenser/process()
 	if(stat & NOPOWER)
 		return
-	if(reagents.total_volume >= patch_size)
+	if((reagents.total_volume >= patch_size) && (stored_patches.len < max_stored_patches))
 		var/obj/item/reagent_containers/pill/patch/P = new(src)
 		reagents.trans_to(P, patch_size)
 		P.name = patch_name

--- a/code/modules/plumbing/plumbers/patch_dispenser.dm
+++ b/code/modules/plumbing/plumbers/patch_dispenser.dm
@@ -25,8 +25,7 @@
 	if(stat & NOPOWER)
 		return
 	if(reagents.total_volume >= patch_size)
-		var/obj/item/reagent_containers/pill/patch/P
-		P = new/obj/item/reagent_containers/pill/patch(drop_location())
+		var/obj/item/reagent_containers/pill/patch/P = new(src)
 		reagents.trans_to(P, patch_size)
 		P.name = patch_name
 		stored_patches += P

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -17,6 +17,7 @@
 	var/list/pill_styles
 	///list of pills stored in the machine, so we dont have 610 pills on one tile
 	var/list/stored_pills = list()
+	var/max_stored_pills = 3
 	///max amount of pills allowed on our tile before we start storing them instead
 	var/max_floor_pills = 10
 
@@ -43,7 +44,7 @@
 /obj/machinery/plumbing/pill_press/process()
 	if(stat & NOPOWER)
 		return
-	if(reagents.total_volume >= pill_size)
+	if((reagents.total_volume >= pill_size) && (stored_pills.len < max_stored_pills))
 		var/obj/item/reagent_containers/pill/P = new(src)
 		reagents.trans_to(P, pill_size)
 		P.name = pill_name


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes patch and bottle dispensers in plumbing spewing out endless bottles on the floor tile casing severe lag when right-clicking the respective tile or even being nearby in severe cases.

## Why It's Good For The Game

Lag is bad, I guess?

## Changelog
:cl:
fix: Patch and bottle dispensers no longer spew out products despite the maximum being dispensed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
