### PR TITLE
Service Borg Speciality Modules

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -193,7 +193,7 @@ RSF
 			mode = 1
 			if(iscyborg(user))
 				var/mob/living/silicon/robot/R = user
-				if(!R.emagged)
+				if(R.emagged)
 					mode = 6
 			if (mode==1)
 				to_chat(user, "Changed synthesizing mode to 'Meat'")

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -180,3 +180,83 @@ RSF
 	else
 		matter--
 	cooldown = world.time + cooldowndelay
+	
+/obj/item/rsf/food
+	name = "\improper Behind The Counter Synthesizer"
+	desc = "A complex synthesizer able to print basic ingredients."
+	matter = 30
+
+/obj/item/rsf/food/attack_self(mob/user)
+	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
+	switch(mode)
+		if(5)
+			mode = 1
+			if(iscyborg(user))
+				var/mob/living/silicon/robot/R = user
+				if(!R.emagged)
+					mode = 6
+			if (mode==1)
+				to_chat(user, "Changed synthesizing mode to 'Meat'")
+			else
+				to_chat(user, "Changed synthesizing mode to 'Mint'")
+		if(6)
+			mode = 1
+			to_chat(user, "Changed synthesizing mode to 'Meat'")
+		if(1)
+			mode = 2
+			to_chat(user, "Changed synthesizing mode to 'Bread Dough'")
+		if(2)
+			mode = 3
+			to_chat(user, "Changed synthesizing mode to 'Pie Dough'")
+		if(3)
+			mode = 4
+			to_chat(user, "Changed synthesizing mode to 'Rice Bowl'")
+		if(4)
+			mode = 5
+			to_chat(user, "Changed synthesizing mode to 'Tortilla'")
+	// Change mode
+
+/obj/item/rsf/food/afterattack(atom/A, mob/user, proximity)
+	. = ..()
+	if(!proximity)
+		return
+	if (!(istype(A, /obj/structure/table) || isfloorturf(A)))
+		return
+
+	if(iscyborg(user))
+		var/mob/living/silicon/robot/R = user
+		if(!R.cell || R.cell.charge < 200)
+			to_chat(user, "<span class='warning'>You do not have enough power to use [src].</span>")
+			return
+	else if (matter < 1)
+		to_chat(user, "<span class='warning'>\The [src] doesn't have enough matter left.</span>")
+		return
+
+	var/turf/T = get_turf(A)
+	playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
+	switch(mode)
+		if(1)
+			to_chat(user, "Synthesizing Meat...")
+			new list(/obj/item/reagent_containers/food/snacks/meat/slab(T)
+			use_matter(40, user)
+		if(2)
+			to_chat(user, "Synthesizing Bread Dough...")
+			new /obj/item/reagent_containers/food/snacks/dough(T)
+			use_matter(50, user)
+		if(3)
+			to_chat(user, "Synthesizing Pie Dough...")
+			new /obj/item/reagent_containers/food/snacks/piedough(T)
+			use_matter(75, user)
+		if(4)
+			to_chat(user, "Synthesizing Rice Bowl...")
+			new /obj/item/reagent_containers/food/snacks/salad/ricebowl(T)
+			use_matter(100, user)
+		if(5)
+			to_chat(user, "Synthesizing Tortilla...")
+			new /obj/item/reagent_containers/food/snacks/tortilla(T)
+			use_matter(100, user)
+		if(6)
+			to_chat(user, "Dispensing Mint...")
+			new /obj/item/reagent_containers/food/snacks/mint(T)
+			use_matter(20, user)
+

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -60,6 +60,13 @@
 	var/rigged = DICE_NOT_RIGGED
 	var/rigged_value
 
+/obj/item/storage/pill_bottle/dice_cup/cyborg
+	desc = "The house always wins..."
+/obj/item/storage/pill_bottle/dice_cup/cyborg/Initialize()
+	. = ..()
+	new /obj/item/dice/d6(src)
+	new /obj/item/dice/d6(src)
+
 /obj/item/dice/Initialize()
 	. = ..()
 	if(!result)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -226,3 +226,30 @@
 	user.visible_message("<span class='suicide'>[user] begins flattening [user.p_their()] head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return BRUTELOSS
 /* Trays  moved to /obj/item/storage/bag */
+/obj/item/kitchen/rollingpin/cyborg
+	name = "rolling pin module"
+	force = 10
+
+/obj/item/kitchen/rollingpin/cyborg/attack(mob/living/target, mob/living/carbon/human/user)
+	if (!iscyborg(user))
+		..()	
+	var/mob/living/silicon/robot/R = user	
+	if(!R.emagged)
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1, -1)
+		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
+	else
+		..()
+
+/obj/item/kitchen/knife/cyborg
+	name = "kitchen knife module"
+	force = 10
+
+/obj/item/kitchen/knife/cyborg/attack(mob/living/target, mob/living/carbon/human/user)
+	if (!iscyborg(user))
+		..()	
+	var/mob/living/silicon/robot/R = user	
+	if(!R.emagged)
+		playsound(src, 'sound/machines/buzz-sigh.ogg',  50, 1, -1)
+		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
+	else
+		..()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -234,7 +234,7 @@
 	if (!iscyborg(user))
 		..()	
 	var/mob/living/silicon/robot/R = user	
-	if(!R.emagged)
+	if(!R.emagged && target.stat != DEAD))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1, -1)
 		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
 	else
@@ -248,7 +248,7 @@
 	if (!iscyborg(user))
 		..()	
 	var/mob/living/silicon/robot/R = user	
-	if(!R.emagged)
+	if(!R.emagged && target.stat != DEAD))
 		playsound(src, 'sound/machines/buzz-sigh.ogg',  50, 1, -1)
 		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
 	else

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -234,7 +234,7 @@
 	if (!iscyborg(user))
 		..()	
 	var/mob/living/silicon/robot/R = user	
-	if(!R.emagged && target.stat != DEAD))
+	if(!R.emagged && target.stat != DEAD)
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 1, -1)
 		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
 	else
@@ -248,7 +248,7 @@
 	if (!iscyborg(user))
 		..()	
 	var/mob/living/silicon/robot/R = user	
-	if(!R.emagged && target.stat != DEAD))
+	if(!R.emagged && target.stat != DEAD)
 		playsound(src, 'sound/machines/buzz-sigh.ogg',  50, 1, -1)
 		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
 	else

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -725,12 +725,12 @@
 			qdel(SPEC)
 		
 		
-	for(var/module in src.addmodules)
-		var/item = locate(module) in R
-		if (!item)
-			item = new(R.module)
-			R.module.basic_modules += item
-			R.module.add_module(item, FALSE, TRUE)
+		for(var/module in src.addmodules)
+			var/item = locate(module) in R
+			if (!item)
+				item = new(R.module)
+				R.module.basic_modules += item
+				R.module.add_module(item, FALSE, TRUE)
 	return .
 	
 /obj/item/borg/upgrade/speciality/deactivate(mob/living/silicon/robot/R, user = usr)
@@ -740,7 +740,8 @@
 		for(var/module in src.addmodules)
 			var/item = locate(module) in R
 			if (item)
-				R.module.remove_module(item, TRUE)
+				R.module.remove_module(item, TRUE)	
+	return .
 
 /obj/item/borg/upgrade/speciality/botany
 	name = "Botany Speciality"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -706,8 +706,9 @@
 			
 /obj/item/borg/upgrade/speciality
 	name = "Speciality Module"
-	desc = "If you read this, contact admins for a complimentary antag token, and never speak of it again."
 	icon_state = "cyborg_upgrade3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/butler
 	var/addmodules = list()
 	
 /obj/item/borg/upgrade/speciality/action(mob/living/silicon/robot/R, user = usr)
@@ -732,7 +733,7 @@
 			R.module.add_module(item, FALSE, TRUE)
 	return .
 	
-/obj/item/borg/upgrade/botany/deactivate(mob/living/silicon/robot/R, user = usr)
+/obj/item/borg/upgrade/speciality/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)		
 		//Remove existing modules indiscriminately
@@ -744,9 +745,6 @@
 /obj/item/borg/upgrade/speciality/botany
 	name = "Botany Speciality"
 	desc = "A service cyborg upgrade allowing for plant tending and manipulation."
-	icon_state = "cyborg_upgrade3"
-	require_module = TRUE
-	module_type = /obj/item/robot_module/butler
 	addmodules = list (
 		/obj/item/storage/bag/plants/portaseeder,
 		/obj/item/hatchet/cyborg,
@@ -757,10 +755,7 @@
 
 /obj/item/borg/upgrade/speciality/kitchen
 	name = "Cook Speciality"
-	desc = "A service cyborg upgrade allowing for food handling and feeding organics."
-	icon_state = "cyborg_upgrade3"
-	require_module = TRUE
-	module_type = /obj/item/robot_module/butler
+	desc = "A service cyborg upgrade allowing for basic food handling."
 	addmodules = list (
 		/obj/item/kitchen/knife/cyborg,
 		/obj/item/kitchen/rollingpin/cyborg,
@@ -769,10 +764,7 @@
 
 /obj/item/borg/upgrade/speciality/casino
 	name = "Cook Speciality"
-	desc = "A service cyborg upgrade allowing for money draining and destroying lives."
-	icon_state = "cyborg_upgrade3"
-	require_module = TRUE
-	module_type = /obj/item/robot_module/butler
+	desc = "It's not crew harm if they do it themselves!"
 	addmodules = list (
 		/obj/item/roulette,
 		/obj/item/storage/pill_bottle/dice_cup/cyborg,

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -701,3 +701,80 @@
 		var/obj/item/borg/apparatus/beaker/extra/E = locate() in R.module.modules
 		if (E)
 			R.module.remove_module(E, TRUE)
+			
+			
+			
+/obj/item/borg/upgrade/speciality
+	name = "Speciality Module"
+	desc = "If you read this, contact admins for a complimentary antag token, and never speak of it again."
+	icon_state = "cyborg_upgrade3"
+	var/addmodules = list()
+	
+/obj/item/borg/upgrade/speciality/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)	
+		for(var/obj/item/borg/upgrade/speciality/SPEC in R.upgrades)
+			if (SPEC == src)	//modules already present
+				to_chat(user, "<span class='warning'>This unit is already equipped with a [src].</span>")
+				return FALSE
+				
+			//in case of different module, change entirely
+			SPEC.deactivate(R, user)
+			R.upgrades -= SPEC
+			qdel(SPEC)
+		
+		
+	for(var/module in src.addmodules)
+		var/item = locate(module) in R
+		if (!item)
+			item = new(R.module)
+			R.module.basic_modules += item
+			R.module.add_module(item, FALSE, TRUE)
+	return .
+	
+/obj/item/borg/upgrade/botany/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)		
+		//Remove existing modules indiscriminately
+		for(var/module in src.addmodules)
+			var/item = locate(module) in R
+			if (item)
+				R.module.remove_module(item, TRUE)
+
+/obj/item/borg/upgrade/speciality/botany
+	name = "Botany Speciality"
+	desc = "A service cyborg upgrade allowing for plant tending and manipulation."
+	icon_state = "cyborg_upgrade3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/butler
+	addmodules = list (
+		/obj/item/storage/bag/plants/portaseeder,
+		/obj/item/hatchet/cyborg,
+		/obj/item/cultivator,
+		/obj/item/plant_analyzer,
+		/obj/item/shovel/spade
+	)
+
+/obj/item/borg/upgrade/speciality/kitchen
+	name = "Cook Speciality"
+	desc = "A service cyborg upgrade allowing for food handling and feeding organics."
+	icon_state = "cyborg_upgrade3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/butler
+	addmodules = list (
+		/obj/item/kitchen/knife/cyborg,
+		/obj/item/kitchen/rollingpin/cyborg,
+		/obj/item/rsf/food
+	)
+
+/obj/item/borg/upgrade/speciality/casino
+	name = "Cook Speciality"
+	desc = "A service cyborg upgrade allowing for money draining and destroying lives."
+	icon_state = "cyborg_upgrade3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/butler
+	addmodules = list (
+		/obj/item/roulette,
+		/obj/item/storage/pill_bottle/dice_cup/cyborg,
+		/obj/item/toy/cards/deck/cyborg,
+	)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -100,7 +100,7 @@
 	if (!iscyborg(user))
 		..()	
 	var/mob/living/silicon/robot/R = user	
-	if(!R.emagged)
+	if(!R.emagged && target.stat != DEAD)
 		playsound(src, 'sound/machines/buzz-sigh.ogg',  50, 1, -1)
 		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
 	else

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -92,6 +92,19 @@
 	user.visible_message("<span class='suicide'>[user] is chopping at [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(src, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 	return (BRUTELOSS)
+	
+/obj/item/hatchet/cyborg
+	name = "hatchet module"
+
+/obj/item/hatchet/cyborg/attack(mob/living/target, mob/living/carbon/human/user)
+	if (!iscyborg(user))
+		..()	
+	var/mob/living/silicon/robot/R = user	
+	if(!R.emagged)
+		playsound(src, 'sound/machines/buzz-sigh.ogg',  50, 1, -1)
+		user.visible_message("<span class='notice'>Safety check failed! Action aborted.</span>")
+	else
+		..()
 
 /obj/item/scythe
 	icon_state = "scythe0"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -776,6 +776,33 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_botany
+	name = "Cyborg Speciality (Botany)"
+	id = "borg_upgrade_botany"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/speciality/botany
+	materials = list(/datum/material/iron = 3000, /datum/material/glass = 1000)
+	construction_time = 40
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_kitchen
+	name = "Cyborg Speciality (Cooking)"
+	id = "borg_upgrade_kitchen"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/speciality/kitchen
+	materials = list(/datum/material/iron = 2500)
+	construction_time = 40
+	category = list("Cyborg Upgrade Modules")
+
+/datum/design/borg_upgrade_casino
+	name = "Cyborg Speciality (Casino)"
+	id = "borg_upgrade_casino"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/speciality/casino
+	materials = list(/datum/material/iron = 2000, /datum/material/gold = 500, /datum/material/silver = 500)
+	construction_time = 40
+	category = list("Cyborg Upgrade Modules")
+
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracking Beacon"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -370,7 +370,7 @@
 /datum/techweb_node/cyborg_upg_service
 	id = "cyborg_upg_service"
 	display_name = "Cyborg Upgrades: Service"
-	description = "Service upgrades for cyborgs."
+	description = "Allows service borgs to specialize with various modules."
 	prereq_ids = list("cyborg_upg_util")
 	design_ids = list("borg_upgrade_casino", "borg_upgrade_kitchen", "borg_upgrade_botany")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -367,6 +367,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 
+/datum/techweb_node/cyborg_upg_service
+	id = "cyborg_upg_service"
+	display_name = "Cyborg Upgrades: Service"
+	description = "Service upgrades for cyborgs."
+	prereq_ids = list("cyborg_upg_util")
+	design_ids = list("borg_upgrade_casino", "borg_upgrade_kitchen", "borg_upgrade_botany")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
+	export_price = 5000
+
 /datum/techweb_node/ai
 	id = "ai"
 	display_name = "Artificial Intelligence"


### PR DESCRIPTION
##  About The Pull Request

Add 1 research node, Borg Service. Requires borg utility and costs 1500RP.
Adds 3 new modules; Kitchen Speciality, Garden Speciality and Casino Speciality.
"Specialty" modules can only be installed 1 at a time, and will uninstall the previous specialty.
Botany comes with hatchet, spade, cultivator, analyzer and portaseeder.
Kitchen comes with roller, knife and food fabricator (fabricates basic foods, like meat, buns, etc)
Casino comes with dice, playing cards and a sort of slot machine
Don't worry, non-emagged service cannot use its knives/hatchets to hurt living organisms.

## Why It's Good For The Game

Engineering cyborg can substitute engineering, when all engineers are dead.
Medical cyborg can substitute medicine, when all medix are dead.
Janitor cyborg can substitute janitors, when all janitors are tiding.
But service can barely replace a bartender. Why shouldn't service get proper upgrade to substitute a failing department?

Feels like service is just leftover code for some scrapped ideas that nobody now knows in which direction was supposed to go and what the end result was supposed to be, so it just kinda is in an unfinished state.

## Changelog
:cl:
add: new tech tree, cyborg service research
add: three new modules for service; kitchen, garden and casino. service may have only one of these "speciality" modules at a time
/:cl: