### PR TITLE
Fix of one forgotten AI feature

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -70,9 +70,9 @@ GLOBAL_LIST_INIT(valid_keys, list(
 			break
 
 	if(holder)
-		holder.key_down(_key, src)
+		holder.key_down(full_key, src)
 	if(mob.focus)
-		mob.focus.key_down(_key, src)
+		mob.focus.key_down(full_key, src)
 
 /client/verb/keyUp(_key as text)
 	set instant = TRUE

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -70,9 +70,9 @@ GLOBAL_LIST_INIT(valid_keys, list(
 			break
 
 	if(holder)
-		holder.key_down(_key, src)
+		holder.key_down(_key, src)  //full_key is not necessary here, _key is enough
 	if(mob.focus)
-		mob.focus.key_down(_key, src)
+		mob.focus.key_down(_key, src) //same as above
 
 /client/verb/keyUp(_key as text)
 	set instant = TRUE

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -70,9 +70,9 @@ GLOBAL_LIST_INIT(valid_keys, list(
 			break
 
 	if(holder)
-		holder.key_down(full_key, src)
+		holder.key_down(_key, src)
 	if(mob.focus)
-		mob.focus.key_down(full_key, src)
+		mob.focus.key_down(_key, src)
 
 /client/verb/keyUp(_key as text)
 	set instant = TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -166,8 +166,14 @@
 	builtInCamera.network = list("ss13")
 
 /mob/living/silicon/ai/key_down(_key, client/user)
+	var/heldctrl = client.keys_held["Ctrl"]
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
-		_key = _key[7] //strings, lists, same thing really
+		if(heldctrl)
+			_key = _key[12] //strings, lists, same thing really
+		else
+			_key = _key[7]
+	else if(heldctrl && length(_key) >= 6)  //for non-numpad
+		_key = _key[6]
 	switch(_key)
 		if("`", "0")
 			if(cam_prev)
@@ -175,7 +181,7 @@
 			return
 		if("1", "2", "3", "4", "5", "6", "7", "8", "9")
 			_key = text2num(_key)
-			if(client.keys_held["Ctrl"]) //do we assign a new hotkey?
+			if(heldctrl) //do we assign a new hotkey?
 				cam_hotkeys[_key] = eyeobj.loc
 				to_chat(src, "Location saved to Camera Group [_key].")
 				return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -166,14 +166,8 @@
 	builtInCamera.network = list("ss13")
 
 /mob/living/silicon/ai/key_down(_key, client/user)
-	var/heldctrl = client.keys_held["Ctrl"]
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
-		if(heldctrl)
-			_key = _key[12] //strings, lists, same thing really
-		else
-			_key = _key[7]
-	else if(heldctrl && length(_key) >= 6)  //for non-numpad
-		_key = _key[6]
+		_key = _key[7] //strings, lists, same thing really
 	switch(_key)
 		if("`", "0")
 			if(cam_prev)
@@ -181,7 +175,7 @@
 			return
 		if("1", "2", "3", "4", "5", "6", "7", "8", "9")
 			_key = text2num(_key)
-			if(heldctrl) //do we assign a new hotkey?
+			if(client.keys_held["Ctrl"]) //do we assign a new hotkey?
 				cam_hotkeys[_key] = eyeobj.loc
 				to_chat(src, "Location saved to Camera Group [_key].")
 				return


### PR DESCRIPTION
## About The Pull Request
This PR changes the key_down function inside keyDown from full_key to _key and as a result fixes one forgotten AI feature, the ability to save camera locations (with ctrl + 1-9) and to jump to them later (with 1-9).

## Why It's Good For The Game
Fixing stuff is always good and this feature is a good alternative for multicam mode.

## Changelog
:cl:
fix: AIs can now save camera locations with CTRL + 1-9 again and jump to them later with 1-9
/:cl: