### PR TITLE
hulk, wallsmash, attack_hand changes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3864,7 +3864,6 @@
 	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
 	emote_hear = list("chitters");
 	faction = list("spiders");
-	harm_intent_damage = 3;
 	health = 200;
 	icon_dead = "guard_dead";
 	icon_gib = "guard_dead";

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -1,15 +1,15 @@
 //Hulk turns your skin green, and allows you to punch through walls.
 /datum/mutation/human/hulk
 	name = "Hulk"
-	desc = "A poorly understood genome that causes the holder's muscles to expand, inhibit speech and gives the person a bad skin condition."
+	desc = "A poorly understood genome that causes rapid muscular growth and accelerated adrenaline production, as well as heavy brain damage and skin defects."
 	quality = POSITIVE
 	locked = TRUE
 	difficulty = 16
 	text_gain_indication = "<span class='notice'>Your muscles hurt!</span>"
-	species_allowed = list("human") //no skeleton/lizard hulk
 	health_req = 25
 	instability = 40
 	locked = TRUE
+	var/cachedcolor = null
 
 /datum/mutation/human/hulk/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
@@ -20,13 +20,18 @@
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_HULK)
 	ADD_TRAIT(owner, TRAIT_NOSTAMCRIT, TRAIT_HULK)
 	ADD_TRAIT(owner, TRAIT_NOLIMBDISABLE, TRAIT_HULK)
+	ADD_TRAIT(owner, TRAIT_NOGUNS, TRAIT_HULK)
 	owner.update_body_parts()
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "hulk", /datum/mood_event/hulk)
 	RegisterSignal(owner, COMSIG_MOB_SAY, .proc/handle_speech)
-
-/datum/mutation/human/hulk/on_attack_hand(atom/target, proximity)
-	if(proximity) //no telekinetic hulk attack
-		return target.attack_hulk(owner)
+	if(owner.dna.species.use_skintones)
+		cachedcolor = owner.skin_tone
+		owner.skin_tone = "green"
+	else if(MUTCOLORS in owner.dna.species.species_traits)
+		cachedcolor = owner.dna.features["mcolor"]
+		owner.dna.features["mcolor"] = "7f0"
+	owner.regenerate_icons()
+	owner.dna.species.punchdamage += 8 //this is so much easier. hulks do about 15 base damage. Simple.
 
 /datum/mutation/human/hulk/on_life()
 	if(owner.health < 0)
@@ -42,8 +47,15 @@
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, TRAIT_HULK)
 	REMOVE_TRAIT(owner, TRAIT_NOSTAMCRIT, TRAIT_HULK)
 	REMOVE_TRAIT(owner, TRAIT_NOLIMBDISABLE, TRAIT_HULK)
+	REMOVE_TRAIT(owner, TRAIT_NOGUNS, TRAIT_HULK)
 	owner.update_body_parts()
 	SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "hulk")
+	owner.dna.species.punchdamage -= 8
+	if(owner.dna.species.use_skintones)
+		owner.skin_tone = cachedcolor
+	else if(MUTCOLORS in owner.dna.species.species_traits)
+		owner.dna.features["mcolor"] = cachedcolor
+	owner.regenerate_icons()
 
 /datum/mutation/human/hulk/proc/handle_speech(original_message, wrapped_message)
 	var/message = wrapped_message[1]

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -280,14 +280,6 @@
 
 	return FALSE
 
-///This atom has been hit by a hulkified mob in hulk mode (user)
-/atom/proc/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	SEND_SIGNAL(src, COMSIG_ATOM_HULK_ATTACK, user)
-	if(does_attack_animation)
-		user.changeNext_move(CLICK_CD_MELEE)
-		log_combat(user, src, "punched", "hulk powers")
-		user.do_attack_animation(src, ATTACK_EFFECT_SMASH)
-
 /**
   * Ensure a list of atoms/reagents exists inside this atom
   *

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -81,9 +81,6 @@
 /obj/machinery/porta_turret_cover/attack_animal(mob/living/simple_animal/user)
 	parent_turret.attack_animal(user)
 
-/obj/machinery/porta_turret_cover/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	return parent_turret.attack_hulk(user)
-
 /obj/machinery/porta_turret_cover/can_be_overridden()
 	. = 0
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -93,13 +93,7 @@
 
 
 /obj/mecha/hulk_damage()
-	return 15
-
-/obj/mecha/attack_hulk(mob/living/carbon/human/user)
-	. = ..()
-	if(.)
-		log_message("Attack by hulk. Attacker - [user].", LOG_MECHA, color="red")
-		log_combat(user, src, "punched", "hulk powers")
+	return 30
 
 /obj/mecha/blob_act(obj/structure/blob/B)
 	log_message("Attack by blob. Attacker - [B].", LOG_MECHA, color="red")

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -23,9 +23,6 @@
 /obj/effect/blob_act(obj/structure/blob/B)
 	return
 
-/obj/effect/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	return 0
-
 /obj/effect/experience_pressure_difference()
 	return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -809,7 +809,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	return
 
-/obj/item/attack_hulk(mob/living/carbon/human/user)
+/obj/item/hulk_damage()
 	return 0
 
 /obj/item/attack_animal(mob/living/simple_animal/M)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -80,11 +80,6 @@
 	if(HAS_TRAIT(user, TRAIT_NOGUNS))
 		to_chat(user, "<span class='warning'>Your fingers can't press the button!</span>")
 		return
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.dna.check_mutation(HULK))
-			to_chat(user, "<span class='warning'>Your fingers can't press the button!</span>")
-			return
 
 	add_fingerprint(user)
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -360,11 +360,6 @@
 	SEND_SIGNAL(src, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRENGTH_BLOOD)
 
 /obj/item/twohanded/dualsaber/attack(mob/target, mob/living/carbon/human/user)
-	if(user.has_dna())
-		if(user.dna.check_mutation(HULK))
-			to_chat(user, "<span class='warning'>You grip the blade too hard and accidentally close it!</span>")
-			unwield()
-			return
 	..()
 	if(HAS_TRAIT(user, TRAIT_CLUMSY) && (wielded) && prob(40))
 		impale(user)
@@ -387,16 +382,7 @@
 		return 0
 	return ..()
 
-/obj/item/twohanded/dualsaber/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)  //In case thats just so happens that it is still activated on the groud, prevents hulk from picking it up
-	if(wielded)
-		to_chat(user, "<span class='warning'>You can't pick up such dangerous item with your meaty hands without losing fingers, better not to!</span>")
-		return 1
-
-/obj/item/twohanded/dualsaber/wield(mob/living/carbon/M) //Specific wield () hulk checks due to reflection chance for balance issues and switches hitsounds.
-	if(M.has_dna())
-		if(M.dna.check_mutation(HULK))
-			to_chat(M, "<span class='warning'>You lack the grace to wield this!</span>")
-			return
+/obj/item/twohanded/dualsaber/wield(mob/living/carbon/M)
 	..()
 	if(wielded)
 		sharpness = IS_SHARP

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -75,20 +75,23 @@
 		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
 
 /obj/proc/hulk_damage()
-	return 150 //the damage hulks do on punches to this object, is affected by melee armor
+	return 100 //the damage hulks do on punches to this object, is affected by melee armor
 
-/obj/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		..(user, 1)
-		user.visible_message("<span class='danger'>[user] smashes [src]!</span>", "<span class='danger'>You smash [src]!</span>", null, COMBAT_MESSAGE_RANGE)
-		if(density)
-			playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
-			user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced="hulk")
-		else
-			playsound(src, 'sound/effects/bang.ogg', 50, 1)
-		take_damage(hulk_damage(), BRUTE, "melee", 0, get_dir(src, user))
-		return 1
-	return 0
+/obj/attack_hand(mob/living/user) 
+	. = ..()
+	if(ishuman(user) && user.a_intent == INTENT_HARM && !isitem(src))
+		var/mob/living/carbon/human/H = user
+		if(H.has_dna())
+			if(H.dna.check_mutation(HULK))
+				H.changeNext_move(CLICK_CD_MELEE)
+				user.visible_message("<span class='danger'>[user] smashes [src]!</span>", "<span class='danger'>You smash [src]!</span>", null, COMBAT_MESSAGE_RANGE)
+				if(density)
+					playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
+					user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced="hulk")
+				else
+					playsound(src, 'sound/effects/bang.ogg', 50, 1)
+				take_damage(hulk_damage(), BRUTE, "melee", 0, get_dir(src, user))
+				return 1
 
 /obj/blob_act(obj/structure/blob/B)
 	if(isturf(loc))

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -95,15 +95,6 @@
 /obj/structure/grille/attack_paw(mob/user)
 	return attack_hand(user)
 
-/obj/structure/grille/hulk_damage()
-	return 60
-
-/obj/structure/grille/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		if(!shock(user, 70))
-			..(user, 1)
-		return TRUE
-
 /obj/structure/grille/attack_hand(mob/living/user)
 	. = ..()
 	if(.)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -127,11 +127,6 @@
 	add_fingerprint(user)
 	playsound(src, 'sound/effects/Glassknock.ogg', 50, 1)
 
-/obj/structure/window/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(!can_be_reached(user))
-		return 1
-	. = ..()
-
 /obj/structure/window/attack_hand(mob/user)
 	. = ..()
 	if(.)

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -136,7 +136,7 @@
 	icon = 'icons/turf/walls/wood_wall.dmi'
 	icon_state = "wood"
 	sheet_type = /obj/item/stack/sheet/mineral/wood
-	hardness = 70
+	hardness = 25
 	explosion_block = 0
 	canSmoothWith = list(/turf/closed/wall/mineral/wood, /obj/structure/falsewall/wood, /turf/closed/wall/mineral/wood/nonmetal)
 
@@ -153,7 +153,7 @@
 /turf/closed/wall/mineral/wood/nonmetal
 	desc = "A solidly wooden wall. It's a bit weaker than a wall made with metal."
 	girder_type = /obj/structure/barricade/wooden
-	hardness = 50
+	hardness = 40
 	canSmoothWith = list(/turf/closed/wall/mineral/wood, /obj/structure/falsewall/wood, /turf/closed/wall/mineral/wood/nonmetal)
 
 /turf/closed/wall/mineral/iron
@@ -169,7 +169,7 @@
 	desc = "A wall made of densely packed snow blocks."
 	icon = 'icons/turf/walls/snow_wall.dmi'
 	icon_state = "snow"
-	hardness = 80
+	hardness = 20
 	explosion_block = 0
 	slicing_duration = 30
 	sheet_type = /obj/item/stack/sheet/mineral/snow

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -42,7 +42,7 @@
 	name = "clockwork wall"
 	desc = "A huge chunk of warm metal. The clanging of machinery emanates from within."
 	explosion_block = 2
-	hardness = 10
+	hardness = 100
 	slicing_duration = 80
 	sheet_type = /obj/item/stack/tile/brass
 	sheet_amount = 1
@@ -123,7 +123,7 @@
 		visible_message("<span class='warning'>[src] sizzles with heat!</span>")
 		playsound(src, 'sound/machines/fryer/deep_fryer_emerge.ogg', 50, TRUE)
 		heated = TRUE
-		hardness = -100 //Lower numbers are tougher, so this makes the wall essentially impervious to smashing
+		hardness = 1000 //twice as durable as a reinforced wall
 		slicing_duration = 150
 		animate(realappearance, color = "#FFC3C3", time = 5)
 	else
@@ -144,7 +144,7 @@
 	icon_state = "iced"
 	desc = "A wall covered in a thick sheet of ice."
 	canSmoothWith = null
-	hardness = 35
+	hardness = 75
 	slicing_duration = 150 //welding through the ice+metal
 	bullet_sizzle = TRUE
 
@@ -152,7 +152,7 @@
 	name = "rusted wall"
 	desc = "A rusted metal wall."
 	icon = 'icons/turf/walls/rusty_wall.dmi'
-	hardness = 45
+	hardness = 30
 
 /turf/closed/wall/rust/rust_heretic_act()
 	if(prob(70))
@@ -163,7 +163,7 @@
 	name = "rusted reinforced wall"
 	desc = "A huge chunk of rusted reinforced metal."
 	icon = 'icons/turf/walls/rusty_reinforced_wall.dmi'
-	hardness = 15
+	hardness = 250
 
 /turf/closed/wall/r_wall/rust/rust_heretic_act()
 	if(prob(50))

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -37,6 +37,104 @@
 /turf/closed/wall/mineral/cult/artificer/devastate_wall()
 	new /obj/effect/temp_visual/cult/turf(get_turf(src))
 
+//Clockwork wall: Causes nearby tinkerer's caches to generate components.
+/turf/closed/wall/clockwork
+	name = "clockwork wall"
+	desc = "A huge chunk of warm metal. The clanging of machinery emanates from within."
+	explosion_block = 2
+	hardness = 10
+	slicing_duration = 80
+	sheet_type = /obj/item/stack/tile/brass
+	sheet_amount = 1
+	girder_type = /obj/structure/girder/bronze
+	baseturfs = /turf/open/floor/clockwork/reebe
+	var/heated
+	var/obj/effect/clockwork/overlay/wall/realappearance
+
+/turf/closed/wall/clockwork/Initialize()
+	. = ..()
+	new /obj/effect/temp_visual/ratvar/wall(src)
+	new /obj/effect/temp_visual/ratvar/beam(src)
+	realappearance = new /obj/effect/clockwork/overlay/wall(src)
+	realappearance.linked = src
+
+/turf/closed/wall/clockwork/Destroy()
+	if(realappearance)
+		qdel(realappearance)
+		realappearance = null
+
+	return ..()
+
+/turf/closed/wall/clockwork/ReplaceWithLattice()
+	..()
+	for(var/obj/structure/lattice/L in src)
+		L.ratvar_act()
+
+/turf/closed/wall/clockwork/narsie_act()
+	..()
+	if(istype(src, /turf/closed/wall/clockwork)) //if we haven't changed type
+		var/previouscolor = color
+		color = "#960000"
+		animate(src, color = previouscolor, time = 8)
+		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
+
+/turf/closed/wall/clockwork/dismantle_wall(devastated=0, explode=0)
+	if(devastated)
+		devastate_wall()
+		ScrapeAway()
+	else
+		playsound(src, 'sound/items/welder.ogg', 100, 1)
+		var/newgirder = break_wall()
+		if(newgirder) //maybe we want a gear!
+			transfer_fingerprints_to(newgirder)
+		ScrapeAway()
+
+	for(var/obj/O in src) //Eject contents!
+		if(istype(O, /obj/structure/sign/poster))
+			var/obj/structure/sign/poster/P = O
+			P.roll_and_drop(src)
+		else
+			O.forceMove(src)
+
+/turf/closed/wall/clockwork/devastate_wall()
+	for(var/i in 1 to 2)
+		new/obj/item/clockwork/alloy_shards/large(src)
+	for(var/i in 1 to 2)
+		new/obj/item/clockwork/alloy_shards/medium(src)
+	for(var/i in 1 to 3)
+		new/obj/item/clockwork/alloy_shards/small(src)
+
+/turf/closed/wall/clockwork/attacked(mob/living/user, damage)
+	. = ..()
+	if(heated && istype(user))
+		to_chat(user, "<span class='userdanger'>The wall is searing hot to the touch!</span>")
+		user.adjustFireLoss(5)
+		playsound(src, 'sound/machines/fryer/deep_fryer_emerge.ogg', 50, TRUE)
+
+/turf/closed/wall/clockwork/mech_melee_attack(obj/mecha/M)
+	..()
+	if(heated)
+		to_chat(M.occupant, "<span class='userdanger'>The wall's intense heat completely reflects your [M.name]'s attack!</span>")
+		M.take_damage(20, BURN)
+
+/turf/closed/wall/clockwork/proc/turn_up_the_heat()
+	if(!heated)
+		name = "superheated [name]"
+		visible_message("<span class='warning'>[src] sizzles with heat!</span>")
+		playsound(src, 'sound/machines/fryer/deep_fryer_emerge.ogg', 50, TRUE)
+		heated = TRUE
+		hardness = -100 //Lower numbers are tougher, so this makes the wall essentially impervious to smashing
+		slicing_duration = 150
+		animate(realappearance, color = "#FFC3C3", time = 5)
+	else
+		name = initial(name)
+		visible_message("<span class='notice'>[src] cools down.</span>")
+		heated = FALSE
+		hardness = initial(hardness)
+		slicing_duration = initial(slicing_duration)
+		animate(realappearance, color = initial(realappearance.color), time = 25)
+
+
 /turf/closed/wall/vault
 	icon = 'icons/turf/walls.dmi'
 	icon_state = "rockvault"

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -7,7 +7,7 @@
 	density = TRUE
 
 	var/d_state = INTACT
-	hardness = 10
+	hardness = 500
 	sheet_type = /obj/item/stack/sheet/plasteel
 	sheet_amount = 1
 	girder_type = /obj/structure/girder/reinforced
@@ -37,30 +37,6 @@
 /turf/closed/wall/r_wall/devastate_wall()
 	new sheet_type(src, sheet_amount)
 	new /obj/item/stack/sheet/iron(src, 2)
-
-/turf/closed/wall/r_wall/attack_animal(mob/living/simple_animal/M)
-	M.changeNext_move(CLICK_CD_MELEE)
-	M.do_attack_animation(src)
-	if(!M.environment_smash)
-		return
-	if(M.environment_smash & ENVIRONMENT_SMASH_RWALLS)
-		dismantle_wall(1)
-		playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
-	else
-		playsound(src, 'sound/effects/bang.ogg', 50, 1)
-		to_chat(M, "<span class='warning'>This wall is far too strong for you to destroy.</span>")
-
-/turf/closed/wall/r_wall/try_destroy(obj/item/I, mob/user, turf/T)
-	if(istype(I, /obj/item/pickaxe/drill/jackhammer))
-		to_chat(user, "<span class='notice'>You begin to smash though [src]...</span>")
-		if(do_after(user, 50, target = src))
-			if(!istype(src, /turf/closed/wall/r_wall))
-				return TRUE
-			I.play_tool_sound(src)
-			visible_message("<span class='warning'>[user] smashes through [src] with [I]!</span>", "<span class='italics'>You hear the grinding of metal.</span>")
-			dismantle_wall()
-			return TRUE
-	return FALSE
 
 /turf/closed/wall/r_wall/try_decon(obj/item/W, mob/user, turf/T)
 	//DECONSTRUCTION

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -139,7 +139,7 @@
 		attacked(M, 100) //5 hits to wreck an rwall, 1 hit for a normal wall
 	else if(M.environment_smash & ENVIRONMENT_SMASH_WALLS)
 		attacked(M, 10) //50 hits for an rwall, 5 hits for a normal wall
-	else if(M.melee_damage >= 5)
+	else if(M.obj_damage >= 20)
 		attacked (M, 1) //50 hits for a normal wall, too many hits to matter for an rwall
 
 /turf/closed/wall/proc/attacked(mob/user, damage = 25)

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -221,7 +221,7 @@
 		overmind.blobstrain.extinguish_reaction(src)
 
 /obj/structure/blob/hulk_damage()
-	return 15
+	return 30
 
 /obj/structure/blob/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_ANALYZER)

--- a/code/modules/antagonists/clock_cult/clockwork_turfs.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_turfs.dm
@@ -106,12 +106,6 @@
 /turf/closed/wall/clockwork/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	return
 
-/turf/closed/wall/clockwork/attack_hulk(mob/user, does_attack_animation)
-	if(prob(10))
-		return ..()
-	to_chat(user, "<span class='warning'>Your slightly dent [src].</span>")
-	return
-
 //========Deconstruction Handled Here=======
 /turf/closed/wall/clockwork/deconstruction_hints(mob/user)
 	switch(d_state)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -37,7 +37,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
-	harm_intent_damage = 0
+	harm_intent_damage = 0.00001
 	friendly = "touches"
 	status_flags = 0
 	wander = FALSE

--- a/code/modules/awaymissions/signpost.dm
+++ b/code/modules/awaymissions/signpost.dm
@@ -36,9 +36,6 @@
 /obj/structure/signpost/attack_paw(mob/user)
 	return interact(user)
 
-/obj/structure/signpost/attack_hulk(mob/user, does_attack_animation = 0)
-	return interact(user)
-
 /obj/structure/signpost/attack_larva(mob/user)
 	return interact(user)
 

--- a/code/modules/awaymissions/super_secret_room.dm
+++ b/code/modules/awaymissions/super_secret_room.dm
@@ -95,9 +95,6 @@
 /obj/structure/speaking_tile/attack_paw(mob/user)
 	return interact(user)
 
-/obj/structure/speaking_tile/attack_hulk(mob/user, does_attack_animation = 0)
-	return interact(user)
-
 /obj/structure/speaking_tile/attack_larva(mob/user)
 	return interact(user)
 

--- a/code/modules/guardian/abilities/special/absolution.dm
+++ b/code/modules/guardian/abilities/special/absolution.dm
@@ -83,16 +83,6 @@
 		return M.attack_animal(M)
 	return ..()
 
-/mob/living/carbon/human/attack_hulk(mob/living/carbon/human/user)
-	if(HAS_TRAIT(src, TRAIT_ONEWAYROAD))
-		return user.attack_hulk(user)
-	return ..()
-
-/mob/living/simple_animal/hostile/guardian/attack_hulk(mob/living/carbon/human/user)
-	if(HAS_TRAIT(src, TRAIT_ONEWAYROAD))
-		return user.attack_hulk(user)
-	return ..()
-
 /mob/living/carbon/human/attack_alien(mob/living/carbon/alien/humanoid/M)
 	if(HAS_TRAIT(src, TRAIT_ONEWAYROAD))
 		return M.attack_alien(M)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -1,61 +1,26 @@
 
-
-/mob/living/carbon/alien/humanoid/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		..(user, 1)
-		adjustBruteLoss(15)
-		var/hitverb = "punches"
-		if(mob_size < MOB_SIZE_LARGE)
-			step_away(src,user,15)
-			sleep(1)
-			step_away(src,user,15)
-			hitverb = "slams"
-		playsound(loc, "punch", 25, 1, -1)
-		visible_message("<span class='danger'>[user] [hitverb] [src]!</span>", \
-		"<span class='userdanger'>[user] [hitverb] you!</span>", null, COMBAT_MESSAGE_RANGE)
-		return 1
-
 /mob/living/carbon/alien/humanoid/attack_hand(mob/living/carbon/human/M)
 	if(..())
 		switch(M.a_intent)
 			if ("harm")
-				var/damage = rand(1, 9)
-				if (prob(90))
-					playsound(loc, "punch", 25, 1, -1)
-					visible_message("<span class='danger'>[M] punches [src]!</span>", \
-							"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-					if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of knocking an alien down.
-						Unconscious(40)
-						visible_message("<span class='danger'>[M] knocks [src] down!</span>", \
-								"<span class='userdanger'>[M] knocks you down!</span>")
-					var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
-					apply_damage(damage, BRUTE, affecting)
-					log_combat(M, src, "attacked")
-				else
-					playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-					visible_message("<span class='danger'>[M]'s punch misses [src]!</span>", \
-						"<span class='userdanger'>[M]'s punch misses you!</span>", null, COMBAT_MESSAGE_RANGE)
+				var/damage = M.dna.species.punchdamage
+				playsound(loc, "punch", 25, 1, -1)
+				visible_message("<span class='danger'>[M] punches [src]!</span>", \
+						"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
+				if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of knocking an alien down.
+					Unconscious(40)
+					visible_message("<span class='danger'>[M] knocks [src] down!</span>", \
+							"<span class='userdanger'>[M] knocks you down!</span>")
+				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
+				apply_damage(damage, BRUTE, affecting)
+				log_combat(M, src, "attacked")
 
 			if ("disarm")
 				if (!(mobility_flags & MOBILITY_STAND))
-					if (prob(5))
-						Unconscious(40)
-						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-						log_combat(M, src, "pushed")
-						visible_message("<span class='danger'>[M] pushed [src] down!</span>", \
-							"<span class='userdanger'>[M] pushed you down!</span>")
-					else
-						if (prob(50))
-							dropItemToGround(get_active_held_item())
-							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-							visible_message("<span class='danger'>[M] disarms [src]!</span>", \
-							"<span class='userdanger'>[M] disarms you!</span>", null, COMBAT_MESSAGE_RANGE)
-						else
-							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-							visible_message("<span class='danger'>[M] fails to disarm [src]!</span>",\
-								"<span class='userdanger'>[M] fails to disarm you!</span>", null, COMBAT_MESSAGE_RANGE)
-
-
+					dropItemToGround(get_active_held_item())
+					playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+					visible_message("<span class='danger'>[M] disarms [src]!</span>", \
+						"<span class='userdanger'>[M] disarms you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 /mob/living/carbon/alien/humanoid/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
 	if(!no_effect && !visual_effect_icon)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -7,10 +7,6 @@
 				playsound(loc, "punch", 25, 1, -1)
 				visible_message("<span class='danger'>[M] punches [src]!</span>", \
 						"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-				if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of knocking an alien down.
-					Unconscious(40)
-					visible_message("<span class='danger'>[M] knocks [src] down!</span>", \
-							"<span class='userdanger'>[M] knocks you down!</span>")
 				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 				apply_damage(damage, BRUTE, affecting)
 				log_combat(M, src, "attacked")

--- a/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
@@ -2,28 +2,13 @@
 
 /mob/living/carbon/alien/larva/attack_hand(mob/living/carbon/human/M)
 	if(..())
-		var/damage = rand(1, 9)
-		if (prob(90))
-			playsound(loc, "punch", 25, 1, -1)
-			log_combat(M, src, "attacked")
-			visible_message("<span class='danger'>[M] kicks [src]!</span>", \
-					"<span class='userdanger'>[M] kicks you!</span>", null, COMBAT_MESSAGE_RANGE)
-			if ((stat != DEAD) && (damage > 4.9))
-				Unconscious(rand(100,200))
-
-			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
-			apply_damage(damage, BRUTE, affecting)
-		else
-			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M]'s kick misses [src]!</span>", \
-					"<span class='userdanger'>[M]'s kick misses you!</span>", null, COMBAT_MESSAGE_RANGE)
-
-/mob/living/carbon/alien/larva/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		..(user, 1)
-		adjustBruteLoss(5 + rand(1,9))
-		new /datum/forced_movement(src, get_step_away(user,src, 30), 1)
-		return 1
+		var/damage = M.dna.species.punchdamage
+		playsound(loc, "punch", 25, 1, -1)
+		log_combat(M, src, "attacked")
+		visible_message("<span class='danger'>[M] kicks [src]!</span>", \
+				"<span class='userdanger'>[M] kicks you!</span>", null, COMBAT_MESSAGE_RANGE)
+		if ((stat != DEAD) && (damage > 4.9))
+			Unconscious(rand(100,200))
 
 /mob/living/carbon/alien/larva/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
 	if(!no_effect && !visual_effect_icon)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -49,7 +49,7 @@
 	if(mind)
 		if(mind.martial_art && !incapacitated(FALSE, TRUE) && mind.martial_art.can_use(src) && mind.martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
 			if(prob(mind.martial_art.deflection_chance))
-				if((mobility_flags & MOBILITY_USE) && dna && !dna.check_mutation(HULK)) //But only if they're otherwise able to use items, and hulks can't do it
+				if((mobility_flags & MOBILITY_USE)) //But only if they're otherwise able to use items
 					if(!isturf(loc)) //if we're inside something and still got hit
 						P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.
 						loc.bullet_act(P)
@@ -195,24 +195,6 @@
 
 	// the attacked_by code varies among species
 	return dna.species.spec_attacked_by(I, user, affecting, a_intent, src)
-
-
-/mob/living/carbon/human/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		var/hulk_verb = pick("smash","pummel")
-		if(check_shields(user, 15, "the [hulk_verb]ing"))
-			return
-		..(user, 1)
-		playsound(loc, user.dna.species.attack_sound, 25, 1, -1)
-		var/message = "[user] has [hulk_verb]ed [src]!"
-		visible_message("<span class='danger'>[message]</span>", \
-								"<span class='userdanger'>[message]</span>")
-		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.zone_selected))
-		if(!affecting)
-			affecting = get_bodypart(BODY_ZONE_CHEST)
-		var/armor_block = run_armor_check(affecting, "melee","","",10)
-		apply_damage(20, BRUTE, affecting, armor_block)
-		return 1
 
 /mob/living/carbon/human/attack_hand(mob/user)
 	if(..())	//to allow surgery to return properly.

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -158,9 +158,6 @@
 	. = ..()
 
 	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
-		if(src.dna.check_mutation(HULK))
-			to_chat(src, "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>")
-			return FALSE
 		if(HAS_TRAIT(src, TRAIT_NOGUNS))
 			to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return FALSE

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -577,10 +577,7 @@ generate/load female uniform sprites matching all previously decided variables
 //produces a key based on the human's limbs
 /mob/living/carbon/human/generate_icon_render_key()
 	. = "[dna.species.limbs_id]"
-
-	if(dna.check_mutation(HULK))
-		. += "-coloured-hulk"
-	else if(dna.species.use_skintones)
+	if(dna.species.use_skintones)
 		. += "-coloured-[skin_tone]"
 	else if(dna.species.fixed_mut_color)
 		. += "-coloured-[dna.species.fixed_mut_color]"

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -54,16 +54,6 @@
 	if(L.a_intent == INTENT_HELP)
 		visible_message("[L.name] rubs its head against [src].")
 
-/mob/living/silicon/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		..(user, 1)
-		adjustBruteLoss(rand(10, 15))
-		playsound(loc, "punch", 25, 1, -1)
-		visible_message("<span class='danger'>[user] punches [src]!</span>", \
-				"<span class='userdanger'>[user] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-		return 1
-	return 0
-
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/silicon/attack_hand(mob/living/carbon/human/M)
 	. = FALSE
@@ -76,10 +66,17 @@
 		if("grab")
 			grabbedby(M)
 		else
-			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
-			playsound(src.loc, 'sound/effects/bang.ogg', 10, 1)
-			visible_message("<span class='danger'>[M] punches [src], but doesn't leave a dent!</span>", \
-				"<span class='warning'>[M] punches you, but doesn't leave a dent!</span>", null, COMBAT_MESSAGE_RANGE)
+			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)	
+			var/damage = M.dna.species.punchdamage
+			if(damage <= 10)
+				playsound(src.loc, 'sound/effects/bang.ogg', 10, 1)
+				visible_message("<span class='danger'>[M] punches [src], but doesn't leave a dent!</span>", \
+					"<span class='warning'>[M] punches you, but doesn't leave a dent!</span>", null, COMBAT_MESSAGE_RANGE)
+			else
+				adjustBruteLoss(damage)
+				playsound(loc, "punch", 25, 1, -1)
+				visible_message("<span class='danger'>[M] punches [src]!</span>", \
+					"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
 
 /mob/living/silicon/attack_drone(mob/living/simple_animal/drone/M)
 	if(M.a_intent == INTENT_HARM)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -13,6 +13,9 @@
 			grabbedby(M)
 
 		if("harm", "disarm")
+			var/damage = M.dna.species.punchdamage
+			if(harm_intent_damage)
+				damage = harm_intent_damage
 			if(HAS_TRAIT(M, TRAIT_PACIFISM))
 				to_chat(M, "<span class='notice'>You don't want to hurt [src]!</span>")
 				return
@@ -20,22 +23,10 @@
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>",\
 				"<span class='userdanger'>[M] [response_harm] you!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(loc, attacked_sound, 25, 1, -1)
-			attack_threshold_check(harm_intent_damage)
+			attack_threshold_check(damage)
 			log_combat(M, src, "attacked")
 			updatehealth()
 			return TRUE
-
-/mob/living/simple_animal/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		if(HAS_TRAIT(user, TRAIT_PACIFISM))
-			to_chat(user, "<span class='notice'>You don't want to hurt [src]!</span>")
-			return FALSE
-		..(user, 1)
-		playsound(loc, "punch", 25, 1, -1)
-		visible_message("<span class='danger'>[user] punches [src]!</span>", \
-			"<span class='userdanger'>[user] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-		adjustBruteLoss(15)
-		return TRUE
 
 /mob/living/simple_animal/attack_paw(mob/living/carbon/monkey/M)
 	if(..()) //successful monkey bite.

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -124,8 +124,6 @@
 	icon_living = "behemoth"
 	maxHealth = 150
 	health = 150
-	response_harm = "harmlessly punches"
-	harm_intent_damage = 0
 	obj_damage = 90
 	melee_damage = 25
 	attacktext = "smashes their armored gauntlet into"

--- a/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
@@ -16,8 +16,6 @@
 	maxHealth = 45
 	health = 45
 	speak_emote = list("telepathically cries")
-
-	harm_intent_damage = 15
 	obj_damage = 60
 	melee_damage = 20
 	attacktext = "blinks at"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
@@ -82,8 +82,6 @@
 
 IGNORE_PROC_IF_NOT_TARGET(attack_hand)
 
-IGNORE_PROC_IF_NOT_TARGET(attack_hulk)
-
 IGNORE_PROC_IF_NOT_TARGET(attack_paw)
 
 IGNORE_PROC_IF_NOT_TARGET(attack_alien)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -15,7 +15,6 @@
 	vision_range = 6
 	aggro_vision_range = 18
 	environment_smash = ENVIRONMENT_SMASH_NONE  //This is to prevent elites smashing up the mining station, we'll make sure they can smash minerals fine below.
-	harm_intent_damage = 0 //Punching elites gets you nowhere
 	stat_attack = UNCONSCIOUS
 	layer = LARGE_MOB_LAYER
 	sentience_type = SENTIENCE_BOSS

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -19,7 +19,6 @@
 	speed = 3
 	maxHealth = 300
 	health = 300
-	harm_intent_damage = 0
 	obj_damage = 100
 	melee_damage = 25
 	attacktext = "pulverizes"

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -82,7 +82,6 @@
 	F.icon_state = "Fugu1"
 	F.obj_damage = 60
 	F.melee_damage = 20
-	F.harm_intent_damage = 0
 	F.throw_message = "is absorbed by the girth of the"
 	F.retreat_distance = null
 	F.minimum_distance = 1
@@ -99,7 +98,6 @@
 		icon_state = "Fugu0"
 		obj_damage = 0
 		melee_damage = 0
-		harm_intent_damage = 6
 		throw_message = "is avoided by the"
 		retreat_distance = 9
 		minimum_distance = 9

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -28,7 +28,7 @@
 	var/response_help   = "pokes"
 	var/response_disarm = "shoves"
 	var/response_harm   = "hits"
-	var/harm_intent_damage = 6 //the damage dealt to a mob when punched. default is default punch damage
+	var/harm_intent_damage = 0 //the damage dealt to a mob when punched. if at 0, uses base attack number
 	var/force_threshold = 0 //Minimum force required to deal any damage
 
 	//Temperature effect

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -315,11 +315,6 @@
 	if(..()) //successful larva bite.
 		attacked += 10
 
-/mob/living/simple_animal/slime/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
-	if(user.a_intent == INTENT_HARM)
-		discipline_slime(user)
-		return ..()
-
 /mob/living/simple_animal/slime/attack_hand(mob/living/carbon/human/M)
 	if(buckled)
 		M.do_attack_animation(src, ATTACK_EFFECT_DISARM)

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -263,9 +263,6 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 /turf/closed/indestructible/hoteldoor/attack_paw(mob/user)
     promptExit(user)
 
-/turf/closed/indestructible/hoteldoor/attack_hulk(mob/living/carbon/human/user, does_attack_animation)
-    promptExit(user)
-
 /turf/closed/indestructible/hoteldoor/attack_larva(mob/user)
     promptExit(user)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -535,7 +535,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
-	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."
+	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed."
 	item = /obj/item/clothing/gloves/rapid
 	cost = 8
 


### PR DESCRIPTION
## About The Pull Request
-hulk, simplemobs, and sonic jackhammer all need a fixed amount of hits to destroy walls now. this is futureproofing for a planned mech revamp
-removes the attack_hulk proc, adding checks to attack_hand instead
-removes most use of the harm_intent_damage var, causing it to check player punch damage instead. 
-hulk now uses mutcolors and skintone instead of an overlay, and has no race restriction
-makes several attack_hand procs use punchdamage instead of their own damage. Silicons are no longer immune to punches, if they do over ten damage
-hulk now increases punch damage
-removes a lot of snowflake checks for hulk. this is a buff.
-removes rng in attack_hand

## Why It's Good For The Game
fucking hate hulk code

## Changelog
:cl:
tweak: hulk, simplemobs, and sonic jackhammer all need a fixed amount of hits to destroy walls now. this is futureproofing for a planned mech revamp
tweak: makes several attack_hand procs use punchdamage instead of their own damage. Silicons are no longer immune to punches, if they do over ten damage
tweak: removes a lot of snowflake checks for hulk. this is a buff.
tweak: rng removal in several attack_hand procs
code: removes most use of the harm_intent_damage var, causing it to check player punch damage instead. 
code: removes the attack_hulk proc, adding checks to attack_hand instead
code: hulk now uses mutcolors and skintone instead of an overlay, and has no race restriction
code: removes the attack_hulk proc, adding checks to attack_hand instead, hulk now increases racial punchdamage
/:cl:
