### PR TITLE
Ambience no longer depends on the order you joined the game

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(ambience)
 
 			if(M)
 				if (istype(M, /mob/dead/new_player)) // Don't play ambience to nerds in the lobby
-					return
+					continue
 
 				src.update_buzz(M) // Update buzz every fire, or every 1/5th second
 


### PR DESCRIPTION
# About The Pull Request

Fixes funny man bug where if players were in the lobby it wouldn't play ambience for anyone after them in the client list

## Why It's Good For The Game

Bug bad

## Changelog
:cl:
fix: Ambience sometimes just not playing fixed
/:cl: