### PR TITLE
Sentinals compromise restores blood volume

### DIFF
--- a/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
@@ -33,6 +33,7 @@
 	M.adjustFireLoss(-M.getFireLoss() * 0.6, FALSE)
 	M.adjustOxyLoss(-M.getOxyLoss() * 0.6, FALSE)
 	M.adjustCloneLoss(-M.getCloneLoss() * 0.6, TRUE)
+	M.blood_volume = BLOOD_VOLUME_NORMAL
 	M.reagents.remove_reagent(/datum/reagent/water/holywater, INFINITY)
 	M.set_nutrition(NUTRITION_LEVEL_FULL)
 	M.bodytemperature = BODYTEMP_NORMAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so sentinels compromise sets blood level to normal

## Why It's Good For The Game

little bit of a "i ded" PR but the clockies sleepers don't help with blood. theoretically you can keep yourself alive by just spam casting the spell but this seems a little but more like a oversight. Bacon be sure to leme know if this was intended or not you can close it then if you don't agree
## Changelog
:cl:
tweak: Sentinel's compromise restores blood volume
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
