### PR TITLE
Re:Readds the headcrab back into the golden slime pool. No zesko edition.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,6 +21,8 @@
 	ventcrawler = VENTCRAWLER_ALWAYS
 	var/datum/mind/origin
 	var/egg_lain = 0
+	gold_core_spawnable = HOSTILE_SPAWN
+
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)


### PR DESCRIPTION
About The Pull Request
Yeah that's right its back, since lings got nerfed and mrp is just lrp and rounds rarely go over 50 minutes this addition will be more than balanced,
![image](https://user-images.githubusercontent.com/57132226/93469782-56ffb380-f8c7-11ea-83fd-456066505062.png)

Last time zesko closed the pr like the tard he is, let the other maintainers voice their opinions.

Why It's Good For The Game
Slugs have always been funny creatures and now they can be spawned with the golden slime hostile injection, and since changelings have been nerfed, now is time for the comeback..

Changelog
🆑
add: HeadCrab back into the golden slime hostile pool.
/🆑