### PR TITLE
Add single storage slot to potted plants

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -315,6 +315,13 @@
 	throw_speed = 2
 	throw_range = 4
 
+/obj/item/twohanded/required/kirbyplants/Initialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete/kirbyplants)
+
+/datum/component/storage/concrete/kirbyplants
+	max_items = 1
+	max_w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/twohanded/required/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)


### PR DESCRIPTION
## About The Pull Request

Adds a single NORMAL weight class storage slot to potted plants, which can be accessed by alt clicking the potted plant (same as you would access any other storage like pockets).

Video: https://streamable.com/8m3x3g

## Why It's Good For The Game

More methods to hide items is cool and fun.

## Changelog
:cl:
add: Added a single storage slot to potted plants
/:cl: