### PR TITLE
billy club no longer as lethal

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -870,12 +870,12 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "classic_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	force = 10
+	force = 5
 	throwforce = 5
 	block_upgrade_walk = 1
 	attack_verb = list("clubbed", "bludgeoned")
 	var/breakforce = 30
-	var/stamforce = 15
+	var/stamforce = 17
 
 /obj/item/club/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))


### PR DESCRIPTION
## About The Pull Request
billy club now only does the same brute as a harmbaton, but has had its stamina boosted.

## Why It's Good For The Game
shitsec keeps using billy clubs to kill people. They're for breaking shields, you dolt. As the one who added them, they arent working as intended

## Changelog
:cl:
balance: billy clubs now do the same brute damage a harmbaton does
/:cl:

