### PR TITLE
fixes VIP

### DIFF
--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -128,5 +128,3 @@
 	ears = /obj/item/radio/headset/heads //VIP can talk loud for no reason
 	uniform = /obj/item/clothing/under/suit/black_really
 	shoes = /obj/item/clothing/shoes/laceup
-
-	implants = list(/obj/item/implant/mindshield) //this fuck gets a mindshield, but he isn't necessarily antag-proof

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -114,8 +114,8 @@
 	title = "VIP"
 	flag = CELEBRITY
 	outfit = /datum/outfit/job/gimmick/celebrity
-	access = list(ACCESS_HEADS, ACCESS_MAINT_TUNNELS) //there is no way whatsoever this could go wrong
-	minimal_access = list(ACCESS_HEADS, ACCESS_MAINT_TUNNELS)
+	access = list(ACCESS_MAINT_TUNNELS) //Assistants with shitloads of money, what could go wrong?
+	minimal_access = list(ACCESS_MAINT_TUNNELS)
 	gimmick = TRUE
 	paycheck = PAYCHECK_VIP //our power is being fucking rich
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

makes VIP not head-level greytiders, and instead simply rich greytiders

## Why It's Good For The Game

VIPs are basically rich greytiders with Bridge and misc head access.

There is no IC reason for a random (even rich) civilian to have the same access level as heads. This is basically a greytider with more default access and more money.

The only additional access they should have is to the corporate lounge where they can drink themselves to death.

## Changelog
:cl: 
tweak: removes access levels from VIP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
