### PR TITLE
Adds maint door admin secret

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -96,6 +96,7 @@ GLOBAL_DATUM_INIT(admin_secrets, /datum/admin_secrets, new)
 		data["Categories"]["Security Level Elevated"] = list(
 			list("Change all maintenance doors to engie/brig access only", "maint_access_engiebrig"),
 			list("Change all maintenance doors to brig access only", "maint_access_brig"),
+			list("Change all maintenance doors to normal access", "maint_access_normal"),
 			list("Remove cap on security officers", "infinite_sec")
 			)
 
@@ -639,6 +640,15 @@ GLOBAL_DATUM_INIT(admin_secrets, /datum/admin_secrets, new)
 					M.req_access = list()
 					M.req_one_access = list(ACCESS_BRIG,ACCESS_ENGINE)
 			message_admins("[key_name_admin(usr)] made all maint doors engineering and brig access-only.")
+		if("maint_access_normal") // allows an admin to revert the effects of maint_access_brig or maint_access_engiebrig
+			if(!check_rights(R_DEBUG))
+				return
+			for(var/obj/machinery/door/airlock/maintenance/M in GLOB.machines)
+				M.check_access()
+				if (ACCESS_MAINT_TUNNELS in M.req_access)
+					M.req_access = list()
+					M.req_one_access = list(ACCESS_MAINT_TUNNELS)
+			message_admins("[key_name_admin(usr)] made all maint doors maint access only")
 		if("infinite_sec")
 			if(!check_rights(R_DEBUG))
 				return


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an admin secret to revert maint doors to ACCESS_MAINT_TUNNELS permission, since currently there is no method to do this.

Maint doors _should_ only have ACCESS_MAINT_TUNNELS by default

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Admins can set the door permissions on maint to be very restrictive, but cannot undo that action. This will let admins restore the correct permissions to maint.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added an admin secret to fix permissions on maint doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
