### PR TITLE
Changeling Infiltrators

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -160,6 +160,8 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	report_type = "changeling infiltration"
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Personnel","Head of Security","Research Director","Chief Engineer","Chief Medical Officer", "Captain", "Brig Physician","VIP","Chaplain","Warden","Quartermaster")	//exclude the possible target roles... Just in case.
 	force_team_mode = TRUE
+	required_players = 40
+	required_enemies = 3
 
 /datum/game_mode/changeling/infiltration/generate_report()
 	return "Worrying reports in your sector indicate the presence of shape shifting alien creatures, the linkes of which we have never seen before. We believe the ultimate goal of these creatures	\

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 
 	var/const/changeling_amount = 4 //hard limit on changelings if scaling is turned off
 	var/list/changelings = list()
+	var/force_team_mode = FALSE
 
 /datum/game_mode/changeling/pre_setup()
 
@@ -64,6 +65,7 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	for(var/datum/mind/changeling in changelings)
 		log_game("[key_name(changeling)] has been selected as a changeling")
 		var/datum/antagonist/changeling/new_antag = new()
+		new_antag.team_mode = force_team_mode
 		changeling.add_antag_datum(new_antag)
 	..()
 
@@ -150,3 +152,16 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 
 	round_credits += ..()
 	return round_credits
+
+
+/datum/game_mode/changeling/infiltration
+	name = "changeling infiltration"
+	config_tag = "changeling infiltration"
+	report_type = "changeling infiltration"
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Personnel","Head of Security","Research Director","Chief Engineer","Chief Medical Officer", "Captain", "Brig Physician","VIP","Chaplain","Warden","Quartermaster")	//exclude the possible target roles... Just in case.
+	force_team_mode = TRUE
+
+/datum/game_mode/changeling/infiltration/generate_report()
+	return "Worrying reports in your sector indicate the presence of shape shifting alien creatures, the linkes of which we have never seen before. We believe the ultimate goal of these creatures	\
+			is to infiltrate the highest ranks of our organisation, but their purpose is unknown. Beware, these creatures can take the guise of any humanoid creature and will become hostile when	\
+			their identity is revealed; please approach them with caution.

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -476,6 +476,52 @@ GLOBAL_LIST_EMPTY(objectives)
 /datum/objective/escape/escape_with_identity/admin_edit(mob/admin)
 	admin_simple_target_pick(admin)
 
+/datum/objective/escape/escape_with_identity/head_hunter
+	name = "escape as highest in command"
+
+/datum/objective/escape/escape_with_identity/head_hunter/find_target(dupe_search_range, blacklist)	//just copy paste the code from base/find_target.
+	var/list/datum/mind/owners = get_owners()
+	if(!dupe_search_range)
+		dupe_search_range = get_owners()
+	var/list/possible_targets = list()
+	var/try_target_late_joiners = TRUE
+	for(var/I in owners)
+		var/datum/mind/O = I
+		if(O.late_joiner)
+			try_target_late_joiners = TRUE
+	for(var/datum/mind/possible_target in get_crewmember_minds())
+		if(!(possible_target in owners) && ishuman(possible_target.current) && (possible_target.current.stat != DEAD) && is_unique_objective(possible_target,dupe_search_range) && !possible_target.isAntagTarget)
+			if (!(possible_target in blacklist))
+				possible_targets += possible_target
+	if(try_target_late_joiners)
+		var/list/all_possible_targets = possible_targets.Copy()
+		for(var/I in all_possible_targets)
+			var/datum/mind/PT = I
+			if(!PT.late_joiner)
+				possible_targets -= PT
+		if(!possible_targets.len)
+			possible_targets = all_possible_targets
+	if(possible_targets.len > 0)		
+		for(var/datum/mind/possible_target in possible_targets)
+			if(get_target_value(possible_target)> 0 && (target==null || get_target_value(possible_target)>get_target_value(target)))
+				target = possible_target	
+		if (target==null)
+			target = pick(possible_targets)
+		target.isAntagTarget = TRUE
+	update_explanation_text()
+	return target
+	
+/datum/objective/escape/escape_with_identity/head_hunter/proc/get_target_value(datum/mind/target)
+	if (target.assigned_role in list("Captain"))
+		return 4
+	else if (target.assigned_role in list("Head of Personnel","Head of Security","Research Director","Chief Engineer","Chief Medical Officer"))
+		return 3
+	else if (target.assigned_role in list("VIP","Chaplain","Warden","Quartermaster"))
+		return 2
+	//else if (target.assigned_role in list("Clown","Mime"))	HEHE no.
+	//	return 1
+	return 0
+
 /datum/objective/survive
 	name = "survive"
 	explanation_text = "Stay alive until the end."

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -26,6 +26,7 @@
 	var/genetic_points_remaining = changeling.geneticpoints
 	var/absorbed_dna_count = changeling.absorbedcount
 	var/true_absorbs = changeling.trueabsorbs
+	var/team_mode = changeling.team_mode
 
 	data["can_readapt"] = can_readapt
 	data["genetic_points_remaining"] = genetic_points_remaining
@@ -37,6 +38,9 @@
 		var/datum/action/changeling/ability = path
 
 		var/dna_cost = initial(ability.dna_cost)
+		var/infiltrate_cost = initial(ability.dnai_cost)	//hack for infiltration
+		if (team_mode && infiltrate_cost>=0)
+			dna_cost = infiltrate_cost	
 		if(dna_cost <= 0)
 			continue
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -388,6 +388,8 @@
 			ac.owner = owner
 			objectives += ac
 			log_objective(owner, ac.explanation_text)
+			
+	// Special objective override -> team_mode objectives
 
 	if(prob(60))
 		if(prob(85))
@@ -430,7 +432,7 @@
 			objectives += maroon_objective
 			log_objective(owner, maroon_objective.explanation_text)
 
-			if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
+			if (!team_mode && !(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
 				var/datum/objective/escape/escape_with_identity/identity_theft = new
 				identity_theft.owner = owner
 				identity_theft.target = maroon_objective.target
@@ -440,20 +442,28 @@
 				escape_objective_possible = FALSE
 
 	if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
-		if(prob(50))
-			var/datum/objective/escape/escape_objective = new
-			escape_objective.owner = owner
-			objectives += escape_objective
-			log_objective(owner, escape_objective.explanation_text)
-		else
-			var/datum/objective/escape/escape_with_identity/identity_theft = new
-			identity_theft.owner = owner
-			if(team_mode)
-				identity_theft.find_target_by_role(role = ROLE_CHANGELING, role_type = TRUE, invert = TRUE)
-			else
+	
+		if(team_mode)	//additionally, team mode changelings have to take the role of a highest in command
+				var/datum/objective/escape/escape_with_identity/head_hunter/identity_theft = new
+				identity_theft.owner = owner
 				identity_theft.find_target()
-			objectives += identity_theft
-			log_objective(owner, identity_theft.explanation_text)
+				objectives += identity_theft
+				log_objective(owner, identity_theft.explanation_text)
+		else	
+			if(prob(50))
+				var/datum/objective/escape/escape_objective = new
+				escape_objective.owner = owner
+				objectives += escape_objective
+				log_objective(owner, escape_objective.explanation_text)
+			else
+				var/datum/objective/escape/escape_with_identity/identity_theft = new
+				identity_theft.owner = owner
+				//if(team_mode)
+				//	identity_theft.find_target_by_role(role = ROLE_CHANGELING, role_type = TRUE, invert = TRUE)
+				//else
+				identity_theft.find_target()
+				objectives += identity_theft
+				log_objective(owner, identity_theft.explanation_text)
 		escape_objective_possible = FALSE
 
 /datum/antagonist/changeling/proc/update_changeling_icons_added()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -371,23 +371,24 @@
 	//If it seems like they'd be able to do it in play, add a 10% chance to have to escape alone
 
 	var/escape_objective_possible = TRUE
-	switch(competitive_objectives ? (team_mode ? rand(1,2) : rand(1,3)) : 1)
-		if(1)
-			var/datum/objective/absorb/absorb_objective = new
-			absorb_objective.owner = owner
-			absorb_objective.gen_amount_goal(6, 8)
-			objectives += absorb_objective
-			log_objective(owner, absorb_objective.explanation_text)
-		if(2)
-			var/datum/objective/absorb_most/ac = new
-			ac.owner = owner
-			objectives += ac
-			log_objective(owner, ac.explanation_text)
-		if(3) //only give the murder other changelings goal if they're not in a team.
-			var/datum/objective/absorb_changeling/ac = new
-			ac.owner = owner
-			objectives += ac
-			log_objective(owner, ac.explanation_text)
+	if (!team_mode)
+		switch(competitive_objectives ?  rand(1,3) : 1)
+			if(1)
+				var/datum/objective/absorb/absorb_objective = new
+				absorb_objective.owner = owner
+				absorb_objective.gen_amount_goal(6, 8)
+				objectives += absorb_objective
+				log_objective(owner, absorb_objective.explanation_text)
+			if(2)
+				var/datum/objective/absorb_most/ac = new
+				ac.owner = owner
+				objectives += ac
+				log_objective(owner, ac.explanation_text)
+			if(3) //only give the murder other changelings goal if they're not in a team.
+				var/datum/objective/absorb_changeling/ac = new
+				ac.owner = owner
+				objectives += ac
+				log_objective(owner, ac.explanation_text)
 			
 	// Special objective override -> team_mode objectives
 

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -10,6 +10,7 @@
 	var/helptext = "" // Details
 	var/chemical_cost = 0 // negative chemical cost is for passive abilities (chemical glands)
 	var/dna_cost = -1 //cost of the sting in dna points. 0 = auto-purchase (see changeling.dm), -1 = cannot be purchased
+	var/dnai_cost = -1	//hack; if 0 or above, overrides DNA cost in infiltrator gamemode
 	var/req_dna = 0  //amount of dna needed to use this ability. Changelings always have atleast 1
 	var/req_human = 0 //if you need to be human to use this ability
 	var/req_absorbs = 0 //similar to req_dna, but only gained from absorbing, not DNA sting

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -5,6 +5,7 @@
 	button_icon_state = "last_resort"
 	chemical_cost = 20
 	dna_cost = 0
+	dnai_cost = 2
 	req_human = 1
 	req_stat = DEAD
 	ignores_fakedeath = TRUE

--- a/code/modules/antagonists/changeling/powers/hivemind.dm
+++ b/code/modules/antagonists/changeling/powers/hivemind.dm
@@ -5,6 +5,7 @@
 	helptext = "We will be able to talk with other changelings with :g. Exchanged DNA do not count towards absorb objectives."
 	needs_button = FALSE
 	dna_cost = 2
+	dnai_cost = 2
 	chemical_cost = -1
 
 /datum/action/changeling/hivemind_comms/on_purchase(mob/user, is_respec)


### PR DESCRIPTION
## About The Pull Request

### Changeling Infiltration

A new twist on changelings, team based changeling game mode, where the changelings must replace the heads of staff while doing their own objectives.

**Abilities**
Infiltrators start with Hivemind Communication by default, but must pay for Headcrab. This makes cooperation easier, but makes them more susceptible to getting caught.

**Unique Objectives**
Each changeling gets a unique objective to impersonate the highest in command. They must work together with other changelings to replace the ones in command and escape alive, maintaining their identity till the shuttle arrives.

The "make sure X changeling escapes as Y" objectives were buggy and not properly implemented. That's why each changeling has its own objective. They don't have shared objectives either to make it a tad more difficult.

## Why It's Good For The Game

Changelings have good team work capabilities, but no good reason to do so. The team based changeling objective was good, but very buggy. 

## Changelog
:cl:
add: Team based changeling game mode; changelings must work together to take over the heads of staff.
/:cl: