### PR TITLE
Cult Buffs - tiles and magic missile

### DIFF
--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -110,14 +110,8 @@
 /turf/open/floor/plasteel/cult
 	icon_state = "cult"
 	name = "engraved floor"
-	CanAtmosPass = ATMOS_PASS_NO
+	CanAtmosPass = ATMOS_PASS_NO	
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-
-/turf/open/floor/plasteel/cult/Initialize()
-	..()
-	if (air)
-		air.copy_from_turf(src)
-		update_air_ref()
 
 /turf/open/floor/plasteel/vaporwave
 	icon_state = "pinkblack"

--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -110,8 +110,14 @@
 /turf/open/floor/plasteel/cult
 	icon_state = "cult"
 	name = "engraved floor"
-	CanAtmosPass = ATMOS_PASS_NO	
+	CanAtmosPass = ATMOS_PASS_NO
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+
+/turf/open/floor/plasteel/cult/Initialize()
+	..()
+	if (air)
+		air.copy_from_turf(src)
+		update_air_ref()
 
 /turf/open/floor/plasteel/vaporwave
 	icon_state = "pinkblack"

--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -110,6 +110,8 @@
 /turf/open/floor/plasteel/cult
 	icon_state = "cult"
 	name = "engraved floor"
+	CanAtmosPass = ATMOS_PASS_NO	
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 
 /turf/open/floor/plasteel/vaporwave
 	icon_state = "pinkblack"

--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -112,6 +112,12 @@
 	name = "engraved floor"
 	CanAtmosPass = ATMOS_PASS_NO	
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+	
+/turf/open/floor/plasteel/cult/Initialize()
+	..()
+	var/datum/gas_mixture/auto_atmos = new (initial_gas_mix)
+	assume_air(auto_atmos)
+	update_air_ref()
 
 /turf/open/floor/plasteel/vaporwave
 	icon_state = "pinkblack"

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -71,7 +71,7 @@
 	//text message
 	C.visible_message("<span class='warning'>[user]'s [BP] detaches itself and takes the form of a snake!</span>",
 			"<span class='userdanger'>Our [BP] forms into a horrifying snake and heads towards our attackers!</span>")
-	BP.dismember()
+	BP.set_disabled(TRUE)
 	BP.Destroy()
 	C.update_mobility()
 	//Deploy limbsnake

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -71,7 +71,7 @@
 	//text message
 	C.visible_message("<span class='warning'>[user]'s [BP] detaches itself and takes the form of a snake!</span>",
 			"<span class='userdanger'>Our [BP] forms into a horrifying snake and heads towards our attackers!</span>")
-	BP.set_disabled(TRUE)
+	BP.dismember()
 	BP.Destroy()
 	C.update_mobility()
 	//Deploy limbsnake

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -173,6 +173,11 @@
 /obj/item/projectile/magic/spell/magic_missile/lesser
 	color = "red" //Looks more culty this way
 	range = 10
+	
+/obj/item/projectile/magic/spell/magic_missile/lesser/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
+	if (iscultist(target))
+		return FALSE
+	return ..()
 
 /obj/effect/proc_holder/spell/targeted/smoke/disable
 	name = "Paralysing Smoke"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cult floor is now atmosproof and should start with air. 
Artificer Magic Missiles no longer stun cultists.

## Why It's Good For The Game

Fastmos was a big fuck you to cult and since the fastmos, cult floors are no longer spaceproof/atmosproof, even though they are supposed to be. This was a huge nerf to cult, especially since cult walls are brittle. This restores some of the cult's former power.

## Changelog
:cl:
balance: cult floor is atmosproof
balance: artificer magic missile no longer stuns cultists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
