### PR TITLE
ghost role cooldown

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -544,3 +544,7 @@
 	config_entry_value = 18000
 	integer = FALSE
 	min_val = 0
+
+/datum/config_entry/number/ghost_role_cooldown
+	config_entry_value = 0
+	min_val = 0

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -475,7 +475,7 @@ obj/effect/sweatsplash/proc/splash()
 								chosen.Insert(M, TRUE, FALSE)
 								to_chat(M, "<span class='userdanger'>As the [chosen] touches your skin, it is promptly absorbed.</span>")
 					if(missing.len) //we regrow one missing limb
-						for(var/Z in missing) //uses the same text and sound a ling's regen does. This can false-flag the host as a changeling. 
+						for(var/Z in missing) //uses the same text and sound a ling's regen does. This can false-flag the host as a changeling.
 							if(M.regenerate_limb(Z, TRUE))
 								playsound(M, 'sound/magic/demon_consume.ogg', 50, 1)
 								M.visible_message("<span class='warning'>[M]'s missing limbs \
@@ -500,7 +500,7 @@ obj/effect/sweatsplash/proc/splash()
 									M.grab_ghost()
 								break
 				if(tetsuo && prob(10) && A.affected_mob.job == "Clown")
-					new /obj/effect/spawner/lootdrop/teratoma/major/clown(M.loc)				
+					new /obj/effect/spawner/lootdrop/teratoma/major/clown(M.loc)
 			if(bruteheal)
 				M.heal_overall_damage(2 * power, required_status = BODYPART_ORGANIC)
 				if(prob(11 * power))
@@ -534,6 +534,7 @@ obj/effect/sweatsplash/proc/splash()
 	flavour_text = {"
 	<b>You are a living teratoma, and your existence is misery. You feel the need to spread woe about the station- but not to kill.
 	"}
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/teratomamonkey/Initialize()
 	. = ..()

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -17,6 +17,7 @@
 	Your goal is to cultivate and spread life wherever it will go while waiting for contact from your creators. \
 	Estimated time of last contact: Deployment, 5000 millennia ago."
 	assignedrole = "Lifebringer"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)
 	var/plant_name = pick("Tomato", "Potato", "Broccoli", "Carrot", "Ambrosia", "Pumpkin", "Ivy", "Kudzu", "Banana", "Moss", "Flower", "Bloom", "Root", "Bark", "Glowshroom", "Petal", "Leaf", \
@@ -52,6 +53,7 @@
 	Fresh sacrifices for your nest."
 	assignedrole = "Ash Walker"
 	var/datum/team/ashwalkers/team
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
 	new_spawn.fully_replace_character_name(null,random_unique_lizard_name(gender))
@@ -91,6 +93,7 @@
 	flavour_text = "Years ago, you sacrificed the lives of your trusted friends and the humanity of yourself to reach the Wish Granter. Though you \
 	did so, it has come at a cost: your very body rejects the light, dooming you to wander endlessly in this horrible wasteland."
 	assignedrole = "Exile"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/exile/Destroy()
 	new/obj/structure/fluff/empty_sleeper(get_turf(src))
@@ -193,6 +196,7 @@
 	has_owner = TRUE
 	name = "inert servant golem shell"
 	mob_name = "a servant golem"
+	use_cooldown = FALSE
 
 
 /obj/effect/mob_spawn/human/golem/adamantine
@@ -201,6 +205,7 @@
 	mob_name = "a free golem"
 	can_transfer = FALSE
 	mob_species = /datum/species/golem/adamantine
+	use_cooldown = TRUE	//Only the roundstart free golems are
 
 //Malfunctioning cryostasis sleepers: Spawns in makeshift shelters in lavaland. Ghosts become hermits with knowledge of how they got to where they are now.
 /obj/effect/mob_spawn/human/hermit
@@ -218,6 +223,7 @@
 	the hostile creatures, and the ash drakes swooping down from the cloudless skies, all you can wish for is the feel of soft grass between your toes and \
 	the fresh air of Earth. These thoughts are dispelled by yet another recollection of how you got here... "
 	assignedrole = "Hermit"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/hermit/Initialize(mapload)
 	. = ..()
@@ -280,6 +286,7 @@
 	though fate has other plans for you."
 	flavour_text = "Good. It seems as though your ship crashed. You remember that you were convicted of "
 	assignedrole = "Escaped Prisoner"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/prisoner_transport/special(mob/living/L)
 	L.fully_replace_character_name(null,"NTP #LL-0[rand(111,999)]") //Nanotrasen Prisoner #Lavaland-(numbers)
@@ -319,6 +326,7 @@
 	flavour_text = "You are a staff member of a top-of-the-line space hotel! Cater to guests and make sure the manager doesn't fire you."
 	important_info = "DON'T leave the hotel"
 	assignedrole = "Hotel Staff"
+	use_cooldown = TRUE
 
 /datum/outfit/hotelstaff
 	name = "Hotel Staff"
@@ -498,6 +506,7 @@
 	r_pocket = /obj/item/restraints/handcuffs
 	l_pocket = /obj/item/assembly/flash/handheld
 	assignedrole = "Ancient Crew"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/oldsec/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
@@ -524,6 +533,7 @@
 	gloves = /obj/item/clothing/gloves/color/fyellow/old
 	l_pocket = /obj/item/tank/internals/emergency_oxygen
 	assignedrole = "Ancient Crew"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/oldeng/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
@@ -549,6 +559,7 @@
 	id = /obj/item/card/id/away/old/sci
 	l_pocket = /obj/item/stack/medical/bruise_pack
 	assignedrole = "Ancient Crew"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/oldsci/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -337,8 +337,7 @@
 	icon_state = "sleeper"
 	short_desc = "You are a space doctor!"
 	assignedrole = "Space Doctor"
-	use_cooldown = TRUE
-	use_cooldown = TRUE
+	use_cooldown = TRUE // Use cooldown
 
 /obj/effect/mob_spawn/human/doctor/alive/equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -30,6 +30,7 @@
 	var/show_flavour = TRUE
 	var/banType = ROLE_LAVALAND
 	var/ghost_usable = TRUE
+	var/use_cooldown = FALSE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/attack_ghost(mob/user)
@@ -42,6 +43,9 @@
 		to_chat(user, "<span class='warning'>You are jobanned!</span>")
 		return
 	if(QDELETED(src) || QDELETED(user))
+		return
+	if(use_cooldown && user.client.next_ghost_role_tick > world.time)
+		to_chat(user, "<span class='warning'>You have died recently, you must wait [(user.client.next_ghost_role_tick - world.time)/10] seconds until you can use a ghost spawner.</span>")
 		return
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)
@@ -333,6 +337,8 @@
 	icon_state = "sleeper"
 	short_desc = "You are a space doctor!"
 	assignedrole = "Space Doctor"
+	use_cooldown = TRUE
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/doctor/alive/equip(mob/living/carbon/human/H)
 	..()
@@ -390,6 +396,7 @@
 	flavour_text = "Time to mix drinks and change lives. Smoking space drugs makes it easier to understand your patrons' odd dialect."
 	assignedrole = "Space Bartender"
 	id_job = "Bartender"
+	use_cooldown = TRUE
 
 /datum/outfit/spacebartender
 	name = "Space Bartender"
@@ -414,6 +421,7 @@
 	short_desc = "You're, like, totally a dudebro, bruh."
 	flavour_text = "Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot chicks, y'knaw?"
 	assignedrole = "Beach Bum"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/beach/alive/lifeguard
 	short_desc = "You're a spunky lifeguard!"
@@ -501,6 +509,7 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	short_desc = "You are a Nanotrasen Commander!"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/nanotrasensoldier/alive
 	death = FALSE
@@ -511,6 +520,7 @@
 	icon_state = "sleeper"
 	faction = "nanotrasenprivate"
 	short_desc = "You are a Nanotrasen Private Security Officer!"
+	use_cooldown = TRUE
 
 
 /////////////////Spooky Undead//////////////////////
@@ -529,6 +539,7 @@
 	short_desc = "By unknown powers, your skeletal remains have been reanimated!"
 	flavour_text = "Walk this mortal plain and terrorize all living adventurers who dare cross your path."
 	assignedrole = "Skeleton"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/skeleton/alive/equip(mob/living/carbon/human/H)
 	var/obj/item/implant/exile/implant = new/obj/item/implant/exile(H)
@@ -548,7 +559,7 @@
 	icon_state = "remains"
 	short_desc = "By unknown powers, your rotting remains have been resurrected!"
 	flavour_text = "Walk this mortal plain and terrorize all living adventurers who dare cross your path."
-
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/abductor
 	name = "abductor"

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -594,6 +594,7 @@
 	short_desc = "You are a syndicate operative recently awoken from cryostasis in an underground outpost."
 	flavour_text = "You are a syndicate operative recently awoken from cryostasis in an underground outpost. Monitor Nanotrasen communications and record information. All intruders should be \
 	disposed of swiftly to assure no gathered information is stolen or lost. Try not to wander too far from the outpost as the caves can be a deadly place even for a trained operative such as yourself."
+	use_cooldown = TRUE
 
 /datum/outfit/snowsyndie
 	name = "Syndicate Snow Operative"

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -111,3 +111,6 @@
 	var/datum/viewData/view_size
 	/// rate limiting for the crew manifest
 	var/crew_manifest_delay
+
+	//Tick when ghost roles are useable again
+	var/next_ghost_role_tick = 0

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -88,7 +88,7 @@
 		reload_fullscreen()
 		client.move_delay = initial(client.move_delay)
 		//This first death of the game will not incur a ghost role cooldown
-		client.next_ghost_role_tick = client.next_ghost_role_tick ? world.time + CONFIG_GET(number/ghost_role_cooldown) : world.time
+		client.next_ghost_role_tick = client.next_ghost_role_tick || suiciding ? world.time + CONFIG_GET(number/ghost_role_cooldown) : world.time
 
 		SSmedals.UnlockMedal(MEDAL_GHOSTS,client)
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -87,7 +87,8 @@
 		reset_perspective(null)
 		reload_fullscreen()
 		client.move_delay = initial(client.move_delay)
-
+		//This first death of the game will not incur a ghost role cooldown
+		client.next_ghost_role_tick = client.next_ghost_role_tick ? world.time + CONFIG_GET(number/ghost_role_cooldown) : world.time
 
 		SSmedals.UnlockMedal(MEDAL_GHOSTS,client)
 

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -114,6 +114,7 @@
 	important_info = "The base is rigged with explosives, DO NOT abandon it or let it fall into enemy hands!"
 	outfit = /datum/outfit/lavaland_syndicate
 	assignedrole = "Lavaland Syndicate"
+	use_cooldown = TRUE
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/special(mob/living/new_spawn)
 	new_spawn.grant_language(/datum/language/codespeak)

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -440,92 +440,92 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
             to_chat(user, "No vacated rooms.")
 
 /obj/effect/mob_spawn/human/doctorhilbert
-    name = "Doctor Hilbert"
-    mob_name = "Doctor Hilbert"
-    mob_gender = "male"
-    assignedrole = null
-    ghost_usable = FALSE
-    oxy_damage = 500
-    mob_species = /datum/species/skeleton
-    id_job = "Head Researcher"
-    id_access = ACCESS_RESEARCH
-    id_access_list = list(ACCESS_AWAY_GENERIC3, ACCESS_RESEARCH)
-    instant = TRUE
-    id = /obj/item/card/id/silver
-    uniform = /obj/item/clothing/under/rank/rnd/research_director
-    shoes = /obj/item/clothing/shoes/sneakers/brown
-    back = /obj/item/storage/backpack/satchel/leather
-    suit = /obj/item/clothing/suit/toggle/labcoat
+	name = "Doctor Hilbert"
+	mob_name = "Doctor Hilbert"
+	mob_gender = "male"
+	assignedrole = null
+	ghost_usable = FALSE
+	oxy_damage = 500
+	mob_species = /datum/species/skeleton
+	id_job = "Head Researcher"
+	id_access = ACCESS_RESEARCH
+	id_access_list = list(ACCESS_AWAY_GENERIC3, ACCESS_RESEARCH)
+	instant = TRUE
+	id = /obj/item/card/id/silver
+	uniform = /obj/item/clothing/under/rank/rnd/research_director
+	shoes = /obj/item/clothing/shoes/sneakers/brown
+	back = /obj/item/storage/backpack/satchel/leather
+	suit = /obj/item/clothing/suit/toggle/labcoat
 	use_cooldown = TRUE
 
 /obj/item/paper/crumpled/docslogs
-    name = "Research Logs"
+	name = "Research Logs"
 
 /obj/item/paper/crumpled/docslogs/Initialize()
-    . = ..()
-    GLOB.hhmysteryRoomNumber = rand(1, SHORT_REAL_LIMIT)
-    info = {"<h4><center>Research Logs</center></h4>
+	. = ..()
+	GLOB.hhmysteryRoomNumber = rand(1, SHORT_REAL_LIMIT)
+	info = {"<h4><center>Research Logs</center></h4>
 	I might just be onto something here!<br>
 	The strange space-warping properties of bluespace have been known about for awhile now, but I might be on the verge of discovering a new way of harnessing it.<br>
 	It's too soon to say for sure, but this might be the start of something quite important!<br>
-    I'll be sure to log any major future breakthroughs. This might be a lot more than I can manage on my own, perhaps I should hire that secretary after all...<br>
+	I'll be sure to log any major future breakthroughs. This might be a lot more than I can manage on my own, perhaps I should hire that secretary after all...<br>
 	<h4>Breakthrough!</h4>
 	I can't believe it, but I did it! Just when I was certain it couldn't be done, I made the final necessary breakthrough.<br>
-    Exploiting the effects of space dilation caused by specific bluespace structures combined with a precise use of geometric calculus, I've discovered a way to correlate an infinite amount of space within a finite area!<br>
-    While the potential applications are endless, I utilized it in quite a nifty way so far by designing a system that recursively constructs subspace rooms and spatially links them to any of the infinite infinitesimally distinct points on the spheres surface.<br>
-    I call it: Hilbert's Hotel!<br>
+	Exploiting the effects of space dilation caused by specific bluespace structures combined with a precise use of geometric calculus, I've discovered a way to correlate an infinite amount of space within a finite area!<br>
+	While the potential applications are endless, I utilized it in quite a nifty way so far by designing a system that recursively constructs subspace rooms and spatially links them to any of the infinite infinitesimally distinct points on the spheres surface.<br>
+	I call it: Hilbert's Hotel!<br>
 	<h4>Goodbye</h4>
 	I can't take this anymore. I know what happens next, and the fear of what is coming leaves me unable to continue working.<br>
-    Any fool in my field has heard the stories. It's not that I didn't believe them, it's just... I guess I underestimated the importance of my own research...<br>
-    Robert has reported a further increase in frequency of the strange, prying visitors who ask questions they have no business asking. I've requested him to keep everything on strict lockdown and have permanently dismissed all other assistants.<br>
-    I've also instructed him to use the encryption method we discussed for any important quantitative data. The poor lad... I don't think he truly understands what he's gotten himself into...<br>
-    It's clear what happens now. One day they'll show up uninvited, and claim my research as their own, leaving me as nothing more than a bullet ridden corpse floating in space.<br>
-    I can't stick around to the let that happen.<br>
-    I'm escaping into the very thing that brought all this trouble to my doorstep in the first place - my hotel.<br>
-    I'll be in <u>[uppertext(num2hex(GLOB.hhmysteryRoomNumber, 0))]</u> (That will make sense to anyone who should know)<br>
-    I'm sorry that I must go like this. Maybe one day things will be different and it will be safe to return... maybe...<br>
-    Goodbye<br>
+	Any fool in my field has heard the stories. It's not that I didn't believe them, it's just... I guess I underestimated the importance of my own research...<br>
+	Robert has reported a further increase in frequency of the strange, prying visitors who ask questions they have no business asking. I've requested him to keep everything on strict lockdown and have permanently dismissed all other assistants.<br>
+	I've also instructed him to use the encryption method we discussed for any important quantitative data. The poor lad... I don't think he truly understands what he's gotten himself into...<br>
+	It's clear what happens now. One day they'll show up uninvited, and claim my research as their own, leaving me as nothing more than a bullet ridden corpse floating in space.<br>
+	I can't stick around to the let that happen.<br>
+	I'm escaping into the very thing that brought all this trouble to my doorstep in the first place - my hotel.<br>
+	I'll be in <u>[uppertext(num2hex(GLOB.hhmysteryRoomNumber, 0))]</u> (That will make sense to anyone who should know)<br>
+	I'm sorry that I must go like this. Maybe one day things will be different and it will be safe to return... maybe...<br>
+	Goodbye<br>
 	<br>
 	<i>Doctor Hilbert</i>"}
 
 /obj/item/paper/crumpled/robertsworkjournal
-    name = "Work Journal"
-    info = {"<h4>First Week!</h4>
+	name = "Work Journal"
+	info = {"<h4>First Week!</h4>
 	First week on the new job. It's a secretarial position, but hey, whatever pays the bills. Plus it seems like some interesting stuff goes on here.<br>
 	Doc says its best that I don't openly talk about his research with others, I guess he doesn't want it getting out or something. I've caught myself slipping a few times when talking to others, it's hard not to brag about something this cool!<br>
 	I'm not really sure why I'm choosing to journal this. Doc seems to log everything. He says it's incase he discovers anything important.<br>
-    I guess that's why I'm doing it too, I've always wanted to be a part of something important.<br>
-    Here's to a new job and to becoming a part of something important!<br>
+	I guess that's why I'm doing it too, I've always wanted to be a part of something important.<br>
+	Here's to a new job and to becoming a part of something important!<br>
 	<h4>Weird times...</h4>
 	Things are starting to get a little strange around here. Just weeks after Doc's amazing breakthrough, weird visitors have began showing up unannounced, asking strange things about Doc's work.<br>
-    I knew Doc wasn't a big fan of company, but even he seemed strangely unnerved when I told him about the visitors.<br>
-    He said it's important that from here on out we keep tight security on everything, even other staff members.<br>
-    He also said something about securing data, something about hexes. What's that mean? Some sort of curse? Doc never struck me as the magic type...<br>
-    He often uses a lot of big sciencey words that I don't really understand, but I kinda dig it, it makes me feel like I'm witnessing something big.<br>
-    I hope things go back to normal soon, but I guess that's the price you pay for being a part of something important.<br>
+	I knew Doc wasn't a big fan of company, but even he seemed strangely unnerved when I told him about the visitors.<br>
+	He said it's important that from here on out we keep tight security on everything, even other staff members.<br>
+	He also said something about securing data, something about hexes. What's that mean? Some sort of curse? Doc never struck me as the magic type...<br>
+	He often uses a lot of big sciencey words that I don't really understand, but I kinda dig it, it makes me feel like I'm witnessing something big.<br>
+	I hope things go back to normal soon, but I guess that's the price you pay for being a part of something important.<br>
 	<h4>Last day I guess?</h4>
 	Things are officially starting to get too strange for me.<br>
-    The visitors have been coming a lot more often, and they all seem increasingly aggressive and nosey. I'm starting to see why they made Doc so nervous, they're certainly starting to creep me out too.<br>
-    Awhile ago Doc started having me keep the place on strict lockdown and requested I refuse entry to anyone else, including previous staff.<br>
-    But the weirdest part?<br>
-    I haven't seen Doc in days. It's not unusual for him to work continuously for long periods of time in the lab, but when I took a peak in their yesterday - he was nowhere to be seen! I didn't risk prying much further, Doc had a habit of leaving the defense systems on these last few weeks.<br>
-    I'm thinking it might be time to call it quits. Can't work much without a boss, plus things are starting to get kind of shady. I wanted to be a part of something important, but you gotta know when to play it safe.<br>
-    As my dad always said, "The smart get famous, but the wise survive..."<br>
+	The visitors have been coming a lot more often, and they all seem increasingly aggressive and nosey. I'm starting to see why they made Doc so nervous, they're certainly starting to creep me out too.<br>
+	Awhile ago Doc started having me keep the place on strict lockdown and requested I refuse entry to anyone else, including previous staff.<br>
+	But the weirdest part?<br>
+	I haven't seen Doc in days. It's not unusual for him to work continuously for long periods of time in the lab, but when I took a peak in their yesterday - he was nowhere to be seen! I didn't risk prying much further, Doc had a habit of leaving the defense systems on these last few weeks.<br>
+	I'm thinking it might be time to call it quits. Can't work much without a boss, plus things are starting to get kind of shady. I wanted to be a part of something important, but you gotta know when to play it safe.<br>
+	As my dad always said, "The smart get famous, but the wise survive..."<br>
 	<br>
 	<i>Robert P.</i>"}
 
 /obj/item/paper/crumpled/bloody/docsdeathnote
-    name = "note"
-    info = {"This is it isn't it?<br>
-    No one's coming to help, that much has become clear.<br>
-    Sure, it's lonely, but do I have much choice? At least I brought the analyzer with me, they shouldn't be able to find me without it.<br>
-    Who knows who's waiting for me out there. Its either die out there in their hands, or die a slower, slightly more comfortable death in here.<br>
-    Everyday I can feel myself slipping away more and more, both physically and mentally. Who knows what happens now...<br>
-    Heh, so it's true then, this must be the inescapable path of all great minds... so be it then.<br>
-    <br>
-    <br>
-    <br>
-    <i>Choose a room, and enter the sphere<br>
-    Lay your head to rest, it soon becomes clear<br>
-    There's always more room around every bend<br>
-    Not all that's countable has an end...<i>"}
+	name = "note"
+	info = {"This is it isn't it?<br>
+	No one's coming to help, that much has become clear.<br>
+	Sure, it's lonely, but do I have much choice? At least I brought the analyzer with me, they shouldn't be able to find me without it.<br>
+	Who knows who's waiting for me out there. Its either die out there in their hands, or die a slower, slightly more comfortable death in here.<br>
+	Everyday I can feel myself slipping away more and more, both physically and mentally. Who knows what happens now...<br>
+	Heh, so it's true then, this must be the inescapable path of all great minds... so be it then.<br>
+	<br>
+	<br>
+	<br>
+	<i>Choose a room, and enter the sphere<br>
+	Lay your head to rest, it soon becomes clear<br>
+	There's always more room around every bend<br>
+	Not all that's countable has an end...<i>"}

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -456,6 +456,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
     shoes = /obj/item/clothing/shoes/sneakers/brown
     back = /obj/item/storage/backpack/satchel/leather
     suit = /obj/item/clothing/suit/toggle/labcoat
+	use_cooldown = TRUE
 
 /obj/item/paper/crumpled/docslogs
     name = "Research Logs"

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -539,5 +539,5 @@ VOTE_AUTOTRANSFER_INITIAL 54000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000
 
-## Ghost role cooldown time after death
+## Ghost role cooldown time after death (In deciseconds)
 GHOST_ROLE_COOLDOWN 3000

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -538,3 +538,6 @@ VOTE_AUTOTRANSFER_ENABLED
 VOTE_AUTOTRANSFER_INITIAL 54000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000
+
+## Ghost role cooldown time after death
+GHOST_ROLE_COOLDOWN 3000

--- a/config/config.txt
+++ b/config/config.txt
@@ -541,3 +541,6 @@ VOTE_AUTOTRANSFER_ENABLED
 VOTE_AUTOTRANSFER_INITIAL 54000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000
+
+## Ghost role cooldown time after death
+GHOST_ROLE_COOLDOWN 3000

--- a/config/config.txt
+++ b/config/config.txt
@@ -542,5 +542,5 @@ VOTE_AUTOTRANSFER_INITIAL 54000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000
 
-## Ghost role cooldown time after death
+## Ghost role cooldown time after death (In deciseconds)
 GHOST_ROLE_COOLDOWN 3000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a short cooldown (5 minutes) for ghost role spawners upon death.

Notes:
 - Does not affect the first death, unless the death was caused by suicide.
 - Does not affect golem shells, xenobiology spawns or any over antagonist related ghost roles (pirates), this only affects the mapping ones such as lavaland doctors.

The effect is very minor (being only 5 minutes after death) and merely prevents spamming while having almost no impact on players that are not abusing them.e

## Why It's Good For The Game

Prevents one player from taking all of the ghost roles and going to try and fight an ash drake with all 3 lives.

## Changelog
:cl:
add: Adds a 5-minute cooldown to non antagonist related ghost roles if the client has more than 2 deaths or has committed suicide.
code: Replaces spaces in hilbert's hotel with tabs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
