### PR TITLE
Refactors cable and disposal pipe construction/deconstruction code to improve performance

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -46,7 +46,6 @@ By design, d1 is the smallest direction and d2 is the highest
 	var/d1 = 0   // cable direction 1 (see above)
 	var/d2 = 1   // cable direction 2 (see above)
 	var/datum/powernet/powernet
-	var/obj/item/stack/cable_coil/stored
 
 	FASTDMM_PROP(\
 		pipe_type = PIPE_TYPE_CABLE,\
@@ -99,11 +98,6 @@ By design, d1 is the smallest direction and d2 is the highest
 		hide(T.intact)
 	GLOB.cable_list += src //add it to the global cable list
 
-	if(d1)
-		stored = new/obj/item/stack/cable_coil(null,2,cable_color)
-	else
-		stored = new/obj/item/stack/cable_coil(null,1,cable_color)
-
 	var/list/cable_colors = GLOB.cable_colors
 	cable_color = param_color || cable_color || pick(cable_colors)
 	if(cable_colors[cable_color])
@@ -114,22 +108,15 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(powernet)
 		cut_cable_from_powernet()				// update the powernets
 	GLOB.cable_list -= src							//remove it from global cable list
-
-	//If we have a stored item at this point, lets just delete it, since that should be
-	//handled by deconstruction
-	if(stored)
-		QDEL_NULL(stored)
 	return ..()									// then go ahead and delete the cable
 
 /obj/structure/cable/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		var/turf/T = get_turf(loc)
 		if(T)
-			stored.forceMove(T)
-			stored = null
-		else
-			qdel(stored)
-	qdel(src)
+			var/obj/item/stack/cable_coil/temp_item = new/obj/item/stack/cable_coil(T, d1 ? 2 : 1, cable_color)
+			transfer_fingerprints_to(temp_item)
+	..()
 
 ///////////////////////////////////
 // General procedures
@@ -155,7 +142,6 @@ By design, d1 is the smallest direction and d2 is the highest
 		if (shock(user, 50))
 			return
 		user.visible_message("[user] cuts the cable.", "<span class='notice'>You cut the cable.</span>")
-		stored.add_fingerprint(user)
 		investigate_log("was cut by [key_name(usr)] in [AREACOORD(src)]", INVESTIGATE_WIRES)
 		deconstruct()
 		return
@@ -205,11 +191,6 @@ By design, d1 is the smallest direction and d2 is the highest
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()
-
-/obj/structure/cable/proc/update_stored(length = 1, colorC = "red")
-	stored.amount = length
-	stored.item_color = colorC
-	stored.update_icon()
 
 ////////////////////////////////////////////
 // Power related
@@ -751,9 +732,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 
 		C.d1 = nd1
 		C.d2 = nd2
-
-		//updates the stored cable coil
-		C.update_stored(2, item_color)
 
 		C.add_fingerprint(user)
 		C.update_icon()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -114,7 +114,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(!(flags_1 & NODECONSTRUCT_1))
 		var/turf/T = get_turf(loc)
 		if(T)
-			var/obj/item/stack/cable_coil/temp_item = new/obj/item/stack/cable_coil(T, d1 ? 2 : 1, cable_color)
+			var/obj/item/stack/cable_coil/temp_item = new /obj/item/stack/cable_coil(T, d1 ? 2 : 1, cable_color)
 			transfer_fingerprints_to(temp_item)
 	..()
 

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -230,8 +230,7 @@
 
 /obj/machinery/disposal/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
-		var/obj/structure/disposalconstruct/temp_structure = new /obj/structure/disposalconstruct(loc, null, SOUTH, FALSE, src)
-		temp_structure.density = TRUE //currently the only way disposalconstruct can be dense: deconstructed disposals!
+		new /obj/structure/disposalconstruct(loc, null, SOUTH, FALSE, src)
 	for(var/atom/movable/AM in src) //out, out, darned crowbar!
 		AM.forceMove(loc)
 	..()

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -23,7 +23,6 @@
 	var/flush_every_ticks = 30 //Every 30 ticks it will look whether it is ready to flush
 	var/flush_count = 0 //this var adds 1 once per tick. When it reaches flush_every_ticks it resets and tries to flush.
 	var/last_sound = 0
-	var/obj/structure/disposalconstruct/stored
 	// create a new disposal
 	// find the attached trunk (if present) and init gas resvr.
 
@@ -32,11 +31,7 @@
 
 	if(make_from)
 		setDir(make_from.dir)
-		make_from.moveToNullspace()
-		stored = make_from
 		pressure_charging = FALSE // newly built disposal bins start with pump off
-	else
-		stored = new /obj/structure/disposalconstruct(null, null , SOUTH , FALSE , src)
 
 	trunk_check()
 
@@ -234,16 +229,11 @@
 	qdel(H)
 
 /obj/machinery/disposal/deconstruct(disassembled = TRUE)
-	var/turf/T = loc
 	if(!(flags_1 & NODECONSTRUCT_1))
-		if(stored)
-			stored.forceMove(T)
-			src.transfer_fingerprints_to(stored)
-			stored.anchored = FALSE
-			stored.density = TRUE
-			stored.update_icon()
+		var/obj/structure/disposalconstruct/temp_structure = new /obj/structure/disposalconstruct(loc, null, SOUTH, FALSE, src)
+		temp_structure.density = TRUE //currently the only way disposalconstruct can be dense: deconstructed disposals!
 	for(var/atom/movable/AM in src) //out, out, darned crowbar!
-		AM.forceMove(T)
+		AM.forceMove(loc)
 	..()
 
 /obj/machinery/disposal/get_dumping_location(obj/item/storage/source,mob/user)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -232,7 +232,7 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		new /obj/structure/disposalconstruct(loc, null, SOUTH, FALSE, src)
 	for(var/atom/movable/AM in src) //out, out, darned crowbar!
-		AM.forceMove(loc)
+		AM.forceMove(get_turf(src))
 	..()
 
 /obj/machinery/disposal/get_dumping_location(obj/item/storage/source,mob/user)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -21,6 +21,7 @@
 		pipe_type = make_from.type
 		setDir(make_from.dir)
 		anchored = TRUE
+		density = initial(pipe_type.density)
 		make_from.transfer_fingerprints_to(src)
 
 	else

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -16,10 +16,12 @@
 
 /obj/structure/disposalconstruct/Initialize(loc, _pipe_type, _dir = SOUTH, flip = FALSE, obj/make_from)
 	. = ..()
+
 	if(make_from)
 		pipe_type = make_from.type
 		setDir(make_from.dir)
 		anchored = TRUE
+		make_from.transfer_fingerprints_to(src)
 
 	else
 		if(_pipe_type)
@@ -159,12 +161,13 @@
 		if(!I.tool_start_check(user, amount=0))
 			return TRUE
 
+		add_fingerprint(user)
 		to_chat(user, "<span class='notice'>You start welding the [pipename] in place...</span>")
 		if(I.use_tool(src, user, 8, volume=50))
 			to_chat(user, "<span class='notice'>The [pipename] has been welded in place.</span>")
 			var/obj/O = new pipe_type(loc, src)
 			transfer_fingerprints_to(O)
-
+			qdel(src)
 	else
 		to_chat(user, "<span class='warning'>You need to attach it to the plating first!</span>")
 	return TRUE

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -10,18 +10,14 @@
 	var/active = FALSE
 	var/turf/target	// this will be where the output objects are 'thrown' to.
 	var/obj/structure/disposalpipe/trunk/trunk // the attached pipe trunk
-	var/obj/structure/disposalconstruct/stored
 	var/start_eject = 0
 	var/eject_range = 2
 
 /obj/structure/disposaloutlet/Initialize(mapload, obj/structure/disposalconstruct/make_from)
 	. = ..()
+
 	if(make_from)
 		setDir(make_from.dir)
-		make_from.forceMove(src)
-		stored = make_from
-	else
-		stored = new /obj/structure/disposalconstruct(src, null , SOUTH , FALSE , src)
 
 	target = get_ranged_target_turf(src, dir, 10)
 
@@ -33,7 +29,6 @@
 	if(trunk)
 		trunk.linked = null
 		trunk = null
-	QDEL_NULL(stored)
 	return ..()
 
 // expel the contents of the holder object, then delete it
@@ -70,12 +65,15 @@
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
 
+	add_fingerprint(user)
 	playsound(src, 'sound/items/welder2.ogg', 100, 1)
 	to_chat(user, "<span class='notice'>You start slicing the floorweld off [src]...</span>")
 	if(I.use_tool(src, user, 20))
 		to_chat(user, "<span class='notice'>You slice the floorweld off [src].</span>")
-		stored.forceMove(loc)
-		transfer_fingerprints_to(stored)
-		stored = null
-		qdel(src)
+		deconstruct()
 	return TRUE
+
+/obj/structure/disposaloutlet/deconstruct(disassembled = TRUE)
+	if(!(flags_1 & NODECONSTRUCT_1))
+		new /obj/structure/disposalconstruct(loc, null, SOUTH, FALSE, src)
+	..()

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -16,18 +16,13 @@
 	var/dpdir = NONE					// bitmask of pipe directions
 	var/initialize_dirs = NONE			// bitflags of pipe directions added on init, see \code\_DEFINES\pipe_construction.dm
 	var/flip_type						// If set, the pipe is flippable and becomes this type when flipped
-	var/obj/structure/disposalconstruct/stored
 
 
 /obj/structure/disposalpipe/Initialize(mapload, obj/structure/disposalconstruct/make_from)
 	. = ..()
 
-	if(!QDELETED(make_from))
+	if(make_from)
 		setDir(make_from.dir)
-		make_from.forceMove(src)
-		stored = make_from
-	else
-		stored = new /obj/structure/disposalconstruct(src, null , SOUTH , FALSE , src)
 
 	if(dir in GLOB.diagonals) // Bent pipes already have all the dirs set
 		initialize_dirs = NONE
@@ -50,7 +45,6 @@
 	if(H)
 		H.active = FALSE
 		expel(H, get_turf(src), 0)
-	QDEL_NULL(stored)
 	return ..()
 
 // returns the direction of the next pipe object, given the entrance dir
@@ -146,6 +140,7 @@
 	if(!I.tool_start_check(user, amount=0))
 		return TRUE
 
+	add_fingerprint(user)
 	to_chat(user, "<span class='notice'>You start slicing [src]...</span>")
 	if(I.use_tool(src, user, 30, volume=50))
 		deconstruct()
@@ -160,19 +155,14 @@
 /obj/structure/disposalpipe/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			if(stored)
-				stored.forceMove(loc)
-				transfer_fingerprints_to(stored)
-				stored.setDir(dir)
-				stored = null
+			new /obj/structure/disposalconstruct(src, null , SOUTH , FALSE , src)
 		else
 			var/turf/T = get_turf(src)
 			for(var/D in GLOB.cardinals)
 				if(D & dpdir)
 					var/obj/structure/disposalpipe/broken/P = new(T)
 					P.setDir(D)
-	qdel(src)
-
+	..()
 
 /obj/structure/disposalpipe/singularity_pull(S, current_size)
 	..()

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -155,7 +155,7 @@
 /obj/structure/disposalpipe/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			new /obj/structure/disposalconstruct(src, null , SOUTH , FALSE , src)
+			new /obj/structure/disposalconstruct(loc, null , SOUTH , FALSE , src)
 		else
 			var/turf/T = get_turf(src)
 			for(var/D in GLOB.cardinals)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

(In case you are curious, my branch names are selected from what I was listening when I created the branch. Maxim Vengerov 1992 recording, it was.)

1. Every cable structure creates and stores a cable coil item since its creation...
1.1. when it is only needed for destruct item drop.
1.2 And every disposal pipe structure also does the same thing with disposalconstruct structure!
2. So, do you know how many cables and disposal pipes are there in a map?
3. And, do you know atmosmachineries already create broken parts in situ? (since tgstation/tgstation#21992 thx MSO)
4. Therefore, this PR fixes the problem by making them create post-destruction objects in situ too, like atmosmachineries!
5. Additionally, the PR ended up making the code simpler.

Finally  a downstream note: AU should revert austation/austation#2311 and make changes to austation/austation#2028 to mirror this PR.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

To summarize, this should shorten the world init time (around 1%), and reduce memory usage a little: around 10MB. ~~why do you use so much memory on these, BYOND~~

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: refactored cable and disposal pipe construction/deconstruction code to remove ugly legacy code
fix: removal of said ugly legacy code improved performance a bit
fix: and fixed cable color bugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
