### PR TITLE
Port the new hijack from TG, created by citadel. 

### DIFF
--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -173,6 +173,12 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"S" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "U" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/window,
@@ -376,7 +382,7 @@ f
 f
 f
 f
-f
+S
 U
 "}
 (9,1,1) = {"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -52,6 +52,14 @@
 #define MAX_LEADERS_GANG		3
 #define INITIAL_DOM_ATTEMPTS	3
 
+//Shuttle elimination hijacking
+/// Does not stop elimination hijacking but itself won't elimination hijack
+#define ELIMINATION_NEUTRAL 0
+/// Needs to be present for shuttle to be elimination hijacked
+#define ELIMINATION_ENABLED 1
+/// Prevents elimination hijack same way as non-antags
+#define ELIMINATION_PREVENT 2
+
 //Syndicate Contracts
 #define CONTRACT_STATUS_INACTIVE 1
 #define CONTRACT_STATUS_ACTIVE 2

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -32,11 +32,6 @@
 #define BLOB_REFLECTOR_COST 15
 #define BLOB_STRAIN_COLOR_LIST list("#BE5532", "#7D6EB4", "#EC8383", "#00E5B1", "#00668B", "#FFF68", "#BBBBAA", "#CD7794", "#57787B", "#3C6EC8", "#AD6570", "#823ABB")
 
-//Shuttle hijacking
-#define HIJACK_NEUTRAL 0 //Does not stop hijacking but itself won't hijack
-#define HIJACK_HIJACKER 1 //Needs to be present for shuttle to be hijacked
-#define HIJACK_PREVENT 2 //Prevents hijacking same way as non-antags
-
 //Overthrow time to update heads obj
 #define OBJECTIVE_UPDATING_TIME 300
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -826,56 +826,6 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 #define is_alpha(X) ((text2ascii(X) <= 122) && (text2ascii(X) >= 97))
 #define is_digit(X) ((length(X) == 1) && (length(text2num(X)) == 1))
 
-//json decode that will return null on parse error instead of runtiming.
-/proc/safe_json_decode(data)
-	try
-		return json_decode(data)
-	catch
-		return
-
-/proc/num2loadingbar(percent as num, numSquares = 20, reverse = FALSE)
-	var/loadstring = ""
-	for (var/i in 1 to numSquares)
-		var/limit = reverse ? numSquares - percent*numSquares : percent*numSquares
-		loadstring += i <= limit ? "█" : "░"
-	return "\[[loadstring]\]"
-
-/**
-  * Formats a number to human readable form with the appropriate SI unit.
-  *
-  * Supports SI exponents between 1e-15 to 1e15, but properly handles numbers outside that range as well.
-  * Examples:
-  * * `siunit(1234, "Pa", 1)` -> `"1.2 kPa"`
-  * * `siunit(0.5345, "A", 0)` -> `"535 mA"`
-  * * `siunit(1000, "Pa", 4)` -> `"1 kPa"`
-  * Arguments:
-  * * value - The number to convert to text. Can be positive or negative.
-  * * unit - The base unit of the number, such as "Pa" or "W".
-  * * maxdecimals - Maximum amount of decimals to display for the final number. Defaults to 1.
-  */
-/proc/siunit(value, unit, maxdecimals=1)
-	var/static/list/prefixes = list("f","p","n","μ","m","","k","M","G","T","P")
-
-	// We don't have prefixes beyond this point
-	// and this also captures value = 0 which you can't compute the logarithm for
-	// and also byond numbers are floats and doesn't have much precision beyond this point anyway
-	if(abs(value) <= 1e-18)
-		return "0 [unit]"
-
-	var/exponent = clamp(log(10, abs(value)), -15, 15) // Calculate the exponent and clamp it so we don't go outside the prefix list bounds
-	var/divider = 10 ** (round(exponent / 3) * 3) // Rounds the exponent to nearest SI unit and power it back to the full form
-	var/coefficient = round(value / divider, 10 ** -maxdecimals) // Calculate the coefficient and round it to desired decimals
-	var/prefix_index = round(exponent / 3) + 6 // Calculate the index in the prefixes list for this exponent
-
-	// An edge case which happens if we round 999.9 to 0 decimals for example, which gets rounded to 1000
-	// In that case, we manually swap up to the next prefix if there is one available
-	if(coefficient >= 1000 && prefix_index < 11)
-		coefficient /= 1e3
-		prefix_index++
-
-	var/prefix = prefixes[prefix_index]
-	return "[coefficient] [prefix][unit]"
-
 /// Slightly expensive proc to scramble a message using equal probabilities of character replacement from a list. DOES NOT SUPPORT HTML!
 /proc/scramble_message_replace_chars(original, replaceprob = 25, list/replacementchars = list("$", "@", "!", "#", "%", "^", "&", "*"), replace_letters_only = FALSE, replace_whitespace = FALSE)
 	var/list/out = list()

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -838,5 +838,5 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		if(replace_letters_only && (!ISINRANGE(char, 65, 90) && !ISINRANGE(char, 97, 122)))
 			out += char
 			continue
-		out += prob(replaceprob)? pick(replacementchars) : char
+		out += prob(replaceprob) ? pick(replacementchars) : char
 	return out.Join("")

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -825,3 +825,68 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 #define is_alpha(X) ((text2ascii(X) <= 122) && (text2ascii(X) >= 97))
 #define is_digit(X) ((length(X) == 1) && (length(text2num(X)) == 1))
+
+//json decode that will return null on parse error instead of runtiming.
+/proc/safe_json_decode(data)
+	try
+		return json_decode(data)
+	catch
+		return
+
+/proc/num2loadingbar(percent as num, numSquares = 20, reverse = FALSE)
+	var/loadstring = ""
+	for (var/i in 1 to numSquares)
+		var/limit = reverse ? numSquares - percent*numSquares : percent*numSquares
+		loadstring += i <= limit ? "█" : "░"
+	return "\[[loadstring]\]"
+
+/**
+  * Formats a number to human readable form with the appropriate SI unit.
+  *
+  * Supports SI exponents between 1e-15 to 1e15, but properly handles numbers outside that range as well.
+  * Examples:
+  * * `siunit(1234, "Pa", 1)` -> `"1.2 kPa"`
+  * * `siunit(0.5345, "A", 0)` -> `"535 mA"`
+  * * `siunit(1000, "Pa", 4)` -> `"1 kPa"`
+  * Arguments:
+  * * value - The number to convert to text. Can be positive or negative.
+  * * unit - The base unit of the number, such as "Pa" or "W".
+  * * maxdecimals - Maximum amount of decimals to display for the final number. Defaults to 1.
+  */
+/proc/siunit(value, unit, maxdecimals=1)
+	var/static/list/prefixes = list("f","p","n","μ","m","","k","M","G","T","P")
+
+	// We don't have prefixes beyond this point
+	// and this also captures value = 0 which you can't compute the logarithm for
+	// and also byond numbers are floats and doesn't have much precision beyond this point anyway
+	if(abs(value) <= 1e-18)
+		return "0 [unit]"
+
+	var/exponent = clamp(log(10, abs(value)), -15, 15) // Calculate the exponent and clamp it so we don't go outside the prefix list bounds
+	var/divider = 10 ** (round(exponent / 3) * 3) // Rounds the exponent to nearest SI unit and power it back to the full form
+	var/coefficient = round(value / divider, 10 ** -maxdecimals) // Calculate the coefficient and round it to desired decimals
+	var/prefix_index = round(exponent / 3) + 6 // Calculate the index in the prefixes list for this exponent
+
+	// An edge case which happens if we round 999.9 to 0 decimals for example, which gets rounded to 1000
+	// In that case, we manually swap up to the next prefix if there is one available
+	if(coefficient >= 1000 && prefix_index < 11)
+		coefficient /= 1e3
+		prefix_index++
+
+	var/prefix = prefixes[prefix_index]
+	return "[coefficient] [prefix][unit]"
+
+/// Slightly expensive proc to scramble a message using equal probabilities of character replacement from a list. DOES NOT SUPPORT HTML!
+/proc/scramble_message_replace_chars(original, replaceprob = 25, list/replacementchars = list("$", "@", "!", "#", "%", "^", "&", "*"), replace_letters_only = FALSE, replace_whitespace = FALSE)
+	var/list/out = list()
+	var/static/list/whitespace = list(" ", "\n", "\t")
+	for(var/i in 1 to length(original))
+		var/char = original[i]
+		if(!replace_whitespace && (char in whitespace))
+			out += char
+			continue
+		if(replace_letters_only && (!ISINRANGE(char, 65, 90) && !ISINRANGE(char, 97, 122)))
+			out += char
+			continue
+		out += prob(replaceprob)? pick(replacementchars) : char
+	return out.Join("")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -685,6 +685,11 @@
 	if(G)
 		G.reenter_corpse()
 
+/// Sets our can_hijack to the fastest speed our antag datums allow.
+/datum/mind/proc/get_hijack_speed()
+	. = 0
+	for(var/datum/antagonist/A in antag_datums)
+		. = max(., A.hijack_speed())
 
 /datum/mind/proc/has_objective(objective_type)
 	for(var/datum/antagonist/A in antag_datums)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -320,8 +320,8 @@ GLOBAL_LIST_EMPTY(objectives)
 
 /datum/objective/hijack
 	name = "hijack"
-	explanation_text = "Hijack the emergency shuttle by hacking its navigational protocols through the control console (alt click emergency shuttle console)."
-	team_explanation_text = "Hijack the emergency shuttle by hacking its navigational protocols through the control console (alt click emergency shuttle console). Leave no team member behind."
+	explanation_text = "Hijack the emergency shuttle by overriding the navigation protocols using the shuttle computer."
+	team_explanation_text = "Hijack the emergency shuttle by overriding the navigation protocols, using the shuttle computer. Leave no team member behind."
 	martyr_compatible = FALSE //Technically you won't get both anyway.
 	/// Overrides the hijack speed of any antagonist datum it is on ONLY, no other datums are impacted.
 	var/hijack_speed_override = 1

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -320,9 +320,11 @@ GLOBAL_LIST_EMPTY(objectives)
 
 /datum/objective/hijack
 	name = "hijack"
-	explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive and out of custody."
-	team_explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive and out of custody. Leave no team member behind."
-	martyr_compatible = 0 //Technically you won't get both anyway.
+	explanation_text = "Hijack the emergency shuttle by hacking its navigational protocols through the control console (alt click emergency shuttle console)."
+	team_explanation_text = "Hijack the emergency shuttle by hacking its navigational protocols through the control console (alt click emergency shuttle console). Leave no team member behind."
+	martyr_compatible = FALSE //Technically you won't get both anyway.
+	/// Overrides the hijack speed of any antagonist datum it is on ONLY, no other datums are impacted.
+	var/hijack_speed_override = 1
 
 /datum/objective/hijack/check_completion() // Requires all owners to escape.
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
@@ -333,24 +335,33 @@ GLOBAL_LIST_EMPTY(objectives)
 			return FALSE
 	return SSshuttle.emergency.is_hijacked()
 
-/datum/objective/hijack/single
-	name = "hijack"
-	explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive and out of custody."
-	team_explanation_text = "Hijack the shuttle to ensure no loyalist Nanotrasen crew escape alive and out of custody. Team members lost is not a concern for this operation."
-	martyr_compatible = 0 //Technically you won't get both anyway.
+/datum/objective/elimination
+	name = "elimination"
+	explanation_text = "Slaughter all loyalist crew aboard the shuttle. You, and any likeminded individuals, must be the only remaining people on the shuttle."
+	team_explanation_text = "Slaughter all loyalist crew aboard the shuttle. You, and any likeminded individuals, must be the only remaining people on the shuttle. Leave no team member behind."
+	martyr_compatible = FALSE
 
-/datum/objective/hijack/single/check_completion() // Requires all owners to escape.
+/datum/objective/elimination/check_completion()
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return FALSE
 	var/list/datum/mind/owners = get_owners()
-	var/single_escape = FALSE
 	for(var/datum/mind/M in owners)
-		if(considered_alive(M) && SSshuttle.emergency.shuttle_areas[get_area(M.current)])
-			single_escape = TRUE
-			break
-	if(!single_escape)
+		if(!considered_alive(M, enforce_human = FALSE) || !SSshuttle.emergency.shuttle_areas[get_area(M.current)])
+			return FALSE
+	return SSshuttle.emergency.elimination_hijack()
+
+/datum/objective/elimination/highlander
+	name="highlander elimination"
+	explanation_text = "Escape on the shuttle alone. Ensure that nobody else makes it out."
+
+/datum/objective/elimination/highlander/check_completion()
+	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return FALSE
-	return SSshuttle.emergency.is_hijacked()
+	var/list/datum/mind/owners = get_owners()
+	for(var/datum/mind/M in owners)
+		if(!considered_alive(M, enforce_human = FALSE) || !SSshuttle.emergency.shuttle_areas[get_area(M.current)])
+			return FALSE
+	return SSshuttle.emergency.elimination_hijack(filter_by_human = FALSE, solo_hijack = TRUE)
 
 /datum/objective/block
 	name = "no organics on shuttle"

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -16,10 +16,13 @@ GLOBAL_LIST(admin_antag_list)
 	var/give_objectives = TRUE //Should the default objectives be generated?
 	var/replace_banned = TRUE //Should replace jobbanned player with ghosts if granted.
 	var/list/objectives = list()
+	var/delay_roundend = TRUE
 	var/antag_memory = ""//These will be removed with antag datum
 	var/antag_moodlet //typepath of moodlet that the mob will gain with their status
-	var/can_hijack = HIJACK_NEUTRAL //If these antags are alone on shuttle hijack happens.
-	var/delay_roundend = TRUE
+	
+	var/can_elimination_hijack = ELIMINATION_NEUTRAL //If these antags are alone when a shuttle elimination happens.
+	/// If above 0, this is the multiplier for the speed at which we hijack the shuttle. Do not directly read, use hijack_speed().
+	var/hijack_speed = 0
 
 	//Antag panel properties
 	var/show_in_antagpanel = TRUE	//This will hide adding this antag type in antag panel, use only for internal subtypes that shouldn't be added directly but still show if possessed by mind
@@ -237,6 +240,11 @@ GLOBAL_LIST(admin_antag_list)
 	if (isnull(new_memo))
 		return
 	antag_memory = new_memo
+
+/// Gets how fast we can hijack the shuttle, return 0 for can not hijack. Defaults to hijack_speed var, override for custom stuff like buffing hijack speed for hijack objectives or something.
+/datum/antagonist/proc/hijack_speed()
+	var/datum/objective/hijack/H = locate() in objectives
+	return H?.hijack_speed_override || hijack_speed
 
 //This one is created by admin tools for custom objectives
 /datum/antagonist/custom

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -3,9 +3,9 @@
 	antagpanel_category = "Brother"
 	job_rank = ROLE_BROTHER
 	var/special_role = ROLE_BROTHER
+	hijack_speed = 0.5
 	var/datum/team/brother_team/team
 	antag_moodlet = /datum/mood_event/focused
-	can_hijack = HIJACK_HIJACKER
 
 /datum/antagonist/brother/create_team(datum/team/brother_team/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -8,7 +8,7 @@
 	antagpanel_category = "Changeling"
 	job_rank = ROLE_CHANGELING
 	antag_moodlet = /datum/mood_event/focused
-
+	hijack_speed = 0.5
 	var/you_are_greet = TRUE
 	var/team_mode = FALSE //Should assign team objectives ?
 	var/competitive_objectives = FALSE //Should we assign objectives in competition with other lings?

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -4,8 +4,9 @@
 	antagpanel_category = "Heretic"
 	antag_moodlet = /datum/mood_event/heretics
 	job_rank = ROLE_HERETIC
-	var/antag_hud_type = ANTAG_HUD_HERETIC
+	var/antag_hud_type = ANTAG_HUD_HERETIC // someone make all the other antags conform to this too lol
 	var/antag_hud_name = "heretic"
+	hijack_speed = 0.5
 	var/give_equipment = TRUE
 	var/list/researched_knowledge = list()
 	var/total_sacrifices = 0

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -11,7 +11,6 @@
 	var/list/researched_knowledge = list()
 	var/total_sacrifices = 0
 	var/ascended = FALSE
-	can_hijack = HIJACK_HIJACKER
 
 /datum/antagonist/heretic/admin_add(datum/mind/new_owner,mob/admin)
 	give_equipment = FALSE

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -16,10 +16,13 @@
 	var/role = "Security Officer"
 	var/list/name_source
 	var/random_names = TRUE
+	var/rip_and_tear = FALSE
+	var/equip_ert = TRUE
+	var/forge_objectives_for_ert = TRUE
+	can_elimination_hijack = ELIMINATION_PREVENT
 	show_in_antagpanel = FALSE
 	show_to_ghosts = TRUE
 	antag_moodlet = /datum/mood_event/focused
-	can_hijack = HIJACK_PREVENT
 
 /datum/antagonist/ert/on_gain()
 	if(random_names)

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -16,9 +16,6 @@
 	var/role = "Security Officer"
 	var/list/name_source
 	var/random_names = TRUE
-	var/rip_and_tear = FALSE
-	var/equip_ert = TRUE
-	var/forge_objectives_for_ert = TRUE
 	can_elimination_hijack = ELIMINATION_PREVENT
 	show_in_antagpanel = FALSE
 	show_to_ghosts = TRUE

--- a/code/modules/antagonists/highlander/highlander.dm
+++ b/code/modules/antagonists/highlander/highlander.dm
@@ -3,7 +3,7 @@
 	var/obj/item/claymore/highlander/sword
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
-	can_hijack = HIJACK_HIJACKER
+	can_elimination_hijack = ELIMINATION_ENABLED
 
 /datum/antagonist/highlander/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/L = owner.current || mob_override
@@ -18,13 +18,9 @@
 	steal_objective.owner = owner
 	steal_objective.set_target(new /datum/objective_item/steal/nukedisc)
 	objectives += steal_objective
-	log_objective(owner, steal_objective.explanation_text)
-
-	var/datum/objective/hijack/hijack_objective = new
-	hijack_objective.explanation_text = "Escape on the shuttle alone. Ensure that nobody else makes it out."
-	hijack_objective.owner = owner
-	objectives += hijack_objective
-	log_objective(owner, hijack_objective.explanation_text)
+	var/datum/objective/elimination/highlander/elimination_objective = new
+	elimination_objective.owner = owner
+	objectives += elimination_objective
 
 /datum/antagonist/highlander/on_gain()
 	forge_objectives()

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -5,7 +5,7 @@
 	var/special_role = ROLE_INCURSION
 	var/datum/team/incursion/team
 	antag_moodlet = /datum/mood_event/focused
-	can_hijack = HIJACK_HIJACKER
+	hijack_speed = 0.5
 
 /datum/antagonist/incursion/create_team(datum/team/incursion/new_team)
 	if(!new_team)
@@ -153,8 +153,8 @@
 	for(var/i = 1 to max(1, CONFIG_GET(number/incursion_objective_amount)))
 		forge_single_objective(CLAMP((5 + !is_hijacker)-i, 1, 3))	//Hijack = 3, 2, 1, 1 no hijack = 3, 3, 2, 1
 	if(is_hijacker)
-		if(!(locate(/datum/objective/hijack/single) in objectives))
-			add_objective(new/datum/objective/hijack/single)
+		if(!(locate(/datum/objective/hijack) in objectives))
+			add_objective(new/datum/objective/hijack)
 	else if(!(locate(/datum/objective/escape/single) in objectives))
 		add_objective(new/datum/objective/escape/single, FALSE)
 

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -10,7 +10,7 @@
 
 /datum/antagonist/ninja/New()
 	if(helping_station)
-		can_hijack = HIJACK_PREVENT
+		can_elimination_hijack = ELIMINATION_PREVENT
 	. = ..()
 
 /datum/antagonist/ninja/apply_innate_effects(mob/living/mob_override)
@@ -152,7 +152,7 @@
 		else
 			return
 	if(helping_station)
-		can_hijack = HIJACK_PREVENT
+		can_elimination_hijack = ELIMINATION_PREVENT
 	new_owner.assigned_role = ROLE_NINJA
 	new_owner.special_role = ROLE_NINJA
 	new_owner.add_antag_datum(src)

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -5,11 +5,11 @@
 	job_rank = ROLE_OPERATIVE
 	antag_moodlet = /datum/mood_event/focused
 	show_to_ghosts = TRUE
+	hijack_speed = 2 //If you can't take out the station, take the shuttle instead.
 	var/datum/team/nuclear/nuke_team
 	var/always_new_team = FALSE //If not assigned a team by default ops will try to join existing ones, set this to TRUE to always create new team.
 	var/send_to_spawnpoint = TRUE //Should the user be moved to default spawnpoint.
 	var/nukeop_outfit = /datum/outfit/syndicate
-	can_hijack = HIJACK_HIJACKER //Alternative way to wipe out the station.
 
 /datum/antagonist/nukeop/proc/update_synd_icons_added(mob/living/M)
 	var/datum/atom_hud/antag/opshud = GLOB.huds[ANTAG_HUD_OPS]

--- a/code/modules/antagonists/official/official.dm
+++ b/code/modules/antagonists/official/official.dm
@@ -2,9 +2,9 @@
 	name = "CentCom Official"
 	show_name_in_check_antagonists = TRUE
 	show_in_antagpanel = FALSE
+	can_elimination_hijack = ELIMINATION_PREVENT
 	var/datum/objective/mission
 	var/datum/team/ert/ert_team
-	can_hijack = HIJACK_PREVENT
 	show_to_ghosts = TRUE
 
 /datum/antagonist/official/greet()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -7,13 +7,13 @@
 	antagpanel_category = "Traitor"
 	job_rank = ROLE_TRAITOR
 	antag_moodlet = /datum/mood_event/focused
+	hijack_speed = 0.5				//10 seconds per hijack stage by default
 	var/special_role = ROLE_TRAITOR
 	var/employer = "The Syndicate"
 	var/should_give_codewords = TRUE
 	var/should_equip = TRUE
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
 	var/datum/contractor_hub/contractor_hub
-	can_hijack = HIJACK_HIJACKER
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && isAI(owner.current))

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -2,7 +2,7 @@
 	name = "Wishgranter Avatar"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
-	can_hijack = HIJACK_HIJACKER
+	hijack_speed = 2 //You literally are here to do nothing else. Might as well be fast about it.
 
 /datum/antagonist/wishgranter/proc/forge_objectives()
 	var/datum/objective/hijack/hijack = new

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -8,6 +8,7 @@
 	var/datum/objective/elimination/highlander/elimination_objective = new
 	elimination_objective.owner = owner
 	objectives += elimination_objective
+	log_objective(owner, elimination_objective.explanation_text)
 
 /datum/antagonist/wishgranter/on_gain()
 	owner.special_role = "Avatar of the Wish Granter"

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -2,13 +2,12 @@
 	name = "Wishgranter Avatar"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
-	hijack_speed = 2 //You literally are here to do nothing else. Might as well be fast about it.
+	can_elimination_hijack = ELIMINATION_ENABLED
 
 /datum/antagonist/wishgranter/proc/forge_objectives()
-	var/datum/objective/hijack/hijack = new
-	hijack.owner = owner
-	objectives += hijack
-	log_objective(owner, hijack.explanation_text)
+	var/datum/objective/elimination/highlander/elimination_objective = new
+	elimination_objective.owner = owner
+	objectives += elimination_objective
 
 /datum/antagonist/wishgranter/on_gain()
 	owner.special_role = "Avatar of the Wish Granter"

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -4,6 +4,7 @@
 	antagpanel_category = "Wizard"
 	job_rank = ROLE_WIZARD
 	antag_moodlet = /datum/mood_event/focused
+	hijack_speed = 0.5
 	var/strip = TRUE //strip before equipping
 	var/allow_rename = TRUE
 	var/hud_version = "wizard"
@@ -11,7 +12,6 @@
 	var/move_to_lair = TRUE
 	var/outfit_type = /datum/outfit/wizard
 	var/wiz_age = WIZARD_AGE_MIN /* Wizards by nature cannot be too young. */
-	can_hijack = HIJACK_HIJACKER
 	show_to_ghosts = TRUE
 
 /datum/antagonist/wizard/on_gain()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -549,7 +549,7 @@
 				// now move the actual emergency shuttle to centcom
 				// unless the shuttle is "hijacked"
 				var/destination_dock = "emergency_away"
-				if(is_hijacked())
+				if(is_hijacked() || elimination_hijack())
 					destination_dock = "emergency_syndicate"
 					minor_announce("Corruption detected in \
 						shuttle navigation protocols. Please contact your \

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -4,6 +4,13 @@
 #define IS_DOCKED (SSshuttle.emergency.mode == SHUTTLE_DOCKED || (ENGINES_STARTED))
 #define SHUTTLE_CONSOLE_ACTION_DELAY (5 SECONDS)
 
+#define NOT_BEGUN 0
+#define STAGE_1 1
+#define STAGE_2 2
+#define STAGE_3 3
+#define STAGE_4 4
+#define HIJACKED 5
+
 /obj/machinery/computer/emergency_shuttle
 	name = "emergency shuttle console"
 	desc = "For shuttle control."
@@ -16,6 +23,23 @@
 	var/auth_need = 3
 	var/list/authorized = list()
 	var/list/acted_recently = list()
+	var/hijack_last_stage_increase = 0 SECONDS
+	var/hijack_stage_time = 5 SECONDS
+	var/hijack_stage_cooldown = 5 SECONDS
+	var/hijack_flight_time_increase = 30 SECONDS
+	var/hijack_completion_flight_time_set = 10 SECONDS	//How long in deciseconds to set shuttle's timer after hijack is done.
+	var/hijack_hacking = FALSE
+	var/hijack_announce = TRUE
+
+/obj/machinery/computer/emergency_shuttle/examine(mob/user)
+	. = ..()
+	if(hijack_announce)
+		. += "<span class='danger'>Security systems present on console. Any unauthorized tampering will result in an emergency announcement.</span>"
+	if(user?.mind?.get_hijack_speed())
+		. += "<span class='danger'>Alt click on this to attempt to hijack the shuttle. This will take multiple tries (current: stage [SSshuttle.emergency.hijack_status]/[HIJACKED]).</span>"
+		. += "<span class='notice'>It will take you [(hijack_stage_time * user.mind.get_hijack_speed()) / 10] seconds to reprogram a stage of the shuttle's navigational firmware, and the console will undergo automated timed lockout for [hijack_stage_cooldown/10] seconds after each stage.</span>"
+		if(hijack_announce)
+			. += "<span class='warning'>It is probably best to fortify your position as to be uninterrupted during the attempt, given the automatic announcements..</span>"
 
 /obj/machinery/computer/emergency_shuttle/attackby(obj/item/I, mob/user,params)
 	if(istype(I, /obj/item/card/id))
@@ -159,6 +183,67 @@
 			[TIME_LEFT] seconds", system_error, alert=TRUE)
 		. = TRUE
 
+/obj/machinery/computer/emergency_shuttle/proc/increase_hijack_stage()
+	var/obj/docking_port/mobile/emergency/shuttle = SSshuttle.emergency
+	shuttle.hijack_status++
+	if(hijack_announce)
+		announce_hijack_stage()
+	hijack_last_stage_increase = world.time
+	say("Navigational protocol error! Rebooting systems.")
+	if(shuttle.mode == SHUTTLE_ESCAPE)
+		if(shuttle.hijack_status == HIJACKED)
+			shuttle.setTimer(hijack_completion_flight_time_set)
+		else
+			shuttle.setTimer(shuttle.timeLeft(1) + hijack_flight_time_increase)		//give the guy more time to hijack if it's already in flight.
+	return shuttle.hijack_status
+
+/obj/machinery/computer/emergency_shuttle/AltClick(user)
+	if(isliving(user))
+		attempt_hijack_stage(user)
+
+/obj/machinery/computer/emergency_shuttle/proc/attempt_hijack_stage(mob/living/user)
+	if(!user.CanReach(src))
+		return
+	if(!user?.mind?.get_hijack_speed())
+		to_chat(user, "<span class='warning'>You manage to open a user-mode shell on [src], and hundreds of lines of debugging output fly through your vision. It is probably best to leave this alone.</span.")
+		return
+	if(hijack_hacking == TRUE)
+		return
+	if(SSshuttle.emergency.hijack_status >= HIJACKED)
+		to_chat(user, "<span class='warning'>The emergency shuttle is already loaded with a corrupt navigational payload. What more do you want from it?</span>")
+		return
+	if(hijack_last_stage_increase >= world.time + hijack_stage_cooldown)
+		say("Error - Catastrophic software error detected. Input is currently on timeout.")
+		return
+	hijack_hacking = TRUE
+	to_chat(user, "<span class='boldwarning'>You [SSshuttle.emergency.hijack_status == NOT_BEGUN? "begin" : "continue"] to override [src]'s navigational protocols.</span>")
+	say("Software override initiated.")
+	. = FALSE
+	if(do_after(user, hijack_stage_time * (1 / user.mind.get_hijack_speed()), target = src))
+		increase_hijack_stage()
+		. = TRUE
+		to_chat(user, "<span class='notice'>You reprogram some of [src]'s programming, putting it on timeout for [hijack_stage_cooldown/10] seconds.</span>")
+	hijack_hacking = FALSE
+
+/obj/machinery/computer/emergency_shuttle/proc/announce_hijack_stage()
+	var/msg
+	switch(SSshuttle.emergency.hijack_status)
+		if(NOT_BEGUN)
+			return
+		if(STAGE_1)
+			msg = "AUTHENTICATING - FAIL. AUTHENTICATING - FAIL. AUTHENTICATING - FAI###### Welcome, technician JOHN DOE."
+		if(STAGE_2)
+			msg = "Warning: Navigational route fails \"IS_AUTHORIZED\". Please try againNN[scramble_message_replace_chars("againagainagainagainagain", 70)]."
+		if(STAGE_3)
+			msg = "CRC mismatch at ~h~ in calculated route buffer. Full reset initiated of FTL_NAVIGATION_SERVICES. Memory decrypted for automatic repair."
+		if(STAGE_4)
+			msg = "~ACS_directive module_load(cyberdyne.exploit.nanotrasen.shuttlenav)... NT key mismatch. Confirm load? Y...###Reboot complete. $SET transponder_state = 0; System link initiated with connected engines..."
+		if(HIJACKED)
+			msg = "<font color='red'><b>SYSTEM OVERRIDE</b></font> - Resetting course to \[[scramble_message_replace_chars("###########", 100)]\] \
+			([scramble_message_replace_chars("#######", 100)]/[scramble_message_replace_chars("#######", 100)]/[scramble_message_replace_chars("#######", 100)]) \
+			{AUTH - ROOT (uid: 0)}.</font>[SSshuttle.emergency.mode == SHUTTLE_ESCAPE ? "Diverting from existing route - Bluespace exit in [hijack_completion_flight_time_set/10] seconds." : ""]"
+	minor_announce(scramble_message_replace_chars(msg, replaceprob = 10), "Emergency Shuttle", TRUE)
+
 /obj/machinery/computer/emergency_shuttle/emag_act(mob/user)
 	// How did you even get on the shuttle before it go to the station?
 	if(!IS_DOCKED)
@@ -209,6 +294,7 @@
 	dir = EAST
 	port_direction = WEST
 	var/sound_played = 0 //If the launch sound has been sent to all players on the shuttle itself
+	var/hijack_status = NOT_BEGUN
 
 /obj/docking_port/mobile/emergency/canDock(obj/docking_port/stationary/S)
 	return SHUTTLE_CAN_DOCK //If the emergency shuttle can't move, the whole game breaks, so it will force itself to land even if it has to crush a few departments in the process
@@ -270,9 +356,19 @@
 		SSshuttle.emergencyLastCallLoc = null
 	priority_announce("The emergency shuttle has been recalled.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/ai/shuttlerecalled.ogg', "Priority")
 
-/obj/docking_port/mobile/emergency/proc/is_hijacked()
+/**
+  * Proc that handles checking if the emergency shuttle was successfully hijacked via being the only people present on the shuttle for the elimination hijack or highlander objective
+  *
+  * Checks for all mobs on the shuttle, checks their status, and checks if they're
+  * borgs or simple animals. Depending on the args, certain mobs may be ignored,
+  * and the presence of other antags may or may not invalidate a hijack.
+  * Args:
+  * filter_by_human, default TRUE, tells the proc that only humans should block a hijack. Borgs and animals are ignored and will not block if this is TRUE.
+  * solo_hijack, default FALSE, tells the proc to fail with multiple hijackers, such as for Highlander mode.
+ */
+/obj/docking_port/mobile/emergency/proc/elimination_hijack(filter_by_human = TRUE, solo_hijack = FALSE)
 	var/has_people = FALSE
-	var/hijacker_present = FALSE
+	var/hijacker_count = 0
 	for(var/mob/living/player in GLOB.player_list)
 		if(player.mind)
 			if(player.stat != DEAD)
@@ -291,17 +387,17 @@
 					//Antag present, doesn't stop but let's see if we actually want to hijack
 					var/prevent = FALSE
 					for(var/datum/antagonist/A in player.mind.antag_datums)
-						if(A.can_hijack == HIJACK_HIJACKER)
-							hijacker_present = TRUE
+						if(A.can_elimination_hijack == ELIMINATION_ENABLED)
+							hijacker_count += 1
 							prevent = FALSE
 							break //If we have both prevent and hijacker antags assume we want to hijack.
-						else if(A.can_hijack == HIJACK_PREVENT)
+						else if(A.can_elimination_hijack == ELIMINATION_PREVENT)
 							prevent = TRUE
 					if(prevent)
 						return FALSE
 
 
-	return has_people && hijacker_present
+	return has_people && ((hijacker_count == 1) || (hijacker_count && !solo_hijack))
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked_by_xenos()
 	var/has_xenos = FALSE
@@ -319,6 +415,9 @@
 			has_xenos = TRUE
 
 	return has_xenos
+
+/obj/docking_port/mobile/emergency/proc/is_hijacked()
+	return hijack_status == HIJACKED
 
 /obj/docking_port/mobile/emergency/proc/ShuttleDBStuff()
 	set waitfor = FALSE
@@ -467,7 +566,7 @@
 	mode = SHUTTLE_ESCAPE
 	launch_status = ENDGAME_LAUNCHED
 	setTimer(SSshuttle.emergencyEscapeTime)
-	priority_announce("The Emergency Shuttle preparing for direct jump. ETA: [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
+	priority_announce("The Emergency Shuttle is preparing for direct jump. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
 
 
 /obj/docking_port/mobile/pod
@@ -638,3 +737,10 @@
 #undef ENGINES_STARTED
 #undef IS_DOCKED
 #undef SHUTTLE_CONSOLE_ACTION_DELAY
+
+#undef NOT_BEGUN
+#undef STAGE_1
+#undef STAGE_2
+#undef STAGE_3
+#undef STAGE_4
+#undef HIJACKED

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -207,6 +207,9 @@
 	if(!user?.mind?.get_hijack_speed())
 		to_chat(user, "<span class='warning'>You manage to open a user-mode shell on [src], and hundreds of lines of debugging output fly through your vision. It is probably best to leave this alone.</span.")
 		return
+	if(!EMERGENCY_AT_LEAST_DOCKED) // prevent advancing hijack stages on BYOS shuttles until the shuttle has "docked"
+		to_chat(user, "<span class='warning'>The flight plans for the shuttle haven't been loaded yet, you can't hack this right now.</span.")
+		return
 	if(hijack_hacking == TRUE)
 		return
 	if(SSshuttle.emergency.hijack_status >= HIJACKED)
@@ -218,9 +221,15 @@
 	hijack_hacking = TRUE
 	to_chat(user, "<span class='boldwarning'>You [SSshuttle.emergency.hijack_status == NOT_BEGUN? "begin" : "continue"] to override [src]'s navigational protocols.</span>")
 	say("Software override initiated.")
+	var/turf/console_hijack_turf = get_turf(src)
+	message_admins("[src] is being overriden for hijack by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(console_hijack_turf)]")
+	log_game("[src] is being overriden for hijack by [key_name(user)] at [AREACOORD(src)]")
 	. = FALSE
 	if(do_after(user, hijack_stage_time * (1 / user.mind.get_hijack_speed()), target = src))
 		increase_hijack_stage()
+		console_hijack_turf = get_turf(src)
+		message_admins("[src] has had its hijack stage increased to stage [SSshuttle.emergency.hijack_status] out of [HIJACKED] by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(console_hijack_turf)]")
+		log_game("[src] has had its hijack stage increased to stage [SSshuttle.emergency.hijack_status] out of [HIJACKED] by [key_name(user)] at [AREACOORD(src)]")
 		. = TRUE
 		to_chat(user, "<span class='notice'>You reprogram some of [src]'s programming, putting it on timeout for [hijack_stage_cooldown/10] seconds.</span>")
 	hijack_hacking = FALSE
@@ -239,7 +248,7 @@
 		if(STAGE_4)
 			msg = "~ACS_directive module_load(cyberdyne.exploit.nanotrasen.shuttlenav)... NT key mismatch. Confirm load? Y...###Reboot complete. $SET transponder_state = 0; System link initiated with connected engines..."
 		if(HIJACKED)
-			msg = "<font color='red'><b>SYSTEM OVERRIDE</b></font> - Resetting course to \[[scramble_message_replace_chars("###########", 100)]\] \
+			msg = "SYSTEM OVERRIDE - Resetting course to \[[scramble_message_replace_chars("###########", 100)]\] \
 			([scramble_message_replace_chars("#######", 100)]/[scramble_message_replace_chars("#######", 100)]/[scramble_message_replace_chars("#######", 100)]) \
 			{AUTH - ROOT (uid: 0)}.</font>[SSshuttle.emergency.mode == SHUTTLE_ESCAPE ? "Diverting from existing route - Bluespace exit in [hijack_completion_flight_time_set/10] seconds." : ""]"
 	minor_announce(scramble_message_replace_chars(msg, replaceprob = 10), "Emergency Shuttle", TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
PORTS
https://github.com/tgstation/tgstation/pull/54146
https://github.com/tgstation/tgstation/pull/54435
https://github.com/tgstation/tgstation/pull/54827
https://github.com/tgstation/tgstation/pull/54913
https://github.com/tgstation/tgstation/pull/55214

The ORIGINAL Pr this is all from is here 
https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10649
In a bullet list:

- Old hijack is turned into an "elimination" objective, that is only a custom objective for highlanders
- In order to hijack now, you have to get access to the shuttle console and alt-click it multiple times, while fighting off interruptions. The crew is made aware of this.
- With every bit of progress, you get some extra time given to you. 
- Emergency shuttle console added to BYOS to prevent it from being OP. 
- In a separate PR I just submitted, the shuttle console is made indestructible. I just thought I'd mention it here. 


Some personal notes:
The way its done on an interface level is fairly clunky, imo. And the objective text is downright ugly. The latter could easily be changed here. Former would be a bit more work and design, it was proposed in the discord to give a disk for it, but I don't like the idea of antags having to carry around more items, and it'd have to apply to *all* hijackers. Maybe at minimum it could eventually be added to the actual shuttle console interface.

Works on my testing at least. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hijack is pretty flawed.

 It's genuinely often impossible to succeed if you decide to actually do your objective. You've got engineers hiding in the goddamn engine, pAIs, etc. ruining it and making it extremely inconsistent with how its requirement works. 

 This makes it about securing the cockpit for a period of time.

 You might worry about losing the right to murderbone but that's up to the admins, it will probably remain in anyways since it's the easiest way to accomplish this. Maybe stuff like roundstart plasmaflooding would go, but who would honestly miss that?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons, /tg/ coders, port by froststahr
add: New hijack! To do it, you must alt-click the shuttle console a series of times. After that has been successfully done 5 times, the hijack is complete. 
add: After each hack, the shuttle in-transit is delayed slightly, and crew are also notified of what is going on. 
add: Who can hijack? Blood brothers, traitors, changelings, wizards, highlanders, incursions, nukies, heretics
del: Old method of hijack no longer works for ordinary antags, if you want your greentext, you MUST secure the console. Not that that'll be difficult compared to killing everything. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
