### PR TITLE
Oversight in IAA code that prevents nonHuman (AI) IAAs from completing their Escape objectives

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -122,7 +122,7 @@
 
 /datum/antagonist/traitor/internal_affairs/reinstate_escape_objective()
 	..()
-	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive
+	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive/exist
 	var/datum/objective/escape_objective = new objtype
 	escape_objective.owner = owner
 	add_objective(escape_objective)
@@ -228,7 +228,7 @@
 /datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()
 	forge_iaa_objectives()
 
-	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive
+	var/objtype = traitor_kind == TRAITOR_HUMAN ? /datum/objective/escape : /datum/objective/survive/exist
 	var/datum/objective/escape_objective = new objtype
 	escape_objective.owner = owner
 	add_objective(escape_objective)


### PR DESCRIPTION
## About The Pull Request

Someone overlooked the IAA code and, by default, IAA gave non humans the "/datum/objective/survive" objective, as opposed to "/datum/objective/survive/exist". This means that non-humans (read, IAA AIs) are unable to complete this objective because they are not considered alive and human at the end of the game, and fail by default.

## Why It's Good For The Game

Removes shitcode.

## Changelog
:cl:
fix: fixed IAA AI being unable to complete the survive objective
/:cl: