### PR TITLE
Captain can no longer get midround special antag lmao

### DIFF
--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -46,7 +46,7 @@
 	E.antagonist_datum = attached_antag_datum
 	E.antag_name = role_name
 	E.preference_type = preference_type
-	E.protected_jobs = restricted_jobs
+	E.protected_jobs = protected_jobs + restricted_jobs
 	E.typepath = /datum/round_event/create_special_antag
 	E.weight = weight
 	E.holidayID = holidayID


### PR DESCRIPTION
## About The Pull Request
Title
PowerfulBacon moment.
Turns out, the only protected role from midrounds become the mighty borg. If this was intentional, it certainly wasn't mentioned.

## Why It's Good For The Game
Title

## Changelog
:cl:
fix: Protected roles no longer get midround antags
/:cl:
