### PR TITLE
[PORT] Limit how often you can use the emergency shuttle console

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -113,8 +113,6 @@
 			minor_announce("Early launch authorization revoked, [remaining] authorizations needed.")
 			log_game("Early launch authorization revoked, [remaining] authorizations needed.")
 	acted_recently += user
-	//if(!QDELETED(user))
-	//	ui_interact(user)
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
 	var/obj/item/card/id/ID = user.get_idcard(TRUE)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -113,8 +113,8 @@
 			minor_announce("Early launch authorization revoked, [remaining] authorizations needed.")
 			log_game("Early launch authorization revoked, [remaining] authorizations needed.")
 	acted_recently += user
-	if(!QDELETED(user))
-		ui_interact(user)
+	//if(!QDELETED(user))
+	//	ui_interact(user)
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
 	var/obj/item/card/id/ID = user.get_idcard(TRUE)
@@ -136,8 +136,6 @@
 
 /obj/machinery/computer/emergency_shuttle/proc/clear_recent_action(mob/user)
 	acted_recently -= user
-	if (!QDELETED(user))
-		ui_interact(user)
 
 /obj/machinery/computer/emergency_shuttle/process()
 	// Launch check is in process in case auth_need changes for some reason

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -2,6 +2,7 @@
 #define ENGINES_START_TIME 100
 #define ENGINES_STARTED (SSshuttle.emergency.mode == SHUTTLE_IGNITING)
 #define IS_DOCKED (SSshuttle.emergency.mode == SHUTTLE_DOCKED || (ENGINES_STARTED))
+#define SHUTTLE_CONSOLE_ACTION_DELAY (5 SECONDS)
 
 /obj/machinery/computer/emergency_shuttle
 	name = "emergency shuttle console"
@@ -13,6 +14,7 @@
 
 	var/auth_need = 3
 	var/list/authorized = list()
+	var/list/acted_recently = list()
 
 /obj/machinery/computer/emergency_shuttle/attackby(obj/item/I, mob/user,params)
 	if(istype(I, /obj/item/card/id))
@@ -27,13 +29,12 @@
 	return GLOB.human_adjacent_state
 
 /obj/machinery/computer/emergency_shuttle/ui_interact(mob/user, datum/tgui/ui)
-
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "EmergencyShuttleConsole")
 		ui.open()
 
-/obj/machinery/computer/emergency_shuttle/ui_data()
+/obj/machinery/computer/emergency_shuttle/ui_data(user)
 	var/list/data = list()
 
 	data["timer_str"] = SSshuttle.emergency.getTimerStr()
@@ -51,7 +52,7 @@
 		A += list(list("name" = name, "job" = job))
 	data["authorizations"] = A
 
-	data["enabled"] = (IS_DOCKED && !ENGINES_STARTED)
+	data["enabled"] = (IS_DOCKED && !ENGINES_STARTED) && !(user in acted_recently)
 	data["emagged"] = obj_flags & EMAGGED ? 1 : 0
 	return data
 
@@ -76,7 +77,11 @@
 		to_chat(user, "<span class='warning'>The access level of your card is not high enough.</span>")
 		return
 
+	if(user in acted_recently)
+		return
+
 	var/old_len = authorized.len
+	addtimer(CALLBACK(src, .proc/clear_recent_action, user), SHUTTLE_CONSOLE_ACTION_DELAY)
 
 	switch(action)
 		if("authorize")
@@ -107,6 +112,9 @@
 		if(repeal)
 			minor_announce("Early launch authorization revoked, [remaining] authorizations needed.")
 			log_game("Early launch authorization revoked, [remaining] authorizations needed.")
+	acted_recently += user
+	if(!QDELETED(user))
+		ui_interact(user)
 
 /obj/machinery/computer/emergency_shuttle/proc/authorize(mob/user, source)
 	var/obj/item/card/id/ID = user.get_idcard(TRUE)
@@ -125,6 +133,11 @@
 	// Now check if we're on our way
 	. = TRUE
 	process()
+
+/obj/machinery/computer/emergency_shuttle/proc/clear_recent_action(mob/user)
+	acted_recently -= user
+	if (!QDELETED(user))
+		ui_interact(user)
 
 /obj/machinery/computer/emergency_shuttle/process()
 	// Launch check is in process in case auth_need changes for some reason
@@ -627,3 +640,4 @@
 #undef ENGINES_START_TIME
 #undef ENGINES_STARTED
 #undef IS_DOCKED
+#undef SHUTTLE_CONSOLE_ACTION_DELAY


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

implements https://github.com/tgstation/tgstation/pull/52522/commits/688406f878fae1730d37e89f70291c48f47c9cfa

and

https://github.com/tgstation/tgstation/pull/52522/commits/adec073d06417649fd3a850e54a5b601cb763bec

from https://github.com/tgstation/tgstation/pull/52522

Credit to @Jared-Fogle 

You can now only use the emergency shuttle console once per 5 seconds.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/3241376/102419807-33cbc980-3fc6-11eb-81f0-bd04bb4287df.png)

Prevents obnoxious spam of the console.

https://www.youtube.com/watch?v=0g3ZRS7Ev7w
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You can now only use the emergency shuttle console once per 5 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
