### PR TITLE
Adds Airlock Charge to traitor uplinks

### DIFF
--- a/code/game/objects/items/devices/doorCharge.dm
+++ b/code/game/objects/items/devices/doorCharge.dm
@@ -1,5 +1,5 @@
 /obj/item/doorCharge
-	name = "airlock charge"
+	name = "Airlock Charge"
 	desc = null //Different examine for traitors
 	icon = 'icons/obj/device.dmi'
 	item_state = "electronic"
@@ -36,7 +36,7 @@
 
 /obj/item/doorCharge/examine(mob/user)
 	. = ..()
-	if(user.mind && user.mind.has_antag_datum(/datum/antagonist/traitor)) //No nuke ops because the device is excluded from nuclear
+	if(user.mind && user.mind.has_antag_datum(/datum/antagonist/traitor, /datum/antagonist/traitor/internal_affairs, /datum/antagonist/incursion, /datum/antagonist/nukeop))
 		. += "A small explosive device that can be used to sabotage airlocks to cause an explosion upon opening. To apply, remove the airlock's maintenance panel and place it within."
 	else
 		. += "A small, suspicious object that feels lukewarm when held."

--- a/code/game/objects/items/devices/doorCharge.dm
+++ b/code/game/objects/items/devices/doorCharge.dm
@@ -1,5 +1,5 @@
 /obj/item/doorCharge
-	name = "Airlock Charge"
+	name = "airlock charge"
 	desc = null //Different examine for traitors
 	icon = 'icons/obj/device.dmi'
 	item_state = "electronic"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1089,9 +1089,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 
 /datum/uplink_item/explosives/doorCharge
-    name = "Airlock Charge"
+	name = "Airlock Charge"		
 	desc = "A small explosive device that can be used to sabotage airlocks to cause an explosion upon opening. \
-	        To apply, remove the airlock's maintenance panel and place it within."
+			To apply, remove the airlock's maintenance panel and place it within."
 	item = /obj/item/doorCharge
 	cost = 4
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1088,6 +1088,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/deployablemine/traitor
 	cost = 4
 
+/datum/uplink_item/explosives/doorCharge
+    name = "Airlock Charge"
+	desc = "A small explosive device that can be used to sabotage airlocks to cause an explosion upon opening. \
+	        To apply, remove the airlock's maintenance panel and place it within."
+	item = /obj/item/doorCharge
+	cost = 4
+
 /datum/uplink_item/explosives/virus_grenade
 	name = "Fungal Tuberculosis Grenade"
 	desc = "A primed bio-grenade packed into a compact box. Comes with five Bio Virus Antidote Kit (BVAK) \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds the airlock charges to uplinks because for whatever reason they were unused and only obtainable in one of the syndi-kit bundles. You can spot airlocks that have them by inspecting them while being within 1 tile of the airlock or by unscrewing the maintenance panel and inspecting them from anywhere, they can be removed by using a crowbar on the airlock while maintenance panel is exposed but make sure you don't get interrupted while removing it or the charge will explode. 

## Why It's Good For The Game
It adds one more way to blow up your targets.

## Changelog
:cl:
add: Adds Airlock Charge to traitor uplinks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
