### PR TITLE
Adds a new traitor objective: bankrupt

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -956,6 +956,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		/datum/objective/survive,
 		/datum/objective/martyr,
 		/datum/objective/steal,
+		/datum/objective/bankrupt,
 		/datum/objective/download,
 		/datum/objective/nuclear,
 		/datum/objective/capture,

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -689,6 +689,31 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		target_amount = count
 	update_explanation_text()
 
+/datum/objective/bankrupt
+	name = "bankrupt"
+	target_amount = 1000
+	var/target_department = ACCOUNT_CAR
+
+/datum/objective/bankrupt/update_explanation_text()
+	..()
+	explanation_text = "Bankrupt the station by ensuring the [SSeconomy.department_accounts[target_department]] has less than [target_amount] credits at the end of the shift."
+
+/datum/objective/bankrupt/check_completion()
+	var/datum/bank_account/D = SSeconomy.get_dep_account(target_department)
+	if(isnull(D) || D.account_balance <= target_amount)
+		return TRUE
+
+	return FALSE
+
+/datum/objective/bankrupt/admin_edit(mob/admin)
+	var/dep_choice = input(admin, "Which target department?", "Department Selection") as null|anything in SSeconomy.department_accounts
+	if(dep_choice)
+		target_department = dep_choice
+	var/amount = input(admin,"What is the target amount?","Target Amount", target_amount) as num|null
+	if(amount)
+		target_amount = amount
+	update_explanation_text()
+
 /datum/objective/capture
 	name = "capture"
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -163,6 +163,12 @@
 			download_objective.owner = owner
 			download_objective.gen_amount_goal()
 			add_objective(download_objective)
+
+		else if(prob(15) && !(locate(/datum/objective/bankrupt) in objectives) && !(owner.assigned_role in list("Captain", "Head of Personnel", "Quartermaster")))
+			var/datum/objective/bankrupt/bankrupt_objective = new
+			bankrupt_objective.owner = owner
+			add_objective(bankrupt_objective)
+
 		else
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = owner


### PR DESCRIPTION
Adds a new traitor objective: bankrupt. The traitor must ensure the target department (currently only cargo, but admins can edit it) ends the round with less than 1000 credits in their department account.

## Changelog
:cl:
add: New traitor objective: bankrupt. Ensure the target department ends the round with less than 1000 credits in its department account.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
