### PR TITLE
Force map json (Mapping Testmerge Helper)

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -130,7 +130,7 @@ GLOBAL_PROTECT(admin_verbs_server)
 	/client/proc/cmd_debug_del_all,
 	/client/proc/toggle_random_events,
 	/client/proc/forcerandomrotate,
-	/client/proc/adminchangemap,
+	/client/proc/forcemapconfig,
 	/client/proc/panicbunker,
 	/client/proc/toggle_hub,
 	/client/proc/toggle_cdn
@@ -176,7 +176,8 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/cmd_display_overlay_log,
 	/client/proc/reload_configuration,
 	/datum/admins/proc/create_or_modify_area,
-	/client/proc/toggle_cdn
+	/client/proc/toggle_cdn,
+	/client/proc/adminchangemap
 	)
 
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -130,7 +130,7 @@ GLOBAL_PROTECT(admin_verbs_server)
 	/client/proc/cmd_debug_del_all,
 	/client/proc/toggle_random_events,
 	/client/proc/forcerandomrotate,
-	/client/proc/forcemapconfig,
+	/client/proc/adminchangemap,
 	/client/proc/panicbunker,
 	/client/proc/toggle_hub,
 	/client/proc/toggle_cdn
@@ -150,6 +150,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/enable_debug_verbs,
 	/client/proc/callproc,
 	/client/proc/callproc_datum,
+	/client/proc/forcemapconfig,
 	/client/proc/SDQL2_query,
 	/client/proc/test_movable_UI,
 	/client/proc/test_snap_UI,
@@ -176,8 +177,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/cmd_display_overlay_log,
 	/client/proc/reload_configuration,
 	/datum/admins/proc/create_or_modify_area,
-	/client/proc/toggle_cdn,
-	/client/proc/adminchangemap
+	/client/proc/toggle_cdn
 	)
 
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -12,7 +12,7 @@
 /client/proc/adminchangemap()
 	set category = "Server"
 	set name = "Change Map"
-		
+
 	var/list/maprotatechoices = list()
 	for (var/map in config.maplist)
 		var/datum/map_config/VM = config.maplist[map]
@@ -43,3 +43,28 @@
 	log_admin("[key_name(usr)] is changing the map to [VM.map_name]")
 	if (SSmapping.changemap(VM) == 0)
 		message_admins("[key_name_admin(usr)] has changed the map to [VM.map_name]")
+
+/client/proc/forcemapconfig()
+	set category = "Debug"
+	set name = "Debug Force Map"
+
+	//Locked behind permissions since it needs serious protection.
+	if(!check_rights(R_DEBUG) || !check_rights(R_SERVER) || !check_rights(R_PERMISSIONS))
+		to_chat(src, "<span class='warning'>Insufficient rights (Requires debug, server and permissions).</span>")
+		return
+
+	var/json_settings = input(usr, "Enter map json name:", "Map Json Name", "") as text|null
+
+	if(!json_settings)
+		return
+
+	var/datum/map_config/config = new
+	if(!config.LoadConfig("_maps/[json_settings].json", TRUE))
+		qdel(config)
+		to_chat(usr, "<span class='warning'>Map json failed to load!</span>")
+		return
+	SSticker.maprotatechecked = 1
+	message_admins("[key_name_admin(usr)] is changing the map to [config.map_name]")
+	log_admin("[key_name(usr)] is changing the map to [config.map_name]")
+	if (SSmapping.changemap(config) == 0)
+		message_admins("[key_name_admin(usr)] has changed the map to [config.map_name]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a debug verb that allows a json to be loaded even if it is not in the config for runnable maps. This allows mapping testmerges to occur without needing config changes; all that is required is a maps json file be testmerged onto the server.

Obviously forcing the potential to force maps that aren't in active rotation is pretty high, so this is restricted to some of the highest permissions (Debug, Server Control and Permissions are all required).

## Why It's Good For The Game

Makes testmerging maps for a single round significantly easier, since it can be done with an in game button by headdevs/headmins/hosts/anyone with debug, server control and permissions control (High rank required to prevent admins running incompatible maps). This prevents the need to constantly add a config, remove the config, add the config etc.

### Local Testing:

#### Test 1:

![image](https://user-images.githubusercontent.com/26465327/103374777-55ea3f00-4ad0-11eb-9804-e20e9f83557d.png)

(Only 2 files were copied from corgstation PR, the map file and the son)

Map loaded successfully:
![image](https://user-images.githubusercontent.com/26465327/103374903-9ba70780-4ad0-11eb-8326-9af56e3b8f59.png)

Only occurring runtimes were due to corgstation specific objects that were coded in but I didn't and copy and paste the code.

#### Test 2:

Entering asirthugasdrg as the station name.
Result:
 - Map json failed to load!

#### Test 3:

Entering donutstation.
Result:
![image](https://user-images.githubusercontent.com/26465327/103375080-1d973080-4ad1-11eb-980c-7946e90540cf.png)

Successful map load, No runtimes occurred.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
