### PR TITLE
Fixes players getting popcap redirected if they have a mob

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -457,8 +457,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	Master.UpdateTickRate()
 
 	if(GLOB.ckey_redirects.Find(ckey))
-		to_chat(src, "<span class='redtext'>The server is full. You will be redirected to [CONFIG_GET(string/redirect_address)] in 10 seconds.</span>")
-		addtimer(CALLBACK(src, .proc/time_to_redirect), (10 SECONDS))
+		if(isliving(mob))
+			GLOB.ckey_redirects -= ckey
+		else
+			to_chat(src, "<span class='redtext'>The server is full. You will be redirected to [CONFIG_GET(string/redirect_address)] in 10 seconds.</span>")
+			addtimer(CALLBACK(src, .proc/time_to_redirect), (10 SECONDS))
 
 /client/proc/time_to_redirect()
 	var/redirect_address = CONFIG_GET(string/redirect_address)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -457,7 +457,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	Master.UpdateTickRate()
 
 	if(GLOB.ckey_redirects.Find(ckey))
-		if(isnewplayer(M))
+		if(isnewplayer(mob))
 			to_chat(src, "<span class='redtext'>The server is full. You will be redirected to [CONFIG_GET(string/redirect_address)] in 10 seconds.</span>")
 			addtimer(CALLBACK(src, .proc/time_to_redirect), (10 SECONDS))
 		else
@@ -1081,4 +1081,3 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			message_admins("[key_name(src)] was removed from the game due to a ban from BeeStation.")
 			qdel(src)
 			return
-

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -457,11 +457,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	Master.UpdateTickRate()
 
 	if(GLOB.ckey_redirects.Find(ckey))
-		if(isliving(mob))
-			GLOB.ckey_redirects -= ckey
-		else
+		if(isnewplayer(M))
 			to_chat(src, "<span class='redtext'>The server is full. You will be redirected to [CONFIG_GET(string/redirect_address)] in 10 seconds.</span>")
 			addtimer(CALLBACK(src, .proc/time_to_redirect), (10 SECONDS))
+		else
+			GLOB.ckey_redirects -= ckey
 
 /client/proc/time_to_redirect()
 	var/redirect_address = CONFIG_GET(string/redirect_address)


### PR DESCRIPTION
There is an oversight in redirect code. If you join prior to popcap, get disconnected after the popcap threshold, and then reconnect... you get redirected. This fixes that.

## Changelog
:cl:
fix: Players will no longer be popcap redirected if they have a mob.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
