### PR TITLE
Firelock Balance Changes

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -297,12 +297,14 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		for(var/FD in firedoors)
 			var/obj/machinery/door/firedoor/D = FD
 			var/cont = !D.welded
-			if(cont && opening)	//don't open if adjacent area is on fire
+			if(cont && opening)	//don't open if adjacent area is on fire or a vacuum
 				for(var/I in D.affecting_areas)
 					var/area/A = I
-					if(A.fire)
+					if(A.fire || A.vacuum)
 						cont = FALSE
 						break
+				if(D.is_holding_pressure()) //If it's holding pressure, leave it closed.
+					continue
 			if(cont && D.is_operational())
 				if(D.operating)
 					D.nextstate = opening ? FIREDOOR_OPEN : FIREDOOR_CLOSED
@@ -445,14 +447,18 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/proc/set_vacuum_alarm_effect() //Just like fire alarm but blue
 	vacuum = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	ModifyFiredoors(FALSE)
 	for(var/obj/machinery/light/L in src)
 		L.update()
+	START_PROCESSING(SSobj, src)
 
 /area/proc/unset_vacuum_alarm_effect()
 	vacuum = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	ModifyFiredoors(TRUE)
 	for(var/obj/machinery/light/L in src)
 		L.update()
+	STOP_PROCESSING(SSobj, src)
 
 /**
   * Update the icon state of the area

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -98,17 +98,17 @@
 	. = ..()
 	if(.)
 		return
-	
+
 	if (!welded && !operating)
-		if (stat & NOPOWER) 				
+		if (stat & NOPOWER)
 			user.visible_message("[user] tries to open \the [src] manually.",
 						 "You operate the manual lever on \the [src].")
 			if (!do_after(user, 30, TRUE, src))
 				return FALSE
 		else if (density && !allow_hand_open(user))
 			return FALSE
-	
-		add_fingerprint(user)		
+
+		add_fingerprint(user)
 		if(density)
 			emergency_close_timer = world.time + 15 // prevent it from instaclosing again if in space
 			open()
@@ -117,7 +117,7 @@
 		return TRUE
 	if(operating || !density)
 		return
-	
+
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	user.visible_message("[user] bangs on \the [src].",
@@ -178,7 +178,7 @@
 			log_game("[key_name(user)] has opened a firelock with a pressure difference at [AREACOORD(loc)]")
 			user.log_message("has opened a firelock with a pressure difference at [AREACOORD(loc)]", LOG_ATTACK)
 			// since we have high-pressure-ness, close all other firedoors on the tile
-			whack_a_mole()
+//			whack_a_mole()
 		if(welded || operating || !density)
 			return // in case things changed during our do_after
 		emergency_close_timer = world.time + 15 // prevent it from instaclosing again if in space
@@ -238,7 +238,7 @@
 /obj/machinery/door/firedoor/close()
 	. = ..()
 	latetoggle()
-
+/* Disabled by comment for now pending change viability checks.
 /obj/machinery/door/firedoor/proc/whack_a_mole(reconsider_immediately = FALSE)
 	set waitfor = 0
 	for(var/cdir in GLOB.cardinals)
@@ -280,20 +280,22 @@
 				turfs[T2] = 1
 	if(turfs.len > 10)
 		return // too big, don't bother
+
 	for(var/obj/machinery/door/firedoor/FD in doors_to_close)
 		FD.emergency_pressure_stop(FALSE)
 		if(reconsider_immediately)
 			var/turf/open/T = FD.loc
 			if(istype(T))
 				T.ImmediateCalculateAdjacentTurfs()
-
+	*/
+/* Disabled by comment for now pending change viability checks.
 /obj/machinery/door/firedoor/proc/emergency_pressure_stop(consider_timer = TRUE)
 	set waitfor = 0
 	if(density || operating || welded)
 		return
 	if(world.time >= emergency_close_timer || !consider_timer)
 		close()
-
+*/
 /obj/machinery/door/firedoor/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		var/obj/structure/firelock_frame/F = new assemblytype(get_turf(src))
@@ -357,7 +359,7 @@
 	var/area/A = get_area(src)
 	if((!A || !A.fire) && !is_holding_pressure())
 		return TRUE
-	whack_a_mole(TRUE) // WOOP WOOP SIDE EFFECTS
+//	whack_a_mole(TRUE) // WOOP WOOP SIDE EFFECTS
 	var/turf/T = loc
 	var/turf/T2 = get_step(T, dir)
 	if(!T || !T2)

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -168,7 +168,9 @@
 	SSair.remove_from_active(src)
 
 /turf/open/proc/equalize_pressure_in_zone(cyclenum)
-/turf/open/proc/consider_firelocks(turf/T2)
+/turf/open/proc/consider_firelocks(turf/T2) //This is referenced by the C component, so I'm just going to neuter it for now.
+	return
+/*
 	var/reconsider_adj = FALSE
 	for(var/obj/machinery/door/firedoor/FD in T2)
 		if((FD.flags_1 & ON_BORDER_1) && get_dir(T2, src) != FD.dir)
@@ -182,7 +184,7 @@
 		reconsider_adj = TRUE
 	if(reconsider_adj)
 		T2.ImmediateCalculateAdjacentTurfs() // We want those firelocks closed yesterday.
-
+*/
 /turf/proc/handle_decompression_floor_rip()
 /turf/open/floor/handle_decompression_floor_rip(sum)
 	if(sum > 20 && prob(CLAMP(sum / 10, 0, 30)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modifies the way firelocks handle breaches.

They now don't immediately respond to pressure drops and prevent them, instead acting as reactionary elements.

Edge-firedoor airlocking is now a manual process.

## Why It's Good For The Game

Firelocks at the moment mitigate 90% of the risk inherent with breaches and being in space to begin with.

That's kinda lame.

The changes to the airlocking process results in additional thought being required when it comes to repair and escape of depressurization or other severe air alarm triggering events.

## Changelog
:cl:
balance: A massive stack of firedoor changes, don't merge this until I've been forced to write a more helpful changelog
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
