### PR TITLE
DraftFlash powder and sonic powder can now damage organs

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -227,14 +227,14 @@
 	var/start_with_cell = TRUE	// if true, this fixture generates a very weak cell at roundstart
 
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
-	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
+	var/nightshift_allowed = FALSE	//Set to FALSE to never let this light get switched to night mode.
 	var/nightshift_brightness = 8
-	var/nightshift_light_power = 0.45
+	var/nightshift_light_power = 0.6
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
-	var/bulb_emergency_brightness_mul = 0.25	// multiplier for this light's base brightness in emergency power mode
+	var/bulb_emergency_brightness_mul = 0.6	// multiplier for this light's base brightness in emergency power mode
 	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -227,14 +227,14 @@
 	var/start_with_cell = TRUE	// if true, this fixture generates a very weak cell at roundstart
 
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
-	var/nightshift_allowed = FALSE	//Set to FALSE to never let this light get switched to night mode.
+	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
 	var/nightshift_brightness = 8
-	var/nightshift_light_power = 0.6
+	var/nightshift_light_power = 0.45
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
 	var/no_emergency = FALSE	// if true, this light cannot ever have an emergency mode
-	var/bulb_emergency_brightness_mul = 0.6	// multiplier for this light's base brightness in emergency power mode
+	var/bulb_emergency_brightness_mul = 0.25	// multiplier for this light's base brightness in emergency power mode
 	var/bulb_emergency_colour = "#FF3232"	// determines the colour of the light while it's in emergency mode
 	var/bulb_emergency_pow_mul = 0.75	// the multiplier for determining the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.5	// the minimum value for the light's power in emergency mode

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -245,6 +245,9 @@
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
 	var/range = created_volume/3
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EYES,created_volume*1.5)
 	if(isatom(holder.my_atom))
 		var/atom/A = holder.my_atom
 		A.flash_lighting_fx(_range = (range + 2), _reset_lighting = FALSE)
@@ -266,6 +269,9 @@
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
 	var/range = created_volume/10
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EYES,created_volume*1.5)
 	if(isatom(holder.my_atom))
 		var/atom/A = holder.my_atom
 		A.flash_lighting_fx(_range = (range + 2), _reset_lighting = FALSE)
@@ -328,6 +334,9 @@
 	holder.remove_reagent(/datum/reagent/sonic_powder, created_volume*3)
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, 1)
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EARS,created_volume*2)
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
 		C.soundbang_act(1, 100, rand(0, 5))
 
@@ -340,6 +349,9 @@
 /datum/chemical_reaction/sonic_powder_deafen/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, 1)
+	if (created_volume >= 15)
+		for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+			C.adjustOrganLoss(ORGAN_SLOT_EARS,created_volume*2)
 	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/10, location))
 		C.soundbang_act(1, 100, rand(0, 5))
 


### PR DESCRIPTION
## About The Pull Request
Flash powder and Sonic powder can now damage organs.

## Why It's Good For The Game
Because it's dumb when massive reactions which can effect half the map don't damage your eyes/ears

## Changelog
:cl:
add: Flash powder and Sonic powder can now damage organs.
/:cl:
