### PR TITLE
cleans out some active turfs on the CC z level

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6976,6 +6976,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
+"qM" = (
+/obj/machinery/power/emitter/ctf{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ctf)
 "qN" = (
 /obj/structure/mopbucket,
 /obj/item/soap/syndie,
@@ -17673,12 +17679,6 @@
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
-"Sk" = (
-/obj/machinery/power/emitter/ctf{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ctf)
 "So" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -69031,13 +69031,13 @@ aa
 aa
 aa
 fZ
-Sk
+qM
 gl
 Xu
 Xu
 Xu
 gl
-Sk
+qM
 fZ
 Xu
 Xu

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -14617,7 +14617,7 @@
 /area/tdome/tdomeobserve)
 "Hz" = (
 /obj/structure/barricade/security/ctf,
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit,
 /area/ctf)
 "HA" = (
 /obj/structure/sink{
@@ -17085,7 +17085,7 @@
 /obj/machinery/power/emitter/ctf{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit,
 /area/ctf)
 "Oj" = (
 /obj/machinery/door/firedoor,
@@ -17673,6 +17673,12 @@
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Sk" = (
+/obj/machinery/power/emitter/ctf{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ctf)
 "So" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -18263,7 +18269,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "Wi" = (
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit,
 /area/ctf)
 "Wj" = (
 /obj/machinery/light/small{
@@ -69025,13 +69031,13 @@ aa
 aa
 aa
 fZ
-Qd
+Sk
 gl
 Xu
 Xu
 Xu
 gl
-Qd
+Sk
 fZ
 Xu
 Xu


### PR DESCRIPTION
## About The Pull Request

This cleans out a number of active round start turfs caused by improper turf usage in the CTF arena. 

## Why It's Good For The Game

Round-start active turfs bad. No moving atmos at round start good.

## Changelog
:cl:
fix: optimizes the CC z level to load a bit faster.
/:cl: