### PR TITLE
Adds job titles to radio messages

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -70,7 +70,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return ""
 
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
-	return ""
+	var/speakerJob = speaker.GetJob()
+	return "[ speakerJob ? " (" +  speakerJob + ")" : ""]"
 
 /atom/movable/proc/say_mod(input, message_mode)
 	var/ending = copytext_char(input, -1)

--- a/code/modules/mob/say_readme.md
+++ b/code/modules/mob/say_readme.md
@@ -96,7 +96,7 @@ global procs
 		Composes the href tags used by the AI for tracking. Returns "" for all mobs except AIs.
 
 	compose_job(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-		Composes the job and the end tag for tracking hrefs. Returns "" for all mobs except AIs.
+		Composes the job and the end tag for tracking hrefs. Returns the job title string.
 
 	hivecheck()
 		Returns 1 if the mob can hear and talk in the alien hivemind.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Radio messages now show the speaker's job after their name, based on the crew manifest job (and updated if it's changed of course). 

Example:
> [Common] John Doe (Assistant) says, "Test."

## Why It's Good For The Game
Allows you to see the jobs of who you're talking to over radio, which is helpful when seeing people asking for help or telling you about stuff they're working on etc. 

## Changelog
:cl:
add: Radio messages now show the speaker's job after their name
/:cl:

Ports:
https://github.com/WaspStation/WaspStation-1.0/pull/30
