### PR TITLE
Refactors cyborg spray bottles, adds cyborg weedspray to janiborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -452,7 +452,8 @@
 		/obj/item/paint/paint_remover,
 		/obj/item/lightreplacer/cyborg,
 		/obj/item/holosign_creator/janibarrier,
-		/obj/item/reagent_containers/spray/cyborg_drying)
+		/obj/item/reagent_containers/spray/cyborg/drying_agent,
+		/obj/item/reagent_containers/spray/cyborg/plantbgone)
 	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_lube)
 	ratvar_modules = list(
 		/obj/item/clock_module/abscond,
@@ -464,11 +465,6 @@
 	hat_offset = -5
 	clean_on_move = TRUE
 
-/obj/item/reagent_containers/spray/cyborg_drying
-	name = "drying agent spray"
-	color = "#A000A0"
-	list_reagents = list(/datum/reagent/drying_agent = 250)
-
 /obj/item/reagent_containers/spray/cyborg_lube
 	name = "lube spray"
 	list_reagents = list(/datum/reagent/lube = 250)
@@ -479,10 +475,6 @@
 	if(LR)
 		for(var/i in 1 to coeff)
 			LR.Charge(R)
-
-	var/obj/item/reagent_containers/spray/cyborg_drying/CD = locate(/obj/item/reagent_containers/spray/cyborg_drying) in basic_modules
-	if(CD)
-		CD.reagents.add_reagent(/datum/reagent/drying_agent, 5 * coeff)
 
 	var/obj/item/reagent_containers/spray/cyborg_lube/CL = locate(/obj/item/reagent_containers/spray/cyborg_lube) in emag_modules
 	if(CL)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -454,7 +454,9 @@
 		/obj/item/holosign_creator/janibarrier,
 		/obj/item/reagent_containers/spray/cyborg/drying_agent,
 		/obj/item/reagent_containers/spray/cyborg/plantbgone)
-	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_lube)
+	emag_modules = list(
+		/obj/item/reagent_containers/spray/cyborg/lube,
+		/obj/item/reagent_containers/spray/cyborg/acid)
 	ratvar_modules = list(
 		/obj/item/clock_module/abscond,
 		/obj/item/clock_module/sigil_submission,
@@ -465,20 +467,12 @@
 	hat_offset = -5
 	clean_on_move = TRUE
 
-/obj/item/reagent_containers/spray/cyborg_lube
-	name = "lube spray"
-	list_reagents = list(/datum/reagent/lube = 250)
-
 /obj/item/robot_module/janitor/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
 	..()
 	var/obj/item/lightreplacer/LR = locate(/obj/item/lightreplacer) in basic_modules
 	if(LR)
 		for(var/i in 1 to coeff)
 			LR.Charge(R)
-
-	var/obj/item/reagent_containers/spray/cyborg_lube/CL = locate(/obj/item/reagent_containers/spray/cyborg_lube) in emag_modules
-	if(CL)
-		CL.reagents.add_reagent(/datum/reagent/lube, 2 * coeff)
 
 /obj/item/robot_module/clown
 	name = "Clown"

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -396,3 +396,15 @@
 	icon_state = "plantbgone"
 	item_state = "plantbgone"
 	set_reagent = /datum/reagent/toxin/plantbgone
+
+/obj/item/reagent_containers/spray/cyborg/lube
+	name = "lube spray"
+	desc = "A spray filled with space lube, for sabotaging the crew."
+	color = "#009CA8"
+	set_reagent = /datum/reagent/lube
+
+/obj/item/reagent_containers/spray/cyborg/acid
+	name = "acid spray"
+	desc = "A spray filled with sulphuric acid for offensive use."
+	color = "#00FF32"
+	set_reagent = /datum/reagent/toxin/acid

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -376,9 +376,9 @@
 		charge_tick = 0
 
 /obj/item/reagent_containers/spray/cyborg/proc/regenerate_reagents()
-	if(iscyborg(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R && R.cell)
+	var/mob/living/silicon/robot/R = loc
+	if(istype(R))
+		if(R.cell)
 			if(reagents.total_volume <= volume)
 				R.cell.use(charge_cost)
 				reagents.add_reagent(set_reagent, 5)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -357,3 +357,42 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	volume = 100
 	list_reagents = list(/datum/reagent/toxin/plantbgone = 100)
+
+/obj/item/reagent_containers/spray/cyborg
+	var/charge_cost = 50
+	var/charge_tick = 0
+	var/recharge_time = 2 //Time it takes for 5u to recharge (in seconds)
+	var/datum/reagent/set_reagent
+
+/obj/item/reagent_containers/spray/cyborg/Initialize()
+	. = ..()
+	reagents.add_reagent(set_reagent, volume)
+	START_PROCESSING(SSobj, src)
+
+/obj/item/reagent_containers/spray/cyborg/process()
+	charge_tick++
+	if(charge_tick >= recharge_time)
+		regenerate_reagents()
+		charge_tick = 0
+
+/obj/item/reagent_containers/spray/cyborg/proc/regenerate_reagents()
+	if(iscyborg(src.loc))
+		var/mob/living/silicon/robot/R = src.loc
+		if(R && R.cell)
+			if(reagents.total_volume <= volume)
+				R.cell.use(charge_cost)
+				reagents.add_reagent(set_reagent, 5)
+
+/obj/item/reagent_containers/spray/cyborg/drying_agent
+	name = "drying agent spray"
+	desc = "A spray for cleaning up wet floors."
+	color = "#A000A0"
+	set_reagent = /datum/reagent/drying_agent
+
+/obj/item/reagent_containers/spray/cyborg/plantbgone
+	name = "Plant-B-Gone"
+	desc = "A bottle of weed killer spray for stopping kudzu-based harm."
+	icon = 'icons/obj/hydroponics/equipment.dmi'
+	icon_state = "plantbgone"
+	item_state = "plantbgone"
+	set_reagent = /datum/reagent/toxin/plantbgone


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Refactors cyborg spray bottles so that more can easily be made and they all recharge chems on their own, at the cost of power. Gives janiborg weed killer spray as a starting module, and adds an acid spray bottle to emagged janiborg. Idea by Fronsis#0357
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's much easier to add cyborg spray bottles with this, and it gives janiborg has more of an endgame use as it can fight kudzu.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds weed killer spray to janiborg
add: Adds acid spray to emagged janiborg
refactor: Refactors cyborg spray bottles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
