### PR TITLE
Heretics no longer ignore antag rep ignoring

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -42,7 +42,7 @@
 	for(var/i in 1 to num_ecult)
 		if(!antag_candidates.len)
 			break
-		var/datum/mind/cultie = antag_pick(antag_candidates)
+		var/datum/mind/cultie = antag_pick(antag_candidates, ROLE_HERETIC)
 		antag_candidates -= cultie
 		cultie.special_role = ROLE_HERETIC
 		cultie.restricted_roles = restricted_jobs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heretics will no longer consume rep if someone has it disabled.

## Why It's Good For The Game

All other antag_picks have it, was forgotten on heretics

## Changelog
:cl:
code: Players who don't want to be a heretic will no longer lose antag rep if selected as a heretic due to low pop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
