### PR TITLE
Adds a traitor spawn minor antagonist role, allows traitors to spawn on some gamemodes.

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1504,6 +1504,7 @@
 #include "code\modules\antagonists\swarmer\swarmer_event.dm"
 #include "code\modules\antagonists\traitor\datum_traitor.dm"
 #include "code\modules\antagonists\traitor\syndicate_contract.dm"
+#include "code\modules\antagonists\traitor\traitor_spawner.dm"
 #include "code\modules\antagonists\traitor\equipment\contractor.dm"
 #include "code\modules\antagonists\traitor\equipment\Malf_Modules.dm"
 #include "code\modules\antagonists\traitor\IAA\internal_affairs.dm"

--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -41,7 +41,6 @@ GLOBAL_VAR(clockcult_eminence)
 	<span class='danger'>Servants</span>: Convert more servants and defend the Ark of the Clockwork Justicar!\n\
 	<span class='notice'>Crew</span>: Prepare yourselfs and destroy the Ark of the Clockwork Justicar."
 
-	allowed_special = list(/datum/special_role/traitor)
 
 	var/clock_cultists = CLOCKCULT_SERVANTS
 	var/list/selected_servants = list()

--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -41,6 +41,8 @@ GLOBAL_VAR(clockcult_eminence)
 	<span class='danger'>Servants</span>: Convert more servants and defend the Ark of the Clockwork Justicar!\n\
 	<span class='notice'>Crew</span>: Prepare yourselfs and destroy the Ark of the Clockwork Justicar."
 
+	allowed_special = list(/datum/special_role/traitor)
+
 	var/clock_cultists = CLOCKCULT_SERVANTS
 	var/list/selected_servants = list()
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -52,7 +52,6 @@
 
 	title_icon = "cult"
 
-	allowed_special = list(/datum/special_role/traitor)
 
 	var/finished = 0
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -52,6 +52,8 @@
 
 	title_icon = "cult"
 
+	allowed_special = list(/datum/special_role/traitor)
+
 	var/finished = 0
 
 	var/acolytes_needed = 10 //for the survive objective

--- a/code/game/gamemodes/devil/devil_game_mode.dm
+++ b/code/game/gamemodes/devil/devil_game_mode.dm
@@ -12,6 +12,8 @@
 	enemy_minimum_age = 0
 	title_icon = "devil"
 
+	allowed_special = list(/datum/special_role/traitor)
+
 	var/traitors_possible = 4 //hard limit on devils if scaling is turned off
 	var/num_modifier = 0 // Used for gamemodes, that are a child of traitor, that need more than the usual.
 	var/objective_count = 2

--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -12,6 +12,8 @@
 	reroll_friendly = 1
 	enemy_minimum_age = 0
 
+	allowed_special = list(/datum/special_role/traitor/higher_chance)
+
 	announce_span = "danger"
 	announce_text = "Heretics have been spotted on the station!\n\
 	<span class='danger'>Heretics</span>: Accomplish your objectives.\n\

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -95,6 +95,7 @@
 
 	for(var/role_to_init in allowed_special)
 		var/datum/special_role/new_role = new role_to_init
+		new_role.setup()
 		if(!prob(new_role.probability))
 			continue
 		new_role.add_to_pool()
@@ -109,7 +110,11 @@
 		for(var/i in 1 to amount)
 			if(candidates.len == 0)
 				return	//No more candidates, end the selection process, and active specials at this time will be handled by latejoins or not included
-			var/mob/person = pick_n_take(candidates)
+			var/mob/person
+			if(special.special_role_flag)
+				person = antag_pick(candidates, special.special_role_flag)
+			else
+				person = pick_n_take(candidates)
 			if(is_banned_from(person.ckey, special.preference_type))
 				continue
 			if(!person)
@@ -117,7 +122,7 @@
 			var/datum/mind/selected_mind = person.mind
 			if(selected_mind.special_role)
 				continue
-			if(person.job in special.protected_jobs)
+			if(person.job in special.restricted_jobs)
 				continue
 			//Would be annoying trying to assasinate someone with special statuses
 			if(selected_mind.isAntagTarget && !special.allowAntagTargets)

--- a/code/game/gamemodes/incursion/incursion.dm
+++ b/code/game/gamemodes/incursion/incursion.dm
@@ -20,9 +20,6 @@
 
 	title_icon = "traitor"
 
-	//Some regular traitors to spice things up once in a while
-	allowed_special = list(/datum/special_role/traitor/higher_chance)
-
 	var/datum/team/incursion/pre_incursionist_team
 	var/const/team_amount = 1 //hard limit on brother teams if scaling is turned off
 	var/const/min_team_size = 2

--- a/code/game/gamemodes/incursion/incursion.dm
+++ b/code/game/gamemodes/incursion/incursion.dm
@@ -20,6 +20,9 @@
 
 	title_icon = "traitor"
 
+	//Some regular traitors to spice things up once in a while
+	allowed_special = list(/datum/special_role/traitor/higher_chance)
+
 	var/datum/team/incursion/pre_incursionist_team
 	var/const/team_amount = 1 //hard limit on brother teams if scaling is turned off
 	var/const/min_team_size = 2

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -16,6 +16,7 @@
 	//----Required for roundspawn----
 	var/allowAntagTargets = FALSE	//Not used in events
 	var/latejoin_allowed = TRUE		//Can latejoins be assigned to this? If you want this to be a midround spawn, put these in the round_event
+	var/list/restricted_jobs = list("Cyborg")
 	var/list/protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Head of Personnel", "Chief Medical Officer", "Chief Engineer", "Research Director", "Captain", "Brig Physician")
 	//----Required for midround----
 	var/weight = 10
@@ -24,6 +25,17 @@
 	var/holidayID = ""
 	//Preferences
 	var/preference_type = ROLE_TRAITOR
+	var/special_role_flag = null	//Will use antag rep if enabled
+
+/datum/special_role/proc/setup()
+	if(CONFIG_GET(flag/protect_roles_from_antagonist))
+		restricted_jobs += protected_jobs
+
+	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
+		restricted_jobs += "Assistant"
+
+	if(CONFIG_GET(flag/protect_heads_from_antagonist))
+		restricted_jobs += GLOB.command_positions
 
 /datum/special_role/proc/add_to_pool()
 	if(spawn_mode == SPAWNTYPE_ROUNDSTART)
@@ -34,7 +46,7 @@
 	E.antagonist_datum = attached_antag_datum
 	E.antag_name = role_name
 	E.preference_type = preference_type
-	E.protected_jobs = protected_jobs
+	E.protected_jobs = restricted_jobs
 	E.typepath = /datum/round_event/create_special_antag
 	E.weight = weight
 	E.holidayID = holidayID
@@ -47,7 +59,7 @@
 	//Shove our event into the subsystem pool :)
 	SSevents.control += E
 
-/datum/special_role/proc/add_antag_status_to(var/datum/mind/M)
+/datum/special_role/proc/add_antag_status_to(datum/mind/M)
 	M.special_role = role_name
 	var/datum/antagonist/special/A = M.add_antag_datum(new attached_antag_datum())
 	A.forge_objectives(M)

--- a/code/modules/antagonists/traitor/traitor_spawner.dm
+++ b/code/modules/antagonists/traitor/traitor_spawner.dm
@@ -1,0 +1,33 @@
+/*
+ * Traitors have been refactored into minor antagonists so they can
+ * be used alongside other compatible gamemodes with ease.
+ * This code is what creates them.
+ */
+
+/datum/special_role/traitor
+	attached_antag_datum = /datum/antagonist/traitor
+	spawn_mode = SPAWNTYPE_ROUNDSTART
+	probability = 15	//15% chance to be plopped ontop
+	proportion = 0.07	//Quite a low amount since we are going alongside other gamemodes.
+	max_amount = 5
+	allowAntagTargets = TRUE
+	latejoin_allowed = TRUE
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician")
+
+	special_role_flag = ROLE_TRAITOR
+	role_name = ROLE_TRAITOR
+
+	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
+
+/datum/special_role/traitor/higher_chance
+	probability = 60
+
+/datum/special_role/traitor/add_antag_status_to(datum/mind/M)
+	addtimer(CALLBACK(src, .proc/reveal_antag_status, M), rand(10,100))
+
+/datum/special_role/traitor/proc/reveal_antag_status(datum/mind/M)
+	M.special_role = role_name
+	var/datum/antagonist/special/A = M.add_antag_datum(new attached_antag_datum())
+	A.forge_objectives(M)
+	A.equip()
+	return A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Needs testmerge, I haven't actually tested this since its hard to test with only 1 person but it should probably be fine.

## About The Pull Request

Adds in a minor antagonist datum that will have a chance to spawn traitors. Has a 7% chance per person with a maximum of 5 traitors.
Chances of appearing at all (If this prob fails then 0 will appear):
 - 60% Heretics (Heretics are relatively weak and some traitors here and there to spice things up and make heretics not the only things to validhunt would be nice)
 - 15% Devil (Devil is shit with no one that needs powers, although this is not in rotation)

## Why It's Good For The Game

Adds a low chance for a few game modes to be a little spicier, and shakes up the sec meta a little.

## Changelog
:cl:
add: Traitors now have a low chance of spawning on heretics (60%), devil (15%).
code: Minor antagonist roles can now be configured to optionally use antagonist rep
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
