### PR TITLE
Adds THICKMATERIAL to various armoured exosuits and helmets

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -15,6 +15,7 @@
 	flags_inv = HIDEHAIR
 	bang_protect = 1
 
+
 	dog_fashion = /datum/dog_fashion/head/helmet
 
 	var/can_flashlight = FALSE //if a flashlight can be mounted. if it has a flashlight and this is false, it is permanently attached.
@@ -49,6 +50,7 @@
 
 /obj/item/clothing/head/helmet/sec
 	can_flashlight = TRUE
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/sec/attackby(obj/item/I, mob/user, params)
 	if(issignaler(I))
@@ -74,11 +76,13 @@
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 15, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	can_flashlight = TRUE
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/old
 	name = "degrading helmet"
 	desc = "Standard issue security helmet. Due to degradation the helmet's visor obstructs the users ability to see long distances."
 	tint = 2
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/blueshirt
 	name = "blue helmet"
@@ -104,6 +108,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/attack_self(mob/user)
 	if(can_toggle && !user.incapacitated())
@@ -158,6 +163,7 @@
 	clothing_flags = STOPSPRESSUREDAMAGE | SNUG_FIT
 	strip_delay = 80
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/police
 	name = "police officer's hat"
@@ -184,6 +190,7 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	strip_delay = 80
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/roman
 	name = "\improper Roman helmet"
@@ -229,6 +236,7 @@
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 20,"energy" = 30, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
 	// Offer about the same protection as a hardhat.
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/bluetaghelm
 	name = "blue laser tag helmet"
@@ -239,6 +247,7 @@
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 20,"energy" = 30, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
 	// Offer about the same protection as a hardhat.
 	dog_fashion = null
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/knight
 	name = "medieval helmet"
@@ -251,6 +260,7 @@
 	strip_delay = 80
 	dog_fashion = null
 	bang_protect = 1
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/knight/blue
 	icon_state = "knight_blue"
@@ -273,6 +283,7 @@
 	icon_state = "skull"
 	item_state = "skull"
 	strip_delay = 100
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/durathread
 	name = "durathread helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -14,7 +14,7 @@
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
 	bang_protect = 1
-
+	clothing_flags = THICKMATERIAL
 
 	dog_fashion = /datum/dog_fashion/head/helmet
 
@@ -50,7 +50,6 @@
 
 /obj/item/clothing/head/helmet/sec
 	can_flashlight = TRUE
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/sec/attackby(obj/item/I, mob/user, params)
 	if(issignaler(I))
@@ -76,13 +75,11 @@
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 15, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	can_flashlight = TRUE
 	dog_fashion = null
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/old
 	name = "degrading helmet"
 	desc = "Standard issue security helmet. Due to degradation the helmet's visor obstructs the users ability to see long distances."
 	tint = 2
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/blueshirt
 	name = "blue helmet"
@@ -108,7 +105,6 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	dog_fashion = null
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/attack_self(mob/user)
 	if(can_toggle && !user.incapacitated())
@@ -163,7 +159,6 @@
 	clothing_flags = STOPSPRESSUREDAMAGE | SNUG_FIT
 	strip_delay = 80
 	dog_fashion = null
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/police
 	name = "police officer's hat"
@@ -190,7 +185,6 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	strip_delay = 80
 	dog_fashion = null
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/roman
 	name = "\improper Roman helmet"
@@ -236,7 +230,6 @@
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 20,"energy" = 30, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
 	// Offer about the same protection as a hardhat.
 	dog_fashion = null
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/bluetaghelm
 	name = "blue laser tag helmet"
@@ -247,7 +240,6 @@
 	armor = list("melee" = 15, "bullet" = 10, "laser" = 20,"energy" = 30, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
 	// Offer about the same protection as a hardhat.
 	dog_fashion = null
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/knight
 	name = "medieval helmet"
@@ -260,7 +252,6 @@
 	strip_delay = 80
 	dog_fashion = null
 	bang_protect = 1
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/knight/blue
 	icon_state = "knight_blue"
@@ -283,7 +274,6 @@
 	icon_state = "skull"
 	item_state = "skull"
 	strip_delay = 100
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/head/helmet/durathread
 	name = "durathread helmet"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -23,6 +23,7 @@
 	item_state = "armoralt"
 	blood_overlay_type = "armor"
 	dog_fashion = /datum/dog_fashion/back
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/vest/alt
 	desc = "An alternate style Type I-B armored vest that provides decent protection against most types of damage. They perform identically in the field."
@@ -53,6 +54,7 @@
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	strip_delay = 80
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/hos/trenchcoat
 	name = "armored trenchoat"
@@ -123,6 +125,7 @@
 	strip_delay = 80
 	equip_delay_other = 60
 	slowdown = 0.05
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"
@@ -132,6 +135,7 @@
 	blood_overlay_type = "armor"
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 25, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "bulletproof armor"
@@ -142,6 +146,7 @@
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	strip_delay = 70
 	equip_delay_other = 50
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "reflector vest"
@@ -152,6 +157,7 @@
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 60, "energy" = 80, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/hit_reflect_chance = 40
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/laserproof/IsReflect(def_zone)
 	if(!(def_zone in list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN))) //If not shot where ablative is covering you, you don't get the reflection bonus!

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -10,6 +10,7 @@
 	max_integrity = 250
 	resistance_flags = NONE
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/Initialize()
 	. = ..()
@@ -23,7 +24,6 @@
 	item_state = "armoralt"
 	blood_overlay_type = "armor"
 	dog_fashion = /datum/dog_fashion/back
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/vest/alt
 	desc = "An alternate style Type I-B armored vest that provides decent protection against most types of damage. They perform identically in the field."
@@ -54,7 +54,6 @@
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	strip_delay = 80
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/hos/trenchcoat
 	name = "armored trenchoat"
@@ -125,7 +124,6 @@
 	strip_delay = 80
 	equip_delay_other = 60
 	slowdown = 0.05
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"
@@ -135,7 +133,6 @@
 	blood_overlay_type = "armor"
 	armor = list("melee" = 35, "bullet" = 25, "laser" = 25, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "bulletproof armor"
@@ -146,7 +143,6 @@
 	armor = list("melee" = 15, "bullet" = 60, "laser" = 10, "energy" = 10, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	strip_delay = 70
 	equip_delay_other = 50
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "reflector vest"
@@ -157,7 +153,6 @@
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 60, "energy" = 80, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/hit_reflect_chance = 40
-	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/armor/laserproof/IsReflect(def_zone)
 	if(!(def_zone in list(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_GROIN))) //If not shot where ablative is covering you, you don't get the reflection bonus!
@@ -186,7 +181,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	allowed = list(/obj/item/gun/energy, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
-	clothing_flags = THICKMATERIAL
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
@@ -201,7 +195,6 @@
 	item_state = "swat_suit"
 	w_class = WEIGHT_CLASS_BULKY
 	gas_transfer_coefficient = 0.9
-	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 3
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
@@ -210,7 +203,6 @@
 /obj/item/clothing/suit/armor/tdome
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	clothing_flags = THICKMATERIAL
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	armor = list("melee" = 80, "bullet" = 80, "laser" = 50, "energy" = 60, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 90)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All current armoured exosuits as well as many helmets are now immune to syringes, parapens and hypos. Use Piercing Syringes or aim at a non-armoured regions when going after an armoured target. 

## Why It's Good For The Game
Feels inconsistent that armour and helmets can block bullets and stab wounds but not a tiny syringe. Chemical warfare currently has few counters, this adds another for one of the more popular tactics. 

## Changelog
:cl:
add: Most armoured suits and helmets' thick reinforced materials now prevent syringes, parapens and hypos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
