### PR TITLE
Disables rust-g's overrides and updates existing procs to use the faster alternative where possible

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -7,8 +7,6 @@
 // Override the .dll/.so detection logic with a fixed path or with detection
 // logic of your own.
 //
-//#define RUSTG_OVERRIDE_BUILTINS
-// Enable replacement rust-g functions for certain builtins. Off by default.
 
 #ifndef RUST_G
 // Default automatic RUST_G detection.
@@ -47,14 +45,9 @@
 
 #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 
-#define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
-#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
-#define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
-
-#ifdef RUSTG_OVERRIDE_BUILTINS
-#define file2text(fname) rustg_file_read("[fname]")
-#define text2file(text, fname) rustg_file_append(text, "[fname]")
-#endif
+#define rustg_file_read(fname) call(RUST_G, "file_read")("[fname]")
+#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, "[fname]")
+#define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, "[fname]")
 
 #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
 #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
@@ -67,20 +60,11 @@
 #define RUSTG_HASH_SHA256 "sha256"
 #define RUSTG_HASH_SHA512 "sha512"
 
-#ifdef RUSTG_OVERRIDE_BUILTINS
-#define md5(thing) (isfile(thing) ? rustg_hash_file(RUSTG_HASH_MD5, "[thing]") : rustg_hash_string(RUSTG_HASH_MD5, thing))
-#endif
-
 #define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
 /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
 
 #define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
 #define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
-
-#ifdef RUSTG_OVERRIDE_BUILTINS
-#define url_encode(text) rustg_url_encode(text)
-#define url_decode(text) rustg_url_decode(text)
-#endif
 
 #define RUSTG_HTTP_METHOD_GET "get"
 #define RUSTG_HTTP_METHOD_PUT "put"

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -7,7 +7,7 @@
 // Override the .dll/.so detection logic with a fixed path or with detection
 // logic of your own.
 //
-#define RUSTG_OVERRIDE_BUILTINS
+//#define RUSTG_OVERRIDE_BUILTINS
 // Enable replacement rust-g functions for certain builtins. Off by default.
 
 #ifndef RUST_G

--- a/code/__HELPERS/_string_lists.dm
+++ b/code/__HELPERS/_string_lists.dm
@@ -1,7 +1,7 @@
 #define pick_list(FILE, KEY) (pick(strings(FILE, KEY)))
 #define pick_list_weighted(FILE, KEY) (pickweight(strings(FILE, KEY)))
 #define pick_list_replacements(FILE, KEY) (strings_replacement(FILE, KEY))
-#define json_load(FILE) (json_decode(file2text(FILE)))
+#define json_load(FILE) (json_decode(rustg_file_read(FILE)))
 
 GLOBAL_LIST(string_cache)
 GLOBAL_VAR(string_filename_current_key)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1130,7 +1130,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 			register_asset(name, thing)
 			for (var/thing2 in targets)
 				send_asset(thing2, key, FALSE)
-			return "<img class='icon icon-misc' src=\"[url_encode(name)]\">"
+			return "<img class='icon icon-misc' src=\"[rustg_url_encode(name)]\">"
 		var/atom/A = thing
 		if (isnull(dir))
 			dir = A.dir
@@ -1155,7 +1155,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	for (var/thing2 in targets)
 		send_asset(thing2, key, FALSE)
 
-	return "<img class='icon icon-[icon_state]' src=\"[url_encode(key)]\">"
+	return "<img class='icon icon-[icon_state]' src=\"[rustg_url_encode(key)]\">"
 
 /proc/icon2base64html(thing)
 	if (!thing)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1166,7 +1166,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 		var/icon_base64 = icon2base64(I)
 
 		if (I.Height() > world.icon_size || I.Width() > world.icon_size)
-			var/icon_md5 = md5(icon_base64)
+			var/icon_md5 = rustg_hash_string(RUSTG_HASH_MD5, icon_base64)
 			icon_base64 = bicon_cache[icon_md5]
 			if (!icon_base64) // Doesn't exist yet, make it.
 				bicon_cache[icon_md5] = icon_base64 = icon2base64(I)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -312,7 +312,7 @@
 
 	if(GLOB.round_id)
 		var/statspage = CONFIG_GET(string/roundstatsurl)
-		var/info = statspage ? "<a href='?action=openLink&link=[url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
+		var/info = statspage ? "<a href='?action=openLink&link=[rustg_url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
 		parts += "[GLOB.TAB]Round ID: <b>[info]</b>"
 	parts += "[GLOB.TAB]Shift Duration: <B>[DisplayTimeText(world.time - SSticker.round_start_time)]</B>"
 	parts += "[GLOB.TAB]Station Integrity: <B>[mode.station_was_nuked ? "<span class='redtext'>Destroyed</span>" : "[popcount["station_integrity"]]%"]</B>"
@@ -353,9 +353,9 @@
 		content = report_parts.Join()
 		C.verbs -= /client/proc/show_previous_roundend_report
 		fdel(filename)
-		text2file(content, filename)
+		rustg_file_append(content, filename)
 	else
-		content = file2text(filename)
+		content = rustg_file_read(filename)
 	roundend_report.set_content(content)
 	roundend_report.stylesheets = list()
 	roundend_report.add_stylesheet("roundend", 'html/browser/roundend.css')

--- a/code/__HELPERS/shell.dm
+++ b/code/__HELPERS/shell.dm
@@ -30,10 +30,10 @@
 		else
 			errorcode = shell("[interpreter] \"[command]\" > [out_file] 2> [err_file]")
 		if(fexists(out_file))
-			stdout = file2text(out_file)
+			stdout = rustg_file_read(out_file)
 			fdel(out_file)
 		if(fexists(err_file))
-			stderr = file2text(err_file)
+			stderr = rustg_file_read(err_file)
 			fdel(err_file)
 		shelleo_ids[shelleo_id] = FALSE
 	else
@@ -53,7 +53,7 @@
 		bad_chars = bad_chars_regex.Find(url)
 		scrubbed_url += copytext(url, last_good, bad_chars)
 		if(bad_chars)
-			bad_match = url_encode(bad_chars_regex.match)
+			bad_match = rustg_url_encode(bad_chars_regex.match)
 			scrubbed_url += bad_match
 			last_good = bad_chars + length(bad_chars_regex.match)
 	while(bad_chars)

--- a/code/__HELPERS/stat_tracking.dm
+++ b/code/__HELPERS/stat_tracking.dm
@@ -8,6 +8,6 @@
 		lines += "[entry] => [num2text(data[STAT_ENTRY_TIME], 10)]ms ([data[STAT_ENTRY_COUNT]]) (avg:[num2text(data[STAT_ENTRY_TIME]/(data[STAT_ENTRY_COUNT] || 1), 99)])"
 
 	if (user)
-		user << browse("<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[url_encode("stats:[REF(stats)]")]")
+		user << browse("<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[rustg_url_encode("stats:[REF(stats)]")]")
 
 	. = lines.Join("\n")

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -648,7 +648,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 	var/list/oldjson = list()
 	var/list/oldentries = list()
 	if(fexists(log))
-		oldjson = json_decode(file2text(log))
+		oldjson = json_decode(rustg_file_read(log))
 		oldentries = oldjson["data"]
 	if(!isemptylist(oldentries))
 		for(var/string in accepted)

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -14,8 +14,8 @@
 //returns an empty list if the file doesn't exist
 /world/proc/file2list(filename, seperator="\n", trim = TRUE)
 	if (trim)
-		return splittext(trim(file2text(filename)),seperator)
-	return splittext(file2text(filename),seperator)
+		return splittext(trim(rustg_file_read(filename)),seperator)
+	return splittext(rustg_file_read(filename),seperator)
 
 //Turns a direction into text
 /proc/dir2text(direction)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1415,7 +1415,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 /proc/GUID()
 	var/const/GUID_VERSION = "b"
 	var/const/GUID_VARIANT = "d"
-	var/node_id = copytext_char(md5("[rand()*rand(1,9999999)][world.name][world.hub][world.hub_password][world.internet_address][world.address][world.contents.len][world.status][world.port][rand()*rand(1,9999999)]"), 1, 13)
+	var/node_id = copytext_char(rustg_hash_string(RUSTG_HASH_MD5, "[rand()*rand(1,9999999)][world.name][world.hub][world.hub_password][world.internet_address][world.address][world.contents.len][world.status][world.port][rand()*rand(1,9999999)]"), 1, 13)
 
 	var/time_high = "[num2hex(text2num(time2text(world.realtime,"YYYY")), 2)][num2hex(world.realtime, 6)]"
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1439,7 +1439,7 @@ If it ever becomes necesary to get a more performant REF(), this lies here in wa
 /proc/REF(datum/input)
 	if(istype(input) && (input.datum_flags & DF_USE_TAG))
 		if(input.tag)
-			return "\[[url_encode(input.tag)]\]"
+			return "\[[rustg_url_encode(input.tag)]\]"
 		stack_trace("A ref was requested of an object with DF_USE_TAG set but no tag: [input]")
 		input.datum_flags &= ~DF_USE_TAG
 	return "\ref[input]"

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -250,7 +250,7 @@
 	votable_modes += "secret"
 
 /datum/controller/configuration/proc/LoadMOTD()
-	motd = file2text("[directory]/motd.txt")
+	motd = rustg_file_read("[directory]/motd.txt")
 	var/tm_info = GLOB.revdata.GetTestMergeInfo()
 	if(motd || tm_info)
 		motd = motd ? "[motd]<br>[tm_info]" : tm_info

--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -145,7 +145,7 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/Shutdown()
 	var/initlog = InitLog()
 	if(initlog)
-		text2file(initlog, "[GLOB.log_directory]/initialize.log")
+		rustg_file_append(initlog, "[GLOB.log_directory]/initialize.log")
 
 #undef BAD_INIT_QDEL_BEFORE
 #undef BAD_INIT_DIDNT_INIT

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -39,9 +39,9 @@ SUBSYSTEM_DEF(chat)
 	message += "<br>"
 
 
-	//url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
+	//rustg_url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
 	//Do the double-encoding here to save nanoseconds
-	var/twiceEncoded = url_encode(url_encode(message))
+	var/twiceEncoded = rustg_url_encode(rustg_url_encode(message))
 
 	if(islist(target))
 		for(var/I in target)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -501,7 +501,7 @@ SUBSYSTEM_DEF(job)
 
 
 /datum/controller/subsystem/job/proc/LoadJobs()
-	var/jobstext = file2text("[global.config.directory]/jobs.txt")
+	var/jobstext = rustg_file_read("[global.config.directory]/jobs.txt")
 	for(var/datum/job/J in occupations)
 		if(J.flag == GIMMICK || J.gimmick) //gimmick job slots are dependant on random maint
 			continue

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(overlays)
 
 
 /datum/controller/subsystem/overlays/Shutdown()
-	text2file(render_stats(stats), "[GLOB.log_directory]/overlay.log")
+	rustg_file_append(render_stats(stats), "[GLOB.log_directory]/overlay.log")
 
 
 /datum/controller/subsystem/overlays/Recover()

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(persistence)
 		var/json_file = file("data/npc_saves/ChiselMessages[SSmapping.config.map_name].json")
 		if(!fexists(json_file))
 			return
-		var/list/json = json_decode(file2text(json_file))
+		var/list/json = json_decode(rustg_file_read(json_file))
 
 		if(!json)
 			return
