### PR TITLE
Gives Blood Brothers a good way to communicate

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1012,6 +1012,7 @@
 #include "code\game\objects\items\grenades\syndieminibomb.dm"
 #include "code\game\objects\items\implants\implant.dm"
 #include "code\game\objects\items\implants\implant_abductor.dm"
+#include "code\game\objects\items\implants\implant_bb.dm"
 #include "code\game\objects\items\implants\implant_chem.dm"
 #include "code\game\objects\items\implants\implant_clown.dm"
 #include "code\game\objects\items\implants\implant_exile.dm"

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -14,12 +14,14 @@
 	. = ..()
 	if(linked_implants.len)
 		var/input = stripped_input(imp_in, "Enter a message to communicate to your blood brother(s).", "Radio Implant", "")
-		if(!input)
+		if(!input || imp_in.stat == DEAD)
+			return
+		if(CHAT_FILTER_CHECK(input))
+			to_chat(imp_in, "<span class='warning'>The message contains prohibited words!</span>")
 			return
 
-		var/preliminary_message = "<span class='bold'>[input]</span>" //apply basic color/bolding
-		var/my_message = "<font color=\"#ff0000\"><b><i>[imp_in]:</i></b></font> [preliminary_message]" //add source, color source with syndie color
-		var/ghost_message = "<font color=\"#ff0000\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [preliminary_message]"
+		var/my_message = "<font color=\"#ff0000\"><b><i>[imp_in]:</i></b></font> [input]" //add sender, color source with syndie color
+		var/ghost_message = "<font color=\"#ff0000\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [input]"
 
 		to_chat(imp_in, my_message) // Sends message to the user
 		for(var/obj/item/implant/bloodbrother/i in linked_implants) // Sends message to all linked implnats
@@ -42,10 +44,8 @@
 	if(BB)
 		if(BB == src) // Don't want to put this implant into itself
 			return
-		if(locate(BB) in linked_implants || locate(src) in BB.linked_implants) // Don't want duplicates in the list
-			return
-		linked_implants += BB
-		BB.linked_implants += src
+		linked_implants |= BB
+		BB.linked_implants |= src
 
 /obj/item/implant/bloodbrother/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -47,7 +47,7 @@
 		linked_implants += BB
 		BB.linked_implants += src
 
-/obj/item/implant/chem/get_data()
+/obj/item/implant/bloodbrother/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Donk Corp(tm) Initiate Communication Implant<BR>
 				<b>Life:</b> Indefinite.<BR>

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -1,0 +1,65 @@
+/obj/item/implant/bloodbrother
+	name = "communication implant"
+	desc = "Use this to communicate with your fellow blood brother(s)."
+	icon = 'icons/obj/radio.dmi'
+	icon_state = "headset"
+	item_color = "r"
+	var/list/linked_implants // All other implants that this communicates to
+
+/obj/item/implant/bloodbrother/Initialize()
+	. = ..()
+	linked_implants = list()
+
+/obj/item/implant/bloodbrother/activate()
+	. = ..()
+	if(linked_implants.len)
+		var/input = stripped_input(imp_in, "Enter a message to communicate to your blood brother(s).", "Radio Implant", "")
+		if(!input)
+			return
+
+		var/preliminary_message = "<span class='bold'>[input]</span>" //apply basic color/bolding
+		var/my_message = "<font color=\"#ff0000\"><b><i>[imp_in]:</i></b></font> [preliminary_message]" //add source, color source with syndie color
+		var/ghost_message = "<font color=\"#ff0000\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [preliminary_message]"
+
+		to_chat(imp_in, my_message) // Sends message to the user
+		for(var/obj/item/implant/bloodbrother/i in linked_implants) // Sends message to all linked implnats
+			var/M = i.imp_in
+			to_chat(M, my_message)
+		for(var/M in GLOB.dead_mob_list) // Sends message to ghosts
+			var/link = FOLLOW_LINK(M, imp_in)
+			to_chat(M, "[link] [ghost_message]")
+
+		imp_in.log_talk(input, LOG_SAY, tag="Blood Brother Implant")
+	else
+		to_chat(imp_in, "<span class='bold'>There are no linked implants!</span>")
+
+/obj/item/implant/bloodbrother/Destroy()
+	. = ..()
+	for(var/obj/item/implant/bloodbrother/i in linked_implants) // Removes this implant from the list of implants
+		i.linked_implants -= src
+
+/obj/item/implant/bloodbrother/proc/link_implant(var/obj/item/implant/bloodbrother/BB)
+	if(BB)
+		if(BB == src) // Don't want to put this implant into itself
+			return
+		if(locate(BB) in linked_implants || locate(src) in BB.linked_implants) // Don't want duplicates in the list
+			return
+		linked_implants += BB
+		BB.linked_implants += src
+
+/obj/item/implant/chem/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Donk Corp(tm) Initiate Communication Implant<BR>
+				<b>Life:</b> Indefinite.<BR>
+				<b>Important Notes: <font color='red'>Illegal</font></B><BR>
+				<HR>
+				<b>Implant Details:</b><BR>
+				<b>Function:</b> Contains a small, directly linked radio device along with a small speaker and microphone. Allows communication between two similar implants.<BR>"}
+	return dat
+
+/obj/item/implanter/bloodbrother
+	name = "implanter (communication)"
+	imp_type = /obj/item/implant/bloodbrother
+
+
+

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -62,6 +62,11 @@
 	give_meeting_area()
 
 /datum/antagonist/brother/proc/finalize_brother()
+	var/obj/item/implant/bloodbrother/I = new /obj/item/implant/bloodbrother()
+	I.implant(owner.current, null, TRUE, TRUE)
+	for(var/datum/mind/M in team.members) // Link the implants of all team members
+		var/obj/item/implant/bloodbrother/T = locate() in M.current.implants
+		I.link_implant(T)
 	SSticker.mode.update_brother_icons_added(owner)
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE)
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -57,7 +57,7 @@
 /datum/antagonist/brother/greet()
 	var/brother_text = get_brother_names()
 	to_chat(owner.current, "<span class='alertsyndie'>You are the [owner.special_role] of [brother_text].</span>")
-	to_chat(owner.current, "The Syndicate only accepts those that have proven themselves. Prove yourself and prove your [team.member_name]s by completing your objectives together!")
+	to_chat(owner.current, "The Syndicate only accepts those that have proven themselves. Prove yourself and prove your [team.member_name]s by completing your objectives together! You and your team are outfitted with communication implants allowing for direct, encrypted communication.")
 	owner.announce_objectives()
 	give_meeting_area()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a communication implant that can be linked to another implant of the same type to communicate secretly. Implants blood brothers with this implant roundstart. Updates BB instruction text to explain the implant.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Blood brothers have always been very underpowered as antags, as they have no good way to communicate that won't get them caught instantly if the AI decides to look at message logs. This is extremely bad for a team antag, and this change works to fix it rather than just giving them TC or some other fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a communication implant
add: Blood brothers get a communication implant to their team roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
