### PR TITLE
Revenant and Engraved messages can't get irradiated anymore

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -5,10 +5,12 @@
 	var/static/list/ignored_things = typecacheof(list(
 		/mob/dead,
 		/mob/camera,
+		/mob/living/simple_animal/revenant,
 		/obj/effect,
 		/obj/docking_port,
 		/atom/movable/lighting_object,
 		/obj/item/projectile,
+		/obj/structure/chisel_message
 		))
 	var/list/processing_list = list(location)
 	. = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

cringe ass nae nae rads
closes #2805

## Changelog
:cl:
fix: revs and engraved messages can't get irradiated anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
