### PR TITLE
Reworked Devil's Infernal Jaunt

### DIFF
--- a/code/__DEFINES/contracts.dm
+++ b/code/__DEFINES/contracts.dm
@@ -24,13 +24,12 @@
 #define OBLIGATION_ANNOUNCEKILL "announcekill"
 #define OBLIGATION_ANSWERTONAME "answername"
 
-#define BAN_HURTWOMAN "hurtwoman"
+#define BAN_SALT "salt"
 #define BAN_CHAPEL "chapel"
-#define BAN_HURTPRIEST "hurtpriest"
-#define BAN_AVOIDWATER "avoidwater"
-#define BAN_STRIKEUNCONSCIOUS "strikeunconscious"
-#define BAN_HURTLIZARD "hurtlizard"
-#define BAN_HURTANIMAL "hurtanimal"
+#define BAN_ANIMAL "animal"
+#define BAN_SILVER "silver"
+#define BAN_RUNES "runes"
+#define BAN_TRASH "trash"
 
 #define BANISH_WATER "water"
 #define BANISH_COFFIN "coffin"

--- a/code/modules/antagonists/devil/devil.dm
+++ b/code/modules/antagonists/devil/devil.dm
@@ -31,13 +31,12 @@ GLOBAL_LIST_INIT(lawlorify, list (
 			BANE_WHITECLOTHES = "Wearing clean white clothing will help ward off this devil.",
 			BANE_HARVEST = "Presenting the labors of a harvest will disrupt the devil.",
 			BANE_TOOLBOX = "That which holds the means of creation also holds the means of the devil's undoing.",
-			BAN_HURTWOMAN = "This devil seems to prefer hunting men.",
-			BAN_CHAPEL = "This devil avoids holy ground.",
-			BAN_HURTPRIEST = "The annointed clergy appear to be immune to his powers.",
-			BAN_AVOIDWATER = "The devil seems to have some sort of aversion to water, though it does not appear to harm him.",
-			BAN_STRIKEUNCONSCIOUS = "This devil only shows interest in those who are awake.",
-			BAN_HURTLIZARD = "This devil will not strike a lizardman first.",
-			BAN_HURTANIMAL = "This devil avoids hurting animals.",
+			BAN_SALT = "This devil cannot manifest around salt.",
+			BAN_CHAPEL = "This devil cannot manifest inside a chapel.",
+			BAN_ANIMAL = "This devil cannot manifest around animals.",
+			BAN_SILVER = "The devil cannot manifest next to silver objects.",
+			BAN_RUNES = "This devil cannot manifest next to runes.",
+			BAN_TRASH = "This devil cannot manifest next to trash.",
 			BANISH_WATER = "To banish the devil, you must infuse its body with holy water.",
 			BANISH_COFFIN = "This devil will return to life if its remains are not placed within a coffin.",
 			BANISH_FORMALDYHIDE = "To banish the devil, you must inject its lifeless body with embalming fluid.",
@@ -112,6 +111,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 		/obj/effect/proc_holder/spell/targeted/conjure_item/violin,
 		/obj/effect/proc_holder/spell/targeted/summon_dancefloor))
 	var/ascendable = FALSE
+	var/can_jaunt = TRUE
 
 /datum/antagonist/devil/can_be_owned(datum/mind/new_owner)
 	. = ..()
@@ -121,6 +121,8 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 	. = ..()
 	.["Toggle ascendable"] = CALLBACK(src,.proc/admin_toggle_ascendable)
 
+/datum/antagonist/devil/proc/set_jaunt(towhat)
+	can_jaunt = towhat
 
 /datum/antagonist/devil/proc/admin_toggle_ascendable(mob/admin)
 	ascendable = !ascendable
@@ -169,7 +171,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 	return pick(OBLIGATION_FOOD, OBLIGATION_FIDDLE, OBLIGATION_DANCEOFF, OBLIGATION_GREET, OBLIGATION_PRESENCEKNOWN, OBLIGATION_SAYNAME, OBLIGATION_ANNOUNCEKILL, OBLIGATION_ANSWERTONAME)
 
 /proc/randomdevilban()
-	return pick(BAN_HURTWOMAN, BAN_CHAPEL, BAN_HURTPRIEST, BAN_AVOIDWATER, BAN_STRIKEUNCONSCIOUS, BAN_HURTLIZARD, BAN_HURTANIMAL)
+	return pick(BAN_SALT,BAN_CHAPEL,BAN_ANIMAL,BAN_SILVER,BAN_RUNES,BAN_TRASH)
 
 /proc/randomdevilbane()
 	return pick(BANE_SALT, BANE_LIGHT, BANE_IRON, BANE_WHITECLOTHES, BANE_SILVER, BANE_HARVEST, BANE_TOOLBOX)
@@ -181,6 +183,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 	if(soulsOwned.Find(soul))
 		return
 	soulsOwned += soul
+	set_jaunt(TRUE)
 	owner.current.set_nutrition(NUTRITION_LEVEL_FULL)
 	to_chat(owner.current, "<span class='warning'>You feel satiated as you received a new soul.</span>")
 	update_hud()
@@ -344,6 +347,7 @@ GLOBAL_LIST_INIT(devil_suffix, list(" the Red", " the Soulless", " the Master", 
 /datum/antagonist/devil/proc/give_base_spells()
 	owner.AddSpell(new /obj/effect/proc_holder/spell/aimed/fireball/hellish(null))
 	owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_item/summon_pitchfork(null))
+	owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/infernal_jaunt(null))
 
 /datum/antagonist/devil/proc/give_blood_spells()
 	owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/conjure_item/summon_pitchfork(null))

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -234,7 +234,7 @@
 		else
 			response = tgalert(target.current, "A devil is offering you another chance at life, at the price of your soul, do you accept?", "Infernal Resurrection", "Yes", "No", "Never for this round", 0, 200)
 		if(response == "Yes")
-			H.revive(1,0)
+			H.revive(TRUE,FALSE)
 			log_combat(user, H, "infernally revived via contract")
 			user.visible_message("<span class='notice'>With a sudden blaze, [H] stands back up.</span>")
 			H.fakefire()

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -143,7 +143,7 @@
 	if (!user.mind)
 		return TRUE
 	var/datum/antagonist/devil/satin = user.mind.has_antag_datum(/datum/antagonist/devil)
-	var/pick_range = 10
+	var/pick_range = 4
 	if (satin)
 		switch(satin.ban)
 			if (BAN_SALT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Infernal Jaunt works differently
* You can jaunt even when dead
* You can only teleport in places far away from your banishment (ie if your banishment is silver, you cannot teleport near a silver statue)
* No longer a channel; instead it refreshes whenever a devil gains a kill
* Fullheals devils on spawn

## Why It's Good For The Game

Adds some counterplay, a little buff to the devil, and makes the banishments actually have an effect on devils, not just be RP enforcments.

## Changelog
:cl:
tweak: reworked devil jaunt; you gain a jaunt charge whenever you earn a soul, you can also jaunt when dead, but cannot teleport near your 'banishments'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
