### PR TITLE
[FIX] Pre Calculates the crate animation math to fix the perfomance issues breaking crate animation

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -25,7 +25,7 @@
 	var/radius_2 = 1.35
 	var/open_angle = 138 //azimuth angle for over 90 degree
 	var/static/list/animation_math //List with lists inside that contain all values needed for an animation
-	var/static/list/animation_index //Assoziative list to get the index for the animation_math list that gets saved to anindex
+	var/static/list/animation_index //associative list to get the index for the animation_math list that gets saved to anindex
 	var/anindex //index from animation_index for animation_math
 	var/crateexeption = FALSE //Set to true if the crate does not use the normal animation code and does not need a list
 
@@ -100,22 +100,22 @@
 		M.Translate(0, door_hinge)
 		return M
 /*The animation_list proc writes into two static lists first animation_math where it creates a new list inside for all the values needed for the crate animation.
-The second list is animation_index this list is an assoziative list where special identify values are saved that are used to determine if there is the need for another list in animation_math or if
+The second list is animation_index this list is an associative list where special identify values are saved that are used to determine if there is the need for another list in animation_math or if
 the current lists are sufficent and it is used to get the right index for animation_math for any possible type of crate.
 Next is anindex this variable is just used to save the index for a crate so that you only need to search for the index once.
 The last one is the for loop it simply uses all given indexes to save the needed values to the lists inside animation_math if a new list is required*/
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	if(!animation_index == 0) //cecks if there is even an animation_index list yet to avoid runtimes
-		anindex = animation_index.Find(door_anim_time+door_anim_angle+open_angle+radius_2) //saves index to anindex
-	if(animation_index == null || animation_index.Find(door_anim_time+door_anim_angle+open_angle+radius_2) == 0)
+		anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") //saves index to anindex
+	if(animation_index == null || animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") == 0)
 		var/num_steps_1 = door_anim_time / world.tick_lag
 		if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list
 			animation_index = new/list()
 		if(animation_math == null) //checks if there is already a list for animation_math if not makes a new list
 			animation_math = new/list()
 		animation_index.len = length(animation_index)+1 //increases list size fo animation index
-		animation_index[length(animation_index)] = door_anim_time+door_anim_angle+open_angle+radius_2 //saves the unique value to the assoziative list
-		anindex = animation_index.Find(door_anim_time+door_anim_angle+open_angle+radius_2)
+		animation_index[length(animation_index)] = "[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]" //saves the unique value to the asssociative list
+		anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]")
 		animation_math.len = anindex //also just increases the list size
 		animation_math[anindex] = new/list(num_steps_1*2+1) //saves another list into animation_math on the index that just got added
 		for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -99,6 +99,7 @@
 		M.Multiply(matrix(1, crateanim_1, 0, 0, crateanim_2, 0))
 		M.Translate(0, door_hinge)
 		return M
+
 /*The animation_list proc writes into two static lists first animation_math where it creates a new list inside for all the values needed for the crate animation.
 The second list is animation_index this list is an associative list where special identify values are saved that are used to determine if there is the need for another list in animation_math or if
 the current lists are sufficent and it is used to get the right index for animation_math for any possible type of crate.
@@ -109,7 +110,7 @@ The last one is the for loop it simply uses all given indexes to save the needed
 		animation_index = new/list()
 		animation_math = new/list()
 	anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") //saves index to anindex
-	if(animation_index == null || animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") == 0)
+	if(animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") == 0)
 		var/num_steps_1 = door_anim_time / world.tick_lag
 		animation_index.len = length(animation_index)+1 //increases list size fo animation index
 		animation_index[length(animation_index)] = "[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]" //saves the unique value to the asssociative list

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -25,13 +25,12 @@
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
 	var/static/list/animation_math //list with pre calculation animation parameter
-	var/crateexeption = FALSE //Set to true if the crate does not use the normal animation code and does not need a list
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
 	if(animation_math == null) //checks if there is already a list for animation_index if not makes a new list also includes animation_math cause why not honestly
 		animation_math = new/list()
-	if(!door_anim_time == 0 && crateexeption == FALSE && !animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"])
+	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"])
 		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -23,7 +23,7 @@
 	drag_slowdown = 0
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
-	var/animation_math
+	var/list/animation_math
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
@@ -69,8 +69,8 @@
 		var/angle = door_anim_angle * (closing ? 1 - (I/num_steps) : (I/num_steps))
 		var/door_state = angle >= 90 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
 		var/door_layer = angle >= 90 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/crateanim_1 = animation_math[1][closing ? num_steps + 1 - I : I + 1]
-		var/crateanim_2 = animation_math[2][closing ? num_steps + 1 - I : I + 1]
+		var/crateanim_1 = animation_math[closing ? num_steps + 1 - I : I + 1]
+		var/crateanim_2 = animation_math[closing ? 2*num_steps + 1 - I : num_steps+ I + 1]
 		var/matrix/M = get_door_transform(crateanim_1, crateanim_2)
 		if(I == 0)
 			door_obj.transform = M
@@ -97,14 +97,14 @@
 
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	var/num_steps_1 = door_anim_time / world.tick_lag
-	animation_math = new/list(2,1+num_steps_1)
+	animation_math = new/list(num_steps_1*2+1)
 	for(var/I in 0 to num_steps_1)
 		var/angle_1 =  I==0 ? 0 : door_anim_angle * (I/num_steps_1)
 		var/polar_angle = abs(arcsin(cos(angle_1)))
 		var/azimuth_angle = angle_1 >= 90 ? 138 : 0
 		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
-		animation_math[1][I+1] = -sin(polar_angle)*sin(azimuth_angle)*radius_cr
-		animation_math[2][I+1] = radius_cr*cos(azimuth_angle)*sin(polar_angle)
+		animation_math[I+1] = -sin(polar_angle)*sin(azimuth_angle)*radius_cr
+		animation_math[num_steps_1+I+1] = radius_cr*cos(azimuth_angle)*sin(polar_angle)
 
 /obj/structure/closet/crate/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -23,6 +23,7 @@
 	drag_slowdown = 0
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
+	var/open_angle = 138 //azmoth angle for over 90 degree
 	var/list/animation_math
 
 /obj/structure/closet/crate/Initialize()
@@ -102,7 +103,7 @@
 	for(var/I in 0 to num_steps_1)
 		var/angle_1 =  I==0 ? 0 : door_anim_angle * (I/num_steps_1)
 		var/polar_angle = abs(arcsin(cos(angle_1)))
-		var/azimuth_angle = angle_1 >= 90 ? 138 : 0
+		var/azimuth_angle = angle_1 >= 90 ? open_angle : 0
 		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
 		animation_math[I+1] = -sin(polar_angle)*sin(azimuth_angle)*radius_cr
 		animation_math[num_steps_1+I+1] = radius_cr*cos(azimuth_angle)*sin(polar_angle)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -21,17 +21,19 @@
 	open_sound_volume = 35
 	close_sound_volume = 50
 	drag_slowdown = 0
+	door_anim_squish = 138 //in this context the azimuth angle for over 90 degree
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
-	var/open_angle = 138 //azimuth angle for over 90 degree
-	var/static/list/animation_math //List with lists inside that contain all values needed for an animation
-	var/static/list/animation_index //associative list to get the index for the animation_math list that gets saved to anindex
-	var/anindex //index from animation_index for animation_math
+	var/static/list/animation_math //list with pre calculation animation parameter
+	var/static/list/animation_index //index list for animation math
 	var/crateexeption = FALSE //Set to true if the crate does not use the normal animation code and does not need a list
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
-	if(!door_anim_time == 0&&crateexeption == FALSE)
+	if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list also includes animation_math cause why not honestly
+		animation_index = new/list()
+		animation_math = new/list()
+	if(!door_anim_time == 0 && crateexeption == FALSE && animation_index.Find("[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]") == 0)
 		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
@@ -70,13 +72,12 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
+	var/list/animation_math_list = animation_math[(animation_index.Find("[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"))]
 	for(var/I in 0 to num_steps)
 		var/angle = door_anim_angle * (closing ? 1 - (I/num_steps) : (I/num_steps))
 		var/door_state = angle >= 90 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
 		var/door_layer = angle >= 90 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/crateanim_1 = animation_math[anindex][closing ? num_steps + 1 - I : I + 1]
-		var/crateanim_2 = animation_math[anindex][closing ? 2*num_steps + 1 - I : num_steps+ I + 1]
-		var/matrix/M = get_door_transform(crateanim_1, crateanim_2)
+		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps + 1 - I : I + 1], animation_math_list[closing ? 2 * num_steps + 1 - I : num_steps + I + 1])
 		if(I == 0)
 			door_obj.transform = M
 			door_obj.icon_state = door_state
@@ -100,30 +101,20 @@
 		M.Translate(0, door_hinge)
 		return M
 
-/*The animation_list proc writes into two static lists first animation_math where it creates a new list inside for all the values needed for the crate animation.
-The second list is animation_index this list is an associative list where special identify values are saved that are used to determine if there is the need for another list in animation_math or if
-the current lists are sufficent and it is used to get the right index for animation_math for any possible type of crate.
-Next is anindex this variable is just used to save the index for a crate so that you only need to search for the index once.
-The last one is the for loop it simply uses all given indexes to save the needed values to the lists inside animation_math if a new list is required*/
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
-	if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list also includes animation_math cause why not honestly
-		animation_index = new/list()
-		animation_math = new/list()
-	anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") //saves index to anindex
-	if(animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") == 0)
-		var/num_steps_1 = door_anim_time / world.tick_lag
-		animation_index.len = length(animation_index)+1 //increases list size fo animation index
-		animation_index[length(animation_index)] = "[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]" //saves the unique value to the asssociative list
-		anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]")
-		animation_math.len = anindex //also just increases the list size
-		animation_math[anindex] = new/list(num_steps_1*2+1) //saves another list into animation_math on the index that just got added
-		for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
-			var/angle_1 =  I==0 ? 0 : door_anim_angle * (I/num_steps_1)
-			var/polar_angle = abs(arcsin(cos(angle_1)))
-			var/azimuth_angle = angle_1 >= 90 ? open_angle : 0
-			var/radius_cr = angle_1 >= 90 ? radius_2 : 1
-			animation_math[anindex][I+1] = -sin(polar_angle)*sin(azimuth_angle)*radius_cr
-			animation_math[anindex][num_steps_1+I+1] = radius_cr*cos(azimuth_angle)*sin(polar_angle)
+	animation_index.len = length(animation_index)+1
+	animation_math.len = length(animation_math)+1
+	animation_index[length(animation_index)] = "[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"
+	var/num_steps_1 = door_anim_time / world.tick_lag
+	var/list/new_animation_math_sublist[num_steps_1 * 2 + 1]
+	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
+		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
+		var/polar_angle = abs(arcsin(cos(angle_1)))
+		var/azimuth_angle = angle_1 >= 90 ? door_anim_squish : 0
+		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
+		new_animation_math_sublist[I+1] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
+		new_animation_math_sublist[num_steps_1+I+1] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
+	animation_math[(animation_index.Find("[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"))] = new_animation_math_sublist
 
 /obj/structure/closet/crate/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -24,7 +24,7 @@
 	door_anim_squish = 138 //in this context the azimuth angle for over 90 degree
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
-	var/static/list/animation_math //list with pre calculation animation parameter
+	var/static/list/animation_math //assoc list with pre calculated values
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -21,7 +21,7 @@
 	open_sound_volume = 35
 	close_sound_volume = 50
 	drag_slowdown = 0
-	door_anim_squish = 138 //in this context the azimuth angle for over 90 degree
+	var/azimuth_angle_2 = 138 //in this context the azimuth angle for over 90 degree
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
 	var/static/list/animation_math //assoc list with pre calculated values
@@ -30,7 +30,7 @@
 	. = ..()
 	if(animation_math == null) //checks if there is already a list for animation_math if not creates one to avoid runtimes
 		animation_math = new/list()
-	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"])
+	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"])
 		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
@@ -69,7 +69,7 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
-	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"]
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
 		var/angle = door_anim_angle * (closing ? 1 - (I/num_steps) : (I/num_steps))
 		var/door_state = angle >= 90 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
@@ -92,11 +92,11 @@
 	COMPILE_OVERLAYS(src)
 
 /obj/structure/closet/crate/get_door_transform(crateanim_1, crateanim_2)
-		var/matrix/M = matrix()
-		M.Translate(0, -door_hinge)
-		M.Multiply(matrix(1, crateanim_1, 0, 0, crateanim_2, 0))
-		M.Translate(0, door_hinge)
-		return M
+	var/matrix/M = matrix()
+	M.Translate(0, -door_hinge)
+	M.Multiply(matrix(1, crateanim_1, 0, 0, crateanim_2, 0))
+	M.Translate(0, door_hinge)
+	return M
 
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	var/num_steps_1 = door_anim_time / world.tick_lag
@@ -104,11 +104,11 @@
 	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
 		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
 		var/polar_angle = abs(arcsin(cos(angle_1)))
-		var/azimuth_angle = angle_1 >= 90 ? door_anim_squish : 0
+		var/azimuth_angle = angle_1 >= 90 ? azimuth_angle_2 : 0
 		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
 		new_animation_math_sublist[I+1] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
 		new_animation_math_sublist[num_steps_1+I+1] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
-	animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"] = new_animation_math_sublist
+	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
 
 /obj/structure/closet/crate/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -24,11 +24,14 @@
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
 	var/open_angle = 138 //azimuth angle for over 90 degree
-	var/list/animation_math
+	var/static/list/animation_math //List with lists inside that contain all values needed for an animation
+	var/static/list/animation_index //Assoziative list to get the index for the animation_math list that gets saved to anindex
+	var/anindex //index from animation_index for animation_math
+	var/crateexeption = FALSE //Set to true if the crate does not use the normal animation code and does not need a list
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
-	if(!door_anim_time == 0)
+	if(!door_anim_time == 0&&crateexeption == FALSE)
 		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
@@ -71,8 +74,8 @@
 		var/angle = door_anim_angle * (closing ? 1 - (I/num_steps) : (I/num_steps))
 		var/door_state = angle >= 90 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
 		var/door_layer = angle >= 90 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/crateanim_1 = animation_math[closing ? num_steps + 1 - I : I + 1]
-		var/crateanim_2 = animation_math[closing ? 2*num_steps + 1 - I : num_steps+ I + 1]
+		var/crateanim_1 = animation_math[anindex][closing ? num_steps + 1 - I : I + 1]
+		var/crateanim_2 = animation_math[anindex][closing ? 2*num_steps + 1 - I : num_steps+ I + 1]
 		var/matrix/M = get_door_transform(crateanim_1, crateanim_2)
 		if(I == 0)
 			door_obj.transform = M
@@ -96,17 +99,32 @@
 		M.Multiply(matrix(1, crateanim_1, 0, 0, crateanim_2, 0))
 		M.Translate(0, door_hinge)
 		return M
