### PR TITLE
Nerfs the Firelock Deathtraps

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -35,8 +35,9 @@
 	var/datum/effect_system/spark_spread/spark_system
 	var/real_explosion_block	//ignore this, just use explosion_block
 	var/red_alert_access = FALSE //if TRUE, this door will always open on red alert
-	var/poddoor = FALSE
+	var/poddoor = FALSE	
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
+	var/open_speed = 0
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -292,9 +293,9 @@
 	operating = TRUE
 	do_animate("opening")
 	set_opacity(0)
-	sleep(5)
+	sleep(5+open_speed)
 	density = FALSE
-	sleep(5)
+	sleep(5+open_speed)
 	layer = initial(layer)
 	update_icon()
 	set_opacity(0)
@@ -324,9 +325,9 @@
 	layer = closingLayer
 	if(air_tight)
 		density = TRUE
-	sleep(5)
+	sleep(5+open_speed)
 	density = TRUE
-	sleep(5)
+	sleep(5+open_speed)
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -37,7 +37,7 @@
 	var/red_alert_access = FALSE //if TRUE, this door will always open on red alert
 	var/poddoor = FALSE	
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
-	var/open_speed = 0
+	var/open_speed = 5
 
 /obj/machinery/door/examine(mob/user)
 	. = ..()
@@ -293,9 +293,9 @@
 	operating = TRUE
 	do_animate("opening")
 	set_opacity(0)
-	sleep(5+open_speed)
+	sleep(open_speed)
 	density = FALSE
-	sleep(5+open_speed)
+	sleep(open_speed)
 	layer = initial(layer)
 	update_icon()
 	set_opacity(0)
@@ -325,9 +325,9 @@
 	layer = closingLayer
 	if(air_tight)
 		density = TRUE
-	sleep(5+open_speed)
+	sleep(open_speed)
 	density = TRUE
-	sleep(5+open_speed)
+	sleep(open_speed)
 	update_icon()
 	if(visible && !glass)
 		set_opacity(1)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -105,7 +105,7 @@
 						 "You operate the manual lever on \the [src].")
 			if (!do_after(user, 30, TRUE, src))
 				return FALSE
-		else if (density || allow_hand_open(user))
+		else if (density && !allow_hand_open(user))
 			return FALSE
 	
 		add_fingerprint(user)		

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -6,7 +6,7 @@
 
 /obj/machinery/door/firedoor
 	name = "firelock"
-	desc = "Apply crowbar."
+	desc = "A convenable firelock. Equipt with a manual lever for operating in case of emergency."
 	icon = 'icons/obj/doors/doorfireglass.dmi'
 	icon_state = "door_open"
 	opacity = FALSE
@@ -101,8 +101,8 @@
 	
 	if (!welded && !operating)
 		if (stat & NOPOWER) 				
-			user.visible_message("[user] tries to force open \the [src].",
-						 "You try to force open \the [src].")
+			user.visible_message("[user] tries to open \the [src] manually.",
+						 "You operate the manual lever on \the [src].")
 			if (!do_after(user, 30, TRUE, src))
 				return FALSE
 		else if (density || allow_hand_open(user))
@@ -110,7 +110,7 @@
 	
 		add_fingerprint(user)		
 		if(density)
-			emergency_close_timer = world.time + 30 // prevent it from instaclosing again if in space
+			emergency_close_timer = world.time + 15 // prevent it from instaclosing again if in space
 			open()
 		else
 			close()
@@ -181,7 +181,7 @@
 			whack_a_mole()
 		if(welded || operating || !density)
 			return // in case things changed during our do_after
-		emergency_close_timer = world.time + 60 // prevent it from instaclosing again if in space
+		emergency_close_timer = world.time + 15 // prevent it from instaclosing again if in space
 		open()
 	else
 		close()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -24,7 +24,7 @@
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 70)
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
 	air_tight = TRUE
-	open_speed = -3
+	open_speed = 2
 	var/emergency_close_timer = 0
 	var/nextstate = null
 	var/boltslocked = TRUE

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -24,6 +24,7 @@
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 70)
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
 	air_tight = TRUE
+	open_speed = -3
 	var/emergency_close_timer = 0
 	var/nextstate = null
 	var/boltslocked = TRUE
@@ -97,8 +98,17 @@
 	. = ..()
 	if(.)
 		return
-	if(!welded && !operating && !(stat & NOPOWER) && (!density || allow_hand_open(user)))
-		add_fingerprint(user)
+	
+	if (!welded && !operating)
+		if (stat & NOPOWER) 				
+			user.visible_message("[user] tries to force open \the [src].",
+						 "You try to force open \the [src].")
+			if (!do_after(user, 30, TRUE, src))
+				return FALSE
+		else if (density || allow_hand_open(user))
+			return FALSE
+	
+		add_fingerprint(user)		
 		if(density)
 			emergency_close_timer = world.time + 30 // prevent it from instaclosing again if in space
 			open()
@@ -107,6 +117,7 @@
 		return TRUE
 	if(operating || !density)
 		return
+	
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	user.visible_message("[user] bangs on \the [src].",
@@ -162,7 +173,7 @@
 		if(is_holding_pressure())
 			// tell the user that this is a bad idea, and have a do_after as well
 			to_chat(user, "<span class='warning'>As you begin crowbarring \the [src] a gush of air blows in your face... maybe you should reconsider?</span>")
-			if(!do_after(user, 20, TRUE, src)) // give them a few seconds to reconsider their decision.
+			if(!do_after(user, 10, TRUE, src)) // give them a few seconds to reconsider their decision.
 				return
 			log_game("[key_name(user)] has opened a firelock with a pressure difference at [AREACOORD(loc)]")
 			user.log_message("has opened a firelock with a pressure difference at [AREACOORD(loc)]", LOG_ATTACK)


### PR DESCRIPTION
## About The Pull Request

3 Simple Nerfs To Firelock Deathtrap
* Makes firelocks open 60% faster by reducing the sleep time when operating (opening/closing) the doors. 
* Halved the time it takes to open firelocks with crowbar. 
* You can open firelocks by using an empty hand. This is thanks to the manual lever that is applied on each and every firelock.

(EDIT) Reduced the time firelocks need to close. This often overrode their automatic close timers, meaning they wouldn't close in time/work properly and caused gas to escape.

## Why It's Good For The Game

So many times have I died to atmos fuckery because firelocks just don't open fast enough, and you have to go through 10 of them to get into a safe area. Sometimes they don't open at all. Whoops! Sometimes they just don't have power so if you don't have a crowbar, you fucked. Even if you do have a crowbar, it takes literal ages to open 10 series of parallel firelocks to get to a safe area. Needless to say, firelocks have killed hundreds and are one of the biggest threats in SS13 at the moment. 

I don't think not having a crowbar should be an absolute death sentence in SS13. In real life, fireproof doors alyways (and I do mean, ALWAYS) have a way to be operated/opened by a human. Don't know why it should not be the same in SS13. They don't have to be a workplace hazard,

## Changelog
:cl:
tweak: firelocks open 60% faster.
tweak: halved the time it takes to open a firelock by crowbar.
tweak: reduced the time it takes for a firelock to close automatically
add: You can now pry open the firelocks with your bare hand.
/:cl:
