### PR TITLE
Deepfrying nonfoods is no longer a qdel

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -237,20 +237,27 @@
 	item_flags = fried.item_flags
 	obj_flags = fried.obj_flags
 
+	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_batter)
+
 	if(istype(fried, /obj/item/reagent_containers/food/snacks))
 		fried.reagents.trans_to(src, fried.reagents.total_volume)
 		qdel(fried)
 	else
 		fried.forceMove(src)
+
+/obj/item/reagent_containers/food/snacks/deepfryholder/proc/clean_batter()
+	qdel(src)
 	
 /obj/item/reagent_containers/food/snacks/deepfryholder/Destroy()
 	if(contents)
-		QDEL_LIST(contents)
+		for(var/atom/movable/A in contents)
+			A.forceMove(src.turf)
 	. = ..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
 	if(contents)
-		QDEL_LIST(contents)
+		for(var/atom/movable/A in contents)
+			A.forceMove(src.turf)
 	..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -247,17 +247,11 @@
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/clean_batter()
 	qdel(src)
-	
-/obj/item/reagent_containers/food/snacks/deepfryholder/Destroy()
-	if(contents)
-		for(var/atom/movable/A in contents)
-			A.forceMove(src.turf)
-	. = ..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
 	if(contents)
 		for(var/atom/movable/A in contents)
-			A.forceMove(src.turf)
+			A.forceMove(eater.loc)
 	..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)


### PR DESCRIPTION

## About The Pull Request
sticking something in the deep fryer or coating it with cooking oil now does nothing more than batter the item. it does not render the item in any way inoperable or irretrievable. Cleaning the item, eating it, etc, removes the oil.

## Why It's Good For The Game
deep frying via oil spray became a meta after some asshole made a video on it. it was already shifty to have a qdel machine right fucking there in the kitchen, that has no checks on item resistance whatsoever.

note that this does not change deep frying behaviour for foods


## Changelog
:cl:
balance: fried items can now be retrieved through eating or cleaning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
