### PR TITLE
Input checking

### DIFF
--- a/code/controllers/subsystem/processing/circuit.dm
+++ b/code/controllers/subsystem/processing/circuit.dm
@@ -6,6 +6,7 @@ PROCESSING_SUBSYSTEM_DEF(circuit)
 
 	var/cipherkey
 
+	var/regex/bad_regex
 	var/list/all_components = list()								// Associative list of [component_name]:[component_path] pairs
 	var/list/cached_components = list()								// Associative list of [component_path]:[component] pairs
 	var/list/all_assemblies = list()								// Associative list of [assembly_name]:[assembly_path] pairs
@@ -17,6 +18,8 @@ PROCESSING_SUBSYSTEM_DEF(circuit)
 /datum/controller/subsystem/processing/circuit/Initialize(start_timeofday)
 	SScircuit.cipherkey = uppertext(random_string(2000+rand(0,10), GLOB.alphabet))
 	circuits_init()
+	//Setup the input regex
+	bad_regex = new("\[^\\w{}:\",.\\-*&+ =\'\\(\\)\\\[\\\]#\]", "g")
 	return ..()
 
 /datum/controller/subsystem/processing/circuit/proc/circuits_init()

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,7 +233,7 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w\{\}\:\"\,\.\-\*\&\+\]", "gi")
+	var/regex/bad_regex = new("\[^\\w{}:\",.\-*&+ ='\]", "gi")
 	if(bad_regex.Find(program))
 		return "Invalid Input. Non-standard characters are not allows."
 

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -232,6 +232,10 @@
 
 	var/error
 
+	//Check for bad inputs
+	var/regex/bad_regex = new("\[^\\w\{\}\:\"\,\.\-\*\&\+\/]", "gi")
+	if(bad_regex.Find(program))
+		return "Invalid Input. Non-standard characters are not allows."
 
 	// Block 1. Assembly.
 	var/list/assembly_params = blocks["assembly"]
@@ -338,8 +342,6 @@
 	var/obj/item/electronic_assembly/assembly_path = all_assemblies[assembly_params["type"]]
 	var/obj/item/electronic_assembly/assembly = new assembly_path(null)
 	assembly.load(assembly_params)
-
-
 
 	// Block 2. Components.
 	for(var/component_params in blocks["components"])

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,8 +233,8 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\\[\\]#\]", "gi")
-	bad_regex.Replace(program, "")
+	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ =\'\\(\\)\\\[\\\]#\]", "gi")
+	bad_regex.Replace(bad_regex, "")
 
 	// Block 1. Assembly.
 	var/list/assembly_params = blocks["assembly"]

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,7 +233,7 @@
 	var/error
 
 	//Check for bad inputs
-	bad_regex.Replace(program, "")
+	program.Replace(bad_regex, "")
 
 	// Block 1. Assembly.
 	var/list/assembly_params = blocks["assembly"]

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,7 +233,7 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w\{\}\:\"\,\.\-\*\&\+\/]", "gi")
+	var/regex/bad_regex = new("\[^\\w\{\}\:\"\,\.\-\*\&\+\]", "gi")
 	if(bad_regex.Find(program))
 		return "Invalid Input. Non-standard characters are not allows."
 

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,7 +233,6 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ =\'\\(\\)\\\[\\\]#\]", "g")
 	bad_regex.Replace(program, "")
 
 	// Block 1. Assembly.

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -227,7 +227,7 @@
 // "requires_upgrades", "unsupported_circuit", "iron_cost", "complexity", "max_complexity", "used_space", "max_space"
 /datum/controller/subsystem/processing/circuit/proc/validate_electronic_assembly(program)
 	//Check for bad inputs
-	bad_regex.Replace(program, "")
+	program = bad_regex.Replace(program, "")
 
 	var/list/blocks = json_decode(program)
 	if(!blocks)

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,8 +233,8 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\\[\\]\]", "gi")
-	if(bad_regex.Find(program))
+	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\\[\\]#\]", "gi")
+	if(bad_regex.Replace(program, ''))
 		return "Invalid Input. Non-standard characters are not allows."
 
 	// Block 1. Assembly.

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -234,7 +234,7 @@
 
 	//Check for bad inputs
 	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\\[\\]#\]", "gi")
-	bad_regex.Replace(program, '')
+	bad_regex.Replace(program, "")
 
 	// Block 1. Assembly.
 	var/list/assembly_params = blocks["assembly"]

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -234,8 +234,7 @@
 
 	//Check for bad inputs
 	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\\[\\]#\]", "gi")
-	if(bad_regex.Replace(program, ''))
-		return "Invalid Input. Non-standard characters are not allows."
+	bad_regex.Replace(program, '')
 
 	// Block 1. Assembly.
 	var/list/assembly_params = blocks["assembly"]

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,7 +233,7 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\]", "gi")
+	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\\[\\]\]", "gi")
 	if(bad_regex.Find(program))
 		return "Invalid Input. Non-standard characters are not allows."
 

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -226,14 +226,14 @@
 // The following parameters area calculated during validation and added to the returned save list:
 // "requires_upgrades", "unsupported_circuit", "iron_cost", "complexity", "max_complexity", "used_space", "max_space"
 /datum/controller/subsystem/processing/circuit/proc/validate_electronic_assembly(program)
+	//Check for bad inputs
+	bad_regex.Replace(program, "")
+
 	var/list/blocks = json_decode(program)
 	if(!blocks)
 		return
 
 	var/error
-
-	//Check for bad inputs
-	program.Replace(bad_regex, "")
 
 	// Block 1. Assembly.
 	var/list/assembly_params = blocks["assembly"]

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,7 +233,7 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w{}:\",.-*&+ ='\]", "gi")
+	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ ='\\(\\)\]", "gi")
 	if(bad_regex.Find(program))
 		return "Invalid Input. Non-standard characters are not allows."
 

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,8 +233,8 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ =\'\\(\\)\\\[\\\]#\]", "gi")
-	bad_regex.Replace(bad_regex, "")
+	var/regex/bad_regex = new("\[^\\w{}:\",.\\-*&+ =\'\\(\\)\\\[\\\]#\]", "g")
+	bad_regex.Replace(program, "")
 
 	// Block 1. Assembly.
 	var/list/assembly_params = blocks["assembly"]

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -233,7 +233,7 @@
 	var/error
 
 	//Check for bad inputs
-	var/regex/bad_regex = new("\[^\\w{}:\",.\-*&+ ='\]", "gi")
+	var/regex/bad_regex = new("\[^\\w{}:\",.-*&+ ='\]", "gi")
 	if(bad_regex.Find(program))
 		return "Invalid Input. Non-standard characters are not allows."
 


### PR DESCRIPTION
Circuit reading from user only allows:
 - Words
 - Spaces
 - Numbers
 - `{}`
 - `:`
 - `,`
 - `.`
 - `&`
 - `*`
 - `=`
 - `()`
 - `'`
 - `"`
 - `#`
Anything else gets replaced with nothing