### PR TITLE
Lowers the movement speed on Sage

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -36,8 +36,8 @@ EMOJIS
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 1.5
-WALK_DELAY 3
+RUN_DELAY 2.5
+WALK_DELAY 3.5
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does the evil. It lowers the walking (slightly) and running (less slightly) speed on Sage, however not to a crawl like on Paradise.

## Why It's Good For The Game

There are several reasons. Primarily, now you actually have time to say something more or less complex to people that are passing by before they zoom out off the screen.
This is also a buff to methamphetamine, ephedrine, adrenals, and other speed sources, as well as explosions, which you cannot outrun as easily anymore.

## Changelog
:cl:
tweak: Moooovemeeeent speeeed oooon Saaaage iiiis noooow slooooweeeer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
