### PR TITLE
Stealth sting no longer charges DNA when stinging people who you have already stung

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -183,7 +183,8 @@
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(!(changeling.has_dna(target.dna)))
 		changeling.add_new_profile(target)
-	return TRUE
+		return TRUE
+	return FALSE
 
 /datum/action/changeling/sting/mute
 	name = "Mute Sting"


### PR DESCRIPTION
## About The Pull Request

Stealth sting no longer charges DNA when stinging people who you have already stung.

## Why It's Good For The Game

Rarely, ling sting would inject the target twice. I've seen it happen, and I have no idea what causes the issue, but this should fix it. (I suspect it's something to do with ling abilities not having cooldowns)

## Changelog
:cl:
fix: ling stealth sting can no longer sting people twice
/:cl: