### PR TITLE
Add solo abductors and fix abductor not knowing all surgerys

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -69,6 +69,15 @@
 	to_chat(owner.current, "<span class='notice'>[greet_text]</span>")
 	owner.announce_objectives()
 
+/datum/antagonist/abductor/scientist/onemanteam/greet()
+	to_chat(owner.current, "<span class='notice'>You are the [owner.special_role]!</span>")
+	to_chat(owner.current, "<span class='notice'>Your supposed to have a team member but you dont, kidnap and experiment on station crew members!</span>")
+	to_chat(owner.current, "<span class='notice'>You are both the agent and the scientist, you can use the console to teleport yourself down</span>")
+	to_chat(owner.current, "<span class='notice'>And you can use your teleport implant to zap yourself back up</span>")
+	to_chat(owner.current, "<span class='notice'>Choose a worthy disguise and plan your targets carefully! Humans will kill you on sight.</span>")
+	to_chat(owner.current, "<span class='notice'>[greet_text]</span>")
+	owner.announce_objectives()
+
 /datum/antagonist/abductor/proc/finalize_abductor()
 	//Equip
 	var/mob/living/carbon/human/H = owner.current

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -8,29 +8,38 @@
 	gamemode_blacklist = list("nuclear","wizard","revolution")
 
 /datum/round_event/ghost_role/abductor
-	minimum_required = 2
+	minimum_required = 1
 	role_name = "abductor team"
 	fakeable = FALSE //Nothing to fake here
 
 /datum/round_event/ghost_role/abductor/spawn_role()
 	var/list/mob/dead/observer/candidates = get_candidates(ROLE_ABDUCTOR, null, ROLE_ABDUCTOR)
 
-	if(candidates.len < 2)
+	if(candidates.len < 1)
 		return NOT_ENOUGH_PLAYERS
+	if(candidates.len >= 2)
+		var/mob/living/carbon/human/agent = makeBody(pick_n_take(candidates))
+		var/mob/living/carbon/human/scientist = makeBody(pick_n_take(candidates))
 
-	var/mob/living/carbon/human/agent = makeBody(pick_n_take(candidates))
-	var/mob/living/carbon/human/scientist = makeBody(pick_n_take(candidates))
+		var/datum/team/abductor_team/T = new
+		if(T.team_number > ABDUCTOR_MAX_TEAMS)
+			return MAP_ERROR
 
-	var/datum/team/abductor_team/T = new
-	if(T.team_number > ABDUCTOR_MAX_TEAMS)
-		return MAP_ERROR
+		log_game("[key_name(scientist)] has been selected as [T.name] abductor scientist.")
+		log_game("[key_name(agent)] has been selected as [T.name] abductor agent.")
 
-	log_game("[key_name(scientist)] has been selected as [T.name] abductor scientist.")
-	log_game("[key_name(agent)] has been selected as [T.name] abductor agent.")
+		scientist.mind.add_antag_datum(/datum/antagonist/abductor/scientist, T)
+		agent.mind.add_antag_datum(/datum/antagonist/abductor/agent, T)
 
-	scientist.mind.add_antag_datum(/datum/antagonist/abductor/scientist, T)
-	agent.mind.add_antag_datum(/datum/antagonist/abductor/agent, T)
+		spawned_mobs += list(agent, scientist)
+	else
+		var/mob/living/carbon/human/sci_agent = makeBody(pick_n_take(candidates))
 
-	spawned_mobs += list(agent, scientist)
+		var/datum/team/abductor_team/T = new
+		if(T.team_number > ABDUCTOR_MAX_TEAMS)
+			return MAP_ERROR
+		log_game("[key_name(sci_agent)] has been selected as [T.name] abductor sci-agent.")
+
+		sci_agent.mind.add_antag_datum(/datum/antagonist/abductor/scientist/onemanteam, T)
 
 	return SUCCESSFUL_SPAWN

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -43,7 +43,7 @@
 	if(replaced_by == /datum/surgery)
 		return FALSE
 
-	if(HAS_TRAIT(user, TRAIT_SURGEON) || istype(user) && user.mind && HAS_TRAIT(user.mind, TRAIT_SURGEON))
+	if(istype(user) && user.mind && HAS_TRAIT(user.mind, TRAIT_SURGEON))
 		if(replaced_by)
 			return FALSE
 		else

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -43,7 +43,7 @@
 	if(replaced_by == /datum/surgery)
 		return FALSE
 
-	if(HAS_TRAIT(user, TRAIT_SURGEON))
+	if(HAS_TRAIT(user, TRAIT_SURGEON) || istype(user) && user.mind && HAS_TRAIT(user.mind, TRAIT_SURGEON))
 		if(replaced_by)
 			return FALSE
 		else

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -43,7 +43,7 @@
 	if(replaced_by == /datum/surgery)
 		return FALSE
 
-	if(HAS_TRAIT(user.mind, TRAIT_SURGEON))
+	if(user.mind && HAS_TRAIT(user.mind, TRAIT_SURGEON))
 		if(replaced_by)
 			return FALSE
 		else

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -43,7 +43,7 @@
 	if(replaced_by == /datum/surgery)
 		return FALSE
 
-	if(istype(user) && user.mind && HAS_TRAIT(user.mind, TRAIT_SURGEON))
+	if(HAS_TRAIT(user.mind, TRAIT_SURGEON))
 		if(replaced_by)
 			return FALSE
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR does 2 things. 1 it fixes a bug where abductor agents did not know all the surgery's(Call me out of this wasent a bug)
And 2. Makes it so if only 1 ghost signs up for abductor it will let him play as a solo abductor
## Why It's Good For The Game

Bug fix good

And its painfull to click yes as a abductor team gets made only for it not to happen because you where the only dead guy. Being alone puts the agent at a disadvantage so I dont think this is super unbalanced

## Changelog
:cl:
add: Abductors can now appear alone
fix: Abductor scientist remember once again how to do surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
