### PR TITLE
Emag shuttles

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -386,7 +386,8 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 			space_ruins_templates[R.name] = R
 
 /datum/controller/subsystem/mapping/proc/preloadShuttleTemplates()
-	var/list/unbuyable = generateMapList("[global.config.directory]/unbuyableshuttles.txt")
+	var/list/unbuyable = generateMapList("[global.config.directory]/shuttles_unbuyable.txt")
+	var/list/illegal = generateMapList("[global.config.directory]/shuttles_illegal.txt")
 
 	for(var/item in subtypesof(/datum/map_template/shuttle))
 		var/datum/map_template/shuttle/shuttle_type = item
@@ -396,6 +397,8 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		var/datum/map_template/shuttle/S = new shuttle_type()
 		if(unbuyable.Find(S.mappath))
 			S.can_be_bought = FALSE
+		if(illegal.Find(S.mappath))
+			S.syndicate_exclusive = TRUE
 
 		shuttle_templates[S.shuttle_id] = S
 		map_templates[S.shuttle_id] = S

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -11,6 +11,7 @@
 
 	var/credit_cost = INFINITY
 	var/can_be_bought = TRUE
+	var/syndicate_exclusive = FALSE	//makes you able to buy the shuttle in emaged comms console even if can_be_bought is FALSE
 
 	var/list/movement_force // If set, overrides default movement_force on shuttle
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -11,7 +11,7 @@
 
 	var/credit_cost = INFINITY
 	var/can_be_bought = TRUE
-	var/syndicate_exclusive = FALSE	//makes you able to buy the shuttle in emaged comms console even if can_be_bought is FALSE
+	var/syndicate_exclusive = FALSE	//makes you able to buy the shuttle at an emagged comms console even if can_be_bought is FALSE
 
 	var/list/movement_force // If set, overrides default movement_force on shuttle
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -566,6 +566,15 @@
 					if(S.prerequisites)
 						dat += "Prerequisites: [S.prerequisites]<BR>"
 					dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
+				else if(obj_flags & EMAGGED)
+					if(S.syndicate_exclusive && S.credit_cost < INFINITY)
+						dat += "<b> Shuttle supplied by Syndicate, order on your own risk: </b>"
+						dat += "<BR>"
+						dat += "[S.name] | [S.credit_cost] Credits<BR>"
+						dat += "[S.description]<BR>"
+						if(S.prerequisites)
+							dat += "Prerequisites: [S.prerequisites]<BR>"
+						dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
 
 	dat += "<BR><BR>\[ [(state != STATE_DEFAULT) ? "<A HREF='?src=[REF(src)];operation=main'>Main Menu</A> | " : ""]<A HREF='?src=[REF(user)];mach_close=communications'>Close</A> \]"
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -568,7 +568,7 @@
 					dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
 				else if(obj_flags & EMAGGED)
 					if(S.syndicate_exclusive && S.credit_cost < INFINITY)
-						dat += "<b> Shuttle supplied by Syndicate, order on your own risk: </b>"
+						dat += "<b> Shuttle supplied by Syndicate, order at your own risk: </b>"
 						dat += "<BR>"
 						dat += "[S.name] | [S.credit_cost] Credits<BR>"
 						dat += "[S.description]<BR>"

--- a/config/Sage/shuttles_illegal.txt
+++ b/config/Sage/shuttles_illegal.txt
@@ -1,0 +1,31 @@
+##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
+##Make sure the shuttle is already unbuyable
+##Maps must be the full path to them
+##Only shuttles with a price in the code will work with this!
+##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
+
+##Station shuttles
+#_maps/shuttles/emergency_birdboat.dmm
+#_maps/shuttles/emergency_box.dmm
+#_maps/shuttles/emergency_delta.dmm
+#_maps/shuttles/emergency_meta.dmm
+#_maps/shuttles/emergency_mini.dmm
+#_maps/shuttles/emergency_pubby.dmm
+
+##Others
+#_maps/shuttles/emergency_asteroid.dmm
+#_maps/shuttles/emergency_arena.dmm
+#_maps/shuttles/emergency_bar.dmm
+#_maps/shuttles/emergency_construction.dmm
+#_maps/shuttles/emergency_clown.dmm
+#_maps/shuttles/emergency_cramped.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
+#_maps/shuttles/emergency_goon.dmm
+#_maps/shuttles/emergency_luxury.dmm
+_maps/shuttles/emergency_meteor.dmm
+#_maps/shuttles/emergency_raven.dmm
+#_maps/shuttles/emergency_russiafightpit.dmm
+#_maps/shuttles/emergency_scrapheap.dmm
+_maps/shuttles/emergency_supermatter.dmm
+#_maps/shuttles/emergency_wabbajack.dmm
+_maps/shuttles/emergency_discoinferno.dmm

--- a/config/Sage/shuttles_illegal.txt
+++ b/config/Sage/shuttles_illegal.txt
@@ -1,4 +1,4 @@
-##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
+##Listing maps here will make the shuttle be available to be bought if comms console is emagged
 ##Make sure the shuttle is already unbuyable
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!

