### PR TITLE
Removes pubbystation from map rotation

### DIFF
--- a/config/Sage/maps.txt
+++ b/config/Sage/maps.txt
@@ -26,6 +26,7 @@ endmap
 map pubbystation
 	maxplayers 50
 	votable
+	disabled
 endmap
 
 map deltastation

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -26,6 +26,7 @@ map pubbystation
 	minplayers 50
 	maxplayers 100
 	votable
+	disabled
 endmap
 
 map deltastation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes pubby from map rotation.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So we got 3 lowpop maps : box, kilo and pubby. Somehow everytime from these 3 pubby gets choosen and crew has to endure rounds of terrible layout, sm delamming every round, map focus on chapel and a lot more until merciful admin force changes it.
I am here to end its misery.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Pubbystation is no more
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
