### PR TITLE
Reduces the disgust you get from Transcendent Olfaction when you are filthy

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -25,9 +25,9 @@
 /datum/mutation/human/olfaction/on_life()
 	var/hygiene_now = owner.hygiene
 
-	if(hygiene_now < 100 && prob(5))
+	if(hygiene_now < 100 && prob(3))
 		owner.adjust_disgust(GET_MUTATION_SYNCHRONIZER(src) * (rand(3,5)))
-	if(hygiene_now < HYGIENE_LEVEL_DIRTY && prob(50))
+	if(hygiene_now < HYGIENE_LEVEL_DIRTY && prob(15))
 		to_chat(owner,"<span class='danger'>You get a whiff of your stench and feel sick!</span>")
 		owner.adjust_disgust(GET_MUTATION_SYNCHRONIZER(src) * rand(5,10))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces the disgust you get from Transcendent Olfaction when you are filthy.

## Why It's Good For The Game

Olfaction is a positive mutation, yet this is annoying. 

Also, there's a chain of events that makes you be hardstunned for a whole 5 minutes with this mutation. Happened to me a while ago. If you are stinky, your disgust decreases. Once you vomit, your disgust decreases further, and you get filthier, and paralyzed. This somehow causes you to be even more disgust, and it snowballs endlessly causing you to vomit every 3 seconds. This can paralyze you for a long duration. I'm pretty sure that's not supposed to happen.

## Changelog
:cl:
balance: Reduced the disgust you get from Transcendent Olfaction when you are filthy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
