### PR TITLE
Corrects the RSC URL in the repo config file

### DIFF
--- a/config/external_rsc_urls.txt
+++ b/config/external_rsc_urls.txt
@@ -1,1 +1,1 @@
-https://rsc.beestation13.com/beestation13.zip
+https://rsc.beestation13.com/beestation.zip


### PR DESCRIPTION
For some reason the repo uses the wrong link for our external RSC (only a problem in Golden's set of config files). It's correct in the README and on the server itself.