### PR TITLE
Adds security gas masks to SecDrobe

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -27,6 +27,7 @@
 					/obj/item/clothing/head/beret/sec = 3,
 					/obj/item/clothing/head/soft/sec = 3,
 					/obj/item/clothing/mask/bandana/red = 3,
+					/obj/item/clothing/mask/gas/sechailer = 6,
 					/obj/item/clothing/under/rank/security/officer/skirt = 3,
 					/obj/item/clothing/under/rank/security/officer/white = 3,
 					/obj/item/clothing/under/pants/khaki = 3,


### PR DESCRIPTION
## Why It's Good For The Game

On most maps you can't get a replacement mask and it makes sense it'd be available in their uniform vendor. 

## Changelog
:cl:
add: Added security gas masks to SecDrobe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
