### PR TITLE
Mining tools rebalance.

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -23,13 +23,22 @@
 	fieldlimit = 6
 	quick_burst_mod = 1
 
-/obj/item/resonator/attack_self(mob/user)
+/obj/item/resonator/AltClick(mob/user)
 	if(burst_time == 50)
 		burst_time = 30
 		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>")
 	else
 		burst_time = 50
 		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 5 seconds.</span>")
+
+/obj/item/resonator/attack_self(mob/user)
+	if(LAZYLEN(fields) == 0)
+		return
+	to_chat(user, "<span class='info'>You detonate all resonator's active fields.</span>")
+	for(var/obj/effect/temp_visual/resonance/F in fields)
+		F.damage_multiplier = quick_burst_mod
+		F.burst()
+
 
 /obj/item/resonator/proc/CreateResonance(target, mob/user)
 	var/turf/T = get_turf(target)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -183,7 +183,7 @@
 		if("Survival Capsule and Explorer's Webbing")
 			new /obj/item/storage/belt/mining/vendor(drop_location)
 		if("Resonator Kit")
-			new /obj/item/extinguisher/mini(drop_location)
+			new /obj/item/storage/firstaid/brute(drop_location)
 			new /obj/item/resonator(drop_location)
 		if("Minebot Kit")
 			new /mob/living/simple_animal/hostile/mining_drone(drop_location)

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -2,10 +2,10 @@
 	projectile_type = /obj/item/projectile/plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
-	delay = 15
+	delay = 20
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/adv
 	projectile_type = /obj/item/projectile/plasma/adv
-	delay = 10
+	delay = 15
 	e_cost = 10

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -38,8 +38,8 @@
 		cell = new cell_type(src)
 	else
 		cell = new(src)
-	if(!dead_cell)
-		cell.give(cell.maxcharge)
+	if(dead_cell)	//this makes much more sense.
+		cell.use(cell.maxcharge)
 	update_ammo_types()
 	recharge_newshot(TRUE)
 	if(selfcharge)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -154,6 +154,7 @@
 /obj/item/gun/energy/plasmacutter/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 25, 105, 0, 'sound/weapons/plasma_cutter.ogg')
+	cell.use(cell.maxcharge)	//This is horrible. I tried to use "/obj/item/stock_parts/cell/empty" as a cell_type, but it won't work for some unknown reason as if Initialize() doesn't work.
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -172,7 +172,7 @@
 			to_chat(user, "<span class='notice'>You try to insert [I] into [src], but it's fully charged.</span>") //my cell is round and full
 			return
 		I.use(1)
-		cell.give(25*charge_multiplier)
+		cell.give(50*charge_multiplier)
 		to_chat(user, "<span class='notice'>You insert [I] in [src], recharging it.</span>")
 	else
 		..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -171,7 +171,7 @@
 			to_chat(user, "<span class='notice'>You try to insert [I] into [src], but it's fully charged.</span>") //my cell is round and full
 			return
 		I.use(1)
-		cell.give(500*charge_multiplier)
+		cell.give(25*charge_multiplier)
 		to_chat(user, "<span class='notice'>You insert [I] in [src], recharging it.</span>")
 	else
 		..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -139,6 +139,7 @@
 	block_upgrade_walk = 1
 	sharpness = IS_SHARP
 	can_charge = FALSE
+	dead_cell = TRUE
 
 	heat = 3800
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
@@ -154,7 +155,6 @@
 /obj/item/gun/energy/plasmacutter/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 25, 105, 0, 'sound/weapons/plasma_cutter.ogg')
-	cell.use(cell.maxcharge)	//This is horrible. I tried to use "/obj/item/stock_parts/cell/empty" as a cell_type, but it won't work for some unknown reason as if Initialize() doesn't work.
 
 /obj/item/gun/energy/plasmacutter/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs both resonators from "It's so comically underpowered it's not even funny" to a decent weapon/mining tool.
You can now use it in hand (default hotkey: Z) to detonate all currently set sonic blasts. Delay change is now on Alt+Click.

Plasma cutters have been nerfed from being comically overpowered. They now eat a bit more plasma and start as discharged. Prior to this change, you would need just 2 pieces of ore/1 plasma sheet to completely refuel the cutter that would last for 40 shots on basic cutter or 100 shots on advanced cutter, each of which was able to mine up to 7 tiles of rock, which is absurd. Now you need 40 ore chunks or 20 plasma sheets for a full charge, which makes a lot more balanced in my opinion. 
Also, the firing speed is a bit smaller, but I'd consider it a good thing since it makes you less likely to run into and shoot a gibtonite in your face (sad experience).

## Why It's Good For The Game

Nobody ever sees the resonator. It is also a free golem buff, but they don't really have meds to heal out after fighting fauna with resonators.
As for cutters, admit it, you rarely charge them at all, because they either outlast your life or you go for an upgrade for a better cutter, or the shift ends.

## Changelog
:cl:
balance: Resonators now detonate all their sonic blasts on use.
balance: Plasma cutters consume more plasma now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
