### PR TITLE
Bumps the savefile version to 31 enabling auto_fit_viewport by default

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	30
+#define SAVEFILE_VERSION_MAX	31
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -47,6 +47,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 30)
 		outline_enabled = TRUE
 		outline_color = COLOR_BLUE_GRAY
+	if(current_version < 31)
+		auto_fit_viewport = TRUE
+
 	return
 
 /datum/preferences/proc/update_character(current_version, savefile/S)


### PR DESCRIPTION
## About The Pull Request

Bumps everyone's savefile to version 31 and makes them autofit by default in doing so

## Why It's Good For The Game

Ugly black bars bad - crossed probably

## Changelog
:cl:
tweak: Made auto viewport fit default
/:cl: