### PR TITLE
Makes mining airlocks more convenient..

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -610,9 +610,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/advanced_airlock_controller/lavaland{
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -764,17 +761,9 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "bX" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
-	name = "Mining External Airlock";
-	opacity = 0;
-	req_access_txt = "54"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Station"
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
@@ -817,16 +806,16 @@
 /area/mine/laborcamp/security)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	desc = "Powered by the tears and sweat of laborers.";
-	name = "Prison Ofitser"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/mob/living/simple_animal/bot/secbot/beepsky{
+	desc = "Powered by the tears and sweat of laborers.";
+	name = "Prison Ofitser"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -4602,18 +4591,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"WD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
-	name = "Mining External Airlock";
-	opacity = 0;
-	req_access_txt = "54"
-	},
-/turf/open/floor/plasteel,
-/area/mine/eva)
 "WE" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -19796,7 +19773,7 @@ ab
 bq
 bC
 gb
-vk
+bP
 xA
 cH
 cO
@@ -21600,7 +21577,7 @@ bf
 ad
 bq
 dc
-bP
+vk
 dM
 dW
 dW
@@ -21851,7 +21828,7 @@ bf
 bf
 bf
 bg
-bX
+bS
 WY
 bf
 ai
@@ -22622,7 +22599,7 @@ aj
 ab
 bf
 bg
-WD
+bX
 bg
 bf
 ai


### PR DESCRIPTION
This replaces the mining station's outer airlocks with regular ones, and adds a tiny fan to the outer one. This removes the long wait times without endangering the mining station.
It also moves frank to the unused smelting room, so he annoys miners less.

This is my first PR. This is my FOURTH attempt at adding it correctly. The methods used for this have utterly skullfucked me. Go easy on me if shit is wrong in any way.

<img width="337" alt="e" src="https://user-images.githubusercontent.com/64592313/93668024-36cc2200-fa8a-11ea-9811-8467f26a6c82.png">

## Changelog
:cl:
fix: Makes mining station's outer airlocks not vent out the entire station if you go through them too fast
/:cl:

