### PR TITLE
fast zombies count as dead

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -391,7 +391,7 @@
 			var/mob/living/carbon/human/H
 			if(ishuman(M.current))
 				H = M.current
-			return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies" || H.dna.species.id != "memezombiesfast")
+			return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies" && H.dna.species.id != "memezombiesfast")
 		else if(isliving(M.current))
 			return M.current.stat != DEAD
 	return FALSE

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -391,7 +391,7 @@
 			var/mob/living/carbon/human/H
 			if(ishuman(M.current))
 				H = M.current
-			return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies")
+			return M.current.stat != DEAD && !issilicon(M.current) && !isbrain(M.current) && (!H || H.dna.species.id != "memezombies" || H.dna.species.id != "memezombiesfast")
 		else if(isliving(M.current))
 			return M.current.stat != DEAD
 	return FALSE


### PR DESCRIPTION

## About The Pull Request
fast zombies count as dead for objectives

## Why It's Good For The Game
oversight

## Changelog
:cl:
fix:fast zombies count as dead for objectives
/:cl:

