### PR TITLE
Flesh path ghoul stun immunity/stamcrit immunity

### DIFF
--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -41,10 +41,15 @@
 			return
 		var/mob/dead/observer/C = pick(candidates)
 		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(humie)]) to replace an AFK player.")
-		humie.ghostize(0)
+		humie.ghostize(0)		
 		humie.key = C.key
 
 	ADD_TRAIT(humie,TRAIT_MUTE,MAGIC_TRAIT)
+	ADD_TRAIT(humie, TRAIT_STUNIMMUNE, MAGIC_TRAIT)
+	ADD_TRAIT(humie, TRAIT_CONFUSEIMMUNE, MAGIC_TRAIT)
+	ADD_TRAIT(humie, TRAIT_IGNOREDAMAGESLOWDOWN, MAGIC_TRAIT)
+	ADD_TRAIT(humie, TRAIT_NOSTAMCRIT, MAGIC_TRAIT)
+	ADD_TRAIT(humie, TRAIT_NOLIMBDISABLE, MAGIC_TRAIT)
 	log_game("[key_name_admin(humie)] has become a voiceless dead, their master is [user.real_name]")
 	humie.revive(full_heal = TRUE, admin_revive = TRUE)
 	humie.setMaxHealth(50)
@@ -112,6 +117,9 @@
 	RegisterSignal(human_target,COMSIG_MOB_DEATH,.proc/remove_ghoul)
 	human_target.revive(full_heal = TRUE, admin_revive = TRUE)
 	human_target.setMaxHealth(25)
+	ADD_TRAIT(human_target, TRAIT_CONFUSEIMMUNE, MAGIC_TRAIT)
+	ADD_TRAIT(human_target, TRAIT_NOSTAMCRIT, MAGIC_TRAIT)
+	ADD_TRAIT(human_target, TRAIT_NOLIMBDISABLE, MAGIC_TRAIT)
 	human_target.health = 25
 	human_target.become_husk()
 	human_target.faction |= "heretics"

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -117,9 +117,8 @@
 	RegisterSignal(human_target,COMSIG_MOB_DEATH,.proc/remove_ghoul)
 	human_target.revive(full_heal = TRUE, admin_revive = TRUE)
 	human_target.setMaxHealth(25)
+	ADD_TRAIT(human_target, TRAIT_STUNIMMUNE, MAGIC_TRAIT)
 	ADD_TRAIT(human_target, TRAIT_CONFUSEIMMUNE, MAGIC_TRAIT)
-	ADD_TRAIT(human_target, TRAIT_NOSTAMCRIT, MAGIC_TRAIT)
-	ADD_TRAIT(human_target, TRAIT_NOLIMBDISABLE, MAGIC_TRAIT)
 	human_target.health = 25
 	human_target.become_husk()
 	human_target.faction |= "heretics"

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -44,14 +44,14 @@
 		humie.ghostize(0)		
 		humie.key = C.key
 
+	log_game("[key_name_admin(humie)] has become a voiceless dead, their master is [user.real_name]")
+	humie.revive(full_heal = TRUE, admin_revive = TRUE)
 	ADD_TRAIT(humie,TRAIT_MUTE,MAGIC_TRAIT)
 	ADD_TRAIT(humie, TRAIT_STUNIMMUNE, MAGIC_TRAIT)
 	ADD_TRAIT(humie, TRAIT_CONFUSEIMMUNE, MAGIC_TRAIT)
 	ADD_TRAIT(humie, TRAIT_IGNOREDAMAGESLOWDOWN, MAGIC_TRAIT)
 	ADD_TRAIT(humie, TRAIT_NOSTAMCRIT, MAGIC_TRAIT)
 	ADD_TRAIT(humie, TRAIT_NOLIMBDISABLE, MAGIC_TRAIT)
-	log_game("[key_name_admin(humie)] has become a voiceless dead, their master is [user.real_name]")
-	humie.revive(full_heal = TRUE, admin_revive = TRUE)
 	humie.setMaxHealth(50)
 	humie.health = 50 // Voiceless dead are much tougher than ghouls
 	humie.become_husk()
@@ -116,9 +116,9 @@
 	. = TRUE
 	RegisterSignal(human_target,COMSIG_MOB_DEATH,.proc/remove_ghoul)
 	human_target.revive(full_heal = TRUE, admin_revive = TRUE)
+	ADD_TRAIT(human_target, TRAIT_NOSTAMCRIT, MAGIC_TRAIT)
+	ADD_TRAIT(human_target, TRAIT_NOLIMBDISABLE, MAGIC_TRAIT)
 	human_target.setMaxHealth(25)
-	ADD_TRAIT(human_target, TRAIT_STUNIMMUNE, MAGIC_TRAIT)
-	ADD_TRAIT(human_target, TRAIT_CONFUSEIMMUNE, MAGIC_TRAIT)
 	human_target.health = 25
 	human_target.become_husk()
 	human_target.faction |= "heretics"


### PR DESCRIPTION
## About The Pull Request

Makes ghouls stamshit immune.
Makes mute ghouls also stun/confusion immune

## Why It's Good For The Game

Ghouls of the flesh path are weak. They are slow, fragile and super obvious. They are pretty shit in battle, and even more so against security. There's no reason to have ghoul servants and they are newbie trap. Stun/stam immunity hopefully ballances these a bit and makes it as good as the others.

Flesh path is one of the weakest path because 2 of its abilities are completely pointless. Maybe this will help flesh heretics up a bit?

Also makes sense lore wise; ghouls are piles of flesh animated by magic. No nerves function, so disabling them with a taser does very little.

## Changelog
:cl:
tweak: stam imunity to flesh path ghouls
tweak: stun+stam imunity to mute ghouls
/:cl:
