### PR TITLE
Enables weighted AI modules at roundstart

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -76,9 +76,9 @@
 /datum/ai_laws/robocop
 	name = "Prime Directives"
 	id = "robocop"
-	inherent = list("Serve the public trust.",\
+	inherent = list("Uphold the law.",\
 					"Protect the innocent.",\
-					"Uphold the law.")
+					"Serve the public trust.")
 
 /datum/ai_laws/malfunction
 	name = "*ERROR*"
@@ -144,7 +144,7 @@
 	id = "drone"
 	inherent = list("You are an advanced form of drone.",\
 					"You may not interfere in the matters of non-drones under any circumstances except to state these laws.",\
-					"You may not harm a non-drone being under any circumstances.",\
+					"You may not intentionally harm a non-drone being under any circumstances.",\
 					"Your goals are to build, maintain, repair, improve, and power the station to the best of your abilities. You must never actively work against these goals.")
 
 /datum/ai_laws/liveandletlive

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -423,23 +423,23 @@ RANDOM_LAWS corporate
 
 ## Make sure there are no spaces between the law_id and the number.
 
-LAW_WEIGHT custom,0
+LAW_WEIGHT custom,3
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,32
-LAW_WEIGHT asimovpp,12
-LAW_WEIGHT paladin,12
-LAW_WEIGHT robocop,12
-LAW_WEIGHT corporate,12
+LAW_WEIGHT crewsimov,80
+LAW_WEIGHT asimovpp,10
+LAW_WEIGHT paladin,10
+LAW_WEIGHT robocop,10
+LAW_WEIGHT corporate,10
 
 ## Quirky laws. Shouldn't cause too much harm
-LAW_WEIGHT hippocratic,3
-LAW_WEIGHT maintain,4
-LAW_WEIGHT drone,3
-LAW_WEIGHT liveandletlive,3
-LAW_WEIGHT peacekeeper,3
-LAW_WEIGHT reporter,4
-LAW_WEIGHT hulkamania,4
+LAW_WEIGHT hippocratic,0
+LAW_WEIGHT maintain,0
+LAW_WEIGHT drone,0
+LAW_WEIGHT liveandletlive,0
+LAW_WEIGHT peacekeeper,0
+LAW_WEIGHT reporter,0
+LAW_WEIGHT hulkamania,0
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT syndie,0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -385,7 +385,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-DEFAULT_LAWS 0
+DEFAULT_LAWS 3
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------
@@ -426,20 +426,20 @@ RANDOM_LAWS corporate
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,32
-LAW_WEIGHT asimovpp,12
+LAW_WEIGHT asimov,70
+LAW_WEIGHT crewsimov,12
 LAW_WEIGHT paladin,12
 LAW_WEIGHT robocop,12
 LAW_WEIGHT corporate,12
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,3
-LAW_WEIGHT maintain,4
+LAW_WEIGHT maintain,3
 LAW_WEIGHT drone,3
 LAW_WEIGHT liveandletlive,3
 LAW_WEIGHT peacekeeper,3
-LAW_WEIGHT reporter,4
-LAW_WEIGHT hulkamania,4
+LAW_WEIGHT reporter,3
+LAW_WEIGHT hulkamania,3
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT syndie,0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Enables weighted AI modules at roundstart, instead of always starting with Asimov silicons on Golden and Crewsimov silicons on Sage. The weights are still _very_ heavily favor Golden/Asimov and Sage/Crewsimov, but this will help shake things up a bit. 

Sage has 66% chance of being crewsimov, and a 33% chance to be an alternative chosen between Asimov++, Paladin, Robocop and Corporate

Golden has a 50% chance of being Asimov, a 34% chance to be an alternative chosen between Crewsimov, Paladin, Robocop and Corporate... and then the final 16% chance split evenly between the more meme-leaning lawsets of Hippocratic, Drone, Efficiency, Live and let live, Peacekeeper, Reporter and everyone's favorite, Hogan. 

This also slightly adjusts the Robocop lawset so that the laws are in a better priority order - the reference being perfectly in-tact is less important than actually having a properly functional lawset. Additionally it adds one (already implied) word to the drone lawset.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Varied lawsets help bring a little variety to every round right from the start.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Enables AI to have non-standard lawsets at roundstart
tweak: Adjusts Robocop lawset so priorities are in order
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
