### PR TITLE
Increases emote input box size

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -422,7 +422,7 @@
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
 	else if(!params)
-		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+		var/custom_emote = copytext(sanitize(input("Choose an emote to display.") as message|null), 1, MAX_MESSAGE_LEN)
 		if(custom_emote && !check_invalid(user, custom_emote))
 			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
 			switch(type)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -24,7 +24,7 @@
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
 ///The me emote verb
-/mob/verb/me_verb(message as text)
+/mob/verb/me_verb(message as message)
 	set name = "Me"
 	set category = "IC"
 


### PR DESCRIPTION
## About The Pull Request
Simply changes the input box for emotes from a single to multi-line.

## Why It's Good For The Game
Mime buff. Easier to type out long emotes, looks visually dissimilar to Say input and helps prevent accidentally sending it before you're finished typing.

## Changelog
:cl:
tweak: Input boxes for emotes are now larger. 
/:cl:

Ports:
https://github.com/WaspStation/WaspStation-1.0/pull/198