### PR TITLE
Recyclers will no longer grind raw materials

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -116,7 +116,7 @@
 				crush_living(AM)
 			else
 				emergency_stop(AM)
-		else if(istype(AM, /obj/item) && !istype(AM0, /obj/item/stack))
+		else if(istype(AM, /obj/item) && !istype(AM, /obj/item/stack))
 			recycle_item(AM)
 			items_recycled++
 		else

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -116,7 +116,7 @@
 				crush_living(AM)
 			else
 				emergency_stop(AM)
-		else if(istype(AM, /obj/item))
+		else if(istype(AM, /obj/item) && !istype(AM0, /obj/item/stack))
 			recycle_item(AM)
 			items_recycled++
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents recycler from destroying raw materials and material stacks.

## Why It's Good For The Game

Sometimes the glass/iron stacks the recycler outputs get looped back into the recycler loop and completely destroyed, rendering the recycler useless.

## Changelog
:cl:
tweak: recycler will no longer grind down raw/material stacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
