### PR TITLE
Allows server operators to dummy out SSBlackbox

### DIFF
--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -48,3 +48,5 @@
 	config_entry_value = 50
 	min_val = 1
 
+/datum/config_entry/flag/limited_feedback	// Enable a more limited form of feedback tracking
+	protection = CONFIG_ENTRY_LOCKED

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -19,6 +19,8 @@ SUBSYSTEM_DEF(blackbox)
 
 /datum/controller/subsystem/blackbox/Initialize()
 	triggertime = world.time
+	if(CONFIG_GET(flag/limited_feedback))
+		return ..()
 	record_feedback("amount", "random_seed", Master.random_seed)
 	record_feedback("amount", "dm_version", DM_VERSION)
 	record_feedback("amount", "dm_build", DM_BUILD)
@@ -98,10 +100,12 @@ SUBSYSTEM_DEF(blackbox)
 
 /datum/controller/subsystem/blackbox/Shutdown()
 	sealed = FALSE
+
+	if (CONFIG_GET(flag/limited_feedback) || !SSdbcore.Connect())
+		return
+
 	FinalFeedback()
 
-	if (!SSdbcore.Connect())
-		return
 
 	var/list/special_columns = list(
 		"datetime" = "NOW()"
@@ -118,7 +122,6 @@ SUBSYSTEM_DEF(blackbox)
 
 	if (!length(sqlrowlist))
 		return
-
 	SSdbcore.MassInsert(format_table_name("feedback"), sqlrowlist, ignore_errors = TRUE, delayed = TRUE, special_columns = special_columns)
 
 /datum/controller/subsystem/blackbox/proc/Seal()
@@ -131,7 +134,7 @@ SUBSYSTEM_DEF(blackbox)
 	return TRUE
 
 /datum/controller/subsystem/blackbox/proc/LogBroadcast(freq)
-	if(sealed)
+	if(sealed || CONFIG_GET(flag/limited_feedback))
 		return
 	switch(freq)
 		if(FREQ_COMMON)
@@ -228,7 +231,7 @@ Versioning
 						"gun_fired" = 2)
 */
 /datum/controller/subsystem/blackbox/proc/record_feedback(key_type, key, increment, data, overwrite)
-	if(sealed || !key_type || !istext(key) || !isnum_safe(increment || !data))
+	if(sealed || !key_type || !istext(key) || !isnum_safe(increment || !data) || CONFIG_GET(flag/limited_feedback))
 		return
 	var/datum/feedback_variable/FV = find_feedback_datum(key, key_type)
 	switch(key_type)

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -40,3 +40,6 @@ BLOCKING_QUERY_TIMEOUT 5
 
 ## The maximum number of additional threads BSQL is allowed to run at once
 BSQL_THREAD_LIMIT 50
+
+## Disable advanced feedback tracking, saving a substantial amount of database space.
+LIMITED_FEEDBACK


### PR DESCRIPTION
This allows marginal savings in performance and substantial savings in database disk size.
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds `/datum/config_entry/flag/limited_feedback`, a config flag allowing server hosts to disable the detailed feedback collection of SSBlackbox. Deaths will still be tracked.

Not specifying the flag will result in the existing behavior of full feedback and metrics tracking.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
haha innodb go brrrrr
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
server: ss13_feedback can now be disabled with the LIMITED_FEEDBACK flag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
