### PR TITLE
Makes MindSwap No Longer Affect Mindshielded Targets

### DIFF
--- a/code/modules/spells/spell_types/mind_transfer.dm
+++ b/code/modules/spells/spell_types/mind_transfer.dm
@@ -60,6 +60,11 @@ Also, you never added distance checking after target is selected. I've went ahea
 			to_chat(user, "<span class='warning'>You're killing yourself! You can't concentrate enough to do this!</span>")
 		return
 
+	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+		if(!silent)
+			to_chat(user, "<span class='warning'>[t_He]'s mind is protected from such magic by an implant. It can be removed by surgery, should you manage to subdue them.")
+		return
+
 	var/datum/mind/TM = target.mind
 	if(target.anti_magic_check() || TM.has_antag_datum(/datum/antagonist/wizard) || TM.has_antag_datum(/datum/antagonist/cult) || TM.has_antag_datum(/datum/antagonist/changeling) || TM.has_antag_datum(/datum/antagonist/rev) || target.key[1] == "@")
 		if(!silent)


### PR DESCRIPTION
Does what it says on the tin.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a single if() statement to check for a mindshield, will inform user of reason of failure apropriately.

## Why It's Good For The Game

No clue why this didn't exist before. Doesn't make much sense. Mindshields seem to stop various magical effects from affecting the brain. Check keeps in line with how Nar'Sie cult conversion handles mindshields. Being implanted will not undo the spell retro-actively. Will only stop spell from being able to target you.

Makes them more consistent.

## Changelog
:cl: DatBoiTim
tweak: Mindshields protect against mindswap spells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
