### PR TITLE
increases the max length of integrated circuit codes

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -1,4 +1,5 @@
 #define MAX_CIRCUIT_CLONE_TIME 3 MINUTES //circuit slow-clones can only take up this amount of time to complete
+#define CIRCUIT_CODE_MAXLENGTH 30000
 
 /obj/item/integrated_circuit_printer
 	name = "integrated circuit printer"
@@ -262,7 +263,7 @@
 			if("load")
 				if(cloning)
 					return
-				var/input = capped_multiline_input(usr, "Put your code there:", "loading", "", 30000)
+				var/input = capped_multiline_input(usr, "Put your code there:", "loading", "", CIRCUIT_CODE_MAXLENGTH)
 				if(!check_interactivity(usr) || cloning)
 					return
 				if(!input)

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -262,7 +262,7 @@
 			if("load")
 				if(cloning)
 					return
-				var/input = capped_multiline_input(usr, "Put your code there:", "loading")
+				var/input = capped_multiline_input(usr, "Put your code there:", "loading", "", 30000)
 				if(!check_interactivity(usr) || cloning)
 					return
 				if(!input)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Currently, there is a limit on the length of integrated circuit codes that can be printed. capped_multiline_input is used to limit the length of input strings. Many circuits don't fit within the limit. This pr increases the limit to 30000 characters.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Makes it possible to print big circuits.

## Changelog
:cl:
tweak: increases max length of circuit codes that can be used
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
