### PR TITLE
Abductors get Agent IDs

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -36,6 +36,7 @@
 	suit = /obj/item/clothing/suit/armor/abductor/vest
 	suit_store = /obj/item/abductor/baton
 	belt = /obj/item/storage/belt/military/abductor/full
+	id = /obj/item/card/id/syndicate
 
 	backpack_contents = list(
 		/obj/item/gun/energy/alien = 1,
@@ -44,6 +45,7 @@
 
 /datum/outfit/abductor/scientist
 	name = "Abductor Scientist"
+	id = /obj/item/card/id/syndicate
 
 	backpack_contents = list(
 		/obj/item/abductor/gizmo = 1
@@ -61,6 +63,7 @@
 	suit = /obj/item/clothing/suit/armor/abductor/vest
 	suit_store = /obj/item/abductor/baton
 	belt = /obj/item/storage/belt/military/abductor/full
+	id = /obj/item/card/id/syndicate
 
 	backpack_contents = list(
 	/obj/item/abductor/gizmo = 1,

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -4,6 +4,7 @@
 	shoes = /obj/item/clothing/shoes/combat
 	back = /obj/item/storage/backpack
 	ears = /obj/item/radio/headset/abductor
+	id = /obj/item/card/id/syndicate
 
 /datum/outfit/abductor/proc/link_to_console(mob/living/carbon/human/H, team_number)
 	var/datum/antagonist/abductor/A = H.mind.has_antag_datum(/datum/antagonist/abductor)
@@ -36,7 +37,6 @@
 	suit = /obj/item/clothing/suit/armor/abductor/vest
 	suit_store = /obj/item/abductor/baton
 	belt = /obj/item/storage/belt/military/abductor/full
-	id = /obj/item/card/id/syndicate
 
 	backpack_contents = list(
 		/obj/item/gun/energy/alien = 1,
@@ -45,7 +45,6 @@
 
 /datum/outfit/abductor/scientist
 	name = "Abductor Scientist"
-	id = /obj/item/card/id/syndicate
 
 	backpack_contents = list(
 		/obj/item/abductor/gizmo = 1
@@ -63,7 +62,6 @@
 	suit = /obj/item/clothing/suit/armor/abductor/vest
 	suit_store = /obj/item/abductor/baton
 	belt = /obj/item/storage/belt/military/abductor/full
-	id = /obj/item/card/id/syndicate
 
 	backpack_contents = list(
 	/obj/item/abductor/gizmo = 1,

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -48,6 +48,7 @@
 		dat += "<a href='?src=[REF(src)];dispense=chem_dispenser'>Reagent Synthesizer (2 Credits)</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=helmet'>Agent Helmet</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=vest'>Agent Vest</A><br>"
+		dat += "<a href='?src=[REF(src)];dispense=agentid'>Agent ID</a><br>"
 		dat += "<a href='?src=[REF(src)];dispense=silencer'>Radio Silencer</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=tool'>Science Tool</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=tongue'>Superlingual Matrix</a><br>"
@@ -118,6 +119,8 @@
 				Dispense(/obj/item/abductor_machine_beacon/chem_dispenser,cost=2)
 			if("tongue")
 				Dispense(/obj/item/organ/tongue/abductor)
+			if("agentid")
+				Dispense(/obj/item/card/id/syndicate)
 	updateUsrDialog()
 
 /obj/machinery/abductor/console/proc/TeleporterRetrieve()

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -48,7 +48,7 @@
 		dat += "<a href='?src=[REF(src)];dispense=chem_dispenser'>Reagent Synthesizer (2 Credits)</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=helmet'>Agent Helmet</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=vest'>Agent Vest</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=agentid'>Agent ID</a><br>"
+		dat += "<a href='?src=[REF(src)];dispense=agentid'>Alien ID</a><br>"
 		dat += "<a href='?src=[REF(src)];dispense=silencer'>Radio Silencer</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=tool'>Science Tool</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=tongue'>Superlingual Matrix</a><br>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Abductors spawn with syndicate agent IDs
They can also buy replacements from their console

This has been implemented on multiple other servers, such as yogs, paradise (iirc)
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Abductors now have no reason to dump you without your ID. 
## Changelog
:cl:Froststahr
add: Abductors now start with agent IDs! Just swipe a victim's ID card onto it to copy their access. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
