### PR TITLE
Gives blood brothers better chat colouring.

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -58,3 +58,16 @@
 #define COLOR_ASSEMBLY_LBLUE   "#5D99BE"
 #define COLOR_ASSEMBLY_BLUE    "#38559E"
 #define COLOR_ASSEMBLY_PURPLE  "#6F6192"
+
+//Colours used by blood brothers
+#define COLOR_LIST_BLOOD_BROTHERS list(\
+	"#FF5050",\
+	"#D977FD",\
+	"#422ED8",\
+	"#2D87A1",\
+	"#3ED8FD",\
+	"#0EF5CE",\
+	"#0DF447",\
+	"#D6B20C",\
+	"#FF902A",\
+)

--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -47,6 +47,7 @@
 			bro.special_role = "brother"
 			bro.restricted_roles = restricted_jobs
 			log_game("[key_name(bro)] has been selected as a Brother")
+		team.team_id = j
 		pre_brother_teams += team
 	return ..()
 

--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -47,7 +47,6 @@
 			bro.special_role = "brother"
 			bro.restricted_roles = restricted_jobs
 			log_game("[key_name(bro)] has been selected as a Brother")
-		team.team_id = j
 		pre_brother_teams += team
 	return ..()
 

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/radio.dmi'
 	icon_state = "headset"
 	item_color = "r"
+	var/implant_colour = "#ff0000"
 	var/list/linked_implants // All other implants that this communicates to
 
 /obj/item/implant/bloodbrother/Initialize()
@@ -20,8 +21,8 @@
 			to_chat(imp_in, "<span class='warning'>The message contains prohibited words!</span>")
 			return
 
-		var/my_message = "<font color=\"#ff0000\"><b><i>[imp_in]:</i></b></font> [input]" //add sender, color source with syndie color
-		var/ghost_message = "<font color=\"#ff0000\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [input]"
+		var/my_message = "<font color=\"[implant_colour]\"><b><i>[imp_in]:</i></b></font> [input]" //add sender, color source with syndie color
+		var/ghost_message = "<font color=\"[implant_colour]\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [input]"
 
 		to_chat(imp_in, my_message) // Sends message to the user
 		for(var/obj/item/implant/bloodbrother/i in linked_implants) // Sends message to all linked implnats

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -64,6 +64,7 @@
 /datum/antagonist/brother/proc/finalize_brother()
 	var/obj/item/implant/bloodbrother/I = new /obj/item/implant/bloodbrother()
 	I.implant(owner.current, null, TRUE, TRUE)
+	I.implant_colour = team.team_id <= 9 ? COLOR_LIST_BLOOD_BROTHERS[team.team_id] : "#ff0000"
 	for(var/datum/mind/M in team.members) // Link the implants of all team members
 		var/obj/item/implant/bloodbrother/T = locate() in M.current.implants
 		I.link_implant(T)
@@ -96,6 +97,7 @@
 /datum/team/brother_team
 	name = "brotherhood"
 	member_name = "blood brother"
+	var/team_id
 	var/meeting_area
 	var/static/meeting_areas = list("The Bar", "Dorms", "Escape Dock", "Arrivals", "Holodeck", "Primary Tool Storage", "Recreation Area", "Chapel", "Library")
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -101,6 +101,11 @@
 	var/meeting_area
 	var/static/meeting_areas = list("The Bar", "Dorms", "Escape Dock", "Arrivals", "Holodeck", "Primary Tool Storage", "Recreation Area", "Chapel", "Library")
 
+/datum/team/brother_team/New(starting_members)
+	. = ..()
+	var/static/blood_teams
+	team_id = ++blood_teams
+
 /datum/team/brother_team/is_solo()
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ghosts struggle to see which team is communicating on blood brothers gamemode. Makes each implant a unique colour so its easier to read.

## Why It's Good For The Game

Better readability for ghosts, nicer colours used.

![image](https://user-images.githubusercontent.com/26465327/102785361-c63ce600-4395-11eb-9efe-6689c2088427.png)

Tested with other colours but I closed the tap.

## Changelog
:cl:
tweak: Makes each blood brother implant colour unique.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
