### PR TITLE
Unlicensed PDA starts with charcoal stylus in

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -228,6 +228,7 @@
 	desc = "A shitty knockoff of a portable microcomputer by Thinktronic Systems, LTD. Complete with a cracked operating system."
 	note = "Error: Unlicensed OS. Please contact your supervisor."
 	icon_state = "pda-knockoff"
+	inserted_item = /obj/item/pen/charcoal
 
 /obj/item/pda/celebrity
 	name = "fancy PDA"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now that https://github.com/BeeStation/BeeStation-Hornet/pull/3039 is merged I thought itd be nice if the charcoal stylus got some more use so this PR adds it to the unlicensed PDA, which is given to the gimmick roles round start. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Using an item that is already in the code is always good and having the ghetto pen in the unofficial PDA works thematically and helps MRPers with their _i m m e r s i o n_
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Alt_Alpha9
tweak: Unlicensed PDA now has a charcoal stylus instead of those fancy pens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
