### PR TITLE
Balance Power Usage

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -233,6 +233,7 @@
 		occupant.reagents.add_reagent(chem_buttons[chem], 10) //emag effect kicks in here so that the "intended" chem is used for all checks, for extra FUUU
 		if(user)
 			log_combat(user, occupant, "injected [chem] into", addition = "via [src]")
+		use_power(100)
 		return TRUE
 
 /obj/machinery/sleeper/proc/chem_allowed(chem)

--- a/code/game/machinery/autodoc.dm
+++ b/code/game/machinery/autodoc.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/machines/autodoc.dmi'
 	icon_state = "autodoc_machine"
 	verb_say = "states"
-	idle_power_usage = 50
+	idle_power_usage = 500
 	circuit = /obj/item/circuitboard/machine/autodoc
 	var/obj/item/organ/storedorgan
 	var/organ_type = /obj/item/organ
@@ -81,6 +81,7 @@
 		occupant.visible_message("<span class='notice'>[src] completes the surgery procedure.", "<span class='notice'>[src] inserts the organ into your body.</span>")
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, 0)
 	processing = FALSE
+	use_power(5000)
 	open_machine()
 
 /obj/machinery/autodoc/open_machine(mob/user)

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -340,7 +340,7 @@
 					var/obj/item/bodypart/BP = I
 					BP.attach_limb(mob_occupant)
 
-			use_power(7500) //This might need tweaking.
+			use_power(5000 * speed_coeff) //This might need tweaking.
 
 		else if(mob_occupant && (mob_occupant.cloneloss <= (100 - heal_level)))
 			connected_message("Cloning Process Complete.")

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -15,7 +15,7 @@
 /obj/machinery/mass_driver/proc/drive(amount)
 	if(stat & (BROKEN|NOPOWER))
 		return
-	use_power(500)
+	use_power(1000)
 	var/O_limit
 	var/atom/target = get_edge_target_turf(src, dir)
 	for(var/atom/movable/O in loc)
@@ -26,7 +26,7 @@
 			if(O_limit >= 20)
 				audible_message("<span class='notice'>[src] lets out a screech, it doesn't seem to be able to handle the load.</span>")
 				break
-			use_power(500)
+			use_power(1000)
 			O.throw_at(target, drive_range * power, power)
 	flick("mass_driver1", src)
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -13,8 +13,8 @@
 	density = TRUE
 	desc = "A covered turret that shoots at its enemies."
 	use_power = IDLE_POWER_USE				//this turret uses and requires power
-	idle_power_usage = 50		//when inactive, this turret takes up constant 50 Equipment power
-	active_power_usage = 300	//when active, this turret takes up constant 300 Equipment power
+	idle_power_usage = 100		//when inactive, this turret takes up constant 50 Equipment power
+	active_power_usage = 600	//when active, this turret takes up constant 300 Equipment power
 	req_access = list(ACCESS_SEC_DOORS)
 	power_channel = AREA_USAGE_EQUIP	//drains power from the EQUIPMENT channel
 

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -5,7 +5,7 @@
 	desc = "A charging dock for energy based weaponry."
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 4
-	active_power_usage = 250
+	active_power_usage = 300
 	circuit = /obj/item/circuitboard/machine/recharger
 	pass_flags = PASSTABLE
 	var/obj/item/charging = null
@@ -125,7 +125,7 @@
 		if(C)
 			if(C.charge < C.maxcharge)
 				C.give(C.chargerate * recharge_coeff)
-				use_power(250 * recharge_coeff)
+				use_power(300 * recharge_coeff)
 				using_power = 1
 			update_icon(using_power)
 
@@ -133,7 +133,7 @@
 			var/obj/item/ammo_box/magazine/recharge/R = charging
 			if(R.stored_ammo.len < R.max_ammo)
 				R.stored_ammo += new R.ammo_type(R)
-				use_power(200 * recharge_coeff)
+				use_power(250 * recharge_coeff)
 				using_power = 1
 			update_icon(using_power)
 			return

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -8,6 +8,8 @@
 	layer = ABOVE_ALL_MOB_LAYER // Overhead
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/recycler
+	idle_power_usage = 50
+	active_power_usage = 200
 	var/safety_mode = FALSE // Temporarily stops machine if it detects a mob
 	var/icon_name = "grinder-o"
 	var/blood = 0

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -8,8 +8,8 @@
 	can_buckle = TRUE
 	buckle_lying = 90
 	circuit = /obj/item/circuitboard/machine/stasis
-	idle_power_usage = 40
-	active_power_usage = 340
+	idle_power_usage = 50
+	active_power_usage = 500
 	fair_market_price = 10
 	payment_department = ACCOUNT_MED
 	var/stasis_enabled = TRUE

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -9,7 +9,7 @@
 	icon_state = "tele0"
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
-	active_power_usage = 2000
+	active_power_usage = 3000
 	circuit = /obj/item/circuitboard/machine/teleporter_hub
 	var/accuracy = 0
 	var/obj/machinery/teleport/station/power_station
@@ -72,7 +72,7 @@
 		return
 	if (ismovableatom(M))
 		if(do_teleport(M, com.target, channel = TELEPORT_CHANNEL_BLUESPACE))
-			use_power(5000)
+			use_power(7500)
 			if(!calibrated && prob(30 - ((accuracy) * 10))) //oh dear a problem
 				log_game("[M] ([key_name(M)]) was turned into a fly person")
 				if(ishuman(M))//don't remove people from the round randomly you jerks

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -209,6 +209,8 @@
 			if(++reagent_transfer >= 10 * efficiency) // Throttle reagent transfer (higher efficiency will transfer the same amount but consume less from the beaker).
 				reagent_transfer = 0
 
+		use_power(1000 * efficiency)
+
 	return 1
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos()

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -26,7 +26,7 @@
 	var/broken = FALSE
 	var/broken_message = "ERROR"
 	idle_power_usage = 150
-	active_power_usage = 2000
+	active_power_usage = 3000
 
 /obj/machinery/atmospherics/miner/Initialize()
 	. = ..()

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/plumbing/plumbers.dmi'
 	icon_state = "pump"
 	density = TRUE
-	active_power_usage = 30
+	active_power_usage = 45
 	use_power = ACTIVE_POWER_USE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	///Plumbing machinery is always gonna need reagents, so we might aswell put it here

--- a/code/modules/plumbing/plumbers/destroyer.dm
+++ b/code/modules/plumbing/plumbers/destroyer.dm
@@ -2,6 +2,7 @@
 	name = "chemical disposer"
 	desc = "Breaks down chemicals and annihilates them."
 	icon_state = "disposal"
+	active_power_usage = 70
 	///we remove 10 reagents per second
 	var/disposal_rate = 10
 

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -7,6 +7,7 @@
 	rcd_cost = 30
 	rcd_delay = 30
 	buffer = 400
+	active_power_usage = 80
 	var/eat_dir = SOUTH
 
 /obj/machinery/plumbing/grinder_chemical/Initialize(mapload, bolt)

--- a/code/modules/plumbing/plumbers/patch_dispenser.dm
+++ b/code/modules/plumbing/plumbers/patch_dispenser.dm
@@ -3,6 +3,8 @@
 	name = "patch dispenser"
 	desc = "A dispenser that dispenses patches."
 	icon_state = "pill_press" //TODO SPRITE IT !!!!!!
+	active_power_usage = 80
+
 	var/patch_name = "factory patch"
 	var/patch_size = 40
 	///the icon_state number for the patch.

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -3,6 +3,7 @@
 	name = "pill press"
 	desc = "A press that presses pills."
 	icon_state = "pill_press"
+	active_power_usage = 100
 	///the minimum size a pill can be
 	var/minimum_pill = 5
 	///the maximum size a pill can be

--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/plumbing/plumbers.dmi'
 	rcd_cost = 25
 	rcd_delay = 15
+	active_power_usage = 500
 
 	///Amount we produce for every process. Ideally keep under 5 since thats currently the standard duct capacity
 	var/amount = 1

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -16,7 +16,7 @@
 
 	use_power = NO_POWER_USE
 	idle_power_usage = 10
-	active_power_usage = 300
+	active_power_usage = 600
 
 	var/icon_state_on = "emitter_+a"
 	var/icon_state_underpowered = "emitter_+u"

--- a/code/modules/research/nanites/nanite_chamber.dm
+++ b/code/modules/research/nanites/nanite_chamber.dm
@@ -8,8 +8,8 @@
 	use_power = IDLE_POWER_USE
 	anchored = TRUE
 	density = TRUE
-	idle_power_usage = 50
-	active_power_usage = 300
+	idle_power_usage = 300
+	active_power_usage = 1200
 
 	var/obj/machinery/computer/nanite_chamber_control/console
 	var/locked = FALSE

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -8,8 +8,8 @@
 	use_power = IDLE_POWER_USE
 	anchored = TRUE
 	density = TRUE
-	idle_power_usage = 50
-	active_power_usage = 300
+	idle_power_usage = 300
+	active_power_usage = 1200
 
 	var/cloud_id = 1
 	var/locked = FALSE


### PR DESCRIPTION
## About The Pull Request

In response to DurrHurrDurr's want for a power usage curved with upgrades. This aims to increase power usage across advanced machinery that makes the game a lot easier or more simplified. The idea is that as the station becomes more advanced, engineering will have to pump out more power to support it, actually giving a reason for complicated engine setups.

Basic list of things affected so far, and I'd love suggestions for things to edit.

- Sleepers use power when you inject chems
- Cloners use more power the more upgraded they are
- Portable turrets use more power
- Cryo cells use power at all, and it correlates with their efficiency
- Gas miners use more power
- All plumbing machinery uses more power
- Emitters use more power
- Nanite chambers use more power
- Autodoc
- Mass Driver
- Recylcer
- Stasis Beds
- Rechargers
- Teleporters

## Why It's Good For The Game

Balance is good and it's good to have a reason to do things at all.

## Changelog
:cl:
balance: Power usage gameplay difficulty curve
/:cl:
