### PR TITLE
Adds melee aiming

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -41,7 +41,6 @@
 	return FALSE
 
 /obj/attackby(obj/item/I, mob/living/user, params)
-	var/turf/T = (get_turf(src))
 	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
 		for(var/mob/living/L in get_turf(src))
 			if(L.stat)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -41,6 +41,15 @@
 	return FALSE
 
 /obj/attackby(obj/item/I, mob/living/user, params)
+	var/turf/T = (get_turf(src))
+	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in T)
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attackby(I, user)
+			return FALSE
 	return ..() || ((obj_flags & CAN_BE_HIT) && I.attack_obj(src, user))
 
 /mob/living/attackby(obj/item/I, mob/living/user, params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -43,7 +43,7 @@
 /obj/attackby(obj/item/I, mob/living/user, params)
 	var/turf/T = (get_turf(src))
 	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
-		for(var/mob/living/L in T)
+		for(var/mob/living/L in get_turf(src))
 			if(L.stat)
 				continue
 			if(user == L)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -335,9 +335,8 @@
 	return
 
 /obj/attack_hand(mob/user)
-	var/turf/T = (get_turf(src))
 	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
-		for(var/mob/living/L in T)
+		for(var/mob/living/L in get_turf(src))
 			if(L.stat)
 				continue
 			if(user == L)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -334,6 +334,21 @@
 /obj/proc/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
 	return
 
+/obj/attack_hand(mob/user)
+	var/turf/T = (get_turf(src))
+	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in T)
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attack_hand(user)
+			user.changeNext_move(CLICK_CD_MELEE)
+			return
+	. = ..()
+	if(.)
+		return
+
 //For returning special data when the object is saved
 //For example, or silos will return a list of their materials which will be dumped on top of them
 //Can be customised if you have something that contains something you want saved

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -212,7 +212,14 @@
 
 	else if(istype(C, /obj/item/twohanded/rcl))
 		handleRCL(C, user)
-
+	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in src)
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attackby(C, user)
+			return FALSE
 	return FALSE
 
 /turf/CanPass(atom/movable/mover, turf/target)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -128,6 +128,15 @@
 	..()
 
 /turf/attack_hand(mob/user)
+	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in src)
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attack_hand(user)
+			user.changeNext_move(CLICK_CD_MELEE)
+			return
 	. = ..()
 	if(.)
 		return


### PR DESCRIPTION
## About The Pull Request
Adds melee aiming. meant to go with https://github.com/BeeStation/BeeStation-Hornet/pull/2430

while on Walk and Harm intent, your melee attacks will hit mobs that are outside of softcrit if they are in the targeted tile, regardless of if you click their sprite or not

## Why It's Good For The Game
speedcombat is still cancer, this accompanies my earlier goal of slowing it down a bit

## Changelog
:cl:
add: you can now hit mobs in melee easier if you are on harm intent and walking (you only need to click the tile, not the sprite itself)
/:cl:

