### PR TITLE
Updates the RSC links

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Web delivery of game resources makes it quicker for players to join and reduces 
 
 1. Edit compile_options.dm to set the `PRELOAD_RSC` define to `0`
 1. Add a url to config/external_rsc_urls pointing to a .zip file containing the .rsc.
-    * If you keep up to date with BeeStation you could reuse our rsc cdn at https://rsc.beestation13.com/beestation.zip. Otherwise you can use cdn services like CDN77 or cloudflare (requires adding a page rule to enable caching of the zip), or roll your own cdn using route 53 and vps providers.
+    * If you keep up to date with BeeStation you could reuse our rsc cdn at http://rsc.beestation13.buzz/beestation.zip. Otherwise you can use cdn services like CDN77 or cloudflare (requires adding a page rule to enable caching of the zip), or roll your own cdn using route 53 and vps providers.
 	* Regardless even offloading the rsc to a website without a CDN will be a massive improvement over the in game system for transferring files.
 
 ## IRC BOT SETUP

--- a/config/Sage/external_rsc_urls.txt
+++ b/config/Sage/external_rsc_urls.txt
@@ -1,1 +1,1 @@
-https://rsc.beestation13.com/beestation.zip
+http://rsc.beestation13.buzz/beestation.zip

--- a/config/external_rsc_urls.txt
+++ b/config/external_rsc_urls.txt
@@ -1,1 +1,1 @@
-https://rsc.beestation13.com/beestation.zip
+http://rsc.beestation13.buzz/beestation.zip


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates all of our RSC URLs and references to use our new CDN URL, `http://rsc.beestation13.buzz/beestation.zip`.

As it turns out, PRELOADING doesn't actually support `https` domains. The only reason we didn't notice before was because our server was fast enough to where it seemed like it was working correctly.

## Why It's Good For The Game

It's good for our downstreams to have an actually functioning external RSC they can use, and it's also good for us because it means obtaining those resources becomes a fair bit faster and should be less error prone.

## Changelog
:cl:
fix: Updates our external RSC url to be actually functional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
