### PR TITLE
Fixes advanced infiltrator shuttle

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -513,7 +513,7 @@
 	name = "basic syndicate infiltrator"
 
 /datum/map_template/shuttle/infiltrator/advanced
-	suffix = "basic"
+	suffix = "advanced"
 	name = "advanced syndicate infiltrator"
 
 /datum/map_template/shuttle/cargo/delta


### PR DESCRIPTION
Thanks Dennok for noticing this

:cl: Dennok
fix: Fixed syndicate shuttle catalog entity, admins can now spawn the advanced syndicate infiltator during a round
/:cl: