### PR TITLE
Fix assmly GUI not working in TGUI TTV

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -128,7 +128,7 @@
 			attached_device = null
 			update_icon()
 		if(href_list["device"])
-			attached_device.attack_self(usr)
+			attached_device.ui_interact(usr)
 
 	attack_self(usr)
 	add_fingerprint(usr)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -127,6 +127,6 @@
 	return ui_interact(user)
 
 /obj/item/assembly/ui_status(mob/user)
-	.= ..()
+	. = ..()
 	if(src.can_interact(user) || holder.can_interact(user))
 		return UI_INTERACTIVE

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -125,3 +125,9 @@
 
 /obj/item/assembly/interact(mob/user)
 	return ui_interact(user)
+
+/obj/item/assembly/ui_status(mob/user)
+	.= ..()
+	if(src.can_interact(user) || holder.can_interact(user))
+		. = max(., UI_INTERACTIVE)
+

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -129,5 +129,4 @@
 /obj/item/assembly/ui_status(mob/user)
 	.= ..()
 	if(src.can_interact(user) || holder.can_interact(user))
-		. = max(., UI_INTERACTIVE)
-
+		return UI_INTERACTIVE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #2700 which prevented you from opening the assembly GUI when its inside the TTV.

This happened because `ui_status` only checked if the object itself can be interacted with and not the object containing itself. It should work with signaler, proximity and timers aswell.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix bug good yes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: assembly's now can be interacted with while inside other objects like TTV
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
