### PR TITLE
Removes tile ripping.

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -184,9 +184,6 @@
 		T2.ImmediateCalculateAdjacentTurfs() // We want those firelocks closed yesterday.
 
 /turf/proc/handle_decompression_floor_rip()
-/turf/open/floor/handle_decompression_floor_rip(sum)
-	if(sum > 20 && prob(CLAMP(sum / 10, 0, 30)))
-		remove_tile()
 
 /turf/open/process_cell(fire_count)
 


### PR DESCRIPTION
##About The Pull Request

Explosive decompression no longer rips tiles off.

## Why It's Good For The Game

Unfun, creates mess, and I am sure nobody ever liked it.

## Changelog
:cl:
del: Removed explosive decompression ripping tiles off.
/:cl:
 
