### PR TITLE
fix strtohex and passkeys for circuits

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -548,7 +548,7 @@ Takes a string and a datum. The string is well, obviously the string being check
 	var/c
 	for(var/i = 1 to length(str))
 		c = text2ascii(str,i)
-		r += num2hex(c, 1)
+		r += num2hex(c, 2)
 	return r
 
 /// Decodes hex to raw byte string. If safe=TRUE, returns null on incorrect input strings instead of CRASHing


### PR DESCRIPTION
#  About The Pull Request

fixes the strtohex function to correctly zero pad values < 15 (15 -> 0f).

## Why It's Good For The Game

fixes broken passkeys for integrated circuits, as the lack of padding will corrupt the JSON access strings most rounds (depends on the value of SScircuit.cipherkey).

## Changelog
:cl:
fix: fixed non-functional passkeys for circuits
/:cl:
