### PR TITLE
Fixes misplaced var that caused abductor lockers to be animated

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -14,7 +14,6 @@
 	name = "strange closet"
 	desc = "It looks alien!"
 	icon_state = "alien"
-	door_anim_time = 0 // no animation
 
 
 /obj/structure/closet/gimmick

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -680,7 +680,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/item/abductor_machine_beacon/chem_dispenser
 	name = "beacon - Reagent Synthesizer"
 	spawned_machine = /obj/machinery/chem_dispenser/abductor
-	
+
 /obj/item/scalpel/alien
 	name = "alien scalpel"
 	desc = "It's a gleaming sharp knife made out of silvery-green metal."
@@ -826,6 +826,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	icon_door = "abductor"
 	can_weld_shut = FALSE
 	material_drop = /obj/item/stack/sheet/mineral/abductor
+	door_anim_time = 0 // no animation
 
 /obj/structure/door_assembly/door_assembly_abductor
 	name = "alien airlock assembly"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes  alien lockers to be non animated and abductor two sided lockers to be animated cause of a missplaced door_anim_time = 0.

## Why It's Good For The Game

Fixes abductor locker beeing animated

## Changelog
:cl:
fix: Fixes Abductor locker to be animated and animates the alien locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
