### PR TITLE
Setting gamemode as default now requires dbranks permission

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -876,7 +876,7 @@
 			return
 
 		if (SSticker.HasRoundStarted())
-			if(check_rights_for(usr.client, R_DBRANKS))
+			if(check_rights(R_DBRANKS, 0))
 				if(askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == 1)
 					SSticker.save_mode(href_list["c_mode2"])
 			else
@@ -888,7 +888,7 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] set the mode as [GLOB.master_mode].</span>")
 		to_chat(world, "<span class='adminnotice'><b>The mode is now: [GLOB.master_mode]</b></span>")
 		Game() // updates the main game menu
-		if(check_rights_for(usr.client, R_DBRANKS))
+		if(check_rights(R_DBRANKS, check_rights))
 			if(askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == 1)
 				SSticker.save_mode(GLOB.master_mode)
 		HandleCMode()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -888,8 +888,8 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] set the mode as [GLOB.master_mode].</span>")
 		to_chat(world, "<span class='adminnotice'><b>The mode is now: [GLOB.master_mode]</b></span>")
 		Game() // updates the main game menu
-		if(check_rights(R_DBRANKS, 0))
-			if(askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == 1)
+		if(check_rights(R_DBRANKS, FALSE))
+			if(askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == TRUE)
 				SSticker.save_mode(GLOB.master_mode)
 		HandleCMode()
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -877,7 +877,7 @@
 
 		if (SSticker.HasRoundStarted())
 			if(check_rights(R_DBRANKS, FALSE))
-				if(askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == TRUE)
+				if(askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == 1)
 					SSticker.save_mode(href_list["c_mode2"])
 			else
 				to_chat(usr, "<span class='warning'>The round has already started!</span>")
@@ -889,7 +889,7 @@
 		to_chat(world, "<span class='adminnotice'><b>The mode is now: [GLOB.master_mode]</b></span>")
 		Game() // updates the main game menu
 		if(check_rights(R_DBRANKS, FALSE))
-			if(askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == TRUE)
+			if(askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == 1)
 				SSticker.save_mode(GLOB.master_mode)
 		HandleCMode()
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -876,7 +876,7 @@
 			return
 
 		if (SSticker.HasRoundStarted())
-			if(check_rights(R_DBRANKS, 0))
+			if(check_rights(R_DBRANKS, FALSE))
 				if(askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == 1)
 					SSticker.save_mode(href_list["c_mode2"])
 			else

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -877,7 +877,7 @@
 
 		if (SSticker.HasRoundStarted())
 			if(check_rights(R_DBRANKS, FALSE))
-				if(askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == 1)
+				if(askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == TRUE)
 					SSticker.save_mode(href_list["c_mode2"])
 			else
 				to_chat(usr, "<span class='warning'>The round has already started!</span>")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -876,8 +876,11 @@
 			return
 
 		if (SSticker.HasRoundStarted())
-			if (askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == 1)
-				SSticker.save_mode(href_list["c_mode2"])
+			if(check_rights_for(usr.client, R_DBRANKS))
+				if(askuser(usr, "The game has already started. Would you like to save this as the default mode effective next round?", "Save mode", "Yes", "Cancel", Timeout = null) == 1)
+					SSticker.save_mode(href_list["c_mode2"])
+			else
+				to_chat(usr, "<span class='warning'>The round has already started!</span>")
 			HandleCMode()
 			return
 		GLOB.master_mode = href_list["c_mode2"]
@@ -885,8 +888,9 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] set the mode as [GLOB.master_mode].</span>")
 		to_chat(world, "<span class='adminnotice'><b>The mode is now: [GLOB.master_mode]</b></span>")
 		Game() // updates the main game menu
-		if (askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == 1)
-			SSticker.save_mode(GLOB.master_mode)
+		if(check_rights_for(usr.client, R_DBRANKS))
+			if(askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == 1)
+				SSticker.save_mode(GLOB.master_mode)
 		HandleCMode()
 
 	else if(href_list["f_secret2"])
@@ -2024,7 +2028,7 @@
 						dat += sanitize(jobs.Join(", "))
 						dat += "<br>"
 					dat += "<hr>"
-					
+
 		var/datum/browser/popup = new(usr, "centcomlookup-[ckey]", "<div align='center'>Central Command Galactic Ban Database</div>", 700, 600)
 		popup.set_content(dat.Join())
 		popup.open(FALSE)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -888,7 +888,7 @@
 		message_admins("<span class='adminnotice'>[key_name_admin(usr)] set the mode as [GLOB.master_mode].</span>")
 		to_chat(world, "<span class='adminnotice'><b>The mode is now: [GLOB.master_mode]</b></span>")
 		Game() // updates the main game menu
-		if(check_rights(R_DBRANKS, check_rights))
+		if(check_rights(R_DBRANKS, 0))
 			if(askuser(usr, "Would you like to save this as the default mode for the server?", "Save mode", "Yes", "No", Timeout = null) == 1)
 				SSticker.save_mode(GLOB.master_mode)
 		HandleCMode()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you change the gamemode the pop up asking you if you want to set the gamemode as default no longer appears if you don't have dbranks.
This time tested and working.

## Why It's Good For The Game

Admins won't change default gamemode anymore by accident.

## Changelog
:cl:
admin: Setting default gamemode now requires dbranks.
/:cl: 

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
