### PR TITLE
Clown gets a choice beacon!

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -216,3 +216,47 @@
 	desc = "Just looking at this makes you want to giggle."
 	icon_state = "laughter"
 	list_reagents = list(/datum/reagent/consumable/laughter = 50)
+
+/obj/item/choice_beacon/clown
+	name = "amusement beacon"
+	desc = "An armament for pranking."
+	icon_state = "gangtool-purple"
+
+/obj/item/choice_beacon/clown/generate_display_names()
+	var/static/list/items = list()
+	var/list/templist = list(/obj/item/choice_beacon/mob/clown,
+							/obj/item/storage/box/clown/pies,
+							/obj/item/storage/box/clown/toys
+							)
+	for(var/V in templist)
+		var/atom/A = V
+		items[initial(A.name)] = A
+	return items
+
+/obj/item/choice_beacon/mob/clown
+	name = "your very own cake cat"
+	desc = "Word of advice: Keep away from hungry assistants."
+	default_name = "Cookie"
+	mob_choice = /mob/living/simple_animal/pet/cat/cak
+	icon_state = "gangtool-purple"
+
+/obj/item/storage/box/clown/pies
+	name = "Pie Launcher Kit"
+
+/obj/item/storage/box/clown/pies/PopulateContents()
+	new /obj/item/pneumatic_cannon/pie(src)
+	new /obj/item/reagent_containers/food/snacks/pie/cream(src)
+	new /obj/item/reagent_containers/food/snacks/pie/cream(src)
+	new /obj/item/reagent_containers/food/snacks/pie/cream(src)
+	new /obj/item/reagent_containers/food/snacks/pie/cream(src)
+	new /obj/item/reagent_containers/food/snacks/pie/cream(src)
+
+/obj/item/storage/box/clown/toys
+	name = "Arcade Token Kit"
+
+/obj/item/storage/box/clown/toys/PopulateContents()
+	new /obj/item/coin/arcade_token(src)
+	new /obj/item/coin/arcade_token(src)
+	new /obj/item/coin/arcade_token(src)
+	new /obj/item/coin/arcade_token(src)
+	new /obj/item/coin/arcade_token(src)

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -77,6 +77,37 @@
 			hero_item_list[initial(A.name)] = A
 	return hero_item_list
 
+/obj/item/choice_beacon/mob
+	name = "animal delivery beacon"
+	desc = "There is no faster way."
+	var/default_name = "Vermin"
+	var/obj/mob_choice = /mob/living/simple_animal/pet/cat
+
+/obj/item/choice_beacon/mob/generate_options(mob/living/M)
+	var/input_name = stripped_input(M, "What would you like your new pet to be named?", "New Pet Name", default_name, MAX_NAME_LEN)
+	if(!input_name)
+		return
+	spawn_mob(M,input_name)
+	uses--
+	if(!uses)
+		qdel(src)
+	else
+		to_chat(M, "<span class='notice'>[uses] use[uses > 1 ? "s" : ""] remaining on the [src].</span>")
+
+/obj/item/choice_beacon/mob/proc/spawn_mob(mob/living/M,name)
+	var/mob/your_pet = new mob_choice()
+	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
+	pod.explosionSize = list(0,0,0,0)
+	your_pet.forceMove(pod)
+	your_pet.name = name
+	var/msg = "<span class=danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(istype(H.ears, /obj/item/radio/headset))
+			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>One pet delivery straight from Central Command. Stand clear!</span> Message ends.\""
+	to_chat(M, msg)
+
+	new /obj/effect/DPtarget(get_turf(src), pod)
 
 /obj/item/storage/box/hero
 	name = "Courageous Tomb Raider - 1940's."
@@ -111,7 +142,7 @@
 
 /obj/item/storage/box/hero/ghostbuster/PopulateContents()
 	new /obj/item/clothing/glasses/welding/ghostbuster(src)
-	new /obj/item/storage/belt/fannypack/bustin(src)	
+	new /obj/item/storage/belt/fannypack/bustin(src)
 	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/clothing/shoes/jackboots(src)
 	new /obj/item/clothing/under/color/khaki/buster(src)
@@ -193,7 +224,7 @@
 			maximum_size = 4
 			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand].</span>")
 			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
-	
+
 /obj/item/clothing/head/that/bluespace/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(!proximity_flag)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clown gets a beacon with 3 choices:
* Pie launcher (and some pies)
* 5 arcade tokens to spawn toys
* His very own pet Cakecat

Thought of putting it in his box of toys, but that might end with mime/assistant stealing it. Instead, what about it being a roundstart item? Suggestions welcome.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Clown gets a beacon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
