### PR TITLE
makes spacevines a tad less annoying

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -99,22 +99,6 @@
 	if(!isvineimmune(eater))
 		eater.adjustToxLoss(5)
 
-/datum/spacevine_mutation/explosive  //OH SHIT IT CAN CHAINREACT RUN!!!
-	name = "explosive"
-	hue = "#ff0000"
-	quality = NEGATIVE
-	severity = 2
-
-/datum/spacevine_mutation/explosive/on_explosion(explosion_severity, target, obj/structure/spacevine/holder)
-	if(explosion_severity < 3)
-		qdel(holder)
-	else
-		. = 1
-		QDEL_IN(holder, 5)
-
-/datum/spacevine_mutation/explosive/on_death(obj/structure/spacevine/holder, mob/hitter, obj/item/I)
-	explosion(holder.loc, 0, 0, severity, 0, 0)
-
 /datum/spacevine_mutation/fire_proof
 	name = "fire proof"
 	hue = "#ff8888"
@@ -128,28 +112,6 @@
 		. = 0
 	else
 		. = expected_damage
-
-/datum/spacevine_mutation/vine_eating
-	name = "vine eating"
-	hue = "#ff7700"
-	quality = MINOR_NEGATIVE
-
-/datum/spacevine_mutation/vine_eating/on_spread(obj/structure/spacevine/holder, turf/target)
-	var/obj/structure/spacevine/prey = locate() in target
-	if(prey && !prey.mutations.Find(src))  //Eat all vines that are not of the same origin
-		qdel(prey)
-
-/datum/spacevine_mutation/aggressive_spread  //very OP, but im out of other ideas currently
-	name = "aggressive spreading"
-	hue = "#333333"
-	severity = 3
-	quality = NEGATIVE
-
-/datum/spacevine_mutation/aggressive_spread/on_spread(obj/structure/spacevine/holder, turf/target)
-	target.ex_act(severity, null, src) // vine immunity handled at /mob/ex_act
-
-/datum/spacevine_mutation/aggressive_spread/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
-	buckled.ex_act(severity, null, src)
 
 /datum/spacevine_mutation/transparency
 	name = "transparent"

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -372,8 +372,6 @@
 
 
 /mob/living/carbon/human/ex_act(severity, target, origin)
-	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))
-		return
 	..()
 	if (!severity || QDELETED(src))
 		return


### PR DESCRIPTION
## About The Pull Request
-spacevines no longer blow shit up, so hullbreaches from them should no longer happen
-removes some snowflake code
-spacevines no longer eat themselves. this should allow them to properly mutate (this is a buff)

## Why It's Good For The Game
spacevines just eat each themselves and blow the fuck out of the station. this should make them work more like intended

## Changelog
:cl:
del: removed spacevine explosives and some snowflake code
del: spacevines no longer eat themselves, so they can now thrive fully
/:cl:

