### PR TITLE
Fix a hallucination runtime

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -364,7 +364,7 @@
 	if(href_list["process_queue"])
 		spawn(0)
 			if(processing_queue || being_built)
-				return FALSE
+				return
 			processing_queue = 1
 			process_queue()
 			processing_queue = 0

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	/datum/hallucination/weird_sounds = 8,
 	/datum/hallucination/stationmessage = 7,
 	/datum/hallucination/fake_flood = 7,
-	/datum/hallucination/stray_bullet = 7,
+	/datum/hallucination/stray_bullet = 3,
 	/datum/hallucination/bolts = 7,
 	/datum/hallucination/items_other = 7,
 	/datum/hallucination/husks = 7,
@@ -1284,7 +1284,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	set waitfor = FALSE
 	..()
 	var/list/turf/startlocs = list()
-	for(var/turf/open/T in view(world.view+1,target)-view(world.view,target))
+	for(var/turf/open/T in view(getexpandedview(world.view, 1, 1),target)-view(world.view,target)) // God this is terrible
 		startlocs += T
 	if(!startlocs.len)
 		qdel(src)


### PR DESCRIPTION
Also fixes a minor DreamChecker issue while I'm at it.

```
[00:11:28] Runtime in Hallucination.dm, line 1287: type mismatch: "17x15" + 1
proc name: New (/datum/hallucination/stray_bullet/New)
src: /datum/hallucination/stray_bul... (/datum/hallucination/stray_bullet)
call stack:
/datum/hallucination/stray_bul... (/datum/hallucination/stray_bullet): New(Whitaker Wyatt (/mob/living/carbon/human), 0)
Whitaker Wyatt (/mob/living/carbon/human): handle hallucinations()
Whitaker Wyatt (/mob/living/carbon/human): handle status effects()
Whitaker Wyatt (/mob/living/carbon/human): Life(2, 709)
Whitaker Wyatt (/mob/living/carbon/human): Life(2, 709)
Whitaker Wyatt (/mob/living/carbon/human): Life(2, 709)
Mobs (/datum/controller/subsystem/mobs): fire(1)
Mobs (/datum/controller/subsystem/mobs): ignite(1)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```

## Changelog
:cl:
fix: Fixed the stray bullet hallucination runtiming.
tweak: Stray bullet hallucination is less frequent.
/:cl:


