### PR TITLE
Add some simple logging to quantum spin inverter 

### DIFF
--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -112,3 +112,6 @@
 		if(ismob(B))
 			var/mob/M = B
 			to_chat(M, "<span class='warning'>[linked_swapper] activates, and you find yourself somewhere else.</span>")
+			//victim ckey is appended which is weird and idk, but I left this here for now.
+			//log_combat(B, "swapped to [AREACOORD(B)], swapper activated by [user.ckey]")
+			log_game("[key_name(B)] has been swapped to [AREACOORD(B)]! Quantum Spin Inverter activated by [key_name(user)].")

--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -112,6 +112,5 @@
 		if(ismob(B))
 			var/mob/M = B
 			to_chat(M, "<span class='warning'>[linked_swapper] activates, and you find yourself somewhere else.</span>")
-			//victim ckey is appended which is weird and idk, but I left this here for now.
-			//log_combat(B, "swapped to [AREACOORD(B)], swapper activated by [user.ckey]")
+			log_combat(user, B, "swapped to [AREACOORD(B)]")
 			log_game("[key_name(B)] has been swapped to [AREACOORD(B)]! Quantum Spin Inverter activated by [key_name(user)].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

add game log for the quantum spin inverter. In short, if a mob is teleported it'll say who teleported it, where they went, and who initiated the swap. 

 There's also a commented out broken form of combat log for it too, if the game log portion is fine and this isn't needed I'll just remove it. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Investigating stuff revolving around this item is hard, especially if it's something naughty that was done. This makes it easy. 
## Changelog
:cl:Froststahr
admin: quantum spin inverter is now logged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
