### PR TITLE
Fixes disappearing plating with Conjure spells.

### DIFF
--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -33,6 +33,8 @@
 			var/N = summoned_object_type
 			if(istype(O, /turf/open) && ispath(N, /turf/closed))
 				new N(O)
+			if(istype(O, /turf/open/floor/plating))
+				new N(O)
 			else
 				O.ChangeTurf(N, flags = CHANGETURF_INHERIT_AIR)
 		else

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -31,9 +31,7 @@
 		if(ispath(summoned_object_type, /turf))
 			var/turf/O = spawn_place
 			var/N = summoned_object_type
-			if(istype(O, /turf/open) && ispath(N, /turf/closed))
-				new N(O)
-			if(istype(O, /turf/open/floor/plating))
+			if(istype(O, /turf/open) && ispath(N, /turf/closed) || istype(O, /turf/open/floor/plating))
 				new N(O)
 			else
 				O.ChangeTurf(N, flags = CHANGETURF_INHERIT_AIR)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -31,7 +31,10 @@
 		if(ispath(summoned_object_type, /turf))
 			var/turf/O = spawn_place
 			var/N = summoned_object_type
-			O.ChangeTurf(N, flags = CHANGETURF_INHERIT_AIR)
+			if(istype(O, /turf/open) && ispath(N, /turf/closed))
+				new N(O)
+			else
+				O.ChangeTurf(N, flags = CHANGETURF_INHERIT_AIR)
 		else
 			var/atom/summoned_object = new summoned_object_type(spawn_place)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prevents unintended behavior of removing plating when building walls via Construct spells on top of plating, causing instant atmos leaks when the walls are removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Will prevent accidental atmos leaks during Cult rounds because of bad handling of the spells.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:ritea
fix: Plating no longer disappears when you build walls with spells!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
