### PR TITLE
Ghost Health Scan now also shows chems

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -62,6 +62,7 @@
 /mob/living/attack_ghost(mob/dead/observer/user)
 	if(user.client && user.health_scan)
 		healthscan(user, src, 1, TRUE)
+		chemscan(user, src, 1, TRUE)
 	return ..()
 
 // ---------------------------------------


### PR DESCRIPTION
## About The Pull Request
Health Scanning someone as a ghost now also shows the chems inside them.

## Why It's Good For The Game
So you become better at backseat gaming by screaming in dchat what someone should do when shot with a certain chemical.
Seriously why did nobody else add this.

## Changelog
:cl:
add: Health scanning someone as a ghost now also shows the chemicals inside their body.
/:cl: