### PR TITLE
Water Buffs

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -183,3 +183,15 @@
 	id = /datum/reagent/consumable/bbqsauce
 	results = list(/datum/reagent/consumable/bbqsauce = 5)
 	required_reagents = list(/datum/reagent/ash = 1, /datum/reagent/consumable/tomatojuice = 1, /datum/reagent/medicine/salglu_solution = 3, /datum/reagent/consumable/blackpepper = 1)
+	
+/datum/chemical_reaction/snow
+	name = "snow"
+	id = "snow"
+	required_temp = 273
+	required_reagents = list(/datum/reagent/water = 30)
+	mix_message = "The water freezes into snow."
+
+/datum/chemical_reaction/snow/on_reaction(datum/reagents/holder, created_volume)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= created_volume, i++)
+		new /obj/item/stack/sheet/mineral/snow(location)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -173,6 +173,12 @@
 		new /obj/item/stack/sheet/wetleather(get_turf(HH), HH.amount)
 		qdel(HH)
 
+/datum/reagent/water/on_mob_life(mob/living/carbon/M)
+	for(var/datum/reagent/R in M.reagents.reagent_list)
+		if(R != src)
+			M.reagents.remove_reagent(R.type,0.25)
+	..()
+
 /*
  *	Water reaction to a mob
  */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Water now removes negative chems (like charcoal).
Also it reacts at 0degC and forms into snow.

## Why It's Good For The Game

Makes water some sort of maints antitox. Now that antitox doesn't remove chemicals, water could be used as an enchantment.
Also the snow reaction is just a gimmick.

## Changelog
:cl:
add: water removes chems from the bloodstream (1/5th the speed of charcoal)
add: water reacts at 273 degrees Kelvin and forms into snow blocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
