### PR TITLE
Revert "Disables the roundstart report on sage."

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -86,7 +86,7 @@ ALERT_DELTA Destruction of the station is imminent. All crew are instructed to o
 ## GAME MODES ###
 
 ## Uncomment to not send a roundstart intercept report. Gamemodes may override this.
-NO_INTERCEPT_REPORT
+#NO_INTERCEPT_REPORT
 
 ## Probablities for game modes chosen in 'secret' and 'random' modes.
 ## Default probablity is 1, increase to make that mode more likely to be picked.


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#2741

Broke station goals, preventing them from showing in the supply catalog. It's also likely to contain false information, so not such a good source of metaknowledge after all.