### PR TITLE
Locker staff fixes and tweaks

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -419,9 +419,9 @@
 
 /obj/structure/closet/decay/Initialize()
 	. = ..()
-	addtimer(CALLBACK(src, .proc/magicly_lock), 5)
+	addtimer(CALLBACK(src, .proc/locker_magic_timer), 5)
 
-/obj/structure/closet/decay/proc/magicly_lock()
+/obj/structure/closet/decay/proc/locker_magic_timer()
 	if(welded)
 		addtimer(CALLBACK(src, .proc/bust_open), 5 MINUTES)
 		icon_state = magic_icon

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -416,18 +416,15 @@
 	material_drop_amount = 0
 	var/magic_icon = "cursed"
 	var/weakened_icon = "decursed"
-	var/auto_destroy = TRUE
 
 /obj/structure/closet/decay/Initialize()
 	. = ..()
-	if(auto_destroy)
-		addtimer(CALLBACK(src, .proc/bust_open), 5 MINUTES)
 	addtimer(CALLBACK(src, .proc/magicly_lock), 5)
-
 /obj/structure/closet/decay/proc/magicly_lock()
 	if(!welded)
 		addtimer(CALLBACK(src, .proc/decay), 15 SECONDS)
 		return
+	addtimer(CALLBACK(src, .proc/bust_open), 5 MINUTES)
 	icon_state = magic_icon
 	update_icon()
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -398,7 +398,7 @@
 	var/obj/structure/closet/decay/C = new(get_turf(src))
 	if(LAZYLEN(contents))
 		for(var/atom/movable/AM in contents)
-			C.insert_m(AM)
+			AM.forceMove(C)
 		C.welded = TRUE
 		C.update_icon()
 	created = TRUE
@@ -434,13 +434,6 @@
 /obj/structure/closet/decay/after_weld(weld_state)
 	if(weld_state)
 		unmagify()
-
-/obj/structure/closet/decay/proc/insert_m(atom/movable/AM)
-	if(insertion_allowed(AM))
-		AM.forceMove(src)
-		return TRUE
-	else
-		return FALSE
 
 /obj/structure/closet/decay/proc/decay()
 	animate(src, alpha = 0, time = 30)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -386,7 +386,7 @@
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
 			qdel(src)
 			return
-		if(!isliving(M) || M.incorporeal_move || M.mob_size > MOB_SIZE_HUMAN || LAZYLEN(contents)>=5)
+		if(M.incorporeal_move || M.mob_size > MOB_SIZE_HUMAN || LAZYLEN(contents)>=5)
 			return ..()
 		M.forceMove(src)
 		return FALSE

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -386,7 +386,7 @@
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
 			qdel(src)
 			return
-		if(!isliving(M) || M.incorporeal_move || M.mob_size > MOB_SIZE_HUMAN)
+		if(!isliving(M) || M.incorporeal_move || M.mob_size > MOB_SIZE_HUMAN || LAZYLEN(contents)>=5)
 			return ..()
 		M.forceMove(src)
 		return FALSE

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -420,13 +420,14 @@
 /obj/structure/closet/decay/Initialize()
 	. = ..()
 	addtimer(CALLBACK(src, .proc/magicly_lock), 5)
+
 /obj/structure/closet/decay/proc/magicly_lock()
-	if(!welded)
+	if(welded)
+		addtimer(CALLBACK(src, .proc/bust_open), 5 MINUTES)
+		icon_state = magic_icon
+		update_icon()
+	else
 		addtimer(CALLBACK(src, .proc/decay), 15 SECONDS)
-		return
-	addtimer(CALLBACK(src, .proc/bust_open), 5 MINUTES)
-	icon_state = magic_icon
-	update_icon()
 
 /obj/structure/closet/decay/after_weld(weld_state)
 	if(weld_state)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -386,7 +386,7 @@
 			M.visible_message("<span class='warning'>[src] vanishes on contact with [A]!</span>")
 			qdel(src)
 			return
-		if(!isliving(M) || M.buckled || M.incorporeal_move || M.mob_size > MOB_SIZE_HUMAN)
+		if(!isliving(M) || M.incorporeal_move || M.mob_size > MOB_SIZE_HUMAN)
 			return ..()
 		M.forceMove(src)
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes known bugs with the locker staff like not putting mobs into locker at all as well as lockers that did not hit any mobs beeing useable to infinitly produce iron. This also includes some tweaks to the lockerstaff first of all there is a cap of 5 people for the lockerstaff now (trough this will be enforced at the bolt scooping people up and not at the locker) so that people above the lockercap are not just spawing ontop of the locker after it hits except those 3 poor random people that got stuck inside buckled people can also be sucked in either buckled on a chair or a vehicle or on a borg. Also lockers that spawn and did not scoop up any mobs will vanish after 18 seconds.
Also small refractor of locker staff code i guess.
closes #2516
## Why It's Good For The Game

Finally fixing lockerstaff and making it actually a usefull item for wizards again

## Changelog
:cl:
tweak: up to 5 mobs can end up in a cursed locker now
tweak: Lockers that did not scoop up any mobs vanish after 18 seconds
tweak: buckled mobs can be scooped up too(not AI)
fix: lockerstaff now actually putting people into lockers
fix: another infinit iron dublication glitch
refactor: deleting some unneeded code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