@@ -88,7 +88,7 @@ SUBSYSTEM_DEF(persistence)
 		var/json_file = file("data/npc_saves/TrophyItems.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = json_decode(file2text(json_file))
+		var/list/json = json_decode(rustg_file_read(json_file))
 		if(!json)
 			return
 		saved_trophies = json["data"]
@@ -98,13 +98,13 @@ SUBSYSTEM_DEF(persistence)
 	var/json_file = file("data/RecentModes.json")
 	if(!fexists(json_file))
 		return
-	var/list/json = json_decode(file2text(json_file))
+	var/list/json = json_decode(rustg_file_read(json_file))
 	if(!json)
 		return
 	saved_modes = json["data"]
 
 /datum/controller/subsystem/persistence/proc/LoadAntagReputation()
-	var/json = file2text(FILE_ANTAG_REP)
+	var/json = rustg_file_read(FILE_ANTAG_REP)
 	if(!json)
 		var/json_file = file(FILE_ANTAG_REP)
 		if(!fexists(json_file))
@@ -150,18 +150,18 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/GetPhotoAlbums()
 	var/album_path = file("data/photo_albums.json")
 	if(fexists(album_path))
-		return json_decode(file2text(album_path))
+		return json_decode(rustg_file_read(album_path))
 
 /datum/controller/subsystem/persistence/proc/GetPhotoFrames()
 	var/frame_path = file("data/photo_frames.json")
 	if(fexists(frame_path))
-		return json_decode(file2text(frame_path))
+		return json_decode(rustg_file_read(frame_path))
 
 /datum/controller/subsystem/persistence/proc/LoadPhotoPersistence()
 	var/album_path = file("data/photo_albums.json")
 	var/frame_path = file("data/photo_frames.json")
 	if(fexists(album_path))
-		var/list/json = json_decode(file2text(album_path))
+		var/list/json = json_decode(rustg_file_read(album_path))
 		if(json.len)
 			for(var/i in photo_albums)
 				var/obj/item/storage/photo_album/A = i
@@ -171,7 +171,7 @@ SUBSYSTEM_DEF(persistence)
 					A.populate_from_id_list(json[A.persistence_id])
 
 	if(fexists(frame_path))
-		var/list/json = json_decode(file2text(frame_path))
+		var/list/json = json_decode(rustg_file_read(frame_path))
 		if(json.len)
 			for(var/i in photo_frames)
 				var/obj/structure/sign/picture_frame/PF = i
@@ -188,7 +188,7 @@ SUBSYSTEM_DEF(persistence)
 	var/list/album_json = list()
 
 	if(fexists(album_path))
-		album_json = json_decode(file2text(album_path))
+		album_json = json_decode(rustg_file_read(album_path))
 		fdel(album_path)
 
 	for(var/i in photo_albums)
@@ -203,7 +203,7 @@ SUBSYSTEM_DEF(persistence)
 	WRITE_FILE(album_path, album_json)
 
 	if(fexists(frame_path))
-		frame_json = json_decode(file2text(frame_path))
+		frame_json = json_decode(rustg_file_read(frame_path))
 		fdel(frame_path)
 
 	for(var/i in photo_frames)
@@ -280,5 +280,5 @@ SUBSYSTEM_DEF(persistence)
 	antag_rep_change = list()
 
 	fdel(FILE_ANTAG_REP)
-	text2file(json_encode(antag_rep), FILE_ANTAG_REP)
+	rustg_file_append(json_encode(antag_rep), FILE_ANTAG_REP)
 

--- a/code/controllers/subsystem/processing/networks.dm
+++ b/code/controllers/subsystem/processing/networks.dm
@@ -43,7 +43,7 @@ PROCESSING_SUBSYSTEM_DEF(networks)
 /datum/controller/subsystem/processing/networks/proc/make_address(string)
 	if(!string)
 		return resolve_collisions? make_address("[num2text(rand(HID_RESTRICTED_END, 999999999), 12)]"):null
-	var/hex = md5(string)
+	var/hex = rustg_hash_string(RUSTG_HASH_MD5, string)
 	if(!hex)
 		return		//errored
 	. = "[copytext_char(hex, 1, 9)]"		//16 ^ 8 possibilities I think.

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -11,7 +11,7 @@ SUBSYSTEM_DEF(tgui)
 	var/basehtml // The HTML base used for all UIs.
 
 /datum/controller/subsystem/tgui/PreInit()
-	basehtml = file2text('tgui/packages/tgui/public/tgui.html')
+	basehtml = rustg_file_read('tgui/packages/tgui/public/tgui.html')
 
 /datum/controller/subsystem/tgui/Shutdown()
 	close_all_uis()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -101,7 +101,7 @@ SUBSYSTEM_DEF(ticker)
 					continue
 				music += S
 
-	var/old_login_music = trim(file2text("data/last_round_lobby_music.txt"))
+	var/old_login_music = trim(rustg_file_read("data/last_round_lobby_music.txt"))
 	if(music.len > 1)
 		music -= old_login_music
 
@@ -582,7 +582,7 @@ SUBSYSTEM_DEF(ticker)
 			addtimer(CALLBACK(player, /mob/dead/new_player.proc/make_me_an_observer), 1)
 
 /datum/controller/subsystem/ticker/proc/load_mode()
-	var/mode = trim(file2text("data/mode.txt"))
+	var/mode = trim(rustg_file_read("data/mode.txt"))
 	if(mode)
 		GLOB.master_mode = mode
 	else
@@ -651,4 +651,4 @@ SUBSYSTEM_DEF(ticker)
 			round_end_sound = "sound/roundend/[pick(tracks)]"
 
 	SEND_SOUND(world, sound(round_end_sound))
-	text2file(login_music, "data/last_round_lobby_music.txt")
+	rustg_file_append(login_music, "data/last_round_lobby_music.txt")

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -13,7 +13,7 @@ SUBSYSTEM_DEF(title)
 		return
 
 	if(fexists("data/previous_title.dat"))
-		var/previous_path = file2text("data/previous_title.dat")
+		var/previous_path = rustg_file_read("data/previous_title.dat")
 		if(istext(previous_path))
 			previous_icon = new(previous_icon)
 	fdel("data/previous_title.dat")

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -87,7 +87,7 @@
 			if(!ignoregloves)
 				H.gloves.add_fingerprint(H, TRUE) //ignoregloves = 1 to avoid infinite loop.
 				return
-		var/full_print = md5(H.dna.uni_identity)
+		var/full_print = rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)
 		LAZYSET(fingerprints, full_print, full_print)
 	return TRUE
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -222,7 +222,7 @@
 		G.fields["rank"]		= assignment
 		G.fields["age"]			= H.age
 		G.fields["species"]	= H.dna.species.name
-		G.fields["fingerprint"]	= md5(H.dna.uni_identity)
+		G.fields["fingerprint"]	= rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)
 		G.fields["p_stat"]		= "Active"
 		G.fields["m_stat"]		= "Stable"
 		G.fields["sex"]			= H.gender
@@ -260,7 +260,7 @@
 
 		//Locked Record
 		var/datum/data/record/L = new()
-		L.fields["id"]			= md5("[H.real_name][H.mind.assigned_role]")	//surely this should just be id, like the others?
+		L.fields["id"]			= rustg_hash_string(RUSTG_HASH_MD5, "[H.real_name][H.mind.assigned_role]")	//surely this should just be id, like the others?
 		L.fields["name"]		= H.real_name
 		L.fields["rank"] 		= H.mind.assigned_role
 		L.fields["age"]			= H.age

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -159,7 +159,7 @@
 	. = ""
 	if(istype(holder))
 		real_name = holder.real_name
-		. += md5(holder.real_name)
+		. += rustg_hash_string(RUSTG_HASH_MD5, holder.real_name)
 	else
 		. += random_string(DNA_UNIQUE_ENZYMES_LEN, GLOB.hex_characters)
 	return .

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -54,7 +54,7 @@
 		log_world("Could not open map_config: [filename]")
 		return
 
-	json = file2text(json)
+	json = rustg_file_read(json)
 	if(!json)
 		log_world("map_config is not text: [filename]")
 		return

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -59,7 +59,7 @@
 		possible = list()
 		var/list/prints = sniffed.return_fingerprints()
 		for(var/mob/living/carbon/C in GLOB.carbon_list)
-			if(prints[md5(C.dna.uni_identity)])
+			if(prints[rustg_hash_string(RUSTG_HASH_MD5, C.dna.uni_identity)])
 				possible |= C
 		if(!length(possible))
 			to_chat(user,"<span class='warning'>Despite your best efforts, there are no scents to be found on [sniffed]...</span>")

--- a/code/datums/profiling.dm
+++ b/code/datums/profiling.dm
@@ -15,4 +15,4 @@ GLOBAL_REAL_VAR(PROFILE_TIME)
 		var/list/data = PROFILE_STORE[entry]
 		lines += "[entry] => [num2text(data[PROFILE_ITEM_TIME], 10)]ms ([data[PROFILE_ITEM_COUNT]]) (avg:[num2text(data[PROFILE_ITEM_TIME]/(data[PROFILE_ITEM_COUNT] || 1), 99)])"
 
-	user << browse("<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[url_encode(GUID())]")
+	user << browse("<ol><li>[lines.Join("</li><li>")]</li></ol>", "window=[rustg_url_encode(GUID())]")

--- a/code/datums/verbs.dm
+++ b/code/datums/verbs.dm
@@ -78,7 +78,7 @@
 				if (childname == "[child.type]")
 					var/list/tree = splittext(childname, "/")
 					childname = tree[tree.len]
-				.[child.type] = "parent=[url_encode(type)];name=[childname]"
+				.[child.type] = "parent=[rustg_url_encode(type)];name=[childname]"
 				. += childlist
 
 	for (var/thing in verblist)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -557,7 +557,7 @@ Class Procs:
 		occupant = null
 
 /obj/machinery/proc/adjust_item_drop_location(atom/movable/AM)	// Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8
-	var/md5 = md5(AM.name)										// Oh, and it's deterministic too. A specific item will always drop from the same slot.
+	var/md5 = rustg_hash_string(RUSTG_HASH_MD5, AM.name)										// Oh, and it's deterministic too. A specific item will always drop from the same slot.
 	for (var/i in 1 to 32)
 		. += hex2num(md5[i])
 	. = . % 9

--- a/code/game/machinery/computer/arena.dm
+++ b/code/game/machinery/computer/arena.dm
@@ -358,7 +358,7 @@
 	dat += "Current arena: [current_arena_template]"
 	dat += "<h2>Arena List:</h2>"
 	for(var/A in arena_templates)
-		dat += "<a href='?src=[REF(src)];change_arena=[url_encode(A)]'>[A]</a><br>"
+		dat += "<a href='?src=[REF(src)];change_arena=[rustg_url_encode(A)]'>[A]</a><br>"
 	dat += "<hr>"
 	dat += "<a href='?src=[REF(src)];upload=1'>Upload new arena</a><br>"
 	dat += "<hr>"

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -582,7 +582,7 @@
 		R.fields["mrace"] = rando_race.type
 
 	R.fields["name"] = mob_occupant.real_name
-	R.fields["id"] = copytext_char(md5(mob_occupant.real_name), 2, 6)
+	R.fields["id"] = copytext_char(rustg_hash_string(RUSTG_HASH_MD5, mob_occupant.real_name), 2, 6)
 	R.fields["UE"] = dna.unique_enzymes
 	R.fields["UI"] = dna.uni_identity
 	R.fields["SE"] = dna.mutation_index

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -49,7 +49,7 @@
 
 	// Give the log a name and store it
 	var/identifier = num2text( rand(-1000,1000) + world.time )
-	log.name = "data packet ([md5(identifier)])"
+	log.name = "data packet ([rustg_hash_string(RUSTG_HASH_MD5, identifier)])"
 	log_entries.Add(log)
 
 	var/can_send = relay_information(signal, /obj/machinery/telecomms/hub)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -51,7 +51,7 @@ GLOBAL_VAR(restart_counter)
 	GLOB.timezoneOffset = text2num(time2text(0,"hh")) * 36000
 
 	if(fexists(RESTART_COUNTER_PATH))
-		GLOB.restart_counter = text2num(trim(file2text(RESTART_COUNTER_PATH)))
+		GLOB.restart_counter = text2num(trim(rustg_file_read(RESTART_COUNTER_PATH)))
 		fdel(RESTART_COUNTER_PATH)
 
 	if(NO_INIT_PARAMETER in params)
@@ -218,7 +218,7 @@ GLOBAL_VAR(restart_counter)
 	else
 		fail_reasons = list("Missing GLOB!")
 	if(!fail_reasons)
-		text2file("Success!", "[GLOB.log_directory]/clean_run.lk")
+		rustg_file_append("Success!", "[GLOB.log_directory]/clean_run.lk")
 	else
 		log_world("Test run failed!\n[fail_reasons.Join("\n")]")
 	sleep(0)	//yes, 0, this'll let Reboot finish and prevent byond memes
@@ -253,7 +253,7 @@ GLOBAL_VAR(restart_counter)
 				if(GLOB.restart_counter >= ruhr)
 					do_hard_reboot = TRUE
 				else
-					text2file("[++GLOB.restart_counter]", RESTART_COUNTER_PATH)
+					rustg_file_append("[++GLOB.restart_counter]", RESTART_COUNTER_PATH)
 					do_hard_reboot = FALSE
 
 		if(do_hard_reboot)

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -128,7 +128,7 @@ GLOBAL_PROTECT(protected_ranks)
 	GLOB.admin_ranks.Cut()
 	GLOB.protected_ranks.Cut()
 	//load text from file and process each entry
-	var/ranks_text = file2text("[global.config.directory]/admin_ranks.txt")
+	var/ranks_text = rustg_file_read("[global.config.directory]/admin_ranks.txt")
 	var/datum/admin_rank/previous_rank
 	var/regex/admin_ranks_regex = new(@"^Name\s*=\s*(.+?)\s*\n+Include\s*=\s*([\l @]*?)\s*\n+Exclude\s*=\s*([\l @]*?)\s*\n+Edit\s*=\s*([\l @]*?)\s*\n*$", "gm")
 	while(admin_ranks_regex.Find(ranks_text))
@@ -172,7 +172,7 @@ GLOBAL_PROTECT(protected_ranks)
 			qdel(query_load_admin_ranks)
 	//load ranks from backup file
 	if(dbfail)
-		var/backup_file = file2text("data/admins_backup.json")
+		var/backup_file = rustg_file_read("data/admins_backup.json")
 		if(!backup_file)
 			log_world("Unable to locate admins backup file.")
 			return FALSE
@@ -222,7 +222,7 @@ GLOBAL_PROTECT(protected_ranks)
 	for(var/datum/admin_rank/R in GLOB.admin_ranks)
 		rank_names[R.name] = R
 	//ckeys listed in admins.txt are always made admins before sql loading is attempted
-	var/admins_text = file2text("[global.config.directory]/admins.txt")
+	var/admins_text = rustg_file_read("[global.config.directory]/admins.txt")
 	var/regex/admins_regex = new(@"^(?!#)(.+?)\s+=\s+(.+)", "gm")
 	while(admins_regex.Find(admins_text))
 		new /datum/admins(rank_names[admins_regex.group[2]], ckey(admins_regex.group[1]), FALSE, TRUE)
@@ -251,7 +251,7 @@ GLOBAL_PROTECT(protected_ranks)
 			if(backup_file_json != null)
 				//already tried
 				return
-			var/backup_file = file2text("data/admins_backup.json")
+			var/backup_file = rustg_file_read("data/admins_backup.json")
 			if(!backup_file)
 				log_world("Unable to locate admins backup file.")
 				return

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -4,7 +4,7 @@
 	if (!create_mob_html)
 		var/mobjs = null
 		mobjs = jointext(typesof(/mob), ";")
-		create_mob_html = file2text('html/create_object.html')
+		create_mob_html = rustg_file_read('html/create_object.html')
 		create_mob_html = replacetext(create_mob_html, "Create Object", "Create Mob")
 		create_mob_html = replacetext(create_mob_html, "null /* object types */", "\"[mobjs]\"")
 

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -8,7 +8,7 @@
 	if (!create_object_html)
 		var/objectjs = null
 		objectjs = jointext(typesof(/obj), ";")
-		create_object_html = file2text('html/create_object.html')
+		create_object_html = rustg_file_read('html/create_object.html')
 		create_object_html = replacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
 
 	user << browse(create_panel_helper(create_object_html), "window=create_object;size=425x475")
@@ -24,7 +24,7 @@
 
 	if (!html_form)
 		var/objectjs = jointext(typesof(path), ";")
-		html_form = file2text('html/create_object.html')
+		html_form = rustg_file_read('html/create_object.html')
 		html_form = replacetext(html_form, "Create Object", "Create [path]")
 		html_form = replacetext(html_form, "null /* object types */", "\"[objectjs]\"")
 		create_object_forms[path] = html_form

--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -3,7 +3,7 @@
 	if (!create_turf_html)
 		var/turfjs = null
 		turfjs = jointext(typesof(/turf), ";")
-		create_turf_html = file2text('html/create_object.html')
+		create_turf_html = rustg_file_read('html/create_object.html')
 		create_turf_html = replacetext(create_turf_html, "Create Object", "Create Turf")
 		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
 

--- a/code/modules/admin/outfits.dm
+++ b/code/modules/admin/outfits.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	var/outfit_file = input("Pick outfit json file:", "File") as null|file
 	if(!outfit_file)
 		return
-	var/filedata = file2text(outfit_file)
+	var/filedata = rustg_file_read(outfit_file)
 	var/json = json_decode(filedata)
 	if(!json)
 		to_chat(admin,"<span class='warning'>JSON decode error.</span>")

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -292,7 +292,7 @@ GLOBAL_DATUM_INIT(admin_secrets, /datum/admin_secrets, new)
 			dat += "<table cellspacing=5><tr><th>Name</th><th>Fingerprints</th></tr>"
 			for(var/mob/living/carbon/human/H in GLOB.carbon_list)
 				if(H.ckey)
-					dat += "<tr><td>[H]</td><td>[md5(H.dna.uni_identity)]</td></tr>"
+					dat += "<tr><td>[H]</td><td>[rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)]</td></tr>"
 			dat += "</table>"
 			usr << browse(dat, "window=fingerprints;size=440x410")
 

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -741,7 +741,7 @@
 				output += "<br>Unbanned by <b>[unban_key]</b> on <b>[unban_datetime]</b> during round <b>#[unban_round_id]</b>."
 			output += "</div><div class='container'><div class='reason'>[reason]</div><div class='edit'>"
 			if(!expired && !unban_datetime)
-				output += "<a href='?_src_=holder;[HrefToken()];editbanid=[ban_id];editbankey=[player_key];editbanip=[player_ip];editbancid=[player_cid];editbanrole=[role];editbanduration=[duration];editbanadmins=[applies_to_admins];editbanreason=[url_encode(reason)];editbanpage=[page];editbanadminkey=[admin_key]'>Edit</a><br>[unban_href]"
+				output += "<a href='?_src_=holder;[HrefToken()];editbanid=[ban_id];editbankey=[player_key];editbanip=[player_ip];editbancid=[player_cid];editbanrole=[role];editbanduration=[duration];editbanadmins=[applies_to_admins];editbanreason=[rustg_url_encode(reason)];editbanpage=[page];editbanadminkey=[admin_key]'>Edit</a><br>[unban_href]"
 			if(edits)
 				output += "<br><a href='?_src_=holder;[HrefToken()];unbanlog=[ban_id]'>Edit log</a>"
 			output += "</div></div></div>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2154,7 +2154,7 @@
 		var/role = href_list["editbanrole"]
 		var/duration = href_list["editbanduration"]
 		var/applies_to_admins = text2num(href_list["editbanadmins"])
-		var/reason = url_decode(href_list["editbanreason"])
+		var/reason = rustg_url_decode(href_list["editbanreason"])
 		var/page = href_list["editbanpage"]
 		var/admin_key = href_list["editbanadminkey"]
 		ban_panel(player_key, player_ip, player_cid, role, duration, applies_to_admins, reason, edit_id, page, admin_key)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -79,7 +79,7 @@
 	return max(arglist(args))
 
 /proc/_md5(T)
-	return md5(T)
+	return rustg_hash_string(RUSTG_HASH_MD5, T)
 
 /proc/_min(...)
 	return min(arglist(args))

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -29,7 +29,7 @@
 	message_admins("[key_name_admin(src)] accessed file: [path]")
 	switch(alert("View (in game), Open (in your system's text editor), or Download?", path, "View", "Open", "Download"))
 		if ("View")
-			src << browse("<pre style='word-wrap: break-word;'>[html_encode(file2text(file(path)))]</pre>", list2params(list("window" = "viewfile.[path]")))
+			src << browse("<pre style='word-wrap: break-word;'>[html_encode(rustg_file_read(file(path)))]</pre>", list2params(list("window" = "viewfile.[path]")))
 		if ("Open")
 			src << run(file(path))
 		if ("Download")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -416,7 +416,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(G_found.mind && !G_found.mind.active)	//mind isn't currently in use by someone/something
 		/*Try and locate a record for the person being respawned through GLOB.data_core.
 		This isn't an exact science but it does the trick more often than not.*/
-		var/id = md5("[G_found.real_name][G_found.mind.assigned_role]")
+		var/id = rustg_hash_string(RUSTG_HASH_MD5, "[G_found.real_name][G_found.mind.assigned_role]")
 
 		record_found = find_record("id", id, GLOB.data_core.locked)
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST(admin_antag_list)
 	stuff.send(owner.current.client)
 	var/datum/browser/popup = new(owner.current, "antagTips", null, 600, 400)
 	popup.set_window_options("titlebar=1;can_minimize=0;can_resize=0")
-	popup.set_content(file2text(file))
+	popup.set_content(rustg_file_read(file))
 	popup.open(FALSE)
 
 /datum/antagonist/New()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -366,7 +366,7 @@
 	if(!length(prints))
 		return FALSE
 	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-		if(prints[md5(H.dna.uni_identity)])
+		if(prints[rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)])
 			possible |= H
 
 /obj/item/voodoo/proc/GiveHint(mob/victim,force=0)

--- a/code/modules/awaymissions/super_secret_room.dm
+++ b/code/modules/awaymissions/super_secret_room.dm
@@ -15,7 +15,7 @@
 	var/json_file = file("data/npc_saves/Poly.json")
 	if(!fexists(json_file))
 		return
-	var/list/json = json_decode(file2text(json_file))
+	var/list/json = json_decode(rustg_file_read(json_file))
 	shenanigans = json["phrases"]
 
 /obj/structure/speaking_tile/interact(mob/user)

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -231,7 +231,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	var/res_name = "spritesheet_[name].css"
 	var/fname = "data/spritesheets/[res_name]"
 	fdel(fname)
-	text2file(generate_css(), fname)
+	rustg_file_append(generate_css(), fname)
 	register_asset(res_name, fcopy_rsc(fname))
 	fdel(fname)
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -442,7 +442,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if (topmenuname == "[topmenu.type]")
 			var/list/tree = splittext(topmenuname, "/")
 			topmenuname = tree[tree.len]
-		winset(src, "[topmenu.type]", "parent=menu;name=[url_encode(topmenuname)]")
+		winset(src, "[topmenu.type]", "parent=menu;name=[rustg_url_encode(topmenuname)]")
 		var/list/entries = topmenu.Generate_list(src)
 		for (var/child in entries)
 			winset(src, "[child]", "[entries[child]]")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -813,7 +813,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		return TRUE
 
 /client/proc/cid_check_reconnect()
-	var/token = md5("[rand(0,9999)][world.time][rand(0,9999)][ckey][rand(0,9999)][address][rand(0,9999)][computer_id][rand(0,9999)]")
+	var/token = rustg_hash_string(RUSTG_HASH_MD5, "[rand(0,9999)][world.time][rand(0,9999)][ckey][rand(0,9999)][address][rand(0,9999)][computer_id][rand(0,9999)]")
 	. = token
 	log_access("Failed Login: [key] [computer_id] [address] - CID randomizer check")
 	var/url = winget(src, null, "url")

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -93,7 +93,7 @@
 
 			var/mob/living/carbon/human/H = A
 			if(!H.gloves)
-				fingerprints += md5(H.dna.uni_identity)
+				fingerprints += rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)
 
 		else if(!ismob(A))
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -178,7 +178,7 @@
 	for (var/I in src)
 		var/atom/movable/O = I
 		if (!QDELETED(O))
-			var/md5name = md5(O.name)				// This needs to happen because of a bug in a TGUI component, https://github.com/ractivejs/ractive/issues/744
+			var/md5name = rustg_hash_string(RUSTG_HASH_MD5, O.name)				// This needs to happen because of a bug in a TGUI component, https://github.com/ractivejs/ractive/issues/744
 			if (listofitems[md5name])				// which is fixed in a version we cannot use due to ie8 incompatibility
 				listofitems[md5name]["amount"]++	// The good news is, #30519 made smartfridge UIs non-auto-updating
 			else

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -157,7 +157,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 /datum/chatOutput/proc/sendMusic(music, list/extra_data)
 	if(!findtext(music, GLOB.is_http_protocol))
 		return
-	var/list/music_data = list("adminMusic" = url_encode(url_encode(music)))
+	var/list/music_data = list("adminMusic" = rustg_url_encode(rustg_url_encode(music)))
 
 	if(extra_data?.len)
 		music_data["musicRate"] = extra_data["pitch"]
@@ -266,7 +266,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 
 	if(islist(target))
 		// Do the double-encoding outside the loop to save nanoseconds
-		var/twiceEncoded = url_encode(url_encode(message))
+		var/twiceEncoded = rustg_url_encode(rustg_url_encode(message))
 		for(var/I in target)
 			var/client/C = CLIENT_FROM_VAR(I) //Grab us a client if possible
 
@@ -302,8 +302,8 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("tmp/iconCache.sav")) //Cache of ico
 			C.chatOutput.messageQueue += message
 			return
 
-		// url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
-		C << output(url_encode(url_encode(message)), "browseroutput:output")
+		// rustg_url_encode it TWICE, this way any UTF-8 characters are able to be decoded by the Javascript.
+		C << output(rustg_url_encode(rustg_url_encode(message)), "browseroutput:output")
 
 /proc/to_chat(target, message, handle_whitespace = TRUE)
 	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized)

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -153,7 +153,7 @@ function linkify_fallback(text) {
 }
 
 function byondDecode(message) {
-	// Basically we url_encode twice server side so we can manually read the encoded version and actually do UTF-8.
+	// Basically we rustg_url_encode twice server side so we can manually read the encoded version and actually do UTF-8.
 	// The replace for + is because FOR SOME REASON, BYOND replaces spaces with a + instead of %20, and a plus with %2b.
 	// Marvelous.
 	message = message.replace(/\+/g, "%20");

--- a/code/modules/guardian/abilities/major/predator.dm
+++ b/code/modules/guardian/abilities/major/predator.dm
@@ -38,7 +38,7 @@
 			var/list/prints = O.return_fingerprints()
 			if(LAZYLEN(prints))
 				for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-					if(H.dna && prints[md5(H.dna.uni_identity)])
+					if(H.dna && prints[rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)])
 						if(!(H in can_track))
 							to_chat(guardian, "<span class='notice italics'>We learn the identity of [H.real_name].</span>")
 							can_track += H

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -152,7 +152,7 @@
 
 /obj/structure/chisel_message/update_icon()
 	..()
-	var/hash = md5(hidden_message)
+	var/hash = rustg_hash_string(RUSTG_HASH_MD5, hidden_message)
 	var/newcolor = copytext_char(hash, 1, 7)
 	add_atom_colour("#[newcolor]", FIXED_COLOUR_PRIORITY)
 	light_color = "#[newcolor]"

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -52,7 +52,7 @@
 /datum/parsed_map/New(tfile, x_lower = -INFINITY, x_upper = INFINITY, y_lower = -INFINITY, y_upper=INFINITY, measureOnly=FALSE)
 	if(isfile(tfile))
 		original_path = "[tfile]"
-		tfile = file2text(tfile)
+		tfile = rustg_file_read(tfile)
 	else if(isnull(tfile))
 		// create a new datum without loading a map
 		return

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -101,7 +101,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		var/atom/parent = mats.parent
 		var/hold_key = "[get_area(parent)]/[mats.category]"
 		ui += "<a href='?src=[REF(src)];remove=[REF(mats)]'>Remove</a>"
-		ui += "<a href='?src=[REF(src)];hold[!holds[hold_key]]=[url_encode(hold_key)]'>[holds[hold_key] ? "Allow" : "Hold"]</a>"
+		ui += "<a href='?src=[REF(src)];hold[!holds[hold_key]]=[rustg_url_encode(hold_key)]'>[holds[hold_key] ? "Allow" : "Hold"]</a>"
 		ui += " <b>[parent.name]</b> in [get_area_name(parent, TRUE)]<br>"
 	if(!connected.len)
 		ui += "Nothing!"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -89,7 +89,7 @@
 				stat(null, "Energy Charge: [round(SN.cell.charge/100)]%")
 				stat(null, "Smoke Bombs: \Roman [SN.s_bombs]")
 				//Ninja status
-				stat(null, "Fingerprints: [md5(dna.uni_identity)]")
+				stat(null, "Fingerprints: [rustg_hash_string(RUSTG_HASH_MD5, dna.uni_identity)]")
 				stat(null, "Unique Identity: [dna.unique_enzymes]")
 				stat(null, "Overall Status: [stat > 1 ? "dead" : "[health]% healthy"]")
 				stat(null, "Nutrition Status: [nutrition]")

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -54,7 +54,7 @@
 		var/json_file = file("data/npc_saves/Punpun.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = json_decode(file2text(json_file))
+		var/list/json = json_decode(rustg_file_read(json_file))
 		ancestor_name = json["ancestor_name"]
 		ancestor_chain = json["ancestor_chain"]
 		relic_hat = json["relic_hat"]

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -8,7 +8,7 @@
 /mob/living/silicon/proc/deadchat_lawchange()
 	var/list/the_laws = laws.get_law_list(include_zeroth = TRUE)
 	var/lawtext = the_laws.Join("<br/>")
-	deadchat_broadcast("<span class='deadsay'><span class='name'>[src]</span>'s laws were changed.</span> <a href='?src=[REF(src)]&printlawtext=[url_encode(lawtext)]'>View</a>", "<span class='name'>[src]</span>", follow_target=src, message_type=DEADCHAT_LAWCHANGE)
+	deadchat_broadcast("<span class='deadsay'><span class='name'>[src]</span>'s laws were changed.</span> <a href='?src=[REF(src)]&printlawtext=[rustg_url_encode(lawtext)]'>View</a>", "<span class='name'>[src]</span>", follow_target=src, message_type=DEADCHAT_LAWCHANGE)
 
 /mob/living/silicon/proc/post_lawchange(announce = TRUE)
 	throw_alert("newlaw", /obj/screen/alert/newlaw)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -132,7 +132,7 @@
 		var/json_file = file("data/npc_saves/Runtime.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = json_decode(file2text(json_file))
+		var/list/json = json_decode(rustg_file_read(json_file))
 		family = json["family"]
 	if(isnull(family))
 		family = list()

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -391,7 +391,7 @@
 		var/json_file = file("data/npc_saves/Ian.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = json_decode(file2text(json_file))
+		var/list/json = json_decode(rustg_file_read(json_file))
 		age = json["age"]
 		record_age = json["record_age"]
 		saved_head = json["saved_head"]

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -321,7 +321,7 @@ Difficulty: Very Hard
 		var/json_file = file("data/npc_saves/Blackbox.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = json_decode(file2text(json_file))
+		var/list/json = json_decode(rustg_file_read(json_file))
 		stored_items = json["data"]
 	if(isnull(stored_items))
 		stored_items = list()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -924,7 +924,7 @@
 		var/json_file = file("data/npc_saves/Poly.json")
 		if(!fexists(json_file))
 			return
-		var/list/json = json_decode(file2text(json_file))
+		var/list/json = json_decode(rustg_file_read(json_file))
 		speech_buffer = json["phrases"]
 		rounds_survived = json["roundssurvived"]
 		longest_survival = json["longestsurvival"]

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -41,8 +41,8 @@
 
 	// hash the original name?
 	if(tr_flags & TR_HASHNAME)
-		O.name = "monkey ([copytext_char(md5(real_name), 2, 6)])"
-		O.real_name = "monkey ([copytext_char(md5(real_name), 2, 6)])"
+		O.name = "monkey ([copytext_char(rustg_hash_string(RUSTG_HASH_MD5, real_name), 2, 6)])"
+		O.real_name = "monkey ([copytext_char(rustg_hash_string(RUSTG_HASH_MD5, real_name), 2, 6)])"
 
 	//handle DNA and other attributes
 	dna.transfer_identity(O)

--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -97,7 +97,7 @@
 	var/json_path = file("[dir]/metadata.json")
 	if(!fexists(json_path))
 		return
-	var/list/json = json_decode(file2text(json_path))
+	var/list/json = json_decode(rustg_file_read(json_path))
 	if(!json[id])
 		return
 	var/datum/picture/P = new
@@ -147,7 +147,7 @@
 	jsonpath = file(jsonpath)
 	var/list/json
 	if(fexists(jsonpath))
-		json = json_decode(file2text(jsonpath))
+		json = json_decode(rustg_file_read(jsonpath))
 		fdel(jsonpath)
 	else
 		json = list()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -397,7 +397,7 @@
 		AM.pixel_y = -8
 		return null
 	else
-		var/md5 = md5(AM.name)
+		var/md5 = rustg_hash_string(RUSTG_HASH_MD5, AM.name)
 		for (var/i in 1 to 32)
 			. += hex2num(md5[i])
 		. = . % 9

--- a/code/modules/tgs/v3210/api.dm
+++ b/code/modules/tgs/v3210/api.dm
@@ -54,7 +54,7 @@
 	return ""
 
 /datum/tgs_api/v3210/proc/file2list(filename)
-	return splittext(trim_left(trim_right(file2text(filename))), "\n")
+	return splittext(trim_left(trim_right(rustg_file_read(filename))), "\n")
 
 /datum/tgs_api/v3210/OnWorldNew(minimum_required_security_level)
 	. = FALSE
@@ -153,7 +153,7 @@
 	. = list()
 	if(!fexists(SERVICE_PR_TEST_JSON))
 		return
-	var/list/json = json_decode(file2text(SERVICE_PR_TEST_JSON))
+	var/list/json = json_decode(rustg_file_read(SERVICE_PR_TEST_JSON))
 	if(!json)
 		return
 	for(var/I in json)

--- a/code/modules/tgs/v4/api.dm
+++ b/code/modules/tgs/v4/api.dm
@@ -54,7 +54,7 @@
 	if(!json_path)
 		TGS_ERROR_LOG("Missing [TGS4_PARAM_INFO_JSON] world parameter!")
 		return
-	var/json_file = file2text(json_path)
+	var/json_file = rustg_file_read(json_path)
 	if(!json_file)
 		TGS_ERROR_LOG("Missing specified json file: [json_path]")
 		return
@@ -217,7 +217,7 @@
 
 	last_interop_response = null
 	fdel(server_commands_json_path)
-	text2file(json, server_commands_json_path)
+	rustg_file_append(json, server_commands_json_path)
 
 	for(var/I = 0; I < EXPORT_TIMEOUT_DS && !last_interop_response; ++I)
 		sleep(1)
@@ -294,7 +294,7 @@
 /datum/tgs_api/v4/ChatChannelInfo()
 	. = list()
 	//no caching cause tgs may change this
-	var/list/json = json_decode(file2text(chat_channels_json_path))
+	var/list/json = json_decode(rustg_file_read(chat_channels_json_path))
 	for(var/I in json)
 		. += DecodeChannel(I)
 

--- a/code/modules/tgs/v4/commands.dm
+++ b/code/modules/tgs/v4/commands.dm
@@ -18,7 +18,7 @@
 	var/commands_file = chat_commands_json_path
 	if(!commands_file)
 		return
-	text2file(json_encode(results), commands_file)
+	rustg_file_append(json_encode(results), commands_file)
 
 /datum/tgs_api/v4/proc/HandleCustomCommand(command_json)
 	var/list/data = json_decode(command_json)

--- a/code/modules/tgs/v5/api.dm
+++ b/code/modules/tgs/v5/api.dm
@@ -233,7 +233,7 @@
 	data[DMAPI5_PARAMETER_ACCESS_IDENTIFIER] = access_identifier
 
 	var/json = json_encode(data)
-	var/encoded_json = url_encode(json)
+	var/encoded_json = rustg_url_encode(json)
 
 	// This is an infinite sleep until we get a response
 	var/datum/http_request/export_response = new()

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -131,7 +131,7 @@
 		initial_data = src_object.ui_data(user)
 	if(!initial_static_data)
 		initial_static_data = src_object.ui_static_data(user)
-	_initial_update = url_encode(get_json(initial_data, initial_static_data))
+	_initial_update = rustg_url_encode(get_json(initial_data, initial_static_data))
 
 	SStgui.on_open(src)
 
@@ -306,7 +306,7 @@
 		return
 	// Send the new JSON to the update() Javascript function.
 	user << output(
-		url_encode(get_json(data, static_data)),
+		rustg_url_encode(get_json(data, static_data)),
 		"[window_id].browser:update")
 
 /**

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -44,7 +44,7 @@ Notes:
 		owner = C
 		var/datum/asset/stuff = get_asset_datum(/datum/asset/simple/jquery)
 		stuff.send(owner)
-		owner << browse(file2text('code/modules/tooltip/tooltip.html'), "window=[control]")
+		owner << browse(rustg_file_read('code/modules/tooltip/tooltip.html'), "window=[control]")
 
 	..()
 

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -65,13 +65,13 @@
 			message += GLOB.revdata.GetTestMergeInfo(FALSE)
 		if(tgalert(src, message, "Report Issue","Yes","No")!="Yes")
 			return
-		var/static/issue_template = file2text(".github/ISSUE_TEMPLATE.md")
+		var/static/issue_template = rustg_file_read(".github/ISSUE_TEMPLATE.md")
 		var/servername = CONFIG_GET(string/servername)
 		var/url_params = "Reporting client version: [byond_version].[byond_build]\n\n[issue_template]"
 		if(GLOB.round_id || servername)
 			url_params = "Issue reported from [GLOB.round_id ? " Round ID: [GLOB.round_id][servername ? " ([servername])" : ""]" : servername]\n\n[url_params]"
 		var/issue_label = CONFIG_GET(string/issue_label)
-		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[url_encode(url_params)][issue_label ? "&labels=[url_encode(issue_label)]" : ""]"))
+		DIRECT_OUTPUT(src, link("[githuburl]/issues/new?body=[rustg_url_encode(url_params)][issue_label ? "&labels=[rustg_url_encode(issue_label)]" : ""]"))
 	else
 		to_chat(src, "<span class='danger'>The Github URL is not set in the server configuration.</span>")
 	return

--- a/tools/Redirector/textprocs.dm
+++ b/tools/Redirector/textprocs.dm
@@ -17,7 +17,7 @@ proc
 			file = file_path
 		else
 			file = file(file_path)
-		return dd_text2list(file2text(file), separator)
+		return dd_text2list(rustg_file_read(file), separator)
 
 
     ////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It was a solid attempt, but sadly this just isn't feasible to continue to maintain. Instead of overriding the built in functions, we'll be pushing to use the rust-g procs over the inbuilt ones where possible. 

The main reason for this swap is the fact that rust-g is incapable of interacting with files loaded into the resource cache. With #2336 on the way, this is the best option.

**Note:** The file hashing is extremely limited due to the technical limitations of rust-g. Due to this, any file hashing should be done using the built in proc.

## Why It's Good For The Game

This returns flexibility lost with the rust-g overrides

## Changelog
:cl:
code: Removed rust-g overrides
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
