### PR TITLE
adds OSHA violations (nerfs floorlength bedhead)

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -319,6 +319,10 @@
 				return
 
 	operating = TRUE
+	
+	if(!safe)
+		for(var/mob/living/carbon/human/H in range(1))
+			H.oshaviolation(src, 1) //if we dont have safeties, their hair may get caught, dragging them in and crushing them
 
 	do_animate("closing")
 	layer = closingLayer

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -18,6 +18,8 @@
 	use_power(500)
 	var/O_limit
 	var/atom/target = get_edge_target_turf(src, dir)
+	for(var/mob/living/carbon/human/H in range(1))
+		H.oshaviolation(src, 2)
 	for(var/atom/movable/O in loc)
 		if(!O.anchored || ismecha(O))	//Mechs need their launch platforms.
 			if(ismob(O) && !isliving(O))

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -74,6 +74,9 @@
 		update_icon()
 	playsound(src, "sparks", 75, 1, -1)
 	to_chat(user, "<span class='notice'>You use the cryptographic sequencer on [src].</span>")
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user 
+		H.oshaviolation(src, 5) //OOPS!
 
 /obj/machinery/recycler/update_icon()
 	..()

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -636,6 +636,18 @@
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
+	if(ishuman(user) && on)
+		var/mob/living/carbon/human/H = user 
+		H.oshaviolation(src, 5)
+
+/obj/item/twohanded/required/chainsaw/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user 
+		H.oshaviolation(src, 1)
+	if(ishuman(target)) //Yes, if this happens, the target is thrown at the user, knocking them both down. I think that is hilarious.
+		var/mob/living/carbon/human/H = target 
+		H.oshaviolation(src, 1)
 
 /obj/item/twohanded/required/chainsaw/doomslayer
 	name = "THE GREAT COMMUNICATOR"

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -103,6 +103,9 @@
 		if("power")
 			on = !on
 			. = TRUE
+			if(on)
+				for(var/mob/living/carbon/human/H in range(1))
+					H.oshaviolation(src, 2)
 		if("eject")
 			if(holding)
 				replace_tank(usr, FALSE)

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -102,6 +102,19 @@
 				update_icon()
 	else
 		startgibbing(user)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user 
+			if(H.oshaviolation(src, 2))
+				H.Stun(50)
+				stoplag(25)
+				H.visible_message("<span class='danger'>[H] is sucked into the gibber!</span>", "<span class='userdanger'>you are sucked into the gibber!</span>")
+				H.forceMove(src)
+				occupant = H
+				update_icon()
+				stoplag(25)
+				if(prob(50))
+					startgibbing(H) //fuck!
+				
 
 /obj/machinery/gibber/attackby(obj/item/P, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "grinder_open", "grinder", P))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -894,3 +894,43 @@
 	ADD_TRAIT(src, TRAIT_NOBLOCK, type)
 	stoplag(50)
 	REMOVE_TRAIT(src, TRAIT_NOBLOCK, type)
+
+/mob/living/carbon/human/proc/oshaviolation(var/obj/O, workplace_accident_prob = 2)
+	var/OSHAVIOLATION = list("Long Bedhead", "Very Long Hair 1", "Very Long Hair 2", "Long Hair 1", "Long Hair 2", "Long Hair 3", "Long Side Part", "Hime Updo", "Hime Cut", "Hime Cut 2", "Drill Hair (Extended)")
+	var/OSHAVIOLATIONPLUS= list("Braid (Floorlength)", "Floorlength Bedhead")
+	if(head)
+		var/obj/item/I = head
+		if(I.flags_inv & HIDEHAIR)
+			return FALSE
+	if(wear_mask)
+		var/obj/item/I = wear_mask
+		if(I.flags_inv & HIDEHAIR)
+			return FALSE
+	if(hair_style in OSHAVIOLATION)
+		if(!prob(workplace_accident_prob))// for some reason, it only works this way
+			return FALSE
+		Stun(10)
+		apply_damage(15,"brute","head")
+		visible_message("<span class='notice'>[src] has their [hair_style] caught in [O]!</span>", "<span class='userdanger'>Your [hair_style] is caught in [O]!</span>")
+		if(prob(workplace_accident_prob * 10))
+			hair_style = "Bedhead"
+			update_hair()
+		emote("scream")
+	else if(hair_style in OSHAVIOLATIONPLUS)
+		if(!prob(workplace_accident_prob * 5))
+			return FALSE
+		Paralyze(20)
+		visible_message("<span class='notice'>[src] has their [hair_style] caught in [O]!</span>", "<span class='userdanger'>Your [hair_style] is caught in [O]!</span>")
+		if(prob(workplace_accident_prob * 20))
+			hair_style = "Long Bedhead"
+			update_hair()
+		apply_damage(15,"brute","head")
+		emote("scream")
+	else 
+		return FALSE
+	if(get_dist(src, O))
+		throw_at(O, get_dist(src, O), 2, spin = FALSE)
+	if(isitem(O))
+		var/obj/item/I = O 
+		attackby(I, src)
+	return TRUE


### PR DESCRIPTION
## About The Pull Request
having long hair is now dangerous around industrial machinery. (if the hair is not covered)
chainsaws, unsafe doors, portable scrubbers, the gibber, the recycler, and mass drivers all have interactions, and new ones are quite easy to add. These interactions are tailor-made to feel like they're out of a gory workplace safety PSA- stand next to a mass driver door? you get sucked in! mass driver activates and pulls you in as well, and you've been spaced! turn on a chainsaw, hair is stuck in? you fall on the saw! etc. New interactions are very easy to add, as simple as calling the proc

comprehensive list is as follows:
normal osha violation hair (very rare for a mishap to occur): "Long Bedhead", "Very Long Hair 1", "Very Long Hair 2", "Long Hair 1", "Long Hair 2", "Long Hair 3", "Long Side Part", "Hime Updo", "Hime Cut", "Hime Cut 2", "Drill Hair (Extended)"
super osha violation hair (5x chance for mishap): "Braid (Floorlength)", "Floorlength Bedhead"

## Why It's Good For The Game
it's midnight and i felt like making this pr. it's funny

plus, only shitters use floorlength bedhead

Edit:
To put a bit more in, this addition is incredibly fitting for the vibe and atmosphere of ss13. Workplace negligence leading to terrible bodily harm? Tell me that doesn't fit! 


## Changelog
:cl:
balance: long hair is now dangerous around industrial machinery
/:cl:
