### PR TITLE
Move the race paywall stuff to config

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -193,6 +193,10 @@
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_FLAG
 
+/datum/config_entry/keyed_list/paywall_races	//races you have to be a subscriber to play as
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_FLAG
+
 /datum/config_entry/keyed_list/roundstart_no_hard_check // Species contained in this list will not cause existing characters with no-longer-roundstart species set to be resetted to the human race.
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_FLAG

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1422,7 +1422,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						var/new_species_type = GLOB.species_list[result]
 						var/datum/species/new_species = new new_species_type()
 
-						if (!new_species.patron_locked || IS_PATRON(parent.ckey) || parent.holder)
+						if (!CONFIG_GET(keyed_list/paywall_races)[new_species.id] || IS_PATRON(parent.ckey) || parent.holder)
 							pref_species = new_species
 							//Now that we changed our species, we must verify that the mutant colour is still allowed.
 							var/temp_hsv = RGBtoHSV(features["mcolor"])

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -90,8 +90,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	//in __DEFINES/mobs.dm, defaults to NONE, so people actually have to think about it
 	var/changesource_flags = NONE
 
-	var/patron_locked = FALSE
-
 ///////////
 // PROCS //
 ///////////

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -14,9 +14,6 @@
 	mutanttail = /obj/item/organ/tail/cat
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
-	// Horny Pays
-	patron_locked = TRUE
-
 /datum/species/human/felinid/qualifies_for_rank(rank, list/features)
 	return TRUE
 

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -494,7 +494,7 @@ ROUNDSTART_RACES ipc
 ##-------------------------------------------------------------------------------------------
 ## Uncommenting races will restrict them behind the patreon paywall
 
-PAYWALL_RACES felinid
+#PAYWALL_RACES felinid
 
 ##-------------------------------------------------------------------------------------------
 

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -490,6 +490,12 @@ ROUNDSTART_RACES ipc
 #ROUNDSTART_RACES military_synth
 #ROUNDSTART_RACES agent
 
+## Paywall Races
+##-------------------------------------------------------------------------------------------
+## Uncommenting races will restrict them behind the patreon paywall
+
+PAYWALL_RACES felinid
+
 ##-------------------------------------------------------------------------------------------
 
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -486,6 +486,12 @@ ROUNDSTART_RACES apid
 #ROUNDSTART_RACES military_synth
 #ROUNDSTART_RACES agent
 
+## Paywall Races
+##-------------------------------------------------------------------------------------------
+## Uncommenting races will restrict them behind the patreon paywall
+
+#PAYWALL_RACES felinid
+
 ##-------------------------------------------------------------------------------------------
 
 ## Uncomment to give players the choice of joining as a human with mutant bodyparts before they join the game


### PR DESCRIPTION
## About The Pull Request

As per @francinum 's request, I've moved the race paywall stuff to config to make it easier on downstream that use the module method.

closes #2578

## Why It's Good For The Game

Config good hardcoded bad

## Changelog
:cl:
add: Added race paywall to config
config: Felinids are no longer paywalled.
/:cl: