### PR TITLE
Recharging Station Crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1541,7 +1541,7 @@
 /datum/supply_pack/science/recharging
 	name = "Recharging Station Crate"
 	desc = "If you are looking for an improvement that makes your station more suitable for silicons, this is the pack for you! Contains all the materials required to put together a recharging station. Tools not included."
-	cost = 5000
+	cost = 2500
 	access = ACCESS_ROBOTICS
 	contains = list(/obj/item/stack/sheet/iron/five,
 					/obj/item/stack/cable_coil/random/five,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1538,6 +1538,20 @@
 	crate_name = "robotics assembly crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
+/datum/supply_pack/science/recharging
+	name = "Recharging Station Crate"
+	desc = "If you are looking for an improvement that makes your station more suitable for silicons, this is the pack for you! Contains all the materials required to put together a recharging station. Tools not included."
+	cost = 5000
+	access = ACCESS_ROBOTICS
+	contains = list(/obj/item/stack/sheet/iron/five,
+					/obj/item/stack/cable_coil/random/five,
+					/obj/item/circuitboard/machine/cyborgrecharger,
+					/obj/item/stock_parts/capacitor,
+					/obj/item/stock_parts/cell,
+					/obj/item/stock_parts/manipulator)
+	crate_name = "recharging station crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+
 /datum/supply_pack/science/rped
 	name = "RPED crate"
 	desc = "Need to rebuild the ORM but science got annihialted after a bomb test? Buy this for the most advanced parts NT can give you."


### PR DESCRIPTION
## About The Pull Request

Adds a new crate purchasable from the science tab: recharging crate, containing all the mats required to put together a recharge station.

## Why It's Good For The Game

Science has a lot of money and only 6 items to spend it on. Also not many people bother setting these up. Maybe these will incentive people to place more of these around.

## Changelog
:cl:
add: Recharging station crate purchasing from cargo consoles
/:cl: