### PR TITLE
fixes radiation filter breaking airlock filter

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -192,9 +192,8 @@
 		P.icon_state = part_id
 		P.name = name
 	if(mask_filter)
-		filters -= mask_filter
+		remove_filter("mask_filter")
 	add_filter("mask_filter", 1, list(type="alpha",icon=mask_file,x=mask_x,y=mask_y))
-	filters += mask_filter
 
 /obj/machinery/door/airlock/proc/update_other_id()
 	for(var/obj/machinery/door/airlock/A in GLOB.airlocks)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -95,7 +95,6 @@
 	var/list/part_overlays
 	var/panel_attachment = "right"
 	var/note_attachment = "left"
-	var/mask_filter = null
 
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
@@ -191,8 +190,7 @@
 		P.icon = icon
 		P.icon_state = part_id
 		P.name = name
-	if(mask_filter)
-		remove_filter("mask_filter")
+	remove_filter("mask_filter")
 	add_filter("mask_filter", 1, list(type="alpha",icon=mask_file,x=mask_x,y=mask_y))
 
 /obj/machinery/door/airlock/proc/update_other_id()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -190,7 +190,6 @@
 		P.icon = icon
 		P.icon_state = part_id
 		P.name = name
-	remove_filter("mask_filter")
 	add_filter("mask_filter", 1, list(type="alpha",icon=mask_file,x=mask_x,y=mask_y))
 
 /obj/machinery/door/airlock/proc/update_other_id()

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -95,7 +95,7 @@
 	var/list/part_overlays
 	var/panel_attachment = "right"
 	var/note_attachment = "left"
-	var/mask_filter
+	var/mask_filter = null
 
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
@@ -193,7 +193,7 @@
 		P.name = name
 	if(mask_filter)
 		filters -= mask_filter
-	mask_filter = filter(type="alpha",icon=mask_file,x=mask_x,y=mask_y)
+	add_filter("mask_filter", 1, list(type="alpha",icon=mask_file,x=mask_x,y=mask_y))
 	filters += mask_filter
 
 /obj/machinery/door/airlock/proc/update_other_id()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because of how the airlock filter was defined the radiation filter list overrided the airlock filter and that made it look really weird cause the airlock parts would not vanish into the sides anymore even after the radiation filter was already gone because the airlock filter proc gets called in initialise so never after that again.

## Why It's Good For The Game

Fixing airlock filter breaking when radiation glow kicks in

## Changelog
:cl:
fix: Radiation filter breaking airlock filter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
