### PR TITLE
Shotgun nerf / rebalance

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -148,6 +148,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define BOLT_TYPE_OPEN 2
 #define BOLT_TYPE_NO_BOLT 3
 #define BOLT_TYPE_LOCKING 4
+#define BOLT_TYPE_PUMP 5	//Requires 2 hands to pump, but standard
 // Sawn off nerfs
 #define SAWN_OFF_ACC_PENALTY 25
 #define SAWN_OFF_RECOIL 1

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -17,7 +17,7 @@
 
 /obj/item/ammo_casing/shotgun/sleepytime
 	name = "soporific shell"
-	desc = "A shotgun shell loaded with a hypodermic needle containing a low strength sleeping agent."
+	desc = "A shotgun shell loaded with a hypodermic needle containing a low strength knock-out agent that will confuse a target on the first shot, and put them to sleep on the second."
 	icon_state = "sleepy"
 	projectile_type = /obj/item/projectile/bullet/sleepy
 
@@ -68,7 +68,7 @@
 	icon_state = "gshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 6
-	variance = 25
+	variance = 10
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
@@ -76,7 +76,7 @@
 	icon_state = "bshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
-	variance = 25
+	variance = 20
 	materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/incapacitate
@@ -85,7 +85,7 @@
 	icon_state = "bountyshell"
 	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_incapacitate
 	pellets = 12//double the pellets, but half the stun power of each, which makes this best for just dumping right in someone's face.
-	variance = 25
+	variance = 20
 	materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/improvised

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -129,14 +129,19 @@
 			chambered.forceMove(src)
 
 /obj/item/gun/ballistic/proc/rack(mob/user = null)
-	if (bolt_type == BOLT_TYPE_NO_BOLT) //If there's no bolt, nothing to rack
-		return
-	if (bolt_type == BOLT_TYPE_OPEN)
-		if(!bolt_locked)	//If it's an open bolt, racking again would do nothing
-			if (user)
-				to_chat(user, "<span class='notice'>\The [src]'s [bolt_wording] is already cocked!</span>")
+	switch(bolt_type)
+		if(BOLT_TYPE_NO_BOLT)
 			return
-		bolt_locked = FALSE
+		if(BOLT_TYPE_OPEN)
+			if(!bolt_locked)	//If it's an open bolt, racking again would do nothing
+				if (user)
+					to_chat(user, "<span class='notice'>\The [src]'s [bolt_wording] is already cocked!</span>")
+				return
+			bolt_locked = FALSE
+		if(BOLT_TYPE_PUMP)
+			if(user.get_inactive_held_item())
+				to_chat(user, "<span class='warning'>You require your other hand to be free to rack the [bolt_wording] of \the [src]!</span>")
+				return
 	if (user)
 		to_chat(user, "<span class='notice'>You rack the [bolt_wording] of \the [src].</span>")
 	process_chamber(!chambered, FALSE)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -22,6 +22,7 @@
 	internal_magazine = TRUE
 	casing_ejector = FALSE
 	bolt_wording = "pump"
+	bolt_type = BOLT_TYPE_PUMP
 	cartridge_wording = "shell"
 	tac_reloads = FALSE
 	fire_rate = 1 //reee
@@ -155,6 +156,7 @@
 	fire_rate = 2
 	automatic = 1
 	recoil = 0
+	bolt_type = BOLT_TYPE_STANDARD	//Not using a pump
 
 /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -18,7 +18,10 @@
 /obj/item/projectile/bullet/sleepy/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && isliving(target))
 		var/mob/living/L = target
-		L.Sleeping(50)
+		if(L.confused)
+			L.Sleeping(50)
+		else
+			L.confused = 80
 	return ..()
 
 /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
@@ -40,7 +43,7 @@
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
 	damage = 20
-	paralyze = 80
+	paralyze = 20
 	hitsound = 'sound/effects/meteorimpact.ogg'
 
 /obj/item/projectile/bullet/shotgun_meteorslug/on_hit(atom/target, blocked = FALSE)
@@ -57,7 +60,7 @@
 /obj/item/projectile/bullet/shotgun_frag12
 	name ="frag12 slug"
 	damage = 25
-	paralyze = 50
+	paralyze = 10
 
 /obj/item/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -70,17 +73,18 @@
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 12.5
+	damage = 9
+	tile_dropoff = 0.5
 
 /obj/item/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
-	stamina = 11
+	stamina = 9
 
 /obj/item/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
 	damage = 1
-	stamina = 6
+	stamina = 5
 
 /obj/item/projectile/bullet/pellet/Range()
 	..()
@@ -106,7 +110,7 @@
 // Mech Scattershot
 
 /obj/item/projectile/bullet/scattershot
-	damage = 24
+	damage = 18
 
 //Breaching Ammo
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 60
+	armour_penetration = -60
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

I know this isn't likely to be popular, but in their current state shotguns are like the debtor's punch ability and are in dire need of a rebalance.

## About The Pull Request

Rebalances the stats of shotguns to make them more similar to other ranged weapons in the game, although on almost all shells this is a nerf due to the power of a majority of shells.

**Calculations:**

All calculations assume a target's hitbox takes up a full tile (Which it does) and works by calculating the probability for each individual pellet hitting at a certain range, then multiplying it by the damage.

**Damage Calculation:**

Edit: Actually I just noticed the calculation was the version 1, it should say -xpt instead of -xt

![image](https://user-images.githubusercontent.com/26465327/102128966-8c745880-3e46-11eb-86af-a9903df1c901.png)

**Spreadsheet:**

![image](https://user-images.githubusercontent.com/26465327/102129006-9b5b0b00-3e46-11eb-9eb9-1e9357074552.png)
(Negative damages are due to being too lazy to clamp value (Projectiles are deleted once they go below 0 damage, so they would deal 0 rather than heal the player).)

**Changes:**
Buckshot: Reduced raw damage from 12.5 to 9. Decreased spread from 25 to 10 degrees.
Beanbag: No Changes
Soporific: First shot now applies 8 seconds of confusion. If hitting a confused target, will put them to sleep for 5 seconds (Old effect: 5 seconds sleep).
Incendiary: No changes
Dragon's Breath: No changes
Stun Slug: Unused, no changes
Meteor Slug: Hard stun reduced from 8 seconds to 2 seconds. Stun is applied if the target hits a wall due to knockback of the shell.
Frag12: 5 seconds of paralysis reduced to 1 second. Not that it really matters since these are generally going to be a 1 hit kill from the explosion or at least limbs will be lost.
Rubbershot: Reduced stamina damage from 11 to 9. Reduced variance from 25 to 20
Incapacitating Shell: Reduced stamina damage from 6 to 5. Reduced variance from 25 to 50
Improvised Shell: No changes
Laser Slug: Reduced damage from 15 to 10. (This thing was ridiculous before and actually pretty easy to make)
Slugs: Given -60 armour penetration making them less effective against armoured targets.

Shotguns: Pump-action shotguns require your second hand to be free to pump the pump (You can still fire with only 1 hand).

Main changes were to shells that hard-stun and pellet based shells with a high spread.

## Why It's Good For The Game

**Opinion:**

The 2 main types of combat in the game, ranged and melee have very different approaches and balance to make different things effective at these ranges. Shotguns follow the balance of the ranged approach to combat, however act more similar in the melee end of things, since they aren't effective at range and are only really useful in close quarters.

Shotguns in their current state are usually an instant win, even when caught off guard, which generally isn't that fun. This PR aims to solve this by changing shotguns to a close-range weapon, without knowing that you can win a fight just by bum-rushing into melee range and 1 tapping your opponent.

Graph of buckshot changes:
![image](https://user-images.githubusercontent.com/26465327/102128768-41f2dc00-3e46-11eb-8d03-ab4b858d8942.png)
Red represents previous damage, blue represents new damage. (Damage is on the Y access, so while it may seem that the lines are not too far apart the new damage is significantly higher at mid ranges.)

The changes to shotgun pump and shell stats were made to make them a little riskier in close-quarter combat since an item that blocks all melee attacks and an item that can deal a significant amount of damage that alone could make melee combat at melee range insignificant was extremely poor to play against. The goal is to make shotguns high-risk high-reward, rather than low-risk high-reward and to encourage shotguns to stay close to a target but still a little out of melee range (2-3 tiles for best effects). Due to the calculations, damage at 1-2 range has been reduced while at 3-5 range has been increased which heavily encourage this playstyle; hopefully, this will promote the use of shotguns as a ranged weapon rather than playing shotguns with a melee weapon playstyle (Since in melee combat currently shotgun overshadow basically all melee weapons).

## Changelog
:cl:
balance: Buckshot - Reduced raw damage from 12.5 to 9. Decreased spread from 25 to 10 degrees.
balance: Soporific - First shot now applies 8 seconds of confusion. If hitting a confused target, will put them to sleep for 5 seconds (Old effect: 5 seconds sleep).
balance: Meteor Slug - Hard stun reduced from 8 seconds to 2 seconds. Stun is applied if the target hits a wall due to knockback of the shell.
balance: Frag12 - 5 seconds of paralysis reduced to 1 second. Not that it really matters since these are generally going to be a 1 hit kill from the explosion or at least limbs will be lost.
balance: Rubbershot - Reduced stamina damage from 11 to 9. Reduced variance from 25 to 20
balance: Incapacitating Shell - Reduced variance from 25 to 20, stamina damaged reduced from 6 to 5
balance: Laser Slug - Reduced damage from 15 to 10. (This thing was ridiculous before and actually pretty easy to make)
balance: Shotguns - Pump-action shotguns now require the pumping hand to be empty.
balance: Mech Scattershot - Pellet damage reduced from 24 to 18.
balance: Slugs now have an armour penetration of -60, making them very effective against unarmoured targets but not armoured targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
