### PR TITLE
Gulag Teleporter Fucky Wucky

### DIFF
--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -115,7 +115,7 @@
 			if(!teleporter || !beacon)
 				return
 			teleporter.locked = TRUE	//autolocks
-			addtimer(CALLBACK(src, .proc/teleport, usr), 5)
+			addtimer(CALLBACK(src, .proc/teleport, usr), 5)	//this timer is the whole reason this issue exists, but it could be to prevent another issue so I won't remove it
 			return TRUE
 
 /obj/machinery/computer/prisoner/gulag_teleporter_computer/proc/scan_machinery()

--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -114,6 +114,7 @@
 		if("teleport")
 			if(!teleporter || !beacon)
 				return
+			teleporter.locked = TRUE	//autolocks
 			addtimer(CALLBACK(src, .proc/teleport, usr), 5)
 			return TRUE
 
@@ -142,7 +143,7 @@
 		contained_id.goal = default_goal
 		say("[contained_id]'s ID card goal defaulting to [contained_id.goal] points.")
 	log_game("[key_name(user)] teleported [key_name(prisoner)] to the Labor Camp [COORD(beacon)] for [id_goal_not_set ? "default goal of ":""][contained_id.goal] points.")
-	teleporter.handle_prisoner(contained_id, temporary_record)
+	teleporter.handle_prisoner(contained_id, temporary_record,prisoner)	//check if the prisoner we send is the same one 
 	playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
 	prisoner.forceMove(get_turf(beacon))
 	prisoner.Paralyze(40) // small travel dizziness

--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -143,7 +143,7 @@
 		contained_id.goal = default_goal
 		say("[contained_id]'s ID card goal defaulting to [contained_id.goal] points.")
 	log_game("[key_name(user)] teleported [key_name(prisoner)] to the Labor Camp [COORD(beacon)] for [id_goal_not_set ? "default goal of ":""][contained_id.goal] points.")
-	if (teleporter.handle_prisoner(contained_id, temporary_record))	//check if the prisoner we send is the same one 
+	if (teleporter.handle_prisoner(contained_id, temporary_record))	//check if the prisoner we send is really inside 
 		playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
 		prisoner.forceMove(get_turf(beacon))
 		prisoner.Paralyze(40) // small travel dizziness

--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -143,15 +143,15 @@
 		contained_id.goal = default_goal
 		say("[contained_id]'s ID card goal defaulting to [contained_id.goal] points.")
 	log_game("[key_name(user)] teleported [key_name(prisoner)] to the Labor Camp [COORD(beacon)] for [id_goal_not_set ? "default goal of ":""][contained_id.goal] points.")
-	teleporter.handle_prisoner(contained_id, temporary_record,prisoner)	//check if the prisoner we send is the same one 
-	playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
-	prisoner.forceMove(get_turf(beacon))
-	prisoner.Paralyze(40) // small travel dizziness
-	to_chat(prisoner, "<span class='warning'>The teleportation makes you a little dizzy.</span>")
-	new /obj/effect/particle_effect/sparks(get_turf(prisoner))
-	playsound(src, "sparks", 50, TRUE)
-	if(teleporter.locked)
-		teleporter.locked = FALSE
-	teleporter.toggle_open()
-	contained_id = null
-	temporary_record = null
+	if (teleporter.handle_prisoner(contained_id, temporary_record))	//check if the prisoner we send is the same one 
+		playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
+		prisoner.forceMove(get_turf(beacon))
+		prisoner.Paralyze(40) // small travel dizziness
+		to_chat(prisoner, "<span class='warning'>The teleportation makes you a little dizzy.</span>")
+		new /obj/effect/particle_effect/sparks(get_turf(prisoner))
+		playsound(src, "sparks", 50, TRUE)
+		if(teleporter.locked)
+			teleporter.locked = FALSE
+		teleporter.toggle_open()
+		contained_id = null
+		temporary_record = null

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -150,7 +150,7 @@ The console is located at computer/gulag_teleporter.dm
 
 /obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R)
 	if (!occupant || !ishuman(occupant))
-		return TRUE
+		return FALSE
 	var/mob/living/carbon/human/prisoner = occupant
 	strip_occupant()
 	if(!isplasmaman(prisoner) && jumpsuit_type)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -149,8 +149,11 @@ The console is located at computer/gulag_teleporter.dm
 					W.forceMove(src)
 
 /obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R)
-	if(!ishuman(occupant))
+	if (!occupant)
 		return FALSE
+	else if (!ishuman(occupant))
+		return TRUE
+	var/mob/living/carbon/human/prisoner = occupant
 	strip_occupant()
 	if(!isplasmaman(prisoner) && jumpsuit_type)
 		prisoner.equip_to_appropriate_slot(new jumpsuit_type)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -149,9 +149,7 @@ The console is located at computer/gulag_teleporter.dm
 					W.forceMove(src)
 
 /obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R)
-	if (!occupant)
-		return FALSE
-	else if (!ishuman(occupant))
+	if (!occupant || !ishuman(occupant))
 		return TRUE
 	var/mob/living/carbon/human/prisoner = occupant
 	strip_occupant()

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -148,11 +148,15 @@ The console is located at computer/gulag_teleporter.dm
 				else
 					W.forceMove(src)
 
-/obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R)
-	if(!ishuman(occupant))
+/obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R, /mob/living/doublecheck)
+	if (occupant && occupant!=doublecheck)
+		return	//dont send out someone else	
+	var/mob/living/carbon/human/prisoner = occupant
+	if (!occupant)
+		prisoner = doublecheck	//fallback rely on the mob data sent by the console
+	if(prisoner && !ishuman(prisoner))
 		return
 	strip_occupant()
-	var/mob/living/carbon/human/prisoner = occupant
 	if(!isplasmaman(prisoner) && jumpsuit_type)
 		prisoner.equip_to_appropriate_slot(new jumpsuit_type)
 	if(shoes_type)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -148,7 +148,7 @@ The console is located at computer/gulag_teleporter.dm
 				else
 					W.forceMove(src)
 
-/obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R, /mob/living/doublecheck)
+/obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R, mob/living/doublecheck)
 	var/mob/living/carbon/human/prisoner = occupant
 	if (!occupant)
 		prisoner = doublecheck	//fallback rely on the mob data sent by the console

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -148,14 +148,9 @@ The console is located at computer/gulag_teleporter.dm
 				else
 					W.forceMove(src)
 
-/obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R, mob/living/doublecheck)
-	var/mob/living/carbon/human/prisoner = occupant
-	if (!occupant)
-		prisoner = doublecheck	//fallback rely on the mob data sent by the console
-	else if (occupant!=doublecheck)
-		return	//dont send out someone else	
-	if(prisoner && !ishuman(prisoner))
-		return
+/obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R)
+	if(!ishuman(occupant))
+		return FALSE
 	strip_occupant()
 	if(!isplasmaman(prisoner) && jumpsuit_type)
 		prisoner.equip_to_appropriate_slot(new jumpsuit_type)
@@ -165,6 +160,7 @@ The console is located at computer/gulag_teleporter.dm
 		prisoner.equip_to_appropriate_slot(id)
 	if(R)
 		R.fields["criminal"] = "Incarcerated"
+	return TRUE
 
 /obj/item/circuitboard/machine/gulag_teleporter
 	name = "labor camp teleporter (Machine Board)"

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -149,11 +149,11 @@ The console is located at computer/gulag_teleporter.dm
 					W.forceMove(src)
 
 /obj/machinery/gulag_teleporter/proc/handle_prisoner(obj/item/id, datum/data/record/R, /mob/living/doublecheck)
-	if (occupant && occupant!=doublecheck)
-		return	//dont send out someone else	
 	var/mob/living/carbon/human/prisoner = occupant
 	if (!occupant)
 		prisoner = doublecheck	//fallback rely on the mob data sent by the console
+	else if (occupant!=doublecheck)
+		return	//dont send out someone else	
 	if(prisoner && !ishuman(prisoner))
 		return
 	strip_occupant()


### PR DESCRIPTION
## About The Pull Request

There's a timer of 5ticks between the instant you press teleport and the instant a prisoner gets teleported. In that second, people can get out of the teleporter. They still get sent to gulag, but the teleporter doesn't process them and doesnt give them proper gear.

## Why It's Good For The Game

Bugfix.

## Changelog
:cl:
fix: people no longer get teleporter out of gulag teleporter without proper gear
/:cl: