### PR TITLE
Fixes the default zone_selected from null to the chest

### DIFF
--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -29,7 +29,7 @@
 	var/list/datum/action/actions = list()
 	/// A special action? No idea why this lives here
 	var/list/datum/action/chameleon_item_actions
-	
+
 	/// Whether a mob is alive or dead. TODO: Move this to living - Nodrak (2019, still here)
 	var/stat = CONSCIOUS
 
@@ -41,7 +41,7 @@
 	*/
 
 	/// The zone this mob is currently targeting
-	var/zone_selected = null
+	var/zone_selected = BODY_ZONE_CHEST
 
 	var/computer_id = null
 	var/list/logging = list()
@@ -51,12 +51,12 @@
 
 	/// Tick time the mob can next move
 	var/next_move = null
-	
+
 	///prevents area creation spam
 	var/create_area_cooldown
 	/**
 	  * Magic var that stops you moving and interacting with anything
-	  * 
+	  *
 	  * Set when you're being turned into something else and also used in a bunch of places
 	  * it probably shouldn't really be
 	  */
@@ -74,7 +74,7 @@
 
 	/**
 	  * back up of the real name during admin possession
-	  * 
+	  *
 	  * If an admin possesses an object it's real name is set to the admin name and this
 	  * stores whatever the real name was previously. When possession ends, the real name
 	  * is reset to this value
@@ -117,12 +117,12 @@
 	var/active_hand_index = 1
 	/**
 	  * list of items held in hands
-	  * 
+	  *
 	  * len = number of hands, eg: 2 nulls is 2 empty hands, 1 item and 1 null is 1 full hand
 	  * and 1 empty hand.
-	  * 
+	  *
 	  * NB: contains nulls!
-	  * 
+	  *
 	  * held_items[active_hand_index] is the actively held item, but please use
 	  * get_active_held_item() instead, because OOP
 	  */
@@ -160,7 +160,7 @@
 	  */
 	var/list/mob_spell_list = list()
 
-	
+
 	/// bitflags defining which status effects can be inflicted (replaces canknockdown, canstun, etc)
 	var/status_flags = CANSTUN|CANKNOCKDOWN|CANUNCONSCIOUS|CANPUSH
 
@@ -203,7 +203,7 @@
 
 	///THe z level this mob is currently registered in
 	var/registered_z = null
-	
+
 	var/memory_throttle_time = 0
 
 	vis_flags = VIS_INHERIT_PLANE //when this be added to vis_contents of something it inherit something.plane, important for visualisation of mob in openspace.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You can now do surgery and hug people with the roundstart intent. It really should not have been set to null.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You now actually target the chest roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
