### PR TITLE
MedSec/Hybrid HUD - Assemby and Dissasembly

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -162,3 +162,12 @@
 				/obj/item/stack/sheet/glass = 1)
 	category = CAT_CLOTHING
 
+
+/datum/crafting_recipe/medsechud
+	name = "Hybrid HUD"
+	result = /obj/item/clothing/glasses/hud/medsec
+	time = 20
+	tools = list(TOOL_SCREWDRIVER)
+	reqs = list(/obj/item/clothing/glasses/hud/health = 1,
+				  /obj/item/clothing/glasses/hud/security = 1)
+	category = CAT_CLOTHING

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -100,12 +100,19 @@
 	icon_state = "sunhudtoggle"
 
 /obj/item/clothing/glasses/hud/medsec
-	name = "medsec HUD"
+	name = "Hybrid HUD"
 	desc = "A combination HUD, providing the user the use of a Medical and Security HUD."
 	icon_state = "medsechud"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
 	alt_hud_type = DATA_HUD_MEDICAL_ADVANCED
 	glass_colour_type = /datum/client_colour/glass_colour/red
+	
+/obj/item/clothing/glasses/hud/medsec/screwdriver_act(mob/living/user, obj/item/I)		
+	sechud = new /obj/item/clothing/glasses/hud/security (get_turf(src)) 
+	medhud = new /obj/item/clothing/glasses/hud/health (get_turf(src)) 
+	qdel(src)	
+	to_chat(user, "<span class='notice'>You disassemble \the [src].</span>")	
+	return TRUE
 
 /obj/item/clothing/glasses/hud/security/chameleon
 	name = "chameleon security HUD"


### PR DESCRIPTION
##  About The Pull Request

Adds the ability to craft MedSec Hud to your little spessman, and the ability to screwdriver it to disassemble into two separate med+sec hud.

## Why It's Good For The Game

Medsec is quite versatile little piece of equipment, suitable for command members and Brrig Physicians. Trade off flash resistance for ability to see both Med and Sec displays at the same time.

## Changelog
:cl:
add: Medsec HUD now can be assembled from the crafting menu; and disassembled with a screwdriver into its original components.
/:cl:
