### PR TITLE
Replaces syndicate playing cards from maintenance tunnels.

### DIFF
--- a/_maps/RandomRooms/5x4/sk_rdm041_deltagamble.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm041_deltagamble.dmm
@@ -41,13 +41,6 @@
 /obj/effect/spawner/lootdrop/trap/reusable,
 /turf/open/floor/carpet/green,
 /area/template_noop)
-"i" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/syndicate{
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/green,
-/area/template_noop)
 "j" = (
 /turf/open/floor/wood,
 /area/template_noop)
@@ -91,6 +84,12 @@
 	icon_state = "wood-broken4"
 	},
 /area/template_noop)
+"Z" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/carpet/green,
+/area/template_noop)
 
 (1,1,1) = {"
 a
@@ -101,7 +100,7 @@ l
 (2,1,1) = {"
 b
 g
-i
+Z
 m
 "}
 (3,1,1) = {"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Syndicate playing cards are a pretty decent traitor item and a free source of illegal technology. They shouldn't be included in this maintenance room (It is an extremely common maint room)

## Why It's Good For The Game

It's a pretty decent item, and I know maints is made to powergame but this room is far too common for these cards.

## Changelog
:cl:
tweak: Replaced syndicate playing cards with a maintenance loot spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
