### PR TITLE
Decal fixes

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -140,6 +140,7 @@
 #define COMSIG_TURF_CHANGE "turf_change"						//! from base of turf/ChangeTurf(): (path, list/new_baseturfs, flags, list/transferring_comps)
 #define COMSIG_TURF_HAS_GRAVITY "turf_has_gravity"				//! from base of atom/has_gravity(): (atom/asker, list/forced_gravities)
 #define COMSIG_TURF_MULTIZ_NEW "turf_multiz_new"				//! from base of turf/New(): (turf/source, direction)
+#define COMSIG_TURF_AFTER_SHUTTLE_MOVE "turf_after_shuttle_move"	//! from base of turf/proc/afterShuttleMove: (turf/new_turf)
 
 // /atom/movable signals
 #define COMSIG_MOVABLE_PRE_MOVE "movable_pre_move"				//! from base of atom/movable/Moved(): (/atom)

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -179,4 +179,6 @@
 		return
 	if(!length(blood_DNA))
 		return
-	parent.AddElement(/datum/element/decal/blood)
+	if(isitem(parent))
+		var/obj/item/I = parent
+		I.AddElement(/datum/element/decal/blood, initial(I.icon) || I.icon, initial(I.icon_state) || I.icon_state)

--- a/code/datums/elements/decal.dm
+++ b/code/datums/elements/decal.dm
@@ -4,15 +4,26 @@
 	var/cleanable
 	var/description
 	var/mutable_appearance/pic
+	/**
+	 *  A short lecture on decal element collision on rotation
+	 *  If a given decal's rotated version is identical to one of existing (at a same target), pre-rotation decals,
+	 *  then the rotated decal won't stay after when the colliding pre-rotation decal gets rotated,
+	 *  resulting in some decal elements colliding into nonexistence. This internal tick-tock prevents
+	 *  such collision by forcing a non-collision.
+	 */
+	var/rotated
 
-/datum/element/decal/Attach(atom/target, _icon, _icon_state, _dir, _cleanable=FALSE, _color, _layer=TURF_LAYER, _description, _alpha=255)
+/datum/element/decal/Attach(atom/target, _icon, _icon_state, _dir, _cleanable=FALSE, _color, _layer=TURF_LAYER, _description, _alpha=255, _rotated=FALSE)
 	. = ..()
-	if(!isatom(target) || !generate_appearance(_icon, _icon_state, _dir, _layer, _color, _alpha, target))
+	if(!isatom(target) || (pic ? FALSE : !generate_appearance(_icon, _icon_state, _dir, _layer, _color, _alpha, target)))
 		return ELEMENT_INCOMPATIBLE
 	description = _description
 	cleanable = _cleanable
+	rotated = _rotated
 
 	RegisterSignal(target,COMSIG_ATOM_UPDATE_OVERLAYS,.proc/apply_overlay, TRUE)
+	if(isturf(target))
+		RegisterSignal(target,COMSIG_TURF_AFTER_SHUTTLE_MOVE,.proc/shuttlemove_react, TRUE)
 	if(target.flags_1 & INITIALIZED_1)
 		target.update_icon() //could use some queuing here now maybe.
 	else
@@ -36,7 +47,7 @@
 	return TRUE
 
 /datum/element/decal/Detach(atom/source, force)
-	UnregisterSignal(source, list(COMSIG_ATOM_DIR_CHANGE, COMSIG_COMPONENT_CLEAN_ACT, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_OVERLAYS))
+	UnregisterSignal(source, list(COMSIG_ATOM_DIR_CHANGE, COMSIG_COMPONENT_CLEAN_ACT, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_OVERLAYS,COMSIG_TURF_AFTER_SHUTTLE_MOVE))
 	source.update_icon()
 	if(isitem(source))
 		INVOKE_ASYNC(source, /obj/item/.proc/update_slot_icon)
@@ -55,6 +66,10 @@
 
 	overlay_list += pic
 
+/datum/element/decal/proc/shuttlemove_react(datum/source, turf/newT)
+	SIGNAL_HANDLER
+	Detach(source)
+	newT.AddElement(/datum/element/decal, pic.icon, pic.icon_state, pic.dir, cleanable, pic.color, pic.layer, description, pic.alpha, rotated)
 
 /datum/element/decal/proc/rotate_react(datum/source, old_dir, new_dir)
 	SIGNAL_HANDLER
@@ -62,7 +77,7 @@
 	if(old_dir == new_dir)
 		return
 	Detach(source)
-	source.AddElement(/datum/element/decal, pic.icon, pic.icon_state, new_dir, cleanable, pic.color, pic.layer, description, pic.alpha)
+	source.AddElement(/datum/element/decal, pic.icon, pic.icon_state, angle2dir(dir2angle(pic.dir)+dir2angle(new_dir)-dir2angle(old_dir)), cleanable, pic.color, pic.layer, description, pic.alpha, !rotated)
 
 /datum/element/decal/proc/clean_react(datum/source, clean_types)
 	SIGNAL_HANDLER

--- a/code/datums/elements/decals/blood.dm
+++ b/code/datums/elements/decals/blood.dm
@@ -1,5 +1,11 @@
 /datum/element/decal/blood
 
+/**
+  * If you are annoyed by lack of blood decal visuals?
+  * Then here's a TODO for you: rework the entire update_icon() family to make COMSIG_ATOM_UPDATE_OVERLAYS and update_overlays() work!
+  * Until the rework, blood decal visuals might not work on some items... (but the name change will work, though)
+  */
+
 /datum/element/decal/blood/Attach(datum/target, _icon, _icon_state, _dir, _cleanable=CLEAN_STRENGTH_BLOOD, _color, _layer=ABOVE_OBJ_LAYER)
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
@@ -13,28 +19,12 @@
 	return ..()
 
 /datum/element/decal/blood/generate_appearance(_icon, _icon_state, _dir, _layer, _color, _alpha, source)
-	var/obj/item/I = source
-	if(!_icon)
-		_icon = 'icons/effects/blood.dmi'
-	if(!_icon_state)
-		_icon_state = "itemblood"
-	var/icon = initial(I.icon)
-	var/icon_state = initial(I.icon_state)
-	if(!icon || !icon_state)
-		// It's something which takes on the look of other items, probably
-		icon = I.icon
-		icon_state = I.icon_state
-	var/static/list/blood_splatter_appearances = list()
-	//try to find a pre-processed blood-splatter. otherwise, make a new one
-	var/index = "[REF(icon)]-[icon_state]"
-	pic = blood_splatter_appearances[index]
-
-	if(!pic)
-		var/icon/blood_splatter_icon = icon(initial(I.icon), initial(I.icon_state), , 1)		//we only want to apply blood-splatters to the initial icon_state for each object
-		blood_splatter_icon.Blend("#fff", ICON_ADD) 			//fills the icon_state with white (except where it's transparent)
-		blood_splatter_icon.Blend(icon(_icon, _icon_state), ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
-		pic = mutable_appearance(blood_splatter_icon, initial(I.icon_state))
-		blood_splatter_appearances[index] = pic
+	if(!_icon || !_icon_state)
+		return FALSE
+	var/icon/blood_splatter_icon = icon(_icon, _icon_state, , 1)		//we only want to apply blood-splatters to the initial icon_state for each object
+	blood_splatter_icon.Blend("#fff", ICON_ADD) 			//fills the icon_state with white (except where it's transparent)
+	blood_splatter_icon.Blend(icon('icons/effects/blood.dmi', "itemblood"), ICON_MULTIPLY) //adds blood and the remaining white areas become transparant
+	pic = mutable_appearance(blood_splatter_icon)
 	return TRUE
 
 /datum/element/decal/blood/proc/get_examine_name(datum/source, mob/user, list/override)

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -45,4 +45,4 @@
 	var/turf/T = loc
 	if(!istype(T)) //you know this will happen somehow
 		CRASH("Turf decal initialized in an object/nullspace")
-	T.AddElement(/datum/element/decal, icon, icon_state, dir, FALSE, color, null, null, alpha)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, FALSE, color, null, null, alpha, FALSE)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -69,6 +69,7 @@ All ShuttleMove procs go here
 /turf/proc/afterShuttleMove(turf/oldT, rotation)
 	//Dealing with the turf we left behind
 	oldT.TransferComponents(src)
+	SEND_SIGNAL(oldT, COMSIG_TURF_AFTER_SHUTTLE_MOVE, src) //Mostly for decals
 	var/shuttle_boundary = baseturfs.Find(/turf/baseturf_skipover/shuttle)
 	if(shuttle_boundary)
 		oldT.ScrapeAway(baseturfs.len - shuttle_boundary + 1, flags = CHANGETURF_FORCEOP)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Decal elements now generate appearance only once, i.e. at the first Attach() call; They are bespoke elements so every decal element datum can have a predetermined appearance.
2. Shuttle movements are now handled properly via a new `COMSIG_TURF_AFTER_SHUTTLE_MOVE` signal.
3. Decal rotation handling now works, but it adds another argument and var, `rotated`, to decal element. If this solution turns out to cause too much overhead, we can spam `addtimer`, which obviously incurs additional cost on rotation, but is more elegant if we assume perfect `SStimer`. _To be honest, I still can't decide which is a better solution. Please let me know if you have opinions on it._
4. Item blood decals are slightly(?) reworked to work a bit more consistently. The greatest problem now is `update_icon()`, `update_overlays()`, and `COMSIG_ATOM_UPDATE_OVERLAYS` system that is in partial use on tg but not in here, but item blood decals system needs it to be visual on every item: we need every `update_icon()` call on item to reach up to `atom/proc/update_icon()`. We can use a temporary solution but that'll be a *big* mess, so I will do the rework on items some day (read: a week later or never).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Floor decals are now a bit more fixed, hooray!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: improved decal performance
fix: decals no longer disappear on shuttle move
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
