### PR TITLE
Temporarily Disables Circuit Clone Printing

### DIFF
--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -7,7 +7,7 @@
 	icon_state = "circuit_printer"
 	w_class = WEIGHT_CLASS_BULKY
 	var/upgraded = FALSE		// When hit with an upgrade disk, will turn true, allowing it to print the higher tier circuits.
-	var/can_clone = FALSE		// Allows the printer to clone circuits, either instantly or over time depending on upgrade. Set to FALSE to disable entirely. -Set To false to remove cloning from all but debug.
+	var/can_clone = TRUE		// Allows the printer to clone circuits, either instantly or over time depending on upgrade. Set to FALSE to disable entirely. -Set To false to remove cloning from all but debug.
 	var/fast_clone = FALSE		// If this is false, then cloning will take an amount of deciseconds equal to the iron cost divided by 100.
 	var/debug = FALSE			// If it's upgraded and can clone, even without config settings.
 	var/current_category = null
@@ -21,14 +21,14 @@
 
 /obj/item/integrated_circuit_printer/upgraded
 	upgraded = TRUE
-	can_clone = FALSE //Set to False to remove cloning temporarily.
-	fast_clone = FALSE //Set to False to remove cloning temporarily.
+	can_clone = TRUE
+	fast_clone = TRUE
 
 /obj/item/integrated_circuit_printer/debug //translation: "integrated_circuit_printer/local_server"
 	name = "debug circuit printer"
 	debug = TRUE
 	upgraded = TRUE
-	can_clone = TRUE // Left as true due to being admin only debug item
+	can_clone = TRUE
 	fast_clone = TRUE
 	w_class = WEIGHT_CLASS_TINY
 

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -7,7 +7,7 @@
 	icon_state = "circuit_printer"
 	w_class = WEIGHT_CLASS_BULKY
 	var/upgraded = FALSE		// When hit with an upgrade disk, will turn true, allowing it to print the higher tier circuits.
-	var/can_clone = TRUE		// Allows the printer to clone circuits, either instantly or over time depending on upgrade. Set to FALSE to disable entirely. -Set To false to remove cloning from all but debug.
+	var/can_clone = TRUE		// Allows the printer to clone circuits, either instantly or over time depending on upgrade. Set to FALSE to disable entirely.
 	var/fast_clone = FALSE		// If this is false, then cloning will take an amount of deciseconds equal to the iron cost divided by 100.
 	var/debug = FALSE			// If it's upgraded and can clone, even without config settings.
 	var/current_category = null

--- a/code/modules/integrated_electronics/core/printer.dm
+++ b/code/modules/integrated_electronics/core/printer.dm
@@ -7,7 +7,7 @@
 	icon_state = "circuit_printer"
 	w_class = WEIGHT_CLASS_BULKY
 	var/upgraded = FALSE		// When hit with an upgrade disk, will turn true, allowing it to print the higher tier circuits.
-	var/can_clone = TRUE		// Allows the printer to clone circuits, either instantly or over time depending on upgrade. Set to FALSE to disable entirely.
+	var/can_clone = FALSE		// Allows the printer to clone circuits, either instantly or over time depending on upgrade. Set to FALSE to disable entirely. -Set To false to remove cloning from all but debug.
 	var/fast_clone = FALSE		// If this is false, then cloning will take an amount of deciseconds equal to the iron cost divided by 100.
 	var/debug = FALSE			// If it's upgraded and can clone, even without config settings.
 	var/current_category = null
@@ -21,14 +21,14 @@
 
 /obj/item/integrated_circuit_printer/upgraded
 	upgraded = TRUE
-	can_clone = TRUE
-	fast_clone = TRUE
+	can_clone = FALSE //Set to False to remove cloning temporarily.
+	fast_clone = FALSE //Set to False to remove cloning temporarily.
 
 /obj/item/integrated_circuit_printer/debug //translation: "integrated_circuit_printer/local_server"
 	name = "debug circuit printer"
 	debug = TRUE
 	upgraded = TRUE
-	can_clone = TRUE
+	can_clone = TRUE // Left as true due to being admin only debug item
 	fast_clone = TRUE
 	w_class = WEIGHT_CLASS_TINY
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -139,7 +139,7 @@
 	display_name = "Advanced Circuit Research"
 	description = "Advanced designs that expand the possibilities of modular circuits."
 	prereq_ids = list("circuitresearch")
-	design_ids = list("icupgadv", "icupgclo")
+	design_ids = list("icupgadv") //Removed the cloning upgrade "icupgclo" temporarily
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -583,7 +583,7 @@ MICE_ROUNDSTART 10
 #EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2
 
 ## Determines if players are allowed to print integrated circuits, uncomment to allow.
-IC_PRINTING
+#IC_PRINTING
 
 ## Uncomment to allow roundstart quirk selection in the character setup menu.
 ## This used to be named traits, hence the config name, but it handles quirks, not the other kind of trait!

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -579,7 +579,7 @@ MICE_ROUNDSTART 10
 #EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2
 
 ## Determines if players are allowed to print integrated circuits, uncomment to allow.
-IC_PRINTING
+#IC_PRINTING
 
 ## Uncomment to allow roundstart quirk selection in the character setup menu.
 ## This used to be named traits, hence the config name, but it handles quirks, not the other kind of trait!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lots of admins have been complaining about circuit issues
This is a temporary fix until other things have been put in place

Removes the clone printing functionality of all circuit printers except the debug one.


(Also I havent tested to see if this works or not but it should)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You actually have to take some time to manually create circuits
This should help prevent people from just pasting grief circuit codes at roundstart.
And should slow down circuit creation in general.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the ability to print circuits from copy-pasted codes
del: Removed the Instant Cloning Circuit upgrade from the techweb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
