### PR TITLE
Fix Nightshift Mode + Emergency Mode Values

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -227,14 +227,14 @@
 	var/start_with_cell = TRUE	// if true, this fixture generates a very weak cell at roundstart
 
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
-	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
+	var/nightshift_allowed = FALSE	//Set to FALSE to never let this light get switched to night mode.
 	var/nightshift_brightness = 8
-	var/nightshift_light_power = 0.45
+	var/nightshift_light_power = 0.6
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
-	var/bulb_emergency_brightness_mul = 0.25	// multiplier for this light's base brightness in emergency power mode
+	var/bulb_emergency_brightness_mul = 0.6	// multiplier for this light's base brightness in emergency power mode
 	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode


### PR DESCRIPTION
## About The Pull Request
Due to the station time starting at 11:30 and night shift starting at 7:30 Most rounds are primary played out in night mode.

On top of this due to bee's lighting nightshift is pitch black, people are seen carrying around lanterns just to make their way around on top of bee's lighting already being darker than most and having shadows in many locations.

I've disabled nightshift until it is better tuned. I.e station starting time being adjusted/reducing nightshift time.

-I don't think having it be dark 50% of the time without any gameplay effect is very interesting
-Players have no ability to disable nightshift themselves unless specific roles.

I've done the following:
-Increased the brightness of nightshift.
-Disabled automatic nightshift.
-Increased the brightness of emergency lighting.

## Why It's Good For The Game
The majority of rounds being super dark is giving me depression.

## Changelog
:cl:
add: Disabled Nightshift, tweached light mode values
/:cl: