### PR TITLE
Borgo renaming logging

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -398,6 +398,7 @@
 			return
 		if(new_name)
 			created_name = new_name
+			log_game("[key_name(usr)] have set \"[new_name]\" as a cyborg shell name at [loc_name(usr)]")
 		else
 			created_name = ""
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -38,15 +38,18 @@
 
 /obj/item/borg/upgrade/rename/attack_self(mob/user)
 	heldname = sanitize_name(stripped_input(user, "Enter new robot name", "Cyborg Reclassification", heldname, MAX_NAME_LEN))
+	log_game("[key_name(user)] have set \"[heldname]\" as a name in a cyborg reclassification board at [loc_name(user)]")
 
-/obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R)
+/obj/item/borg/upgrade/rename/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
 		var/oldname = R.real_name
+		var/oldkeyname = key_name(R)
 		R.custom_name = heldname
 		R.updatename()
 		if(oldname == R.real_name)
 			R.notify_ai(RENAME, oldname, R.real_name)
+		log_game("[key_name(user)] have used a cyborg reclassification board to rename [oldkeyname] to [key_name(R)] at [loc_name(user)]")
 
 /obj/item/borg/upgrade/restart
 	name = "cyborg emergency reboot module"
@@ -697,4 +700,4 @@
 	if (.)
 		var/obj/item/borg/apparatus/beaker/extra/E = locate() in R.module.modules
 		if (E)
-			R.module.remove_module(E, TRUE) 
+			R.module.remove_module(E, TRUE)


### PR DESCRIPTION

## About The Pull Request

Renaming cyborgs via cyborg reclassification board or by using a multitool on a cyborg shell is now logged.

[2020-08-20 01:15:22.003] GAME: st0rmc4st3r/(Wumeek-Taeed) have set "Yiffmaster Coomer" as a cyborg shell name at (Robotics Lab (175, 121, 2))

[2020-08-20 01:19:28.636] GAME: st0rmc4st3r/(Wumeek-Taeed) have set "Something Inappropriate" as a name in a cyborg reclassification board at (Robotics Lab (176, 124, 2))
[2020-08-20 01:19:42.207] GAME: st0rmc4st3r/(Wumeek-Taeed) have used a cyborg reclassification board to rename @St0rmC4st3r[DC]/(Whitaker Flickinger) to @St0rmC4st3r[DC]/(Something Inappropriate) at (Robotics Lab (176, 122, 2))


This solves issue #2308.
## Why It's Good For The Game

Now you can track who came up with the name "Yiffmaster Coomer" for that cyborg.

## Changelog
:cl:
admin: Cyborg renaming is now logged
/:cl:
