### PR TITLE
bullets now need gunpowder

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -346,6 +346,60 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
+/datum/crafting_recipe/slug
+	name = "Shotgun Slug"
+	result = /obj/item/ammo_casing/shotgun
+	reqs = list(/obj/item/ammo_casing/shotgun/hull = 1,
+				/obj/item/stack/sheet/iron = 1,
+				/datum/reagent/blackpowder = 10)
+	tools = list(TOOL_SCREWDRIVER)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/buckshot
+	name = "Buckshot"
+	result = /obj/item/ammo_casing/shotgun/buckshot
+	reqs = list(/obj/item/ammo_casing/shotgun/hull = 1,
+				/obj/item/stack/sheet/iron = 1,
+				/datum/reagent/blackpowder = 10)
+	tools = list(TOOL_SCREWDRIVER)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/dart
+	name = "Shotgun Dart"
+	result = /obj/item/ammo_casing/shotgun/dart
+	reqs = list(/obj/item/ammo_casing/shotgun/hull = 1,
+				/obj/item/reagent_containers/syringe = 2,
+				/datum/reagent/blackpowder = 10)
+	tools = list(TOOL_SCREWDRIVER)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/incendiary
+	name = "Incendiary Shotgun Round"
+	result = /obj/item/ammo_casing/shotgun/incendiary
+	reqs = list(/obj/item/ammo_casing/shotgun/hull = 1,
+				/datum/reagent/fuel = 5,
+				/datum/reagent/blackpowder = 5)
+	tools = list(TOOL_SCREWDRIVER)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/hull
+	name = "Empty Shotgun Shell"
+	result = /obj/item/ammo_casing/shotgun/hull
+	reqs = list(/obj/item/grenade/chem_grenade = 1,
+				/datum/reagent/fuel = 10)//still needs a primer
+	tools = list(TOOL_SCREWDRIVER)
+	time = 5
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
 /datum/crafting_recipe/arrow
 	name = "Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/wood

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -114,6 +114,12 @@
 	pellets = 6
 	variance = 35
 
+/obj/item/ammo_casing/shotgun/hull
+	name = "unloaded shotgun shell"
+	desc = "A basic shotgun's shell casing, full of potential."
+	icon_state = "gshell"
+	projectile_type = null
+
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"
 	desc = "A high-tech shotgun shell which can be loaded with materials to produce unique effects."

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -545,26 +545,20 @@
 /datum/design/beanbag_slug
 	name = "Beanbag Slug"
 	id = "beanbag_slug"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/ammo_casing/shotgun/beanbag
-	category = list("initial", "Security")
+	category = list("initial", "Security", "Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/rubbershot
 	name = "Rubber Shot"
 	id = "rubber_shot"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
-	category = list("initial", "Security")
-
-/datum/design/c38
-	name = "Speed Loader (.38)"
-	id = "c38"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 20000)
-	build_path = /obj/item/ammo_box/c38
-	category = list("initial", "Security")
+	category = list("initial", "Security", "Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/recorder
 	name = "Universal Recorder"
@@ -761,85 +755,32 @@
 	build_path = /obj/item/weaponcrafting/receiver
 	category = list("hacked", "Security")
 
-/datum/design/shotgun_slug
-	name = "Shotgun Slug"
-	id = "shotgun_slug"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
-	build_path = /obj/item/ammo_casing/shotgun
-	category = list("hacked", "Security")
-
-/datum/design/buckshot_shell
-	name = "Buckshot Shell"
-	id = "buckshot_shell"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/buckshot
-	category = list("hacked", "Security")
-
-/datum/design/shotgun_dart
-	name = "Shotgun Dart"
-	id = "shotgun_dart"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/dart
-	category = list("hacked", "Security")
-
-/datum/design/incendiary_slug
-	name = "Incendiary Slug"
-	id = "incendiary_slug"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
-	build_path = /obj/item/ammo_casing/shotgun/incendiary
-	category = list("hacked", "Security")
+/datum/design/shotgun_hull
+	name = "Empty Shotgun Shell"
+	id = "shotgun_hull"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 500)
+	build_path = /obj/item/ammo_casing/shotgun/hull
+	category = list("hacked", "Security", "Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/riot_dart
 	name = "Foam Riot Dart"
 	id = "riot_dart"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 1000) //Discount for making individually - no box = less metal!
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
-	category = list("hacked", "Security")
+	category = list("hacked", "Security", "Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/riot_darts
 	name = "Foam Riot Dart Box"
 	id = "riot_darts"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE
 	materials = list(/datum/material/iron = 50000) //Comes with 40 darts
 	build_path = /obj/item/ammo_box/foambox/riot
-	category = list("hacked", "Security")
-
-/datum/design/a357
-	name = ".357 Casing"
-	id = "a357"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
-	build_path = /obj/item/ammo_casing/a357
-	category = list("hacked", "Security")
-
-/datum/design/c10mm
-	name = "Ammo Box (10mm)"
-	id = "c10mm"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30000)
-	build_path = /obj/item/ammo_box/c10mm
-	category = list("hacked", "Security")
-
-/datum/design/c45
-	name = "Ammo Box (.45)"
-	id = "c45"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30000)
-	build_path = /obj/item/ammo_box/c45
-	category = list("hacked", "Security")
-
-/datum/design/c9mm
-	name = "Ammo Box (9mm)"
-	id = "c9mm"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30000)
-	build_path = /obj/item/ammo_box/c9mm
-	category = list("hacked", "Security")
+	category = list("hacked", "Security", "Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/cleaver
 	name = "Butcher's Cleaver"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -545,20 +545,26 @@
 /datum/design/beanbag_slug
 	name = "Beanbag Slug"
 	id = "beanbag_slug"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/ammo_casing/shotgun/beanbag
-	category = list("initial", "Security", "Ammo", "initial")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	category = list("initial", "Security")
 
 /datum/design/rubbershot
 	name = "Rubber Shot"
 	id = "rubber_shot"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
-	category = list("initial", "Security", "Ammo", "initial")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	category = list("initial", "Security")
+
+/datum/design/c38
+	name = "Speed Loader (.38)"
+	id = "c38"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 20000)
+	build_path = /obj/item/ammo_box/c38
+	category = list("initial", "Security")
 
 /datum/design/recorder
 	name = "Universal Recorder"
@@ -758,29 +764,26 @@
 /datum/design/shotgun_hull
 	name = "Empty Shotgun Shell"
 	id = "shotgun_hull"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/ammo_casing/shotgun/hull
-	category = list("hacked", "Security", "Ammo", "initial")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	category = list("hacked", "Security")
 
 /datum/design/riot_dart
 	name = "Foam Riot Dart"
 	id = "riot_dart"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 1000) //Discount for making individually - no box = less metal!
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
-	category = list("hacked", "Security", "Ammo", "initial")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	category = list("hacked", "Security")
 
 /datum/design/riot_darts
 	name = "Foam Riot Dart Box"
 	id = "riot_darts"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 50000) //Comes with 40 darts
 	build_path = /obj/item/ammo_box/foambox/riot
-	category = list("hacked", "Security", "Ammo", "initial")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	category = list("hacked", "Security")
 
 /datum/design/cleaver
 	name = "Butcher's Cleaver"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -6,6 +6,7 @@
 	id = "sec_38"
 	build_type = PROTOLATHE
 	category = list("Ammo")
+	reagents_list = list(/datum/reagent/blackpowder = 5)
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/c38_trac
@@ -14,6 +15,7 @@
 	id = "c38_trac"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 20000, /datum/material/silver = 5000, /datum/material/gold = 1000)
+	reagents_list = list(/datum/reagent/blackpowder = 5)
 	build_path = /obj/item/ammo_box/c38/trac
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
@@ -24,6 +26,7 @@
 	id = "c38_hotshot"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 20000, /datum/material/plasma = 5000)
+	reagents_list = list(/datum/reagent/blackpowder = 5)
 	build_path = /obj/item/ammo_box/c38/hotshot
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
@@ -34,6 +37,7 @@
 	id = "c38_iceblox"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 20000, /datum/material/plasma = 5000)
+	reagents_list = list(/datum/reagent/blackpowder = 5) 
 	build_path = /obj/item/ammo_box/c38/iceblox
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
@@ -64,24 +68,28 @@
 	id = "sec_slug"
 	build_type = PROTOLATHE
 	category = list("Ammo")
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/buckshot_shell/sec
 	id = "sec_bshot"
 	build_type = PROTOLATHE
 	category = list("Ammo")
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/shotgun_dart/sec
 	id = "sec_dart"
 	build_type = PROTOLATHE
 	category = list("Ammo")
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/incendiary_slug/sec
 	id = "sec_Islug"
 	build_type = PROTOLATHE
 	category = list("Ammo")
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/breaching_slug/sec

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -44,6 +44,7 @@
 	build_type = PROTOLATHE
 	category = list("Ammo")
 	materials = list(/datum/material/iron = 4000, /datum/material/silver = 400, /datum/material/copper = 400)
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	build_path = /obj/item/ammo_casing/shotgun/sleepytime
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
@@ -323,6 +324,7 @@
 	id = "mag_oldsmg"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4000)
+	reagents_list = list(/datum/reagent/blackpowder = 30)
 	build_path = /obj/item/ammo_box/magazine/wt550m9
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
@@ -332,6 +334,7 @@
 	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_ap"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600)
+	reagents_list = list(/datum/reagent/blackpowder = 30)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtap
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
@@ -340,6 +343,7 @@
 	desc = "A 20 round armour piercing magazine for the out of date security WT-550 Auto Rifle"
 	id = "mag_oldsmg_ic"
 	materials = list(/datum/material/iron = 6000, /datum/material/silver = 600, /datum/material/glass = 1000)
+	reagents_list = list(/datum/reagent/blackpowder = 30)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wtic
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
@@ -350,6 +354,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 200)
 	build_path = /obj/item/ammo_casing/shotgun/stunslug
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
@@ -359,6 +364,7 @@
 	id = "techshotshell"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200)
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	build_path = /obj/item/ammo_casing/shotgun/techshell
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
@@ -399,6 +405,7 @@
 	id = "shotgundartcryostasis"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 3500)
+	reagents_list = list(/datum/reagent/blackpowder = 10)
 	build_path = /obj/item/ammo_casing/shotgun/dart/noreact
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -411,4 +418,55 @@
 	materials = list(/datum/material/iron = 300, /datum/material/glass = 150)
 	build_path = /obj/item/flashbulb
 	category = list("Weapons")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+//moved autolathe designs
+/datum/design/a357
+	name = ".357 Casing"
+	id = "a357"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/a357
+	category = list("Ammo", "initial")
+	reagents_list = list(/datum/reagent/blackpowder = 10)//expensive as a slug
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/c10mm
+	name = "Ammo Box (10mm)"
+	id = "c10mm"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 30000)
+	reagents_list = list(/datum/reagent/blackpowder = 50) //full box is pricey
+	build_path = /obj/item/ammo_box/c10mm
+	category = list("Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/c45
+	name = "Ammo Box (.45)"
+	id = "c45"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 30000)
+	reagents_list = list(/datum/reagent/blackpowder = 50) //full box is pricey
+	build_path = /obj/item/ammo_box/c45
+	category = list("Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/c9mm
+	name = "Ammo Box (9mm)"
+	id = "c9mm"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 30000)
+	reagents_list = list(/datum/reagent/blackpowder = 50) //full box is pricey
+	build_path = /obj/item/ammo_box/c9mm
+	category = list("Ammo", "initial")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/c38
+	name = "Speed Loader (.38)"
+	id = "c38"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 20000)
+	reagents_list = list(/datum/reagent/blackpowder = 20) //speedloader needs a bit more
+	build_path = /obj/item/ammo_box/c38
+	category = list("Ammo", "initial")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY


### PR DESCRIPTION
## About The Pull Request
-bullets and shotgun shells printed from protolathes now need gunpowder. Rubbershot is excempt
-basic autolathe shotgun shell types are now crafted, using a special empty hull type, which is also craftable
-autolathe no longer prints most ammo. Most is relegated to the seclathe, but it does print empty shells

## Why It's Good For The Game
lethal ammo is way too easy to produce. Making it require inter-departmental cooperation should discourage shotgun shitsec- because shitsec doesnt know how to ask chem for gunpowder

## Changelog
:cl:
del: Removed most ammo from autolathe, moved to seclathe
tweak: basic shotgun ammo is craftable
balance: printing ammo from lathes uses black powder
/:cl:

