### PR TITLE
Runechat text now works while inside another object.

### DIFF
--- a/code/modules/mob/living/burgerchat.dm
+++ b/code/modules/mob/living/burgerchat.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	var/datum/language/D = GLOB.language_datum_instances[message_language]
 
 	// create 2 messages, one that appears if you know the language, and one that appears when you don't know the language
-	var/image/I = image(loc = target, layer=FLY_LAYER)
+	var/image/I = image(loc = get_atom_on_turf(target), layer=FLY_LAYER)
 	I.alpha = 0
 	I.maptext_width = 128
 	I.maptext_height = 64
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	I.maptext = "<center><span class='chatOverhead' style='[css]'>[message]</span></center>"
 
-	var/image/O = image(loc = target, layer=FLY_LAYER)
+	var/image/O = image(loc = get_atom_on_turf(target), layer=FLY_LAYER)
 	O.alpha = 0
 	O.maptext_width = 128
 	O.maptext_height = 64


### PR DESCRIPTION
## About The Pull Request
Basically tgstation/tgstation#52738
Runechat text will now be displayed even when inside lockers or crates and other object like that.

## Why It's Good For The Game
Your screams for help coming from the inside of a welded locker (probably) won't be ignored.

## Changelog
:cl:
add: Runechat text will be displayed even when inside another object such as lockers or crates.
/:cl: