### PR TITLE
Lucky null crates or your money back.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1804,7 +1804,7 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	cost = 11
 	item = /obj/item/pneumatic_cannon/pie/selfcharge
 	restricted_roles = list("Clown")
-	surplus = 5 //No fun unless you're the clown or just plain lucky.
+    surplus = 5 //No fun unless you're the clown or just plain lucky.
 
 /datum/uplink_item/role_restricted/blastcannon
 	name = "Blast Cannon"
@@ -1953,7 +1953,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 	item = /obj/item/his_grace
 	cost = 20
 	restricted_roles = list("Chaplain")
-	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
+	surplus = 5 //If you get this then i hope you don't die to it.
 
 /datum/uplink_item/role_restricted/cultconstructkit
 	name = "Cult Construct Kit"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2152,7 +2152,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 			manufactured to pack a little bit more of a punch if your client needs some convincing."
 	item = /obj/item/storage/secure/briefcase/syndie
 	cost = 1
-    surplus_nullcrates = 1 // now you can self fund your null cate addiction
+    surplus_nullcrates = 69 // now you can self fund your null cate addiction
 	restricted = TRUE
 
 /datum/uplink_item/badass/syndiecards

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -413,7 +413,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	item = /obj/item/pneumatic_cannon/pie/selfcharge
 	surplus = 0
-    surplus_nullcrates = 1 // the honkmother blessed you with luck.
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/dangerous/bananashield
@@ -1195,6 +1194,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/assault
 	refundable = TRUE
 	cost = 64
+    surplus_nullcrates = 1 
 	restricted = TRUE
 
 /datum/uplink_item/support/reinforcement/medical_borg
@@ -1205,6 +1205,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/medical
 	refundable = TRUE
 	cost = 32
+    surplus_nullcrates = 1
 	restricted = TRUE
 
 /datum/uplink_item/support/reinforcement/saboteur_borg
@@ -1215,6 +1216,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/saboteur
 	refundable = TRUE
 	cost = 32
+    surplus_nullcrates = 1
 	restricted = TRUE
 
 /datum/uplink_item/support/gygax
@@ -1802,7 +1804,7 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	cost = 11
 	item = /obj/item/pneumatic_cannon/pie/selfcharge
 	restricted_roles = list("Clown")
-	surplus = 0 //No fun unless you're the clown!
+	surplus = 5 //No fun unless you're the clown or just plain lucky.
 
 /datum/uplink_item/role_restricted/blastcannon
 	name = "Blast Cannon"
@@ -1896,6 +1898,7 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 			Premium features can be unlocked with a cryptographic sequencer!"
 	item = /obj/vehicle/sealed/car/clowncar
 	cost = 20
+    surplus_nullcrates = 5 // i mean you can get it discounted as non clowns.
 	restricted_roles = list("Clown")
 	exclude_modes = list(/datum/game_mode/incursion)
 
@@ -1957,6 +1960,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 	desc = "Recovered from an abandoned Nar'sie cult lair two construct shells and a stash of empty soulstones was found. These were purified to prevent occult contamination and have been put in a belt so they may be used as an accessible source of disposable minions. The construct shells have been packaged into two beacons for rapid and portable deployment."
 	item = /obj/item/storage/box/syndie_kit/cultconstructkit
 	cost = 20
+    surplus_nullcrates = 5 // enslave your victims or make a neat cult base.
 	restricted_roles = list("Chaplain")
 
 /datum/uplink_item/role_restricted/spanish_flu

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1949,8 +1949,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 	To activate His Grace, simply unlatch Him."
 	item = /obj/item/his_grace
 	cost = 20
-	restricted_roles = list("Chaplain")
-	surplus = 5 //If you get this then i hope you don't die to it.
+	restricted_roles = list("Chaplain"}
 
 /datum/uplink_item/role_restricted/cultconstructkit
 	name = "Cult Construct Kit"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -413,6 +413,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	item = /obj/item/pneumatic_cannon/pie/selfcharge
 	surplus = 0
+    surplus_nullcrates = 1 // the honkmother blessed you with luck.
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/dangerous/bananashield
@@ -527,7 +528,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/guardiancreator/tech
 	cost = 18
 	surplus = 10
-	surplus_nullcrates = 0
+	surplus_nullcrates = 1 // gotta have luck 100.
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	player_minimum = 25
 	restricted = TRUE
@@ -2151,6 +2152,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 			manufactured to pack a little bit more of a punch if your client needs some convincing."
 	item = /obj/item/storage/secure/briefcase/syndie
 	cost = 1
+    surplus_nullcrates = 40 // now you can self fund your null cate addiction
 	restricted = TRUE
 
 /datum/uplink_item/badass/syndiecards

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2152,7 +2152,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 			manufactured to pack a little bit more of a punch if your client needs some convincing."
 	item = /obj/item/storage/secure/briefcase/syndie
 	cost = 1
-    surplus_nullcrates = 69 // now you can self fund your null cate addiction
+    surplus_nullcrates = 10// now you can self fund your null cate addiction
 	restricted = TRUE
 
 /datum/uplink_item/badass/syndiecards

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2152,7 +2152,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 			manufactured to pack a little bit more of a punch if your client needs some convincing."
 	item = /obj/item/storage/secure/briefcase/syndie
 	cost = 1
-    surplus_nullcrates = 40 // now you can self fund your null cate addiction
+    surplus_nullcrates = 1 // now you can self fund your null cate addiction
 	restricted = TRUE
 
 /datum/uplink_item/badass/syndiecards

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1194,7 +1194,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/assault
 	refundable = TRUE
 	cost = 64
-    surplus_nullcrates = 1 
 	restricted = TRUE
 
 /datum/uplink_item/support/reinforcement/medical_borg
@@ -1205,7 +1204,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/medical
 	refundable = TRUE
 	cost = 32
-    surplus_nullcrates = 1
 	restricted = TRUE
 
 /datum/uplink_item/support/reinforcement/saboteur_borg
@@ -1216,7 +1214,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/saboteur
 	refundable = TRUE
 	cost = 32
-    surplus_nullcrates = 1
 	restricted = TRUE
 
 /datum/uplink_item/support/gygax


### PR DESCRIPTION
## About The Pull Request
This pr adds a super rare chance for nullcates to contain stands or some role restricted items.
Will you hit the jackpot?
_disclaimer: money back guarantee is not guaranteed _

## Why It's Good For The Game
This pr would give an incentive for traitors/Cargo/anyone with AA to waste all their tc on cash briefcases or make the station broke.
i've also made it so they might just get their money back(or not).

## Changelog
:cl:
add: Added a 1% chance for  stands to spawn in null crates( just like the good old days).
tweak: certain restricted items( banana pie cannon, cult kit and clowncar(honk honk!)) now have a 5% chance to be in null crates since they can be discounted as any role, nullcrates now have 10% chance of partially refunding their purchase via cash briefcases. 

/:cl:

