### PR TITLE
Re-adds Kilo into the map rotation

### DIFF
--- a/config/Sage/maps.txt
+++ b/config/Sage/maps.txt
@@ -49,5 +49,4 @@ endmap
 
 map kilostation
 	maxplayers 60
-	disabled
 endmap

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -48,8 +48,6 @@ map multiz_debug
 endmap
 
 map kilostation
-    minplayers 30
-    maxplayers 80
+    maxplayers 60
 	votable
-	disabled
 endmap


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Kilo back into the map rotation per @PowerfulBacon's request

## Why It's Good For The Game

More maps

## Changelog
:cl:
config: Kilo is back in rotation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
