### PR TITLE
Adds verbose logging to the emergency shuttle console

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -85,7 +85,7 @@
 		if("repeal")
 			authorized -= ID
 			message_admins("[ADMIN_LOOKUPFLW(user)] has deauthorized early shuttle launch, now [authorized.len] of [auth_need] needed")
-			log_game("[key_name(user)] has deauthorized early shuttle launch in [COORD(src),] [authorized.len] of [auth_need] needed.")
+			log_game("[key_name(user)] has deauthorized early shuttle launch in [COORD(src)], now [authorized.len] of [auth_need] needed.")
 
 		if("abort")
 			if(authorized.len)
@@ -118,8 +118,8 @@
 
 	authorized += ID
 
-	message_admins("[ADMIN_LOOKUPFLW(user)] has authorized early shuttle launch.")
-	log_game("[key_name(user)] has authorized early shuttle launch in [COORD(src)].")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has authorized early shuttle launch, [authorized.len] of [auth_need] needed.")
+	log_game("[key_name(user)] has authorized early shuttle launch in [COORD(src)], [authorized.len] of [auth_need] needed..")
 	// Now check if we're on our way
 	. = TRUE
 	process()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -83,6 +83,8 @@
 			. = authorize(user)
 
 		if("repeal")
+			if(!(ID in authorized))
+				return //cannot retract auth if never given originally
 			authorized -= ID
 			message_admins("[ADMIN_LOOKUPFLW(user)] has deauthorized early shuttle launch, now [authorized.len] of [auth_need] needed")
 			log_game("[key_name(user)] has deauthorized early shuttle launch in [COORD(src)], now [authorized.len] of [auth_need] needed.")

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -84,11 +84,15 @@
 
 		if("repeal")
 			authorized -= ID
+			message_admins("[ADMIN_LOOKUPFLW(user)] has deauthorized early shuttle launch, now [authorized.len] of [auth_need] needed")
+			log_game("[key_name(user)] has deauthorized early shuttle launch in [COORD(src),] [authorized.len] of [auth_need] needed.")
 
 		if("abort")
 			if(authorized.len)
 				// Abort. The action for when heads are fighting over whether
 				// to launch early.
+				message_admins("[ADMIN_LOOKUPFLW(user)] has revoked early shuttle launch.")
+				log_game("[key_name(user)] has revoked early shuttle launch in [COORD(src)].")
 				authorized.Cut()
 				. = TRUE
 
@@ -100,6 +104,7 @@
 			minor_announce("[remaining] authorizations needed until shuttle is launched early.", null, alert)
 		if(repeal)
 			minor_announce("Early launch authorization revoked, [remaining] authorizations needed.")
+			log_game("Early launch authorization revoked, [remaining] authorizations needed.")
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
 	var/obj/item/card/id/ID = user.get_idcard(TRUE)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a specific log for when authorization to early launch is revoked, or when auth is removed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Admins can now see when the HoP cancels the emergency launch because they left Ian behind in their office.

Will add: 
https://github.com/tgstation/tgstation/pull/52522
when I can figure out how to cherry pick

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: increased emergency shuttle verbosity logging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
