### PR TITLE
Cap slaughter & laughter demons to 1 each 

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -389,7 +389,7 @@
 	name = "Bottle of Blood"
 	desc = "A bottle of magically infused blood, the smell of which will attract extradimensional beings when broken. Be careful though, the kinds of creatures summoned by blood magic are indiscriminate in their killing, and you yourself may become a victim."
 	item_path = /obj/item/antag_spawner/slaughter_demon
-	limit = 3
+	limit = 1
 	category = "Assistance"
 
 /datum/spellbook_entry/item/hugbottle
@@ -403,7 +403,7 @@
 		destructive."
 	item_path = /obj/item/antag_spawner/slaughter_demon/laughter
 	cost = 1 //non-destructive; it's just a jape, sibling!
-	limit = 3
+	limit = 1
 	category = "Assistance"
 
 /datum/spellbook_entry/item/mjolnir


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
3 -> 1

remember 2 touch wiki

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
one last nerf to this meta w/o outright deleting them
you can spend at most 3 points now. spawning several is excessively dangerous to an early crew (you cant even shove them) and on top of that is a repetitive way to play 

## Changelog
:cl:froststahr
balance: wizard demons have been capped to one each
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
