### PR TITLE
Makes meteors appear after 50 minutes only

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -6,7 +6,7 @@
 	weight = 4
 	min_players = 15
 	max_occurrences = 3
-	earliest_start = 25 MINUTES
+	earliest_start = 50 MINUTES
 
 /datum/round_event/meteor_wave
 	startWhen		= 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Meteors can now only appear after 50 minutes.

## Why It's Good For The Game

Short rounds aren't that fun for the antags or the crew. The damage is generally hard to fix and this event is almost 90% guaranteed to get the round ended faster.

## Changelog
:cl:
tweak: meteors can now only appear after 50 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
