### PR TITLE
Custom shuttle offsets and view range depends on ship size.

### DIFF
--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -263,7 +263,7 @@
 		return
 	return ..()
 
-/obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(new_id) 
+/obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(new_id)
 	shuttleId = new_id
 	shuttlePortId = "shuttle[new_id]_custom"
 

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -264,12 +264,12 @@
 	return ..()
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(new_id)
-	shuttleId = port.id
+	shuttleId = new_id
 	shuttlePortId = "shuttle[new_id]_custom"
 
 	//Take info from connected port and calculate amendments
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(new_id)
 	var/list/shuttlebounds = M.return_coords()
-	view_range = round(max(width, height)*0.5)
+	view_range = min(round(max(width, height)*0.5), 36)
 	x_offset = round((shuttlebounds[1] + shuttlebounds[3])*0.5) - M.x
 	y_offset = round((shuttlebounds[2] + shuttlebounds[4])*0.5) - M.y

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -270,6 +270,6 @@
 	//Take info from connected port and calculate amendments
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(new_id)
 	var/list/shuttlebounds = M.return_coords()
-	view_range = min(round(max(width, height)*0.5), 36)
+	view_range = min(round(max(M.width, M.height)*0.5), 36)
 	x_offset = round((shuttlebounds[1] + shuttlebounds[3])*0.5) - M.x
 	y_offset = round((shuttlebounds[2] + shuttlebounds[4])*0.5) - M.y

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -270,6 +270,6 @@
 	//Take info from connected port and calculate amendments
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(new_id)
 	var/list/shuttlebounds = M.return_coords()
-	view_range = min(round(max(M.width, M.height)*0.5), 36)
+	view_range = min(round(max(M.width, M.height)*0.5), 15)
 	x_offset = round((shuttlebounds[1] + shuttlebounds[3])*0.5) - M.x
 	y_offset = round((shuttlebounds[2] + shuttlebounds[4])*0.5) - M.y

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -263,7 +263,7 @@
 		return
 	return ..()
 
-/obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(new_id)
+/obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(new_id) 
 	shuttleId = new_id
 	shuttlePortId = "shuttle[new_id]_custom"
 

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -263,12 +263,13 @@
 		return
 	return ..()
 
-/obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(var/new_id)
-	connect_to_shuttle(SSshuttle.getShuttle(new_id))
+/obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(new_id)
+	shuttleId = port.id
 	shuttlePortId = "shuttle[new_id]_custom"
 
 	//Take info from connected port and calculate amendments
-	var/list/shuttlebounds = shuttle_port.return_coords()
-	view_range = round(max((shuttlebounds[1] - shuttlebounds[3]), (shuttlebounds[2] - shuttlebounds[4]))/2)
-	x_offset = round((shuttlebounds[1] + shuttlebounds[3])*0.5) - shuttle_port.x
-	y_offset = round((shuttlebounds[2] + shuttlebounds[4])*0.5) - shuttle_port.y
+	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(new_id)
+	var/list/shuttlebounds = M.return_coords()
+	view_range = round(max(width, height)*0.5)
+	x_offset = round((shuttlebounds[1] + shuttlebounds[3])*0.5) - M.x
+	y_offset = round((shuttlebounds[2] + shuttlebounds[4])*0.5) - M.y

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -264,5 +264,11 @@
 	return ..()
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/custom/proc/linkShuttle(var/new_id)
-	shuttleId = new_id
+	connect_to_shuttle(SSshuttle.getShuttle(new_id))
 	shuttlePortId = "shuttle[new_id]_custom"
+
+	//Take info from connected port and calculate amendments
+	var/list/shuttlebounds = shuttle_port.return_coords()
+	view_range = round(max((shuttlebounds[1] - shuttlebounds[3]), (shuttlebounds[2] - shuttlebounds[4]))/2)
+	x_offset = round((shuttlebounds[1] + shuttlebounds[3])*0.5) - shuttle_port.x
+	y_offset = round((shuttlebounds[2] + shuttlebounds[4])*0.5) - shuttle_port.y


### PR DESCRIPTION

## About The Pull Request

Now shuttle docker on custom shuttle get more reasonable view range, and center eye on center of ship.

## Why It's Good For The Game

No more giant view for micro shuttle.
Eye centers on your ship, so you can see all long and thin shuttle.

## Changelog
:cl:
tweak: Custom ship navigation computer now get offsets and view range depends on ship size.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
