### PR TITLE
[Port] Fixes log collisions

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -563,7 +563,7 @@
 		if(LOG_EMOTE)
 			colored_message = "(EMOTE) [colored_message]"
 
-	var/list/timestamped_message = list("\[[time_stamp()]\] [key_name(src)] [loc_name(src)]" = colored_message)
+	var/list/timestamped_message = list("\[[time_stamp()]\] [key_name(src)] [loc_name(src)] (Event #[LAZYLEN(logging[smessage_type])])" = colored_message)
 
 	logging[smessage_type] += timestamped_message
 


### PR DESCRIPTION
## About The Pull Request

This fixes some instances where things being logged within the same tic caused inaccuracies and duplication in the logging.
See the original PR https://github.com/tgstation/tgstation/pull/55829 for the nuts and bolts.

## Changelog
:cl: Ryll/Shaps
admin: Fixed an issue with player logs becoming confused when someone triggers multiple events within one second (like being attacked by two people at the same time) that would cause holes in the logs
/:cl:
