### PR TITLE
Fixes 4 Random Runtimes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -184,7 +184,7 @@
 /datum/mind/proc/has_antag_datum(datum_type, check_subtypes = TRUE)
 	if(!datum_type)
 		return
-	. = FALSE
+
 	for(var/a in antag_datums)
 		var/datum/antagonist/A = a
 		if(check_subtypes && istype(A, datum_type))

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -64,12 +64,15 @@
 		user.reset_perspective(null)
 		if(eyeobj.visible_icon && user.client)
 			user.client.images -= eyeobj.user_image
+
+		user.client.view_size.unsupress()
+
 	eyeobj.eye_user = null
 	user.remote_control = null
 
 	current_user = null
 	user.unset_machine()
-	user.client.view_size.unsupress()
+
 	playsound(src, 'sound/machines/terminal_off.ogg', 25, FALSE)
 
 /obj/machinery/computer/camera_advanced/check_eye(mob/user)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -39,7 +39,7 @@
 	return ..()
 
 /obj/item/twohanded/kinetic_crusher/examine(mob/living/user)
-	..()
+	. = ..()
 	to_chat(user, "<span class='notice'>Mark a large creature with the destabilizing force, then hit them in melee to do <b>[force + detonation_damage]</b> damage.</span>")
 	to_chat(user, "<span class='notice'>Does <b>[force + detonation_damage + backstab_bonus]</b> damage if the target is backstabbed, instead of <b>[force + detonation_damage]</b>.</span>")
 	for(var/t in trophies)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -16,13 +16,13 @@
 	if(with_bodyparts)
 		switch(dna.species.species_gibs)
 			if("human")
-				new /obj/effect/gibspawner/human(get_turf(src), dna, get_static_viruses())
+				new /obj/effect/gibspawner/human(get_turf(src), src, get_static_viruses())
 			if("robotic")
 				new /obj/effect/gibspawner/robot(get_turf(src))
 	else
 		switch(dna.species.species_gibs)
 			if("human")
-				new /obj/effect/gibspawner/human(get_turf(src), dna, get_static_viruses())
+				new /obj/effect/gibspawner/human(get_turf(src), src, get_static_viruses())
 			if("robotic")
 				new /obj/effect/gibspawner/robot(get_turf(src))
 


### PR DESCRIPTION
# About The Pull Request

Fixes 4 random runtimes I observed while looking through logs.

One of which fixes gibs on human death

You can also examine kinetic crushers again

## Why It's Good For The Game

Because errors cause lag when logging and are bad and cannot be ignored forever.

## Changelog
:cl:
fix: 4 random runtimes, including gibs not always spawning on human death
/:cl: