### PR TITLE
Adds auto deadmin options into the config

### DIFF
--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -405,6 +405,14 @@ PREFERENCE_MAP_VOTING 0
 ## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
 #MAPROTATIONCHANCEDELTA 0.5
 
+## Auto Deadmin
+## Force admins to de-admin when joining as a player or specific role.
+auto_deadmin_players
+#auto_deadmin_antagonists
+#auto_deadmin_heads
+#auto_deadmin_silicons
+#auto_deadmin_security
+
 ## AUTOADMIN
 ## The default admin rank
 AUTOADMIN_RANK Admin

--- a/config/config.txt
+++ b/config/config.txt
@@ -402,6 +402,14 @@ PREFERENCE_MAP_VOTING 0
 ## A value of 0.5 would mean the map rotation chance is half of the round length in minutes (hour long round == 30% rotation chance)
 #MAPROTATIONCHANCEDELTA 0.5
 
+## Auto Deadmin
+## Force admins to de-admin when joining as a player or specific role.
+auto_deadmin_players
+#auto_deadmin_antagonists
+#auto_deadmin_heads
+#auto_deadmin_silicons
+#auto_deadmin_security
+
 ## AUTOADMIN
 ## The default admin rank
 AUTOADMIN_RANK Admin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes to our internal policy requires admins to de-admin themselves whenever they opt to join the round as a player. These options automate the process.

## Changelog
:cl:
config: Admins will automatically deadmin while playing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
