### PR TITLE
Panacea - Soft Viro Nerf

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -106,6 +106,7 @@
 	new /obj/item/reagent_containers/food/drinks/bottle/synthflesh(src)
 	new /obj/item/card/id/departmental_budget/med(src)
 	new /obj/item/extrapolator(src)
+	new /obj/item/reagent_containers/syringe/panacea(src)
 
 /obj/structure/closet/secure_closet/animal
 	name = "animal control"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -68,7 +68,7 @@
 /datum/supply_pack/emergency/bio
 	name = "Biological Emergency Crate"
 	desc = "This crate holds 2 full bio suits which will protect you from viruses."
-	cost = 1500
+	cost = 20000
 	contains = list(/obj/item/clothing/head/bio_hood,
 					/obj/item/clothing/head/bio_hood,
 					/obj/item/clothing/suit/bio_suit,
@@ -76,6 +76,8 @@
 					/obj/item/storage/bag/bio,
 					/obj/item/reagent_containers/syringe/antiviral,
 					/obj/item/reagent_containers/syringe/antiviral,
+					/obj/item/reagent_containers/syringe/antiviral,
+					/obj/item/reagent_containers/syringe/panacea,
 					/obj/item/clothing/gloves/color/latex/nitrile,
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "bio suit crate"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1599,23 +1599,20 @@
 
 /datum/reagent/medicine/panacea
 	name = "Panacea"
-	description = "The marvel of modern medicine, a miracle cure capable of curing any and all diseases."
+	description = "The marvel of modern medicine, boosts your immune system to fight all diseases."
 	reagent_state = LIQUID
 	color = "#CC6666"
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	taste_description = "snake oil"
 	process_flags = ORGANIC
-	overdose_threshold = 10
 	random_unrestricted = FALSE
 
-/datum/reagent/medicine/panacea/overdose_start(mob/living/carbon/L)
-	..()
-	metabolization_rate = 0.75 * REAGENTS_METABOLISM
-	for(var/thing in L.diseases)
-		var/datum/disease/D = thing
-		D.cure(FALSE)
-
-/datum/reagent/medicine/panacea/overdose_process(mob/living/M)
+/datum/reagent/medicine/panacea/on_mob_life(mob/living/M)
+	if (volume>10)
+		for(var/thing in L.diseases)
+			var/datum/disease/D = thing
+			D.cure(FALSE)
+			
 	if (prob(5))
 		M.Dizzy(3 SECONDS)
 	if (prob(15))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1596,3 +1596,30 @@
 		M.Jitter(5)
 	M.losebreath = 0
 	..()
+
+/datum/reagent/medicine/panacea
+	name = "Panacea"
+	description = "The marvel of modern medicine, a miracle cure capable of curing any and all diseases."
+	reagent_state = LIQUID
+	color = "#CC6666"
+	metabolization_rate = REAGENTS_METABOLISM
+	taste_description = "snake oil"
+	process_flags = ORGANIC
+	overdose_threshold = 10
+	random_unrestricted = FALSE
+
+/datum/reagent/medicine/panacea/overdose_start(mob/living/carbon/L)
+	..()
+	metabolization_rate = 0.75 * REAGENTS_METABOLISM
+	for(var/thing in L.diseases)
+		var/datum/disease/D = thing
+		D.cure(FALSE)
+
+/datum/reagent/medicine/panacea/overdose_process(mob/living/M)
+	if (prob(5))
+		M.Dizzy(3 SECONDS)
+	if (prob(15))
+		M.adjustToxLoss(2, 0)
+	if (prob(30))
+		M.adjustStaminaLoss(5)
+	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1608,15 +1608,15 @@
 	random_unrestricted = FALSE
 
 /datum/reagent/medicine/panacea/on_mob_life(mob/living/M)
-	if (volume>10)
-		for(var/thing in L.diseases)
+	if(volume>10)
+		for(var/thing in M.diseases)
 			var/datum/disease/D = thing
 			D.cure(FALSE)
 			
-	if (prob(5))
+	if(prob(5))
 		M.Dizzy(3 SECONDS)
-	if (prob(15))
+	if(prob(15))
 		M.adjustToxLoss(2, 0)
-	if (prob(30))
+	if(prob(30))
 		M.adjustStaminaLoss(5)
 	..()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -231,6 +231,11 @@
 	desc = "Contains charcoal."
 	list_reagents = list(/datum/reagent/medicine/charcoal = 15)
 
+/obj/item/reagent_containers/syringe/panacea
+	name = "syringe (panacea)"
+	desc = "Contains panacea."
+	list_reagents = list(/datum/reagent/medicine/panacea = 15)
+
 /obj/item/reagent_containers/syringe/antitoxin
 	name = "syringe (antitoxin)"
 	desc = "Contains antitoxin."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds panacea, a reagent that boosts your immune system. On overdose, it cures all diseases without making antibodies, but the user takes stamina damage for a while. Only available in CMO locker and purchasable from cargo in a 20000cr crate.

## Why It's Good For The Game

Viro can make diseases that can decimate entire populations. Once that reaches, it becomes quite unstoppable and very few people (CMO, chemists and maybe the Captain) can stop it. Other departments can't really do anything against it. 

This isn't meant to be widely distributed and cure an entire disease. Instead, it is meant to be taken by one person (ie chemist, CMO) so they can treat the disease without getting infected and it becoming a race against time.

With the upcomming Chem Dispenser chip, viro can truly become unstoppable if he takes out the proper people. This is an idea on how to control that.

IMO viro recieved a couple of buffs that put it a bit over the edge. This adds a little bit of counterplay maybe. Just an idea.

## Changelog
:cl:
add: New reagent: panacea, that cures all current diseases on injected.
add: Bio Emergency Crate comes with one injection of panacea, and CMO has one in their locker
/:cl: