### PR TITLE
Reballanced Hallucinogenic Sting to inject cbz into the target

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -219,8 +219,8 @@
 	desc = "We induce our victim with a mixture of synthesized BZ gas. Costs 10 chemicals. Our body will absorb a part of the chemicals."
 	helptext = "We evolve the ability to sting a target with a BZ based hallucinogenic chemical. The compound will cause hallucination in regular humans, and disable other changelings' ability to generate chemicals for a short while. However, the process will inject some BZ into our body as well."
 	button_icon_state = "sting_lsd"
-	chemical_cost = 30
-	dna_cost = 2
+	chemical_cost = 25
+	dna_cost = 1
 	req_absorbs = 3
 
 /datum/action/changeling/sting/CBZ/sting_action(mob/user, mob/living/carbon/target)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -216,8 +216,8 @@
 
 /datum/action/changeling/sting/CBZ
 	name = "Hallucination Sting"
-	desc = "We induce our victim with a mixture of synthesized BZ gas. Costs 25 chemicals."
-	helptext = "We evolve the ability to sting a target with a BZ based hallucinogenic chemical. The compound will cause hallucination in regular humans, and disable other changelings' ability to generate chemicals for a short while. "
+	desc = "We inject our victim with a mixture of hallucinogenic BZ gas. Costs 25 chemicals."
+	helptext = "We evolve the ability to sting a target with a BZ based hallucinogenic chemical. The compound will cause hallucination in regular humans, and disable other changelings' ability to generate chemicals for a short while."
 	button_icon_state = "sting_lsd"
 	chemical_cost = 25
 	dna_cost = 1

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -216,8 +216,8 @@
 
 /datum/action/changeling/sting/CBZ
 	name = "Hallucination Sting"
-	desc = "We induce our victim with a mixture of synthesized BZ gas. Costs 10 chemicals. Our body will absorb a part of the chemicals."
-	helptext = "We evolve the ability to sting a target with a BZ based hallucinogenic chemical. The compound will cause hallucination in regular humans, and disable other changelings' ability to generate chemicals for a short while. However, the process will inject some BZ into our body as well."
+	desc = "We induce our victim with a mixture of synthesized BZ gas. Costs 25 chemicals."
+	helptext = "We evolve the ability to sting a target with a BZ based hallucinogenic chemical. The compound will cause hallucination in regular humans, and disable other changelings' ability to generate chemicals for a short while. "
 	button_icon_state = "sting_lsd"
 	chemical_cost = 25
 	dna_cost = 1

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -214,21 +214,26 @@
 	target.blur_eyes(40)
 	return TRUE
 
-/datum/action/changeling/sting/LSD
+/datum/action/changeling/sting/CBZ
 	name = "Hallucination Sting"
-	desc = "We cause mass terror to our victim."
-	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
+	desc = "We induce our victim with a mixture of synthesized BZ gas. Costs 10 chemicals. Our body will absorb a part of the chemicals."
+	helptext = "We evolve the ability to sting a target with a BZ based hallucinogenic chemical. The compound will cause hallucination in regular humans, and disable other changelings' ability to generate chemicals for a short while. However, the process will inject some BZ into our body as well."
 	button_icon_state = "sting_lsd"
 	chemical_cost = 10
-	dna_cost = 1
-	stealthy = TRUE
+	dna_cost = 2
+	req_absorbs = 3
 
-/datum/action/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
+/datum/action/changeling/sting/CBZ/sting_action(mob/user, mob/living/carbon/target)
 	log_combat(user, target, "stung", "LSD sting")
 	addtimer(CALLBACK(src, .proc/hallucination_time, target), rand(300,600))
+	if(target.reagents)
+		target.reagents.add_reagent(/datum/reagent/bz_metabolites, 6)
+		target.reagents.add_reagent(/datum/reagent/concentrated_bz, 3)	
+	if(user.reagents)	//risky
+		user.reagents.add_reagent(/datum/reagent/bz_metabolites, 8)
 	return TRUE
 
-/datum/action/changeling/sting/LSD/proc/hallucination_time(mob/living/carbon/target)
+/datum/action/changeling/sting/CBZ/proc/hallucination_time(mob/living/carbon/target)
 	if(target)
 		target.hallucination = max(90, target.hallucination)
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -219,7 +219,7 @@
 	desc = "We induce our victim with a mixture of synthesized BZ gas. Costs 10 chemicals. Our body will absorb a part of the chemicals."
 	helptext = "We evolve the ability to sting a target with a BZ based hallucinogenic chemical. The compound will cause hallucination in regular humans, and disable other changelings' ability to generate chemicals for a short while. However, the process will inject some BZ into our body as well."
 	button_icon_state = "sting_lsd"
-	chemical_cost = 10
+	chemical_cost = 30
 	dna_cost = 2
 	req_absorbs = 3
 
@@ -227,10 +227,7 @@
 	log_combat(user, target, "stung", "LSD sting")
 	addtimer(CALLBACK(src, .proc/hallucination_time, target), rand(300,600))
 	if(target.reagents)
-		target.reagents.add_reagent(/datum/reagent/bz_metabolites, 6)
-		target.reagents.add_reagent(/datum/reagent/concentrated_bz, 3)	
-	if(user.reagents)	//risky
-		user.reagents.add_reagent(/datum/reagent/bz_metabolites, 8)
+		target.reagents.add_reagent(/datum/reagent/bz_metabolites, 9)
 	return TRUE
 
 /datum/action/changeling/sting/CBZ/proc/hallucination_time(mob/living/carbon/target)


### PR DESCRIPTION
## About The Pull Request

Hallucinogenic sting remake. Now injects CBZ and BZ metabolites into your target AND yourself. Risky to move, but only way to disable other lings and prevent them from headcrabbing. Requires 3 people to absorb, to prevent lings from self-salading and just fucking with other lings for the sake of it.

## Why It's Good For The Game

Makes ling hunting AND absorbing a viable strat. You will no longer be unable to absorb other lings because they headcrab as soon as they realize what's going on.

## Changelog
:cl:
tweak: Ling hallucinogenic sting also injects some CBZ into targets. Cannot be used right away, as it requires lings to absorb 3 other targets.
/:cl: