### PR TITLE
[Bounty] Battle Royale on round delay + Battle royale bettering

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -642,6 +642,19 @@ SUBSYSTEM_DEF(ticker)
 
 	world.Reboot()
 
+/datum/controller/subsystem/ticker/proc/get_game_state_string()
+	switch(current_state)
+		if(GAME_STATE_FINISHED)
+			return "Finished"
+		if(GAME_STATE_PLAYING)
+			return "Playing"
+		if(GAME_STATE_PREGAME)
+			return "Pregame"
+		if(GAME_STATE_SETTING_UP)
+			return "Setup"
+		if(GAME_STATE_STARTUP)
+			return "Startup"
+
 /datum/controller/subsystem/ticker/Shutdown()
 	gather_newscaster() //called here so we ensure the log is created even upon admin reboot
 	save_admin_data()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1092,7 +1092,7 @@
 	if(!log_globally)
 		return
 
-	var/log_text = "[key_name(src)] [message] [loc_name(src)]"
+	var/log_text = "([SSticker.get_game_state_string()]) [key_name(src)] [message] [loc_name(src)]"
 	switch(message_type)
 		if(LOG_ATTACK)
 			log_attack(log_text)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -721,7 +721,7 @@
 			message_admins("[key_name(usr)] HAS TRIGGERED BATTLE ROYALE")
 			GLOB.battle_royale = new()
 			GLOB.battle_royale.ticket_count = TRUE
-			INVOKE_ASYNC(GLOB.battle_royale, /datum/battle_royale_controller.proc/start)
+			GLOB.battle_royale.start_async()
 	else
 		if(alert(usr, "Really cancel current round end delay? The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Undelay round end", "Yes", "No") != "Yes")
 			return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -721,7 +721,7 @@
 			message_admins("[key_name(usr)] HAS TRIGGERED BATTLE ROYALE")
 			GLOB.battle_royale = new()
 			GLOB.battle_royale.ticket_count = TRUE
-			INVOKE_ASYNC(GLOB.battle_royale, .proc/start)
+			INVOKE_ASYNC(GLOB.battle_royale, /datum/battle_royale_controller.proc/start)
 	else
 		if(alert(usr, "Really cancel current round end delay? The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Undelay round end", "Yes", "No") != "Yes")
 			return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -716,6 +716,12 @@
 		SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
 		if(isnull(SSticker.admin_delay_notice))
 			return
+		if(check_rights(R_FUN) && !GLOB.battle_royale && alert("Would you like to run battle royale while waiting?", "Battle Royale", "Yes", "No") == "Yes")
+			log_admin("[key_name(usr)] HAS TRIGGERED BATTLE ROYALE")
+			message_admins("[key_name(usr)] HAS TRIGGERED BATTLE ROYALE")
+			GLOB.battle_royale = new()
+			GLOB.battle_royale.ticket_count = TRUE
+			GLOB.battle_royale.start()
 	else
 		if(alert(usr, "Really cancel current round end delay? The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Undelay round end", "Yes", "No") != "Yes")
 			return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -721,7 +721,7 @@
 			message_admins("[key_name(usr)] HAS TRIGGERED BATTLE ROYALE")
 			GLOB.battle_royale = new()
 			GLOB.battle_royale.ticket_count = TRUE
-			GLOB.battle_royale.start()
+			INVOKE_ASYNC(GLOB.battle_royale, .proc/start)
 	else
 		if(alert(usr, "Really cancel current round end delay? The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Undelay round end", "Yes", "No") != "Yes")
 			return

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -1,107 +1,106 @@
 //Global lists so they can be editted by admins
 GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
-		/obj/item/soap,
-		/obj/item/kitchen/knife,
-		/obj/item/kitchen/knife/combat,
-		/obj/item/kitchen/knife/poison,
-		/obj/item/throwing_star,
-		/obj/item/syndie_glue,
-		/obj/item/book_of_babel,
-		/obj/item/card/emag,
-		/obj/item/storage/box/emps,
-		/obj/item/storage/box/lethalshot,
-		/obj/item/storage/box/gorillacubes,
-		/obj/item/storage/box/teargas,
-		/obj/item/storage/box/security/radio,
-		/obj/item/storage/box/medsprays,
-		/obj/item/storage/toolbox/syndicate,
-		/obj/item/storage/box/syndie_kit/bee_grenades,
-		/obj/item/storage/box/syndie_kit/centcom_costume,
-		/obj/item/storage/box/syndie_kit/chameleon,
-		/obj/item/storage/box/syndie_kit/chemical,
-		/obj/item/storage/box/syndie_kit/emp,
-		/obj/item/storage/box/syndie_kit/imp_adrenal,
-		/obj/item/storage/box/syndie_kit/imp_freedom,
-		/obj/item/storage/box/syndie_kit/imp_radio,
-		/obj/item/storage/box/syndie_kit/imp_stealth,
-		/obj/item/storage/box/syndie_kit/imp_storage,
-		/obj/item/storage/box/syndie_kit/imp_uplink,
-		/obj/item/storage/box/syndie_kit/origami_bundle,
-		/obj/item/storage/box/syndie_kit/throwing_weapons,
-		/obj/item/storage/box/syndicate/bundle_A,
-		/obj/item/storage/box/syndicate/bundle_B,
-		/obj/item/gun/ballistic/automatic/pistol,
-		/obj/item/gun/energy/disabler,
-		/obj/item/construction/rcd,
-		/obj/item/clothing/glasses/chameleon/flashproof,
-		/obj/item/clothing/glasses/clockwork/wraith_spectacles,
-		/obj/item/clothing/glasses/sunglasses/advanced,
-		/obj/item/clothing/glasses/thermal/eyepatch,
-		/obj/item/clothing/glasses/thermal/syndi,
-		/obj/item/clothing/suit/space,
-		/obj/item/clothing/suit/armor/riot,
-		/obj/item/clothing/suit/armor/vest,
-		/obj/item/clothing/suit/armor/vest/russian_coat,
-		/obj/item/clothing/suit/armor/hos/trenchcoat,
-		/obj/item/clothing/mask/chameleon,
-		/obj/item/clothing/head/centhat,
-		/obj/item/clothing/head/crown,
-		/obj/item/clothing/head/HoS/syndicate,
-		/obj/item/clothing/head/helmet,
-		/obj/item/clothing/head/helmet/clockcult,
-		/obj/item/clothing/head/helmet/space,
-		/obj/item/clothing/head/helmet/sec,
-		/obj/item/clothing/under/syndicate,
-		/obj/item/clothing/gloves/combat,
-		/obj/item/deployablemine/stun,
-		/obj/item/switchblade,
-		/obj/item/club/tailclub,
-		/obj/item/nullrod/tribal_knife,
-		/obj/item/nullrod/fedora,
-		/obj/item/nullrod/godhand,
-		/obj/item/melee/baton/loaded,
-		/obj/item/melee/chainofcommand/tailwhip/kitty,
-		/obj/item/melee/classic_baton,
-		/obj/item/melee/ghost_sword,
-		/obj/item/melee/powerfist,
-		/obj/item/storage/firstaid/advanced,
-		/obj/item/storage/firstaid/brute,
-		/obj/item/storage/firstaid/fire,
-		/obj/item/storage/firstaid/medical,
-		/obj/item/storage/firstaid/tactical,
-		/obj/item/gun/energy/ionrifle,
-		/obj/item/organ/regenerative_core/battle_royale
+		/obj/item/soap = 4,
+		/obj/item/kitchen/knife = 5,
+		/obj/item/kitchen/knife/combat = 3,
+		/obj/item/kitchen/knife/poison = 3,
+		/obj/item/throwing_star = 2,
+		/obj/item/syndie_glue = 4,
+		/obj/item/book_of_babel = 2,
+		/obj/item/card/emag = 2,
+		/obj/item/storage/box/emps = 3,
+		/obj/item/storage/box/lethalshot = 4,
+		/obj/item/storage/box/gorillacubes = 1,
+		/obj/item/storage/box/teargas = 2,
+		/obj/item/storage/box/security/radio = 5,
+		/obj/item/storage/box/medsprays = 5,
+		/obj/item/storage/toolbox/syndicate = 5,
+		/obj/item/storage/box/syndie_kit/bee_grenades = 3,
+		/obj/item/storage/box/syndie_kit/centcom_costume = 4,
+		/obj/item/storage/box/syndie_kit/chameleon = 3,
+		/obj/item/storage/box/syndie_kit/chemical = 3,
+		/obj/item/storage/box/syndie_kit/emp = 2,
+		/obj/item/storage/box/syndie_kit/imp_adrenal = 1,
+		/obj/item/storage/box/syndie_kit/imp_freedom = 1,
+		/obj/item/storage/box/syndie_kit/imp_radio = 1,
+		/obj/item/storage/box/syndie_kit/imp_stealth = 1,
+		/obj/item/storage/box/syndie_kit/imp_storage = 1,
+		/obj/item/storage/box/syndie_kit/imp_uplink = 1,
+		/obj/item/storage/box/syndie_kit/origami_bundle = 2,
+		/obj/item/storage/box/syndie_kit/throwing_weapons = 2,
+		/obj/item/storage/box/syndicate/bundle_A = 1,
+		/obj/item/storage/box/syndicate/bundle_B = 1,
+		/obj/item/gun/ballistic/automatic/pistol = 1,
+		/obj/item/gun/energy/disabler = 2,
+		/obj/item/construction/rcd = 4,
+		/obj/item/clothing/glasses/chameleon/flashproof = 4,
+		/obj/item/clothing/glasses/clockwork/wraith_spectacles = 4,
+		/obj/item/clothing/glasses/sunglasses/advanced = 4,
+		/obj/item/clothing/glasses/thermal/eyepatch = 3,
+		/obj/item/clothing/glasses/thermal/syndi = 3,
+		/obj/item/clothing/suit/space/hardsuit/syndi = 5,
+		/obj/item/clothing/suit/armor/riot = 3,
+		/obj/item/clothing/suit/armor/vest = 5,
+		/obj/item/clothing/suit/armor/vest/russian_coat = 5,
+		/obj/item/clothing/suit/armor/hos/trenchcoat = 5,
+		/obj/item/clothing/mask/chameleon = 3,
+		/obj/item/clothing/head/centhat = 2,
+		/obj/item/clothing/head/crown = 2,
+		/obj/item/clothing/head/HoS/syndicate = 2,
+		/obj/item/clothing/head/helmet = 2,
+		/obj/item/clothing/head/helmet/clockcult = 1,
+		/obj/item/clothing/head/helmet/sec = 5,
+		/obj/item/clothing/under/syndicate = 4,
+		/obj/item/clothing/gloves/combat = 5,
+		/obj/item/deployablemine/stun = 3,
+		/obj/item/switchblade = 5,
+		/obj/item/club/tailclub = 5,
+		/obj/item/nullrod/tribal_knife = 2,
+		/obj/item/nullrod/fedora = 2,
+		/obj/item/nullrod/godhand = 2,
+		/obj/item/melee/baton/loaded = 4,
+		/obj/item/melee/chainofcommand/tailwhip/kitty = 3,
+		/obj/item/melee/classic_baton = 3,
+		/obj/item/melee/ghost_sword = 2,
+		/obj/item/melee/powerfist = 1,
+		/obj/item/storage/firstaid/advanced = 4,
+		/obj/item/storage/firstaid/brute = 4,
+		/obj/item/storage/firstaid/fire = 4,
+		/obj/item/storage/firstaid/medical = 4,
+		/obj/item/storage/firstaid/tactical = 4,
+		/obj/item/gun/energy/ionrifle = 4,
+		/obj/item/organ/regenerative_core/battle_royale = 8
 	))
 
 GLOBAL_LIST_INIT(battle_royale_good_loot, list(
-		/obj/item/hand_tele,
-		/obj/item/gun/ballistic/bow/clockbolt,
-		/obj/item/gun/ballistic/rifle/boltaction,
-		/obj/item/gun/ballistic/shotgun/doublebarrel,
-		/obj/item/gun/energy/laser/captain,
-		/obj/item/gun/ballistic/revolver/mateba,
-		/obj/item/gun/ballistic/automatic/c20r,
-		/obj/item/ammo_box/magazine/smgm45,
-		/obj/item/ammo_box/magazine/pistolm9mm,
-		/obj/item/katana,
-		/obj/item/melee/transforming/energy/sword,
-		/obj/item/twohanded/dualsaber,
-		/obj/item/twohanded/fireaxe,
-		/obj/item/stack/telecrystal/five,
-		/obj/item/stack/telecrystal/twenty,
-		/obj/item/clothing/suit/space/hardsuit/syndi
+		/obj/item/hand_tele = 1,
+		/obj/item/gun/ballistic/bow/clockbolt = 1,
+		/obj/item/gun/ballistic/rifle/boltaction = 1,
+		/obj/item/gun/ballistic/shotgun/doublebarrel = 1,
+		/obj/item/gun/energy/laser/captain = 1,
+		/obj/item/gun/ballistic/revolver/mateba, = 1
+		/obj/item/gun/ballistic/automatic/c20r = 1,
+		/obj/item/ammo_box/magazine/smgm45 = 1,
+		/obj/item/ammo_box/magazine/pistolm9mm = 1,
+		/obj/item/katana = 1,
+		/obj/item/melee/transforming/energy/sword = 1,
+		/obj/item/twohanded/dualsaber = 1,
+		/obj/item/twohanded/fireaxe = 1,
+		/obj/item/stack/telecrystal/five = 1,
+		/obj/item/stack/telecrystal/twenty = 1,
+		/obj/item/clothing/suit/space/hardsuit/syndi = 1
 	))
 
 GLOBAL_LIST_INIT(battle_royale_insane_loot, list(
-		/obj/item/gun/ballistic/automatic/l6_saw/unrestricted,
-		/obj/item/energy_katana,
-		/obj/item/clothing/suit/space/hardsuit/shielded/syndi,
-		/obj/item/his_grace,
-		/obj/mecha/combat/marauder/mauler/loaded,
-		/obj/item/guardiancreator/tech,
-		/obj/item/twohanded/mjollnir,
-		/obj/item/pneumatic_cannon/pie/selfcharge,
-		/obj/item/uplink/nuclear
+		/obj/item/gun/ballistic/automatic/l6_saw/unrestricted = 1,
+		/obj/item/energy_katana = 1,
+		/obj/item/clothing/suit/space/hardsuit/shielded/syndi = 1,
+		/obj/item/his_grace = 1,
+		/obj/mecha/combat/marauder/mauler/loaded = 1, //lol?
+		/obj/item/guardiancreator/tech = 1,
+		/obj/item/twohanded/mjollnir = 1,
+		/obj/item/pneumatic_cannon/pie/selfcharge = 1,
+		/obj/item/uplink/nuclear = 1
 	))
 
 GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
@@ -184,12 +183,18 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 
 /datum/battle_royale_controller
 	var/list/players
-	var/datum/proximity_monitor/advanced/battle_royale/field_wall
+	//Radius of the deathwall
 	var/radius = 118
+	//Process tick
 	var/process_num = 0
+	//Each element of the wall
 	var/list/death_wall
+	//The speed of the wall
 	var/field_delay = 15
+	//Will disable winning
 	var/debug_mode = FALSE
+	//If auto triggered, will speed up the game when tickets are done
+	var/ticket_count = FALSE
 
 /datum/battle_royale_controller/Destroy(force, ...)
 	QDEL_LIST(death_wall)
@@ -209,6 +214,12 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	//Once every 100 seconds.
 	if(prob(1))
 		generate_good_drop()
+	//Check tickets
+	if(ticket_count && (GLOB.ahelp_tickets.unclaimed_tickets.len || GLOB.ahelp_tickets.active_tickets.len))
+		to_chat(world, "<span class='narsie'>SUDDEN DEATH.</span>")
+		to_chat(world, "<span class='warning'>The wall speed has been increased to the maximum speed!</span>")
+		field_delay = 0
+		ticket_count = FALSE
 	var/living_victims = 0
 	var/mob/winner
 	for(var/mob/living/M as() in players)
@@ -237,14 +248,14 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		return
 	//Once every 15 seconsd
 	// 1,920 seconds (about 32 minutes per game)
-	if(process_num % (field_delay) == 0)
+	if(process_num % (field_delay) == 0 && radius > 3)
 		for(var/obj/effect/death_wall/wall as() in death_wall)
 			wall.decrease_size()
 			if(QDELETED(wall))
 				death_wall -= wall
 			CHECK_TICK
 		radius--
-	if(radius < 70 && prob(1))
+	if(radius < 90 && prob(1))
 		generate_endgame_drop()
 
 //==================================
@@ -324,6 +335,9 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		H.status_flags |= GODMODE
 		//Assistant gang
 		H.equipOutfit(/datum/outfit/job/assistant)
+		//Give them their gear
+		var/obj/item/choice_beacon/battleroyale/BR_item = new(get_turf(H))
+		H.equip_to_appropriate_slot(BR_item)
 		//Give them a spell
 		H.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/knock)
 		H.key = key
@@ -354,18 +368,24 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 
 /datum/battle_royale_controller/proc/generate_basic_loot(amount=1)
 	for(var/i in 1 to amount)
-		send_item(pick(GLOB.battle_royale_basic_loot))
+		var/list/items = list()
+		for(var/i in 1 to rand(2, 4)
+			if(prob(95))
+				items += pickweight(GLOB.battle_royale_basic_loot)
+			else
+				items += pickweight(GLOB.battle_royale_good_loot)
+		send_item(items)
 		stoplag()
 
 /datum/battle_royale_controller/proc/generate_good_drop()
 	var/list/good_drops = list()
 	for(var/i in 1 to rand(1,3))
-		good_drops += pick(GLOB.battle_royale_good_loot)
-	send_item(good_drops, announce = "Incomming extended supply materials.", force_time = 600)
+		good_drops += pickweight(GLOB.battle_royale_good_loot)
+	send_item(good_drops, announce = "Incomming extended supply materials.", force_time = 300)
 
 /datum/battle_royale_controller/proc/generate_endgame_drop()
-	var/obj/item = pick(GLOB.battle_royale_insane_loot)
-	send_item(item, announce = "We found a weird looking package in the back of our warehouse. We have no idea what is in it, but it is marked as incredibily dangerous and could be a superweapon.", force_time = 9000)
+	var/obj/item = pickweight(GLOB.battle_royale_insane_loot)
+	send_item(item, announce = "We found a weird looking package in the back of our warehouse. We have no idea what is in it, but it is marked as incredibily dangerous and could be a superweapon.", force_time = 600)
 
 /datum/battle_royale_controller/proc/send_item(item_path, style = STYLE_BOX, announce=FALSE, force_time = 0)
 	if(!item_path)
@@ -440,3 +460,21 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 // =====
 /obj/item/organ/regenerative_core/battle_royale
 	preserved = TRUE
+
+// ===
+// Kits
+// ===
+
+/obj/item/choice_beacon/battleroyale
+	name = "participant beacon"
+	desc = "Trust me; You will need this."
+
+/obj/item/choice_beacon/battleroyale/generate_display_names()
+	var/static/list/battle_royale_list
+	if(!battle_royale_list)
+		battle_royale_list = list()
+		battle_royale_list["Operative Hardsuit"] = /obj/item/clothing/suit/space/hardsuit/syndi
+		battle_royale_list["Energy Sword"] = /obj/item/melee/transforming/energy/sword
+		battle_royale_list["Combat Medkit"] = /obj/item/storage/firstaid/tactical
+		battle_royale_list["Syndicate Balloon"] = /obj/item/toy/syndicateballoon
+	return battle_royale_list

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -190,7 +190,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	//Each element of the wall
 	var/list/death_wall
 	//The speed of the wall
-	var/field_delay = 15
+	var/field_delay = 10
 	//Will disable winning
 	var/debug_mode = FALSE
 	//If auto triggered, will speed up the game when tickets are done
@@ -246,8 +246,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 			new /obj/item/melee/supermatter_sword(get_turf(winner))
 		qdel(src)
 		return
-	//Once every 15 seconsd
-	// 1,920 seconds (about 32 minutes per game)
+	//Once every 10 seconsd
 	if(process_num % (field_delay) == 0 && radius > 3)
 		for(var/obj/effect/death_wall/wall as() in death_wall)
 			wall.decrease_size()

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -323,7 +323,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	var/list/participants = pollGhostCandidates("Would you like to partake in BATTLE ROYALE?")
 	var/turf/spawn_turf = get_safe_random_station_turf()
 	var/obj/structure/closet/supplypod/centcompod/pod = new()
-	pod.setStyle()
+	pod.setStyle(STYLE_CENTCOM)
 	players = list()
 	for(var/mob/M in participants)
 		var/key = M.key
@@ -494,4 +494,6 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	box = /obj/item/storage/box/survival
 	belt = /obj/item/storage/belt/utility/full
 	gloves = /obj/item/clothing/gloves/color/yellow
-	l_pocket = /obj/item/choice_beacon/battleroyale
+	backpack_contents = list(
+		/obj/item/choice_beacon/battleroyale = 1
+	)

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/ammo_box/magazine/smgm45 = 1,
 		/obj/item/ammo_box/magazine/pistolm9mm = 1,
 		/obj/item/katana = 1,
-		/obj/item/melee/transforming/energy/sword = 1,
+		/obj/item/melee/transforming/energy/sword/saber = 1,
 		/obj/item/twohanded/dualsaber = 1,
 		/obj/item/twohanded/fireaxe = 1,
 		/obj/item/stack/telecrystal/five = 1,
@@ -475,7 +475,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	if(!battle_royale_list)
 		battle_royale_list = list()
 		battle_royale_list["Operative Hardsuit"] = /obj/item/clothing/suit/space/hardsuit/syndi
-		battle_royale_list["Energy Sword"] = /obj/item/melee/transforming/energy/sword
+		battle_royale_list["Energy Sword"] = /obj/item/melee/transforming/energy/sword/saber
 		battle_royale_list["Combat Medkit"] = /obj/item/storage/firstaid/tactical
 		battle_royale_list["Syndicate Balloon"] = /obj/item/toy/syndicateballoon
 	return battle_royale_list

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -261,6 +261,9 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 // INITIALIZATION
 //==================================
 
+/datum/battle_royale_controller/proc/start_async()
+	INVOKE_ASYNC(src, .proc/start)
+
 /datum/battle_royale_controller/proc/start()
 	//Give Verbs to admins
 	for(var/client/C in GLOB.admins)
@@ -323,7 +326,6 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	var/list/participants = pollGhostCandidates("Would you like to partake in BATTLE ROYALE?")
 	var/turf/spawn_turf = get_safe_random_station_turf()
 	var/obj/structure/closet/supplypod/centcompod/pod = new()
-	pod.setStyle(STYLE_CENTCOM)
 	players = list()
 	for(var/mob/M in participants)
 		var/key = M.key

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -366,20 +366,20 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 // EVENTS / DROPS
 //==================================
 
-/datum/battle_royale_controller/proc/generate_basic_loot(amount=1)
+/datum/battle_royale_controller/proc/generate_basic_loot(amount = 1)
 	for(var/i in 1 to amount)
-		var/list/items = list()
-		for(var/i in 1 to rand(2, 4)
+		var/list/drops = list()
+		for(var/j in 1 to rand(1, 3))
 			if(prob(95))
-				items += pickweight(GLOB.battle_royale_basic_loot)
+				drops += pickweight(GLOB.battle_royale_basic_loot)
 			else
-				items += pickweight(GLOB.battle_royale_good_loot)
-		send_item(items)
+				drops += pickweight(GLOB.battle_royale_good_loot)
+		send_item(drops)
 		stoplag()
 
 /datum/battle_royale_controller/proc/generate_good_drop()
 	var/list/good_drops = list()
-	for(var/i in 1 to rand(1,3))
+	for(var/i in 1 to rand(2,5))
 		good_drops += pickweight(GLOB.battle_royale_good_loot)
 	send_item(good_drops, announce = "Incomming extended supply materials.", force_time = 300)
 

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -215,10 +215,10 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	if(prob(1))
 		generate_good_drop()
 	//Check tickets
-	if(ticket_count && (GLOB.ahelp_tickets.unclaimed_tickets.len || GLOB.ahelp_tickets.active_tickets.len))
+	if(ticket_count && !GLOB.ahelp_tickets.unclaimed_tickets.len && !GLOB.ahelp_tickets.active_tickets.len)
 		to_chat(world, "<span class='narsie'>SUDDEN DEATH.</span>")
 		to_chat(world, "<span class='warning'>The wall speed has been increased to the maximum speed!</span>")
-		field_delay = 0
+		field_delay = 1
 		ticket_count = FALSE
 	var/living_victims = 0
 	var/mob/winner
@@ -332,11 +332,8 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		var/mob/living/carbon/human/H = new(pod)
 		ADD_TRAIT(H, TRAIT_PACIFISM, BATTLE_ROYALE_TRAIT)
 		H.status_flags |= GODMODE
-		//Assistant gang
-		H.equipOutfit(/datum/outfit/job/assistant)
-		//Give them their gear
-		var/obj/item/choice_beacon/battleroyale/BR_item = new(get_turf(H))
-		H.equip_to_appropriate_slot(BR_item)
+		//Greytide gang
+		H.equipOutfit(/datum/outfit/battle_royale)
 		//Give them a spell
 		H.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/knock)
 		H.key = key
@@ -477,3 +474,20 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		battle_royale_list["Combat Medkit"] = /obj/item/storage/firstaid/tactical
 		battle_royale_list["Syndicate Balloon"] = /obj/item/toy/syndicateballoon
 	return battle_royale_list
+
+// ===
+// OUTFIT
+// ===
+/datum/outfit/battle_royale
+	name = "Battle Royale Gear"
+
+	uniform = /obj/item/clothing/under/color/grey
+	id = /obj/item/card/id/syndicate
+	ears = /obj/item/radio/headset/syndicate
+	r_pocket =  = /obj/item/pda
+	back = /obj/item/storage/backpack
+	shoes = /obj/item/clothing/shoes/sneakers/black
+	box = /obj/item/storage/box/survival
+	belt = /obj/item/storage/belt/utility/full
+	gloves = /obj/item/clothing/gloves/color/yellow
+	l_pocket = /obj/item/choice_beacon/battleroyale

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/storage/firstaid/medical = 4,
 		/obj/item/storage/firstaid/tactical = 4,
 		/obj/item/gun/energy/ionrifle = 4,
-		/obj/item/organ/regenerative_core/battle_royale = 8
+		/obj/item/organ/regenerative_core/battle_royale = 8,
 	))
 
 GLOBAL_LIST_INIT(battle_royale_good_loot, list(
@@ -78,7 +78,7 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/gun/ballistic/rifle/boltaction = 1,
 		/obj/item/gun/ballistic/shotgun/doublebarrel = 1,
 		/obj/item/gun/energy/laser/captain = 1,
-		/obj/item/gun/ballistic/revolver/mateba, = 1
+		/obj/item/gun/ballistic/revolver/mateba = 1,
 		/obj/item/gun/ballistic/automatic/c20r = 1,
 		/obj/item/ammo_box/magazine/smgm45 = 1,
 		/obj/item/ammo_box/magazine/pistolm9mm = 1,
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(battle_royale_good_loot, list(
 		/obj/item/twohanded/fireaxe = 1,
 		/obj/item/stack/telecrystal/five = 1,
 		/obj/item/stack/telecrystal/twenty = 1,
-		/obj/item/clothing/suit/space/hardsuit/syndi = 1
+		/obj/item/clothing/suit/space/hardsuit/syndi = 1,
 	))
 
 GLOBAL_LIST_INIT(battle_royale_insane_loot, list(
@@ -100,7 +100,7 @@ GLOBAL_LIST_INIT(battle_royale_insane_loot, list(
 		/obj/item/guardiancreator/tech = 1,
 		/obj/item/twohanded/mjollnir = 1,
 		/obj/item/pneumatic_cannon/pie/selfcharge = 1,
-		/obj/item/uplink/nuclear = 1
+		/obj/item/uplink/nuclear = 1,
 	))
 
 GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
@@ -109,7 +109,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	/client/proc/battle_royale_speed,\
 	/client/proc/battle_royale_varedit,\
 	/client/proc/battle_royale_spawn_loot,\
-	/client/proc/battle_royale_spawn_loot_good\
+	/client/proc/battle_royale_spawn_loot_good,\
 )
 
 /client/proc/battle_royale()

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -332,6 +332,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		var/mob/living/carbon/human/H = new(pod)
 		ADD_TRAIT(H, TRAIT_PACIFISM, BATTLE_ROYALE_TRAIT)
 		H.status_flags |= GODMODE
+		H.pass_flags |= PASSMOB
 		//Greytide gang
 		H.equipOutfit(/datum/outfit/battle_royale)
 		//Give them a spell
@@ -355,6 +356,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	for(var/mob/M in GLOB.player_list)
 		M.RemoveSpell(/obj/effect/proc_holder/spell/aoe_turf/knock)
 		M.status_flags -= GODMODE
+		M.pass_flags &= ~PASSMOB
 		REMOVE_TRAIT(M, TRAIT_PACIFISM, BATTLE_ROYALE_TRAIT)
 		to_chat(M, "<span class='greenannounce'>You are no longer a pacafist. Be the last [M.gender == MALE ? "man" : "woman"] standing.</span>")
 
@@ -454,6 +456,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 //=====
 // Heal
 // =====
+
 /obj/item/organ/regenerative_core/battle_royale
 	preserved = TRUE
 
@@ -478,13 +481,14 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 // ===
 // OUTFIT
 // ===
+
 /datum/outfit/battle_royale
 	name = "Battle Royale Gear"
 
 	uniform = /obj/item/clothing/under/color/grey
 	id = /obj/item/card/id/syndicate
 	ears = /obj/item/radio/headset/syndicate
-	r_pocket =  = /obj/item/pda
+	r_pocket = /obj/item/pda
 	back = /obj/item/storage/backpack
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	box = /obj/item/storage/box/survival

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -535,6 +535,9 @@
 		stack_trace("Empty message")
 		return
 
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		return ..()
+
 	// Cannot use the list as a map if the key is a number, so we stringify it (thank you BYOND)
 	var/smessage_type = num2text(message_type)
 
@@ -551,7 +554,7 @@
 			colored_message = "<font color=[color]>[message]</font>"
 		else
 			colored_message = "<font color='[color]'>[message]</font>"
-	
+
 	//This makes readability a bit better for admins.
 	switch(message_type)
 		if(LOG_WHISPER)
@@ -563,7 +566,7 @@
 		if(LOG_EMOTE)
 			colored_message = "(EMOTE) [colored_message]"
 
-	var/list/timestamped_message = list("\[[time_stamp()]\] [key_name(src)] [loc_name(src)]" = colored_message)
+	var/list/timestamped_message = list("\[[time_stamp()]\] ([SSticker.get_game_state_string()]) [key_name(src)] [loc_name(src)]" = colored_message)
 
 	logging[smessage_type] += timestamped_message
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

resolves https://github.com/BeeStation/BeeStation-Hornet/issues/3060

## About The Pull Request

When delaying round end admins will be prompted if they want to run battle royale.
When all the tickets are completed, battle royale will enter sudden death mode and the wall speed will be set to 0. (The game will then last for radius second which is a maximum of ~120)
Basic loot drops will now spawn more than 1 item, since usually they are useless.
Players now spawn with a choice beacon containing a syndicate hardsuit, energy sword, combat medkit or syndicate balloon.
Battle royale loot is now weighted.
Fixed super rare drops taking 900 seconds to arrive.
Players will no longer collide with each other during the first 30 seconds of the game.
Players will now spawn with a toolbelt and insulated gloves.

This took way longer than it should have.

## Why It's Good For The Game

Improvements to battle royale and a bounty. If admins are doing long tickets they will now be prompted to trigger battle royale after the round ends, and the game mode will run itself without them needing to do things, so they can focus on the tickets.

## Changelog
:cl:
add: Upon delaying rounded, admins will be prompted if they want to start battle royale.
tweak: Battle royale loot is now weighted
tweak: Battle royale players will now spawn with a toolbelt and insulated gloves.
tweak: Players can no longer collide with each other in the first 30 seconds of battle royale.
tweak: Players now spawn with a choice beacon in battle royale.
tweak: Battle royale will have the wall speed set to maximum upon all tickets being completed.
tweak: Battle royale wall now has a minimum radius of 3.
balance: Battle royale basic drops will now spawn 1 - 3 items
fix: Elite battle royale drops no longer take 15 minutes to land.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
