### PR TITLE
Roundstart Slimepeople Race: Oozelings

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2317,6 +2317,7 @@
 #include "code\modules\mob\living\carbon\human\species_types\lizardpeople.dm"
 #include "code\modules\mob\living\carbon\human\species_types\mothmen.dm"
 #include "code\modules\mob\living\carbon\human\species_types\mushpeople.dm"
+#include "code\modules\mob\living\carbon\human\species_types\oozelings.dm"
 #include "code\modules\mob\living\carbon\human\species_types\plasmamen.dm"
 #include "code\modules\mob\living\carbon\human\species_types\podpeople.dm"
 #include "code\modules\mob\living\carbon\human\species_types\shadowpeople.dm"

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -63,6 +63,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 #define isjellyperson(A) (is_species(A, /datum/species/jelly))
 #define isslimeperson(A) (is_species(A, /datum/species/jelly/slime))
 #define isluminescent(A) (is_species(A, /datum/species/jelly/luminescent))
+#define isoozeling(A) (is_species(A, /datum/species/oozeling))
 #define iszombie(A) (is_species(A, /datum/species/zombie))
 #define isskeleton(A) (is_species(A, /datum/species/skeleton))
 #define ismoth(A) (is_species(A, /datum/species/moth))

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -269,6 +269,12 @@ Key procs
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/slime = list(LANGUAGE_ATOM))
 
+/datum/language_holder/oozeling
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/slime = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/slime = list(LANGUAGE_ATOM))
+
 /datum/language_holder/lightbringer
 	understood_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/slime = list(LANGUAGE_ATOM))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -615,7 +615,7 @@
 	//Agent cards lower threatlevel.
 	if(istype(idcard, /obj/item/card/id/syndicate))
 		threatcount -= 5
-	
+
 	//individuals wearing tinfoil hats are 30% more likely to be criminals
 	if(istype(get_item_by_slot(SLOT_HEAD), /obj/item/clothing/head/foilhat))
 		threatcount += 2
@@ -1252,6 +1252,9 @@
 
 /mob/living/carbon/human/species/jelly
 	race = /datum/species/jelly
+
+/mob/living/carbon/human/species/oozeling
+	race = /datum/species/oozeling
 
 /mob/living/carbon/human/species/jelly/slime
 	race = /datum/species/jelly/slime

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -1,0 +1,153 @@
+/datum/species/oozeling
+	name = "Oozeling"
+	id = "oozeling"
+	default_color = "00FF90"
+	say_mod = "says"
+	species_traits = list(MUTCOLORS,EYECOLOR,NOBLOOD,HAIR,FACEHAIR)
+	inherent_traits = list(TRAIT_TOXINLOVER,TRAIT_NOFIRE)
+	hair_color = "mutcolor"
+	hair_alpha = 150
+	mutantlungs = /obj/item/organ/lungs/oozeling
+	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime
+	exotic_blood = /datum/reagent/toxin/slimejelly/slimeooze
+	damage_overlay_type = ""
+	var/datum/action/innate/regenerate_limbs/regenerate_limbs
+	coldmod = 6   // = 3x cold damage
+	heatmod = 0.5 // = 1/4x heat damage
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	inherent_factions = list("slime")
+	species_language_holder = /datum/language_holder/oozeling
+	limbs_id = "jelly"
+
+
+/datum/species/oozeling/on_species_loss(mob/living/carbon/C)
+	if(regenerate_limbs)
+		regenerate_limbs.Remove(C)
+	..()
+
+/datum/species/oozeling/on_species_gain(mob/living/carbon/C, datum/species/old_species)
+	..()
+	if(ishuman(C))
+		regenerate_limbs = new
+		regenerate_limbs.Grant(C)
+
+/datum/species/oozeling/spec_life(mob/living/carbon/human/H)
+
+	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely
+		return
+	if(!H.blood_volume)
+		H.blood_volume += 5
+		H.adjustBruteLoss(5)
+		to_chat(H, "<span class='danger'>You feel empty!</span>")
+
+	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+		if(H.blood_volume <= 672)
+			H.blood_volume += 1
+
+	if(H.nutrition <= NUTRITION_LEVEL_HUNGRY)
+		if(H.nutrition <= NUTRITION_LEVEL_STARVING)
+			H.blood_volume += -8
+			if(prob(5))
+				to_chat(H, "<span class='info'>You're starving! Get some food!</span>")
+		else
+			if(prob(35))
+				H.blood_volume += -2
+				if(prob(5))
+					to_chat(H, "<span class='danger'>You're feeling pretty hungry...</span>")
+
+	var/atmos_sealed = FALSE
+	if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing))
+		var/obj/item/clothing/CS = H.wear_suit
+		var/obj/item/clothing/CH = H.head
+		if (CS.clothing_flags & CH.clothing_flags & STOPSPRESSUREDAMAGE)
+			atmos_sealed = TRUE
+	if(H.w_uniform && H.head)
+		var/obj/item/clothing/CU = H.w_uniform
+		var/obj/item/clothing/CH = H.head
+		if (CU.envirosealed && (CH.clothing_flags & STOPSPRESSUREDAMAGE))
+			atmos_sealed = TRUE
+	if(!atmos_sealed)
+		var/datum/gas_mixture/environment = H.loc.return_air()
+		if(environment)
+			if(environment.total_moles())
+				if(environment.get_moles(/datum/gas/water_vapor) >= 1)
+					H.blood_volume += -15
+					if(prob(50))
+						to_chat(H, "<span class='danger'>Your ooze melts away rapidly in the water vapor!</span>")
+				if(environment.get_moles(/datum/gas/plasma) >= 1)
+					if(H.blood_volume <= 672)
+						H.blood_volume += 15
+
+
+	if(H.blood_volume < BLOOD_VOLUME_OKAY)
+		if(prob(5))
+			to_chat(H, "<span class='danger'>You feel drained!</span>")
+	if(H.blood_volume < BLOOD_VOLUME_BAD)
+		Cannibalize_Body(H)
+	if(regenerate_limbs)
+		regenerate_limbs.UpdateButtonIcon()
+
+/datum/species/oozeling/proc/Cannibalize_Body(mob/living/carbon/human/H)
+	var/list/limbs_to_consume = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG) - H.get_missing_limbs()
+	var/obj/item/bodypart/consumed_limb
+	if(!limbs_to_consume.len)
+		H.losebreath++
+		return
+	if(H.get_num_legs(FALSE)) //Legs go before arms
+		limbs_to_consume -= list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+	consumed_limb = H.get_bodypart(pick(limbs_to_consume))
+	consumed_limb.drop_limb()
+	to_chat(H, "<span class='userdanger'>Your [consumed_limb] is drawn back into your body, unable to maintain its shape!</span>")
+	qdel(consumed_limb)
+	H.blood_volume += 80
+	H.nutrition += 20
+
+/datum/action/innate/regenerate_limbs
+	name = "Regenerate Limbs"
+	check_flags = AB_CHECK_CONSCIOUS
+	button_icon_state = "slimeheal"
+	icon_icon = 'icons/mob/actions/actions_slime.dmi'
+	background_icon_state = "bg_alien"
+
+/datum/action/innate/regenerate_limbs/IsAvailable()
+	if(..())
+		var/mob/living/carbon/human/H = owner
+		var/list/limbs_to_heal = H.get_missing_limbs()
+		if(limbs_to_heal.len < 1)
+			return 0
+		if(H.blood_volume >= BLOOD_VOLUME_OKAY+40)
+			return 1
+		return 0
+
+/datum/action/innate/regenerate_limbs/Activate()
+	var/mob/living/carbon/human/H = owner
+	var/list/limbs_to_heal = H.get_missing_limbs()
+	if(limbs_to_heal.len < 1)
+		to_chat(H, "<span class='notice'>You feel intact enough as it is.</span>")
+		return
+	to_chat(H, "<span class='notice'>You focus intently on your missing [limbs_to_heal.len >= 2 ? "limbs" : "limb"]...</span>")
+	if(H.blood_volume >= 40*limbs_to_heal.len+BLOOD_VOLUME_OKAY)
+		H.regenerate_limbs()
+		H.blood_volume -= 40*limbs_to_heal.len
+		to_chat(H, "<span class='notice'>...and after a moment you finish reforming!</span>")
+		return
+	else if(H.blood_volume >= 40)//We can partially heal some limbs
+		while(H.blood_volume >= BLOOD_VOLUME_OKAY+40)
+			var/healed_limb = pick(limbs_to_heal)
+			H.regenerate_limb(healed_limb)
+			limbs_to_heal -= healed_limb
+			H.blood_volume -= 40
+		to_chat(H, "<span class='warning'>...but there is not enough of you to fix everything! You must attain more mass to heal completely!</span>")
+		return
+	to_chat(H, "<span class='warning'>...but there is not enough of you to go around! You must attain more mass to heal!</span>")
+
+
+/datum/species/oozeling/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
+	. = ..()
+	if(chem.type == /datum/reagent/water)
+		if(chem.volume > 10)
+			H.reagents.remove_reagent(chem.type, chem.volume - 10)
+			to_chat(H, "<span class='warning'>The water you consumed is melting away your insides!</span>")
+		H.blood_volume += -25
+		H.reagents.remove_reagent(chem.type, chem.metabolization_rate)
+		return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1227,6 +1227,23 @@
 	. = 1
 	..()
 
