### PR TITLE
Liver failure is actually deadly again

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -50,8 +50,8 @@
 				to_chat(C, "<span class='warning'>You feel a dull pain in your abdomen.</span>")
 
 		else	//for when our liver's failing
-			reagents.end_metabolization(C, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
-			reagents.metabolize(C, can_overdose=FALSE, liverless = TRUE)
+			C.reagents.end_metabolization(C, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
+			C.reagents.metabolize(C, can_overdose=FALSE, liverless = TRUE)
 			if(HAS_TRAIT(C, TRAIT_STABLELIVER))
 				return
 			C.adjustToxLoss(4, TRUE,  TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Liver failure was never properly processed, meaning that players could get away with destroying their liver and going on like normal. This wasn't exactly a buff either, since any reagents added would pile up until a new liver was added.

Fixes #2107

## Why It's Good For The Game

Liver failure is a bit more realistic again

## Changelog
:cl:
fix: Liver failure is actually deadly again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
