### PR TITLE
Service Borg QoL Changes

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -43,6 +43,16 @@ RSF
 	switch(mode)
 		if(5)
 			mode = 1
+			if(iscyborg(user))
+				var/mob/living/silicon/robot/R = user
+				if(!R.emagged)
+					mode = 6
+			if (mode==1)
+				to_chat(user, "Changed dispensing mode to 'Drinking Glass'")
+			else
+				to_chat(user, "Changed dispensing mode to 'Explosive Cigarette'")
+		if(6)
+			mode = 1
 			to_chat(user, "Changed dispensing mode to 'Drinking Glass'")
 		if(1)
 			mode = 2
@@ -97,6 +107,10 @@ RSF
 			to_chat(user, "Dispensing Cigarette...")
 			new /obj/item/clothing/mask/cigarette(T)
 			use_matter(10, user)
+		if(6)
+			to_chat(user, "Dispensing Explosive Cigarette...")
+			new /obj/item/clothing/mask/cigarette/plasma(T)
+			use_matter(20, user)
 
 /obj/item/rsf/proc/use_matter(charge, mob/user)
 	if (iscyborg(user))

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -326,6 +326,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/clothing/mask/cigarette/carp
 	desc = "A Carp Classic brand cigarette."
+	
+/obj/item/clothing/mask/cigarette/plasma
+	list_reagents = list(/datum/reagent/toxin/plasma = 5) 
 
 /obj/item/clothing/mask/cigarette/syndicate
 	desc = "An unknown brand cigarette."

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -946,3 +946,27 @@
 	. = ..()
 	if(istype(A, /obj/item/aiModule) && !stored) //If an admin wants a borg to upload laws, who am I to stop them? Otherwise, we can hint that it fails
 		to_chat(user, "<span class='warning'>This circuit board doesn't seem to have standard robot apparatus pin holes. You're unable to pick it up.</span>")
+		
+////////////////////
+//versatile service holder//
+////////////////////
+
+/obj/item/borg/apparatus/beaker/service
+	name = "versatile service grasper"
+	desc = "Specially designed for carrying glasses, food and seeds. Alt-Z or right-click to drop the stored object."
+	storable = list(/obj/item/reagent_containers/food,
+	/obj/item/seeds,
+	/obj/item/storage/fancy/donut_box,
+	/obj/item/storage/fancy/egg_box,
+	/obj/item/clothing/mask/cigarette,
+	/obj/item/storage/fancy/cigarettes,
+	/obj/item/reagent_containers/glass/beaker,
+	/obj/item/reagent_containers/glass/bottle,
+	/obj/item/reagent_containers/food/drinks/drinkingglass,
+	/obj/structure/mopbucket
+	)
+
+/obj/item/borg/apparatus/beaker/service/examine()
+	. = ..()
+	if(stored)
+		. += "You are currently holding [stored]."

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -962,7 +962,7 @@
 	/obj/item/storage/fancy/cigarettes,
 	/obj/item/reagent_containers/glass/beaker,
 	/obj/item/reagent_containers/glass/bottle,
-	/obj/structure/mopbucket
+	/obj/item/reagent_containers/glass/bucket
 	)
 
 /obj/item/borg/apparatus/beaker/service/examine()

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -962,7 +962,6 @@
 	/obj/item/storage/fancy/cigarettes,
 	/obj/item/reagent_containers/glass/beaker,
 	/obj/item/reagent_containers/glass/bottle,
-	/obj/item/reagent_containers/food/drinks/drinkingglass,
 	/obj/structure/mopbucket
 	)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -475,6 +475,7 @@
 		/obj/item/razor,
 		/obj/item/borg/charger,
 		/obj/item/rsf,
+		/obj/item/cookiesynth,
 		/obj/item/instrument/piano_synth,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/lighter,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -468,20 +468,16 @@
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/reagent_containers/food/drinks/drinkingglass,
-		/obj/item/reagent_containers/food/condiment/enzyme,
 		/obj/item/pen,
 		/obj/item/toy/crayon/spraycan/borg,
 		/obj/item/extinguisher/mini,
 		/obj/item/hand_labeler/borg,
 		/obj/item/borg/charger,
-		/obj/item/razor,
 		/obj/item/rsf,
 		/obj/item/instrument/piano_synth,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/lighter,
-		/obj/item/storage/bag/tray,
-		/obj/item/borg/apparatus/beaker,
-		/obj/item/cookiesynth,
+		/obj/item/borg/apparatus/beaker/service,
 		/obj/item/reagent_containers/borghypo/borgshaker)
 	emag_modules = list(/obj/item/reagent_containers/borghypo/borgshaker/hacked)
 	moduleselect_icon = "service"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -472,6 +472,7 @@
 		/obj/item/toy/crayon/spraycan/borg,
 		/obj/item/extinguisher/mini,
 		/obj/item/hand_labeler/borg,
+		/obj/item/razor,
 		/obj/item/borg/charger,
 		/obj/item/rsf,
 		/obj/item/instrument/piano_synth,

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -197,6 +197,7 @@ Borg Shaker
 			/datum/reagent/consumable/ethanol/vodka,
 			/datum/reagent/consumable/ethanol/whiskey,
 			/datum/reagent/consumable/ethanol/wine,
+			/datum/reagent/consumable/enzyme,
 			/datum/reagent/consumable/banana,
 			/datum/reagent/consumable/coffee,
 			/datum/reagent/consumable/cream,


### PR DESCRIPTION
## About The Pull Request

**Problem:** Service borg modules are clunky and not functional.
**Solution:** Quality of life changes.

**Problem:** Service borg has 3 useless modules (enzime, razor, tray) that clutter the inventory and don't serve any purpose or can be replaced by other modules.
**Solution:** Removed those modules. Now, the shaker can synthesize enzime. The beaker aparatus can carry various service items, like food items, ingredients, bottles and cigarettes.

**Problem:** Cookie synthesizer has no purpose here. It makes sense on Peacekeeper to reward good behavior, but it is no substitute for proper food.
**Solution:** Removed entirely. The beaker/grasper can dispense food instead, so this has no reason to be here. To make up for the lack of emag functionality, the borg's RSF can now dispense plasma cigs.

## Why It's Good For The Game

Like I mentioned, service has 3 useless modules that just clutter the UI. Its current modules do not allow it to do almost any of the service jobs. Very useless and boring to play. 

## Changelog
:cl:
del: Razor from service cyborg
del: Tray from service cyborg
add: service beaker aparatus replaced with a grasper aparatus, that can also carry food items, cigs, etc
del: Enzime bottle from service cyborg
add: cyborg shaker can synthesize its own enzime
del: cookie synthesizer from service cyborg
add: emagged RSF can dispense plasma cigs
/:cl:

