### PR TITLE
Changelings Snowball

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -829,13 +829,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 			continue
 		var/datum/antagonist/changeling/changeling = M.has_antag_datum(/datum/antagonist/changeling)
 		if(!changeling)
-			continue
-		var/total_genetic_points = changeling.geneticpoints
-
-		for(var/datum/action/changeling/p in changeling.purchasedpowers)
-			total_genetic_points += p.dna_cost
-
-		if(total_genetic_points > initial(changeling.geneticpoints))
+			continue		
+		if(changeling.absorbedothers > 0)
 			return TRUE
 	return FALSE
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -2,11 +2,11 @@
 #define LING_DEAD_GENETICDAMAGE_HEAL_CAP	50	//The lowest value of geneticdamage handle_changeling() can take it to while dead.
 #define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 
-#define LING_CHEM_STORAGE_BASE				50
+#define LING_CHEM_STORAGE_BASE				60
 #define LING_CHEM_STORAGE_ADD				10
 
-#define LING_GENE_STORAGE_BASE				6
-#define LING_GENE_STORAGE_ADD				0.5
+#define LING_GENE_STORAGE_BASE				8
+#define LING_GENE_STORAGE_ADD				4
 
 /datum/antagonist/changeling
 	name = "Changeling"
@@ -25,9 +25,10 @@
 	var/datum/changelingprofile/first_prof = null
 	var/absorbedcount = 0
 	var/trueabsorbs = 0//dna gained using absorb, not dna sting
+	var/absorbedothers = 0
 	var/chem_charges = 20
 	var/chem_storage = LING_CHEM_STORAGE_BASE
-	var/chem_recharge_rate = 1.5
+	var/chem_recharge_rate = 1
 	var/chem_recharge_slowdown = 0
 	var/sting_range = 2
 	var/changelingID = "Changeling"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -2,6 +2,12 @@
 #define LING_DEAD_GENETICDAMAGE_HEAL_CAP	50	//The lowest value of geneticdamage handle_changeling() can take it to while dead.
 #define LING_ABSORB_RECENT_SPEECH			8	//The amount of recent spoken lines to gain on absorbing a mob
 
+#define LING_CHEM_STORAGE_BASE				50
+#define LING_CHEM_STORAGE_ADD				10
+
+#define LING_GENE_STORAGE_BASE				6
+#define LING_GENE_STORAGE_ADD				0.5
+
 /datum/antagonist/changeling
 	name = "Changeling"
 	roundend_category  = "changelings"
@@ -20,8 +26,8 @@
 	var/absorbedcount = 0
 	var/trueabsorbs = 0//dna gained using absorb, not dna sting
 	var/chem_charges = 20
-	var/chem_storage = 75
-	var/chem_recharge_rate = 1
+	var/chem_storage = LING_CHEM_STORAGE_BASE
+	var/chem_recharge_rate = 1.5
 	var/chem_recharge_slowdown = 0
 	var/sting_range = 2
 	var/changelingID = "Changeling"

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -123,7 +123,7 @@
 		if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
 			to_chat(user, "<span class='boldnotice'>[target] was one of us. We have absorbed their power.</span>")
 			target_ling.remove_changeling_powers()
-			changeling.geneticpoints += 2
+			//	changeling.geneticpoints += 2	handled separately; you can eat lings to gain their progress
 			target_ling.geneticpoints = 0
 			target_ling.canrespec = 0
 			target_ling.chem_charges = 0
@@ -133,7 +133,8 @@
 			target_ling.absorbedcount = 0
 			target_ling.was_absorbed = TRUE
 
-
+	changeling.chem_storage = LING_CHEM_STORAGE_BASE + changeling.absorbedcount * LING_CHEM_STORAGE_ADD
+	changeling.geneticpoints = LING_GENE_STORAGE_BASE + floor(changeling.absorbedcount * LING_GENE_STORAGE_ADD)
 	changeling.chem_charges=min(changeling.chem_charges+10, changeling.chem_storage)
 
 	changeling.isabsorbing = 0

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -134,7 +134,7 @@
 			target_ling.was_absorbed = TRUE
 
 	changeling.chem_storage = LING_CHEM_STORAGE_BASE + changeling.absorbedcount * LING_CHEM_STORAGE_ADD
-	changeling.geneticpoints = LING_GENE_STORAGE_BASE + floor(changeling.absorbedcount * LING_GENE_STORAGE_ADD)
+	changeling.geneticpoints = LING_GENE_STORAGE_BASE + floor(changeling.absorbedcount * LING_GENE_STORAGE_ADD)	// couldn't find a math.floor method. does this work?
 	changeling.chem_charges=min(changeling.chem_charges+10, changeling.chem_storage)
 
 	changeling.isabsorbing = 0

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -129,12 +129,13 @@
 			target_ling.chem_charges = 0
 			target_ling.chem_storage = 0
 			changeling.absorbedcount += (target_ling.absorbedcount)
+			changeling.trueabsorbs += (target_ling.trueabsorbs)
 			target_ling.stored_profiles.len = 1
 			target_ling.absorbedcount = 0
 			target_ling.was_absorbed = TRUE
 
-	changeling.chem_storage = LING_CHEM_STORAGE_BASE + changeling.absorbedcount * LING_CHEM_STORAGE_ADD
-	changeling.geneticpoints = LING_GENE_STORAGE_BASE + floor(changeling.absorbedcount * LING_GENE_STORAGE_ADD)	// couldn't find a math.floor method. does this work?
+	changeling.chem_storage = LING_CHEM_STORAGE_BASE + changeling.trueabsorbs * LING_CHEM_STORAGE_ADD
+	changeling.geneticpoints = LING_GENE_STORAGE_BASE + floor(changeling.trueabsorbs * LING_GENE_STORAGE_ADD)	// couldn't find a math.floor method. does this work?
 	changeling.chem_charges=min(changeling.chem_charges+10, changeling.chem_storage)
 
 	changeling.isabsorbing = 0

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -132,12 +132,13 @@
 			target_ling.chem_storage = 0
 			changeling.absorbedcount += (target_ling.absorbedcount)
 			changeling.trueabsorbs += (target_ling.trueabsorbs)
+			changeling.absorbedothers++
 			target_ling.stored_profiles.len = 1
 			target_ling.absorbedcount = 0
 			target_ling.was_absorbed = TRUE
 
 	changeling.chem_storage = LING_CHEM_STORAGE_BASE + changeling.trueabsorbs * LING_CHEM_STORAGE_ADD
-	changeling.geneticpoints = LING_GENE_STORAGE_BASE + floor(changeling.trueabsorbs * LING_GENE_STORAGE_ADD)	// couldn't find a math.floor method. does this work?
+	changeling.geneticpoints = LING_GENE_STORAGE_BASE + floor(changeling.absorbedothers * LING_GENE_STORAGE_ADD)	// couldn't find a math.floor method. does this work?
 	changeling.chem_charges=min(changeling.chem_charges+10, changeling.chem_storage)
 
 	changeling.isabsorbing = 0

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -55,7 +55,6 @@
 
 	if(!changeling.has_dna(target.dna))
 		changeling.add_new_profile(target)
-		changeling.trueabsorbs++
 
 	if(user.nutrition < NUTRITION_LEVEL_WELL_FED)
 		user.set_nutrition(min((user.nutrition + target.nutrition), NUTRITION_LEVEL_WELL_FED))
@@ -63,6 +62,9 @@
 	if(target.mind && user.mind)//if the victim and user have minds
 		// Absorb a lizard, speak Draconic.
 		owner.copy_languages(target, LANGUAGE_ABSORB)
+		
+		//moved this here to prevent lings off feeding on mo0mkes
+		changeling.trueabsorbs++
 
 		var/datum/mind/suckedbrain = target.mind
 		user.mind.memory += "<BR><b>We've absorbed [target]'s memories into our own...</b><BR>[suckedbrain.memory]<BR>"


### PR DESCRIPTION
## About The Pull Request

Reworked changelings gene/DNA caps to scale the more victims they trueabsorb. This is to allow them to scale into lategame (like most antagonists). You no longer gain direct gene points from absorbing other lings, but you will gain their trueabsorbs and scale off that. Hopefully pairs off well with my CBZ sting pull, and allows ling hunting lings to turn into monstrous superantags lategame...

## Why It's Good For The Game

Changelings are very weak at the moment and overnerfed to the point they can't do anything much. Their abilities are kinda shit and easily to counter when you know the easily available counters. I'm not even talking about CBZ; just set them on fire and their healing is disabled. Weld the vents and their headcrab is disabled. BZ in the air and they can't do shit. You can buy BZ and CBZ fairly easy.

It's nearly impossible for a changeling to go loud at this point. While I know "their point is not to be loud", they are strictly a stealth antag and even more pathetic than heretics when exposed/faced against 2 seccies.

## Changelog
:cl:
tweak: changelings now start with less overall DNA points and genetic points, but gain more the more victims they absorb
del: removed changeling's ability to gain gene points when they absorb other lings
/:cl: