### PR TITLE
Jaunting ignores slowdown.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -254,6 +254,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define CAPTURE_THE_FLAG_TRAIT "capture-the-flag"
 #define EYE_OF_GOD_TRAIT "eye-of-god"
 #define SHAMEBRERO_TRAIT "shamebrero"
+#define JAUNT_TRAIT "jaunt"
 #define CHRONOSUIT_TRAIT "chronosuit"
 #define LOCKED_HELMET_TRAIT "locked-helmet"
 #define NINJA_SUIT_TRAIT "ninja-suit"

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -475,3 +475,4 @@
 /mob/living/proc/ignore_slowdown(source)
 	ADD_TRAIT(src, TRAIT_IGNORESLOWDOWN, source)
 	update_movespeed(FALSE)
+	client?.move_delay = world.time

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -31,10 +31,12 @@
 	target.forceMove(holder)
 	target.reset_perspective(holder)
 	target.notransform=0 //mob is safely inside holder now, no need for protection.
+	target.ignore_slowdown(JAUNT_TRAIT)
 	jaunt_steam(mobloc)
 
 	sleep(jaunt_duration)
 
+	target.unignore_slowdown(JAUNT_TRAIT)
 	if(target.loc != holder) //mob warped out of the warp
 		qdel(holder)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes jaunting ignore slowdown.
Makes it so when you jaunt in you can start moving immediately.

## Why It's Good For The Game

Especially with short-ranged jaunts such as ash jaunt, if you jaunt while bola'd you can't move at all due to the way client.movedelay works. Makes it so when you jaunt you are not slowed down and can move as soon as you jaunt in (rather than having to wait for your move delay to finish).

## Changelog
:cl:
tweak: Jaunting ignores slowdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
