### PR TITLE
Synthflesh recipe now has silver sulfadizine in it.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -66,7 +66,7 @@
 	name = "Synthflesh"
 	id = /datum/reagent/medicine/synthflesh
 	results = list(/datum/reagent/medicine/synthflesh = 3)
-	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1, /datum/chemical_reaction/silver_sulfadiazine = 1)
+	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1, /datum/reagent/medicine/silver_sulfadiazine = 1)
 
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -65,7 +65,7 @@
 /datum/chemical_reaction/synthflesh
 	name = "Synthflesh"
 	id = /datum/reagent/medicine/synthflesh
-	results = list(/datum/reagent/medicine/synthflesh = 3)
+	results = list(/datum/reagent/medicine/synthflesh = 4)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1, /datum/reagent/medicine/silver_sulfadiazine = 1)
 
 /datum/chemical_reaction/styptic_powder

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -66,7 +66,7 @@
 	name = "Synthflesh"
 	id = /datum/reagent/medicine/synthflesh
 	results = list(/datum/reagent/medicine/synthflesh = 3)
-	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
+	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1, /datum/chemical_reaction/silver_sulfadiazine = 1)
 
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"


### PR DESCRIPTION
## About The Pull Request
Changes synthflesh recipe by adding silver sulfadizine to it in order to make synthflesh slightly harder to create.


## Why It's Good For The Game
Synthflesh is stupidly effective and has a very simple recipe, synthflesh recipe also has no chem in it that heals burn damage, only the styptic powder that heals brute damage.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Adds silver sulfadizine to synthflesh recipe.
/:cl:
