### PR TITLE
Fixes prosperity prism.

### DIFF
--- a/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
@@ -62,8 +62,10 @@
 	if(!powered)
 		powered = TRUE
 		update_icon_state()
-	for(var/mob/living/L in range(4))
+	for(var/mob/living/L in range(4, src))
 		if(!is_servant_of_ratvar(L))
+			continue
+		if(!L.toxloss && !L.staminaloss && !L.bruteloss && !L.fireloss)
 			continue
 		if(use_power(4))
 			L.adjustToxLoss(-10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The prosperity prism was healing around 'usr' on a process() proc, so I have no idea what the fuck it was healing.

## Why It's Good For The Game

Prosperity prism now actually heals and will only use power if necessary.

## Changelog
:cl:
fix: Prosperity prisms now heal servants.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
