### PR TITLE
Make dangerous shuttles unbuyable + emags & hacking

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -398,7 +398,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		if(unbuyable.Find(S.mappath))
 			S.can_be_bought = FALSE
 		if(illegal.Find(S.mappath))
-			S.syndicate_exclusive = TRUE
+			S.illegal_shuttle = TRUE
 
 		shuttle_templates[S.shuttle_id] = S
 		map_templates[S.shuttle_id] = S

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -386,7 +386,8 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 			space_ruins_templates[R.name] = R
 
 /datum/controller/subsystem/mapping/proc/preloadShuttleTemplates()
-	var/list/unbuyable = generateMapList("[global.config.directory]/unbuyableshuttles.txt")
+	var/list/unbuyable = generateMapList("[global.config.directory]/shuttles_unbuyable.txt")
+	var/list/illegal = generateMapList("[global.config.directory]/shuttles_illegal.txt")
 
 	for(var/item in subtypesof(/datum/map_template/shuttle))
 		var/datum/map_template/shuttle/shuttle_type = item
@@ -396,6 +397,8 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		var/datum/map_template/shuttle/S = new shuttle_type()
 		if(unbuyable.Find(S.mappath))
 			S.can_be_bought = FALSE
+		if(illegal.Find(S.mappath))
+			S.syndicate_exclusive = TRUE
 
 		shuttle_templates[S.shuttle_id] = S
 		map_templates[S.shuttle_id] = S

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -11,7 +11,7 @@
 
 	var/credit_cost = INFINITY
 	var/can_be_bought = TRUE
-	var/syndicate_exclusive = FALSE	//makes you able to buy the shuttle at an emagged comms console even if can_be_bought is FALSE
+	var/illegal_shuttle = FALSE	//makes you able to buy the shuttle at a hacked/emagged comms console even if can_be_bought is FALSE
 
 	var/list/movement_force // If set, overrides default movement_force on shuttle
 

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -11,6 +11,7 @@
 
 	var/credit_cost = INFINITY
 	var/can_be_bought = TRUE
+	var/syndicate_exclusive = FALSE	//makes you able to buy the shuttle at an emagged comms console even if can_be_bought is FALSE
 
 	var/list/movement_force // If set, overrides default movement_force on shuttle
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -556,8 +556,10 @@
 			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 			dat += "Budget: [D.account_balance] Credits.<BR>"
 			dat += "<BR>"
-			dat += "<b>Caution: Purchasing dangerous shuttles may lead to mutiny and/or death.</b><br>"
-			dat += "<BR>"
+			if(obj_flags & EMAGGED)
+				dat += "<b>WARNING: Safety features disabled. Non-certified shuttles included. Order at your own peril.</b><BR><BR>" 
+			else 
+				dat += "<b>Safety protocols in effect: The listed shuttles fulfill NT safety standards.</b><BR><BR>" //not that they're very high but these won't kill everyone aboard
 			for(var/shuttle_id in SSmapping.shuttle_templates)
 				var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]
 				if(S.can_be_bought && S.credit_cost < INFINITY)
@@ -566,10 +568,11 @@
 					if(S.prerequisites)
 						dat += "Prerequisites: [S.prerequisites]<BR>"
 					dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
-				else if(obj_flags & EMAGGED)
-					if(S.syndicate_exclusive && S.credit_cost < INFINITY)
-						dat += "<b> Shuttle supplied by Syndicate, order at your own risk: </b>"
-						dat += "<BR>"
+			if(obj_flags & EMAGGED)
+				dat += "<b>NON-CERTIFIED SHUTTLES APPENDED BELOW.</b><BR><BR>"
+				for(var/shuttle_id in SSmapping.shuttle_templates)
+					var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]
+					if(S.illegal_shuttle && S.credit_cost < INFINITY)
 						dat += "[S.name] | [S.credit_cost] Credits<BR>"
 						dat += "[S.description]<BR>"
 						if(S.prerequisites)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -566,6 +566,15 @@
 					if(S.prerequisites)
 						dat += "Prerequisites: [S.prerequisites]<BR>"
 					dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
+				else if(obj_flags & EMAGGED)
+					if(S.syndicate_exclusive && S.credit_cost < INFINITY)
+						dat += "<b> Shuttle supplied by Syndicate, order at your own risk: </b>"
+						dat += "<BR>"
+						dat += "[S.name] | [S.credit_cost] Credits<BR>"
+						dat += "[S.description]<BR>"
+						if(S.prerequisites)
+							dat += "Prerequisites: [S.prerequisites]<BR>"
+						dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
 
 	dat += "<BR><BR>\[ [(state != STATE_DEFAULT) ? "<A HREF='?src=[REF(src)];operation=main'>Main Menu</A> | " : ""]<A HREF='?src=[REF(user)];mach_close=communications'>Close</A> \]"
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -171,7 +171,7 @@
 							SSshuttle.existing_shuttle = SSshuttle.emergency
 							SSshuttle.action_load(S)
 							D.adjust_money(-S.credit_cost)
-							minor_announce("[usr.real_name] has purchased [S.name] for [S.credit_cost] credits.[S.extra_desc ? " [S.extra_desc]" : ""]" , "Shuttle Purchase")
+							minor_announce("[S.name] has been purchased for [S.credit_cost] credits! Purchase authorized by [auth_id] [S.extra_desc ? " [S.extra_desc]" : ""]" , "Shuttle Purchase")
 							message_admins("[ADMIN_LOOKUPFLW(usr)] purchased [S.name].")
 							log_game("[key_name(usr)] has purchased [S.name].")
 							SSblackbox.record_feedback("text", "shuttle_purchase", 1, "[S.name]")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -554,12 +554,13 @@
 
 		if(STATE_PURCHASE)
 			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+			var/obj/item/circuitboard/computer/communications/CM = circuit
 			dat += "Budget: [D.account_balance] Credits.<BR>"
 			dat += "<BR>"
-			if(obj_flags & EMAGGED)
+			if(obj_flags & EMAGGED || CM.insecure)
 				dat += "<b>WARNING: Safety features disabled. Non-certified shuttles included. Order at your own peril.</b><BR><BR>" 
 			else 
-				dat += "<b>Safety protocols in effect: The listed shuttles fulfill NT safety standards.</b><BR><BR>" //not that they're very high but these won't kill everyone aboard
+				dat += "<b>Safety protocols in effect: These shuttles all fulfill NT safety standards.</b><BR><BR>" //not that they're very high but these won't kill everyone aboard
 			for(var/shuttle_id in SSmapping.shuttle_templates)
 				var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]
 				if(S.can_be_bought && S.credit_cost < INFINITY)
@@ -568,7 +569,7 @@
 					if(S.prerequisites)
 						dat += "Prerequisites: [S.prerequisites]<BR>"
 					dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
-			if(obj_flags & EMAGGED)
+			if(obj_flags & EMAGGED || CM.insecure)
 				dat += "<b>NON-CERTIFIED SHUTTLES APPENDED BELOW.</b><BR><BR>"
 				for(var/shuttle_id in SSmapping.shuttle_templates)
 					var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -569,7 +569,7 @@
 					if(S.prerequisites)
 						dat += "Prerequisites: [S.prerequisites]<BR>"
 					dat += "<A href='?src=[REF(src)];operation=buyshuttle;chosen_shuttle=[REF(S)]'>(<font color=red><i>Purchase</i></font>)</A><BR><BR>"
-			if(obj_flags & EMAGGED || CM.insecure)
+			if((obj_flags & EMAGGED) || CM.insecure)
 				dat += "<b>NON-CERTIFIED SHUTTLES APPENDED BELOW.</b><BR><BR>"
 				for(var/shuttle_id in SSmapping.shuttle_templates)
 					var/datum/map_template/shuttle/S = SSmapping.shuttle_templates[shuttle_id]

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -557,7 +557,7 @@
 			var/obj/item/circuitboard/computer/communications/CM = circuit
 			dat += "Budget: [D.account_balance] Credits.<BR>"
 			dat += "<BR>"
-			if(obj_flags & EMAGGED || CM.insecure)
+			if((obj_flags & EMAGGED) || CM.insecure)
 				dat += "<b>WARNING: Safety features disabled. Non-certified shuttles included. Order at your own peril.</b><BR><BR>" 
 			else 
 				dat += "<b>Safety protocols in effect: These shuttles all fulfill NT safety standards.</b><BR><BR>" //not that they're very high but these won't kill everyone aboard

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -55,7 +55,7 @@
 /obj/item/circuitboard/computer/communications/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		insecure = (insecure == 0) ? 1 : 0 
-		if(insecure == 1)
+		if(insecure)
 			desc = "Tampering has removed some safety features from this circuit board. A screwdriver can undo this."
 			to_chat(user, "<span class='notice'>You disable the shuttle safety features of the board.</span>")
 		else

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -47,6 +47,7 @@
 /obj/item/circuitboard/computer/communications
 	name = "Communications (Computer Board)"
 	icon_state = "command"
+	desc = "Can be modified using a screwdriver."
 	build_path = /obj/machinery/computer/communications
 	var/lastTimeUsed = 0
 	var/insecure = 0 // Forbids shuttles that are set as illegal. 

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -54,7 +54,7 @@
 
 /obj/item/circuitboard/computer/communications/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		insecure = (insecure == 0) ? 1 : 0 
+		insecure = !insecure
 		if(insecure)
 			desc = "Tampering has removed some safety features from this circuit board. A screwdriver can undo this."
 			to_chat(user, "<span class='notice'>You disable the shuttle safety features of the board.</span>")

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -49,6 +49,19 @@
 	icon_state = "command"
 	build_path = /obj/machinery/computer/communications
 	var/lastTimeUsed = 0
+	var/insecure = 0 // Forbids shuttles that are set as illegal. 
+
+/obj/item/circuitboard/computer/communications/attackby(obj/item/I, mob/user, params)
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		insecure = (insecure == 0) ? 1 : 0 
+		if(insecure == 1)
+			desc = "Tampering has removed some safety features from this circuit board. A screwdriver can undo this."
+			to_chat(user, "<span class='notice'>You disable the shuttle safety features of the board.</span>")
+		else
+			desc = "Can be modified using a screwdriver."
+			to_chat(user, "<span class='notice'>You re-enable the shuttle safety features of the board.</span>")
+	else
+		return ..()
 
 //obj/item/circuitboard/computer/shield
 //	name = "Shield Control (Computer Board)"

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -50,7 +50,7 @@
 	desc = "Can be modified using a screwdriver."
 	build_path = /obj/machinery/computer/communications
 	var/lastTimeUsed = 0
-	var/insecure = 0 // Forbids shuttles that are set as illegal. 
+	var/insecure = FALSE // Forbids shuttles that are set as illegal. 
 
 /obj/item/circuitboard/computer/communications/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)

--- a/config/Sage/shuttles_illegal.txt
+++ b/config/Sage/shuttles_illegal.txt
@@ -1,4 +1,5 @@
-##Listing maps here will make the shuttle not available to buy in comms console.
+##Listing maps here will make the shuttle be available to be bought if comms console is emagged
+##Make sure the shuttle is already unbuyable
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!
 ##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
@@ -13,18 +14,18 @@
 
 ##Others
 #_maps/shuttles/emergency_asteroid.dmm
-#_maps/shuttles/emergency_airless.dmm
 #_maps/shuttles/emergency_arena.dmm
 #_maps/shuttles/emergency_bar.dmm
+#_maps/shuttles/emergency_construction.dmm
 #_maps/shuttles/emergency_clown.dmm
 #_maps/shuttles/emergency_cramped.dmm
-#_maps/shuttles/emergency_imfedupwiththisworld.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
 #_maps/shuttles/emergency_goon.dmm
 #_maps/shuttles/emergency_luxury.dmm
-#_maps/shuttles/emergency_meteor.dmm
+_maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_raven.dmm
 #_maps/shuttles/emergency_russiafightpit.dmm
 #_maps/shuttles/emergency_scrapheap.dmm
-#_maps/shuttles/emergency_supermatter.dmm
+_maps/shuttles/emergency_supermatter.dmm
 #_maps/shuttles/emergency_wabbajack.dmm
-#_maps/shuttles/emergency_discoinferno.dmm
+_maps/shuttles/emergency_discoinferno.dmm

--- a/config/Sage/shuttles_unbuyable.txt
+++ b/config/Sage/shuttles_unbuyable.txt
@@ -1,0 +1,30 @@
+##Listing maps here will make the shuttle not be available to be bought
+##Maps must be the full path to them
+##Only shuttles with a price in the code will work with this!
+##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
+
+##Station shuttles
+#_maps/shuttles/emergency_birdboat.dmm
+#_maps/shuttles/emergency_box.dmm
+#_maps/shuttles/emergency_delta.dmm
+#_maps/shuttles/emergency_meta.dmm
+#_maps/shuttles/emergency_mini.dmm
+#_maps/shuttles/emergency_pubby.dmm
+
+##Others
+#_maps/shuttles/emergency_asteroid.dmm
+#_maps/shuttles/emergency_arena.dmm
+#_maps/shuttles/emergency_bar.dmm
+#_maps/shuttles/emergency_construction.dmm
+#_maps/shuttles/emergency_clown.dmm
+#_maps/shuttles/emergency_cramped.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
+#_maps/shuttles/emergency_goon.dmm
+#_maps/shuttles/emergency_luxury.dmm
+_maps/shuttles/emergency_meteor.dmm
+#_maps/shuttles/emergency_raven.dmm
+#_maps/shuttles/emergency_russiafightpit.dmm
+#_maps/shuttles/emergency_scrapheap.dmm
+_maps/shuttles/emergency_supermatter.dmm
+#_maps/shuttles/emergency_wabbajack.dmm
+_maps/shuttles/emergency_discoinferno.dmm

--- a/config/shuttles_illegal.txt
+++ b/config/shuttles_illegal.txt
@@ -1,4 +1,4 @@
-##Listing maps here will make the shuttle be available to be bought if comms console is emagged
+##Listing maps here will make the shuttle be available to be bought if comms console is emagged or hacked
 ##Make sure the shuttle is already unbuyable
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!
@@ -14,7 +14,7 @@
 
 ##Others
 #_maps/shuttles/emergency_asteroid.dmm
-#_maps/shuttles/emergency_arena.dmm
+_maps/shuttles/emergency_arena.dmm
 #_maps/shuttles/emergency_bar.dmm
 #_maps/shuttles/emergency_construction.dmm
 #_maps/shuttles/emergency_clown.dmm

--- a/config/shuttles_illegal.txt
+++ b/config/shuttles_illegal.txt
@@ -1,4 +1,5 @@
-##Listing maps here will make the shuttle not available to buy in comms console.
+##Listing maps here will make the shuttle be available to be bought if comms console is emagged
+##Make sure the shuttle is already unbuyable
 ##Maps must be the full path to them
 ##Only shuttles with a price in the code will work with this!
 ##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
@@ -18,13 +19,13 @@
 #_maps/shuttles/emergency_construction.dmm
 #_maps/shuttles/emergency_clown.dmm
 #_maps/shuttles/emergency_cramped.dmm
-#_maps/shuttles/emergency_imfedupwiththisworld.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
 #_maps/shuttles/emergency_goon.dmm
 #_maps/shuttles/emergency_luxury.dmm
-#_maps/shuttles/emergency_meteor.dmm
+_maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_raven.dmm
 #_maps/shuttles/emergency_russiafightpit.dmm
 #_maps/shuttles/emergency_scrapheap.dmm
-#_maps/shuttles/emergency_supermatter.dmm
+_maps/shuttles/emergency_supermatter.dmm
 #_maps/shuttles/emergency_wabbajack.dmm
-#_maps/shuttles/emergency_discoinferno.dmm
+_maps/shuttles/emergency_discoinferno.dmm

--- a/config/shuttles_unbuyable.txt
+++ b/config/shuttles_unbuyable.txt
@@ -1,0 +1,30 @@
+##Listing maps here will make the shuttle not be available to be bought
+##Maps must be the full path to them
+##Only shuttles with a price in the code will work with this!
+##SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
+
+##Station shuttles
+#_maps/shuttles/emergency_birdboat.dmm
+#_maps/shuttles/emergency_box.dmm
+#_maps/shuttles/emergency_delta.dmm
+#_maps/shuttles/emergency_meta.dmm
+#_maps/shuttles/emergency_mini.dmm
+#_maps/shuttles/emergency_pubby.dmm
+
+##Others
+#_maps/shuttles/emergency_asteroid.dmm
+#_maps/shuttles/emergency_arena.dmm
+#_maps/shuttles/emergency_bar.dmm
+#_maps/shuttles/emergency_construction.dmm
+#_maps/shuttles/emergency_clown.dmm
+#_maps/shuttles/emergency_cramped.dmm
+_maps/shuttles/emergency_imfedupwiththisworld.dmm
+#_maps/shuttles/emergency_goon.dmm
+#_maps/shuttles/emergency_luxury.dmm
+_maps/shuttles/emergency_meteor.dmm
+#_maps/shuttles/emergency_raven.dmm
+#_maps/shuttles/emergency_russiafightpit.dmm
+#_maps/shuttles/emergency_scrapheap.dmm
+_maps/shuttles/emergency_supermatter.dmm
+#_maps/shuttles/emergency_wabbajack.dmm
+_maps/shuttles/emergency_discoinferno.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Here's all it does: 
A. Dangerous shuttles are no longer available for purchase by default, these are the arena, disco shuttle, oh hi daniel, hyperfractal, and the giant meteor.
B. However, the comms console can be emagged to re-enable these. Emag also anonymizes your name (it did this before but i don't think people knew)
C. In addition, you can use a screwdriver on a communications console circuit board to re-enable them as well. Antags without emags can thus order them, and captains with crew approval/intense circumstances can order them as well. 
D. The ID of the one who authorized the purchase is printed in the chat. So if you use a captain's ID, it will look like they ordered it. 
E. Dangerous shuttles are presented in their own category at the bottom, and text has been altered to indicate these changes.

 I based this off of Archanial's PR #2841 & PowerfulBacon's recommendation. So thanks to them. 

Closes #2828. 
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Dangerous shuttles are banbait generally. This makes it so that you have to be much more deliberate in calling them, while also opening the door for hijackers and other antags to keep them from being dead content. 

## Changelog
:cl:Froststahr
add: Emags allow traitors to anonymously purchase any shuttle they want without ID! Screwdrivers can be used on circuit boards as well, but adequate access is still required in that case.
tweak: The name of the authorizer, not the buyer, is printed on purchase of a shuttle. 
tweak: Unsafe shuttles are now unavailable for purchase without emags/hacking. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
