### PR TITLE
Fixes bugs from the carpet port and adds it to cargo.

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -176,7 +176,7 @@
 	singular_name = "retro floor tile"
 	desc = "A stack of floor tiles that remind you of simpler times.."
 	icon_state = "tile_eighties"
-	turf_type = /turf/open/floor/carpet/eighties
+	turf_type = /turf/open/floor/eighties
 
 /obj/item/stack/tile/carpet/fifty
 	amount = 50
@@ -208,7 +208,7 @@
 /obj/item/stack/tile/carpet/royalblue/fifty
 	amount = 50
 
-/obj/item/stack/tile/eighties
+/obj/item/stack/tile/eighties/fifty
 	amount = 50
 
 /obj/item/stack/tile/fakespace

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -241,7 +241,7 @@
 	floor_tile = /obj/item/stack/tile/carpet/royalblue
 	canSmoothWith = list(/turf/open/floor/carpet/royalblue)
 
-/turf/open/floor/carpet/eighties
+/turf/open/floor/eighties
 	name = "retro floor"
 	desc = "This one takes you back."
 	icon_state = "eighties"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1713,6 +1713,8 @@
 					/obj/item/stack/tile/carpet/red/fifty,
 					/obj/item/stack/tile/carpet/royalblue/fifty,
 					/obj/item/stack/tile/carpet/royalblue/fifty,
+					/obj/item/stack/tile/eighties/fifty,
+					/obj/item/stack/tile/eighties/fifty,
 					/obj/item/stack/tile/carpet/royalblack/fifty,
 					/obj/item/stack/tile/carpet/royalblack/fifty)
 	crate_name = "exotic carpet crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes bugs associated with: #2524 and adds the carpet to the exotic cargo crate order.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fixes: the eighties floor not spawning.
adds:the eighties floor tiles to the carpet luxury crate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
