### PR TITLE
Deputy Upgrades Passes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -37594,11 +37594,6 @@
 "bpp" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
 /obj/item/reagent_containers/food/snacks/donut/jelly/choco,
 /obj/effect/turf_decal/tile/red{
 	dir = 1

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -5535,11 +5535,6 @@
 "aiK" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
-/obj/item/clothing/accessory/armband/deputy,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -725,7 +725,7 @@
 	desc = "To be issued to those authorized to act as deputy of security."
 
 /obj/item/storage/box/deputy/PopulateContents()
-	for(var/i in 1 to 4)	//not too many, otherwise zesko will say it is OP
+	for(var/i in 1 to 4)	//not too many
 		new /obj/item/clothing/accessory/armband/deputy(src)
 		new /obj/item/card/deputy_access_card(src)
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -725,8 +725,9 @@
 	desc = "To be issued to those authorized to act as deputy of security."
 
 /obj/item/storage/box/deputy/PopulateContents()
-	for(var/i in 1 to 7)
+	for(var/i in 1 to 4)	//not too many, otherwise zesko will say it is OP
 		new /obj/item/clothing/accessory/armband/deputy(src)
+		new /obj/item/card/deputy_access_card(src)
 
 /obj/item/storage/box/metalfoam
 	name = "box of metal foam grenades"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -148,6 +148,7 @@
 	new /obj/item/clothing/gloves/krav_maga/sec(src)
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
+	new /obj/item/storage/box/deputy(src)
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"

--- a/code/modules/jobs/job_types/deputy.dm
+++ b/code/modules/jobs/job_types/deputy.dm
@@ -39,3 +39,21 @@
 	satchel = /obj/item/storage/backpack/satchel/sec
 	duffelbag = /obj/item/storage/backpack/duffelbag/sec
 	box = /obj/item/storage/box/survival
+	
+/obj/item/card/deputy_access_card
+	name = "deputy access card"
+	desc = "A small card, that when used on any ID, will basic security access."
+	icon_state = "data_1"
+
+/obj/item/card/deputy_access_card/afterattack(atom/movable/AM, mob/user, proximity)
+	. = ..()
+	if(istype(AM, /obj/item/card/id) && proximity)
+		var/obj/item/card/id/I = AM
+		I.access |=	ACCESS_SEC_DOORS
+		I.access |= ACCESS_MAINT_TUNNELS
+		I.access |= ACCESS_COURT
+		I.access |= ACCESS_BRIG
+		I.access |= ACCESS_WEAPONS
+		to_chat(user, "You upgrade [I] with basic security access.")
+		log_id("[key_name(user)] added basic security access to '[I]' using [src] at [AREACOORD(user)].")
+		qdel(src)

--- a/code/modules/jobs/job_types/deputy.dm
+++ b/code/modules/jobs/job_types/deputy.dm
@@ -41,19 +41,20 @@
 	box = /obj/item/storage/box/survival
 	
 /obj/item/card/deputy_access_card
-	name = "deputy access card"
-	desc = "A small card, that when used on any ID, will basic security access."
+	name = "deputy assignment card"
+	desc = "A small card, that when used on any ID, will grant basic security access and the role of Deputy."
 	icon_state = "data_1"
 
 /obj/item/card/deputy_access_card/afterattack(atom/movable/AM, mob/user, proximity)
 	. = ..()
 	if(istype(AM, /obj/item/card/id) && proximity)
 		var/obj/item/card/id/I = AM
+		I.assignment = "Deputy"
 		I.access |=	ACCESS_SEC_DOORS
 		I.access |= ACCESS_MAINT_TUNNELS
 		I.access |= ACCESS_COURT
 		I.access |= ACCESS_BRIG
 		I.access |= ACCESS_WEAPONS
-		to_chat(user, "You upgrade [I] with basic security access.")
+		to_chat(user, "You have been assigned as deputy.")
 		log_id("[key_name(user)] added basic security access to '[I]' using [src] at [AREACOORD(user)].")
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request

Adds deputy access cards that instantly promote someone to deputy and add access. Convenable and neat. Adds maints and basic sec access when attached to an ID.

## Why It's Good For The Game

Deputies are a neat mechanic and this makes them easy to promote.

## Changelog
:cl:
add: Deputy access upgrades in warden's and HoS's locker.
/:cl: