### PR TITLE
Fix to mutation toxins

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -433,6 +433,7 @@
 									"Your appendages begin morphing." = MUT_MSG_EXTENDED,
 									"You feel as though you're about to change at any moment!" = MUT_MSG_ABOUT2TURN)
 	var/cycles_to_turn = 20 //the current_cycle threshold / iterations needed before one can transform
+	can_synth = FALSE
 
 /datum/reagent/mutationtoxin/on_mob_life(mob/living/carbon/human/H)
 	. = TRUE


### PR DESCRIPTION
## About The Pull Request
in my mutation toxin nerf, I accidentally removed the can_synth = FALSE from base mutation toxin, so any random reagent call can get it. this fixes that

note that botnis can still mix mutation toxins from unstable mutation toxin, which is still in the pool. This is intentional, from when can_synth was set to false in the first place
## Why It's Good For The Game
mutation toxins are used for grief and shittery and should be restricted outside of farmable methods in most cases

## Changelog
:cl:
fix: mutation toxin is restricted again
/:cl:


