### PR TITLE
Proper QDEL_NULL for looping_sound

### DIFF
--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -33,6 +33,10 @@
 	soundloop = new(list(src),  FALSE)
 	update_icon()
 
+/obj/machinery/fat_sucker/Destroy()
+	QDEL_NULL(soundloop)
+	return ..()
+
 /obj/machinery/fat_sucker/RefreshParts()
 	..()
 	var/rating = 0

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -37,6 +37,7 @@
 	soundloop = new(list(src), FALSE)
 
 /obj/item/geiger_counter/Destroy()
+	QDEL_NULL(soundloop)
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -26,8 +26,9 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/head/helmet/space/hardsuit/Destroy()
-	. = ..()
+	QDEL_NULL(soundloop)
 	STOP_PROCESSING(SSobj, src)
+	return ..()
 
 /obj/item/clothing/head/helmet/space/hardsuit/attack_self(mob/user)
 	on = !on

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -60,6 +60,10 @@ God bless America.
 	RefreshParts()
 	fry_loop = new(list(src), FALSE)
 
+/obj/machinery/deepfryer/Destroy()
+	QDEL_NULL(fry_loop)
+	return ..()
+
 /obj/machinery/deepfryer/RefreshParts()
 	var/oil_efficiency
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -86,6 +86,7 @@
 	..()
 
 /obj/machinery/grill/Destroy()
+	QDEL_NULL(grill_loop)
 	grilled_item = null
 	. = ..()
 

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -40,6 +40,7 @@
 
 /obj/machinery/microwave/Destroy()
 	eject()
+	QDEL_NULL(soundloop)
 	if(wires)
 		QDEL_NULL(wires)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

(This thing started while doing #2962; other ideas(?) have spawned too but this was the one I could do without much hassle)

1. Quite a few objects uses /datum/looping_sound
2. Some objects didn't clean it up via QDEL_NULL on Destroy like some others
3. Sadly leaving /datum/looping_sound alive causes a little bit of memory leak (remind you, unstopped /datum/looping_sound consists of three datums: the looping_sound itself, the timer, and the callback; and the looping_sound stores a ref to the object using it.)
4. This PR fixes it by checking every non-cleanup of /datum/looping_sound

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Memory leak is bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a minor /datum/looping_sound-related memory leak
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
