### PR TITLE
Fixes heretics getting IC mutted for spamming grasp.

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -23,7 +23,7 @@
 /obj/item/melee/touch_attack/shock
 	name = "\improper shock touch"
 	desc = "This is kind of like when you rub your feet on a shag rug so you can zap your friends, only a lot less safe."
-	catchphrase = null
+	catchphrases = list(null)
 	on_use_sound = 'sound/weapons/zapbang.ogg'
 	icon_state = "zapper"
 	item_state = "zapper"

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -45,7 +45,7 @@
 	desc = "A sinister looking aura that distorts the flow of reality around it. Causes knockdown, major stamina damage aswell as some Brute. It gains additional beneficial effects with certain knowledges you can research."
 	icon_state = "mansus_grasp"
 	item_state = "mansus_grasp"
-	catchphrase = "R'CH T'H TR'TH"
+	catchphrases = list("M'SUS 'N B'N","S'L GR'SP", "R'CH 'N TH' SO'L", "S'C C'MB")
 
 /obj/item/melee/touch_attack/mansus_fist/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag || target == user)
@@ -122,7 +122,7 @@
 	desc = "A sinister looking aura that distorts the flow of reality around it."
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
-	catchphrase = "R'BRTH"
+	catchphrases = list("LA'IF","ST'L","M'NE","DR'IN")
 
 /obj/item/melee/touch_attack/blood_siphon/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag)

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -1,7 +1,7 @@
 /obj/item/melee/touch_attack
 	name = "\improper outstretched hand"
 	desc = "High Five?"
-	var/catchphrase = "High Five!"
+	var/catchphrases = list("High Five!")
 	var/on_use_sound = null
 	var/obj/effect/proc_holder/spell/targeted/touch/attached_spell
 	icon = 'icons/obj/items_and_weapons.dmi'
@@ -31,7 +31,7 @@
 
 /obj/item/melee/touch_attack/afterattack(atom/target, mob/user, proximity)
 	. = ..()
-	user.say(catchphrase, forced = "spell")
+	user.say(pick(catchphrases), forced = "spell")
 	playsound(get_turf(user), on_use_sound,50,1)
 	charges--
 	if(charges <= 0)
@@ -45,7 +45,7 @@
 /obj/item/melee/touch_attack/disintegrate
 	name = "\improper disintegrating touch"
 	desc = "This hand of mine glows with an awesome power!"
-	catchphrase = "EI NATH!!"
+	catchphrases = list("EI NATH!!","NATH ERMAC!!", "EI EN' NATH!!")
 	on_use_sound = 'sound/magic/disintegrate.ogg'
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
@@ -84,7 +84,7 @@
 /obj/item/melee/touch_attack/fleshtostone
 	name = "\improper petrifying touch"
 	desc = "That's the bottom line, because flesh to stone said so!"
-	catchphrase = "STAUN EI!!"
+	catchphrases = list("STAUN EI!!","PETRIFY!!", "STAPH STATUN!!")
 	on_use_sound = 'sound/magic/fleshtostone.ogg'
 	icon_state = "fleshtostone"
 	item_state = "fleshtostone"
@@ -112,7 +112,7 @@
 /obj/item/melee/touch_attack/megahonk
 	name = "\improper honkmother's blessing"
 	desc = "You've got a feeling they won't be laughing after this one. Honk honk."
-	catchphrase = "HONKDOOOOUKEN!"
+	catchphrases = list("HONKDOOOOUKEN!")
 	on_use_sound = 'sound/items/airhorn.ogg'
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_honker"
@@ -120,7 +120,7 @@
 /obj/item/melee/touch_attack/megahonk/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(!proximity || !iscarbon(target) || !iscarbon(user) || user.handcuffed)
 		return
-	user.say(catchphrase, forced = "spell")
+	user.say(pick(catchphrases), forced = "spell")
 	playsound(get_turf(target), on_use_sound,100,1)
 	for(var/mob/living/carbon/M in (hearers(1, target) - user)) //3x3 around the target, not affecting the user
 		if(ishuman(M))


### PR DESCRIPTION
## About The Pull Request

Adds multiple catch phrases to grasp touch melee spells, to prevent them from IC muting the caster. This is especially notable for heretics' mansus grasp.

## Why It's Good For The Game

Oversight.

## Changelog
:cl:
tweak: touch spells cycle through multiple 'catchphrases' to prevent casters (especially heretics) from getting muted by casting them repeatedly.
/:cl: