### PR TITLE
Flux wave anomalies are now much rarer

### DIFF
--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -2,9 +2,9 @@
 	name = "Anomaly: Hyper-Energetic Flux"
 	typepath = /datum/round_event/anomaly/anomaly_flux
 
-	min_players = 10
+	min_players = 40
 	max_occurrences = 5
-	weight = 20
+	weight = 5
 
 /datum/round_event/anomaly/anomaly_flux
 	startWhen = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Decreased weight on the flux wave anomaly event. Also upped the pop requirement to 40 players.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These happen WAAAAY too often. They end in a large explosion, unless defused, and in the majority of cases they are not. 
Nobody likes them and nobody will miss them. A competent (or incompetent) engineer can make unexplosive variants from the supermatter. 
Every time one of these explodes, it is either a shuttle call because engineers are doing whatever they are doing instead of fixing the hole, or.... A shuttle call because the explosion damaged some of the departments to the point where all the employees are just tiding because their workplace is ruined.
Add in monstermos that just sucks all the air in the breach and goodbye.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Flux anomalies are now much more rare.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