+/datum/reagent/medicine/regen_jelly/regen_ooze
+	name = "Regenerative Ooze"
+	description = "Gradually regenerates all types of damage, without harming slime anatomy."
+	reagent_state = LIQUID
+	color = "#65d891"
+	taste_description = "jelly"
+
+/datum/reagent/medicine/regen_jelly/regen_ooze/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-0.5*REM, 0)
+	M.adjustFireLoss(-0.5*REM, 0)
+	M.adjustOxyLoss(-0.5*REM, 0)
+	M.adjustToxLoss(-0.5*REM, 0, TRUE) //heals TOXINLOVERs
+	. = 1
+	..()
+
+
+
 /datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs
 	name = "Restorative Nanites"
 	description = "Miniature medical robots that swiftly restore bodily damage."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -180,6 +180,10 @@
 /datum/reagent/water/reaction_mob(mob/living/M, method=TOUCH, reac_volume)//Splashing people with water can help put them out!
 	if(!istype(M))
 		return
+	if(isoozeling(M))
+		M.blood_volume += -30
+		to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
+		return
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))
 		M.ExtinguishMob()

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -245,6 +245,44 @@
 			L.extract_cooldown = max(0, L.extract_cooldown - 20)
 	..()
 
+
+/datum/reagent/teslium/energized_jelly/energized_ooze
+	name = "Energized Ooze"
+	description = "Electrically-charged Ooze. Boosts Oozeling's nervous system, but only shocks other lifeforms."
+	reagent_state = LIQUID
+	color = "#CAFF43"
+	taste_description = "slime"
+	overdose_threshold = 30
+
+/datum/reagent/teslium/energized_jelly/energized_ooze/on_mob_life(mob/living/carbon/M)
+	if(isjellyperson(M))
+		shock_timer = 0 //immune to shocks
+		M.AdjustAllImmobility(-40, FALSE)
+		M.adjustStaminaLoss(-2, 0)
+		if(isluminescent(M))
+			var/mob/living/carbon/human/H = M
+			var/datum/species/jelly/luminescent/L = H.dna.species
+			L.extract_cooldown = max(0, L.extract_cooldown - 20)
+	if(isoozeling(M))
+		shock_timer = 0 //immune to shocks
+		M.AdjustAllImmobility(-40, FALSE)
+		M.adjustStaminaLoss(-2, 0)
+	..()
+
+/datum/reagent/teslium/energized_jelly/overdose_process(mob/living/carbon/M)
+	shock_timer++
+	if(isoozeling(M))
+		shock_timer = (rand(0,2))
+		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
+		playsound(M, "sparks", 50, 1)
+	..()
+	if(isjellyperson(M))
+		shock_timer = (rand(0,2))
+		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
+		playsound(M, "sparks", 50, 1)
+	..()
+
+
 /datum/reagent/firefighting_foam
 	name = "Firefighting Foam"
 	description = "A historical fire suppressant. Originally believed to simply displace oxygen to starve fires, it actually interferes with the combustion reaction itself. Vastly superior to the cheap water-based extinguishers found on NT vessels."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -122,6 +122,25 @@
 		. = 1
 	..()
 
+/datum/reagent/toxin/slimejelly/slimeooze
+	name = "Slime Ooze"
+	description = "A gooey semi-liquid produced from Oozelings"
+	color = "#611e80"
+	toxpwr = 0
+	taste_description = "slime"
+	taste_mult = 1.5
+
+/datum/reagent/toxin/slimejelly/slimeooze/on_mob_life(mob/living/carbon/M)
+	if(prob(10))
+		to_chat(M, "<span class='danger'>Your insides are burning!</span>")
+		M.adjustToxLoss(rand(1,10)*REM, 0)
+		. = 1
+	else if(prob(40))
+		M.heal_bodypart_damage(5*REM)
+		. = 1
+	..()
+
+
 /datum/reagent/toxin/minttoxin
 	name = "Mint Toxin"
 	description = "Useful for dealing with undesirable customers."

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -252,6 +252,13 @@
 	results = list(/datum/reagent/medicine/regen_jelly = 2)
 	required_reagents = list(/datum/reagent/medicine/tricordrazine = 1, /datum/reagent/toxin/slimejelly = 1)
 
+
+/datum/chemical_reaction/regen_jelly/regen_ooze
+	name = "Regenerative Ooze"
+	id = /datum/reagent/medicine/regen_jelly/regen_ooze
+	results = list(/datum/reagent/medicine/regen_jelly/regen_ooze = 2)
+	required_reagents = list(/datum/reagent/medicine/tricordrazine = 1, /datum/reagent/toxin/slimejelly/slimeooze = 1)
+
 /datum/chemical_reaction/corazone
 	name = "Corazone"
 	id = /datum/reagent/medicine/corazone

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -419,6 +419,15 @@
 	required_reagents = list(/datum/reagent/toxin/slimejelly = 1, /datum/reagent/teslium = 1)
 	mix_message = "<span class='danger'>The slime jelly starts glowing intermittently.</span>"
 
+
+/datum/chemical_reaction/energized_jelly/energized_ooze
+	name = "Energized Ooze"
+	id = /datum/reagent/teslium/energized_jelly/energized_ooze
+	results = list(/datum/reagent/teslium/energized_jelly/energized_ooze = 2)
+	required_reagents = list(/datum/reagent/toxin/slimejelly/slimeooze = 1, /datum/reagent/teslium = 1)
+	mix_message = "<span class='danger'>The slime ooze starts glowing intermittently.</span>"
+
+
 /datum/chemical_reaction/reagent_explosion/teslium_lightning
 	name = "Teslium Destabilization"
 	id = "teslium_lightning"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -406,6 +406,14 @@
 	safe_toxins_min = 16 //We breath THIS!
 	safe_toxins_max = 0
 
+/obj/item/organ/lungs/oozeling
+	name = "oozling vacuole"
+	desc = "A large organelle designed to store oxygen and filter plasma."
+
+	safe_oxygen_min = 16 //We breath THIS!
+	safe_toxins_min = 0 //We dont't breath this
+	safe_toxins_max = 0
+
 /obj/item/organ/lungs/slime
 	name = "vacuole"
 	desc = "A large organelle designed to store oxygen and other important gasses."

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -471,6 +471,7 @@ ROUNDSTART_RACES ipc
 ## Races that are better than humans in some ways, but worse in others
 ROUNDSTART_RACES ethereal
 ROUNDSTART_RACES apid
+ROUNDSTART_RACES oozeling
 #ROUNDSTART_RACES jelly
 #ROUNDSTART_RACES iron_golem
 #ROUNDSTART_RACES adamantine_golem
@@ -489,7 +490,6 @@ ROUNDSTART_RACES apid
 #ROUNDSTART_RACES pod
 #ROUNDSTART_RACES military_synth
 #ROUNDSTART_RACES agent
-ROUNDSTART_RACES oozeling
 
 ## Paywall Races
 ##-------------------------------------------------------------------------------------------

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -489,6 +489,7 @@ ROUNDSTART_RACES apid
 #ROUNDSTART_RACES pod
 #ROUNDSTART_RACES military_synth
 #ROUNDSTART_RACES agent
+ROUNDSTART_RACES oozeling
 
 ## Paywall Races
 ##-------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
* Unique blood type: Slime Ooze
* Cannot ignite when exposed to flames
* 80% reduced burn damage from high heat, but not burn damage from other sources.
* 300% increased burn damage from cold temperature exposure.
* Takes reverse of normal toxin damage - Take toxin damage from tox-healing medicines and heal toxin damage when consuming normally toxic things
* Has no food preferences despite their gluttonous nature, so no major mood buffs or debuffs from eating.
* Limb regeneration ability
* Random limb vanishes when blood volume is critical, restores some blood volume and nutrition when this happens
* Loses blood volume gradually when hungry
* Loses blood volume rapidly when starving
* Loses blood volume rapidly when processing toxic chemicals
* Loses blood volume rapidly when exposed to water, water vapor, fire extinguishers, and showers
* Slime Vacuole Organ
* Slime faction
* Starts with Galactic Common and Slime Languages + Slime speech verbs

* Reagent: Slime Ooze - Should be interchangeable for Slime Jelly as far as blood transfusions go - it should instantly restore the appropriate blood volume instead just like slime jelly currently does for the existing slime races.
* Reagent: Regenerative Ooze - Restores 0.5 Brute, Burn, Toxin, and clone damage at 0.4u per tick. Created by combining Slime Ooze with Tricordrizine just like its counterpart.
* Reagent: Energizing Ooze - Same as Energizing Jelly, but with an overdose threshold that when reached will shock as if you had plain Teslium in your system. (Slime Ooze + Teslium to make)




## Why It's Good For The Game

Slime Roundstart Race
What more is there to say?



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Oozelings, a new race!
add: Added Slime Ooze (bloodtype for Oozelings)
add: Added Slime Vacuole Organ
add: Added Regenerative Ooze - Restores 0.5 Brute, Burn, Toxin, and clone damage at 0.4u per tick. Created by combining Slime Ooze with Tricordrizine
add: Added Energizing Ooze - Boosts Oozeling's nervous system, but only shocks other lifeforms. OD at 30u for teslium shocks. Created by combining Slime Ooze with Teslium
tweak: adjusted watertouch code to interact with Oozelings
config: Oozelings are now in Roundstart Races!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
