### PR TITLE
Held mobs no longer lose their sprites if they were resting

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1285,9 +1285,9 @@
 	. = ..()
 
 /mob/living/proc/mob_pickup(mob/living/L)
-	if(src.resting)
-		src.resting = FALSE
-		src.update_resting()
+	if(resting)
+		resting = FALSE
+		update_resting()
 	var/obj/item/clothing/head/mob_holder/holder = new(get_turf(src), src, held_state, head_icon, held_lh, held_rh, worn_slot_flags)
 	L.visible_message("<span class='warning'>[L] scoops up [src]!</span>")
 	L.put_in_hands(holder)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1285,6 +1285,9 @@
 	. = ..()
 
 /mob/living/proc/mob_pickup(mob/living/L)
+	if(src.resting)
+		src.resting = FALSE
+		src.update_resting()
 	var/obj/item/clothing/head/mob_holder/holder = new(get_turf(src), src, held_state, head_icon, held_lh, held_rh, worn_slot_flags)
 	L.visible_message("<span class='warning'>[L] scoops up [src]!</span>")
 	L.put_in_hands(holder)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically I make them not rest so they have their sprites.

## Why It's Good For The Game
Fix

## Changelog
:cl:
fix: Held mobs no longer lose their sprites if they were resting. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
