### PR TITLE
Emag Vape Changes

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -912,16 +912,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		s.set_up(reagents, 4, 24, loc)
 		s.start()
 		vapetime = 0
-		if(prob(5))//small chance for the vape to break and deal damage if it's emagged
-			playsound(get_turf(src), 'sound/effects/pop_expl.ogg', 50, 0)
-			M.apply_damage(20, BURN, BODY_ZONE_HEAD)
-			M.Paralyze(300, 1, 0)
-			var/datum/effect_system/spark_spread/sp = new /datum/effect_system/spark_spread
-			sp.set_up(5, 1, src)
-			sp.start()
-			to_chat(M, "<span class='userdanger'>[src] suddenly explodes in your mouth!</span>")
-			qdel(src)
-			return
 
 	if(reagents && reagents.total_volume)
 		hand_reagents()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -227,16 +227,16 @@
 	var/start_with_cell = TRUE	// if true, this fixture generates a very weak cell at roundstart
 
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
-	var/nightshift_allowed = FALSE	//Set to FALSE to never let this light get switched to night mode.
+	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
 	var/nightshift_brightness = 8
-	var/nightshift_light_power = 0.6
+	var/nightshift_light_power = 0.45
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
 	var/bulb_emergency_brightness_mul = 0.6	// multiplier for this light's base brightness in emergency power mode
 	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
-	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
+	var/bulb_emergency_pow_mul = 0.25	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode
 
 	var/bulb_vacuum_colour = "#4F82FF"	// colour of the light when air alarm is set to severe

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -227,14 +227,14 @@
 	var/start_with_cell = TRUE	// if true, this fixture generates a very weak cell at roundstart
 
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
-	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
+	var/nightshift_allowed = FALSE	//Set to FALSE to never let this light get switched to night mode.
 	var/nightshift_brightness = 8
-	var/nightshift_light_power = 0.45
+	var/nightshift_light_power = 0.6
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
-	var/bulb_emergency_brightness_mul = 0.25	// multiplier for this light's base brightness in emergency power mode
+	var/bulb_emergency_brightness_mul = 0.6	// multiplier for this light's base brightness in emergency power mode
 	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode


### PR DESCRIPTION
## About The Pull Request
Removes the explosion chance from emagged vapes.

## Why It's Good For The Game
Why without the change it's bad.
1. Emagging a vape and using it basically declares that you're a traitor.
2. No one is going to use an emagged vape that you give them then randomly explode.
3. 'haha vapes explode sometimes tho thats funny'

An emagged vape is now just a better version of an overclocked vape. You could already use circuits to accomplish this but now there are pros/cons to both methods! Emagged vape is more efficient, while circuits allow up to (don't quote me) up to 45 units per reaction in a smoke machine.

## Changelog
:cl:
Removed: Emagged vapes no longer have a chance to explode.
/:cl: