### PR TITLE
Changes Ash Lizards to Lavaland Kobolds

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -78,3 +78,12 @@
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
 	inherent_traits = list(TRAIT_NOGUNS,TRAIT_NOBREATH)
 	species_language_holder = /datum/language_holder/lizard/ash
+
+/datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+  . = ..() //call everything from species/on_species_gain()
+  C.dna.add_mutation(DWARFISM)
+
+/datum/species/lizard/ashwalker/on_species_loss(mob/living/carbon/C, datum/species/old_species, pref_load)
+  . = ..() //call everything from species/on_species_gain()
+  C.dna.remove_mutation(DWARFISM)
+


### PR DESCRIPTION
## About The Pull Request

 This is a small rework that only gives Ash lizards dwarfism for the sole purpose of making Ash lizards more distinguishable from Station/Mining lizards, whilst also making lavaland a little more immersive with a simple change. This also helps make them more noticeable if they sneak on to the station or mining base. 

![kobold king](https://user-images.githubusercontent.com/27740099/95035012-de4b7600-0680-11eb-81db-11be5636a6ab.png)


## Why It's Good For The Game

**_Kobold.- (in Germanic mythology) a spirit that haunts houses or lives underground in caves or mines._** 

I think this would be a small change to the ash lizards that would make diplomatic relationships funnier and lavaland more immersive. As it stands, currently ash lizards are just lizards that can't use technology or mining equipment. Ash lizards being Kobolds leads to more meme worthy shenanigans and further ties another fantasy trope to lavaland. This also sets up a rival faction to dwarves if you ever decide to add them. 

Fantasy kobolds also fit the slot for what ash lizards are. In fantasy, Kobolds are mining mooks that commit horrible tribal atrocities such as eating humanoids and being a nuisance in caves and mines. They are the best miners in fantasy, outpacing even Dwarves (but not matching their intellect). They also worship dragons. We have dragons. Now we should have kobolds. 

I also didn't change the name, so as to avoid any stigma with kobolds, as kobolds seem to be sexualized according to the coders I presented this idea to. They're Ash Lizards, if the players wish to call them Kobolds that's their choice. This can be changed if the maintainers wish it too however. 

![kobold](https://user-images.githubusercontent.com/27740099/95035696-1e135d00-0683-11eb-9f92-76eb0076f886.png)

## Changelog
:cl:
add: Gave the Ash lizard Subspecies Dwarfism.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
