### PR TITLE
Adds a fire that doesn't require oxygen to ashwalker lavaland base

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1168,9 +1168,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dg" = (
-/obj/structure/bonfire/dense,
 /obj/structure/stone_tile/center,
 /obj/effect/mapping_helpers/no_lava,
+/obj/structure/bonfire/dense/askwalker,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "di" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -1168,9 +1168,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dg" = (
+/obj/structure/bonfire/dense/askwalker,
 /obj/structure/stone_tile/center,
 /obj/effect/mapping_helpers/no_lava,
-/obj/structure/bonfire/dense/askwalker,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "di" = (

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -238,7 +238,7 @@ obj/item/seeds/bamboo
 	return FALSE
 
 /obj/structure/bonfire/proc/StartBurning()
-	if(!burning && CheckOxygen() || !burning && needs_oxygen == FALSE)
+	if(!burning && (!needs_oxygen || CheckOxygen()))
 		icon_state = burn_icon
 		burning = TRUE
 		set_light(6)
@@ -280,7 +280,7 @@ obj/item/seeds/bamboo
 			O.microwave_act()
 
 /obj/structure/bonfire/process()
-	if(!CheckOxygen() && needs_oxygen == TRUE)
+	if(needs_oxygen && !CheckOxygen())
 		extinguish()
 		return
 	if(!grill)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -156,9 +156,13 @@ obj/item/seeds/bamboo
 	var/burn_icon = "bonfire_on_fire" //for a softer more burning embers icon, use "bonfire_warm"
 	var/grill = FALSE
 	var/fire_stack_strength = 5
+	var/needs_oxygen = TRUE
 
 /obj/structure/bonfire/dense
 	density = TRUE
+
+/obj/structure/bonfire/dense/askwalker
+	needs_oxygen = FALSE
 
 /obj/structure/bonfire/prelit/Initialize()
 	. = ..()
@@ -234,7 +238,7 @@ obj/item/seeds/bamboo
 	return FALSE
 
 /obj/structure/bonfire/proc/StartBurning()
-	if(!burning && CheckOxygen())
+	if(!burning && CheckOxygen() || !burning && needs_oxygen == FALSE)
 		icon_state = burn_icon
 		burning = TRUE
 		set_light(6)
@@ -276,7 +280,7 @@ obj/item/seeds/bamboo
 			O.microwave_act()
 
 /obj/structure/bonfire/process()
-	if(!CheckOxygen())
+	if(!CheckOxygen() && needs_oxygen == TRUE)
 		extinguish()
 		return
 	if(!grill)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lavaland has a randomly generated atmospheric composition, which may or may not contain enough oxygen for the bonfire to burn. This is completely random and out of the ashlizards control. The bonfire is vital for them and I think it being random on if it will or will not light is kinda stupid.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The ashwalker's bonfire does not require oxygen to burn anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
