### PR TITLE
Jungle Fever Buffs

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -127,11 +127,11 @@
 	if(affected_mob.mind && !is_monkey(affected_mob.mind))
 		add_monkey(affected_mob.mind)
 	if(ishuman(affected_mob))
-		GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(affected_mob)
-		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(96))
+		if(affected_mob && !is_monkey_leader(affected_mob.mind) && !prob(4))
 			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPVIRUS | TR_KEEPSE)
 			M.ventcrawler = VENTCRAWLER_ALWAYS
-			GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(M)
+			var/datum/atom_hud/H = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+			H.add_hud_to(M)
 		else
 			affected_mob.junglegorillize()
 

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -126,14 +126,14 @@
 /datum/disease/transformation/jungle_fever/do_disease_transformation(mob/living/carbon/affected_mob)
 	if(affected_mob.mind && !is_monkey(affected_mob.mind))
 		add_monkey(affected_mob.mind)
-	if(ishuman(affected_mob))
-		if(affected_mob && !is_monkey_leader(affected_mob.mind) && !prob(4))
-			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPVIRUS | TR_KEEPSE)
+	if(affected_mob && ishuman(affected_mob))
+		if((is_monkey_leader(affected_mob.mind) || prob(4)))
+			affected_mob.junglegorillize()
+		else
+			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPVIRUS | TR_KEEPSE)
 			M.ventcrawler = VENTCRAWLER_ALWAYS
 			var/datum/atom_hud/H = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 			H.add_hud_to(M)
-		else
-			affected_mob.junglegorillize()
 
 /datum/disease/transformation/jungle_fever/stage_act()
 	..()

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -128,7 +128,7 @@
 		add_monkey(affected_mob.mind)
 	if(ishuman(affected_mob))
 		GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(affected_mob)
-		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(4))
+		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(96))
 			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPVIRUS | TR_KEEPSE)
 			M.ventcrawler = VENTCRAWLER_ALWAYS
 		else

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -138,7 +138,7 @@
 	..()
 	switch(stage)
 		if(1)
-			H.add_hud_to(new/datum/atom_hud/data/human/medical/advanced())
+			affected_mob.add_hud_to(new/datum/atom_hud/data/human/medical/advanced())
 		if(2)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='notice'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")
@@ -152,7 +152,7 @@
 
 /datum/disease/transformation/jungle_fever/cure()
 	remove_monkey(affected_mob.mind)
-	H.remove_hud_from(new/datum/atom_hud/data/human/medical/advanced())
+	affected_mob.remove_hud_from(new/datum/atom_hud/data/human/medical/advanced())
 	..()
 
 /datum/disease/transformation/jungle_fever/monkeymode

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -97,8 +97,8 @@
 			new_mob.ghostize(can_reenter_corpse = FALSE)
 			new_mob.key = null
 
-/datum/disease/transformation/jungle_fever
 	name = "Jungle Fever"
+/datum/disease/transformation/jungle_fever
 	cure_text = "Death."
 	cures = list(/datum/reagent/medicine/adminordrazine)
 	spread_text = "Monkey Bites"
@@ -127,8 +127,9 @@
 	if(affected_mob.mind && !is_monkey(affected_mob.mind))
 		add_monkey(affected_mob.mind)
 	if(ishuman(affected_mob))
-		if(affected_mob && !is_monkey_leader(affected_mob.mind))
-			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_KEEPSE)
+		H.add_hud_to(new/datum/atom_hud/data/human/medical/advanced())
+		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(96))
+			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPVIRUS | TR_KEEPSE)
 			M.ventcrawler = VENTCRAWLER_ALWAYS
 		else
 			affected_mob.junglegorillize()
@@ -136,6 +137,8 @@
 /datum/disease/transformation/jungle_fever/stage_act()
 	..()
 	switch(stage)
+		if(1)
+			H.add_hud_to(new/datum/atom_hud/data/human/medical/advanced())
 		if(2)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='notice'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")
@@ -149,6 +152,7 @@
 
 /datum/disease/transformation/jungle_fever/cure()
 	remove_monkey(affected_mob.mind)
+	H.remove_hud_from(new/datum/atom_hud/data/human/medical/advanced())
 	..()
 
 /datum/disease/transformation/jungle_fever/monkeymode

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -128,7 +128,7 @@
 		add_monkey(affected_mob.mind)
 	if(ishuman(affected_mob))
 		H.add_hud_to(new/datum/atom_hud/data/human/medical/advanced())
-		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(96))
+		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(4))
 			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPVIRUS | TR_KEEPSE)
 			M.ventcrawler = VENTCRAWLER_ALWAYS
 		else

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -97,8 +97,8 @@
 			new_mob.ghostize(can_reenter_corpse = FALSE)
 			new_mob.key = null
 
-	name = "Jungle Fever"
 /datum/disease/transformation/jungle_fever
+	name = "Jungle Fever"
 	cure_text = "Death."
 	cures = list(/datum/reagent/medicine/adminordrazine)
 	spread_text = "Monkey Bites"
@@ -127,7 +127,7 @@
 	if(affected_mob.mind && !is_monkey(affected_mob.mind))
 		add_monkey(affected_mob.mind)
 	if(ishuman(affected_mob))
-		H.add_hud_to(new/datum/atom_hud/data/human/medical/advanced())
+		GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(affected_mob)
 		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(4))
 			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPVIRUS | TR_KEEPSE)
 			M.ventcrawler = VENTCRAWLER_ALWAYS
@@ -138,7 +138,7 @@
 	..()
 	switch(stage)
 		if(1)
-			affected_mob.add_hud_to(new/datum/atom_hud/data/human/medical/advanced())
+			GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(affected_mob)
 		if(2)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='notice'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")
@@ -152,7 +152,7 @@
 
 /datum/disease/transformation/jungle_fever/cure()
 	remove_monkey(affected_mob.mind)
-	affected_mob.remove_hud_from(new/datum/atom_hud/data/human/medical/advanced())
+	GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].remove_hud_from(affected_mob)
 	..()
 
 /datum/disease/transformation/jungle_fever/monkeymode

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -131,14 +131,13 @@
 		if(affected_mob && !is_monkey_leader(affected_mob.mind) && prob(96))
 			var/mob/living/carbon/monkey/M = affected_mob.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPVIRUS | TR_KEEPSE)
 			M.ventcrawler = VENTCRAWLER_ALWAYS
+			GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(M)
 		else
 			affected_mob.junglegorillize()
 
 /datum/disease/transformation/jungle_fever/stage_act()
 	..()
 	switch(stage)
-		if(1)
-			GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(affected_mob)
 		if(2)
 			if(prob(2))
 				to_chat(affected_mob, "<span class='notice'>Your [pick("back", "arm", "leg", "elbow", "head")] itches.</span>")
@@ -152,7 +151,6 @@
 
 /datum/disease/transformation/jungle_fever/cure()
 	remove_monkey(affected_mob.mind)
-	GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].remove_hud_from(affected_mob)
 	..()
 
 /datum/disease/transformation/jungle_fever/monkeymode

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -541,7 +541,8 @@
 	invisibility = INVISIBILITY_MAXIMUM
 	var/mob/living/simple_animal/hostile/gorilla/rabid/new_gorilla = new (get_turf(src))
 	new_gorilla.a_intent = INTENT_HARM
-	GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(new_gorilla)
+	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	H.add_hud_to(new_gorilla)
 	if(mind)
 		mind.transfer_to(new_gorilla)
 	else

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -541,6 +541,7 @@
 	invisibility = INVISIBILITY_MAXIMUM
 	var/mob/living/simple_animal/hostile/gorilla/rabid/new_gorilla = new (get_turf(src))
 	new_gorilla.a_intent = INTENT_HARM
+	GLOB.huds[DATA_HUD_MEDICAL_ADVANCED].add_hud_to(new_gorilla)
 	if(mind)
 		mind.transfer_to(new_gorilla)
 	else


### PR DESCRIPTION
## About The Pull Request

**add: Jungle Fever: Added advanced huds to all monkeys and gorillas**
Big buff: Monkeys are able to see who is infected and who is not. Prevents gorillas from attacking people already infected.

**add: Jungle Fever: 4% chance to turn into a gorilla instead of regular momke**
It feels like monkey fever only goes one way: monkeys get overpowered and lose. Maybe this will even the odds.

**add: Jungle Fever Transformation always fullheals monkeys**
Gorillas often delimb people or have to delimb the very agressive ones or deal more damage. This almost always puts a monkey at a disadvantage and renders it useless. Not anymore.

## Why It's Good For The Game

It feels like monkey can be a good gamemode, but it just needs a little but more buffs. This is to keep monkeys from becoming pretty much useless once gorillas die/ai electrifies doors/ai N2O floods/etc. Monkey is really onesided with strong early game, but snowballs down as the round progresses.

## Changelog
:cl:
add: Jungle Fever: Added advanced huds to all monkeys and gorillas.
tweak: Jungle Fever: 4% chance to turn into a gorilla instead of regular momke
tweak: Jungle Fever Transformation always fullheals monkeys.
/:cl: