### PR TITLE
Really annoying autolathe bug fix

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -522,7 +522,6 @@
 	being_built = null
 	icon_state = "autolathe"
 	busy = FALSE
-	updateDialog()
 
 /obj/machinery/autolathe/RefreshParts()
 	var/T = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug with the autolathe that made the UI open to anyone in range when anything was printed.

## Why It's Good For The Game

It was very annoying.

## Changelog
:cl:
fix: Autolathe nolonger opens when something is printed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
