### PR TITLE
Fixes dynamic bug 

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR_INIT(dynamic_midround_delay_max, (35 MINUTES))
 
 // Are HIGHLANDER_RULESETs allowed to stack?
 GLOBAL_VAR_INIT(dynamic_no_stacking, TRUE)
-// A number between -5 and +5. 
+// A number between -5 and +5.
 // A negative value will give a more peaceful round and
 // a positive value will give a round with higher threat.
 GLOBAL_VAR_INIT(dynamic_curve_centre, 0)
@@ -27,7 +27,7 @@ GLOBAL_VAR_INIT(dynamic_curve_centre, 0)
 // Higher value will favour extreme rounds and
 // lower value rounds closer to the average.
 GLOBAL_VAR_INIT(dynamic_curve_width, 1.8)
-// If enabled only picks a single starting rule and executes only autotraitor midround ruleset. 
+// If enabled only picks a single starting rule and executes only autotraitor midround ruleset.
 GLOBAL_VAR_INIT(dynamic_classic_secret, FALSE)
 // How many roundstart players required for high population override to take effect.
 GLOBAL_VAR_INIT(dynamic_high_pop_limit, 55)
@@ -38,7 +38,7 @@ GLOBAL_VAR_INIT(dynamic_forced_extended, FALSE)
 GLOBAL_VAR_INIT(dynamic_stacking_limit, 90)
 // List of forced roundstart rulesets.
 GLOBAL_LIST_EMPTY(dynamic_forced_roundstart_ruleset)
-// Forced threat level, setting this to zero or higher forces the roundstart threat to the value. 
+// Forced threat level, setting this to zero or higher forces the roundstart threat to the value.
 GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 /datum/game_mode/dynamic
@@ -50,14 +50,14 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	announce_text = "Dynamic mode!" // This needs to be changed maybe
 
 	reroll_friendly = FALSE;
-	
+
 	// Threat logging vars
 	/// The "threat cap", threat shouldn't normally go above this and is used in ruleset calculations
-	var/threat_level = 0 
+	var/threat_level = 0
 	/// Set at the beginning of the round. Spent by the mode to "purchase" rules.
-	var/threat = 0 
+	var/threat = 0
 	/// Running information about the threat. Can store text or datum entries.
-	var/list/threat_log = list() 
+	var/list/threat_log = list()
 	/// List of roundstart rules used for selecting the rules.
 	var/list/roundstart_rules = list()
 	/// List of latejoin rules used for selecting the rules.
@@ -83,7 +83,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/list/third_rule_prob = list(0,0,0,0,60,60,80,90,100,100)
 	/// Threat requirement for a second ruleset when high pop override is in effect.
 	var/high_pop_second_rule_req = 40
-	/// Threat requirement for a third ruleset when high pop override is in effect. 
+	/// Threat requirement for a third ruleset when high pop override is in effect.
 	var/high_pop_third_rule_req = 60
 	/// The amount of additional rulesets waiting to be picked.
 	var/extra_rulesets_amount = 0
@@ -179,7 +179,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		show_threatlog(usr)
 	else if (href_list["stacking_limit"])
 		GLOB.dynamic_stacking_limit = input(usr,"Change the threat limit at which round-endings rulesets will start to stack.", "Change stacking limit", null) as num
-	
+
 	admin_panel() // Refreshes the window
 
 // Checks if there are HIGHLANDER_RULESETs and calls the rule's round_result() proc
@@ -323,18 +323,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			if ("Midround")
 				if (ruleset.weight)
 					midround_rules += ruleset
-		if(configuration)
-			if(!configuration[ruleset.ruletype])
-				continue
-			if(!configuration[ruleset.ruletype][ruleset.name])
-				continue
-			var/rule_conf = configuration[ruleset.ruletype][ruleset.name]
-			for(var/variable in rule_conf)
-				if(isnull(ruleset.vars[variable]))
-					stack_trace("Invalid dynamic configuration variable [variable] in [ruleset.ruletype] [ruleset.name].")
-					continue
-				ruleset.vars[variable] = rule_conf[variable]
-	
+		configure_ruleset(ruleset)
+
 	for(var/mob/dead/new_player/player in GLOB.player_list)
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind)
 			roundstart_pop_ready++
@@ -346,10 +336,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	if (roundstart_rules.len <= 0)
 		log_game("DYNAMIC: [roundstart_rules.len] rules.")
 		return TRUE
-	
+
 	if(GLOB.dynamic_forced_roundstart_ruleset.len > 0)
 		rigged_roundstart()
-	else 
+	else
 		roundstart()
 
 	var/starting_rulesets = ""
@@ -513,7 +503,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/datum/dynamic_ruleset/rule = pickweight(drafted_rules)
 	if(!rule)
 		return FALSE
-	
+
 	if(!forced)
 		if(only_ruleset_executed)
 			return FALSE
@@ -531,7 +521,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 					if(drafted_rules.len <= 0)
 						return FALSE
 					rule = pickweight(drafted_rules)
-	
+
 	if(!rule.repeatable)
 		if(rule.ruletype == "Latejoin")
 			latejoin_rules = remove_from_list(latejoin_rules, rule.type)
@@ -546,14 +536,15 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/datum/dynamic_ruleset/midround/new_rule
 	if(ispath(ruletype))
 		new_rule = new ruletype() // You should only use it to call midround rules though.
+		configure_ruleset(new_rule)
 	else if(istype(ruletype, /datum/dynamic_ruleset))
 		new_rule = ruletype
 	else
 		return FALSE
-	
+
 	if(!new_rule)
 		return FALSE
-	
+
 	if(!forced)
 		if(only_ruleset_executed)
 			return FALSE
@@ -565,7 +556,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			if(threat_level > GLOB.dynamic_stacking_limit && GLOB.dynamic_no_stacking)
 				if(highlander_executed)
 					return FALSE
-	
+
 	update_playercounts()
 	if ((forced || (new_rule.acceptable(current_players[CURRENT_LIVING_PLAYERS].len, threat_level) && new_rule.cost <= threat)))
 		new_rule.trim_candidates()
@@ -622,19 +613,19 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	if (midround_injection_cooldown < world.time)
 		if (GLOB.dynamic_forced_extended)
 			return
-		
+
 		// Somehow it managed to trigger midround multiple times so this was moved here.
 		// There is no way this should be able to trigger an injection twice now.
 		var/midround_injection_cooldown_middle = 0.5*(GLOB.dynamic_midround_delay_max + GLOB.dynamic_midround_delay_min)
 		midround_injection_cooldown = (round(CLAMP(EXP_DISTRIBUTION(midround_injection_cooldown_middle), GLOB.dynamic_midround_delay_min, GLOB.dynamic_midround_delay_max)) + world.time)
-		
+
 		// Time to inject some threat into the round
 		if(EMERGENCY_ESCAPED_OR_ENDGAMED) // Unless the shuttle is gone
 			return
 
 		message_admins("DYNAMIC: Checking for midround injection.")
 		log_game("DYNAMIC: Checking for midround injection.")
-			
+
 		update_playercounts()
 		if (get_injection_chance())
 			var/list/drafted_rules = list()
@@ -648,7 +639,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 						drafted_rules[rule] = rule.get_weight()
 			if (drafted_rules.len > 0)
 				picking_midround_latejoin_rule(drafted_rules)
-	
+
 /// Updates current_players.
 /datum/game_mode/dynamic/proc/update_playercounts()
 	current_players[CURRENT_LIVING_PLAYERS] = list()
@@ -747,7 +738,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				if (threat_level > GLOB.dynamic_stacking_limit && GLOB.dynamic_no_stacking)
 					if(rule.flags & HIGHLANDER_RULESET && highlander_executed)
 						continue
-					
+
 				rule.candidates = list(newPlayer)
 				rule.trim_candidates()
 				if (rule.ready())
@@ -794,3 +785,22 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			return RULE_OF_THREE(40, 20, x) + 50
 		if (20 to INFINITY)
 			return rand(90, 100)
+
+/datum/game_mode/dynamic/proc/configure_ruleset(datum/dynamic_ruleset/ruleset)
+	if(configuration)
+		if(!configuration[ruleset.ruletype])
+			return
+		if(!configuration[ruleset.ruletype][ruleset.name])
+			return
+		var/rule_conf = configuration[ruleset.ruletype][ruleset.name]
+		for(var/variable in rule_conf)
+			if(isnull(ruleset.vars[variable]))
+				stack_trace("Invalid dynamic configuration variable [variable] in [ruleset.ruletype] [ruleset.name].")
+				continue
+			ruleset.vars[variable] = rule_conf[variable]
+		if(CONFIG_GET(flag/protect_roles_from_antagonist))
+			ruleset.restricted_roles |= ruleset.protected_roles
+		if(CONFIG_GET(flag/protect_assistant_from_antagonist))
+			ruleset.restricted_roles |= "Assistant"
+		if(CONFIG_GET(flag/protect_heads_from_antagonist))
+			ruleset.restricted_roles |= GLOB.command_positions

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -82,12 +82,6 @@
 
 /datum/dynamic_ruleset/New()
 	..()
-	if(CONFIG_GET(flag/protect_roles_from_antagonist))
-		restricted_roles += protected_roles
-	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
-		restricted_roles += "Assistant"
-	if(CONFIG_GET(flag/protect_heads_from_antagonist))
-		restricted_roles += GLOB.command_positions
 
 	if (istype(SSticker.mode, /datum/game_mode/dynamic))
 		mode = SSticker.mode


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Ports https://github.com/tgstation/tgstation/pull/54452/files

### About The Pull Request

In short:
picking_specific_rule didn't apply configs.

### Why It's Good For The Game

Probably good to not ignore configurations.

### Changelog

:cl:TheChosenEvilOne 
fix: Dynamic midround traitor triggered by roundstart traitor ruleset no longer ignores protected roles.
/:cl:
