### PR TITLE
Some lavaland map qol fixes - science outpost and hermit

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -3,7 +3,7 @@
 /turf/closed/mineral/volcanic/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "b" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
+/turf/closed/wall/mineral/sandstone,
 /area/ruin/powered)
 "c" = (
 /turf/closed/wall/mineral/iron,
@@ -162,10 +162,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/powered)
 "J" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
+/turf/open/floor/mineral/titanium/blue,
 /area/ruin/powered)
 "M" = (
 /obj/item/stack/sheet/iron/twenty,
@@ -173,6 +170,13 @@
 /turf/open/floor/plating/asteroid{
 	name = "dirt"
 	},
+/area/ruin/powered)
+"P" = (
+/turf/closed/wall/rust,
+/area/ruin/powered)
+"Q" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/pod/dark,
 /area/ruin/powered)
 "W" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -257,8 +261,8 @@ a
 a
 a
 a
-b
 c
+b
 b
 t
 t
@@ -274,8 +278,8 @@ a
 a
 a
 a
-b
-b
+c
+c
 n
 n
 t
@@ -292,7 +296,7 @@ a
 a
 a
 b
-b
+c
 m
 o
 o
@@ -307,9 +311,9 @@ s
 "}
 (8,1,1) = {"
 a
-b
-b
-b
+c
+c
+c
 c
 f
 o
@@ -318,14 +322,14 @@ o
 o
 z
 C
-t
+Q
 s
 s
 s
 "}
 (9,1,1) = {"
-b
-b
+c
+c
 f
 i
 g
@@ -336,7 +340,7 @@ o
 o
 t
 t
-t
+F
 s
 s
 s
@@ -360,16 +364,16 @@ s
 s
 "}
 (11,1,1) = {"
-c
+b
 e
 h
 g
 M
-c
+P
 p
 r
 c
-c
+P
 c
 b
 a
@@ -378,15 +382,15 @@ s
 s
 "}
 (12,1,1) = {"
-b
-b
+c
+c
 f
 k
 W
+c
+c
 b
-b
-b
-b
+c
 a
 a
 a
@@ -397,11 +401,11 @@ E
 "}
 (13,1,1) = {"
 a
-b
-b
-b
-b
-b
+c
+P
+P
+P
+c
 a
 a
 a
@@ -411,7 +415,7 @@ a
 a
 F
 I
-F
+J
 "}
 (14,1,1) = {"
 a
@@ -429,7 +433,7 @@ a
 a
 F
 I
-F
+J
 "}
 (15,1,1) = {"
 a
@@ -447,7 +451,7 @@ a
 a
 G
 J
-G
+J
 "}
 (16,1,1) = {"
 a

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -3315,11 +3315,11 @@
 	dir = 8
 	},
 /obj/structure/barricade/wooden/crude,
-/obj/machinery/door/airlock/research{
-	name = "Testing Lab";
-	req_access_txt = "47"
-	},
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/door/airlock/research/glass{
+	name = "Research Division Atrium";
+	req_one_access_txt = "47,54"
+	},
 /turf/open/floor/plasteel,
 /area/mine/science)
 "pi" = (
@@ -4508,7 +4508,7 @@
 "Ef" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Division Atrium";
-	req_access_txt = "47"
+	req_one_access_txt = "47,54"
 	},
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -5446,11 +5446,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/research{
-	name = "Outpost Transport Dock";
-	req_access_txt = "47"
-	},
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/machinery/door/airlock/research/glass{
+	name = "Research Division Atrium";
+	req_one_access_txt = "47,54"
+	},
 /turf/open/floor/plasteel,
 /area/mine/science)
 "Pd" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds mining station access to 3 doors in the science outpost, removing mobility restrictions that hindered the ability to power up the outpost.

Changed all rock walls surrounding the hermit cave to processed walls that aren't affected by plasmacutters and other mining tools.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Miners shouldn't be expected to destroy the science outpost in their efforts to make it habitable.  The doors that are necessary for leaving the science outpost, as well as the doors necessary to activate the shuttle shouldn't need to be busted open or hacked in the process of doing a favor for the science team.

The hermit cave is often destroyed well before the player ever takes control of the role, leading to immediately CO2 inhalation on many occasions that may result in a death that is mostly not the fault of the person playing Hermit.  Given that the hermit only has a single spawn per round, it is important that they are not wasted in this way.  The new walls are made of materials that the hermit could have realistically sourced from their surroundings - rough iron, sandstone and some titanium from their escape pod.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Science outpost doors now allow miners to travel a little more freely.
tweak: Hermits no longer wake up to discover that their cave is flooded with toxic gas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
