### PR TITLE
Dragnet Beacons

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -468,6 +468,7 @@
 	},
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -63605,7 +63605,7 @@
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/nettingportal,
+/obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -63605,7 +63605,6 @@
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -63605,6 +63605,7 @@
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -63605,6 +63605,7 @@
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -47499,7 +47499,6 @@
 	},
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/item/beacon/nettingportal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "bXH" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -47499,6 +47499,7 @@
 	},
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/beacon/nettingportal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "bXH" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -47499,7 +47499,7 @@
 	},
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/nettingportal,
+/obj/item/beacon/nettingportal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "bXH" = (

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -47499,6 +47499,7 @@
 	},
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/nettingportal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "bXH" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -38505,6 +38505,7 @@
 	pixel_y = 4
 	},
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/beacon/nettingportal,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bdM" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -38505,7 +38505,6 @@
 	pixel_y = 4
 	},
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/item/beacon/nettingportal,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bdM" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -38505,7 +38505,7 @@
 	pixel_y = 4
 	},
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/nettingportal,
+/obj/item/beacon/nettingportal,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bdM" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -38505,6 +38505,7 @@
 	pixel_y = 4
 	},
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/nettingportal,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bdM" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3744,6 +3744,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/nettingportal,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3744,7 +3744,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/nettingportal,
+/obj/item/beacon/nettingportal,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3744,7 +3744,6 @@
 /obj/item/storage/fancy/donut_box,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/item/beacon/nettingportal,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3744,6 +3744,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/beacon/nettingportal,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -63621,6 +63621,7 @@
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -63621,7 +63621,6 @@
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -63621,6 +63621,7 @@
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -63621,7 +63621,7 @@
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
-/obj/effect/nettingportal,
+/obj/item/beacon/nettingportal,
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -47,6 +47,6 @@
 /obj/item/beacon/nettingportal
 	//dragnet location beacon
 	name = "\improper DROPnet"
-	desc = "A beacon designated for DRAGnets; all captured targets will teleport to it. Also acts as a regular beacon."
+	desc = "A beacon designated for DRAGnets; all captured targets will teleport to it. Remember to activate before you deploy."
 	nettingportal = TRUE
-	enabled = FALSE	//can no longer teleport to Warden's office
+	enabled = FALSE	//can no longer teleport to Warden's office roundstart

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -8,6 +8,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	var/enabled = TRUE
 	var/renamed = FALSE
+	var/nettingportal = FALSE
 
 /obj/item/beacon/Initialize()
 	. = ..()
@@ -42,3 +43,9 @@
 		return
 	else	
 		return ..()
+		
+/obj/item/beacon/nettingportal
+	//dragnet location beacon
+	name = "\improper DRAGnet beacon"
+	desc = "A beacon designated for DRAGnets, where all captured targets will teleport. Also acts as a regular beacon."	
+	nettingportal = TRUE

--- a/code/game/objects/items/devices/beacon.dm
+++ b/code/game/objects/items/devices/beacon.dm
@@ -46,6 +46,7 @@
 		
 /obj/item/beacon/nettingportal
 	//dragnet location beacon
-	name = "\improper DRAGnet beacon"
-	desc = "A beacon designated for DRAGnets, where all captured targets will teleport. Also acts as a regular beacon."	
+	name = "\improper DROPnet"
+	desc = "A beacon designated for DRAGnets; all captured targets will teleport to it. Also acts as a regular beacon."
 	nettingportal = TRUE
+	enabled = FALSE	//can no longer teleport to Warden's office

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -542,7 +542,8 @@
 	cost = 1500
 	contains = list(/obj/item/gun/energy/e_gun/dragnet,
 					/obj/item/gun/energy/e_gun/dragnet,
-					/obj/item/gun/energy/e_gun/dragnet)
+					/obj/item/gun/energy/e_gun/dragnet,
+					/obj/item/beacon/nettingportal)
 	crate_name = "\improper DRAGnet crate"
 
 /datum/supply_pack/security/armory/energy_single

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -542,8 +542,7 @@
 	cost = 1500
 	contains = list(/obj/item/gun/energy/e_gun/dragnet,
 					/obj/item/gun/energy/e_gun/dragnet,
-					/obj/item/gun/energy/e_gun/dragnet,
-					/obj/item/beacon/nettingportal)
+					/obj/item/gun/energy/e_gun/dragnet)
 	crate_name = "\improper DRAGnet crate"
 
 /datum/supply_pack/security/armory/energy_single

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -32,12 +32,32 @@
 /obj/effect/nettingportal/Initialize()
 	. = ..()
 	var/obj/item/beacon/teletarget = null
-	for(var/obj/machinery/computer/teleporter/com in GLOB.machines)
-		if(com.target)
-			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
-				teletarget = com.target
+	
+	for(var/obj/item/beacon/bea in GLOB.teleportbeacons)
+		if(is_eligible(bea) && bea.nettingportal) //is it quick dragnet beacon?
+			teletarget = bea
+
+	// --- THINKING OF REMOVING THIS CODE ENTIRELY
+	if (teletarget==null) //revert to old timer
+		for(var/obj/machinery/computer/teleporter/com in GLOB.machines)
+			if(com.target)
+				if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
+					teletarget = com.target
+	// --- END COMMENT
 
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
+
+/obj/effect/nettingportal/proc/is_eligible(atom/movable/AM)
+	//this code has to be ported in so it is not abused
+	var/turf/T = get_turf(AM)
+	if(!T)
+		return FALSE
+	if(is_centcom_level(T.z) || is_away_level(T.z))
+		return FALSE
+	var/area/A = get_area(T)
+	if(!A || A.noteleport)
+		return FALSE
+	return TRUE
 
 /obj/effect/nettingportal/proc/pop(teletarget)
 	if(teletarget)

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -49,10 +49,12 @@
 
 /obj/effect/nettingportal/proc/is_eligible(atom/movable/AM)
 	//this code has to be ported in so it is not abused
+	
 	var/turf/T = get_turf(AM)
 	if(!T)
 		return FALSE
-	if(is_centcom_level(T.z) || is_away_level(T.z))
+		
+	if(get_turf(src).z != T.z)	//cannot teleport to another Zlevel
 		return FALSE
 	var/area/A = get_area(T)
 	if(!A || A.noteleport)

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -54,7 +54,7 @@
 	if(!T)
 		return FALSE
 		
-	if(get_turf(src).z != T.z)	//cannot teleport to another Zlevel
+	if (get_turf(src).z != T.z)	//cannot teleport to another Zlevel
 		return FALSE
 	var/area/A = get_area(T)
 	if(!A || A.noteleport)

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -37,14 +37,6 @@
 		if(is_eligible(bea) && bea.nettingportal) //is it quick dragnet beacon?
 			teletarget = bea
 
-	// --- THINKING OF REMOVING THIS CODE ENTIRELY
-	if (teletarget==null) //revert to old timer
-		for(var/obj/machinery/computer/teleporter/com in GLOB.machines)
-			if(com.target)
-				if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
-					teletarget = com.target
-	// --- END COMMENT
-
 	addtimer(CALLBACK(src, .proc/pop, teletarget), 30)
 
 /obj/effect/nettingportal/proc/is_eligible(atom/movable/AM)

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -53,8 +53,9 @@
 	var/turf/T = get_turf(AM)
 	if(!T)
 		return FALSE
-		
-	if (get_turf(src).z != T.z)	//cannot teleport to another Zlevel
+	
+	var/turf/S = get_turf(src)
+	if (S.z != T.z)	//cannot teleport to another Zlevel
 		return FALSE
 	var/area/A = get_area(T)
 	if(!A || A.noteleport)

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -13,6 +13,16 @@
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/dragnetbeacon
+	name = "DRAGnet Beacon"
+	desc = "A beacon marking the location where criminals will be teleported via DRAGnet devices."
+	id = "dragnetbeacon"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 150, /datum/material/glass = 200)
+	build_path = /obj/item/beacon/nettingportal
+	category = list("Bluespace Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/bag_holding
 	name = "Bag of Holding"
 	desc = "A backpack that opens into a localized pocket of bluespace."

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -14,7 +14,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/dragnetbeacon
-	name = "DRAGnet Beacon"
+	name = "DROPnet"
 	desc = "A beacon marking the location where criminals will be teleported via DRAGnet devices."
 	id = "dragnetbeacon"
 	build_type = PROTOLATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -198,7 +198,7 @@
 	display_name = "Basic Bluespace Theory"
 	description = "Basic studies into the mysterious alternate dimension known as bluespace."
 	prereq_ids = list("base")
-	design_ids = list("beacon", "xenobioconsole", "telesci_gps", "bluespace_crystal", "spaceship_navigation_beacon")
+	design_ids = list("beacon", "dragnetbeacon", "xenobioconsole", "telesci_gps", "bluespace_crystal", "spaceship_navigation_beacon")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request

Implements new item, dragnet beacon. These beacons act like teleporter beacons, except dragnet portals will search for them before searching for teleporter consoles. Can be printed at Secfab.

EDIT: Also spawns one deactivated beacon on all maps.

## Why It's Good For The Game

Dragnets are unreliable if someone tampers with portals. They are a nice device but quite messy and not well thought out.

## Changelog
:cl:
tweak: DRAGnets will now teleport targets at beacons designated for Dragnet portals.
add: Dragnet beacons printable at secfab.
add: Dragnet beacons in armory on every map.
/:cl: