### PR TITLE
Round will not end the instant all heretics are dead

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -6,7 +6,7 @@
 	false_report_weight = 5
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician")
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 0
+	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1

--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -6,7 +6,7 @@
 	false_report_weight = 5
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician")
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 20
+	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
@@ -65,3 +65,13 @@
 /datum/game_mode/heretics/generate_report()
 	return "Cybersun Industries has announced that they have successfully raided a high-security library. The library contained a very dangerous book that was \
 	shown to posses anomalous properties. We suspect that the book has been copied over, Stay vigilant!"
+
+/datum/game_mode/heretics/generate_credit_text()
+	var/list/round_credits = list()
+
+	round_credits += "<center><h1>The Eldrich Cult:</h1>"
+	for(var/datum/mind/M in culties)
+		round_credits += "<center><h2>[M.name] as a heretic</h2>"
+
+	round_credits += ..()
+	return round_credits

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -137,6 +137,7 @@ CONTINUOUS WIZARD
 #CONTINUOUS MONKEY
 CONTINUOUS HIVEMIND
 CONTINUOUS CLOCKCULT
+CONTINUOUS HERESY
 
 #Prevents the death of round-ending antagonist rulesets ending the round immediately.
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -137,6 +137,7 @@ CONTINUOUS WIZARD
 #CONTINUOUS MONKEY
 CONTINUOUS HIVEMIND
 CONTINUOUS CLOCKCULT
+CONTINUOUS HERESY
 
 #Prevents the death of round-ending antagonist rulesets ending the round immediately.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heretics are not conversion antags so the round should not end when they die.
Prevents the round ending the instant all heretics are dead.
Also adds heretics to the endgame credits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The round wont end prematurely because the sole heretic died somewhere at maints.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Round will not end the instant all heretics are dead
tweak: Adds heretics to the endgame credits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
