### PR TITLE
Slight shotgun screenshake.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -26,6 +26,7 @@
 	tac_reloads = FALSE
 	fire_rate = 1 //reee
 	block_upgrade_walk = 1
+	recoil = 1
 	pb_knockback = 2
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
@@ -133,7 +134,7 @@
 
 /obj/item/gun/ballistic/shotgun/bulldog
 	name = "\improper Bulldog Shotgun"
-	desc = "A semi-auto, mag-fed shotgun for combat in narrow corridors, nicknamed 'Bulldog' by boarding parties. Compatible only with specialized 8-round drum magazines."
+	desc = "A semi-auto, mag-fed shotgun for combat in narrow corridors with a built in recoil dampening system, nicknamed 'Bulldog' by boarding parties. Compatible only with specialized 8-round drum magazines."
 	icon_state = "bulldog"
 	item_state = "bulldog"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -153,7 +154,7 @@
 	tac_reloads = TRUE
 	fire_rate = 2
 	automatic = 1
-
+	recoil = 0
 
 /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
 	pin = /obj/item/firing_pin
@@ -214,6 +215,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 	sawn_desc = "I'm just here for the gasoline."
 	unique_reskin = null
+	recoil = 2
 	var/slung = FALSE
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/attackby(obj/item/A, mob/user, params)

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -59,6 +59,7 @@
 	casing_ejector = FALSE
 	can_suppress = FALSE
 	pb_knockback = 0
+	recoil = 0
 
 /obj/item/gun/ballistic/shotgun/toy/update_icon()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives shotguns some recoil, for a more satisfying kick when firing.

## Why It's Good For The Game

Shotguns are a powerful tool when used in close range, now with a little screenshake on firing too. Bulldog drum shotgun has no recoil along with the toy shotgun, since the toy shotgun has no blast and the bulldog is an advanced shotgun with 'integrated recoil control systems'.

## Changelog
:cl:
add: Adds small recoil to shotguns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
