### PR TITLE
Changes felinid diet to be more like a cat's and less like a human's

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -4,6 +4,9 @@
 	id = "felinid"
 	limbs_id = "human"
 
+	disliked_food = VEGETABLES | SUGAR
+	liked_food = DAIRY | MEAT
+
 	mutant_bodyparts = list("ears", "tail_human")
 	default_features = list("mcolor" = "FFF", "tail_human" = "Cat", "ears" = "Cat", "wings" = "None")
 
@@ -89,7 +92,7 @@
 			NT.Insert(H, drop_if_replaced = FALSE)
 		else
 			tail.Remove(H)
-			
+
 /datum/species/human/felinid/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/M)
 	.=..()
 	if(chem.type == /datum/reagent/consumable/coco)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -142,6 +142,11 @@
 	toxpwr = 2
 	taste_description = "fish"
 
+/datum/reagent/toxin/carpotoxin/on_mob_life(mob/living/carbon/M)
+	if(iscatperson(M))
+		toxpwr = 0
+	..()
+
 /datum/reagent/toxin/zombiepowder
 	name = "Zombie Powder"
 	description = "A strong neurotoxin that puts the subject into a death-like state."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -142,8 +142,8 @@
 	toxpwr = 2
 	taste_description = "fish"
 
-/datum/reagent/toxin/carpotoxin/on_mob_life(mob/living/carbon/M)
-	if(iscatperson(M))
+/datum/reagent/toxin/carpotoxin/on_mob_metabolize(mob/living/carbon/L)
+	if(iscatperson(L))
 		toxpwr = 0
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes felinids like meat and dairy, makes them dislike vegetables and sugar, and makes them immune to carpotoxin (so they can eat fish without being slightly annoyed by a very baby sauce toxin). They're also now neutral to gross and raw foods, which lets them eat mice and raw meats.


NSV codelads port this or I uh (vague but clearly joking threat IDk im tired)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes a playable species slightly less identical to human
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Felinids are now immune to carpotoxin and can have little a fish
tweak: Felinids like meat and dairy, and dislike vegetables and sugar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
