### PR TITLE
More AT cleanup on CC and Lavaland Z Levels

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -839,7 +839,7 @@
 	roundstart_template = /datum/map_template/shuttle/science;
 	width = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland,
 /area/lavaland/surface/outdoors)
 "dv" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -5906,7 +5906,7 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "Uh" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/lavaland,
 /area/lavaland/surface/outdoors)
 "Un" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6976,6 +6976,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
+"qM" = (
+/obj/machinery/power/emitter/ctf{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ctf)
 "qN" = (
 /obj/structure/mopbucket,
 /obj/item/soap/syndie,
@@ -17673,12 +17679,6 @@
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
-"Sk" = (
-/obj/machinery/power/emitter/ctf{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ctf)
 "So" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -69031,13 +69031,13 @@ aa
 aa
 aa
 fZ
-Sk
+qM
 gl
 Xu
 Xu
 Xu
 gl
-Sk
+qM
 fZ
 Xu
 Xu

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -17370,12 +17370,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"Qd" = (
-/obj/machinery/power/emitter/ctf{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms,
-/area/ctf)
 "Qe" = (
 /turf/open/ai_visible,
 /area/ai_multicam_room)
@@ -83186,9 +83180,9 @@ gA
 gR
 gR
 fZ
-Qd
+qM
 hC
-Qd
+qM
 fZ
 aa
 aa
@@ -83958,7 +83952,7 @@ gR
 gR
 fZ
 fZ
-Qd
+qM
 fZ
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -14617,7 +14617,7 @@
 /area/tdome/tdomeobserve)
 "Hz" = (
 /obj/structure/barricade/security/ctf,
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit,
 /area/ctf)
 "HA" = (
 /obj/structure/sink{
@@ -17085,7 +17085,7 @@
 /obj/machinery/power/emitter/ctf{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit,
 /area/ctf)
 "Oj" = (
 /obj/machinery/door/firedoor,
@@ -17673,6 +17673,12 @@
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Sk" = (
+/obj/machinery/power/emitter/ctf{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ctf)
 "So" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -18263,7 +18269,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "Wi" = (
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit,
 /area/ctf)
 "Wj" = (
 /obj/machinery/light/small{
@@ -69025,13 +69031,13 @@ aa
 aa
 aa
 fZ
-Qd
+Sk
 gl
 Xu
 Xu
 Xu
 gl
-Qd
+Sk
 fZ
 Xu
 Xu

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -3,6 +3,10 @@
 	icon_state = "plating"
 	initial_gas_mix = AIRLESS_ATMOS
 
+/turf/open/floor/plating/lavaland
+	icon_state = "plating"
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+
 /turf/open/floor/plating/abductor
 	name = "alien floor"
 	icon_state = "alienpod1"


### PR DESCRIPTION
## About The Pull Request

Creates a plating turf that starts with lavaland atmos for the science shuttle dock, and cleans up a few active turfs on the CC z level that I missed with #3105. 

## Why It's Good For The Game

As mentioned in 3105, active turfs bad. Changelog not required because it does basically the same thing as 3105, which had a changelog entry. If you really want one I can write up one really quick.

## Changelog


