### PR TITLE
Smartfridges will load items when hit by them

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -136,6 +136,18 @@
 		return ..()
 
 
+/obj/machinery/smartfridge/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)	
+	if (istype(AM, /obj/item))
+		var/obj/item/O = AM
+		if(!stat)
+			if(contents.len < max_n_of_items && accept_check(O))
+				load(O)
+				updateUsrDialog()
+				if (visible_contents)
+					update_icon()
+				return TRUE
+	return ..()
+
 
 /obj/machinery/smartfridge/proc/accept_check(obj/item/O)
 	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/) || istype(O, /obj/item/seeds/) || istype(O, /obj/item/grown/))

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -137,9 +137,9 @@
 
 
 /obj/machinery/smartfridge/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)	
-	if (istype(AM, /obj/item))
-		var/obj/item/O = AM
-		if(!stat)
+	if(!stat)
+		if (istype(AM, /obj/item))		
+			var/obj/item/O = AM
 			if(contents.len < max_n_of_items && accept_check(O))
 				load(O)
 				updateUsrDialog()


### PR DESCRIPTION
## About The Pull Request

When hit by a item, a smartfridge will check if the said item can be stored. If yes, it will load it in.

## Why It's Good For The Game

Not so immersive to throw items in a smartfridge and they get absorbed, but allows conveyor belts to load items in smartfridge automatically. Very good for automation.

## Changelog
:cl:
add: smartfridges will automatically load items off conveyor belts, or items thrown at them.
/:cl: