### PR TITLE
Contractor Balance Changes

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -297,10 +297,12 @@
 
 	var/obj/item1 = pick_n_take(item_list)
 	var/obj/item2 = pick_n_take(item_list)
+	var/obj/item3 = pick_n_take(item_list)
 
 	// Create two, non repeat items from the list.
 	new item1(src)
 	new item2(src)
+	new item3(src)
 
 	// Paper guide
 	new /obj/item/paper/contractor_guide(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -269,6 +269,7 @@
 	new /obj/item/card/id/syndicate(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter(src)
+	new /obj/item/jammer(src)
 
 /obj/item/storage/box/syndicate/contract_kit/PopulateContents()
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
@@ -279,31 +280,27 @@
 	var/list/item_list = list(
 		/obj/item/storage/backpack/duffelbag/syndie/x4,
 		/obj/item/storage/box/syndie_kit/throwing_weapons,
-		/obj/item/pen/edagger,
 		/obj/item/pen/sleepy,
 		/obj/item/storage/box/syndie_kit/emp,
 		/obj/item/clothing/shoes/chameleon/noslip,
 		/obj/item/storage/firstaid/tactical,
-		/obj/item/encryptionkey/binary,
 		/obj/item/clothing/glasses/thermal/syndi,
-		/obj/item/slimepotion/slime/sentience/nuclear,
 		/obj/item/storage/box/syndie_kit/imp_radio,
 		/obj/item/clothing/gloves/krav_maga/combatglovesplus,
 		/obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot,
 		/obj/item/reagent_containers/hypospray/medipen/pumpup,
 		/obj/item/compressionkit,
-		/obj/item/book/granter/martial/karate,
-		/obj/item/storage/box/syndie_kit/imp_freedom
+		/obj/item/storage/box/syndie_kit/imp_freedom,
+		/obj/item/storage/box/syndie_kit/chameleon,
+		/obj/item/healthanalyzer/rad_laser
 	)
 
 	var/obj/item1 = pick_n_take(item_list)
 	var/obj/item2 = pick_n_take(item_list)
-	var/obj/item3 = pick_n_take(item_list)
 
 	// Create two, non repeat items from the list.
 	new item1(src)
 	new item2(src)
-	new item3(src)
 
 	// Paper guide
 	new /obj/item/paper/contractor_guide(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull adds radio jammer to standard contractor loadout, adds chameleon kit and rad laser to their random items starting pool and removes energy dagger, karate scroll, binary encryption key, syndicate sentience potion from it.

As of now contractor is not guaranteed to start with a silencing equipment which means unless you got lucky with equipment your kidnaping victim will yell on the radio as soon as you stun them immediately summoning security, validhunters and AI to your location. Radio jammer being part of standard loadout will help solve the issue and make contractor kit significatly more enjoyable to play.

Energy dagger and karate scroll are largely made obsolete by your contractor baton - why would you use dagger or karate when you have excellent baton which does the job better. Binary encryption has some rare case use to contractor such as when AI is an IAA after you or if you subvert the AI however its too rare to justify keeping it in starting items pool. Syndicate sentience potion can be uselfull however there is a good chance no ghost will take the role and its only uselfull on slimes unless you plan to waste time in xenobiology instead of contracting.

Rad laser is an inexpensive stealthy knockout tool and chameleon kit is and upgrade over your starting chameleon kit allowing you to disguise fully. I belive both items fit the contractor theme well and can somewhat fill the gap after removed items so i decided to add them
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes contractor kit less RNG dependant and fun to play by adding radio jammer as part of standard loadout and tweaks its starting item pool to make sure you dont get useless items
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Radio jammer is now part of contractor kit standard loadout
tweak: Tweaks contractor kit starting items pool by removing useless items and adding some new
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
