### PR TITLE
(Synthflesh factory nerf) Mutagen can't be used to mass produce blood

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -358,6 +358,7 @@
 /datum/chemical_reaction/mix_virus/rem_virus
 	name = "Devolve Virus"
 	id = "remvirus"
+	results = null
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
@@ -373,6 +374,7 @@
 /datum/chemical_reaction/mix_virus/neuter_virus
 	name = "Neuter Virus"
 	id = "neutervirus"
+	results = null
 	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
@@ -388,6 +390,7 @@
 /datum/chemical_reaction/mix_virus/preserve_virus
 	name = "Preserve Virus"
 	id = "preservevirus"
+	results = null
 	required_reagents = list(/datum/reagent/cryostylane = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
@@ -403,6 +406,7 @@
 /datum/chemical_reaction/mix_virus/falter_virus
 	name = "Falter Virus"
 	id = "faltervirus"
+	results = null
 	required_reagents = list(/datum/reagent/medicine/spaceacillin = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -48,7 +48,7 @@
 	id = "Fake CBZ"
 	results = list(/datum/reagent/fake_cbz = 1)
 	required_reagents = list(/datum/reagent/concentrated_bz = 1, /datum/reagent/medicine/neurine = 3)
-	
+
 /datum/chemical_reaction/cryptobiolin
 	name = "Cryptobiolin"
 	id = /datum/reagent/cryptobiolin
@@ -262,10 +262,10 @@
 		if(D)
 			D.Evolve(level_min, level_max)
 
-
 /datum/chemical_reaction/mix_virus/mix_virus_2
 	name = "Mix Virus 2"
 	id = "mixvirus2"
+	results = null
 	required_reagents = list(/datum/reagent/toxin/mutagen = 1)
 	level_min = 2
 	level_max = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The mutagen + blood reaction no longer turns that mutagen into additional blood.

I'd also recommend that following this PR that the recent silver sulfadizine addition is removed, since it doesn't have much effect on Synthflesh's difficulty to create.

## Why It's Good For The Game
Synthflesh factories can replace all of Medbay's healing and revival needs with just 5-10 minutes of setup. This makes it so that Synthflesh is not so easy to mass produce, and at the very least Medbay staff need to manually add blood from monkeys, mindless clones or themselves in order to fuel the factory. 

Synthflesh requiring some manual work to be produced then forces it to be regularly evaluated by doctors whether they should produce some more or at that moment just use tend wounds for healing and revival. 

## Changelog
:cl:
del: Mutagen can't be used to mass produce blood. Additionally neither can synaptazine, spaceacillin, formaldehyde and cryostylane.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
