### PR TITLE
Crew manifest for cyborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -273,6 +273,11 @@
 	alerts.set_content(dat)
 	alerts.open()
 
+/mob/living/silicon/robot/verb/view_manifest()
+	set name = "View Crew Manifest"
+	set category = "Robot Commands"
+	ai_roster()
+
 /mob/living/silicon/robot/proc/ionpulse()
 	if(!ionpulse_on)
 		return


### PR DESCRIPTION
## About The Pull Request

Makes the crew manifest available for cyborgs under Robot Commands

## Why It's Good For The Game

Cyborgs have to constantly ask the AI, get to a security console or have to drag a tablet behind them to check if someone is on the crew manifest. This just makes it easier for cyborgs to check for crew members.

## Changelog
:cl:
add: Crew manifest available for cyborgs under "Robot Commands"
/:cl: