### PR TITLE
New Item: Translator (grants Galactic Common and Uncommon)

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -335,3 +335,57 @@
 			message = replacetextEx(message,regex(capitalize(key),"g"), "[capitalize(value)]")
 			message = replacetextEx(message,regex(key,"g"), "[value]")
 	speech_args[SPEECH_MESSAGE] = trim(message)
+	
+/obj/item/clothing/mask/translator
+	name = "galactic translator"
+	desc = "Allows you to speak and understand galactic common and uncommon."
+	icon_state = "tonguerobot"
+	item_state = "sechailer"
+	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
+	flags_inv = HIDEFACIALHAIR|HIDEFACE
+	w_class = WEIGHT_CLASS_SMALL
+	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
+	visor_flags_inv = HIDEFACE
+	flags_cover = MASKCOVERSMOUTH
+	visor_flags_cover = MASKCOVERSMOUTH
+	var/list/languages = list(/datum/language/common, /datum/language/uncommon)
+
+/obj/item/clothing/mask/translator/equipped(mob/user, slot)
+	if(!ishuman(user))
+		return
+	if(slot == SLOT_HEAD)
+	for(/datum/language/l in languages)
+		user.grant_language(l, TRUE, TRUE, LANGUAGE_HAT)
+		user.grant_language(/datum/language/uncommon/, TRUE, TRUE, LANGUAGE_HAT)
+	
+/obj/item/clothing/mask/translator/dropped(mob/user)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(H.get_item_by_slot(SLOT_HEAD) == src)
+		for(/datum/language/l in languages)
+			user.remove_language(l, TRUE, TRUE, LANGUAGE_HAT)
+	
+/obj/item/clothing/mask/translator/universal
+	name = "universal translator"
+	desc = "Allows you to speak and understand all known languages."
+	languages = list(
+		/datum/language/aphasia,
+		/datum/language/apidite,
+		/datum/language/beachbum,
+		/datum/language/buzzwords,
+		/datum/language/calcic,
+		/datum/language/codespeak,
+		/datum/language/common,
+		/datum/language/draconic,
+		/datum/language/moffic,
+		/datum/language/monkey,
+		/datum/language/narsie,
+		//datum/language/piratespeak,	Don't want funny interactions with pirate hat
+		/datum/language/ratvar,
+		/datum/language/rlyehian,
+		/datum/language/shadowtongue,
+		/datum/language/slime,
+		/datum/language/sylvan,
+		/datum/language/terrum,
+		/datum/language/uncommon)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -341,11 +341,9 @@
 	desc = "Allows you to speak and understand galactic common and uncommon."
 	icon_state = "tonguerobot"
 	item_state = "sechailer"
-	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
+	//clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	flags_inv = HIDEFACIALHAIR|HIDEFACE
 	w_class = WEIGHT_CLASS_SMALL
-	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
-	visor_flags_inv = HIDEFACE
 	flags_cover = MASKCOVERSMOUTH
 	visor_flags_cover = MASKCOVERSMOUTH
 	var/list/languages = list(/datum/language/common, /datum/language/uncommon)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -352,7 +352,7 @@
 	if(!ishuman(user))
 		return
 	if(slot == SLOT_HEAD)
-	for(/datum/language/l in languages)
+	for(var/datum/language/l in languages)
 		user.grant_language(l, TRUE, TRUE, LANGUAGE_HAT)
 		user.grant_language(/datum/language/uncommon/, TRUE, TRUE, LANGUAGE_HAT)
 	

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -361,7 +361,7 @@
 		return
 	var/mob/living/carbon/human/H = user
 	if(H.get_item_by_slot(SLOT_HEAD) == src)
-		for(/datum/language/l in languages)
+		for(var/datum/language/l in languages)
 			user.remove_language(l, TRUE, TRUE, LANGUAGE_HAT)
 	
 /obj/item/clothing/mask/translator/universal

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -48,7 +48,7 @@
 	uniform = /obj/item/clothing/under/rank/civilian/head_of_personnel
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	head = /obj/item/clothing/head/hopcap
-	backpack_contents = list(/obj/item/storage/box/ids=1,\
+	backpack_contents = list(/obj/item/storage/box/ids=1, /obj/item/clothing/mask/translator=1,\
 		/obj/item/melee/classic_baton/police/telescopic=1, /obj/item/modular_computer/tablet/preset/advanced = 1)
 
 	chameleon_extras = list(/obj/item/gun/energy/e_gun, /obj/item/stamp/hop)

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -11,6 +11,7 @@
 					/obj/item/cartridge/security = 10,
 					/obj/item/cartridge/janitor = 10,
 					/obj/item/cartridge/signal/toxins = 10,
+					/obj/item/clothing/mask/translator = 3,
 					/obj/item/pda/heads = 10,
 					/obj/item/cartridge/captain = 3,
 					/obj/item/cartridge/quartermaster = 10)

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -10,6 +10,7 @@
 					/obj/item/restraints/handcuffs/cable/zipties = 10,
 					/obj/item/grenade/flashbang = 4,
 					/obj/item/assembly/flash/handheld = 5,
+					/obj/item/clothing/mask/translator = 3,
 					/obj/item/reagent_containers/food/snacks/donut = 12,
 					/obj/item/storage/box/evidence = 6,
 					/obj/item/flashlight/seclite = 4,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -230,7 +230,9 @@
 					/obj/item/clothing/glasses/regular/jamjar = 1,
 					/obj/item/storage/bag/books = 1,
 					/obj/item/clothing/under/plasmaman/curator = 1,
-					/obj/item/clothing/head/helmet/space/plasmaman/replacement/curator = 1)
+					/obj/item/clothing/head/helmet/space/plasmaman/replacement/curator = 1,
+					/obj/item/clothing/mask/translator = 3)
+	premium = list(/obj/item/clothing/mask/translator/universal = 1)	//a little treat for powergaming Curators
 	refill_canister = /obj/item/vending_refill/wardrobe/curator_wardrobe
 	payment_department = ACCOUNT_CIV
 /obj/item/vending_refill/wardrobe/curator_wardrobe


### PR DESCRIPTION
## The Pull Request

New mask item: translator. Grants you common/uncommon languages. New item, universal translator, grants you all languages, only avaialbe in hacked curadrobe. Common translators are available in some machines, including curator, cartridge and sec vendings. HoP roundstart item.

## Why It's Good For The Game

Foreigner trait is never used because it's a neutral 0 point trait that puts you at a disadvantage not being able to correct that. Translators somehow fix that. They are not freely available in limitless supply, so they won't be overused. They also can't be used as internals or whatever, so they will need to be replaced when inevitably, Monstermos will sweep the station.

Also, it's 25xx. We have this kind of tech in 2020 but it was somehow forgotten 500 years later?

## Changelog
:cl:
add: translators, available in key vending machines
/:cl: