### PR TITLE
Cyborg QoL Changes

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -712,7 +712,7 @@
 	if(.)
 		var/obj/item/crowbar/cyborg/E = locate() in R.module.modules
 		if(E)
-			to_chat(user, "<span class='warning'>This is already equipted with a crowbar.</span>")
+			to_chat(user, "<span class='warning'>This is already equipted with a crowbar module.</span>")
 			return FALSE
 
 		E = new(R.module)
@@ -737,7 +737,7 @@
 	if(.)
 		var/obj/item/healthanalyzer/E = locate() in R.module.modules
 		if(E)
-			to_chat(user, "<span class='warning'>This is already equipted with a health analyzer.</span>")
+			to_chat(user, "<span class='warning'>This is already equipted with a health analyzer module.</span>")
 			return FALSE
 
 		E = new(R.module)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -704,9 +704,7 @@
 
 /obj/item/borg/upgrade/crowbar
 	name = "cyborg crowbar module"
-	desc = "A crowbar module that allows the cyborg to \
-		open powered down doors and \
-		deal with pests."
+	desc = "A crowbar module that allows the cyborg to \ open powered down doors and \ deal with pests."
 	icon_state = "cyborg_upgrade3"
 
 /obj/item/borg/upgrade/crowbar/action(mob/living/silicon/robot/R, user = usr)
@@ -731,8 +729,7 @@
 
 /obj/item/borg/upgrade/healthanalyzer
 	name = "cyborg health analyzer module"
-	desc = "Allows the cyborg to analyze / 
-	the health and well being of crewmembers."
+	desc = "Allows the cyborg to analyze / the health and well being of crewmembers."
 	icon_state = "cyborg_upgrade3"
 
 /obj/item/borg/upgrade/healthanalyzer/action(mob/living/silicon/robot/R, user = usr)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -701,3 +701,55 @@
 		var/obj/item/borg/apparatus/beaker/extra/E = locate() in R.module.modules
 		if (E)
 			R.module.remove_module(E, TRUE)
+
+/obj/item/borg/upgrade/crowbar
+	name = "cyborg crowbar module"
+	desc = "A crowbar module that allows the cyborg to \
+		open powered down doors and \
+		deal with pests."
+	icon_state = "cyborg_upgrade3"
+
+/obj/item/borg/upgrade/crowbar/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		var/obj/item/crowbar/cyborg/E = locate() in R.module.modules
+		if(E)
+			to_chat(user, "<span class='warning'>This is already equipted with a crowbar.</span>")
+			return FALSE
+
+		E = new(R.module)
+		R.module.basic_modules += E
+		R.module.add_module(E, FALSE, TRUE)
+
+/obj/item/borg/upgrade/crowbar/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		var/obj/item/crowbar/cyborg/E = locate() in R.module.modules
+		if (E)
+			R.module.remove_module(E, TRUE)
+
+
+/obj/item/borg/upgrade/healthanalyzer
+	name = "cyborg health analyzer module"
+	desc = "Allows the cyborg to analyze / 
+	the health and well being of crewmembers."
+	icon_state = "cyborg_upgrade3"
+
+/obj/item/borg/upgrade/healthanalyzer/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		var/obj/item/healthanalyzer/E = locate() in R.module.modules
+		if(E)
+			to_chat(user, "<span class='warning'>This is already equipted with a health analyzer.</span>")
+			return FALSE
+
+		E = new(R.module)
+		R.module.basic_modules += E
+		R.module.add_module(E, FALSE, TRUE)
+
+/obj/item/borg/upgrade/healthanalyzer/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		var/obj/item/healthanalyzer/E = locate() in R.module.modules
+		if (E)
+			R.module.remove_module(E, TRUE)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -376,9 +376,7 @@
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
 		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/borg/projectile_dampen,		
-		/obj/item/crowbar/cyborg,
-		/obj/item/healthanalyzer
+		/obj/item/borg/projectile_dampen
 		)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	cyborg_base_icon = "peace"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -244,7 +244,8 @@
 		/obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/soap/nanotrasen,
 		/obj/item/borg/cyborghug,
-		/obj/item/instrument/piano_synth)
+		/obj/item/instrument/piano_synth,
+		/obj/item/analyzer)
 	emag_modules = list(/obj/item/melee/transforming/energy/sword/cyborg)
 	moduleselect_icon = "standard"
 	hat_offset = -3
@@ -375,7 +376,10 @@
 		/obj/item/borg/cyborghug/peacekeeper,
 		/obj/item/extinguisher,
 		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/borg/projectile_dampen)
+		/obj/item/borg/projectile_dampen,		
+		/obj/item/crowbar/cyborg,
+		/obj/item/healthanalyzer
+		)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/peace/hacked)
 	cyborg_base_icon = "peace"
 	moduleselect_icon = "standard"
@@ -521,9 +525,11 @@
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/charger,
-		/obj/item/borg/cyborghug/peacekeeper)
+		/obj/item/borg/cyborghug/peacekeeper,	
+		/obj/item/extinguisher/mini)
 	cyborg_base_icon = "borgi"
 	moduleselect_icon = "standard"
+	emag_modules = list(/obj/item/gun/energy/laser/cyborg, /obj/item/card/emag)
 
 /obj/item/robot_module/miner
 	name = "Miner"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -731,6 +731,24 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_crowbar
+	name = "Cyborg Upgrade (Crowbar)"
+	id = "borg_upgrade_crowbar"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/crowbar
+	materials = list(/datum/material/iron = 2500)
+	construction_time = 30
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_healthanalyzer
+	name = "Cyborg Upgrade (Health Analyzer)"
+	id = "borg_upgrade_healthanalyzer"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/healthanalyzer
+	materials = list(/datum/material/iron = 2500)
+	construction_time = 30
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/boris_ai_controller
 	name = "B.O.R.I.S. AI-Cyborg Remote Control Module"
 	id = "borg_ai_control"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -345,7 +345,7 @@
 	display_name = "Cyborg Upgrades: Utility"
 	description = "Utility upgrades for cyborgs."
 	prereq_ids = list("engineering")
-	design_ids = list("borg_upgrade_holding", "borg_upgrade_lavaproof", "borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_rped", "borg_upgrade_circuitapp")
+	design_ids = list("borg_upgrade_holding", "borg_upgrade_lavaproof", "borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_rped", "borg_upgrade_circuitapp", "borg_upgrade_healthanalyzer", "borg_upgrade_crowbar")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

**add: air analyzer to standard cyborg**
Small tweak to standard cyborgs to better interact with the environment

**add: crowbar module upgrade**
Some cyborgs don't have this module, meaning they can get stuck in walls if there is no power. Only standard, janitor and engineering have crowbars. This is sad.

**add: health analyzer module upgrade**
They already see the health and diseases of crewmembers. I don't see why this shouldn't be a upgrade module.

**Borgi changes**
Emagged borgi for 20TC?

## Why It's Good For The Game

It makes some modules a bit more versatile, especially peacekeeper and security.

## Changelog
:cl:
add: air analyzer to standard cyborg
add: crowbar module upgrade for all borgs that do not have it
add: health analyzer module upgrade for all borgs that do not have it
/:cl:
