### PR TITLE
Tooth/Suicide Implant

### DIFF
--- a/code/game/objects/items/implants/implant_escape.dm
+++ b/code/game/objects/items/implants/implant_escape.dm
@@ -1,0 +1,30 @@
+
+/obj/item/implant/escape
+	name = "tooth implant"
+	desc = "Bite into it to fall into a fake death."
+	icon_state = "fake_death"
+	uses = 3
+
+/obj/item/implant/escape/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Fake Tooth Implant<BR>
+				<b>Life:</b> Three uses.<BR>
+				<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
+				<HR>
+				<b>Implant Details:</b> Subjects injected with implant can activate an injection of sneaky cocktails that induce a death-like state.<BR>
+				<b>Function:</b> Causes a fake death-like state.<BR>
+				<b>Integrity:</b> Implant can only be used three times before reserves are depleted."}
+	return dat
+
+/obj/item/implant/escape/activate()
+	. = ..()
+	to_chat(imp_in, "<span class='notice'>You bite into your fake tooth and suddenly feel dizzy...</span>")
+
+	imp_in.reagents.add_reagent(/datum/reagent/toxin/zombiepowder, 30)
+	if(!uses)
+		qdel(src)
+
+/obj/item/implanter/escape
+	name = "implanter (fake tooth)"
+	imp_type = /obj/item/implant/escape
+

--- a/code/game/objects/items/implants/implant_escape.dm
+++ b/code/game/objects/items/implants/implant_escape.dm
@@ -20,7 +20,8 @@
 	. = ..()
 	to_chat(imp_in, "<span class='notice'>You bite into your fake tooth and suddenly feel dizzy...</span>")
 
-	imp_in.reagents.add_reagent(/datum/reagent/toxin/zombiepowder, 30)
+	imp_in.reagents.add_reagent(/datum/reagent/toxin/zombiepowder, 10)
+	imp_in.reagents.add_reagent(/datum/reagent/medical/omnizine, 10)
 	if(!uses)
 		qdel(src)
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -560,3 +560,9 @@
 	new /obj/item/storage/belt/soulstone/full/purified(src)
 	new /obj/item/sbeacondrop/constructshell(src)
 	new /obj/item/sbeacondrop/constructshell(src)
+
+/obj/item/storage/box/syndie_kit/imp_escape
+	name = "fake tooth implant box"
+
+/obj/item/storage/box/syndie_kit/imp_escape/PopulateContents()
+	new /obj/item/implanter/escape(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1743,6 +1743,12 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/esc_implant
+	name = "Fake Tooth Implant"
+	desc = "Implant this fake tooth into your mouth and bite really hard, and it will release a combination of toxins that will put you into a fake death-like state, which will even fool most machines and advanced scanners!"
+	cost = 4
+	item = /obj/item/storage/box/syndie_kit/imp_escape
+
 
 //Race-specific items
 /datum/uplink_item/race_restricted
@@ -2098,8 +2104,7 @@ datum/uplink_item/role_restricted/superior_honkrender
 	cost = 12
 	item = /obj/item/autosurgeon/syndicate/laser_arm
 	restricted_roles = list("Roboticist", "Research Director")
-
-
+	
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"
@@ -2168,10 +2173,3 @@ datum/uplink_item/role_restricted/superior_honkrender
 	item = /obj/item/storage/fancy/cigarettes/cigpack_syndicate
 	cost = 2
 	illegal_tech = FALSE
-
-/datum/uplink_item/race_restricted/esc_implant
-	name = "Fake Tooth Implant"
-	desc = "Having disposable teeth can put you at an advantage compared to other races. Implant this fake tooth into your mouth and bite really hard, and it will release a combination of toxins that will put you into a fake death-like state, which will even fool most machines and advanced scanners!"
-	cost = 2
-	item = /obj/item/storage/box/syndie_kit/imp_escape
-	restricted_species = list("human")

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2168,3 +2168,10 @@ datum/uplink_item/role_restricted/superior_honkrender
 	item = /obj/item/storage/fancy/cigarettes/cigpack_syndicate
 	cost = 2
 	illegal_tech = FALSE
+
+/datum/uplink_item/race_restricted/esc_implant
+	name = "Fake Tooth Implant"
+	desc = "Having disposable teeth can put you at an advantage compared to other races. Implant this fake tooth into your mouth and bite really hard, and it will release a combination of toxins that will put you into a fake death-like state, which will even fool most machines and advanced scanners!"
+	cost = 2
+	item = /obj/item/storage/box/syndie_kit/imp_escape
+	restricted_species = list("human")


### PR DESCRIPTION
## About The Pull Request

Adds a human role restricted implant case that has 3 uses. Injects 30u of zombie powder on use, faking death and possibly get you to escape a sticky situation.

It was initially meant to inject Initropidril, but that had very limited uses. Initropidril and 1u romerol may be a good idea for 20 TC, no?

## Why It's Good For The Game

It's a unique idea I got from watching Superjail. Why not? It can have its uses.

## Changelog
:cl:
add: new implant available to debtors that allows you to fake death
/:cl: