### PR TITLE
Improves powertool code + Changes some cases of checking for tool typepaths to tool behaviours instead.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -125521,7 +125521,7 @@
 	dir = 1
 	},
 /obj/item/stack/sheet/plasteel/fifty,
-/obj/item/crowbar/power,
+/obj/item/powertool/jaws_of_life,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
@@ -125766,7 +125766,7 @@
 "wEB" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
-/obj/item/wrench/power,
+/obj/item/powertool/hand_drill,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -35587,7 +35587,7 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/item/crowbar/power,
+/obj/item/powertool/jaws_of_life,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43453,7 +43453,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/screwdriver/power,
+/obj/item/powertool/hand_drill,
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
 "bku" = (

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -433,8 +433,8 @@
 "bo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/table,
-/obj/item/screwdriver/power,
-/obj/item/wirecutters/power,
+/obj/item/powertool/hand_drill,
+/obj/item/powertool/jaws_of_life,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "bp" = (

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -448,8 +448,8 @@
 /area/engine/atmos)
 "bo" = (
 /obj/structure/table,
-/obj/item/screwdriver/power,
-/obj/item/wirecutters/power,
+/obj/item/powertool/hand_drill,
+/obj/item/powertool/jaws_of_life,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bp" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4211,7 +4211,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
 /obj/item/crowbar/red,
-/obj/item/crowbar/power,
+/obj/item/powertool/jaws_of_life,
 /obj/item/storage/belt/security/full,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7364,7 +7364,7 @@
 	},
 /obj/item/stack/rods/fifty,
 /obj/item/stack/cable_coil/white,
-/obj/item/screwdriver/power,
+/obj/item/powertool/hand_drill,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -7400,7 +7400,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/handcuffs,
 /obj/item/crowbar/red,
-/obj/item/crowbar/power,
+/obj/item/powertool/jaws_of_life,
 /obj/item/storage/belt/security/full,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
@@ -7650,7 +7650,7 @@
 "sa" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
-/obj/item/wirecutters/power,
+/obj/item/powertool/jaws_of_life,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
 "sb" = (
@@ -8946,7 +8946,7 @@
 "uP" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/packageWrap,
-/obj/item/crowbar/power,
+/obj/item/powertool/jaws_of_life,
 /obj/item/wrench,
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/stripes/line{

--- a/beestation.dme
+++ b/beestation.dme
@@ -1075,6 +1075,7 @@
 #include "code\game\objects\items\tanks\tanks.dm"
 #include "code\game\objects\items\tanks\watertank.dm"
 #include "code\game\objects\items\tools\crowbar.dm"
+#include "code\game\objects\items\tools\powertools.dm"
 #include "code\game\objects\items\tools\screwdriver.dm"
 #include "code\game\objects\items\tools\weldingtool.dm"
 #include "code\game\objects\items\tools\wirecutters.dm"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -173,6 +173,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_T_RAY_VISIBLE     "t-ray-visible" // Visible on t-ray scanners if the atom/var/level == 1
 #define TRAIT_NO_TELEPORT		"no-teleport" //you just can't
 #define TRAIT_STARGAZED			"stargazed"	//Affected by a stargazer
+#define TRAIT_DOOR_PRYER		"door-pryer"	//Item can be used on airlocks to pry them open (even when powered)
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"
@@ -271,3 +272,4 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define PARRY_TRAIT	"parry_trait"
 #define BATTLE_ROYALE_TRAIT "battleroyale_trait"
 #define MADE_UNCLONEABLE "made-uncloneable"
+#define TRAIT_JAWS_OF_LIFE "jaws-of-life"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1109,7 +1109,7 @@
 				return
 		INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
 
-	if(istype(I, /obj/item/crowbar/power))
+	if(HAS_TRAIT(I, TRAIT_DOOR_PRYER))
 		if(isElectrified())
 			shock(user,100)//it's like sticking a forck in a power socket
 			return

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -74,8 +74,8 @@
 	item_state = "utility_ce"
 
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
-	new /obj/item/screwdriver/power(src)
-	new /obj/item/crowbar/power(src)
+	new /obj/item/powertool/hand_drill(src)
+	new /obj/item/powertool/jaws_of_life(src)
 	new /obj/item/weldingtool/experimental(src)//This can be changed if this is too much
 	new /obj/item/multitool(src)
 	new /obj/item/stack/cable_coil(src,30,pick("red","yellow","orange"))

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -42,6 +42,7 @@
 	STR.max_combined_w_class = 21
 	var/static/list/can_hold = typecacheof(list(
 		/obj/item/crowbar,
+		/obj/item/powertool,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
 		/obj/item/wirecutters,
@@ -126,6 +127,7 @@
 	STR.max_items = 7
 	var/static/list/can_hold = typecacheof(list(
 		/obj/item/crowbar,
+		/obj/item/powertool,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
 		/obj/item/wirecutters,
@@ -317,6 +319,7 @@
 	STR.max_combined_w_class = 20
 	STR.can_hold = typecacheof(list(
 		/obj/item/crowbar,
+		/obj/item/powertool,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
 		/obj/item/wirecutters,

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -13,7 +13,6 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 4
-	STR.cant_hold = typecacheof(list(/obj/item/screwdriver/power)) //Must be specifically called out since normal screwdrivers can fit but not the wrench form of the drill
 	STR.can_hold = typecacheof(list(
 		/obj/item/stack/spacecash,
 		/obj/item/holochip,

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -56,31 +56,6 @@
 	item_state = "crowbar"
 	toolspeed = 0.7
 
-/obj/item/crowbar/power
-	name = "jaws of life"
-	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
-	icon_state = "jaws_pry"
-	item_state = "jawsoflife"
-	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25)
-
-	usesound = 'sound/items/jaws_pry.ogg'
-	force = 15
-	toolspeed = 0.7
-
-/obj/item/crowbar/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
-	playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
-	return (BRUTELOSS)
-
-/obj/item/crowbar/power/attack_self(mob/user)
-	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
-	var/obj/item/wirecutters/power/cutjaws = new /obj/item/wirecutters/power(drop_location())
-	to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
-	qdel(src)
-	user.put_in_active_hand(cutjaws)
-
 /obj/item/crowbar/cyborg
 	name = "hydraulic crowbar"
 	desc = "A hydraulic prying tool, simple but powerful."

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -1,0 +1,141 @@
+/obj/item/powertool
+	name = "Power tool"
+	desc = "A basic powertool that does nothing."
+	icon = 'icons/obj/tools.dmi'
+	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+	w_class = WEIGHT_CLASS_SMALL
+	materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
+	flags_1 = CONDUCT_1
+	slot_flags = ITEM_SLOT_BELT
+
+/obj/item/powertool/attack_self(mob/user)
+	toggle_mode(user)
+
+/obj/item/powertool/proc/toggle_mode(mob/user)
+	return
+
+//Hand Drill
+
+/obj/item/powertool/hand_drill
+	name = "hand drill"
+	desc = "A simple powered hand drill. It's fitted with a screw bit."
+	icon_state = "drill_screw"
+	item_state = "drill"
+
+	force = 8 //might or might not be too high, subject to change
+	throwforce = 8
+	throw_speed = 2
+	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far
+
+	hitsound = 'sound/items/drill_hit.ogg'
+
+	tool_behaviour = TOOL_SCREWDRIVER
+	usesound = 'sound/items/drill_use.ogg'
+
+/obj/item/powertool/hand_drill/toggle_mode(mob/user)
+	playsound(get_turf(user), 'sound/items/change_drill.ogg', 50, 1)
+	if(tool_behaviour == TOOL_SCREWDRIVER)
+		to_chat(user, "<span class='notice'>You attach the bolt driver bit to [src].</span>")
+		become_wrench()
+	else
+		to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
+		become_screwdriver()
+
+/obj/item/powertool/hand_drill/proc/become_wrench()
+	icon_state = "drill_bolt"
+	tool_behaviour = TOOL_WRENCH
+
+	hitsound = null
+
+	attack_verb = list("drilled", "screwed", "jabbed")
+	throw_range = 7
+
+/obj/item/powertool/hand_drill/proc/become_screwdriver()
+	icon_state = "drill_screw"
+	tool_behaviour = TOOL_SCREWDRIVER
+
+	hitsound = 'sound/items/drill_hit.ogg'
+
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	throw_range = 3
+
+/obj/item/powertool/hand_drill/suicide_act(mob/user)
+	if(tool_behaviour == TOOL_SCREWDRIVER)
+		user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	else
+		user.visible_message("<span class='suicide'>[user] is pressing [src] against [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return BRUTELOSS
+
+//Jaws of life
+
+/obj/item/powertool/jaws_of_life
+	name = "jaws of life"
+	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a prying head."
+	usesound = 'sound/items/jaws_pry.ogg'
+	icon_state = "jaws_pry"
+	item_state = "jawsoflife"
+
+	toolspeed = 0.7
+	tool_behaviour = TOOL_CROWBAR
+
+	force = 15
+	throwforce = 7
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+
+/obj/item/powertool/jaws_of_life/toggle_mode(mob/user)
+	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
+	if(tool_behaviour == TOOL_CROWBAR)
+		to_chat(user, "<span class='notice'>You attach the cutting jaws to [src].</span>")
+		become_wirecutters()
+	else
+		to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
+		become_crowbar()
+
+/obj/item/powertool/jaws_of_life/proc/become_wirecutters()
+	icon_state = "jaws_cutter"
+	tool_behaviour = TOOL_WIRECUTTER
+
+	usesound = 'sound/items/jaws_cut.ogg'
+
+	attack_verb = list("pinched", "nipped")
+	force = 6
+	throw_speed = 3
+
+	REMOVE_TRAIT(src, TRAIT_DOOR_PRYER, TRAIT_JAWS_OF_LIFE)
+
+/obj/item/powertool/jaws_of_life/proc/become_crowbar()
+	icon_state = "jaws_pry"
+	tool_behaviour = TOOL_CROWBAR
+
+	usesound = 'sound/items/jaws_pry.ogg'
+
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	force = 15
+	throw_speed = 2
+
+	ADD_TRAIT(src, TRAIT_DOOR_PRYER, TRAIT_JAWS_OF_LIFE)
+
+/obj/item/powertool/jaws_of_life/suicide_act(mob/user)
+	if(tool_behaviour == TOOL_CROWBAR)
+		user.visible_message("<span class='suicide'>[user] is putting [user.p_their()] head in [src], it looks like [user.p_theyre()] trying to commit suicide!</span>")
+		playsound(loc, 'sound/items/jaws_pry.ogg', 50, 1, -1)
+	else
+		user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
+		playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
+			if(BP)
+				BP.drop_limb()
+				playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
+	return BRUTELOSS
+
+/obj/item/powertool/jaws_of_life/attack(mob/living/M, mob/living/user)
+	if(tool_behaviour == TOOL_WIRECUTTER && istype(C) && C.handcuffed)
+		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
+		qdel(C.handcuffed)
+		return
+	else
+		..()

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -144,7 +144,7 @@
 				playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
 	return BRUTELOSS
 
-/obj/item/powertool/jaws_of_life/attack(mob/living/C, mob/living/user)
+/obj/item/powertool/jaws_of_life/attack(mob/living/carbon/C, mob/living/user)
 	if(tool_behaviour == TOOL_WIRECUTTER && istype(C) && C.handcuffed)
 		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
 		qdel(C.handcuffed)

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -50,7 +50,7 @@
 
 	hitsound = null
 
-	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked"
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
 	throw_range = 7
 
 /obj/item/powertool/hand_drill/proc/become_screwdriver()

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -68,6 +68,18 @@
 		user.visible_message("<span class='suicide'>[user] is pressing [src] against [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return BRUTELOSS
 
+/obj/item/powertool/hand_drill/attack(mob/living/M, mob/living/user)
+	if(!istype(M) || tool_behaviour != TOOL_SCREWDRIVER)
+		return ..()
+	if(user.zone_selected != BODY_ZONE_PRECISE_EYES && user.zone_selected != BODY_ZONE_HEAD)
+		return ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You don't want to harm [M]!</span>")
+		return
+	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
+		M = user
+	return eyestab(M,user)
+
 //Jaws of life
 
 /obj/item/powertool/jaws_of_life

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -144,7 +144,7 @@
 				playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
 	return BRUTELOSS
 
-/obj/item/powertool/jaws_of_life/attack(mob/living/M, mob/living/user)
+/obj/item/powertool/jaws_of_life/attack(mob/living/C, mob/living/user)
 	if(tool_behaviour == TOOL_WIRECUTTER && istype(C) && C.handcuffed)
 		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
 		qdel(C.handcuffed)

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -50,7 +50,7 @@
 
 	hitsound = null
 
-	attack_verb = list("drilled", "screwed", "jabbed")
+	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked"
 	throw_range = 7
 
 /obj/item/powertool/hand_drill/proc/become_screwdriver()
@@ -59,7 +59,7 @@
 
 	hitsound = 'sound/items/drill_hit.ogg'
 
-	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked")
+	attack_verb = list("drilled", "screwed", "jabbed")
 	throw_range = 3
 
 /obj/item/powertool/hand_drill/suicide_act(mob/user)

--- a/code/game/objects/items/tools/powertools.dm
+++ b/code/game/objects/items/tools/powertools.dm
@@ -9,6 +9,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 30)
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	toolspeed = 0.7
 
 /obj/item/powertool/attack_self(mob/user)
 	toggle_mode(user)
@@ -89,7 +90,6 @@
 	icon_state = "jaws_pry"
 	item_state = "jawsoflife"
 
-	toolspeed = 0.7
 	tool_behaviour = TOOL_CROWBAR
 
 	force = 15

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -104,36 +104,6 @@
 /obj/item/screwdriver/abductor/get_belt_overlay()
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "screwdriver_nuke")
 
-/obj/item/screwdriver/power
-	name = "hand drill"
-	desc = "A simple powered hand drill. It's fitted with a screw bit."
-	icon_state = "drill_screw"
-	item_state = "drill"
-	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25) //done for balance reasons, making them high value for research, but harder to get
-	force = 8 //might or might not be too high, subject to change
-	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 8
-	throw_speed = 2
-	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far
-	attack_verb = list("drilled", "screwed", "jabbed","whacked")
-	hitsound = 'sound/items/drill_hit.ogg'
-	usesound = 'sound/items/drill_use.ogg'
-	toolspeed = 0.7
-	random_color = FALSE
-
-/obj/item/screwdriver/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is putting [src] to [user.p_their()] temple. It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return(BRUTELOSS)
-
-/obj/item/screwdriver/power/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/wrench/power/b_drill = new /obj/item/wrench/power(drop_location())
-	to_chat(user, "<span class='notice'>You attach the bolt driver bit to [src].</span>")
-	qdel(src)
-	user.put_in_active_hand(b_drill)
-
 /obj/item/screwdriver/cyborg
 	name = "automated screwdriver"
 	desc = "A powerful automated screwdriver, designed to be both precise and quick."

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -83,43 +83,6 @@
 
 	random_color = FALSE
 
-/obj/item/wirecutters/power
-	name = "jaws of life"
-	desc = "A set of jaws of life, compressed through the magic of science. It's fitted with a cutting head."
-	icon_state = "jaws_cutter"
-	item_state = "jawsoflife"
-
-	materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25)
-	usesound = 'sound/items/jaws_cut.ogg'
-	toolspeed = 0.7
-	random_color = FALSE
-
-/obj/item/wirecutters/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!</span>")
-	playsound(loc, 'sound/items/jaws_cut.ogg', 50, 1, -1)
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
-		if(BP)
-			BP.drop_limb()
-			playsound(loc,pick('sound/misc/desceration-01.ogg','sound/misc/desceration-02.ogg','sound/misc/desceration-01.ogg') ,50, 1, -1)
-	return (BRUTELOSS)
-
-/obj/item/wirecutters/power/attack_self(mob/user)
-	playsound(get_turf(user), 'sound/items/change_jaws.ogg', 50, 1)
-	var/obj/item/crowbar/power/pryjaws = new /obj/item/crowbar/power(drop_location())
-	to_chat(user, "<span class='notice'>You attach the pry jaws to [src].</span>")
-	qdel(src)
-	user.put_in_active_hand(pryjaws)
-
-/obj/item/wirecutters/power/attack(mob/living/carbon/C, mob/user)
-	if(istype(C) && C.handcuffed)
-		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
-		qdel(C.handcuffed)
-		return
-	else
-		..()
-
 /obj/item/wirecutters/cyborg
 	name = "powered wirecutters"
 	desc = "Cuts wires with the power of ELECTRICITY. Faster than normal wirecutters."

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -39,34 +39,6 @@
 	usesound = 'sound/effects/empulse.ogg'
 	toolspeed = 0.1
 
-
-/obj/item/wrench/power
-	name = "hand drill"
-	desc = "A simple powered hand drill. It's fitted with a bolt bit."
-	icon_state = "drill_bolt"
-	item_state = "drill"
-	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	usesound = 'sound/items/drill_use.ogg'
-	materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25)
- //done for balance reasons, making them high value for research, but harder to get
-	force = 8 //might or might not be too high, subject to change
-	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 8
-	attack_verb = list("drilled", "screwed", "jabbed")
-	toolspeed = 0.7
-
-/obj/item/wrench/power/attack_self(mob/user)
-	playsound(get_turf(user),'sound/items/change_drill.ogg',50,1)
-	var/obj/item/wirecutters/power/s_drill = new /obj/item/screwdriver/power(drop_location())
-	to_chat(user, "<span class='notice'>You attach the screw driver bit to [src].</span>")
-	qdel(src)
-	user.put_in_active_hand(s_drill)
-
-/obj/item/wrench/power/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is pressing [src] against [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return (BRUTELOSS)
-
 /obj/item/wrench/medical
 	name = "medical wrench"
 	desc = "A medical wrench with common(medical?) uses. Can be found in your hand."

--- a/code/game/objects/noose.dm
+++ b/code/game/objects/noose.dm
@@ -15,7 +15,7 @@
 	var/mutable_appearance/overlay
 
 /obj/structure/chair/noose/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/wirecutters))
+	if(W.tool_behaviour == TOOL_WIRECUTTER)
 		user.visible_message("[user] cuts the noose.", "<span class='notice'>You cut the noose.</span>")
 		if(has_buckled_mobs())
 			for(var/m in buckled_mobs)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -26,7 +26,7 @@
 	var/max_mob_size = MOB_SIZE_HUMAN //Biggest mob_size accepted by the container
 	var/mob_storage_capacity = 3 // how many human sized mob/living can fit together inside a closet.
 	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate then open it in a populated area to crash clients.
-	var/cutting_tool = /obj/item/weldingtool
+	var/cutting_tool = TOOL_WELDER
 	var/open_sound = 'sound/machines/closet_open.ogg'
 	var/close_sound = 'sound/machines/closet_close.ogg'
 	var/open_sound_volume = 35
@@ -270,8 +270,8 @@
 /obj/structure/closet/proc/tool_interact(obj/item/W, mob/user)//returns TRUE if attackBy call shouldnt be continued (because tool was used/closet was of wrong type), FALSE if otherwise
 	. = TRUE
 	if(opened)
-		if(istype(W, cutting_tool))
-			if(W.tool_behaviour == TOOL_WELDER)
+		if(W.tool_behaviour == cutting_tool)
+			if(cutting_tool == TOOL_WELDER)
 				if(!W.tool_start_check(user, amount=0))
 					return
 

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -8,7 +8,7 @@
 	max_integrity = 70
 	integrity_failure = 0
 	can_weld_shut = 0
-	cutting_tool = /obj/item/wirecutters
+	cutting_tool = TOOL_WIRECUTTER
 	open_sound = "rustle"
 	material_drop = /obj/item/stack/sheet/cardboard
 	delivery_icon = "deliverybox"
@@ -70,7 +70,7 @@
 	mob_storage_capacity = 5
 	resistance_flags = NONE
 	move_speed_multiplier = 2
-	cutting_tool = /obj/item/weldingtool
+	cutting_tool = TOOL_WELDER
 	open_sound = 'sound/machines/crate_open.ogg'
 	close_sound = 'sound/machines/crate_close.ogg'
 	open_sound_volume = 35

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -166,7 +166,7 @@
 /turf/open/floor/proc/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	if(T.turf_type == type)
 		return
-	var/obj/item/crowbar/CB = user.is_holding_item_of_type(/obj/item/crowbar)
+	var/obj/item/CB = user.is_holding_tool_quality(TOOL_CROWBAR)
 	if(!CB)
 		return
 	var/turf/open/floor/plating/P = pry_tile(CB, user, TRUE)

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -30,9 +30,9 @@
 /turf/open/floor/wood/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	if(T.turf_type == type)
 		return
-	var/obj/item/tool = user.is_holding_item_of_type(/obj/item/screwdriver)
+	var/obj/item/tool = user.is_holding_tool_quality(TOOL_SCREWDRIVER)
 	if(!tool)
-		tool = user.is_holding_item_of_type(/obj/item/crowbar)
+		tool = user.is_holding_tool_quality(TOOL_CROWBAR)
 	if(!tool)
 		return
 	var/turf/open/floor/plating/P = pry_tile(tool, user, TRUE)

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -31,6 +31,10 @@
 	message = "of wirecutters"
 	export_types = list(/obj/item/wirecutters)
 
+/datum/export/powertool
+	cost = 15
+	unit_name = "powertool"
+	export_types = list(/obj/item/powertool)
 
 /datum/export/weldingtool
 	cost = 5

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -18,7 +18,7 @@
 	gas_transfer_coefficient = 0.9
 	permeability_coefficient = 0.5
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/extinguisher, /obj/item/crowbar)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/extinguisher, /obj/item/crowbar, /obj/item/powertool/jaws_of_life)
 	slowdown = 1
 	armor = list("melee" = 15, "bullet" = 5, "laser" = 20, "energy" = 10, "bomb" = 20, "bio" = 10, "rad" = 20, "fire" = 100, "acid" = 50)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
@@ -49,7 +49,7 @@
 	icon_state = "atmos_firesuit"
 	item_state = "firesuit_atmos"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	allowed = list(/obj/item/flashlight, /obj/item/extinguisher, /obj/item/crowbar, /obj/item/tank/internals)
+	allowed = list(/obj/item/flashlight, /obj/item/extinguisher, /obj/item/crowbar, /obj/item/tank/internals, /obj/item/powertool/jaws_of_life)
 
 /*
  * Bomb protection

--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -42,6 +42,7 @@ God bless America.
 		/obj/item/wirecutters,
 		/obj/item/multitool,
 		/obj/item/weldingtool,
+		/obj/item/powertool,
 		/obj/item/reagent_containers/glass,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/food/condiment,

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -327,7 +327,7 @@
 			if(prob(50))
 				neck = /obj/item/bedsheet/rd/royal_cape
 			if(prob(10))
-				l_pocket = pick(list(/obj/item/crowbar/power, /obj/item/wrench/power, /obj/item/weldingtool/experimental))
+				l_pocket = pick(list(/obj/item/powertool/jaws_of_life, /obj/item/powertool/hand_drill, /obj/item/weldingtool/experimental))
 		if("YeOlde")
 			mob_gender = FEMALE
 			uniform = /obj/item/clothing/under/costume/maid

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -9,7 +9,7 @@
 	id = "handdrill"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 3500, /datum/material/silver = 1500, /datum/material/titanium = 2500)
-	build_path = /obj/item/screwdriver/power
+	build_path = /obj/item/powertool/hand_drill
 	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
@@ -17,7 +17,7 @@
 	name = "Jaws of Life"
 	desc = "A small, compact Jaws of Life with an interchangeable pry jaws and cutting jaws"
 	id = "jawsoflife" // added one more requirment since the Jaws of Life are a bit OP
-	build_path = /obj/item/crowbar/power
+	build_path = /obj/item/powertool/jaws_of_life
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 4500, /datum/material/silver = 2500, /datum/material/titanium = 3500)
 	category = list("Tool Designs")

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -114,8 +114,15 @@
 //drill bone
 /datum/surgery_step/drill
 	name = "drill bone"
-	implements = list(TOOL_DRILL = 100, /obj/item/screwdriver/power = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 20)
+	implements = list(TOOL_DRILL = 100, /obj/item/powertool/hand_drill = 80, /obj/item/pickaxe/drill = 60, TOOL_SCREWDRIVER = 20)
 	time = 30
+
+/datum/surgery_step/drill/tool_check(mob/user, obj/item/tool)
+	if(istype(tool, /obj/item/powertool/hand_drill))
+		var/obj/item/powertool/hand_drill = tool
+		if(hand_drill.tool_behaviour != TOOL_SCREWDRIVER)
+			return FALSE
+	return TRUE
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the previous powertools code with new powertool code.
Previously every time you swap the tool mode of the jaws of life / power drill, the old one would get deleted and it would be replaced with a new version. Obviously, this is a really stupid way of doing it, since that causes all traits, atom colours etc. to be lost. This version simply changes some of the vars that needs changing and the tool_behaviour.
Also replaces some instances where instead of checking for tool_behaviour, the typepath of the tool was checked.

## Why It's Good For The Game

Code QOL.

## Changelog
:cl:
code: Refactors power tool code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
