### PR TITLE
you can now VV atoms with invalid icons

### DIFF
--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -28,7 +28,8 @@
 	if(istype(D, /atom))
 		sprite = getFlatIcon(D)
 		hash = md5(sprite)
-		src << browse_rsc(sprite, "vv[hash].png")
+		if(hash) //Fixes VV shitting it's pants if the icon isn't valid
+			src << browse_rsc(sprite, "vv[hash].png")
 
 	title = "[D] ([REF(D)]) = [type]"
 	var/formatted_type = replacetext("[type]", "/", "<wbr>/")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

atoms with invalid/empty icons caused a runtime from a null hash.

## Why It's Good For The Game

now it doesn't

## Changelog
:cl:
admin: VV now works more reliably
fix: VV can now show the panel of objects with invalid iconstates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
