### PR TITLE
adding a hack wire to the quantum pad

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -572,6 +572,7 @@
 #include "code\datums\wires\microwave.dm"
 #include "code\datums\wires\mulebot.dm"
 #include "code\datums\wires\particle_accelerator.dm"
+#include "code\datums\wires\quantum_pad.dm"
 #include "code\datums\wires\r_n_d.dm"
 #include "code\datums\wires\radio.dm"
 #include "code\datums\wires\robot.dm"

--- a/code/datums/wires/quantum_pad.dm
+++ b/code/datums/wires/quantum_pad.dm
@@ -9,6 +9,9 @@
 	var/obj/machinery/quantumpad/Q = holder
 	switch(wire)
 		if(WIRE_ACTIVATE)
-			Q.interact()
-			holder.visible_message("<span class='notice'>[icon2html(Q, viewers(holder))] The activation light flickers.</span>")
+			if(Q.cover_open)
+				holder.visible_message("<span class='notice'>[icon2html(Q, viewers(holder))] The activation light flickers.</span>")
+				return
+			else
+				Q.interact()
 	..()

--- a/code/datums/wires/quantum_pad.dm
+++ b/code/datums/wires/quantum_pad.dm
@@ -9,7 +9,7 @@
 	var/obj/machinery/quantumpad/Q = holder
 	switch(wire)
 		if(WIRE_ACTIVATE)
-			if(Q.cover_open)
+			if(Q.panel_open)
 				holder.visible_message("<span class='notice'>[icon2html(Q, viewers(holder))] The activation light flickers.</span>")
 				return
 			else

--- a/code/datums/wires/quantum_pad.dm
+++ b/code/datums/wires/quantum_pad.dm
@@ -1,0 +1,14 @@
+/datum/wires/quantum_pad
+	holder_type = /obj/machinery/quantumpad
+
+/datum/wires/quantum_pad/New(atom/holder)
+	wires = list(WIRE_ACTIVATE)
+	..()
+
+/datum/wires/quantum_pad/on_pulse(wire)
+	var/obj/machinery/quantumpad/Q = holder
+	switch(wire)
+		if(WIRE_ACTIVATE)
+			Q.interact()
+			holder.visible_message("<span class='notice'>[icon2html(Q, viewers(holder))] The activation light flickers.</span>")
+	..()

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -22,6 +22,7 @@
 
 /obj/machinery/quantumpad/Initialize()
 	. = ..()
+	wires = new /datum/wires/quantum_pad(src)
 	if(map_pad_id)
 		mapped_quantum_pads[map_pad_id] = src
 
@@ -53,6 +54,9 @@
 /obj/machinery/quantumpad/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "pad-idle-o", "qpad-idle", I))
 		return
+	else if(panel_open && I.tool_behaviour == TOOL_WIRECUTTER)
+		wires.interact(user)
+		return TRUE
 
 	if(panel_open)
 		if(I.tool_behaviour == TOOL_MULTITOOL)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this PR adds a hack wire for the quantum pad that when pulsed activates the pad
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
there is currently no way to remotely activate quantum pads
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add:quantum pad wire datum
add:quantum pad machine interaction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
