### PR TITLE
no more fastmos stunlock

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -80,7 +80,7 @@
 				hurt = FALSE
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Paralyze(20)
+			Knockdown(20)
 			take_bodypart_damage(10,check_armor = TRUE)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom


### PR DESCRIPTION

## About The Pull Request
hitting a wall too hard knocks down, instead of stunning

## Why It's Good For The Game
stunlock bad

## Changelog
:cl:
balance: hitting a closed turf when thrown stuns carbons, as opposed to paralysis
/:cl:

