### PR TITLE
[PORT] restart votes check for deadmins

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -159,7 +159,7 @@ SUBSYSTEM_DEF(vote)
 						C.post_status("shuttle")
 	if(restart)
 		var/active_admins = 0
-		for(var/client/C in GLOB.admins)
+		for(var/client/C in GLOB.admins+GLOB.deadmins)
 			if(!C.is_afk() && check_rights_for(C, R_SERVER))
 				active_admins = 1
 				break

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -135,17 +135,17 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/result()
 	. = announce_result()
-	var/restart = 0
+	var/restart = FALSE
 	if(.)
 		switch(mode)
 			if("restart")
 				if(. == "Restart Round")
-					restart = 1
+					restart = TRUE
 			if("gamemode")
 				if(GLOB.master_mode != .)
 					SSticker.save_mode(.)
 					if(SSticker.HasRoundStarted())
-						restart = 1
+						restart = TRUE
 					else
 						GLOB.master_mode = .
 			if("map")
@@ -158,10 +158,10 @@ SUBSYSTEM_DEF(vote)
 					if(C)
 						C.post_status("shuttle")
 	if(restart)
-		var/active_admins = 0
+		var/active_admins = FALSE
 		for(var/client/C in GLOB.admins+GLOB.deadmins)
 			if(!C.is_afk() && check_rights_for(C, R_SERVER))
-				active_admins = 1
+				active_admins = TRUE
 				break
 		if(!active_admins)
 			SSticker.Reboot("Restart vote successful.", "restart vote")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ports a "fix" from austation

Restart votes now check for deadmins, also cleans up some code


## Why It's Good For The Game

unaware deadmins could miss the restart vote and are forced to admin in order to cancel the vote, qol improvement

## Changelog
:cl: jupyterkat
admin: restart votes check for active deadmins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
