### PR TITLE
Emergency clockcult patch, fixes deconversion, removes broadcasting from the hierophant relay.

### DIFF
--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -78,6 +78,7 @@
 	autolinkers = list("h_relay")
 	icon = 'icons/obj/clockwork_objects.dmi'
 	icon_state = "relay"
+	broadcasting = FALSE	//It only recieves
 
 //Generic preset relay
 /obj/machinery/telecomms/relay/preset/auto

--- a/code/modules/antagonists/clock_cult/clockwork_outfits.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_outfits.dm
@@ -13,8 +13,8 @@
 /datum/outfit/clockcult/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	if(weapon)
-		weapon = new weapon(get_turf(H))
-		H.put_in_inactive_hand(weapon)
+		var/weapon_to_spawn = new weapon(get_turf(H))
+		H.put_in_inactive_hand(weapon_to_spawn)
 
 /datum/outfit/clockcult/armaments
 	name = "Servant of Ratvar - Armaments"

--- a/code/modules/antagonists/clock_cult/mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clock_cult/mobs/clockwork_marauder.dm
@@ -28,6 +28,8 @@
 	melee_damage = 24
 	faction = list("ratvar")
 
+	initial_language_holder = /datum/language_holder/clockmob
+
 	var/shield_health = MARAUDER_SHIELD_MAX
 	var/next_shield_recharge = 0
 

--- a/code/modules/antagonists/clock_cult/mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clock_cult/mobs/clockwork_marauder.dm
@@ -67,6 +67,7 @@
 		damage_shield()
 		to_chat(src, "<span class='warning'>Your shield blocks the attack.</span>")
 		return BULLET_ACT_BLOCK
+	return ..()
 
 /mob/living/simple_animal/clockwork_marauder/proc/damage_shield()
 	if(shield_health == MARAUDER_SHIELD_MAX)

--- a/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/_clockwork_scripture.dm
@@ -29,6 +29,7 @@
 		end_invoke()
 		return
 	GLOB.clockcult_power -= power_cost
+	GLOB.clockcult_vitality -= vitality_cost
 	invoke_success()
 
 /datum/clockcult/scripture/proc/invoke_success()

--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -46,12 +46,12 @@
 	owner.language_holder.grant_language(/datum/language/ratvar)
 
 /datum/antagonist/servant_of_ratvar/on_removal()
-	. = ..()
 	team.remove_member(owner)
 	GLOB.servants_of_ratvar -= owner
 	GLOB.all_servants_of_ratvar -= owner
 	GLOB.human_servants_of_ratvar -= owner
 	GLOB.cyborg_servants_of_ratvar -= owner
+	. = ..()
 
 /datum/antagonist/servant_of_ratvar/apply_innate_effects(mob/living/M)
 	. = ..()

--- a/code/modules/antagonists/clock_cult/structure/clockwork_structure.dm
+++ b/code/modules/antagonists/clock_cult/structure/clockwork_structure.dm
@@ -10,7 +10,7 @@
 	density = TRUE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	var/can_be_repaired = TRUE //if a fabricator can repair it
-	break_message = "<span class='warning'>The frog isn't a meme after all!</span>" //The message shown when a structure breaks
+	break_message = "<span class='warning'>Sparks fly as the brass structure shatters across the ground.</span>" //The message shown when a structure breaks
 	break_sound = 'sound/magic/clockwork/anima_fragment_death.ogg' //The sound played when a structure breaks
 	debris = list(/obj/item/clockwork/alloy_shards/large = 1, \
 		/obj/item/clockwork/alloy_shards/medium = 2, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes deconversion on clockcult.
Removes broadcasting from the cult comms relay.

## Why It's Good For The Game

Bug fix, repairs an annoying feature.
Reported from austation.

## Changelog
:cl:
del: Hierophant relay no longer transmits the radio channels of people on Reebe, but will still recieve them.
fix: Clockies can now be deconverted properly.
fix: More than 1 of each weapon can now be summoned.
fix: Clockwork marauders can now speak rat'varian
fix: Clockwork marauders can now take damage from bullets
fix: Spells will now consume vitality when they are meant to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
