### PR TITLE
Makes stasis beds halt progressions of diseases

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -65,6 +65,9 @@
 /datum/disease/proc/stage_act()
 	var/cure = has_cure()
 
+	if(affected_mob.isinstasis())
+		return
+
 	if(carrier && !cure)
 		return
 

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -66,7 +66,7 @@
 	var/cure = has_cure()
 
 	var/mob/living/L = affected_mob
-	if(L.isinstasis())
+	if(L.IsInStasis())
 		return
 
 	if(carrier && !cure)

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -65,7 +65,8 @@
 /datum/disease/proc/stage_act()
 	var/cure = has_cure()
 
-	if(affected_mob.isinstasis())
+	var/mob/living/L = affected_mob
+	if(L.isinstasis())
 		return
 
 	if(carrier && !cure)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -51,7 +51,8 @@
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/body_egg/alien_embryo/egg_process()
-	if(owner.isinstasis())
+	var/mob/living/L = owner
+	if(L.isinstasis())
 		return
 	if(stage < 5 && prob(3))
 		stage++

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -51,6 +51,8 @@
 			owner.adjustToxLoss(10)
 
 /obj/item/organ/body_egg/alien_embryo/egg_process()
+	if(owner.isinstasis())
+		return
 	if(stage < 5 && prob(3))
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -52,7 +52,7 @@
 
 /obj/item/organ/body_egg/alien_embryo/egg_process()
 	var/mob/living/L = owner
-	if(L.isinstasis())
+	if(L.IsInStasis())
 		return
 	if(stage < 5 && prob(3))
 		stage++

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -55,7 +55,9 @@
 	var/time
 
 /obj/item/organ/body_egg/changeling_egg/egg_process()
-	// Changeling eggs grow in dead people
+	// Changeling eggs grow in dead people, but not people in stasis
+	if(owner.isinstasis())
+		return
 	time++
 	if(time >= EGG_INCUBATION_TIME)
 		Pop()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -57,7 +57,7 @@
 /obj/item/organ/body_egg/changeling_egg/egg_process()
 	// Changeling eggs grow in dead people, but not people in stasis
 	var/mob/living/L = owner
-	if(L.isinstasis())
+	if(L.IsInStasis())
 		return
 	time++
 	if(time >= EGG_INCUBATION_TIME)

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -56,7 +56,8 @@
 
 /obj/item/organ/body_egg/changeling_egg/egg_process()
 	// Changeling eggs grow in dead people, but not people in stasis
-	if(owner.isinstasis())
+	var/mob/living/L = owner
+	if(L.isinstasis())
 		return
 	time++
 	if(time >= EGG_INCUBATION_TIME)

--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -43,6 +43,8 @@
 /obj/item/organ/zombie_infection/process()
 	if(!owner)
 		return
+	if(owner.IsInStasis())
+		return
 	if(!(src in owner.internal_organs))
 		Remove(owner)
 	if (causes_damage && !iszombie(owner) && owner.stat != DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes stasis beds stop the progressions of diseases, xeno eggs, zombie infections and changeling eggs

## Why It's Good For The Game

Doesn't make much sense if they can't halt the diseases

## Changelog
:cl:
fix: Stasis beds now stop diseases from progressing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
