### PR TITLE
Nutriment and Water can overdose

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -57,7 +57,7 @@
 		. = 1
 	..()
 
-/datum/reagent/consumable/nutriment/overdose_process(mob/living/M)
+/datum/reagent/consumable/nutriment/overdose_process(mob/living/carbon/M)
 	metabolization_rate = 3 * REAGENTS_METABOLISM
 	if (prob(15))
 		M.vomit(5)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -46,6 +46,7 @@
 	nutriment_factor = 15 * REAGENTS_METABOLISM
 	color = "#664330" // rgb: 102, 67, 48
 	random_unrestricted = TRUE
+	overdose_threshold = 100
 
 	var/brute_heal = 1
 	var/burn_heal = 0
@@ -54,6 +55,12 @@
 	if(prob(50))
 		M.heal_bodypart_damage(brute_heal,burn_heal, 0)
 		. = 1
+	..()
+
+/datum/reagent/consumable/nutriment/overdose_process(mob/living/M)
+	metabolization_rate = 3 * REAGENTS_METABOLISM
+	if (prob(15))
+		M.vomit(5)
 	..()
 
 /datum/reagent/consumable/nutriment/on_new(list/supplied_data)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -124,6 +124,7 @@
 	shot_glass_icon_state = "shotglassclear"
 	process_flags = ORGANIC | SYNTHETIC
 	random_unrestricted = FALSE
+	overdose_threshold = 200
 
 /*
  *	Water reaction to turf
@@ -183,6 +184,15 @@
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))
 		M.ExtinguishMob()
+	..()
+
+/*
+ *	Water OD
+ */
+
+/datum/reagent/water/overdose_process(mob/living/M)
+	metabolization_rate = 5 * REAGENTS_METABOLISM
+	M.adjustOxyLoss(1.5, 0)
 	..()
 
 /datum/reagent/water/holywater


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nutriment can overdose, causing you to vomit.
Water can overdose, making you take oxy damage.

## Why It's Good For The Game

Gimmicky. Ever wanted to kill someone by drowning them with water?

## Changelog
:cl:
add: Added overdose effects for nutriment and water
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
