### PR TITLE
Nutrition number tweaks

### DIFF
--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -1,7 +1,7 @@
 //nutrition
 /datum/mood_event/fat
 	description = "<span class='warning'><B>I'm so fat...</B></span>\n" //muh fatshaming
-	mood_change = -6
+	mood_change = -3
 
 /datum/mood_event/wellfed
 	description = "<span class='nicegreen'>I'm stuffed!</span>\n"
@@ -13,11 +13,11 @@
 
 /datum/mood_event/hungry
 	description = "<span class='warning'>I'm getting a bit hungry.</span>\n"
-	mood_change = -10
+	mood_change = -5
 
 /datum/mood_event/starving
 	description = "<span class='boldwarning'>I'm starving!</span>\n"
-	mood_change = -16
+	mood_change = -8
 
 //charge
 /datum/mood_event/charged

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -5,7 +5,7 @@
 
 /datum/mood_event/wellfed
 	description = "<span class='nicegreen'>I'm stuffed!</span>\n"
-	mood_change = 8
+	mood_change = 12
 
 /datum/mood_event/fed
 	description = "<span class='nicegreen'>I have recently had some food.</span>\n"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1117,10 +1117,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(H.overeatduration > 1)
 			H.overeatduration -= 2 //doubled the unfat rate
 
-	var/metabomism_fat = 2
+	var/metabomism_fat = .75
 	var/metabomism_regular = 1
 	var/metabomism_vigor = 1
-	var/metabomism_hungry = .75
+	var/metabomism_hungry = 2
 
 	here
 	//metabolism change

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1083,7 +1083,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(H.overeatduration >= 100)
 			to_chat(H, "<span class='danger'>You suddenly feel blubbery!</span>")
 			ADD_TRAIT(H, TRAIT_FAT, OBESITY)
-			H.add_movespeed_modifier(MOVESPEED_ID_FAT, multiplicative_slowdown = 1.5)
+			H.add_movespeed_modifier(MOVESPEED_ID_FAT, multiplicative_slowdown = 1.2)
 			H.update_inv_w_uniform()
 			H.update_inv_wear_suit()
 
@@ -1117,21 +1117,27 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(H.overeatduration > 1)
 			H.overeatduration -= 2 //doubled the unfat rate
 
+	var/metabomism_fat = .75
+	var/metabomism_regular = 1
+	var/metabomism_vigor = 1
+	var/metabomism_hungry = 2
+
+	here
 	//metabolism change
 	if(H.nutrition > NUTRITION_LEVEL_FAT)
-		H.metabolism_efficiency = 1
+		H.metabolism_efficiency = metabomism_fat
 	else if(H.nutrition > NUTRITION_LEVEL_FED && H.satiety > 80)
-		if(H.metabolism_efficiency != 1.25 && !HAS_TRAIT(H, TRAIT_NOHUNGER))
+		if(H.metabolism_efficiency != metabomism_vigor && !HAS_TRAIT(H, TRAIT_NOHUNGER))
 			to_chat(H, "<span class='notice'>You feel vigorous.</span>")
-			H.metabolism_efficiency = 1.25
+			H.metabolism_efficiency = metabomism_vigor
 	else if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		if(H.metabolism_efficiency != 0.8)
+		if(H.metabolism_efficiency != metabomism_hungry)
 			to_chat(H, "<span class='notice'>You feel sluggish.</span>")
-		H.metabolism_efficiency = 0.8
+		H.metabolism_efficiency = metabomism_hungry
 	else
-		if(H.metabolism_efficiency == 1.25)
+		if(H.metabolism_efficiency == metabomism_vigor)
 			to_chat(H, "<span class='notice'>You no longer feel vigorous.</span>")
-		H.metabolism_efficiency = 1
+		H.metabolism_efficiency = metabomism_regular
 
 	//Hunger slowdown for if mood isn't enabled
 	if(CONFIG_GET(flag/disable_human_mood))
@@ -1535,6 +1541,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 
 	var/weakness = H.check_weakness(I, user)
+	if (I.damtype == STAMINA && HAS_TRAIT(H, TRAIT_FAT))
+		I.force*=2 //stamina fat multiplier under NUTRITION_LEVEL_STARVING
 	apply_damage(I.force * weakness, I.damtype, def_zone, armor_block, H)
 
 	H.send_item_attack_message(I, user, hit_area)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1117,10 +1117,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(H.overeatduration > 1)
 			H.overeatduration -= 2 //doubled the unfat rate
 
-	var/metabomism_fat = .75
+	var/metabomism_fat = 2
 	var/metabomism_regular = 1
 	var/metabomism_vigor = 1
-	var/metabomism_hungry = 2
+	var/metabomism_hungry = .75
 
 	here
 	//metabolism change
@@ -1541,7 +1541,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 
 	var/weakness = H.check_weakness(I, user)
-	if (I.damtype == STAMINA && HAS_TRAIT(H, TRAIT_FAT))
+	if (I.damtype == STAMINA && H.nutrition < NUTRITION_LEVEL_STARVING)
 		I.force*=2 //stamina fat multiplier under NUTRITION_LEVEL_STARVING
 	apply_damage(I.force * weakness, I.damtype, def_zone, armor_block, H)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1117,12 +1117,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(H.overeatduration > 1)
 			H.overeatduration -= 2 //doubled the unfat rate
 
-	var/metabomism_fat = .75
+	var/metabomism_fat = 0.75
 	var/metabomism_regular = 1
 	var/metabomism_vigor = 1
 	var/metabomism_hungry = 2
 
-	here
 	//metabolism change
 	if(H.nutrition > NUTRITION_LEVEL_FAT)
 		H.metabolism_efficiency = metabomism_fat

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -5,8 +5,8 @@
 
 /datum/surgery/lipoplasty/can_start(mob/user, mob/living/carbon/target)
 	if(HAS_TRAIT(target, TRAIT_FAT))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 
 //cut fat


### PR DESCRIPTION
## About The Pull Request

Reduced the slowdown on fat, and metabolism rates related to satiation.
Being fat increases stamina damage and reduces metabolism rate (increases the time chemicals stay in your body)
Being hungry doubles your metabolism speed.
Values on all hunger related moodlets halved.

## Why It's Good For The Game

First of all, fat slowdown seems ridiculous. 50%? Really?

Previous metabolism made no sense. It would slow down when you were hungry (meaning healing chems would stay longer) and increase when you were fat. This isn't very realistic either; being fat/overfed slows down the rate your body handles chemicals, while being hungry increases it.

Gameplay wise makes no sense either. Being hungry increases the efficiency of all healing chems by 20% (they stay longer in your body), being well fed actually has the opposite effect and makes healing chems last 20% shorter... And being fat incurs the dreaded 33% slowdown that everyone hates. And you have the moodlets slowing you down on top of that.

And on top of that it's really easy to get fat, too. Just eat a burger that has been cooked with a T4 microwave that has 100u nutriment that, by the time they synthesize, you will have 3 times the amount of body fat.

## Changelog
:cl:
tweak: halved the mood effect of positive and negative hunger related moodlets
tweak: reduced fat slowdown
add: being hungry doubles all incoming stamina damage
tweak: being hungry doubles metabolism rate
tweak: being fat reduces metabolism rate
/:cl:
