### PR TITLE
Mechs will now knock people down on melee, rather than make them unconcious.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -104,7 +104,6 @@
 			step_away(src,M,15)
 		switch(M.damtype)
 			if(BRUTE)
-				Unconscious(20)
 				take_overall_damage(rand(M.force/2, M.force))
 				playsound(src, 'sound/weapons/punch4.ogg', 50, 1)
 			if(BURN)
@@ -410,7 +409,7 @@
 		else
 			E.extrapolate(src, diseases, user)
 		return TRUE
-	else 
+	else
 		return FALSE
 
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -104,6 +104,7 @@
 			step_away(src,M,15)
 		switch(M.damtype)
 			if(BRUTE)
+				Knockdown(20)
 				take_overall_damage(rand(M.force/2, M.force))
 				playsound(src, 'sound/weapons/punch4.ogg', 50, 1)
 			if(BURN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes unconciousness from mech brute attacks.

## Why It's Good For The Game

Stun combat has long been considered one of the poorer aspects of the game. Mechs go one step up and have sleep combat, so if you get hit by a mech you don't even get the chance to run or react, you are just immediately put to sleep.

## Changelog
:cl:
del: Removes unconciousness from mech brute attacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
