### PR TITLE
Increased View Width 17x15

### DIFF
--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -30,4 +30,5 @@
 		var/proportion = viewX / viewY
 		viewX += zoom_amt * proportion
 		viewY += zoom_amt
-	return "[viewX]x[viewY]"
+	//God, I hate that we have to round this.
+	return "[round(viewX)]x[round(viewY)]"

--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -16,3 +16,18 @@
 	var/turf/source = get_turf(user)
 	var/turf/target = get_turf(A)
 	return ISINRANGE(target.x, source.x - view_range[1], source.x + view_range[1]) && ISINRANGE(target.y, source.y - view_range[1], source.y + view_range[1])
+
+//Returns an in proportion scaled out view, with zoom_amt extra tiles on the y axis.
+/proc/get_zoomed_view(view, zoom_amt)
+	var/viewX
+	var/viewY
+	if(isnum_safe(view))
+		return view + zoom_amt
+	else
+		var/list/viewrangelist = splittext(view,"x")
+		viewX = text2num(viewrangelist[1])
+		viewY = text2num(viewrangelist[2])
+		var/proportion = viewX / viewY
+		viewX += zoom_amt * proportion
+		viewY += zoom_amt
+	return "[viewX]x[viewY]"

--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -1,14 +1,14 @@
-/proc/getviewsize(view)
+/proc/getviewsize(view, extra_x = 0, extra_y = 0)
 	var/viewX
 	var/viewY
 	if(isnum_safe(view))
 		var/totalviewrange = (view < 0 ? -1 : 1) + 2 * view
-		viewX = totalviewrange
-		viewY = totalviewrange
+		viewX = totalviewrange + extra_x
+		viewY = totalviewrange + extra_y
 	else
 		var/list/viewrangelist = splittext(view,"x")
-		viewX = text2num(viewrangelist[1])
-		viewY = text2num(viewrangelist[2])
+		viewX = text2num(viewrangelist[1]) + extra_x
+		viewY = text2num(viewrangelist[2]) + extra_y
 	return list(viewX, viewY)
 
 /proc/in_view_range(mob/user, atom/A)

--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -13,8 +13,8 @@
 	screen borders. NORTH-1, for example, is the row just below the upper edge. Useful if you want your
 	UI to scale with screen size.
 
-	The size of the user's screen is defined by client.view (indirectly by world.view), in our case "15x15".
-	Therefore, the top right corner (except during admin shenanigans) is at "15,15"
+	The size of the user's screen is defined by client.view (indirectly by world.view), in our case "17x15".
+	Therefore, the top right corner (except during admin shenanigans) is at "17,15"
 */
 
 //Lower left, persistent menu

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -484,6 +484,9 @@
 /datum/config_entry/string/default_view
 	config_entry_value = "15x15"
 
+/datum/config_entry/flag/menu_square_view
+	config_entry_value = "15x15"
+
 /datum/config_entry/flag/log_pictures
 
 /datum/config_entry/flag/picture_logging_camera

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -485,7 +485,6 @@
 	config_entry_value = "15x15"
 
 /datum/config_entry/flag/menu_square_view
-	config_entry_value = "15x15"
 
 /datum/config_entry/flag/log_pictures
 

--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -14,15 +14,23 @@
 	var/x = target.x
 	var/y = target.y
 	var/z = target.z
-	var/turf/southwest = locate(CLAMP(x - (direction & WEST ? range : 0), 1, world.maxx), CLAMP(y - (direction & SOUTH ? range : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
-	var/turf/northeast = locate(CLAMP(x + (direction & EAST ? range : 0), 1, world.maxx), CLAMP(y + (direction & NORTH ? range : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
+
+	var/rangex = range
+	var/rangey = range
+
+	if(istext(rangex))
+		rangex = getviewsize(range)[1]
+		rangey = getviewsize(range)[2]
+
+	var/turf/southwest = locate(CLAMP(x - (direction & WEST ? rangex : 0), 1, world.maxx), CLAMP(y - (direction & SOUTH ? rangey : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
+	var/turf/northeast = locate(CLAMP(x + (direction & EAST ? rangex : 0), 1, world.maxx), CLAMP(y + (direction & NORTH ? rangey : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
 	//holder.vis_contents += block(southwest, northeast) // This doesnt work because of beta bug memes
 	for(var/i in block(southwest, northeast))
 		holder.vis_contents += i
 	if(direction & SOUTH)
-		holder.pixel_y -= world.icon_size * range
+		holder.pixel_y -= world.icon_size * rangey
 	if(direction & WEST)
-		holder.pixel_x -= world.icon_size * range
+		holder.pixel_x -= world.icon_size * rangex
 
 /datum/component/mirage_border/Destroy()
 	QDEL_NULL(holder)

--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -15,22 +15,18 @@
 	var/y = target.y
 	var/z = target.z
 
-	var/rangex = range
-	var/rangey = range
+	if(istext(range))
+		range = max(getviewsize(range)[1], getviewsize(range)[2])
 
-	if(istext(rangex))
-		rangex = getviewsize(range)[1]
-		rangey = getviewsize(range)[2]
-
-	var/turf/southwest = locate(CLAMP(x - (direction & WEST ? rangex : 0), 1, world.maxx), CLAMP(y - (direction & SOUTH ? rangey : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
-	var/turf/northeast = locate(CLAMP(x + (direction & EAST ? rangex : 0), 1, world.maxx), CLAMP(y + (direction & NORTH ? rangey : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
+	var/turf/southwest = locate(CLAMP(x - (direction & WEST ? range : 0), 1, world.maxx), CLAMP(y - (direction & SOUTH ? range : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
+	var/turf/northeast = locate(CLAMP(x + (direction & EAST ? range : 0), 1, world.maxx), CLAMP(y + (direction & NORTH ? range : 0), 1, world.maxy), CLAMP(z, 1, world.maxz))
 	//holder.vis_contents += block(southwest, northeast) // This doesnt work because of beta bug memes
 	for(var/i in block(southwest, northeast))
 		holder.vis_contents += i
 	if(direction & SOUTH)
-		holder.pixel_y -= world.icon_size * rangey
+		holder.pixel_y -= world.icon_size * range
 	if(direction & WEST)
-		holder.pixel_x -= world.icon_size * rangex
+		holder.pixel_x -= world.icon_size * range
 
 /datum/component/mirage_border/Destroy()
 	QDEL_NULL(holder)

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -117,8 +117,8 @@ GLOBAL_LIST_EMPTY(explosions)
 				var/baseshakeamount
 				if(orig_max_distance - dist > 0)
 					baseshakeamount = sqrt((orig_max_distance - dist)*0.1)
-				// If inside the blast radius + world.view - 2
-				if(dist <= round(max_range + world.view - 2, 1))
+				// If inside the blast radius + world.view (x) - 2
+				if(dist <= round(max_range + getviewsize(world.view)[1] - 2, 1))
 					M.playsound_local(epicenter, null, 100, 1, frequency, falloff = 5, S = explosion_sound)
 					if(baseshakeamount > 0)
 						shake_camera(M, 25, CLAMP(baseshakeamount, 0, 10))
@@ -222,7 +222,7 @@ GLOBAL_LIST_EMPTY(explosions)
 				var/throw_range = rand(throw_dist, max_range)
 				var/turf/throw_at = get_ranged_target_turf(I, throw_dir, throw_range)
 				I.throw_at(throw_at, throw_range, EXPLOSION_THROW_SPEED)
-		
+
 		for(var/mob/living/L in T)
 			if(!L.anchored)
 				var/throw_range = rand(throw_dist, max_range)

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -116,7 +116,7 @@
 	//Ready for this one?
 	setTo(radius)
 
-/proc/getScreenSize(widescreen, mob/M) //IMPORTANT: If widescreen toggle preference gets ported, several uses of this proc need to be changed from FALSE to the player pref
+/proc/getScreenSize(mob/M) //IMPORTANT: If widescreen toggle preference gets ported, several uses of this proc need to be changed from FALSE to the player pref
 	if(CONFIG_GET(flag/menu_square_view) && M && istype(M, /mob/dead/new_player))
 		return "15x15"	//Return 15x15 for new players because we have normal sized menu screens
 	return CONFIG_GET(string/default_view) //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -119,6 +119,4 @@
 /proc/getScreenSize(widescreen, mob/M) //IMPORTANT: If widescreen toggle preference gets ported, several uses of this proc need to be changed from FALSE to the player pref
 	if(CONFIG_GET(flag/menu_square_view) && M && istype(M, /mob/dead/new_player))
 		return "15x15"	//Return 15x15 for new players because we have normal sized menu screens
-	if(widescreen)
-		return CONFIG_GET(string/default_view)
-	return "17x15" //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config
+	return CONFIG_GET(string/default_view) //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -116,7 +116,9 @@
 	//Ready for this one?
 	setTo(radius)
 
-/proc/getScreenSize(widescreen) //IMPORTANT: If widescreen toggle preference gets ported, several uses of this proc need to be changed from FALSE to the player pref
+/proc/getScreenSize(widescreen, mob/M) //IMPORTANT: If widescreen toggle preference gets ported, several uses of this proc need to be changed from FALSE to the player pref
+	if(CONFIG_GET(flag/menu_square_view) && M && istype(M, /mob/dead/new_player))
+		return "15x15"	//Return 15x15 for new players because we have normal sized menu screens
 	if(widescreen)
 		return CONFIG_GET(string/default_view)
-	return "15x15" //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config
+	return "17x15" //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -168,7 +168,7 @@
 		cyclelinkedairlock = null
 	if (!cyclelinkeddir)
 		return
-	var/limit = world.view
+	var/limit = 15
 	var/turf/T = get_turf(src)
 	var/obj/machinery/door/airlock/FoundDoor
 	do

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -929,7 +929,7 @@
 			_y = -zoom_amt
 		if(WEST)
 			_x = -zoom_amt
-	C.change_view(getviewsize, zoom_out_amt, zoom_out_amt)
+	C.change_view(get_zoomed_view(world.view, zoom_out_amt))
 	C.pixel_x = world.icon_size*_x
 	C.pixel_y = world.icon_size*_y
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -929,7 +929,7 @@
 			_y = -zoom_amt
 		if(WEST)
 			_x = -zoom_amt
-	C.change_view(world.view + zoom_out_amt)
+	C.change_view(getviewsize, zoom_out_amt, zoom_out_amt)
 	C.pixel_x = world.icon_size*_x
 	C.pixel_y = world.icon_size*_y
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -12,7 +12,7 @@
 
  	// Looping through the player list has the added bonus of working for mobs inside containers
 	var/sound/S = sound(get_sfx(soundin))
-	var/maxdistance = (world.view + extrarange)
+	var/maxdistance = (getviewsize(world.view)[1] + extrarange)
 	var/z = turf_source.z
 	var/list/listeners = SSmobs.clients_by_zlevel[z]
 	if(!ignore_walls) //these sounds don't carry through walls
@@ -49,7 +49,7 @@
 		//sound volume falloff with distance
 		var/distance = get_dist(T, turf_source)
 
-		S.volume -= max(distance - world.view, 0) * 2 //multiplicative falloff to add on top of natural audio falloff.
+		S.volume -= max(distance - getviewsize(world.view)[1], 0) * 2 //multiplicative falloff to add on top of natural audio falloff.
 
 		if(pressure_affected)
 			//Atmosphere affects sound

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -722,7 +722,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(view_size.getView() == view_size.default)
 		view_size.setTo(input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128) - 7)
 	else
-		view_size.resetToDefault(getScreenSize(FALSE))
+		view_size.resetToDefault(getScreenSize(FALSE, mob))
 
 	log_admin("[key_name(usr)] changed their view range to [view].")
 	//message_admins("\blue [key_name_admin(usr)] changed their view range to [view].")	//why? removed by order of XSI

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -722,7 +722,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(view_size.getView() == view_size.default)
 		view_size.setTo(input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128) - 7)
 	else
-		view_size.resetToDefault(getScreenSize(FALSE, mob))
+		view_size.resetToDefault(getScreenSize(mob))
 
 	log_admin("[key_name(usr)] changed their view range to [view].")
 	//message_admins("\blue [key_name_admin(usr)] changed their view range to [view].")	//why? removed by order of XSI

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -456,7 +456,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if (menuitem)
 			menuitem.Load_checked(src)
 
-	view_size = new(src, getScreenSize(FALSE, mob))
+	view_size = new(src, getScreenSize(mob))
 	view_size.resetFormat()
 	view_size.setZoomMode()
 	fit_viewport()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -456,7 +456,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		if (menuitem)
 			menuitem.Load_checked(src)
 
-	view_size = new(src, getScreenSize(FALSE))
+	view_size = new(src, getScreenSize(FALSE, mob))
 	view_size.resetFormat()
 	view_size.setZoomMode()
 	fit_viewport()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1774,7 +1774,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							pixel_size = PIXEL_SCALING_3X
 						if(PIXEL_SCALING_3X)
 							pixel_size = PIXEL_SCALING_AUTO
-					user.client.view_size.setDefault(getScreenSize(FALSE, user))	//Fix our viewport size so it doesn't reset on change
+					user.client.view_size.setDefault(getScreenSize(user))	//Fix our viewport size so it doesn't reset on change
 					user.client.view_size.apply() //Let's winset() it so it actually works
 
 				if("scaling_method")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1774,6 +1774,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							pixel_size = PIXEL_SCALING_3X
 						if(PIXEL_SCALING_3X)
 							pixel_size = PIXEL_SCALING_AUTO
+					user.client.view_size.setDefault(getScreenSize(FALSE, user))	//Fix our viewport size so it doesn't reset on change
 					user.client.view_size.apply() //Let's winset() it so it actually works
 
 				if("scaling_method")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -103,7 +103,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/ambientocclusion = TRUE
 	///Should we automatically fit the viewport?
-	var/auto_fit_viewport = FALSE
+	var/auto_fit_viewport = TRUE
 	///What size should pixels be displayed as? 0 is strech to fit
 	var/pixel_size = 0
 	///What scaling method should we use?

--- a/code/modules/guardian/guardian.dm
+++ b/code/modules/guardian/guardian.dm
@@ -105,7 +105,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	if(!client)
 		return
 	cut_barriers()
-	if(!summoner?.current || !is_deployed() || (range <= 1 || (stats && stats.range <= 1)) || get_dist_euclidian(summoner.current, src) < (range - world.view))
+	if(!summoner?.current || !is_deployed() || (range <= 1 || (stats && stats.range <= 1)) || get_dist_euclidian(summoner.current, src) < (range - getviewsize(world.view)[2]))
 		return
 	var/sx = summoner.current.x
 	var/sy = summoner.current.y

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -338,7 +338,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(mind.current.key && mind.current.key[1] != "@")	//makes sure we don't accidentally kick any clients
 		to_chat(usr, "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>")
 		return
-	client.view_size.setDefault(getScreenSize(FALSE, src))//Let's reset so people can't become allseeing gods
+	client.view_size.setDefault(getScreenSize(src))//Let's reset so people can't become allseeing gods
 	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
 	mind.current.key = key
 	return TRUE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -338,7 +338,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(mind.current.key && mind.current.key[1] != "@")	//makes sure we don't accidentally kick any clients
 		to_chat(usr, "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>")
 		return
-	client.view_size.setDefault(getScreenSize(FALSE))//Let's reset so people can't become allseeing gods
+	client.view_size.setDefault(getScreenSize(FALSE, src))//Let's reset so people can't become allseeing gods
 	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
 	mind.current.key = key
 	return TRUE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -67,7 +67,7 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
-		client.change_view(getScreenSize(FALSE, src)) // Resets the client.view in case it was changed.
+		client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
 
 		if(client.player_details.player_actions.len)
 			for(var/datum/action/A in client.player_details.player_actions)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -67,6 +67,7 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
+		client.view_size.setDefault(getScreenSize(src))	// Sets the defaul view_size because it can be different to what it was on the lobby.
 		client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
 
 		if(client.player_details.player_actions.len)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -67,7 +67,7 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
-		client.change_view(getScreenSize(FALSE)) // Resets the client.view in case it was changed.
+		client.change_view(getScreenSize(FALSE, src)) // Resets the client.view in case it was changed.
 
 		if(client.player_details.player_actions.len)
 			for(var/datum/action/A in client.player_details.player_actions)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -67,7 +67,7 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
-		client.view_size.setDefault(getScreenSize(src))	// Sets the defaul view_size because it can be different to what it was on the lobby.
+		client.view_size?.setDefault(getScreenSize(src))	// Sets the defaul view_size because it can be different to what it was on the lobby.
 		client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
 
 		if(client.player_details.player_actions.len)

--- a/code/world.dm
+++ b/code/world.dm
@@ -5,7 +5,7 @@
 	mob = /mob/dead/new_player
 	turf = /turf/open/space/basic
 	area = /area/space
-	view = "15x15"
+	view = "17x15"
 	hub = "Exadv1.spacestation13"
 	hub_password = "kMZy3U5jJHSiBQjr"
 	name = "BeeStation 13"

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -489,7 +489,10 @@ ROUNDS_UNTIL_HARD_RESTART 3
 ##	By default, this is 15x15, which gets simplified to 7 by BYOND, as it is a 1:1 screen ratio.
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 15x15
+DEFAULT_VIEW 17x15
+
+##Should we use square view (15x15) while a new player (main menu)
+MENU_SQUARE_VIEW
 
 METACURRENCY_NAME BeeCoin
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -486,7 +486,10 @@ ROUNDS_UNTIL_HARD_RESTART 3
 ##	By default, this is 15x15, which gets simplified to 7 by BYOND, as it is a 1:1 screen ratio.
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 15x15
+DEFAULT_VIEW 17x15
+
+##Should we use square view (15x15) while a new player (main menu)
+MENU_SQUARE_VIEW
 
 ## Name your perpetual currency here
 ## This is used within the metashop and earned by playing the game.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Note: I recommend doing this at the same time as TGUI stat since then the verbs won't be reordered twice

## About The Pull Request

Increases the view width to 17x15.
Doesn't increase the view width of the main title screen, so while on the title screen the title images will not look broken.
Changes some code to account for world.view not being a square (Sound etc.) (View("17x15") works however we were doing "15x15" + 5 before (how did that even work? I assume "15x15" gets converted to 15 by byond automatically)).
Adds a new proc for zooming out things in proportion.

## Concerns / Frequently raised points:

**Won't this break everything since it assumes the game is a 15x15 square?**
The byond proc that checks if an object is visible (used in things like the statue mob that cannot move while being observed) will account for the screen size change automatically and should work like you would expect.

**Will this mess up the admin tabs and make them multiple lines?**
No, the view increase in this proc is not enough to make it go onto multiple lines.
![image](https://user-images.githubusercontent.com/26465327/95630494-d6714480-0a79-11eb-93c2-99ffc457b717.png)

**Will seeing more give people more of an advantage?**
Everyone will be able to see 1 more tile off to the left and right, so there will be no balance issues since everyone will still see the same thing.

**No. This isn't my spaceman game.**
Try it first, you might like it. Originally I was strongly against it. I recommend playing NSV for a while and seeing how it is, since they use 17x15.

**How does this look on weird sized monitors?**

1920x1080:
![image](https://user-images.githubusercontent.com/26465327/95630806-657e5c80-0a7a-11eb-9ffd-ab5a4f4ac010.png)

1680x1050:
![image](https://user-images.githubusercontent.com/26465327/95630819-6e6f2e00-0a7a-11eb-9fe4-30f82af95dff.png)

1600x1024:
![image](https://user-images.githubusercontent.com/26465327/95630843-76c76900-0a7a-11eb-92fd-86479d724b17.png)

1600x900: (Resolution is so low at this point the upper parts of the screen aren't in view)
![image](https://user-images.githubusercontent.com/26465327/95630874-85158500-0a7a-11eb-87e4-2aa0d621643b.png)

## Why It's Good For The Game

It looks significantly nicer and more modern.

## Changelog
:cl:
tweak: Changed the view width to 17x15
fix: Mirage borders sometimes not working properly
code: Proper zooming out procs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
