### PR TITLE
Attempts to track down a disease runtime

### DIFF
--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -9,6 +9,9 @@
 		diseases = _diseases
 	else
 		diseases = list(_diseases)
+	if(!diseases.len || isnull(diseases[1]))
+		stack_trace("Infective component initialized without any diseases!")
+		qdel(src)
 	if(expire_in)
 		expire_time = world.time + expire_in
 		QDEL_IN(src, expire_in)


### PR DESCRIPTION
```
runtime error: Cannot execute null.GetDiseaseID().  - proc name: CanContractDisease 
(/mob/living/proc/CanContractDisease)  -   source file: _MobProcs.dm,14  -   usr: (src)  -   src: 
Heart Broken (/mob/living/silicon/robot)  -   src.loc: the floor (160,148,2) 
(/turf/open/floor/plasteel)  -   call stack:  - Heart Broken (/mob/living/silicon/robot): 
CanContractDisease(null)  - Heart Broken (/mob/living/silicon/robot): 
ContactContractDisease(null, "l_foot")  - /datum/component/infective 
(/datum/component/infective): try infect(Heart Broken (/mob/living/silicon/robot), "l_foot")  
- /datum/component/infective (/datum/component/infective): try infect crossed(the infested 
floor (/obj/structure/alien/flesh), Heart Broken (/mob/living/silicon/robot))  - 
CallAsync(/datum/component/infective (/datum/component/infective), 
/datum/component/infective/pro... (/datum/component/infective/proc/try_infect_crossed), 
/list (/list))  - the infested floor (/obj/structure/alien/flesh):  SendSignal("movable_crossed",
 /list (/list))  - the infested floor (/obj/structure/alien/flesh): Crossed(Heart Broken 
(/mob/living/silicon/robot), null)
--
```

For some reason the infective component is trying to infect with a null disease.