### PR TITLE
Adds enhanced chameleon bowman, glasses and gloves to traitor uplink

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -353,6 +353,13 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/clothing/glasses/chameleon/flashproof
+	name = "welding goggles"
+	desc = "Protects the eyes from welders; approved by the mad scientist association."
+	icon_state = "welding-g"
+	item_state = "welding-g"
+	flash_protect = 2
+
 /obj/item/clothing/gloves/chameleon
 	desc = "These gloves will protect the wearer from electric shock."
 	name = "insulated gloves"
@@ -381,6 +388,20 @@
 /obj/item/clothing/gloves/chameleon/broken/Initialize()
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/clothing/gloves/chameleon/combat
+	name = "combat gloves"
+	desc = "These tactical gloves are fireproof and shock resistant."
+	icon_state = "cgloves"
+	item_state = "combatgloves"
+	siemens_coefficient = 0
+	permeability_coefficient = 0.05
+	strip_delay = 80
+	cold_protection = HANDS
+	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
+	heat_protection = HANDS
+	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 /obj/item/clothing/head/chameleon
 	name = "grey cap"
@@ -610,6 +631,12 @@
 /obj/item/radio/headset/chameleon/broken/Initialize()
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/radio/headset/chameleon/bowman
+	name = "bowman headset"
+	icon_state = "syndie_headset"
+	item_state = "syndie_headset"
+	bang_protect = 1
 
 /obj/item/pda/chameleon
 	name = "PDA"

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -446,7 +446,6 @@
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	flash_protect = 2
 	bang_protect = 1
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -358,7 +358,7 @@
 	desc = "Protects the eyes from welders; approved by the mad scientist association."
 	icon_state = "welding-g"
 	item_state = "welding-g"
-	flash_protect = 2
+	flash_protect = 3
 
 /obj/item/clothing/gloves/chameleon
 	desc = "These gloves will protect the wearer from electric shock."
@@ -636,7 +636,7 @@
 	name = "bowman headset"
 	icon_state = "syndie_headset"
 	item_state = "syndie_headset"
-	bang_protect = 1
+	bang_protect = 3
 
 /obj/item/pda/chameleon
 	name = "PDA"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1354,19 +1354,19 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	name = "Chameleon Bangproof Headset"
 	desc = "A headset reinforced to protect the ears from flashbangs, enhanced with chameleon disguise technology."
 	item = /obj/item/radio/headset/chameleon/bowman
-	cost = 3
+	cost = 2
 
 /datum/uplink_item/stealthy_tools/chamweldinggoggles
 	name = "Chameleon Flashproof Glasses"
 	desc = "A pair of glasses reinforced to protect the eyes from welding flashes, enhanced with chameleon disguise technology."
 	item = /obj/item/clothing/glasses/chameleon/flashproof
-	cost = 3
+	cost = 2
 
 /datum/uplink_item/stealthy_tools/chaminsuls
 	name = "Chameleon Combat Gloves"
 	desc = "A pair of gloves reinforced with fire and shock resistance, enhanced with chameleon disguise technology."
 	item = /obj/item/clothing/gloves/chameleon/combat
-	cost = 3
+	cost = 1
 
 /datum/uplink_item/stealthy_tools/jammer
 	name = "Radio Jammer"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1350,6 +1350,24 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	exclude_modes = list()
 	include_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_tools/chambowman
+	name = "Chameleon Bangproof Headset"
+	desc = "A headset reinforced to protect the ears from flashbangs, enhanced with chameleon disguise technology."
+	item = /obj/item/radio/headset/chameleon/bowman
+	cost = 3
+
+/datum/uplink_item/stealthy_tools/chamweldinggoggles
+	name = "Chameleon Flashproof Glasses"
+	desc = "A pair of glasses reinforced to protect the eyes from welding flashes, enhanced with chameleon disguise technology."
+	item = /obj/item/clothing/glasses/chameleon/flashproof
+	cost = 3
+
+/datum/uplink_item/stealthy_tools/chaminsuls
+	name = "Chameleon Combat Gloves"
+	desc = "A pair of gloves reinforced with fire and shock resistance, enhanced with chameleon disguise technology."
+	item = /obj/item/clothing/gloves/chameleon/combat
+	cost = 3
+
 /datum/uplink_item/stealthy_tools/jammer
 	name = "Radio Jammer"
 	desc = "This device will disrupt any nearby outgoing radio communication when activated. Does not affect binary chat."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For 2 TC each you can now buy a Chameleon Bangproof Headset (flashbang proof) or Chameleon Flashproof Glasses (welding flashes proof), and for 1 TC you can get Chameleon Combat Gloves (fire and shock resistant). 

## Why It's Good For The Game
High utility items for various traitor activities, very useful if you're unable or unwilling to procure the non-chameleon versions of these items especially. 

## Changelog
:cl:
add: Adds 3 new chameleon items to the traitor uplink: Chameleon Bangproof Headset, Chameleon Flashproof Glasses and Chameleon Combat Gloves. 
tweak: Chameleon plasmaman envirohelmet is no longer permanently flashproof.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
