### PR TITLE
Fix station goals and give report

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -157,11 +157,11 @@
 			)
 			query_round_game_mode.Execute()
 			qdel(query_round_game_mode)
-	if(report)
-		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
 	create_special_antags()
 	generate_station_goals()
-	if(!report) // goals only become purchasable when on_report is called, this also makes a replacement announcement.
+	if(report)
+		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
+	else // goals only become purchasable when on_report is called, this also makes a replacement announcement.
 		for(var/datum/station_goal/G in station_goals)
 			G.prepare_report()
 	gamemode_ready = TRUE

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -161,6 +161,9 @@
 		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
 	create_special_antags()
 	generate_station_goals()
+	if(!report) // goals only become purchasable when on_report is called, this also makes a replacement announcement.
+		for(var/datum/station_goal/G in station_goals)
+			G.prepare_report()
 	gamemode_ready = TRUE
 	return 1
 

--- a/code/modules/station_goals/station_goal.dm
+++ b/code/modules/station_goals/station_goal.dm
@@ -11,6 +11,9 @@
 	var/completed = FALSE
 	var/report_message = "Complete this goal."
 
+/datum/station_goal/proc/prepare_report()
+	addtimer(CALLBACK(src, .proc/send_report), 1200) // 2 min, less than avg 4 for intercept report
+
 /datum/station_goal/proc/send_report()
 	priority_announce("Priority Nanotrasen directive received. Project \"[name]\" details inbound.", "Incoming Priority Message", 'sound/ai/commandreport.ogg')
 	print_command_report(get_report(),"Nanotrasen Directive [pick(GLOB.phonetic_alphabet)] \Roman[rand(1,50)]", announce=FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Without the round intercept report, station goals would generate but wouldn't be available for purchase. This fixes that and reuses an existing function to give an alternative report 2 minutes in. 


edit: closes https://github.com/BeeStation/BeeStation-Hornet/pull/2830 and also closes https://github.com/BeeStation/BeeStation-Hornet/issues/2839
## Why It's Good For The Game
Unbreak a thing. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Froststahr
fix: Station goals are buyable again
add: You also get a centcomm report telling you what the goal is, in absence of the intercept report. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->