### PR TITLE
People drift through z levels properly now (#52686)

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -173,6 +173,7 @@
 		//now we're on the new z_level, proceed the space drifting
 		stoplag()//Let a diagonal move finish, if necessary
 		A.newtonian_move(A.inertia_dir)
+		A.inertia_moving = TRUE
 
 
 /turf/open/space/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/52686

One line bug fix

:cl:LemonInTheDark
fix: You will keep your angle when you drift through space now. Oh and immovable rods do the same, so things might get a bit more messy then usual.
/:cl: