### PR TITLE
Fixes reviving stasis double deathgasp

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -23,9 +23,6 @@
 		to_chat(user, "<span class='notice'>We have revived ourselves.</span>")
 	else
 		to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
-		if(user.stat != DEAD)
-			user.emote("deathgasp")
-			user.tod = station_time_timestamp()
 		user.fakedeath("changeling") //play dead
 		user.update_stat()
 		user.update_mobility()


### PR DESCRIPTION
:cl:
fix: Changelings don't deathgasp twice when entering reviving stasis
/:cl: