### PR TITLE
Adjusts Bananium to Actually Spawn

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -184,7 +184,7 @@
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium = 2, /turf/closed/mineral/diamond = 1, /turf/closed/mineral/gold = 4, /turf/closed/mineral/titanium = 4,
 		/turf/closed/mineral/silver = 6, /turf/closed/mineral/copper = 6, /turf/closed/mineral/plasma = 15, /turf/closed/mineral/iron = 40,
-		/turf/closed/mineral/gibtonite = 2, /turf/closed/mineral/bscrystal = 1)
+		/turf/closed/mineral/gibtonite = 2, /turf/closed/mineral/bananium = 2, /turf/closed/mineral/bscrystal = 1)
 
 
 /turf/closed/mineral/random/volcanic
@@ -363,8 +363,8 @@
 /turf/closed/mineral/bananium
 	mineralType = /obj/item/stack/ore/bananium
 	mineralAmt = 3
-	spreadChance = 0
-	spread = 0
+	spreadChance = 5
+	spread = 1
 	scan_state = "rock_Bananium"
 
 


### PR DESCRIPTION
Bananium is as common as Gibtonite now. Adjusts Spread a bit.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out Bananium didn't get added to the spawn list. I have changed this to make it a rarer spawn(roughly in line with Gibtonite)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Loll111/Derpling noted that due to Bananium's rarity, it was sad to never see clown gear made. This is meant to change that. Now clown stuff is possible to make, given miners are willing to gather enough of it, and science researches the tech for it, roboticists make and assemble it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:DatBoiTim
add: Added bananium to low_chance spawn pools with a weight identical to gibtonite within said pool.
tweak: Adjusted Bananium mineral spread chance and spread range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
