### PR TITLE
No more revolution speedruns

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -304,13 +304,13 @@
 			var/list/datum/mind/non_heads = members - head_revolutionaries
 			var/list/datum/mind/promotable = list()
 			var/list/datum/mind/nonhuman_promotable = list()
-			for(var/datum/mind/khrushchev in non_heads)
-				if(khrushchev.current && !khrushchev.current.incapacitated() && !khrushchev.current.restrained() && khrushchev.current.client && khrushchev.current.stat != DEAD)
-					if(ROLE_REV in khrushchev.current.client.prefs.be_special)
-						if(ishuman(khrushchev.current))
-							promotable += khrushchev
+			for(var/datum/mind/H in non_heads)
+				if(!H.current?.incapacitated() && !H.current?.restrained() && H.current?.client && H.current?.stat != DEAD && H.current?.job != "Shaft Miner")
+					if(ROLE_REV in H.current?.client?.prefs.be_special)
+						if(ishuman(H.current))
+							promotable += H
 						else
-							nonhuman_promotable += khrushchev
+							nonhuman_promotable += H
 			if(!promotable.len && nonhuman_promotable.len) //if only nonhuman revolutionaries remain, promote one of them to the leadership.
 				promotable = nonhuman_promotable
 			if(promotable.len)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -304,13 +304,13 @@
 			var/list/datum/mind/non_heads = members - head_revolutionaries
 			var/list/datum/mind/promotable = list()
 			var/list/datum/mind/nonhuman_promotable = list()
-			for(var/datum/mind/H in non_heads)
-				if(!H.current?.incapacitated() && !H.current?.restrained() && H.current?.client && H.current?.stat != DEAD && H.current?.job != "Shaft Miner")
-					if(ROLE_REV in H.current?.client?.prefs.be_special)
-						if(ishuman(H.current))
-							promotable += H
+			for(var/datum/mind/khrushchev in non_heads)
+				if(khrushchev.current && !khrushchev.current.incapacitated() && !khrushchev.current.restrained() && khrushchev.current.client && khrushchev.current.stat != DEAD && khrushchev.current.job != "Shaft Miner")
+					if(ROLE_REV in khrushchev.current.client.prefs.be_special)
+						if(ishuman(khrushchev.current))
+							promotable += khrushchev
 						else
-							nonhuman_promotable += H
+							nonhuman_promotable += khrushchev
 			if(!promotable.len && nonhuman_promotable.len) //if only nonhuman revolutionaries remain, promote one of them to the leadership.
 				promotable = nonhuman_promotable
 			if(promotable.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the head rev pick logic to not grab shaft miners. Yanno, just in case, see below:
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![Imgur img](https://i.imgur.com/sWCLuJb.png)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Shaft miners are no longer picked as roundstart headrevs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
