### PR TITLE
Remove the based assistant plant meta

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -28,6 +28,7 @@
 	var/rustle_sound = TRUE							//play rustle sound on interact.
 	var/allow_quick_empty = FALSE					//allow empty verb which allows dumping on the floor of everything inside quickly.
 	var/allow_quick_gather = FALSE					//allow toggle mob verb which toggles collecting all items from a tile.
+	var/insert_on_attack = TRUE						//allow inserting items by clicking the storage with another item, if this is FALSE you will have to open the storage and click the slots
 
 	var/collection_mode = COLLECT_EVERYTHING
 
@@ -463,6 +464,8 @@
 
 //This proc is called when you want to place an item into the storage item.
 /datum/component/storage/proc/attackby(datum/source, obj/item/I, mob/M, params)
+	if(!insert_on_attack)
+		return FALSE
 	if(istype(I, /obj/item/hand_labeler))
 		var/obj/item/hand_labeler/labeler = I
 		if(labeler.mode)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -28,7 +28,7 @@
 	var/rustle_sound = TRUE							//play rustle sound on interact.
 	var/allow_quick_empty = FALSE					//allow empty verb which allows dumping on the floor of everything inside quickly.
 	var/allow_quick_gather = FALSE					//allow toggle mob verb which toggles collecting all items from a tile.
-	var/insert_on_attack = TRUE						//allow inserting items by clicking the storage with another item, if this is FALSE you will have to open the storage and click the slots
+	var/insert_while_closed = TRUE					//the user can insert items while the storage is closed, if not the user will have to click/alt click to open it before they can insert items
 
 	var/collection_mode = COLLECT_EVERYTHING
 
@@ -464,8 +464,6 @@
 
 //This proc is called when you want to place an item into the storage item.
 /datum/component/storage/proc/attackby(datum/source, obj/item/I, mob/M, params)
-	if(!insert_on_attack)
-		return FALSE
 	if(istype(I, /obj/item/hand_labeler))
 		var/obj/item/hand_labeler/labeler = I
 		if(labeler.mode)
@@ -562,6 +560,8 @@
 	var/atom/host = parent
 	if(real_location == I.loc)
 		return FALSE //Means the item is already in the storage item
+	if(!insert_while_closed && !(M in is_using))
+		return FALSE
 	if(locked)
 		if(M && !stop_messages)
 			host.add_fingerprint(M)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -322,6 +322,7 @@
 /datum/component/storage/concrete/kirbyplants
 	max_items = 1
 	max_w_class = WEIGHT_CLASS_NORMAL
+	attack_hand_interact = FALSE
 
 /obj/item/twohanded/required/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -322,7 +322,7 @@
 /datum/component/storage/concrete/kirbyplants
 	max_items = 1
 	max_w_class = WEIGHT_CLASS_NORMAL
-	insert_on_attack = FALSE // We don't want clicking plants with items to insert it, you have to alt click then click the slots
+	insert_while_closed = FALSE // We don't want clicking plants with items to insert it, you have to alt click then click the slots
 
 /obj/item/twohanded/required/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -322,7 +322,7 @@
 /datum/component/storage/concrete/kirbyplants
 	max_items = 1
 	max_w_class = WEIGHT_CLASS_NORMAL
-	attack_hand_interact = FALSE
+	insert_on_attack = FALSE // We don't want clicking plants with items to insert it, you have to alt click then click the slots
 
 /obj/item/twohanded/required/kirbyplants/equipped(mob/living/user)
 	var/image/I = image(icon = 'icons/obj/flora/plants.dmi' , icon_state = src.icon_state, loc = user)


### PR DESCRIPTION
## About The Pull Request

Fixes the massive based funny where if you clicked a plant it would put items in it even if you hadn't opened it by alt clicking. This allowed assistants to wield plants and then drop them when they were about to get batoned, making sec put their stunbatons in the plant.

## Why It's Good For The Game

Funny but questionable on the gameplay aspect

## Changelog
:cl:
fix: Putting items in plants by just clicking the plant
/:cl:
