### PR TITLE
Balances security around the new greytide meta

### DIFF
--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -2,28 +2,28 @@
 	projectile_type = /obj/item/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
-	e_cost = 200
+	e_cost = 5
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/electrode/spec
-	e_cost = 100
+	e_cost = 5
 
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/gunshot.ogg'
-	e_cost = 100
+	e_cost = 5
 
 /obj/item/ammo_casing/energy/electrode/hos
-	e_cost = 400
+	e_cost = 5
 
 /obj/item/ammo_casing/energy/electrode/old
-	e_cost = 1000
+	e_cost = 5
 
 /obj/item/ammo_casing/energy/disabler
 	projectile_type = /obj/item/projectile/beam/disabler
 	select_name  = "disable"
-	e_cost = 40
+	e_cost = 5
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/disabler/hos
-	e_cost = 50
+	e_cost = 5


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Security players have issues properly using their guns. This will buff security so that they can track down greytiders and arrest them

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because lethal energy weapons may be getting bigger, we need to make it easier for security players to take down bad guys with their disabler.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced non-lethal energy weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
