### PR TITLE
Fixes the 4th character slot

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				max_save_slots = 8
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
-		if(md5("extra character slot") in purchased_gear)
+		if("6030fe461e610e2be3a2c3e75c06067e" in purchased_gear) //MD5 hash of, "extra character slot"
 			max_save_slots += 1
 		if(load_character())
 			return

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				max_save_slots = 8
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
-		if("extra character slot" in purchased_gear)
+		if(md5("extra character slot") in purchased_gear)
 			max_save_slots += 1
 		if(load_character())
 			return


### PR DESCRIPTION
This is really stupid but I'd rather fix it ASAP and improve it later. Gear IDs are just md5 hashes of the display names so this _should_ work but it's untested.

## Changelog
:cl:
fix: Fixed the 4th character slot for players that have purchased it with beecoins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
