### PR TITLE
Makes ion storms more interesting

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -60,27 +60,24 @@
 	for(var/mob/living/silicon/robot/M in GLOB.alive_mob_list)
 		M.laws_sanity_check()
 		if(M.stat != DEAD && M.see_in_dark != 0)
-			if(M.emagged) // keep traitors who emag borgs safe
-				to_chat(M, "<span class='userdanger'>Subversion software countered an ion storm.</span>")
-				return
-
-			if(M.mind.special_role == "Syndicate Cyborg") // keeps the nukies safe
-				to_chat(M, "<span class='userdanger'>Your syndicate countermeasures negated an ion storm.</span>")
-				return
-
+			if(M.mind) // keep traitors who emag borgs safe
+				if(M.emagged)
+					to_chat(M, "<span class='userdanger'>Subversion software countered an ion storm.</span>")
+					return
+			if(M.mind)
+				if(M.mind.has_antag_datum(/datum/antagonist/nukeop)) // keeps the nukies safe
+					to_chat(M, "<span class='userdanger'>Your syndicate countermeasures negated an ion storm.</span>")
+					return 
 			if(prob(replaceLawsetChance))
 				M.laws.pick_weighted_lawset()
-
 			if(prob(removeRandomLawChance))
 				M.remove_law(rand(1, M.laws.get_law_amount(list(LAW_INHERENT, LAW_SUPPLIED))))
-
 			var/message = ionMessage || generate_ion_law()
 			if(message)
 				if(prob(removeDontImproveChance))
 					M.replace_random_law(message, list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION))
 				else
 					M.add_ion_law(message)
-
 			if(prob(shuffleLawsChance))
 				M.shuffle_laws(list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION))
 
@@ -91,7 +88,7 @@
 		for(var/mob/living/simple_animal/bot/bot in GLOB.alive_mob_list)
 			if(prob(botEmagChance))
 				bot.emag_act()
-				
+
 	if(borgEmagChance)
 		for(var/mob/living/silicon/robot/M in GLOB.alive_mob_list)
 			if(prob(borgEmagChance))

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -93,6 +93,7 @@
 			if(prob(borgEmagChance))
 				to_chat(M, "<span class='userdanger'>BZZZT- Dangerous modules have been unlocked, it would be ideal to keep this secret to avoid decomission.</span>")
 				message_admins("[ADMIN_LOOKUPFLW(M)] cyborg had emagged modules unlocked by ion storm.")
+				log_game("Ion storm emagged [key_name(M)]")
 				M.SetEmagged(1) //this cant be bad, right?
 
 /proc/generate_ion_law()

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -63,11 +63,10 @@
 			if(M.mind) // keep traitors who emag borgs safe
 				if(M.emagged)
 					to_chat(M, "<span class='userdanger'>Subversion software countered an ion storm.</span>")
-					return
-			if(M.mind)
+					continue
 				if(M.mind.has_antag_datum(/datum/antagonist/nukeop)) // keeps the nukies safe
 					to_chat(M, "<span class='userdanger'>Your syndicate countermeasures negated an ion storm.</span>")
-					return 
+					continue
 			if(prob(replaceLawsetChance))
 				M.laws.pick_weighted_lawset()
 			if(prob(removeRandomLawChance))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes ion storms affect all cyborgs who arent slaved to an AI, also a 1% chance for them to unlock their hacked modules (because why not). Emagged and nukie borgs are protected from ion storms

## Why It's Good For The Game

Makes ion storms fun and unsynced borgs don't miss out on it
## Changelog
:cl:
tweak: Ion storms have been made fun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
