### PR TITLE
Adds gas miners to atmos

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -34657,10 +34657,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/engine/atmos)
-"bUU" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "bUV" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
@@ -35972,10 +35968,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bYU" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "bYV" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
@@ -36921,10 +36913,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"cbX" = (
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/engine/plasma,
-/area)
 "cbZ" = (
 /obj/structure/sink{
 	dir = 4;
@@ -37177,10 +37165,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"ccB" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "ccC" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
@@ -39837,16 +39821,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"clT" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "clU" = (
 /turf/open/floor/engine/n2,
-/area/engine/atmos)
-"clV" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "clW" = (
 /turf/open/floor/engine/o2,
@@ -46243,6 +46219,10 @@
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"cVt" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "cWf" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -47123,6 +47103,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"ekq" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "ekG" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -47135,11 +47119,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"ekP" = (
-/obj/machinery/atmospherics/miner,
-/obj/machinery/atmospherics/miner,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "ekU" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -47475,6 +47454,10 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"eDJ" = (
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "eEb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -49643,6 +49626,10 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"hhj" = (
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "hhs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -54616,6 +54603,9 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nvR" = (
+/turf/open/floor/engine/plasma,
+/area)
 "nxv" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -55787,10 +55777,6 @@
 	dir = 5
 	},
 /area/science/research)
-"pcC" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "pcI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -57371,10 +57357,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qVc" = (
-/obj/machinery/atmospherics/miner/n2o,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "qVo" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 6
@@ -60357,10 +60339,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"vcF" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "vdl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -60378,6 +60356,10 @@
 	dir = 8
 	},
 /area/science/research)
+"veN" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "vhl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -96088,7 +96070,7 @@ nDO
 aaf
 bQA
 ckU
-clT
+cVt
 cmU
 bOh
 ccw
@@ -96346,7 +96328,7 @@ bVu
 ckb
 ckW
 clU
-ekP
+clU
 bOh
 ccw
 ccw
@@ -97116,7 +97098,7 @@ nDO
 aaf
 bQA
 ckX
-clV
+veN
 cmV
 bOh
 cig
@@ -97374,7 +97356,7 @@ bVu
 ckb
 ckZ
 clW
-vcF
+clW
 bOh
 cig
 aaa
@@ -99668,15 +99650,15 @@ bPm
 bPm
 bOh
 bTW
-bUU
+eDJ
 bTW
 bOh
 bXW
-bYU
+hhj
 bXW
 bOh
 cbH
-ccB
+ekq
 cbH
 bOh
 aaf
@@ -99926,15 +99908,15 @@ bPm
 bOh
 bTW
 bUW
-qVc
+bTW
 bOh
 bXY
 bYW
-cbX
+nvR
 bOh
 cbH
 ccD
-pcC
+cbH
 bOh
 aaf
 aaf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36921,6 +36921,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"cbX" = (
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area)
 "cbZ" = (
 /obj/structure/sink{
 	dir = 4;
@@ -47131,6 +47135,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"ekP" = (
+/obj/machinery/atmospherics/miner,
+/obj/machinery/atmospherics/miner,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "ekU" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -55778,6 +55787,10 @@
 	dir = 5
 	},
 /area/science/research)
+"pcC" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "pcI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -56161,7 +56174,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "pIP" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
@@ -57356,6 +57371,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qVc" = (
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "qVo" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 6
@@ -58349,7 +58368,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ssh" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
@@ -60336,6 +60357,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"vcF" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "vdl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -96321,7 +96346,7 @@ bVu
 ckb
 ckW
 clU
-clU
+ekP
 bOh
 ccw
 ccw
@@ -97349,7 +97374,7 @@ bVu
 ckb
 ckZ
 clW
-clW
+vcF
 bOh
 cig
 aaa
@@ -99901,15 +99926,15 @@ bPm
 bOh
 bTW
 bUW
-bTW
+qVc
 bOh
 bXY
 bYW
-bXW
+cbX
 bOh
 cbH
 ccD
-cbH
+pcC
 bOh
 aaf
 aaf

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -27032,10 +27032,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
-"aXW" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "aXX" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
@@ -29427,10 +29423,6 @@
 /obj/machinery/air_sensor/atmos/oxygen_tank,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
-"bbO" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "bbP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30942,10 +30934,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
-"bev" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "bew" = (
@@ -32762,10 +32750,6 @@
 /area/engine/atmos)
 "bhv" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
-"bhw" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "bhx" = (
@@ -34875,12 +34859,6 @@
 "bkG" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
-"bkH" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide{
-	valve_open = 1
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -120904,10 +120882,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
-"gjt" = (
-/obj/machinery/atmospherics/miner/n2o,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "goa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -121143,10 +121117,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gVf" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "gVM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -121559,6 +121529,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"ipC" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "isT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -122517,10 +122491,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"lxY" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "lyU" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
 	dir = 8
@@ -122572,6 +122542,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"lEN" = (
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "lFh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -123658,10 +123632,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"prv" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "psi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
@@ -123899,6 +123869,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"qiM" = (
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "qjp" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	id_tag = "commissarydoor";
@@ -124500,6 +124474,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/shuttledock)
+"sNZ" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "sOi" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -124687,10 +124665,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tlE" = (
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "tub" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -124841,6 +124815,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"tUY" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "udo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -146830,15 +146808,15 @@ hFo
 aRF
 aWt
 aXV
-prv
+aWt
 aRF
 bcX
 beu
-tlE
+bcX
 aRF
 biT
 bkG
-gjt
+biT
 aRF
 bpO
 brT
@@ -147086,15 +147064,15 @@ aFr
 aSQ
 aRF
 aWu
-aXW
+sNZ
 aWt
 aRF
 bcY
-bev
+lEN
 bcX
 aRF
 biU
-bkH
+qiM
 biT
 aRF
 bpO
@@ -154541,11 +154519,11 @@ aVa
 aTl
 aRF
 bal
-bbO
+tUY
 bam
 aRF
 bgg
-bhw
+ipC
 bgh
 aRF
 aMN
@@ -154799,11 +154777,11 @@ aTl
 aRF
 bam
 bbP
-lxY
+bam
 aRF
 bgh
 bhx
-gVf
+bgh
 aRF
 aMO
 alf

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -120904,6 +120904,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
+"gjt" = (
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "goa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -121139,6 +121143,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gVf" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "gVM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -122509,6 +122517,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"lxY" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "lyU" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
 	dir = 8
@@ -123238,7 +123250,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -123644,6 +123658,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"prv" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "psi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bodycontainer/morgue{
@@ -124669,6 +124687,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tlE" = (
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "tub" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -146808,15 +146830,15 @@ hFo
 aRF
 aWt
 aXV
-aWt
+prv
 aRF
 bcX
 beu
-bcX
+tlE
 aRF
 biT
 bkG
-biT
+gjt
 aRF
 bpO
 brT
@@ -154777,11 +154799,11 @@ aTl
 aRF
 bam
 bbP
-bam
+lxY
 aRF
 bgh
 bhx
-bgh
+gVf
 aRF
 aMO
 alf

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -82754,7 +82754,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "gjM" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -42101,10 +42101,6 @@
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"bQa" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "bQb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -43535,10 +43531,6 @@
 /area/engine/atmos)
 "bSW" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
-"bSX" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "bSY" = (
@@ -45051,10 +45043,6 @@
 /area/space/nearstation)
 "bWe" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
-"bWf" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "bWg" = (
@@ -47267,15 +47255,7 @@
 "cbs" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
-"cbt" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "cbu" = (
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
-"cbv" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "cbw" = (
@@ -55657,10 +55637,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"fMb" = (
-/obj/machinery/atmospherics/miner/toxins,
-/turf/open/floor/engine/plasma,
-/area/engine/atmos)
 "fNd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -58831,10 +58807,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kUR" = (
-/obj/machinery/atmospherics/miner/n2o,
-/turf/open/floor/engine/n2o,
-/area/engine/atmos)
 "kXb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -59703,6 +59675,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"mOL" = (
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "mPh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/directions/evac{
@@ -60246,6 +60222,10 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"nQz" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "nSj" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -60311,6 +60291,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"nXG" = (
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "nYn" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
@@ -60470,6 +60454,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"olS" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "onn" = (
 /obj/structure/chair{
 	dir = 1
@@ -60578,6 +60566,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"osg" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "ost" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -62493,10 +62485,6 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
-"rpx" = (
-/obj/machinery/atmospherics/miner/oxygen,
-/turf/open/floor/engine/o2,
-/area/engine/atmos)
 "rrb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -63908,10 +63896,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"umF" = (
-/obj/machinery/atmospherics/miner/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engine/atmos)
 "uos" = (
 /obj/machinery/computer/camera_advanced/base_construction,
 /obj/effect/turf_decal/stripes/line{
@@ -65741,10 +65725,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"xzY" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
-/turf/open/floor/engine/co2,
-/area/engine/atmos)
 "xDj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -101264,7 +101244,7 @@ bZd
 bZL
 caz
 cbs
-umF
+cbs
 bJP
 aaa
 aaa
@@ -101520,7 +101500,7 @@ eKK
 abI
 bMi
 caA
-cbt
+osg
 ccm
 bJP
 aaa
@@ -102292,7 +102272,7 @@ bZd
 bZL
 caC
 cbu
-rpx
+cbu
 bJP
 abI
 aby
@@ -102548,7 +102528,7 @@ eKK
 abI
 bMi
 caD
-cbv
+nQz
 ccn
 bJP
 aaa
@@ -106131,15 +106111,15 @@ bLe
 bLe
 bJP
 bPh
-bQa
+nXG
 bPh
 bJP
 bSk
-bSX
+mOL
 bSk
 bJP
 bVo
-bWf
+olS
 bVo
 bJP
 aht
@@ -106389,15 +106369,15 @@ bLe
 bJP
 bPh
 bQb
-kUR
+bPh
 bJP
 bSl
 bSY
-fMb
+bSk
 bJP
 bVo
 bWg
-xzY
+bVo
 bJP
 oex
 bYw

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -55657,6 +55657,10 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
+"fMb" = (
+/obj/machinery/atmospherics/miner/toxins,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "fNd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -58827,6 +58831,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kUR" = (
+/obj/machinery/atmospherics/miner/n2o,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "kXb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -59021,7 +59029,9 @@
 /obj/machinery/conveyor_switch{
 	id = "SciLoad"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	pixel_x = 24
+	},
 /obj/structure/cable/yellow,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -62483,6 +62493,10 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"rpx" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "rrb" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -63894,6 +63908,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"umF" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "uos" = (
 /obj/machinery/computer/camera_advanced/base_construction,
 /obj/effect/turf_decal/stripes/line{
@@ -65723,6 +65741,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"xzY" = (
+/obj/machinery/atmospherics/miner/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "xDj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -101242,7 +101264,7 @@ bZd
 bZL
 caz
 cbs
-cbs
+umF
 bJP
 aaa
 aaa
@@ -102270,7 +102292,7 @@ bZd
 bZL
 caC
 cbu
-cbu
+rpx
 bJP
 abI
 aby
@@ -106367,15 +106389,15 @@ bLe
 bJP
 bPh
 bQb
-bPh
+kUR
 bJP
 bSl
 bSY
-bSk
+fMb
 bJP
 bVo
 bWg
-bVo
+xzY
 bJP
 oex
 bYw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds gas miners to atmos, now also deletes old cans.

## Why It's Good For The Game

With the fusion "fix" demanding high amounts of gasses, there's a strong possibility that some atmosians in training can use up all the stored gasses as I have done once before. This leaves the station fighting for air. this change makes running out of gas impossible and indirectly encourages more experimentation in atmos (infinite resources to play with).
Also just realized CL = Change Log i'm not a grandpa I swear
## Changelog
:cl:
add: Puts Gas miners into their respective gas chambers.
del: Deletes the old gas cans from the chambers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
