### PR TITLE
Station bounced radio QOL

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -21,6 +21,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	item_state = "headset"
 	materials = list(/datum/material/iron=75)
 	subspace_transmission = TRUE
+	headset = TRUE
 	canhear_range = 0 // can't hear headsets from very far away
 	var/bang_protect = 0 //this isn't technically clothing so it needs its own bang_protect var
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -101,22 +101,18 @@
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 /obj/item/radio/AltClick(mob/user)
-	if(!headset)
-		if(broadcasting)
-			broadcasting = FALSE
-			to_chat(user, "<span class='notice'>You toggle broadcasting off.</span>")
-		else
-			broadcasting = TRUE
-			to_chat(user, "<span class='notice'>You toggle broadcasting on.</span>")
+	if(headset)
+		. = ..()
+	else
+		broadcasting = !broadcasting
+		to_chat(user, "<span class='notice'>You toggle broadcasting [broadcasting ? "on" : "off"].</span>")
 
 /obj/item/radio/CtrlShiftClick(mob/user)
-	if(!headset)
-		if(listening)
-			listening = FALSE
-			to_chat(user, "<span class='notice'>You toggle speaker off.</span>")
-		else
-			listening = TRUE
-			to_chat(user, "<span class='notice'>You toggle speaker on.</span>")
+	if(headset)
+		. = ..()
+	else
+		listening = !listening
+		to_chat(user, "<span class='notice'>You toggle speaker [listening ? "on" : "off"].</span>")
 
 /obj/item/radio/interact(mob/user)
 	if(unscrewed && !isAI(user))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -106,7 +106,6 @@
 	else
 		..()
 
-
 /obj/item/radio/ui_state(mob/user)
 	return GLOB.inventory_state
 
@@ -427,3 +426,20 @@
 /obj/item/radio/off	// Station bounced radios, their only difference is spawning with the speakers off, this was made to help the lag.
 	listening = 0			// And it's nice to have a subtype too for future features.
 	dog_fashion = /datum/dog_fashion/back
+	desc = "A basic handheld radio that communicates with local telecommunication networks.<br/>Alt-click on the station bounced radio to toggle broadcasting.<br/>Ctrl-click on the station bounced radio to toggle speaker"
+
+/obj/item/radio/off/AltClick(mob/user)
+	if(broadcasting)
+		broadcasting = FALSE
+		to_chat(user, "<span class='notice'>You turn radio broadcasting off.</span>")
+	else
+		broadcasting = TRUE
+		to_chat(user, "<span class='notice'>You turn radio broadcasting on.</span>")
+
+/obj/item/radio/off/CtrlClick(mob/user)
+	if(listening)
+		listening = FALSE
+		to_chat(user, "<span class='notice'>You turn radio speaker off.</span>")
+	else
+		listening = TRUE
+		to_chat(user, "<span class='notice'>You turn radio speaker on.</span>")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -5,7 +5,7 @@
 	name = "station bounced radio"
 	icon_state = "walkietalkie"
 	item_state = "walkietalkie"
-	desc = "A basic handheld radio that communicates with local telecommunication networks.<br/>Alt-click on the station bounced radio to toggle broadcasting.<br/>Ctrl-click on the station bounced radio to toggle speaker"
+	desc = "A basic handheld radio that communicates with local telecommunication networks."
 	dog_fashion = /datum/dog_fashion/back
 
 	flags_1 = CONDUCT_1 | HEAR_1
@@ -20,6 +20,7 @@
 	var/frequency = FREQ_COMMON
 	var/canhear_range = 3  // The range around the radio in which mobs can hear what it receives.
 	var/emped = 0  // Tracks the number of EMPs currently stacked.
+	var/headset = FALSE
 
 	var/broadcasting = FALSE  // Whether the radio will transmit dialogue it hears nearby.
 	var/listening = TRUE  // Whether the radio is currently receiving.
@@ -100,20 +101,20 @@
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 /obj/item/radio/AltClick(mob/user)
-	if(broadcasting)
-		broadcasting = FALSE
-		to_chat(user, "<span class='notice'>You turn radio broadcasting off.</span>")
-	else
-		broadcasting = TRUE
-		to_chat(user, "<span class='notice'>You turn radio broadcasting on.</span>")
+	if(!headset)
+		if(broadcasting)
+			to_chat(user, "<span class='notice'>You toggle broadcasting off.</span>")
+		else
+			to_chat(user, "<span class='notice'>You toggle broadcasting on.</span>")
+		broadcasting = !broadcasting
 
 /obj/item/radio/CtrlClick(mob/user)
-	if(listening)
-		listening = FALSE
-		to_chat(user, "<span class='notice'>You turn radio speaker off.</span>")
-	else
-		listening = TRUE
-		to_chat(user, "<span class='notice'>You turn radio speaker on.</span>")
+	if(!headset)
+		if(listening)
+			to_chat(user, "<span class='notice'>You toggle speaker off.</span>")
+		else
+			to_chat(user, "<span class='notice'>You toggle speaker on.</span>")
+		listening = !listening
 
 /obj/item/radio/interact(mob/user)
 	if(unscrewed && !isAI(user))
@@ -350,6 +351,8 @@
 		. += "<span class='notice'>It can be attached and modified.</span>"
 	else
 		. += "<span class='notice'>It cannot be modified or attached.</span>"
+	if (in_range(src, user) && !headset)
+		. += "<span class='info'>Ctrl-click on the [name] to toggle speaker.<br/>Alt-click on the [name] to toggle broadcasting.</span>"
 
 /obj/item/radio/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -5,7 +5,7 @@
 	name = "station bounced radio"
 	icon_state = "walkietalkie"
 	item_state = "walkietalkie"
-	desc = "A basic handheld radio that communicates with local telecommunication networks."
+	desc = "A basic handheld radio that communicates with local telecommunication networks.<br/>Alt-click on the station bounced radio to toggle broadcasting.<br/>Ctrl-click on the station bounced radio to toggle speaker"
 	dog_fashion = /datum/dog_fashion/back
 
 	flags_1 = CONDUCT_1 | HEAR_1
@@ -98,6 +98,22 @@
 /obj/item/radio/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
+
+/obj/item/radio/AltClick(mob/user)
+	if(broadcasting)
+		broadcasting = FALSE
+		to_chat(user, "<span class='notice'>You turn radio broadcasting off.</span>")
+	else
+		broadcasting = TRUE
+		to_chat(user, "<span class='notice'>You turn radio broadcasting on.</span>")
+
+/obj/item/radio/CtrlClick(mob/user)
+	if(listening)
+		listening = FALSE
+		to_chat(user, "<span class='notice'>You turn radio speaker off.</span>")
+	else
+		listening = TRUE
+		to_chat(user, "<span class='notice'>You turn radio speaker on.</span>")
 
 /obj/item/radio/interact(mob/user)
 	if(unscrewed && !isAI(user))
@@ -426,20 +442,3 @@
 /obj/item/radio/off	// Station bounced radios, their only difference is spawning with the speakers off, this was made to help the lag.
 	listening = 0			// And it's nice to have a subtype too for future features.
 	dog_fashion = /datum/dog_fashion/back
-	desc = "A basic handheld radio that communicates with local telecommunication networks.<br/>Alt-click on the station bounced radio to toggle broadcasting.<br/>Ctrl-click on the station bounced radio to toggle speaker"
-
-/obj/item/radio/off/AltClick(mob/user)
-	if(broadcasting)
-		broadcasting = FALSE
-		to_chat(user, "<span class='notice'>You turn radio broadcasting off.</span>")
-	else
-		broadcasting = TRUE
-		to_chat(user, "<span class='notice'>You turn radio broadcasting on.</span>")
-
-/obj/item/radio/off/CtrlClick(mob/user)
-	if(listening)
-		listening = FALSE
-		to_chat(user, "<span class='notice'>You turn radio speaker off.</span>")
-	else
-		listening = TRUE
-		to_chat(user, "<span class='notice'>You turn radio speaker on.</span>")

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -108,7 +108,7 @@
 			to_chat(user, "<span class='notice'>You toggle broadcasting on.</span>")
 		broadcasting = !broadcasting
 
-/obj/item/radio/CtrlClick(mob/user)
+/obj/item/radio/CtrlShiftClick(mob/user)
 	if(!headset)
 		if(listening)
 			to_chat(user, "<span class='notice'>You toggle speaker off.</span>")
@@ -352,7 +352,7 @@
 	else
 		. += "<span class='notice'>It cannot be modified or attached.</span>"
 	if (in_range(src, user) && !headset)
-		. += "<span class='info'>Ctrl-click on the [name] to toggle speaker.<br/>Alt-click on the [name] to toggle broadcasting.</span>"
+		. += "<span class='info'>Ctrl-Shift-click on the [name] to toggle speaker.<br/>Alt-click on the [name] to toggle broadcasting.</span>"
 
 /obj/item/radio/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -103,18 +103,20 @@
 /obj/item/radio/AltClick(mob/user)
 	if(!headset)
 		if(broadcasting)
+			broadcasting = FALSE
 			to_chat(user, "<span class='notice'>You toggle broadcasting off.</span>")
 		else
+			broadcasting = TRUE
 			to_chat(user, "<span class='notice'>You toggle broadcasting on.</span>")
-		broadcasting = !broadcasting
 
 /obj/item/radio/CtrlShiftClick(mob/user)
 	if(!headset)
 		if(listening)
+			listening = FALSE
 			to_chat(user, "<span class='notice'>You toggle speaker off.</span>")
 		else
+			listening = TRUE
 			to_chat(user, "<span class='notice'>You toggle speaker on.</span>")
-		listening = !listening
 
 /obj/item/radio/interact(mob/user)
 	if(unscrewed && !isAI(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ctrl-Shift-clicking station bounced radio/intercom will toggle the speakers.
Alt-clicking station bounced radio/intercom will toggle broadcasting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Using station bounced radios is more convenient now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ctrl-Shift-clicking station bounced radio/intercom will toggle the speakers.
tweak: Alt-clicking station bounced radio/intercom will toggle broadcasting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
