### PR TITLE
Borgs no longer get confused after they get flashed/flashbanged

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -25,7 +25,7 @@
 	var/distance = max(0,get_dist(get_turf(src),T))
 
 //Flash
-	if(M.flash_act(affect_silicon = 1))
+	M.flash_act(affect_silicon = 1)
 //Bang
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
 		var/protection = max(1, M.get_ear_protection())

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -26,7 +26,6 @@
 
 //Flash
 	if(M.flash_act(affect_silicon = 1))
-		M.confused += (max(20/max(1,distance), 6))
 //Bang
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
 		var/protection = max(1, M.get_ear_protection())

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -232,7 +232,6 @@
 		log_combat(user, R, "flashed", src)
 		update_icon(1)
 		R.Paralyze(70)
-		var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
 		R.flash_act(affect_silicon = 1, type = /obj/screen/fullscreen/flash/static)
 		user.visible_message("<span class='disarm'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
 		return TRUE

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -233,7 +233,6 @@
 		update_icon(1)
 		R.Paralyze(70)
 		var/diff = 5 * CONFUSION_STACK_MAX_MULTIPLIER - M.confused
-		R.confused += min(5, diff)
 		R.flash_act(affect_silicon = 1, type = /obj/screen/fullscreen/flash/static)
 		user.visible_message("<span class='disarm'>[user] overloads [R]'s sensors with the flash!</span>", "<span class='danger'>You overload [R]'s sensors with the flash!</span>")
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Borgs are already easy to hardstun, if you fail at chainflashing you should get punished.
and overall confusion is really bad, annoying effect so begone

## Why It's Good For The Game

this is really small buff to borgs since most of the time they will just get chainflashed to death.

## Changelog
:cl:
tweak: Cyborgs no longer get confused after getting flashed/flashbanged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
