### PR TITLE
Makes radio sounds only play to mobs that are holding them.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -209,8 +209,11 @@
 		return
 
 	if(!radio_silent)//Radios make small static noises now
-		var/sound/radio_sound = pick("sound/effects/radio1.ogg", "sound/effects/radio2.ogg")
-		playsound(M.loc, radio_sound, 50, 1)
+		var/mob/sender = loc
+		if(istype(sender) && sender.hears_radio())
+			var/sound/radio_sound = sound(pick("sound/effects/radio1.ogg", "sound/effects/radio2.ogg"), volume = 50)
+			radio_sound.frequency = get_rand_frequency()
+			SEND_SOUND(sender, radio_sound)
 
 	if(use_command)
 		spans |= SPAN_COMMAND

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -429,3 +429,6 @@
 
 /mob/living/silicon/rust_heretic_act()
 	adjustBruteLoss(500)
+
+/mob/living/silicon/hears_radio()
+	return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1282,3 +1282,7 @@
 	for(var/obj/item/I in held_items)
 		if(I.item_flags & SLOWS_WHILE_IN_HAND)
 			. += I.slowdown
+
+// Returns TRUE if the hearer should hear radio noises
+/mob/proc/hears_radio()
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes radios to only send the sound to mobs if it is being held by one (/ is contained by one).
Makes AIs not hear radio sounds.
Makes intercoms not play radio sounds.

## Why It's Good For The Game

Reports of them being very weird and can also get annoying for silicon (Since AI hears nothing except radio sounds).

## Changelog
:cl:
tweak: Radios now only play to the person wearing the headset / holding the radio.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
