### PR TITLE
The return of qwerty lighting

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -237,8 +237,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Hallway
 
 /area/hallway
-	lighting_colour_tube = "#fdf3ea"
-	lighting_colour_bulb = "#ffebd6"
+	lighting_colour_tube = "#ffce99"
+	lighting_colour_bulb = "#ffdbb4"
+	lighting_brightness_tube = 8
+
 
 /area/hallway/primary/aft
 	name = "Aft Primary Hallway"
@@ -290,6 +292,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Bridge"
 	icon_state = "bridge"
 	ambientsounds = list('sound/ambience/signal.ogg')
+
+	lighting_colour_tube = "#ffce99"
+	lighting_colour_bulb = "#ffdbb4"
+	lighting_brightness_tube = 8
 
 /area/bridge/meeting_room
 	name = "Heads of Staff Meeting Room"
@@ -343,14 +349,17 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 //Crew
 
+/area/crew_quarters
+	lighting_colour_tube = "#ffce99"
+	lighting_colour_bulb = "#ffdbb4"
+	lighting_brightness_tube = 8
+
 /area/crew_quarters/dorms
 	name = "Dormitories"
 	icon_state = "Sleep"
 	safe = TRUE
 	mood_bonus = 3
 	mood_message = "<span class='nicegreen'>There's no place like the dorms!\n</span>"
-	lighting_colour_tube = "#fff4d6"
-	lighting_colour_bulb = "#ffebc1"
 
 /area/crew_quarters/cryopods
 	name = "Cryopod Room"
@@ -446,8 +455,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Library"
 	icon_state = "library"
 	flags_1 = NONE
-	lighting_colour_tube = "#fff1cc"
-	lighting_colour_bulb = "#ffe9b9"
+
+	lighting_colour_tube = "#ffce99"
+	lighting_colour_bulb = "#ffdbb4"
+	lighting_brightness_tube = 8
 
 /area/library/lounge
 	name = "Library Lounge"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -73,7 +73,10 @@
 	var/lighting_colour_tube = "#FFF6ED"
 	var/lighting_colour_bulb = "#FFE6CC"
 	var/lighting_colour_night = "#FFDBB5"
-	
+	var/lighting_brightness_tube = 10
+	var/lighting_brightness_bulb = 6
+	var/lighting_brightness_night = 6
+
 /**
   * A list of teleport locations
   *

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -211,8 +211,8 @@
 	var/on = FALSE					// 1 if on, 0 if off
 	var/on_gs = FALSE
 	var/static_power_used = 0
-	var/brightness = 11			// luminosity when on, also used in power calculation
-	var/bulb_power = 0.75			// basically the alpha of the emitted light source
+	var/brightness = 10			// luminosity when on, also used in power calculation
+	var/bulb_power = 1			// basically the alpha of the emitted light source
 	var/bulb_colour = "#FFF6ED"	// befault colour of the light.
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = FALSE
@@ -228,8 +228,8 @@
 
 	var/nightshift_enabled = FALSE	//Currently in night shift mode?
 	var/nightshift_allowed = TRUE	//Set to FALSE to never let this light get switched to night mode.
-	var/nightshift_brightness = 8
-	var/nightshift_light_power = 0.45
+	var/nightshift_brightness = 7
+	var/nightshift_light_power = 0.75
 	var/nightshift_light_color = "#FFDBB5" //qwerty's more cozy light
 
 	var/emergency_mode = FALSE	// if true, the light is in emergency mode
@@ -295,10 +295,14 @@
 	if(bulb_colour == initial(bulb_colour))
 		if(istype(src, /obj/machinery/light/small))
 			bulb_colour = A.lighting_colour_bulb
+			brightness = A.lighting_brightness_bulb
 		else
 			bulb_colour = A.lighting_colour_tube
+			brightness = A.lighting_brightness_bulb
+
 	if(nightshift_light_color == initial(nightshift_light_color))
 		nightshift_light_color = A.lighting_colour_night
+		nightshift_brightness = A.lighting_brightness_night
 
 	if(!mapload) //sync up nightshift lighting for player made lights
 		var/obj/machinery/power/apc/temp_apc = A.get_apc()


### PR DESCRIPTION
## About The Pull Request

Partially reverts #1205 and brings back more cozy lighting. The biggest reason it was removed in the first place was because medbay and other similar departments should be bright and sterile. Now that we have departmental lighting, we can bring back the cozy lighting only where it should be.

![image](https://user-images.githubusercontent.com/24400628/94487298-62e05500-01a6-11eb-9a05-76842c37ef86.png)


## Why It's Good For The Game

A lot of people liked qwerty lighting before and only wanted it gone because of the cozy medbay. It looks nicer, and it has nicer immersion.

## Changelog
:cl:
add: Re-add qwerty lighting in specific areas
code: You can now specify area bulb brightness
/:cl:
