### PR TITLE
vehicles no longer block projectiles

### DIFF
--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -24,6 +24,13 @@
 	var/obj/vehicle/trailer
 	var/are_legs_exposed = FALSE
 
+/obj/vehicle/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover, /obj/item)) //thrown objects and projectiles bypass vehicles
+		return 1
+	if(HAS_TRAIT(mover, TRAIT_PASSTABLE)) 
+		return 1
+	return ..()
+
 /obj/vehicle/Initialize(mapload)
 	. = ..()
 	occupants = list()

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -2,6 +2,10 @@
 	var/enter_delay = 20
 	var/mouse_pointer
 
+/obj/vehicle/sealed/CanPass(atom/movable/mover, turf/target)
+	if(mover in buckled_mobs)
+		return 1
+
 /obj/vehicle/sealed/generate_actions()
 	. = ..()
 	initialize_passenger_action_type(/datum/action/vehicle/sealed/climb_out)


### PR DESCRIPTION

## About The Pull Request
non-sealed vehicles (so, vehicles other than clown car) no longer block projectiles. 
they can also be passed by mobs that pass over tables
## Why It's Good For The Game
stop using scooters as a shield against shotgun blasts

## Changelog
:cl:
tweak: vehicles no longer block bullets for you
tweak: mobs which pass tables can move past vehicles
/:cl:
