### PR TITLE
[FIX] Window Firelock now drops reinforced glass

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -591,9 +591,20 @@
 					user.visible_message("<span class='notice'>[user] cuts apart [src]!</span>", \
 										 "<span class='notice'>You cut [src] into iron.</span>")
 					var/turf/T = get_turf(src)
-					new /obj/item/stack/sheet/iron(T, 3)
-					if(reinforced)
-						new /obj/item/stack/sheet/plasteel(T, 2)
+					switch(firelock_type)
+						if(/obj/machinery/door/firedoor/heavy)
+							user.visible_message("<span class='notice'>[user] cuts apart [src]!</span>", \
+										 "<span class='notice'>You cut [src] into iron and plasteel.</span>")
+							new /obj/item/stack/sheet/plasteel(T, 2)
+							new /obj/item/stack/sheet/iron(T, 3)
+						if(/obj/machinery/door/firedoor/window)
+							user.visible_message("<span class='notice'>[user] cuts apart [src]!</span>", \
+										 "<span class='notice'>You cut [src] into reinforced glass.</span>")
+							new /obj/item/stack/sheet/rglass(T,2)
+						else
+							user.visible_message("<span class='notice'>[user] cuts apart [src]!</span>", \
+										 "<span class='notice'>You cut [src] into iron.</span>")
+							new /obj/item/stack/sheet/iron(T, 3)
 					qdel(src)
 				return
 			if(istype(C, /obj/item/electronics/firelock))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -588,8 +588,6 @@
 				if(C.use_tool(src, user, 40, volume=50, amount=1))
 					if(constructionStep != CONSTRUCTION_NOCIRCUIT)
 						return
-					user.visible_message("<span class='notice'>[user] cuts apart [src]!</span>", \
-										 "<span class='notice'>You cut [src] into iron.</span>")
 					var/turf/T = get_turf(src)
 					switch(firelock_type)
 						if(/obj/machinery/door/firedoor/heavy)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes window firelock frame dropping iron when deconstructed and now drops actual reinforced glass properly

## Why It's Good For The Game

Bugfix of my own oversight

## Changelog
:cl:
fix: Fix firelock windows dropping iron instead of reinforced glass
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
