### PR TITLE
Fix a bug in in table mood interaction.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -77,13 +77,17 @@
 	timeout = 2 MINUTES
 
 /datum/mood_event/table/add_effects()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
+	var/datum/component/L = owner //owner is lying about its type, its component/mood while pretending to be mob. You must cast it to use it properly
+	var/mob/living/T = L.parent
+	if(ishuman(T))
+		var/mob/living/carbon/human/H = T
 		if(iscatperson(H))
 			H.dna.species.start_wagging_tail(H)
 			addtimer(CALLBACK(H.dna.species, /datum/species.proc/stop_wagging_tail, H), 30)
 			description =  "<span class='nicegreen'>They want to play on the table!</span>\n"
 			mood_change = 2
+
+
 
 /datum/mood_event/table_headsmash
 	description = "<span class='warning'>My fucking head, that hurt...</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR will fix a bug inside `code\datums\mood_events\generic_negative_events.dm(line 79)`. There apparently is supposed to be a positive moodlet when you table a felinid but this never worked because the variable `owner` lies about it type. Its a `/datum/component/mood` but pretends to be a `mob`. When cast it works perfectly fine and its name also is `/datum/component/mood` but it will throw compiler errors when attempted to be used directly.

This is a band aid solution for a perhaps larger problem with moodlets. This is just the only time this feature actually got used

Also besure to comment I dont know what is efficient for byond code
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix nice and I can play psychiatrist now and table felinids as a valid anti-depressant
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

fix: Felinds are supposed to like getting thrown on tables

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
