### PR TITLE
Removes nonviolent quirk from wizards and nuclear operatives

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -25,8 +25,7 @@
 	var/mob/living/M = mob_override || owner.current
 	update_synd_icons_added(M)
 	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, NUKEOP_TRAIT)
-	if(owner && owner.current)
-		owner.current.remove_quirk(/datum/quirk/nonviolent)
+	M.remove_quirk(/datum/quirk/nonviolent)
 
 /datum/antagonist/nukeop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -25,6 +25,8 @@
 	var/mob/living/M = mob_override || owner.current
 	update_synd_icons_added(M)
 	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, NUKEOP_TRAIT)
+	if(owner && owner.current)
+		owner.current.remove_quirk(/datum/quirk/nonviolent)
 
 /datum/antagonist/nukeop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -24,8 +24,7 @@
 	. = ..()
 	if(allow_rename)
 		rename_wizard()
-	if(owner && owner.current)
-		owner.current.remove_quirk(/datum/quirk/nonviolent)
+	owner.current.remove_quirk(/datum/quirk/nonviolent)
 
 /datum/antagonist/wizard/proc/register()
 	SSticker.mode.wizards |= owner

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -24,6 +24,8 @@
 	. = ..()
 	if(allow_rename)
 		rename_wizard()
+	if(owner && owner.current)
+		owner.current.remove_quirk(/datum/quirk/nonviolent)
 
 /datum/antagonist/wizard/proc/register()
 	SSticker.mode.wizards |= owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Untested

## About The Pull Request

Removes nonviolent trait from wizards and nuclear operatives
Removes nonviolent trait from wizards and nuclear operatives
Removes nonviolent trait from wizards and nuclear operatives
Removes nonviolent trait from wizards and nuclear operatives
Removes nonviolent trait from wizards and nuclear operatives
Removes nonviolent trait from wizards and nuclear operatives
Removes nonviolent trait from wizards and nuclear operatives
Removes nonviolent trait from wizards and nuclear operatives

## Why It's Good For The Game

Also removes nonviolent trait from wizards and nuclear operatives

## Changelog
:cl:
tweak: Wizards and nukeops are no longer pacafists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
