### PR TITLE
Rebalancing Foreigner

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -220,6 +220,26 @@
 	lose_text = "<span class='notice'>You feel sturdy again.</span>"
 	medical_record_text = "Patient has unusually frail bones, recommend calcium-rich diet."
 
+/datum/quirk/foreigner
+	name = "Foreigner"
+	desc = "You're not from around here. You don't know Galactic Common!"
+	value = -1
+	gain_text = "<span class='notice'>The words being spoken around you don't make any sense."
+	lose_text = "<span class='notice'>You've developed fluency in Galactic Common."
+	medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
+
+/datum/quirk/foreigner/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(ishuman(H) && !isipc(H) && H.job != "Curator")
+		H.add_blocked_language(/datum/language/common)
+		H.grant_language(/datum/language/uncommon)
+
+/datum/quirk/foreigner/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(ishuman(H) && !isipc(H) && H.job != "Curator")
+		H.remove_blocked_language(/datum/language/common)
+		H.remove_language(/datum/language/uncommon)
+
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
 	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up."

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -10,26 +10,6 @@
 	lose_text = "<span class='notice'>You can taste again!</span>"
 	medical_record_text = "Patient suffers from ageusia and is incapable of tasting food or reagents."
 
-/datum/quirk/foreigner
-	name = "Foreigner"
-	desc = "You're not from around here. You don't know Galactic Common!"
-	value = 0
-	gain_text = "<span class='notice'>The words being spoken around you don't make any sense."
-	lose_text = "<span class='notice'>You've developed fluency in Galactic Common."
-	medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
-
-/datum/quirk/foreigner/add()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(ishuman(H) && !isipc(H) && H.job != "Curator")
-		H.add_blocked_language(/datum/language/common)
-		H.grant_language(/datum/language/uncommon)
-
-/datum/quirk/foreigner/remove()
-	var/mob/living/carbon/human/H = quirk_holder
-	if(ishuman(H) && !isipc(H) && H.job != "Curator")
-		H.remove_blocked_language(/datum/language/common)
-		H.remove_language(/datum/language/uncommon)
-
 /datum/quirk/vegetarian
 	name = "Vegetarian"
 	desc = "You find the idea of eating meat morally and physically repulsive."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to it limiting communication. I am rebalancing this trait to a negative value of 1. This will make it more appealing to use. Despite having a decent impact, it does not remove race specific languages, therefore not warranting a 2.

## Why It's Good For The Game

Actually makes it reasonable to have the Foreigner Trait. Properly categorized and all.

## Changelog
:cl: DatBoiTim
balance: Adjusted Foreigner to be a Negative trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
