### PR TITLE
Coffee Cart

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14408,7 +14408,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMB" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/food_cart/coffee,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMC" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18270,7 +18270,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aKw" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/food_cart/coffee,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14961,7 +14961,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aEP" = (
-/obj/structure/closet/secure_closet/bar,
+/obj/machinery/food_cart/coffee,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/bar";
 	dir = 1;
@@ -18270,7 +18270,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aKw" = (
-/obj/machinery/food_cart/coffee,
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -18839,7 +18839,7 @@
 	},
 /area/crew_quarters/bar)
 "aQU" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/food_cart/coffee,
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
 	dir = 2

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -166,11 +166,11 @@
 	var/B = rand(0,3)
 	var/C = rand(0,3)
 	var/D = rand(0,1)	
-	mixer.add_reagent(/datum/reagent/consumable/cafe_latte, A*20)
-	mixer.add_reagent(/datum/reagent/consumable/icecoffee, B*20)
-	mixer.add_reagent(/datum/reagent/consumable/soy_latte, C*20)
-	mixer.add_reagent(/datum/reagent/consumable/pumpkin_latte, D*20)	
-	mixer.add_reagent(/datum/reagent/consumable/coffee, (10-A-B-C-D)*20)
+	mixer.reagents.add_reagent(/datum/reagent/consumable/cafe_latte, A*20)
+	mixer.reagents.add_reagent(/datum/reagent/consumable/icecoffee, B*20)
+	mixer.reagents.add_reagent(/datum/reagent/consumable/soy_latte, C*20)
+	mixer.reagents.add_reagent(/datum/reagent/consumable/pumpkin_latte, D*20)	
+	mixer.reagents.add_reagent(/datum/reagent/consumable/coffee, (10-A-B-C-D)*20)
 
 #undef STORAGE_CAPACITY
 #undef LIQUID_CAPACIY

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -137,7 +137,7 @@
 				mixer.reagents.trans_id_to(DG, mixer.reagents.reagent_list[text2num(href_list["m_pour"])]?.type, portion)
 
 	if(href_list["mix"])
-		if(reagents.trans_id_to(mixer, reagents.reagent_list[text2num(href_list["mix"])]?.type, portion) == 0)
+		if(!reagents.trans_id_to(mixer, reagents.reagent_list[text2num(href_list["mix"])]?.type, portion))
 			to_chat(usr, "<span class='warning'>[mixer] is full!</span>")
 
 	if(href_list["transfer"])

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -81,7 +81,7 @@
 	dat += "<br><b>STORED INGREDIENTS AND DRINKS</b><br><div class='statusDisplay'>"
 	dat += "Remaining glasses: [glasses]<br>"
 	dat += "Portion: <a href='?src=[REF(src)];portion=1'>[portion]</a><br>"
-	for(var/i=1 to LAZYLEN(reagents.reagent_list))
+	for(var/i in 1 to LAZYLEN(reagents.reagent_list))
 		var/datum/reagent/R = reagents.reagent_list[i]
 		dat += "[R.name]: [R.volume] "
 		dat += "<a href='?src=[REF(src)];disposeI=[i]'>Purge</a>"

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -159,6 +159,7 @@
 	desc = "Ah! The bitter drink of the Gods."
 	icon_state = "icecream_vat"
 	glasses = 10
+	portion = 20
 	
 /obj/machinery/food_cart/coffee/Initialize()
 	..()
@@ -166,11 +167,11 @@
 	var/B = rand(0,3)
 	var/C = rand(0,3)
 	var/D = rand(0,1)	
-	mixer.reagents.add_reagent(/datum/reagent/consumable/cafe_latte, A*20)
-	mixer.reagents.add_reagent(/datum/reagent/consumable/icecoffee, B*20)
-	mixer.reagents.add_reagent(/datum/reagent/consumable/soy_latte, C*20)
-	mixer.reagents.add_reagent(/datum/reagent/consumable/pumpkin_latte, D*20)	
-	mixer.reagents.add_reagent(/datum/reagent/consumable/coffee, (10-A-B-C-D)*20)
+	reagents.add_reagent(/datum/reagent/consumable/cafe_latte, A*20)
+	reagents.add_reagent(/datum/reagent/consumable/icecoffee, B*20)
+	reagents.add_reagent(/datum/reagent/consumable/soy_latte, C*20)
+	reagents.add_reagent(/datum/reagent/consumable/pumpkin_latte, D*20)	
+	reagents.add_reagent(/datum/reagent/consumable/coffee, (10-A-B-C-D)*20)
 
 #undef STORAGE_CAPACITY
 #undef LIQUID_CAPACIY

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -111,7 +111,7 @@
 		return
 
 	if(href_list["disposeI"])
-		reagents.del_reagent(reagents.reagent_list[text2num(href_list["disposeI"])].type)
+		reagents.del_reagent(reagents.reagent_list[text2num(href_list["disposeI"])]?.type)
 
 	if(href_list["dispense"])
 		if(stored_food[href_list["dispense"]]-- <= 0)
@@ -132,16 +132,16 @@
 		else
 			var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = new(loc)
 			if(href_list["pour"])
-				reagents.trans_id_to(DG, reagents.reagent_list[text2num(href_list["pour"])].type, portion)
+				reagents.trans_id_to(DG, reagents.reagent_list[text2num(href_list["pour"])]?.type, portion)
 			if(href_list["m_pour"])
-				mixer.reagents.trans_id_to(DG, mixer.reagents.reagent_list[text2num(href_list["m_pour"])].type, portion)
+				mixer.reagents.trans_id_to(DG, mixer.reagents.reagent_list[text2num(href_list["m_pour"])]?.type, portion)
 
 	if(href_list["mix"])
-		if(reagents.trans_id_to(mixer, reagents.reagent_list[text2num(href_list["mix"])].type, portion) == 0)
+		if(reagents.trans_id_to(mixer, reagents.reagent_list[text2num(href_list["mix"])]?.type, portion) == 0)
 			to_chat(usr, "<span class='warning'>[mixer] is full!</span>")
 
 	if(href_list["transfer"])
-		if(mixer.reagents.trans_id_to(src, mixer.reagents.reagent_list[text2num(href_list["transfer"])].type, portion) == 0)
+		if(mixer.reagents.trans_id_to(src, mixer.reagents.reagent_list[text2num(href_list["transfer"])]?.type, portion) == 0)
 			to_chat(usr, "<span class='warning'>[src] is full!</span>")
 
 	updateDialog()

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -141,7 +141,7 @@
 			to_chat(usr, "<span class='warning'>[mixer] is full!</span>")
 
 	if(href_list["transfer"])
-		if(mixer.reagents.trans_id_to(src, mixer.reagents.reagent_list[text2num(href_list["transfer"])]?.type, portion) == 0)
+		if(!mixer.reagents.trans_id_to(src, mixer.reagents.reagent_list[text2num(href_list["transfer"])]?.type, portion))
 			to_chat(usr, "<span class='warning'>[src] is full!</span>")
 
 	updateDialog()

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -153,6 +153,24 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		new /obj/item/stack/sheet/iron(loc, 4)
 	qdel(src)
+	
+/obj/machinery/food_cart/coffee
+	name = "coffee cart"
+	desc = "Ah! The bitter drink of the Gods."
+	icon_state = "icecream_vat"
+	glasses = 10
+	
+/obj/machinery/food_cart/coffee/Initialize()
+	..()
+	var/A = rand(0,3)
+	var/B = rand(0,3)
+	var/C = rand(0,3)
+	var/D = rand(0,1)	
+	mixer.add_reagent(/datum/reagent/consumable/cafe_latte, A*20)
+	mixer.add_reagent(/datum/reagent/consumable/icecoffee, B*20)
+	mixer.add_reagent(/datum/reagent/consumable/soy_latte, C*20)
+	mixer.add_reagent(/datum/reagent/consumable/pumpkin_latte, D*20)	
+	mixer.add_reagent(/datum/reagent/consumable/coffee, (10-A-B-C-D)*20)
 
 #undef STORAGE_CAPACITY
 #undef LIQUID_CAPACIY

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -89,7 +89,7 @@
 			dat += "<a href='?src=[REF(src)];pour=[i]'>Pour in a glass</a>"
 		dat += "<a href='?src=[REF(src)];mix=[i]'>Add to the mixer</a><br>"
 	dat += "</div><br><b>MIXER CONTENTS</b><br><div class='statusDisplay'>"
-	for(var/i=1 to LAZYLEN(mixer.reagents.reagent_list))
+	for(var/i in 1 to LAZYLEN(mixer.reagents.reagent_list))
 		var/datum/reagent/R = mixer.reagents.reagent_list[i]
 		dat += "[R.name]: [R.volume] "
 		dat += "<a href='?src=[REF(src)];transfer=[i]'>Transfer back</a>"

--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -27,35 +27,6 @@
 	QDEL_NULL(mixer)
 	return ..()
 
-/obj/machinery/food_cart/ui_interact(mob/user)
-	. = ..()
-	var/dat
-	dat += "<br><b>STORED INGREDIENTS AND DRINKS</b><br><div class='statusDisplay'>"
-	dat += "Remaining glasses: [glasses]<br>"
-	dat += "Portion: <a href='?src=[REF(src)];portion=1'>[portion]</a><br>"
-	for(var/datum/reagent/R in reagents.reagent_list)
-		dat += "[R.name]: [R.volume] "
-		dat += "<a href='?src=[REF(src)];disposeI=[R.type]'>Purge</a>"
-		if (glasses > 0)
-			dat += "<a href='?src=[REF(src)];pour=[R.type]'>Pour in a glass</a>"
-		dat += "<a href='?src=[REF(src)];mix=[R.type]'>Add to the mixer</a><br>"
-	dat += "</div><br><b>MIXER CONTENTS</b><br><div class='statusDisplay'>"
-	for(var/datum/reagent/R in mixer.reagents.reagent_list)
-		dat += "[R.name]: [R.volume] "
-		dat += "<a href='?src=[REF(src)];transfer=[R.type]'>Transfer back</a>"
-		if (glasses > 0)
-			dat += "<a href='?src=[REF(src)];m_pour=[R.type]'>Pour in a glass</a>"
-		dat += "<br>"
-	dat += "</div><br><b>STORED FOOD</b><br><div class='statusDisplay'>"
-	for(var/V in stored_food)
-		if(stored_food[V] > 0)
-			dat += "<b>[V]: [stored_food[V]]</b> <a href='?src=[REF(src)];dispense=[V]'>Dispense</a><br>"
-	dat += "</div><br><a href='?src=[REF(src)];refresh=1'>Refresh</a> <a href='?src=[REF(src)];close=1'>Close</a>"
-
-	var/datum/browser/popup = new(user, "foodcart","Food Cart", 500, 350, src)
-	popup.set_content(dat)
-	popup.open()
-
 /obj/machinery/food_cart/proc/isFull()
 	return food_stored >= STORAGE_CAPACITY
 
@@ -104,12 +75,43 @@
 		. = ..()
 	updateDialog()
 
+/obj/machinery/food_cart/ui_interact(mob/user)
+	. = ..()
+	var/dat
+	dat += "<br><b>STORED INGREDIENTS AND DRINKS</b><br><div class='statusDisplay'>"
+	dat += "Remaining glasses: [glasses]<br>"
+	dat += "Portion: <a href='?src=[REF(src)];portion=1'>[portion]</a><br>"
+	for(var/i=1 to LAZYLEN(reagents.reagent_list))
+		var/datum/reagent/R = reagents.reagent_list[i]
+		dat += "[R.name]: [R.volume] "
+		dat += "<a href='?src=[REF(src)];disposeI=[i]'>Purge</a>"
+		if (glasses > 0)
+			dat += "<a href='?src=[REF(src)];pour=[i]'>Pour in a glass</a>"
+		dat += "<a href='?src=[REF(src)];mix=[i]'>Add to the mixer</a><br>"
+	dat += "</div><br><b>MIXER CONTENTS</b><br><div class='statusDisplay'>"
+	for(var/i=1 to LAZYLEN(mixer.reagents.reagent_list))
+		var/datum/reagent/R = mixer.reagents.reagent_list[i]
+		dat += "[R.name]: [R.volume] "
+		dat += "<a href='?src=[REF(src)];transfer=[i]'>Transfer back</a>"
+		if (glasses > 0)
+			dat += "<a href='?src=[REF(src)];m_pour=[i]'>Pour in a glass</a>"
+		dat += "<br>"
+	dat += "</div><br><b>STORED FOOD</b><br><div class='statusDisplay'>"
+	for(var/V in stored_food)
+		if(stored_food[V] > 0)
+			dat += "<b>[V]: [stored_food[V]]</b> <a href='?src=[REF(src)];dispense=[V]'>Dispense</a><br>"
+	dat += "</div><br><a href='?src=[REF(src)];refresh=1'>Refresh</a> <a href='?src=[REF(src)];close=1'>Close</a>"
+
+	var/datum/browser/popup = new(user, "foodcart","Food Cart", 500, 350, src)
+	popup.set_content(dat)
+	popup.open()
+
 /obj/machinery/food_cart/Topic(href, href_list)
 	if(..())
 		return
 
 	if(href_list["disposeI"])
-		reagents.del_reagent(href_list["disposeI"])
+		reagents.del_reagent(reagents.reagent_list[text2num(href_list["disposeI"])].type)
 
 	if(href_list["dispense"])
 		if(stored_food[href_list["dispense"]]-- <= 0)
@@ -130,16 +132,16 @@
 		else
 			var/obj/item/reagent_containers/food/drinks/drinkingglass/DG = new(loc)
 			if(href_list["pour"])
-				reagents.trans_id_to(DG, href_list["pour"], portion)
+				reagents.trans_id_to(DG, reagents.reagent_list[text2num(href_list["pour"])].type, portion)
 			if(href_list["m_pour"])
-				mixer.reagents.trans_id_to(DG, href_list["m_pour"], portion)
+				mixer.reagents.trans_id_to(DG, mixer.reagents.reagent_list[text2num(href_list["m_pour"])].type, portion)
 
 	if(href_list["mix"])
-		if(reagents.trans_id_to(mixer, href_list["mix"], portion) == 0)
+		if(reagents.trans_id_to(mixer, reagents.reagent_list[text2num(href_list["mix"])].type, portion) == 0)
 			to_chat(usr, "<span class='warning'>[mixer] is full!</span>")
 
 	if(href_list["transfer"])
-		if(mixer.reagents.trans_id_to(src, href_list["transfer"], portion) == 0)
+		if(mixer.reagents.trans_id_to(src, mixer.reagents.reagent_list[text2num(href_list["transfer"])].type, portion) == 0)
 			to_chat(usr, "<span class='warning'>[src] is full!</span>")
 
 	updateDialog()
@@ -153,24 +155,24 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		new /obj/item/stack/sheet/iron(loc, 4)
 	qdel(src)
-	
+
 /obj/machinery/food_cart/coffee
 	name = "coffee cart"
 	desc = "Ah! The bitter drink of the Gods."
 	icon_state = "icecream_vat"
 	glasses = 10
 	portion = 20
-	
+
 /obj/machinery/food_cart/coffee/Initialize()
 	..()
 	var/A = rand(0,3)
 	var/B = rand(0,3)
 	var/C = rand(0,3)
-	var/D = rand(0,1)	
+	var/D = rand(0,1)
 	reagents.add_reagent(/datum/reagent/consumable/cafe_latte, A*20)
 	reagents.add_reagent(/datum/reagent/consumable/icecoffee, B*20)
 	reagents.add_reagent(/datum/reagent/consumable/soy_latte, C*20)
-	reagents.add_reagent(/datum/reagent/consumable/pumpkin_latte, D*20)	
+	reagents.add_reagent(/datum/reagent/consumable/pumpkin_latte, D*20)
 	reagents.add_reagent(/datum/reagent/consumable/coffee, (10-A-B-C-D)*20)
 
 #undef STORAGE_CAPACITY


### PR DESCRIPTION
## About The Pull Request

Adds coffee cart; a food cart that comes preloaded with random coffee assortments. 
Available on Box, Delta and Pubby! Replaces the vending machine in bar, and the extra bartender closet on pubby.

EDIT: Also I noticed that the reagent mixer of the food vat wasn't working at all. This is because the UI was passing down R.type as string, which didn't work. I made a fix. It's probably shitcode. Take a look.

## Why It's Good For The Game

It's not. Most people won't notice it's there. Very few people will notice it exists. It will probably just get in the way of the bartender, like the Food Cart and Icecream Vat. But now it exists and the very few people that notice it can use it as their gimmick.

## Changelog
:cl:
add: coffee cart on Box, Delta and Pubby
fix: fixed a bug with food vat not dispensing/mixing reagents properly (at all)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
