### PR TITLE
Command, QM and Warden now require more playtime hours

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -12,8 +12,8 @@
 	chat_color = "#FFDC9B"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 480
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 1200
+	exp_type = EXP_TYPE_COMMAND
 	exp_type_department = EXP_TYPE_COMMAND
 
 	outfit = /datum/outfit/job/captain

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -13,8 +13,8 @@
 	chat_color = "#CFBB72"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 360
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 1200
+	exp_type = EXP_TYPE_ENGINEERING
 	exp_type_department = EXP_TYPE_ENGINEERING
 
 	outfit = /datum/outfit/job/ce

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -13,8 +13,8 @@
 	chat_color = "#7A97DA"
 	req_admin_notify = 1
 	minimal_player_age = 7
-	exp_requirements = 360
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 1200
+	exp_type = EXP_TYPE_MEDICAL
 	exp_type_department = EXP_TYPE_MEDICAL
 
 	outfit = /datum/outfit/job/cmo

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -13,9 +13,9 @@
 	chat_color = "#7979d3"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 1200
-	exp_type = EXP_TYPE_SUPPLY
-	exp_type_department = EXP_TYPE_SUPPLY
+	exp_requirements = 600
+	exp_type = EXP_TYPE_SERVICE
+	exp_type_department = EXP_TYPE_SERVICE
 
 	outfit = /datum/outfit/job/hop
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -13,8 +13,8 @@
 	chat_color = "#7979d3"
 	req_admin_notify = 1
 	minimal_player_age = 10
-	exp_requirements = 360
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 1200
+	exp_type = EXP_TYPE_SUPPLY
 	exp_type_department = EXP_TYPE_SUPPLY
 
 	outfit = /datum/outfit/job/hop

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -13,8 +13,8 @@
 	chat_color = "#D33049"
 	req_admin_notify = 1
 	minimal_player_age = 14
-	exp_requirements = 600
-	exp_type = EXP_TYPE_CREW
+	exp_requirements = 1200
+	exp_type = EXP_TYPE_SECURITY
 	exp_type_department = EXP_TYPE_SECURITY
 
 	outfit = /datum/outfit/job/hos

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -9,6 +9,9 @@
 	supervisors = "the head of personnel"
 	selection_color = "#d7b088"
 	chat_color = "#C79C52"
+	exp_requirements = 600
+	exp_type = EXP_TYPE_SUPPLY
+	exp_type_department = EXP_TYPE_SUPPLY
 
 	outfit = /datum/outfit/job/quartermaster
 

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -13,9 +13,9 @@
 	chat_color = "#974EA9"
 	req_admin_notify = 1
 	minimal_player_age = 7
+	exp_requirements = 1200
+	exp_type = EXP_TYPE_SCIENCE
 	exp_type_department = EXP_TYPE_SCIENCE
-	exp_requirements = 240
-	exp_type = EXP_TYPE_CREW
 
 	outfit = /datum/outfit/job/rd
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -11,7 +11,7 @@
 	selection_color = "#ffeeee"
 	chat_color = "#EA545E"
 	minimal_player_age = 7
-	exp_requirements = 420
+	exp_requirements = 600
 	exp_type = EXP_TYPE_SECURITY
 	exp_type_department = EXP_TYPE_SECURITY
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[This thread](https://forums.beestation13.com/t/increase-required-playtime-for-all-head-roles-and-above-to-50h-minimum/7351/32) raised a lot of good points so I've upped all Command roles to require 20 hours playtime from their relevant department, except HOP who requires 10 hours Service. Warden and QM also now requires 10 hours each. 

## Why It's Good For The Game
See thread for the discussion. 

One such good reason from Aeder:
"I really do not see any advantage of letting some chuckle fuck that has played a handful of rounds, possibly in only one role in the department, being the leader and in charge of game and station changing roles. It should be a reward for learning to be given the opportunity to govern."

## Changelog
:cl:
tweak: All Command roles now require 20h playtime in the relevant department, except HOP requires 10h Service. Warden and QM require 10h each. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
