### PR TITLE
[HOTFIX] Stack max amount check

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -38,9 +38,7 @@
 	. = ..()
 	if(new_amount != null)
 		amount = new_amount
-	while(amount > max_amount)
-		amount -= max_amount
-		new type(loc, max_amount, FALSE)
+	check_max_amount()
 	if(!merge_type)
 		merge_type = type
 	if(merge)
@@ -49,6 +47,11 @@
 				merge(S)
 	update_weight()
 	update_icon()
+
+/obj/item/stack/proc/check_max_amount()
+	while(amount > max_amount)
+		amount -= max_amount
+		new type(loc, max_amount, FALSE)
 
 /obj/item/stack/proc/update_weight()
 	if(amount <= (max_amount * (1/3)))
@@ -318,6 +321,7 @@
 		source.add_charge(amount * cost)
 	else
 		src.amount += amount
+		check_max_amount()
 	update_icon()
 	update_weight()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stacks no longer exceed `max_amount` when `add()` demands them so. This is a hotfix for cerulean crossbreed of #2946, which did things like this:
![88_in_a_stack](https://user-images.githubusercontent.com/8010007/100428623-8b69ca00-30d7-11eb-8e1e-01b2b88fa862.PNG)
_Fig 1. 88 items in a stack?? Reported from AU_
Feel free to close this when the author makes a more proper collection of patches.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

`max_amount` should be observed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: stack max_amount is now enforced more thoroughly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
