### PR TITLE
Makes chloral hydrate bottle have 30u

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -45,7 +45,7 @@
 	name = "chloral hydrate bottle"
 	desc = "A small bottle of Choral Hydrate. Mickey's Favorite!"
 	icon_state = "bottle20"
-	list_reagents = list(/datum/reagent/toxin/chloralhydrate = 15)
+	list_reagents = list(/datum/reagent/toxin/chloralhydrate = 30)
 
 /obj/item/reagent_containers/glass/bottle/mannitol
 	name = "mannitol bottle"


### PR DESCRIPTION


## About The Pull Request
@yyzsong complained that chloral hydrate bottle in boxstation medbay had only 15u. Well, after a brief investigation, turned out that some smart soul back from 2012 thought that chloral hydrate was too overpowered.
![image](https://user-images.githubusercontent.com/34888552/103369934-19b8dd80-4ad4-11eb-8dbd-ba04a98c17cd.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There is not a single reason for that bottle having 15u instead of 30. It is also piss-easy to make anyway.

## Changelog
:cl:
fix: chloral hydrate bottle now has 30u instead of 15u.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
