### PR TITLE
Fix Cult floor now actually atmos proof

### DIFF
--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -110,14 +110,6 @@
 /turf/open/floor/plasteel/cult
 	icon_state = "cult"
 	name = "engraved floor"
-	CanAtmosPass = ATMOS_PASS_NO	
-	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-	
-/turf/open/floor/plasteel/cult/Initialize()
-	..()
-	var/datum/gas_mixture/auto_atmos = new (initial_gas_mix)
-	assume_air(auto_atmos)
-	update_air_ref()
 
 /turf/open/floor/plasteel/vaporwave
 	icon_state = "pinkblack"

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -153,6 +153,7 @@
 	icon_state = "plating"
 	floor_tile = null
 	var/obj/effect/clockwork/overlay/floor/bloodcult/realappearance
+	CanAtmosPass = ATMOS_PASS_NO
 
 
 /turf/open/floor/engine/cult/Initialize()

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -154,6 +154,7 @@
 	floor_tile = null
 	var/obj/effect/clockwork/overlay/floor/bloodcult/realappearance
 	CanAtmosPass = ATMOS_PASS_NO
+	CanAtmosPassVertical =	ATMOS_PASS_NO
 
 
 /turf/open/floor/engine/cult/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just a bit ago there was a PR similar to this but it got closed again for some reason.
Makes Cultfloor atmos proof again trough using CanAtmosPass = ATMOS_PASS_NO note trough this does not make the turf itself atmos proof you can still remove the CanAtmosPass = ATMOS_PASS_NO from the turf by simply deconstructing the cult floor(using a wrench).
Only problem with this is that the CO2 on a turf that currently has a cult floor is trapped there and slowly rising as people use up the O2. But given how long cult rounds usually take this should not become a problem not more than the normal scrubber only filter out co2 and vents replace it with n2 o2 mix that slowly deludes the o2 in an area thing anyway
closes #2259
Note the floor edited by https://github.com/BeeStation/BeeStation-Hornet/pull/2988 is not the cult floor that is us by cult its used in the map files so it does not really change anything for cult rounds the reason why there are two types of cult floors is beyond me trough. Also partially reverts  https://github.com/BeeStation/BeeStation-Hornet/pull/2988 now
## Why It's Good For The Game

This was a problem since the first introduction of monstmos and really should be fixed
## Changelog
:cl:
fix: cult floor is atmos proof again
tweak: makes space ruin version of cult floor non atmos proof again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
