### PR TITLE
ghost overhead chat

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -15,6 +15,7 @@ GLOBAL_LIST_EMPTY(mob_directory)			//mob_id -> mob
 GLOBAL_LIST_EMPTY(alive_mob_list)			//all alive mobs, including clientless. Excludes /mob/dead/new_player
 GLOBAL_LIST_EMPTY(suicided_mob_list)		//contains a list of all mobs that suicided, including their associated ghosts.
 GLOBAL_LIST_EMPTY(drones_list)
+GLOBAL_LIST_EMPTY(dead_clients_list)		//All dead clients
 GLOBAL_LIST_EMPTY(dead_mob_list)			//all dead mobs, including clientless. Excludes /mob/dead/new_player
 GLOBAL_LIST_EMPTY(joined_player_list)		//all clients that have joined the game at round-start or as a latejoin.
 GLOBAL_LIST_EMPTY(new_player_list)			//all /mob/dead/new_player, in theory all should have clients and those that don't are in the process of spawning and get deleted when done.

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -117,12 +117,14 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	var/turf/T = get_turf(src)
 	if (isturf(T))
 		update_z(T.z)
+	GLOB.dead_clients_list += client
 
 /mob/dead/auto_deadmin_on_login()
 	return
 
 /mob/dead/Logout()
 	update_z(null)
+	GLOB.dead_clients_list -= client
 	return ..()
 
 /mob/dead/onTransitZ(old_z,new_z)

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -27,3 +27,5 @@
 	var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling)
 		changeling.regain_powers()
+
+	GLOB.dead_clients_list -= client

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -78,6 +78,7 @@
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[emoji_parse(spanned)]</span></span>"
 	log_talk(message, LOG_SAY, tag="DEAD")
 	deadchat_broadcast(rendered, follow_target = src, speaker_key = key)
+	INVOKE_ASYNC(GLOBAL_PROC, /.proc/animate_chat, src, message, /datum/language/common, 0, GLOB.dead_clients_list, 50)
 
 ///Check if this message is an emote
 /mob/proc/check_emote(message, forced)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Talking in dead chat now displays an overhead chat message.

## Why It's Good For The Game

Its quite nice, allows ghosts to talk to each other easier.

![image](https://user-images.githubusercontent.com/26465327/103172738-6939a800-484d-11eb-8086-9f5ec2cc4a6e.png)

## Changelog
:cl:
add: Runechat for ghosts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
