### PR TITLE
Xenolings are back + a nerf.

### DIFF
--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -120,9 +120,12 @@
 
 
 		var/datum/antagonist/changeling/target_ling = target.mind.has_antag_datum(/datum/antagonist/changeling)
+		var/datum/antagonist/changeling/target_xenobioling = target.mind.has_antag_datum(/datum/antagonist/changeling/xenobio)
 		if(target_ling)//If the target was a changeling, suck out their extra juice and objective points!
 			to_chat(user, "<span class='boldnotice'>[target] was one of us. We have absorbed their power.</span>")
 			target_ling.remove_changeling_powers()
+			if(!target_xenobioling)
+				changeling.geneticpoints += 2
 			changeling.geneticpoints += 2
 			target_ling.geneticpoints = 0
 			target_ling.canrespec = 0

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -21,6 +21,7 @@
 	ventcrawler = VENTCRAWLER_ALWAYS
 	var/datum/mind/origin
 	var/egg_lain = 0
+	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/headcrab/proc/Infect(mob/living/carbon/victim)
 	var/obj/item/organ/body_egg/changeling_egg/egg = new(victim)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Readds Xenolings to xenobiology and they come with a nerf, xenolings can't gain dna points form absorbing other xenolings pretty much making them hunter dogs for real lings. The only reason they were removed in the first place was that along time ago lings were broken as fuck, and could kill the entire station, now they are "stealth" antags who are weak as shit and can be easily cucked, literally no one fears lings anymore lol. The point of this pr is to bring xenolings back allowing skillful traitor xenobiologists, trade 50 minutes of build-up aka getting gold and rainbow slimes in exchange for a chance to getting ling. Or for xenobiologists to go ling hunting. 

Also remember that getting xenoling is pretty much going to cost you an entire shift since it's behind multiple layers of rng + risks to get it. And you won't ever see them in lrp since rounds end in 30 minutes lol, and in mrp even less since people there don't know how to xenobio and rounds generally end at the one hour mark.

https://www.youtube.com/watch?v=WzfFdHUg-78
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xenolings are always fun, and are stacked up upon multiple layers of rng, making them very hard to get and very dangerous as well since they are present in the golden slime hostile pool, meaning that the scientist needs to kill a bunch of hostile mobs first before getting the headslug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added xenolings back
nerfed: xenolings so they won't be able to get dna points from absorbing other xenolings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
