### PR TITLE
Removes SRM-8 missile rack from security autolathe

### DIFF
--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -224,17 +224,6 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
-/datum/design/mech_missile_rack
-	name = "Exosuit Weapon (SRM-8 Missile Rack)"
-	desc = "Allows for the construction of an SRM-8 Missile Rack."
-	id = "mech_missile_rack"
-	build_type = PROTOLATHE
-	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack
-	materials = list(/datum/material/iron=22000,/datum/material/gold=6000,/datum/material/silver=8000)
-	construction_time = 100
-	category = list("Weapons")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
 /datum/design/clusterbang_launcher
 	name = "Exosuit Module (SOB-3 Clusterbang Launcher)"
 	desc = "A weapon that violates the Geneva Convention at 3 rounds per minute"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the SRM-8 missile rack from the security autolathe. (Admin spawned and nuclear operative mechs can still get them.)

## Why It's Good For The Game

A mech using an SRM-8 put a deathsquad into crit with a single shot, they are stupidly overpowered due to the way missiles work and can do a lot of damage to the hull. Doesn't really make sense balance wise to give non-antags a way to 1 hit kill heavily armoured opponents and doesn't make sense for Nanotrasen to be giving the crew weapons that can blow through the hull.

Zesko told me that missile would no longer be as strong after the move explosives thing, but it made them multiple times stronger.

I would add a weaker version back to replace it, but there is no way to do it in a balanced way imo. (The grenade launcher is a much better replacement since it actually needs the grenades to be made rather than put it on and free missiles.)

## Changelog
:cl:
del: SRM-8 Missile Rack can no longer be printed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
