### PR TITLE
Nerfs bumpslams

### DIFF
--- a/code/__DEFINES/_mob_properties.dm
+++ b/code/__DEFINES/_mob_properties.dm
@@ -166,6 +166,7 @@ To remove:
 */
 
 #define PROP_CANTMOVE(x) x("cantmove", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE) // Currently-unused example
+#define PROP_CANTBUMPSLAM(x) x("cantbumpslam", APPLY_MOB_PROPERTY_SIMPLE, REMOVE_MOB_PROPERTY_SIMPLE) // Used in /mob/living/Bump(atom/A) to have a bumpslam cooldown without another mob var
 
 // In lieu of comments, these are the indexes used for list access in the macros below.
 #define MOB_PROPERTY_ACTIVE_VALUE 1

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -53,6 +53,9 @@
 /mob/living/proc/OpenCraftingMenu()
 	return
 
+/mob/living/proc/can_bumpslam()
+	REMOVE_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type)
+
 //Generic Bump(). Override MobBump() and ObjBump() instead of this.
 /mob/living/Bump(atom/A)
 	if(..()) //we are thrown onto something
@@ -60,11 +63,13 @@
 	if(buckled || now_pushing)
 		return
 	if(!ismovableatom(A) || is_blocked_turf(A))  // ported from VORE, sue me
-		if((confused || is_blind()) && stat == CONSCIOUS && m_intent=="run" && mobility_flags & MOBILITY_STAND)
+		if((confused || is_blind()) && stat == CONSCIOUS && prob(10) && m_intent == "run" && (mobility_flags & MOBILITY_STAND) && !HAS_MOB_PROPERTY(src, PROP_CANTBUMPSLAM))
 			playsound(get_turf(src), "punch", 25, 1, -1)
 			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
 			apply_damage(5, BRUTE)
 			Paralyze(40)
+			APPLY_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type)
+			addtimer(CALLBACK(src, .proc/can_bumpslam), 100)
 
 	if(ismob(A))
 		var/mob/M = A

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -62,15 +62,14 @@
 		return
 	if(buckled || now_pushing)
 		return
-	if(!ismovableatom(A) || is_blocked_turf(A))  // ported from VORE, sue me
-		if((confused || is_blind()) && stat == CONSCIOUS && m_intent == "run" && (mobility_flags & MOBILITY_STAND) && !HAS_MOB_PROPERTY(src, PROP_CANTBUMPSLAM))
-			if(prob(10))
-				playsound(get_turf(src), "punch", 25, 1, -1)
-				visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
-				apply_damage(5, BRUTE)
-				Paralyze(40)
-			APPLY_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type) //Bump() is called continuously so ratelimit the check to once every 5 seconds maximum
-			addtimer(CALLBACK(src, .proc/can_bumpslam), 50)
+	if((confused || is_blind()) && stat == CONSCIOUS && (mobility_flags & MOBILITY_STAND) && m_intent == "run" && (!ismovableatom(A) || is_blocked_turf(A)) && !HAS_MOB_PROPERTY(src, PROP_CANTBUMPSLAM))  // ported from VORE, sue me
+		if(prob(10))
+			playsound(get_turf(src), "punch", 25, 1, -1)
+			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
+			apply_damage(5, BRUTE)
+			Paralyze(40)
+		APPLY_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type) //Bump() is called continuously so ratelimit the check to once every 5 seconds maximum
+		addtimer(CALLBACK(src, .proc/can_bumpslam), 50)
 
 	if(ismob(A))
 		var/mob/M = A

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -63,13 +63,16 @@
 	if(buckled || now_pushing)
 		return
 	if((confused || is_blind()) && stat == CONSCIOUS && (mobility_flags & MOBILITY_STAND) && m_intent == "run" && (!ismovableatom(A) || is_blocked_turf(A)) && !HAS_MOB_PROPERTY(src, PROP_CANTBUMPSLAM))  // ported from VORE, sue me
+		APPLY_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type) //Bump() is called continuously so ratelimit the check to 20 seconds if it passes or 5 if it doesn't
 		if(prob(10))
 			playsound(get_turf(src), "punch", 25, 1, -1)
 			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
 			apply_damage(5, BRUTE)
 			Paralyze(40)
-		APPLY_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type) //Bump() is called continuously so ratelimit the check to once every 5 seconds maximum
-		addtimer(CALLBACK(src, .proc/can_bumpslam), 50)
+			addtimer(CALLBACK(src, .proc/can_bumpslam), 200)
+		else
+			addtimer(CALLBACK(src, .proc/can_bumpslam), 50)
+
 
 	if(ismob(A))
 		var/mob/M = A

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -63,13 +63,14 @@
 	if(buckled || now_pushing)
 		return
 	if(!ismovableatom(A) || is_blocked_turf(A))  // ported from VORE, sue me
-		if((confused || is_blind()) && stat == CONSCIOUS && prob(10) && m_intent == "run" && (mobility_flags & MOBILITY_STAND) && !HAS_MOB_PROPERTY(src, PROP_CANTBUMPSLAM))
-			playsound(get_turf(src), "punch", 25, 1, -1)
-			visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
-			apply_damage(5, BRUTE)
-			Paralyze(40)
-			APPLY_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type)
-			addtimer(CALLBACK(src, .proc/can_bumpslam), 100)
+		if((confused || is_blind()) && stat == CONSCIOUS && m_intent == "run" && (mobility_flags & MOBILITY_STAND) && !HAS_MOB_PROPERTY(src, PROP_CANTBUMPSLAM))
+			if(prob(10))
+				playsound(get_turf(src), "punch", 25, 1, -1)
+				visible_message("<span class='warning'>[src] [pick("ran", "slammed")] into \the [A]!</span>")
+				apply_damage(5, BRUTE)
+				Paralyze(40)
+			APPLY_MOB_PROPERTY(src, PROP_CANTBUMPSLAM, src.type) //Bump() is called continuously so ratelimit the check to once every 5 seconds maximum
+			addtimer(CALLBACK(src, .proc/can_bumpslam), 50)
 
 	if(ismob(A))
 		var/mob/M = A


### PR DESCRIPTION
This is really really stupid and Kev should be taken behind the shed and shot. Thanks to swept for bringing the stupidity to my attention.

Uses the new mob properties so I don't have to toss another cooldown var on mobs. Untested but should work fine as long as mob properties aren't broken.

## Changelog
:cl:
balance: Reduces bumpslams to a 10% chance. The 10% chance has a 5 second cooldown if it fails or a 20 second cooldown if it passes (aka you can't get bumpslammed successfully twice in 20 seconds).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
