### PR TITLE
Fixes fusion by fixing stim_ball reaction

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -510,7 +510,7 @@
 	air.adjust_moles(/datum/gas/nitrogen, 8*stim_used)
 	air.adjust_moles(/datum/gas/pluoxium, -pluox_used)
 	air.adjust_moles(/datum/gas/stimulum, -stim_used)
-	air.adjust_moles(/datum/gas/plasma, air.get_moles(/datum/gas/plasma)/2)
+	air.adjust_moles(/datum/gas/plasma, -air.get_moles(/datum/gas/plasma)/2)
 	if(energy_released)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![Screenshot 2020-09-25 131446](https://user-images.githubusercontent.com/8010007/94227789-55249880-ff36-11ea-80b4-89fd5043f7a0.png)

The short answer: This PR fixes stim_ball reaction in order to prevent fusion from suddenly dying to room temp or annihilating spacetime.

ref: #1833 tgstation/tgstation#43362

The long answer: ~~I am too tired to write it. However, if you request it, I will try to write one.~~
A madlad actaully requested it, and I am not exhausted right now, so here it comes!

### The Long Answer

#### Prelude: Fusion is Broken

Fusion has always been a subject of some sort of mystery, as if it was a high arcane maigc only a few seasoned and professional atmosians can pull off and make it happen. And, indeed, it is a thing that requires time, patience, and extensive knowledge in atmos. It requires whooping 10000K and a grand amount of 250 moles each of plasma and carbon dioxide... plus some tritium! Damn, how hard would it be, if it were to happen in the middle of batshit chaos called SS13? So it is some sort of a meme stuff only the craziest players (or admemes) would do. The amount of heat produced by fusion was (rightfully) locked behind the meme-zone... at least in Austation, the server I play.

And, oh boy, it breaks reality or dies really easily.

![Fusion ded](https://cdn.discordapp.com/attachments/563171237635948564/750946340422549625/Fusion_is_ROUGH.png)
_Fig 1. Fusion dies under suspicious circumstances_

But it wasn't meant to do that, for...

#### Fusion is Meant to be Chaotically Boring

Fusion V6 really has an enchanting name: Chaos Hyper-torus something something. [Standard maps](https://en.wikipedia.org/wiki/Standard_map) and other mathematical stuffs indeed are cool (and nigh-incomprehensible, I'd say) but it explains nothing and causes confusion. The more you read the original PR (tgstation/tgstation#42748) the less you will know about fusion because the PR actually is bad at explaining it. What fusion actually does is: it translates tritium into ridiculous amounts of heat.

That's all. Chaos Hyper-torus means practically nothing when it is literally limited like hell. Hyper-torus-like chaos really happens but it can be brushed off in the long term, because nothing will go outside of our expectations:

![Screenshot 2020-09-26 164207](https://user-images.githubusercontent.com/8010007/94335605-a9537980-0017-11eb-83de-99f2d658ae45.png)
_Fig 2. How fusion happens, summed in one badly drawn graph (don't mind the gaps; they mean nothing)_

The "hyper-torus" in fusion doesn't exceed itself. Nothing goes out of their way because our fusion mix will happily ping-pong inside the torus. Since the torodial_size where everything ping-pongs can't be larger than `2.5*pi` and is tied to volume, the range which plasma and carbon dioxide ping-pongs is `250 ~ 250+(V/pi*(2pi+arctan((V-1000)/1000))))`. For example, turf's volume is 2500, so the plasma and carbon dioxide will ping-pong inside the range of 250 ~ 6032.08 moles. The fusion CAN'T make the moles go outside of its range by itself. Excess gases only serve to intensify the chaotic ping-pong, since the fusion_power only effects instability, and the instability *loops* inside the torodial_size, giving fusion mix enough leeway against high-instability endothermicity.

![Screenshot 2020-09-26 171102](https://user-images.githubusercontent.com/8010007/94336124-8fb43100-001b-11eb-9e1c-11d4a7803321.png)
_Fig 3.1. How plasma and carbon dioxide ping-pongs (don't mind the gaps; they mean nothing)_

![Screenshot 2020-09-26 171148](https://user-images.githubusercontent.com/8010007/94336127-95aa1200-001b-11eb-991a-543541a915d8.png)
_Fig 3.2. How Instability loops inside the torodial_size (don't mind the gaps; they mean nothing)_

And all of these super-hot ping-pong requires a measly 1 mole of tritium per reaction. As long as you supply enough tritium, the fusion won't die, and the mix can mostly stay dormant (and ready to do it again) as long as you don't vent it... theoretically. So, then, why things like Fig 1 happen?

#### Other Reactions

The author of Fusion V6 indeed admitted that interactions with other reactions weren't thoroughly examined. Yet no one cares, because everyone knows that nothing will really interfere with them, provided that the fusion constantly goes brrr. That is true, because waste gases will be peanuts, and won't cause serious amounts of random reactions. There won't be enough oxygen to burn the plasma out of the fusion ping-pong nor create tritium. Tiny amount of nitrous oxide will create tiny amount of BZ, etc etc.

But it does, and we already know the culprit: an error at #1833. The image at header explains the error. Instead of halving the plasma at stim_ball, the stim_ball "literally magics half as much plasma is already in the reaction into the world" (quote: ohagi-chan) because of the lack of -, which this PR strives to re-add.

#### How Fusion Dies

So let's go back to Fig 1 for a brief postmortem, just to see how and why it died. The most prominent of them all are ridiculously low temperature and impossibly high amount of plasma. That is because the broken stim_ball exponentially creates plasma and cools the mix (for it increases heat capacity) til it reaches sub-fire temperature. So instead of reaching cold-as-space temps, it does the final reaction, lurching from >100C to -100~100C area, and the whole thing dies irreversibly down as the stim_ball requires >100C.

Fusion certainly won't like it, and it tries to consume exponentially increasing plasma as long as its dwindling tritium reserves and plunging temperatures allow it. As exponentially increasing plasma going above the fusion ping-pong area *will* create exothermic fusion (as long as there are enough carbon dioxide and tritium), the exothermic waste gases can be seen in ridiculous amounts: oxygen, nitrous oxide, and the nitrogen from nitrous oxide.

But the broken stim_ball reaction isn't the death sentence of fusion. Well-controlled fusion (read: fusion with constant tritium supply) does live without meeting its gelid fate. How does that happen? Because what actually happens is a tug-of-war between fusion and stim_ball; stim_ball starts as soon as the fusion starts, because the fusion creates pluoxium and stimulum *real* quick.

![Screenshot 2020-09-26 174305](https://user-images.githubusercontent.com/8010007/94336684-dc9a0680-001f-11eb-962e-ccb0c28c8951.png)
_Fig 4. The life cycle of a fusion, depicted by -delta_plasma (don't mind the gaps; they mean nothing)_

When the fusion hums happily, fully-stocked with tritium, the fusion can handle stim_ball's exponential plasma increments since fusion always puts plasma mole numbers inside the range I mentioned earlier. The heat consumption can be counteracted too, for fusion creates insane amounts of heat. The first part of Fig 4, where red dots are spread across the 10000~0 region, (it actually extends down to -5000 but the graph is in logarithmic scale so it had to be cut) represents this first stage.

Things get ugly as the fusion starts to run out of tritium. At this stage, the fusion starts to have problems controlling stim_ball. stim_ball can happen as long as there are enough plasma, pluoxium, stimulum and nitryl -- at which all of them is abundant in fusion mix. But fusion depends on tritium -- a gas which really *really really* rarely gets created in fusion. Thus, while stim_ball never stops, the fusion will happen more and more sparsely, and it can be seen in the second (and linear) part of Fig 4: exponentially increasing -delta_plasma(=plasma burnt in fusion), where fusion intermittently burns excess plasma outside of its range, creating immense lumps of heat. Paradoxically, the fusion doesn't look like dying, and to casual observers who doesn't know this dynamic, the fusion seems okay, for it indeed creates huge heat.

The terminal phase is where fusion is mostly gone due to lack of tritium, and stim_ball plasma exponentiation dominates. As stim_ball plasma will cool the entire mix to <100C (or it gets stopped due to lack of stimulum or whatever), the fusion can't be revived once it happens. This phase is represented by the last parts of Fig 4 (and beyond), where the fusion rarely happens (seen as dots getting noticeably sparser) and therefore reaches a point of no return, where the fusion is unable to counteract the cooling accompanied by stim_ball plasma exponentiation.

#### Closing the Long Answer

An error at a random line of another reaction breaks fusion reaction. This is epitome of SS13 atmos machine. Its intertwinedness created a bug which shouldn't be *this* hard to debug. I spent my whole Thursday night just to debug this, and the fix is just one letter, mending a typo which shouldn't have happened in the first place. This is infuriating. This is madness. I love it. I even created 42 MB of logs and dozens of barely informative graphs just in order to make a PR which adds one letter to the codebase.

![Screenshot 2020-09-25 145444](https://user-images.githubusercontent.com/8010007/94337316-81b6de00-0024-11eb-926c-a9f972593848.png)
_Fig 5. The total size of logs I created to debug this_

On a side note, stim_ball plasma can also be an opportunity to create stronger fusion. A fusion against gazillions of moles of plasma will create unrealistic heats, and potentially breaks reality by going ham... if you bootstrap it and cycle that madness enough times. It will require great shrewdness.

However, none of these will matter when this PR gets merged. The fusion will be boring again(?), and I might become that guy who killed fun in fusion. (or that guy who debugged fusion?) But, hey, you can now use fusion as a truly epic heat source.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Atmos is less likely to transcend logic and break reality.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: stim_ball reaction now properly consumes plasma
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
