### PR TITLE
Exempt Fusion From Hotspot Reaction

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -70,7 +70,7 @@
 
 	location.active_hotspot = src
 
-	bypassing = !just_spawned && (volume > CELL_VOLUME*0.95)
+	bypassing = !just_spawned && (volume > CELL_VOLUME*0.95) || location.air.return_temperature() > FUSION_TEMPERATURE_THRESHOLD
 
 	if(bypassing)
 		volume = location.air.reaction_results["fire"]*FIRE_GROWTH_RATE

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -79,7 +79,7 @@
 		var/datum/gas_mixture/affected = location.air.remove_ratio(volume/location.air.return_volume())
 		if(affected) //in case volume is 0
 			affected.set_temperature(temperature)
-			affected.react(src)
+			affected.react(src, typecacheof(/datum/gas_reaction/fusion,FALSE,TRUE))
 			temperature = affected.return_temperature()
 			volume = affected.reaction_results["fire"]*FIRE_GROWTH_RATE
 			location.assume_air(affected)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -79,7 +79,7 @@
 		var/datum/gas_mixture/affected = location.air.remove_ratio(volume/location.air.return_volume())
 		if(affected) //in case volume is 0
 			affected.set_temperature(temperature)
-			affected.react(src, typecacheof(/datum/gas_reaction/fusion,FALSE,TRUE))
+			affected.react(src)
 			temperature = affected.return_temperature()
 			volume = affected.reaction_results["fire"]*FIRE_GROWTH_RATE
 			location.assume_air(affected)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		set_moles(path, text2num(gas[id]))
 	return 1
 
-/datum/gas_mixture/react(datum/holder, reactions_exempted = list())
+/datum/gas_mixture/react(datum/holder)
 	. = NO_REACTION
 	var/list/reactions = list()
 	for(var/I in get_gases())
@@ -183,9 +183,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	reaction_loop:
 		for(var/r in reactions)
 			var/datum/gas_reaction/reaction = r
-
-			if(is_type_in_typecache(reaction,reactions_exempted))
-				continue
 
 			var/list/min_reqs = reaction.min_requirements
 			if((min_reqs["TEMP"] && temp < min_reqs["TEMP"]) \

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		set_moles(path, text2num(gas[id]))
 	return 1
 
-/datum/gas_mixture/react(datum/holder)
+/datum/gas_mixture/react(datum/holder, reactions_exempted = list())
 	. = NO_REACTION
 	var/list/reactions = list()
 	for(var/I in get_gases())
@@ -183,6 +183,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	reaction_loop:
 		for(var/r in reactions)
 			var/datum/gas_reaction/reaction = r
+
+			if(is_type_in_typecache(reaction,reactions_exempted))
+				continue
 
 			var/list/min_reqs = reaction.min_requirements
 			if((min_reqs["TEMP"] && temp < min_reqs["TEMP"]) \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hotspot effect is great. It contributes to faster open turf fire, and it creates... fire-like graphics. But it fucks quite a lot with fusion, because the hotspot might try to call fusion (via react proc) on a _part_ (via remove_ratio proc) of an open turf's gasmixture and fusion doesn't act very cooperative with it. This PR fixes it by simply exempting fusion from called by hotspot.

![Screenshot 2020-10-06 200252](https://user-images.githubusercontent.com/8010007/95193990-a7579a80-080f-11eb-84da-810c26659167.png)
_This graph shows what this PR tries to fix_

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A tiny bit less jitteriness at fusion.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: fusion is no longer caused by hotspot react()
fix: fire probably became a tiny tiny bit faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
