### PR TITLE
Adds in some job scaling to jobs.txt

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -524,7 +524,7 @@ SUBSYSTEM_DEF(job)
 	for(var/datum/job/J in occupations)
 		if(J.flag == GIMMICK || J.gimmick) //gimmick job slots are dependant on random maint
 			continue
-		var/regex/jobs = new("[J.title]=(-1|\\d+),(-1|\\d+)")
+		var/regex/jobs = new("[J.title]=(-1|\\d+),(-1|\\d+),(-1|\\d+),(-1|\\d+)")
 		if(jobs.Find(jobstext))
 			J.total_positions = text2num(jobs.group[1])
 			J.spawn_positions = text2num(jobs.group[2])

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -528,6 +528,8 @@ SUBSYSTEM_DEF(job)
 		if(jobs.Find(jobstext))
 			J.total_positions = text2num(jobs.group[1])
 			J.spawn_positions = text2num(jobs.group[2])
+			J.min_spawn_positions = text2num(jobs.group[3])
+			J.scaling_amount = text2num(jobs.group[4])
 		else
 			log_runtime("Error in /datum/controller/subsystem/job/proc/LoadJobs: Failed to locate job of title [J.title] in jobs.txt")
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -26,6 +26,10 @@
 	//How many players can spawn in as this job
 	var/spawn_positions = 0
 
+	//Calculating high pop scaling
+	var/min_spawn_positions = 0
+	var/scaling_amount = 1
+
 	//How many players have this job
 	var/current_positions = 0
 
@@ -64,6 +68,11 @@
 
 	var/tmp/list/gear_leftovers = list()
 	var/gimmick = FALSE //least hacky way i could think of for this
+
+/datum/job/proc/calculate_spawn_scaling(population = 0)
+	if(!scaling_amount0)
+		return
+	spawn_positions = min(spawn_positions, min_spawn_positions + FLOOR(population / scaling_amount, 1))
 
 //Only override this proc, unless altering loadout code. Loadouts act on H but get info from M
 //H is usually a human unless an /equip override transformed it

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -70,7 +70,7 @@
 	var/gimmick = FALSE //least hacky way i could think of for this
 
 /datum/job/proc/calculate_spawn_scaling(population = 0)
-	if(!scaling_amount0)
+	if(!scaling_amount)
 		return
 	spawn_positions = min(spawn_positions, min_spawn_positions + FLOOR(population / scaling_amount, 1))
 

--- a/config/Sage/jobs.txt
+++ b/config/Sage/jobs.txt
@@ -41,6 +41,7 @@ Station Engineer=7,5,2,20
 Atmospheric Technician=4,2,0,0
 
 Medical Doctor=8,6,3,20
+Paramedic=2,1,0,0
 Chemist=3,2,0,0
 Geneticist=2,2,0,0
 Virologist=1,1,0,0
@@ -51,6 +52,8 @@ Roboticist=2,2,0,0
 Warden=1,1,0,0
 Detective=1,1,0,0
 Security Officer=10,8,2,10
+Brig Physician=1,1,0,0
+Deputy=0,0,0,0
 
 AI=1,1,0,0
 Cyborg=1,1,0,0

--- a/config/Sage/jobs.txt
+++ b/config/Sage/jobs.txt
@@ -38,7 +38,7 @@ Lawyer=2,2,0,0
 Chaplain=1,1,0,0
 
 Station Engineer=7,5,2,20
-Atmospheric Technician=4,2,0,0
+Atmospheric Technician=2,2,0,0
 
 Medical Doctor=8,6,3,20
 Paramedic=2,1,0,0

--- a/config/Sage/jobs.txt
+++ b/config/Sage/jobs.txt
@@ -1,46 +1,56 @@
 #This allows easy configuration of the number of positions allowed for each job
-#Format is: [Job name]=[total positions],[spawn positions]
+#Format is: [Job name]=[max positions],[max spawn positions],[default spawn positions],[pop per extra position]
 #Job names must be identical to the title var of each job datum
 #Positions can be set to -1 to allow unlimited slots
-Captain=1,1
-Head of Personnel=1,1
-Head of Security=1,1
-Chief Engineer=1,1
-Research Director=1,1
-Chief Medical Officer=1,1
+#If the pop per extra position is set to 0, then scaling will be disabled and the spawn positions will be at maximum
+#Otherwise at 0 pop, the default spawn positions will spawn, then 1 extra job will be added for every (pop per extra position) people
+#capped at the max spawn positions
+# EXAMPLE:
+# Scientist=8,6,3,20
+# Maximum of 8 scientists can late join
+# At pop of 0 there will be 3 scientists
+# At pop of 20 there will be up to 4 roundstart
+# At pop of 40 there will be up to 5 roundstart
+# At pop of 60+ there will be up to 6 roundstart
+Captain=1,1,1,0
+Head of Personnel=1,1,0,0
+Head of Security=1,1,0,0
+Chief Engineer=1,1,0,0
+Research Director=1,1,0,0
+Chief Medical Officer=1,1,0,0
 
-Assistant=-1,-1
+Assistant=-1,-1,0,0
 
-Quartermaster=1,1
-Cargo Technician=6,4
-Shaft Miner=4,4
+Quartermaster=1,1,0,0
+Cargo Technician=6,4,4,20
+Shaft Miner=3,3,0,0
 
-Bartender=2,1
-Cook=2,1
-Botanist=4,3
-Janitor=3,2
+Bartender=2,1,1,40
+Cook=2,1,0,0
+Botanist=4,3,0,0
+Janitor=3,2,0,0
 
-Clown=1,1
-Mime=1,1
-Curator=1,1
-Lawyer=2,2
+Clown=1,1,0,0
+Mime=1,1,0,0
+Curator=1,1,0,0
+Lawyer=2,2,0,0
 
-Chaplain=1,1
+Chaplain=1,1,0,0
 
-Station Engineer=7,5
-Atmospheric Technician=4,2
+Station Engineer=7,5,2,20
+Atmospheric Technician=4,2,0,0
 
-Medical Doctor=8,6
-Chemist=3,2
-Geneticist=3,2
-Virologist=1,1
+Medical Doctor=8,6,3,20
+Chemist=3,2,0,0
+Geneticist=2,2,0,0
+Virologist=1,1,0,0
 
-Scientist=8,6
-Roboticist=2,2
+Scientist=8,6,3,20
+Roboticist=2,2,0,0
 
-Warden=1,1
-Detective=1,1
-Security Officer=10,8
+Warden=1,1,0,0
+Detective=1,1,0,0
+Security Officer=10,8,2,10
 
-AI=1,1
-Cyborg=1,1
+AI=1,1,0,0
+Cyborg=1,1,0,0

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -41,6 +41,7 @@ Station Engineer=7,5,2,20
 Atmospheric Technician=4,2,0,0
 
 Medical Doctor=8,6,3,20
+Paramedic=2,1,0,0
 Chemist=3,2,0,0
 Geneticist=2,2,0,0
 Virologist=1,1,0,0
@@ -51,6 +52,8 @@ Roboticist=2,2,0,0
 Warden=1,1,0,0
 Detective=1,1,0,0
 Security Officer=10,8,2,10
+Brig Physician=1,1,0,0
+Deputy=0,0,0,0
 
 AI=1,1,0,0
 Cyborg=1,1,0,0

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -38,7 +38,7 @@ Lawyer=2,2,0,0
 Chaplain=1,1,0,0
 
 Station Engineer=7,5,2,20
-Atmospheric Technician=4,2,0,0
+Atmospheric Technician=2,2,0,0
 
 Medical Doctor=8,6,3,20
 Paramedic=2,1,0,0

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -1,49 +1,56 @@
 #This allows easy configuration of the number of positions allowed for each job
-#Format is: [Job name]=[total positions],[spawn positions]
+#Format is: [Job name]=[max positions],[max spawn positions],[default spawn positions],[pop per extra position]
 #Job names must be identical to the title var of each job datum
 #Positions can be set to -1 to allow unlimited slots
-Captain=1,1
-Head of Personnel=1,1
-Head of Security=1,1
-Chief Engineer=1,1
-Research Director=1,1
-Chief Medical Officer=1,1
+#If the pop per extra position is set to 0, then scaling will be disabled and the spawn positions will be at maximum
+#Otherwise at 0 pop, the default spawn positions will spawn, then 1 extra job will be added for every (pop per extra position) people
+#capped at the max spawn positions
+# EXAMPLE:
+# Scientist=8,6,3,20
+# Maximum of 8 scientists can late join
+# At pop of 0 there will be 3 scientists
+# At pop of 20 there will be up to 4 roundstart
+# At pop of 40 there will be up to 5 roundstart
+# At pop of 60+ there will be up to 6 roundstart
+Captain=1,1,1,0
+Head of Personnel=1,1,0,0
+Head of Security=1,1,0,0
+Chief Engineer=1,1,0,0
+Research Director=1,1,0,0
+Chief Medical Officer=1,1,0,0
 
-Assistant=-1,-1
+Assistant=-1,-1,0,0
 
-Quartermaster=1,1
-Cargo Technician=4,2
-Shaft Miner=3,3
+Quartermaster=1,1,0,0
+Cargo Technician=6,4,4,20
+Shaft Miner=3,3,0,0
 
-Bartender=2,1
-Cook=2,1
-Botanist=3,2
-Janitor=3,2
+Bartender=2,1,1,40
+Cook=2,1,0,0
+Botanist=4,3,0,0
+Janitor=3,2,0,0
 
-Clown=1,1
-Mime=1,1
-Curator=1,1
-Lawyer=2,2
+Clown=1,1,0,0
+Mime=1,1,0,0
+Curator=1,1,0,0
+Lawyer=2,2,0,0
 
-Chaplain=1,1
+Chaplain=1,1,0,0
 
-Station Engineer=6,5
-Atmospheric Technician=4,2
+Station Engineer=7,5,2,20
+Atmospheric Technician=4,2,0,0
 
-Medical Doctor=7,4
-Paramedic=2,1
-Chemist=3,2
-Geneticist=3,2
-Virologist=2,2
+Medical Doctor=8,6,3,20
+Chemist=3,2,0,0
+Geneticist=2,2,0,0
+Virologist=1,1,0,0
 
-Scientist=6,4
-Roboticist=2,2
+Scientist=8,6,3,20
+Roboticist=2,2,0,0
 
-Warden=1,1
-Detective=1,1
-Security Officer=5,5
-Brig Physician=1,1
-Deputy=0,0
+Warden=1,1,0,0
+Detective=1,1,0,0
+Security Officer=10,8,2,10
 
-AI=1,1
-Cyborg=1,1
+AI=1,1,0,0
+Cyborg=1,1,0,0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Spawned on MRP as a 4th shaft miner in a random spawn, went to look in jobs.txt and found the settings are utterly insane. The settings for LRP seem to be perfectly normal, but for some reason our MRP job settings are all over the place. (4 shaft miners, 3 geneticists despite 2 computers, 10 security officers roundstart no matter the pop).

Rather than just lower the numbers on some of them, since some of the job slots have wayyyyy too many slots I added the ability for jobs to have population scaling, so there can be less at 0 pop and more at 80 pop.

## Why It's Good For The Game

Adds more jobs with more pop, but still getting a diverse station on low pops.

## Changelog
:cl:
add: Job slots scale
del: Removed sages ability for 4 miners to spawn despite no maps supporting this
del: Removes sages ability for 3 geneticists to spawn despite no maps supporting this
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