-
+/*The animation_list proc writes into two static lists first animation_math where it creates a new list inside for all the values needed for the crate animation.
+The second list is animation_index this list is an assoziative list where special identify values are saved that are used to determine if there is the need for another list in animation_math or if
+the current lists are sufficent and it is used to get the right index for animation_math for any possible type of crate.
+Next is anindex this variable is just used to save the index for a crate so that you only need to seach for the index once.
+The last one is the for loop it simply uses all given indexes to save the needed values to the lists inside animation_math if a new list is required*/
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
-	var/num_steps_1 = door_anim_time / world.tick_lag
-	animation_math = new/list(num_steps_1*2+1)
-	for(var/I in 0 to num_steps_1)
-		var/angle_1 =  I==0 ? 0 : door_anim_angle * (I/num_steps_1)
-		var/polar_angle = abs(arcsin(cos(angle_1)))
-		var/azimuth_angle = angle_1 >= 90 ? open_angle : 0
-		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
-		animation_math[I+1] = -sin(polar_angle)*sin(azimuth_angle)*radius_cr
-		animation_math[num_steps_1+I+1] = radius_cr*cos(azimuth_angle)*sin(polar_angle)
+	if(!animation_index == 0) //cecks if there is even an animation_index list yet to avoid runtimes
+		anindex = animation_index.Find(door_anim_time+door_anim_angle+open_angle+radius_2) //saves index to anindex
+	if(animation_index == null || animation_index.Find(door_anim_time+door_anim_angle+open_angle+radius_2) == 0)
+		var/num_steps_1 = door_anim_time / world.tick_lag
+		if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list
+			animation_index = new/list()
+		if(animation_math == null) //checks if there is already a list for animation_math if not makes a new list
+			animation_math = new/list()
+		animation_index.len = length(animation_index)+1 //increases list size fo animation index
+		animation_index[length(animation_index)] = door_anim_time+door_anim_angle+open_angle+radius_2 //saves the unique value to the assoziative list
+		anindex = animation_index.Find(door_anim_time+door_anim_angle+open_angle+radius_2)
+		animation_math.len = anindex //also just increases the list size
+		animation_math[anindex] = new/list(num_steps_1*2+1) //saves another list into animation_math on the index that just got added
+		for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
+			var/angle_1 =  I==0 ? 0 : door_anim_angle * (I/num_steps_1)
+			var/polar_angle = abs(arcsin(cos(angle_1)))
+			var/azimuth_angle = angle_1 >= 90 ? open_angle : 0
+			var/radius_cr = angle_1 >= 90 ? radius_2 : 1
+			animation_math[anindex][I+1] = -sin(polar_angle)*sin(azimuth_angle)*radius_cr
+			animation_math[anindex][num_steps_1+I+1] = radius_cr*cos(azimuth_angle)*sin(polar_angle)
 
 /obj/structure/closet/crate/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -27,7 +27,8 @@
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
-	animation_list()
+	if(!door_anim_time == 0)
+		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
 	if(!istype(mover, /obj/structure/closet))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -105,7 +105,7 @@ the current lists are sufficent and it is used to get the right index for animat
 Next is anindex this variable is just used to save the index for a crate so that you only need to search for the index once.
 The last one is the for loop it simply uses all given indexes to save the needed values to the lists inside animation_math if a new list is required*/
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
-	if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list also include animatioN_math cause why not honestly
+	if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list also includes animation_math cause why not honestly
 		animation_index = new/list()
 		animation_math = new/list()
 	anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") //saves index to anindex

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -105,14 +105,12 @@ the current lists are sufficent and it is used to get the right index for animat
 Next is anindex this variable is just used to save the index for a crate so that you only need to search for the index once.
 The last one is the for loop it simply uses all given indexes to save the needed values to the lists inside animation_math if a new list is required*/
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
-	if(!animation_index == 0) //cecks if there is even an animation_index list yet to avoid runtimes
-		anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") //saves index to anindex
+	if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list also include animatioN_math cause why not honestly
+		animation_index = new/list()
+		animation_math = new/list()
+	anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") //saves index to anindex
 	if(animation_index == null || animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]") == 0)
 		var/num_steps_1 = door_anim_time / world.tick_lag
-		if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list
-			animation_index = new/list()
-		if(animation_math == null) //checks if there is already a list for animation_math if not makes a new list
-			animation_math = new/list()
 		animation_index.len = length(animation_index)+1 //increases list size fo animation index
 		animation_index[length(animation_index)] = "[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]" //saves the unique value to the asssociative list
 		anindex = animation_index.Find("[door_anim_time]-[door_anim_angle]-[open_angle]-[radius_2]")

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -28,6 +28,7 @@
 /obj/structure/closet/crate/Initialize()
 	. = ..()
 	animation_list()
+
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
 	if(!istype(mover, /obj/structure/closet))
 		var/obj/structure/closet/crate/locatedcrate = locate(/obj/structure/closet/crate) in get_turf(mover)
@@ -93,6 +94,7 @@
 		M.Multiply(matrix(1, crateanim_1, 0, 0, crateanim_2, 0))
 		M.Translate(0, door_hinge)
 		return M
+
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	var/num_steps_1 = door_anim_time / world.tick_lag
 	animation_math = new/list(2,1+num_steps_1)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -28,7 +28,7 @@
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
-	if(animation_math == null) //checks if there is already a list for animation_index if not makes a new list also includes animation_math cause why not honestly
+	if(animation_math == null) //checks if there is already a list for animation_math if not creates one to avoid runtimes
 		animation_math = new/list()
 	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"])
 		animation_list()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -23,7 +23,7 @@
 	drag_slowdown = 0
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
-	var/open_angle = 138 //azmoth angle for over 90 degree
+	var/open_angle = 138 //azimuth angle for over 90 degree
 	var/list/animation_math
 
 /obj/structure/closet/crate/Initialize()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -102,7 +102,7 @@
 /*The animation_list proc writes into two static lists first animation_math where it creates a new list inside for all the values needed for the crate animation.
 The second list is animation_index this list is an assoziative list where special identify values are saved that are used to determine if there is the need for another list in animation_math or if
 the current lists are sufficent and it is used to get the right index for animation_math for any possible type of crate.
-Next is anindex this variable is just used to save the index for a crate so that you only need to seach for the index once.
+Next is anindex this variable is just used to save the index for a crate so that you only need to search for the index once.
 The last one is the for loop it simply uses all given indexes to save the needed values to the lists inside animation_math if a new list is required*/
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	if(!animation_index == 0) //cecks if there is even an animation_index list yet to avoid runtimes

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -25,15 +25,13 @@
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
 	var/static/list/animation_math //list with pre calculation animation parameter
-	var/static/list/animation_index //index list for animation math
 	var/crateexeption = FALSE //Set to true if the crate does not use the normal animation code and does not need a list
 
 /obj/structure/closet/crate/Initialize()
 	. = ..()
-	if(animation_index == null) //checks if there is already a list for animation_index if not makes a new list also includes animation_math cause why not honestly
-		animation_index = new/list()
+	if(animation_math == null) //checks if there is already a list for animation_index if not makes a new list also includes animation_math cause why not honestly
 		animation_math = new/list()
-	if(!door_anim_time == 0 && crateexeption == FALSE && animation_index.Find("[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]") == 0)
+	if(!door_anim_time == 0 && crateexeption == FALSE && !animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"])
 		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
@@ -72,7 +70,7 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
-	var/list/animation_math_list = animation_math[(animation_index.Find("[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"))]
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"]
 	for(var/I in 0 to num_steps)
 		var/angle = door_anim_angle * (closing ? 1 - (I/num_steps) : (I/num_steps))
 		var/door_state = angle >= 90 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
@@ -102,9 +100,6 @@
 		return M
 
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
-	animation_index.len = length(animation_index)+1
-	animation_math.len = length(animation_math)+1
-	animation_index[length(animation_index)] = "[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"
 	var/num_steps_1 = door_anim_time / world.tick_lag
 	var/list/new_animation_math_sublist[num_steps_1 * 2 + 1]
 	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
@@ -114,7 +109,7 @@
 		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
 		new_animation_math_sublist[I+1] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
 		new_animation_math_sublist[num_steps_1+I+1] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
-	animation_math[(animation_index.Find("[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"))] = new_animation_math_sublist
+	animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"] = new_animation_math_sublist
 
 /obj/structure/closet/crate/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -16,6 +16,7 @@
 	door_hinge = 5.5
 	door_anim_angle = 90
 	door_anim_squish = 0.35
+	crateexeption = TRUE
 
 /obj/structure/closet/crate/critter/Initialize()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -41,9 +41,9 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"]
 	for(var/I in 0 to num_steps)
-		var/angle = door_anim_angle * (closing ? 1 - (I/num_steps) : (I/num_steps))
-		var/matrix/M = get_door_transform(angle)
+		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps + 1 - I : I + 1], animation_math_list[closing ? 2 * num_steps + 1 - I : num_steps + I + 1])
 
 		if(I == 0)
 			door_obj.transform = M
@@ -59,10 +59,10 @@
 	update_icon()
 	COMPILE_OVERLAYS(src)
 
-/obj/structure/closet/crate/critter/get_door_transform(angle)
+/obj/structure/closet/crate/critter/get_door_transform(crateanim_1, crateanim_2)
 	var/matrix/M = matrix()
 	M.Translate(-door_hinge, 0)
-	M.Multiply(matrix(cos(angle), 0, 0, sin(angle) * door_anim_squish, 1, 0))
+	M.Multiply(matrix(crateanim_1, 0, 0, crateanim_2, 1, 0))
 	M.Translate(door_hinge, 0)
 	return M
 
@@ -79,3 +79,10 @@
 		return null
 
 /obj/structure/closet/crate/critter/animation_list()
+	var/num_steps_1 = door_anim_time / world.tick_lag
+	var/list/new_animation_math_sublist[num_steps_1 * 2 + 1]
+	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
+		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
+		new_animation_math_sublist[I+1] = cos(angle_1)
+		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * door_anim_squish
+	animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"] = new_animation_math_sublist

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -16,7 +16,6 @@
 	door_hinge = 5.5
 	door_anim_angle = 90
 	door_anim_squish = 0.35
-	crateexeption = TRUE
 
 /obj/structure/closet/crate/critter/Initialize()
 	. = ..()
@@ -78,3 +77,5 @@
 		return tank.return_analyzable_air()
 	else
 		return null
+
+/obj/structure/closet/crate/critter/animation_list()

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -15,7 +15,7 @@
 	var/obj/item/tank/internals/emergency_oxygen/tank
 	door_hinge = 5.5
 	door_anim_angle = 90
-	door_anim_squish = 0.35
+	azimuth_angle_2 = 0.35
 
 /obj/structure/closet/crate/critter/Initialize()
 	. = ..()
@@ -41,7 +41,7 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
-	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"]
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
 		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps + 1 - I : I + 1], animation_math_list[closing ? 2 * num_steps + 1 - I : num_steps + I + 1])
 
@@ -84,5 +84,5 @@
 	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
 		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
 		new_animation_math_sublist[I+1] = cos(angle_1)
-		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * door_anim_squish
-	animation_math["[door_anim_time]-[door_anim_angle]-[door_anim_squish]-[radius_2]"] = new_animation_math_sublist
+		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * azimuth_angle_2
+	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"] = new_animation_math_sublist


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The animation math for crate was a bit to extensive for byond inside a for loop so i moved it out into an extra proc.
Said proc creates a assoc list for all the needed animation values with a unique value as the index means you can have crates with the same animation parameter share a list while crates with different parameter share another list and so on.
This allows for using pre calculated lists but holds the amount of lists to a minimum while still allowing for a great flexibility and easy crate implementation with new parameter.
Also thanks to park66665 for helping me out with the assoc list.
## Why It's Good For The Game

Fixes currently broken looking crate animation

## Changelog
:cl:

fix: crate animation looking broken
code: Move animation math into a extra proc to pre calculate it
refactor: Adding a association list to allow easy adding of additional crates with unique values while still keeping the amount of actual lists to a minimum.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
