### PR TITLE
Save The Fusion From Dying to 2.7K

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -272,7 +272,7 @@
 	if(!air.analyzer_results)
 		air.analyzer_results = new
 	var/list/cached_scan_results = air.analyzer_results
-	var/old_heat_capacity = air.heat_capacity()
+	var/old_thermal_energy = air.thermal_energy()
 	var/reaction_energy = 0 //Reaction energy can be negative or positive, for both exothermic and endothermic reactions.
 	var/initial_plasma = air.get_moles(/datum/gas/plasma)
 	var/initial_carbon = air.get_moles(/datum/gas/carbon_dioxide)
@@ -302,7 +302,7 @@
 	else if (reaction_energy < 0)
 		reaction_energy *= (instability-FUSION_INSTABILITY_ENDOTHERMALITY)**0.5
 
-	if(air.return_temperature()*old_heat_capacity + reaction_energy < 0) //No using energy that doesn't exist.
+	if(old_thermal_energy + reaction_energy < 0) //No using energy that doesn't exist.
 		air.set_moles(/datum/gas/plasma, initial_plasma)
 		air.set_moles(/datum/gas/carbon_dioxide, initial_carbon)
 		return NO_REACTION
@@ -325,7 +325,7 @@
 
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
-			air.set_temperature(CLAMP(((air.return_temperature()*old_heat_capacity + reaction_energy)/new_heat_capacity),TCMB,INFINITY))
+			air.set_temperature(CLAMP(((old_thermal_energy + reaction_energy)/new_heat_capacity),TCMB,INFINITY))
 		return REACTING
 
 /datum/gas_reaction/nitrylformation //The formation of nitryl. Endothermic. Requires N2O as a catalyst.

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -302,7 +302,7 @@
 	else if (reaction_energy < 0)
 		reaction_energy *= (instability-FUSION_INSTABILITY_ENDOTHERMALITY)**0.5
 
-	if(air.thermal_energy() + reaction_energy < 0) //No using energy that doesn't exist.
+	if(air.return_temperature()*old_heat_capacity + reaction_energy < 0) //No using energy that doesn't exist.
 		air.set_moles(/datum/gas/plasma, initial_plasma)
 		air.set_moles(/datum/gas/carbon_dioxide, initial_carbon)
 		return NO_REACTION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Short Story: Fusion should die when things go bad, but not to 2.7K. This PR fixes it by making the negative energy check to use correct thermal energy instead of inflated one, which is caused by a massive production of plasma.

### The Long Story

Writers note: It feels like this is meaningless at this point, but I am doing this for the sake of documentation. For brave future atmos coders!

#### Fusion Went Space Cold?

Fusion is rough. Fusion can die, and it is intended to commit suicide on some cases, like when a huge endothermic reaction happens while the mix doesn't have enough thermal energy to stay 10000K; indeed, we experience many deaths when you try to do fusion without enough plasma -- yog atmosians, venerated for their ability to document on how to reliably make a powerful fusion mix, recommended 6000 moles plasma for the initial fusion mix.

![Screenshot 2020-10-07 233617](https://user-images.githubusercontent.com/8010007/95345910-3939d300-08f6-11eb-8ccb-987c049b7018.png)
_Fig 1. A common cause of fusion death, where plasma fire burns too much plasma away, knocking the mix out of minimal number of moles of plasma_

But there are quite common cases where fusion somehow dies to 2.7 Kelvin -- the space cold -- and it quite is famous. But why 2.7K?

![Fusion ded](https://i.imgur.com/Ow0lupV.png)
_Fig 2. Fusion dies to 2.7K_

Let's have a close look at how fusion decides its resulting temperature.

#### Fusion's Temperature Calculation

Fusion's resulting temperature is decided with following code:

https://github.com/BeeStation/BeeStation-Hornet/blob/ecf6232afafdd366700dcb758a1ebcc0b5815fa5/code/modules/atmospherics/gasmixtures/reactions.dm#L328

Firstly, fusion calculates its resulting temperature while preserving its thermal energy at `(air.return_temperature()*old_heat_capacity + reaction_energy)/new_heat_capacity)` air.return_temperature() is the temperature of the mix, which is not touched by the reaction until this point, and old_heat_capacity is the heat capacity of the mix at the start of the reaction; so `air.return_temperature()*old_heat_capacity` is a way to calculate its initial thermal energy. Therefore, adding the reaction_energy (the energy change caused by fusion) and dividing with new_heat_capacity (post-reaction heat capacity) is a totally valid way to output its resulting temperature while preserving the thermal energy.

But that's not the end of the calculation. The intermediary CLAMP() define does what it say on the tin. It ensures the value is in a predetermined range, which is 2.7K ~ 1e31K in this case. And the resulting clamped value goes to air.set_temperature, actually setting the temperature.

A-ha! So somehow the result of initial calculation turned out to be lower than 2.7K, so it is set to 2.7K! But... how?

#### An Impossible Reaction

Negative energy is an infuriating situation, always on the verge of breaking literally everything. Notwithstanding the theorizing done by some physicists who says negative energy is somehow important and involved in a lot of... physical mumbo jumbo, negative thermal energy -- aka negative temperature -- shouldn't be a thing that happens in SS13; and it even creates more plasma than it should be able to. But it happens, and it is just averted by a clamp. How could the fusion reaction let this happen?

It turns out, the fusion reaction actively tried to prevent this situation. The following fail-safe is an attempt at it:
https://github.com/BeeStation/BeeStation-Hornet/blob/ecf6232afafdd366700dcb758a1ebcc0b5815fa5/code/modules/atmospherics/gasmixtures/reactions.dm#L305-L308

It seems okay, but it isn't. Let me show why.

#### When Fail-safe Fails

When a fusion decides to create huge amounts of plasma, it ups the heat capacity of the mix by _a lot._ Blame Plasma's high heat capacity. But when does it happen? _Before_ the aforementioned fail-safe:

https://github.com/BeeStation/BeeStation-Hornet/blob/ecf6232afafdd366700dcb758a1ebcc0b5815fa5/code/modules/atmospherics/gasmixtures/reactions.dm#L295-L296

And it is a reasonable decision, because actual real delta of plasma can be calculated afterwards, since calculation of delta of plasma is a prerequisite of calculating the reaction_energy, which is a prerequisite of the fail-safe in turn. What is problematic here is the fact that the fail-safe uses mix's thermal energy (via air.thermal_energy()) which is a product of temperature and heat capacity, and heat capacity will turn out to be _much larger than it originally was_ if fusion has decided to produce a lot of plasma, for the fail-safe happens _after the mole changes._ So it ends up comparing reaction energy to an inflated thermal energy.

EDIT: tg's original fusion code is free from this bug, for they are using cached gas: moles changed by fusion are still in cached state while thermal_energy() is calculated using actual gas moles, thereby returning initial thermal energy, not the inflated thermal energy. So other codebases using C++ atmos backend, exempli gratia, Yogstation and Citadel Station 13, are affected by this bug because of, y'know, oversight.

Therefore, there are going to be cases where (initial thermal energy + reaction energy < 0) but (inflated thermal energy used at the fail safe + reaction energy > 0); such cases wrongly pass the fail-safe, ending up being stopped right before causing negative temperature -- all of them goes to 2.7K instead.

![Screenshot 2020-10-08 001735](https://user-images.githubusercontent.com/8010007/95351141-d814fe00-08fb-11eb-85b1-173ac95dc988.png)
_Fig 3. The face of 2.7K fusion death bug. From left to right: reaction_energy, initial temperature, resulting temperature, initial thermal energy, resulting thermal energy. [EDIT: The last column means initial heat capacity. It serves no meaning but I accidentally included it] You can clearly see that this reaction shouldn't have happened in the first place._

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

#### Reinstating The Fail-safe

So we have to fix it. ~~I opted to do it in a kinda lazy but obvious way by properly calculating the initial thermal energy at the fail-safe by using `air.return_temperature()*old_heat_capacity`. At least that's how other coders do, right?~~ EDIT: After thinking about it for a long long time, I decided to cache the initial thermal energy for micro-optimization and visibility.

## Why It's Good For The Game

No more dying to 2.7K; in cases where fusion would've ended up dying to 2.7K, the fusion just stops instead, waiting for changes in its composition etc to die to a higher temperature or to continue to live.

Furthermore, as the original author of fusion V6 intended, it no longer uses energy that doesn't exist since a fusion mix dying to 2.7K creates more plasma than it could make using all of its thermal energy.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fusion no longer dies to 2.7K. Instead, the fusion just stops, waiting eagerly for a fate other than 2.7K.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
