### PR TITLE
Renames the donut box containing null

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -17,8 +17,8 @@
 /obj/item/storage/fancy
 	icon = 'icons/obj/food/containers.dmi'
 	icon_state = "donutbox6"
-	name = "donut box"
-	desc = "Mmm. Donuts."
+	name = "null box do not use"
+	desc = "Mmm. Runtimes."
 	resistance_flags = FLAMMABLE
 	var/icon_type = "donut"
 	var/spawn_type = null
@@ -67,6 +67,7 @@
 	icon_state = "donutbox6"
 	icon_type = "donut"
 	name = "donut box"
+	desc = "Mmm. Donuts."
 	spawn_type = /obj/item/reagent_containers/food/snacks/donut
 	fancy_open = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the name and description of the parent datum to the box of donuts to "null box do not use" since spawning it causes a runtime. It is indistinguishable from an actual box of donuts other than its datum path.

## Why It's Good For The Game

To help prevent mappers and admins from spawning a box containing a runtime error.

## Changelog
:cl:
code: tiny renaming of a runtime error datum
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