--- a/config/Sage/shuttles_unbuyable.txt
+++ b/config/Sage/shuttles_unbuyable.txt
@@ -1,0 +1,31 @@
+##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
+##Make sure the shuttle is already unbuyable
+##Maps must be the full path to them
+##Only shuttles with a price in the code will work with this!
+##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
+
+##Station shuttles
+#_maps/shuttles/emergency_birdboat.dmm
+#_maps/shuttles/emergency_box.dmm
+#_maps/shuttles/emergency_delta.dmm
+#_maps/shuttles/emergency_meta.dmm
+#_maps/shuttles/emergency_mini.dmm
+#_maps/shuttles/emergency_pubby.dmm
+
+##Others
+#_maps/shuttles/emergency_asteroid.dmm
+#_maps/shuttles/emergency_arena.dmm
+#_maps/shuttles/emergency_bar.dmm
+#_maps/shuttles/emergency_construction.dmm
+#_maps/shuttles/emergency_clown.dmm
+#_maps/shuttles/emergency_cramped.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
+#_maps/shuttles/emergency_goon.dmm
+#_maps/shuttles/emergency_luxury.dmm
+_maps/shuttles/emergency_meteor.dmm
+#_maps/shuttles/emergency_raven.dmm
+#_maps/shuttles/emergency_russiafightpit.dmm
+#_maps/shuttles/emergency_scrapheap.dmm
+_maps/shuttles/emergency_supermatter.dmm
+#_maps/shuttles/emergency_wabbajack.dmm
+_maps/shuttles/emergency_discoinferno.dmm

--- a/config/Sage/shuttles_unbuyable.txt
+++ b/config/Sage/shuttles_unbuyable.txt
@@ -1,5 +1,4 @@
-##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
-##Make sure the shuttle is already unbuyable
+##Listing maps here will make the shuttle not be available to be bought
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!
 ##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START

--- a/config/shuttles_illegal.txt
+++ b/config/shuttles_illegal.txt
@@ -1,4 +1,5 @@
-##Listing maps here will make the shuttle not available to buy in comms console.
+##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
+##Make sure the shuttle is already unbuyable
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!
 ##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
@@ -18,13 +19,13 @@
 #_maps/shuttles/emergency_construction.dmm
 #_maps/shuttles/emergency_clown.dmm
 #_maps/shuttles/emergency_cramped.dmm
-#_maps/shuttles/emergency_imfedupwiththisworld.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
 #_maps/shuttles/emergency_goon.dmm
 #_maps/shuttles/emergency_luxury.dmm
-#_maps/shuttles/emergency_meteor.dmm
+_maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_raven.dmm
 #_maps/shuttles/emergency_russiafightpit.dmm
 #_maps/shuttles/emergency_scrapheap.dmm
-#_maps/shuttles/emergency_supermatter.dmm
+_maps/shuttles/emergency_supermatter.dmm
 #_maps/shuttles/emergency_wabbajack.dmm
-#_maps/shuttles/emergency_discoinferno.dmm
+_maps/shuttles/emergency_discoinferno.dmm

--- a/config/shuttles_illegal.txt
+++ b/config/shuttles_illegal.txt
@@ -1,4 +1,4 @@
-##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
+##Listing maps here will make the shuttle be available to be bought if comms console is emagged
 ##Make sure the shuttle is already unbuyable
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!

--- a/config/shuttles_unbuyable.txt
+++ b/config/shuttles_unbuyable.txt
@@ -1,5 +1,4 @@
-##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
-##Make sure the shuttle is already unbuyable
+##Listing maps here will make the shuttle not be available to be bought
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!
 ##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START

--- a/config/shuttles_unbuyable.txt
+++ b/config/shuttles_unbuyable.txt
@@ -1,4 +1,5 @@
-##Listing maps here will make the shuttle not available to buy in comms console.
+##Listing maps here will make the shuttle be avaialable to be bought if comms console is emagged
+##Make sure the shuttle is already unbuyable
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!
 ##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
@@ -13,18 +14,18 @@
 
 ##Others
 #_maps/shuttles/emergency_asteroid.dmm
-#_maps/shuttles/emergency_airless.dmm
 #_maps/shuttles/emergency_arena.dmm
 #_maps/shuttles/emergency_bar.dmm
+#_maps/shuttles/emergency_construction.dmm
 #_maps/shuttles/emergency_clown.dmm
 #_maps/shuttles/emergency_cramped.dmm
-#_maps/shuttles/emergency_imfedupwiththisworld.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
 #_maps/shuttles/emergency_goon.dmm
 #_maps/shuttles/emergency_luxury.dmm
-#_maps/shuttles/emergency_meteor.dmm
+_maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_raven.dmm
 #_maps/shuttles/emergency_russiafightpit.dmm
 #_maps/shuttles/emergency_scrapheap.dmm
-#_maps/shuttles/emergency_supermatter.dmm
+_maps/shuttles/emergency_supermatter.dmm
 #_maps/shuttles/emergency_wabbajack.dmm
-#_maps/shuttles/emergency_discoinferno.dmm
+_maps/shuttles/emergency_discoinferno.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This here adds new config file (and renames the old one) in which you specify which shuttles can be bought if the comms console has been emagged.
I've locked a few shuttles behind emag in this PR but this is still subject to change.
closes #2828

## Why It's Good For The Game

Bad shuttles are literal banbait right now. This limits them while not completely removing from the game.
Also this adds actual use to emagging the comms console.

## Changelog
:cl:
add: New option to have a shuttle be only buy-able after comms console is emagged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
