### PR TITLE
[FIX] weapon circuit logging

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -132,7 +132,7 @@
 	//Shooting Code:
 	A.preparePixelProjectile(target, src)
 	A.ignore_source_check = TRUE //needed else writing into firer will mess with the projectile collision
-	A.firer = "[usr.ckey]/[usr] trough [assembly] circuit"
+	A.firer = "[usr.ckey]/[usr] trough [assembly]/[REF(assembly)] circuit"
 	A.fire()
 	log_attack("[assembly] [REF(assembly)] has fired [installed_gun].")
 	return A

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -132,7 +132,7 @@
 	//Shooting Code:
 	A.preparePixelProjectile(target, src)
 	A.ignore_source_check = TRUE //needed else writing into firer will mess with the projectile collision
-	A.firer = "[usr.ckey]/[usr]"
+	A.firer = "[usr.ckey]/[usr] trough [assembly] circuit"
 	A.fire()
 	log_attack("[assembly] [REF(assembly)] has fired [installed_gun].")
 	return A

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -131,6 +131,8 @@
 	installed_gun.cell.use(shot.e_cost)
 	//Shooting Code:
 	A.preparePixelProjectile(target, src)
+	A.ignore_source_check = TRUE //needed else writing into firer will mess with the projectile collision
+	A.firer = "[usr.ckey]/[usr]"
 	A.fire()
 	log_attack("[assembly] [REF(assembly)] has fired [installed_gun].")
 	return A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Current logging does not include the shooter so admins have a hard time figuring out who shot the mob trough its attack log this implements a basic shooter logging for that exact purpose also works if the circuit is not in hand (currently tested with microphone equal gate assembly)

## Why It's Good For The Game

Admins actually beeing able to figure out who shot is good.

## Changelog
:cl:
admin: logs the shooter and circuit name of the weapon circuit in the attack log of the victim
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
