### PR TITLE
Moves player list out of status topic

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -123,6 +123,14 @@
 /datum/world_topic/adminwho/Run(list/input, addr)
 	return ircadminwho()
 
+/datum/world_topic/playerlist
+	keyword = "playerlist"
+
+/datum/world_topic/playerlist/Run(list/input, addr)
+	. = list()
+    for(var/client/C as() in GLOB.clients)
+        . += C.ckey
+
 /datum/world_topic/status
 	keyword = "status"
 
@@ -140,11 +148,6 @@
 	.["revision"] = GLOB.revdata.commit
 	.["revision_date"] = GLOB.revdata.date
 	.["hub"] = GLOB.hub_visibility
-
-	var/client_num = 0
-	for(var/client/C in GLOB.clients)
-		.["client[client_num]"] = C.key
-		client_num++
 
 	var/list/adm = get_admin_counts()
 	var/list/presentmins = adm["present"]

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -128,8 +128,8 @@
 
 /datum/world_topic/playerlist/Run(list/input, addr)
 	. = list()
-    for(var/client/C as() in GLOB.clients)
-        . += C.ckey
+	for(var/client/C as() in GLOB.clients)
+		. += C.ckey
 
 /datum/world_topic/status
 	keyword = "status"


### PR DESCRIPTION
`status` contained a really stupid assoc list of clients. This moves it to `playerlist` and makes it not stupid.

DNM until @qwertyquerty signs off.

## Changelog
:cl:
refactor: world/Topic()'s player list has been moved from "status" to "playerlist"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
