### PR TITLE
Updates the rust-g binary and dm file to v0.4.6.1

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -45,6 +45,7 @@
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
 #define rustg_dmi_resize_png(path, width, height, resizetype) call(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
+
 #define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
 #define rustg_file_exists(fname) call(RUST_G, "file_exists")(fname)
 #define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
@@ -85,6 +86,7 @@
 /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
 
 #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
+
 #define rustg_sql_connect_pool(options) call(RUST_G, "sql_connect_pool")(options)
 #define rustg_sql_query_async(handle, query, params) call(RUST_G, "sql_query_async")(handle, query, params)
 #define rustg_sql_query_blocking(handle, query, params) call(RUST_G, "sql_query_blocking")(handle, query, params)

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -7,7 +7,7 @@
 // Override the .dll/.so detection logic with a fixed path or with detection
 // logic of your own.
 //
-//#define RUSTG_OVERRIDE_BUILTINS
+// #define RUSTG_OVERRIDE_BUILTINS
 // Enable replacement rust-g functions for certain builtins. Off by default.
 
 #ifndef RUST_G
@@ -44,12 +44,16 @@
 
 #define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
+#define rustg_dmi_resize_png(path, width, height, resizetype) call(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
+#define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
+#define rustg_file_exists(fname) call(RUST_G, "file_exists")(fname)
+#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
+#define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
 
-#define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
-
-#define rustg_file_read(fname) call(RUST_G, "file_read")("[fname]")
-#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, "[fname]")
-#define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, "[fname]")
+#ifdef RUSTG_OVERRIDE_BUILTINS
+    #define file2text(fname) rustg_file_read("[fname]")
+    #define text2file(text, fname) rustg_file_append(text, "[fname]")
+#endif
 
 #define rustg_git_revparse(rev) call(RUST_G, "rg_git_revparse")(rev)
 #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
@@ -62,11 +66,9 @@
 #define RUSTG_HASH_SHA256 "sha256"
 #define RUSTG_HASH_SHA512 "sha512"
 
-#define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
-/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
-
-#define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
-#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
+#ifdef RUSTG_OVERRIDE_BUILTINS
+#define md5(thing) (isfile(thing) ? rustg_hash_file(RUSTG_HASH_MD5, "[thing]") : rustg_hash_string(RUSTG_HASH_MD5, thing))
+#endif
 
 #define RUSTG_HTTP_METHOD_GET "get"
 #define RUSTG_HTTP_METHOD_PUT "put"
@@ -78,9 +80,25 @@
 #define rustg_http_request_async(method, url, body, headers) call(RUST_G, "http_request_async")(method, url, body, headers)
 #define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
 
+#define rustg_json_is_valid(text) (call(RUST_G, "json_is_valid")(text) == "true")
+#define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
+/proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
+
+#define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)
 #define rustg_sql_connect_pool(options) call(RUST_G, "sql_connect_pool")(options)
 #define rustg_sql_query_async(handle, query, params) call(RUST_G, "sql_query_async")(handle, query, params)
 #define rustg_sql_query_blocking(handle, query, params) call(RUST_G, "sql_query_blocking")(handle, query, params)
 #define rustg_sql_connected(handle) call(RUST_G, "sql_connected")(handle)
 #define rustg_sql_disconnect_pool(handle) call(RUST_G, "sql_disconnect_pool")(handle)
 #define rustg_sql_check_query(job_id) call(RUST_G, "sql_check_query")("[job_id]")
+
+#define rustg_unzip_download_async(url, unzip_directory) call(RUST_G, "unzip_download_async")(url, unzip_directory)
+#define rustg_unzip_check(job_id) call(RUST_G, "unzip_check")("[job_id]")
+
+#define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
+#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
+
+#ifdef RUSTG_OVERRIDE_BUILTINS
+    #define url_encode(text) rustg_url_encode(text)
+    #define url_decode(text) rustg_url_decode(text)
+#endif

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -42,14 +42,14 @@
 #define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
 #define RUSTG_JOB_ERROR "JOB PANICKED"
 
-#define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")(fname)
+#define rustg_dmi_strip_metadata(fname) call(RUST_G, "dmi_strip_metadata")("[fname]")
 #define rustg_dmi_create_png(path, width, height, data) call(RUST_G, "dmi_create_png")(path, width, height, data)
 #define rustg_dmi_resize_png(path, width, height, resizetype) call(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
 
-#define rustg_file_read(fname) call(RUST_G, "file_read")(fname)
-#define rustg_file_exists(fname) call(RUST_G, "file_exists")(fname)
-#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, fname)
-#define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, fname)
+#define rustg_file_read(fname) call(RUST_G, "file_read")("[fname]")
+#define rustg_file_exists(fname) call(RUST_G, "file_exists")("[fname]")
+#define rustg_file_write(text, fname) call(RUST_G, "file_write")(text, "[fname]")
+#define rustg_file_append(text, fname) call(RUST_G, "file_append")(text, "[fname]")
 
 #ifdef RUSTG_OVERRIDE_BUILTINS
     #define file2text(fname) rustg_file_read("[fname]")
@@ -60,7 +60,7 @@
 #define rustg_git_commit_date(rev) call(RUST_G, "rg_git_commit_date")(rev)
 
 #define rustg_hash_string(algorithm, text) call(RUST_G, "hash_string")(algorithm, text)
-#define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, fname)
+#define rustg_hash_file(algorithm, fname) call(RUST_G, "hash_file")(algorithm, "[fname]")
 
 #define RUSTG_HASH_MD5 "md5"
 #define RUSTG_HASH_SHA1 "sha1"
@@ -82,7 +82,7 @@
 #define rustg_http_check_request(req_id) call(RUST_G, "http_check_request")(req_id)
 
 #define rustg_json_is_valid(text) (call(RUST_G, "json_is_valid")(text) == "true")
-#define rustg_log_write(fname, text, format) call(RUST_G, "log_write")(fname, text, format)
+#define rustg_log_write(fname, text, format) call(RUST_G, "log_write")("[fname]", text, format)
 /proc/rustg_log_close_all() return call(RUST_G, "log_close_all")()
 
 #define rustg_noise_get_at_coordinates(seed, x, y) call(RUST_G, "noise_get_at_coordinates")(seed, x, y)

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -13,7 +13,7 @@ if [[ -f "Dockerfile" ]]; then
 fi
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.5.2
+export RUST_G_VERSION=0.4.6.1
 
 #node version
 export NODE_VERSION=12


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates rust-g to bring in the following changes along with various code improvements. The DM file has also been updated and reorganized accordingly. 

Add dmi_resize_png (by ShadowLarkens https://github.com/tgstation/rust-g/pull/39)
Adds unzip module (by Cyberboss https://github.com/tgstation/rust-g/pull/53)

Notable additions:

```dm
rustg_dmi_resize_png(path, width, height, resizetype)
rustg_json_is_valid(text)
rustg_unzip_download_async(url, unzip_directory)
rustg_unzip_check(job_id)
```


## Why It's Good For The Game

More useful functions and some good stability changes that might help reduce crashing.

## Changelog
:cl:
tweak: Updated the rust-g dependency
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
