### PR TITLE
Removes Forward Slashes From Warden Alt Jacket Description

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -73,7 +73,7 @@
 
 /obj/item/clothing/suit/armor/vest/warden
 	name = "warden's jacket"
-	desc = "A navy-blue armored jacket with blue shoulder designations and '/Warden/' stitched into one of the chest pockets."
+	desc = "A navy-blue armored jacket with blue shoulder designations and 'Warden' stitched into one of the chest pockets."
 	icon_state = "warden_alt"
 	item_state = "armor"
 	body_parts_covered = CHEST|GROIN|ARMS


### PR DESCRIPTION
Either this was a weird stylistic choice, or a typo with escape characters, which weren't needed to begin with.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes what I believe may be a typo with escape characters in an item description.

Before:
![WardenTypo](https://user-images.githubusercontent.com/68963748/101287593-21c87a80-37bf-11eb-8631-d9622372e85b.png)

After:
![WardenTypoAfter](https://user-images.githubusercontent.com/68963748/101287598-2bea7900-37bf-11eb-8bf9-c55c344fc4ef.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a typo. This is a very simple PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
fix: Fixed a typo on Warden's blue jacket description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
