### PR TITLE
Makes the microwave cleanable by the damp rag

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -147,10 +147,13 @@
 			to_chat(user, "<span class='warning'>You need more space cleaner!</span>")
 		return TRUE
 
-	if(istype(O, /obj/item/soap))
-		var/obj/item/soap/P = O
+	if(istype(O, /obj/item/soap) || istype(O, /obj/item/reagent_containers/glass/rag))
+		var/cleanspeed = 50
+		if(istype(O, /obj/item/soap))
+			var/obj/item/soap/used_soap = O
+			cleanspeed = used_soap.cleanspeed
 		user.visible_message("[user] starts to clean \the [src].", "<span class='notice'>You start to clean \the [src]...</span>")
-		if(do_after(user, P.cleanspeed, target = src))
+		if(do_after(user, cleanspeed, target = src))
 			user.visible_message("[user] has cleaned \the [src].", "<span class='notice'>You clean \the [src].</span>")
 			dirty = 0
 			update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is a port of https://github.com/tgstation/tgstation/pull/51983 by kriskog and is yet another instalment of "Alt_Alpha9 tries to port something from the things to port page". basically it just makes it so that you can use a damp rag to clean a microwave when before it was only soap that could be used.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chefs don't always have access to soap so its nice for them to have something else to clean with and seeing as the damp cloth is right there and designed to clean it seems like the obvious solution.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Alt_Alpha9
tweak: The damp rag can now clean microwaves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
