### PR TITLE
Artificer Build Floor Spell also places tiny fans

### DIFF
--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -33,7 +33,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/floor
 	name = "Summon Cult Floor"
-	desc = "This spell enchants the floor to sustain life."
+	desc = "This spell enchants places a runed tile and also enhances it to support life."
 
 	school = "conjuration"
 	charge_max = 20
@@ -54,7 +54,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/wall
 	name = "Summon Cult Wall"
-	desc = "This spell constructs a cult wall."
+	desc = "This spell constructs a runed wall."
 
 	school = "conjuration"
 	charge_max = 100
@@ -70,7 +70,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/door
 	name = "Summon Cult Door"
-	desc = "This spell constructs a cult Airlock."
+	desc = "This spell constructs a runed Airlock."
 
 	school = "conjuration"
 	charge_max = 300

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -41,11 +41,16 @@
 	invocation = "none"
 	invocation_type = "none"
 	range = 0
-	summon_type = list(/turf/open/floor/engine/cult)
+	summon_type = list(/turf/open/floor/engine/cult, /obj/structure/fans/tiny/cult)
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "floorconstruct"
 	action_background_icon_state = "bg_cult"
 
+/obj/structure/fans/tiny/cult
+	name = "pulsating essence"
+	desc = "An enchanced tile that prevents airflow."
+	icon = 'icons/obj/cult.dmi'
+	icon_state = "hole"
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/wall
 	name = "Summon Cult Wall"

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -33,7 +33,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/floor
 	name = "Summon Cult Floor"
-	desc = "This spell constructs a cult floor."
+	desc = "This spell enchants the floor to always sustain life."
 
 	school = "conjuration"
 	charge_max = 20
@@ -47,7 +47,7 @@
 	action_background_icon_state = "bg_cult"
 
 /obj/structure/fans/tiny/cult
-	name = "pulsating essence"
+	name = "floor enchantment"
 	desc = "An enchanced tile that prevents airflow."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "hole"

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -33,7 +33,7 @@
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/floor
 	name = "Summon Cult Floor"
-	desc = "This spell enchants the floor to always sustain life."
+	desc = "This spell enchants the floor to sustain life."
 
 	school = "conjuration"
 	charge_max = 20
@@ -49,8 +49,8 @@
 /obj/structure/fans/tiny/cult
 	name = "floor enchantment"
 	desc = "An enchanced tile that prevents airflow."
-	icon = 'icons/obj/cult.dmi'
-	icon_state = "hole"
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "dark_seed"
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/wall
 	name = "Summon Cult Wall"


### PR DESCRIPTION
## About The Pull Request

Artificer Place Floor spell now also places a tiny fan on the tile, 

## Why It's Good For The Game

Fixes a feature that was broken with the fastmos release, and adds a little bit of use to the artificer spell. 

Cultbases now have big trouble dealing with atmos and it is really easy for them to be spaced out, leaving the cult hopeless.

## Changelog
:cl:
add: artificers can atmosproof cultbases with the floor spell now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
