### PR TITLE
Makes "inverseDir" a global proc

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1605,11 +1605,8 @@ config_setting should be one of the following:
 
 /proc/invertDir(var/input_dir)
 	switch(input_dir)
-		if(NORTH)
-			return SOUTH
-		if(SOUTH)
-			return NORTH
-		if(EAST)
-			return WEST
-		if(WEST)
-			return EAST
+		if(UP, DOWN)
+			CRASH("Can't turn vertical directions!")
+		if(-INFINITY to 0, 11 to INFINITY)
+			CRASH("Can't turn invalid directions!")
+		else return turn(input_dir, 180)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1611,4 +1611,4 @@ config_setting should be one of the following:
 			return UP
 		if(-INFINITY to 0, 11 to INFINITY)
 			CRASH("Can't turn invalid directions!")
-		return turn(input_dir, 180)
+	return turn(input_dir, 180)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1605,8 +1605,11 @@ config_setting should be one of the following:
 
 /proc/invertDir(var/input_dir)
 	switch(input_dir)
-		if(UP, DOWN)
-			CRASH("Can't turn vertical directions!")
+		if(UP)
+			return DOWN
+		if(DOWN)
+			return UP
 		if(-INFINITY to 0, 11 to INFINITY)
 			CRASH("Can't turn invalid directions!")
-		else return turn(input_dir, 180)
+			return
+		return turn(input_dir, 180)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1602,3 +1602,14 @@ config_setting should be one of the following:
 /proc/get_final_z(atom/A)
 	var/turf/T = get_turf(A)
 	return T ? T.z : A.z
+
+/proc/invertDir(var/input_dir)
+	switch(input_dir)
+		if(NORTH)
+			return SOUTH
+		if(SOUTH)
+			return NORTH
+		if(EAST)
+			return WEST
+		if(WEST)
+			return EAST

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1611,5 +1611,4 @@ config_setting should be one of the following:
 			return UP
 		if(-INFINITY to 0, 11 to INFINITY)
 			CRASH("Can't turn invalid directions!")
-			return
 		return turn(input_dir, 180)

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -161,17 +161,6 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 		position = WEST
 	return position
 
-/obj/item/shuttle_creator/proc/invertDir(var/input_dir)
-	if(input_dir == NORTH)
-		return SOUTH
-	else if(input_dir == SOUTH)
-		return NORTH
-	else if(input_dir == EAST)
-		return WEST
-	else if(input_dir == WEST)
-		return EAST
-	return null
-
 /obj/item/shuttle_creator/proc/shuttle_create_docking_port(atom/target, mob/user)
 
 	if(loggedTurfs.len == 0 || !recorded_shuttle_area)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

proc now utilizes switch instead of else if and removes unneeded null return

## Why It's Good For The Game

inversedir could be used elsewhere in the future

## Changelog
:cl:
code: inversedir is now a global proc
/:cl:

