### PR TITLE
Refactors most things that check if the player is walking to check actual speed (and a few other things)

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -132,7 +132,7 @@
 
 /datum/brain_trauma/mild/muscle_weakness/on_life()
 	var/fall_chance = 1
-	if(owner.m_intent == MOVE_INTENT_RUN)
+	if(!owner.carefulmovement())
 		fall_chance += 2
 	if(prob(fall_chance) && (owner.mobility_flags & MOBILITY_STAND))
 		to_chat(owner, "<span class='warning'>Your leg gives out!</span>")

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -132,7 +132,7 @@
 
 /datum/brain_trauma/mild/muscle_weakness/on_life()
 	var/fall_chance = 1
-	if(!owner.carefulmovement())
+	if(!owner.movingcarefully())
 		fall_chance += 2
 	if(prob(fall_chance) && (owner.mobility_flags & MOBILITY_STAND))
 		to_chat(owner, "<span class='warning'>Your leg gives out!</span>")

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -129,7 +129,7 @@
 	if(owner.IsSleeping())
 		return
 	var/sleep_chance = 1
-	if(owner.m_intent == MOVE_INTENT_RUN)
+	if(!owner.carefulmovement())
 		sleep_chance += 2
 	if(owner.drowsyness)
 		sleep_chance += 3

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -129,7 +129,7 @@
 	if(owner.IsSleeping())
 		return
 	var/sleep_chance = 1
-	if(!owner.carefulmovement())
+	if(!owner.movingcarefully())
 		sleep_chance += 2
 	if(owner.drowsyness)
 		sleep_chance += 3

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -27,7 +27,7 @@
 		if(HAS_TRAIT(H, TRAIT_PIERCEIMMUNE))
 			return
 
-		if((flags & CALTROP_IGNORE_WALKERS) && H.carefulmovement())
+		if((flags & CALTROP_IGNORE_WALKERS) && H.movingcarefully())
 			return
 
 		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -27,7 +27,7 @@
 		if(HAS_TRAIT(H, TRAIT_PIERCEIMMUNE))
 			return
 
-		if((flags & CALTROP_IGNORE_WALKERS) && H.m_intent == MOVE_INTENT_WALK)
+		if((flags & CALTROP_IGNORE_WALKERS) && H.carefulmovement())
 			return
 
 		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -27,7 +27,7 @@
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
 			return
-		if(C.carefulmovement())
+		if(C.movingcarefully())
 			return // stealth
 	steps++
 

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -27,7 +27,7 @@
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
 			return
-		if(ishuman(C) && C.m_intent == MOVE_INTENT_WALK)
+		if(C.carefulmovement())
 			return // stealth
 	steps++
 

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -159,7 +159,7 @@
 
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if (M.m_intent != MOVE_INTENT_WALK && anchored)
+		if (!M.carefulmovement() && anchored)
 			flash()
 
 /obj/machinery/flasher/portable/attackby(obj/item/W, mob/user, params)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -159,7 +159,7 @@
 
 	if(istype(AM, /mob/living/carbon))
 		var/mob/living/carbon/M = AM
-		if (!M.carefulmovement() && anchored)
+		if (!M.movingcarefully() && anchored)
 			flash()
 
 /obj/machinery/flasher/portable/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -57,7 +57,7 @@
 		var/mob/living/L = AM
 		if(L.movement_type & FLYING)
 			return
-		if(!L.carefulmovement() && prob(40))
+		if(!L.movingcarefully() && prob(40))
 			var/acid_used = min(acid_level*0.05, 20)
 			if(L.acid_act(10, acid_used, "feet"))
 				acid_level = max(0, acid_level - acid_used*10)

--- a/code/game/objects/effects/alien_acid.dm
+++ b/code/game/objects/effects/alien_acid.dm
@@ -57,7 +57,7 @@
 		var/mob/living/L = AM
 		if(L.movement_type & FLYING)
 			return
-		if(L.m_intent != MOVE_INTENT_WALK && prob(40))
+		if(!L.carefulmovement() && prob(40))
 			var/acid_used = min(acid_level*0.05, 20)
 			if(L.acid_act(10, acid_used, "feet"))
 				acid_level = max(0, acid_level - acid_used*10)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -488,7 +488,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				return 0
 		else
 			return 0
-	if(owner.carefulmovement())
+	if(owner.movingcarefully())
 		final_block_level += block_upgrade_walk
 	switch(relative_dir)
 		if(180, -180)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -488,7 +488,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				return 0
 		else
 			return 0
-	if(owner.m_intent == MOVE_INTENT_WALK)
+	if(owner.carefulmovement())
 		final_block_level += block_upgrade_walk
 	switch(relative_dir)
 		if(180, -180)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -431,7 +431,7 @@
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if(ishuman(H) || issilicon(H)) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
-		if(issilicon(H) || !M.carefulmovement())
+		if(issilicon(H) || !M.movingcarefully())
 			to_chat(M, "<span class='danger'>You step on the snap pop!</span>")
 			pop_burst(2, 0)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -431,7 +431,7 @@
 /obj/item/toy/snappop/Crossed(H as mob|obj)
 	if(ishuman(H) || issilicon(H)) //i guess carp and shit shouldn't set them off
 		var/mob/living/carbon/M = H
-		if(issilicon(H) || M.m_intent == MOVE_INTENT_RUN)
+		if(issilicon(H) || !M.carefulmovement())
 			to_chat(M, "<span class='danger'>You step on the snap pop!</span>")
 			pop_burst(2, 0)
 

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -64,7 +64,7 @@
 		return 1
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
-		if(allow_walk && C.carefulmovement())
+		if(allow_walk && C.movingcarefully())
 			return 1
 
 /obj/structure/holosign/barrier/wetsign

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -64,7 +64,7 @@
 		return 1
 	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
-		if(allow_walk && C.m_intent == MOVE_INTENT_WALK)
+		if(allow_walk && C.carefulmovement())
 			return 1
 
 /obj/structure/holosign/barrier/wetsign

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -40,7 +40,7 @@
 	if(!istype(H))
 		return
 	var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-	if(H.shoes || feetCover || !(H.mobility_flags & MOBILITY_STAND) || HAS_TRAIT(H, TRAIT_PIERCEIMMUNE) || H.carefulmovement())
+	if(H.shoes || feetCover || !(H.mobility_flags & MOBILITY_STAND) || HAS_TRAIT(H, TRAIT_PIERCEIMMUNE) || H.movingcarefully())
 		return
 	if((world.time >= last_bump + 100) && prob(5))
 		to_chat(H, "<span class='warning'>You stub your toe on the [name]!</span>")

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -40,7 +40,7 @@
 	if(!istype(H))
 		return
 	var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-	if(H.shoes || feetCover || !(H.mobility_flags & MOBILITY_STAND) || HAS_TRAIT(H, TRAIT_PIERCEIMMUNE) || H.m_intent == MOVE_INTENT_WALK)
+	if(H.shoes || feetCover || !(H.mobility_flags & MOBILITY_STAND) || HAS_TRAIT(H, TRAIT_PIERCEIMMUNE) || H.carefulmovement())
 		return
 	if((world.time >= last_bump + 100) && prob(5))
 		to_chat(H, "<span class='warning'>You stub your toe on the [name]!</span>")

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -196,7 +196,7 @@
 		else
 			if(!(C.mobility_flags & MOBILITY_STAND) || !(C.status_flags & CANKNOCKDOWN)) // can't slip unbuckled mob if they're lying or can't fall.
 				return 0
-			if(C.m_intent == MOVE_INTENT_WALK && (lube&NO_SLIP_WHEN_WALKING))
+			if(C.carefulmovement() && (lube&NO_SLIP_WHEN_WALKING))
 				return 0
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -196,7 +196,7 @@
 		else
 			if(!(C.mobility_flags & MOBILITY_STAND) || !(C.status_flags & CANKNOCKDOWN)) // can't slip unbuckled mob if they're lying or can't fall.
 				return 0
-			if(C.carefulmovement() && (lube&NO_SLIP_WHEN_WALKING))
+			if(C.movingcarefully() && (lube&NO_SLIP_WHEN_WALKING))
 				return 0
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -105,7 +105,7 @@
 			if(!(MM.movement_type & FLYING))
 				if(ishuman(AM))
 					var/mob/living/carbon/H = AM
-					if(H.m_intent == MOVE_INTENT_RUN)
+					if(!H.carefulmovement())
 						triggered(H)
 						H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 										  "<span class='warning'>You accidentally step on [src]</span>")

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -105,7 +105,7 @@
 			if(!(MM.movement_type & FLYING))
 				if(ishuman(AM))
 					var/mob/living/carbon/H = AM
-					if(!H.carefulmovement())
+					if(!H.movingcarefully())
 						triggered(H)
 						H.visible_message("<span class='warning'>[H] accidentally steps on [src].</span>", \
 										  "<span class='warning'>You accidentally step on [src]</span>")

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -35,3 +35,12 @@
 			adjust_nutrition(-(HUNGER_FACTOR/10))
 			if(m_intent == MOVE_INTENT_RUN)
 				adjust_nutrition(-(HUNGER_FACTOR/10))
+	
+/mob/living/carbon/carefulmovement()
+	if(buckled) //sitting down, being in a vehicle, etc
+		return FALSE 
+	if(stat) //iron out edgecases
+		return FALSE
+	if(m_intent == MOVE_INTENT_WALK)
+		return TRUE 
+	return FALSE

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -36,7 +36,7 @@
 			if(m_intent == MOVE_INTENT_RUN)
 				adjust_nutrition(-(HUNGER_FACTOR/10))
 	
-/mob/living/carbon/carefulmovement()
+/mob/living/carbon/movingcarefully()
 	if(buckled) //sitting down, being in a vehicle, etc
 		return FALSE 
 	if(stat) //iron out edgecases

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -80,7 +80,7 @@
 		return TRUE
 	return ..()
 
-/mob/living/carbon/human/carefulmovement()
+/mob/living/carbon/human/movingcarefully()
 	if(buckled) //sitting down, being in a vehicle, etc
 		return FALSE 
 	if(stat) //iron out edgecases

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -79,3 +79,12 @@
 	if(dna.species.space_move(src))
 		return TRUE
 	return ..()
+
+/mob/living/carbon/human/carefulmovement()
+	if(buckled) //sitting down, being in a vehicle, etc
+		return FALSE 
+	if(stat) //iron out edgecases
+		return FALSE
+	if((cached_multiplicative_slowdown + dna.species.movement_delay(src)) >= CONFIG_GET(number/movedelay/walk_delay) && mobility_flags & MOBILITY_STAND) //later, i want walk to not slow you down past walk delay. later.
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -60,7 +60,7 @@
 	if(buckled || now_pushing)
 		return
 	if(!ismovableatom(A) || is_blocked_turf(A))  // ported from VORE, sue me
-		if((confused || is_blind()) && stat == CONSCIOUS && m_intent=="run" && mobility_flags & MOBILITY_STAND)
+		if((confused || is_blind()) && stat == CONSCIOUS && !carefulmovement() && mobility_flags & MOBILITY_STAND)
 			playsound(get_turf(src), "punch", 25, 1, -1)
 			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
 			apply_damage(5, BRUTE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -60,7 +60,7 @@
 	if(buckled || now_pushing)
 		return
 	if(!ismovableatom(A) || is_blocked_turf(A))  // ported from VORE, sue me
-		if((confused || is_blind()) && stat == CONSCIOUS && !carefulmovement() && mobility_flags & MOBILITY_STAND)
+		if((confused || is_blind()) && stat == CONSCIOUS && !movingcarefully() && mobility_flags & MOBILITY_STAND)
 			playsound(get_turf(src), "punch", 25, 1, -1)
 			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
 			apply_damage(5, BRUTE)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -61,3 +61,6 @@
 
 /mob/living/canZMove(dir, turf/target)
 	return can_zTravel(target, dir) && (movement_type & FLYING)
+
+/mob/living/proc/carefulmovement()
+	return FALSE

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -62,5 +62,5 @@
 /mob/living/canZMove(dir, turf/target)
 	return can_zTravel(target, dir) && (movement_type & FLYING)
 
-/mob/living/proc/carefulmovement()
+/mob/living/proc/movingcarefully()
 	return FALSE

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -137,7 +137,7 @@
 	else
 		move_delay = world.time
 
-	if(L.confused && L.m_intent == MOVE_INTENT_RUN && !HAS_TRAIT(L, TRAIT_CONFUSEIMMUNE))
+	if(L.confused && !L.carefulmovement() && !HAS_TRAIT(L, TRAIT_CONFUSEIMMUNE))
 		var/newdir = 0
 		if(L.confused > 40)
 			newdir = pick(GLOB.alldirs)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -137,7 +137,7 @@
 	else
 		move_delay = world.time
 
-	if(L.confused && !L.carefulmovement() && !HAS_TRAIT(L, TRAIT_CONFUSEIMMUNE))
+	if(L.confused && !L.movingcarefully() && !HAS_TRAIT(L, TRAIT_CONFUSEIMMUNE))
 		var/newdir = 0
 		if(L.confused > 40)
 			newdir = pick(GLOB.alldirs)


### PR DESCRIPTION

## About The Pull Request
adds the carefulmovement() proc. This proc, provided a mob
-is conscious
-is not buckled to something 
-has a speed equal to or less than the speed of a walking mob
will return true.  this replaces most checks that check if the mob is walking

## Why It's Good For The Game
walking is a rudimentary check that can be bypassed by speedups, vehicles, etc. A more standardized approach is both more difficult to bypass and easier to modify.

in the future, i may 
-make walking not stalk with other slowdowns
-make carefulmove() return true when standing still for a set amount of time

## Changelog
:cl:
code: most instances of code that check if the player is walking now check speed. This should have very little difference gameplay-wise, though vehicles will now no longer allow you to count as walking
/:cl:
