### PR TITLE
Removes mob_has_gravity()

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -569,7 +569,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	SEND_SIGNAL(M, COMSIG_EXIT_AREA, src) //The atom that exits the area
 
 /**
-  * Returns true if this atom has gravity for the passed in turf
+  * Returns true if this atom has gravity for the passed in turf or other gravity-mimicking behaviors
+  * In other words, it returns whether the atom can be *on* the turf (i.e. not forced to float)
   *
   * Sends signals COMSIG_ATOM_HAS_GRAVITY and COMSIG_TURF_HAS_GRAVITY, both can force gravity with
   * the forced gravity var

--- a/code/game/objects/noose.dm
+++ b/code/game/objects/noose.dm
@@ -20,7 +20,7 @@
 		if(has_buckled_mobs())
 			for(var/m in buckled_mobs)
 				var/mob/living/buckled_mob = m
-				if(buckled_mob.mob_has_gravity())
+				if(buckled_mob.has_gravity())
 					buckled_mob.visible_message("<span class='danger'>[buckled_mob] falls over and hits the ground!</span>")
 					to_chat(buckled_mob, "<span class='userdanger'>You fall over and hit the ground!</span>")
 					buckled_mob.adjustBruteLoss(10)
@@ -126,7 +126,7 @@
 		else
 			animate(src, pixel_x = 3, time = 45, easing = ELASTIC_EASING)
 			animate(m, pixel_x = 3, time = 45, easing = ELASTIC_EASING)
-		if(buckled_mob.mob_has_gravity())
+		if(buckled_mob.has_gravity())
 			if(buckled_mob.get_bodypart("head"))
 				if(buckled_mob.stat != DEAD)
 					if(!HAS_TRAIT(buckled_mob, TRAIT_NOBREATH))

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -37,7 +37,7 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
-	return clothing_flags & NOSLIP
+	return isspaceturf(get_turf(src)) ? FALSE : magpulse
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -37,7 +37,7 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
-	return isspaceturf(get_turf(src)) ? FALSE : magpulse
+	return isspaceturf(get_turf(src)) ? FALSE : magpulse //We don't mimick gravity on space turfs
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -35,7 +35,7 @@
 			return 0
 	return ..()
 
-/mob/living/carbon/human/has_gravity()
+/mob/living/carbon/human/has_gravity(turf/T)
 	return ..() || mob_negates_gravity()
 
 /mob/living/carbon/human/mob_negates_gravity()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -35,11 +35,8 @@
 			return 0
 	return ..()
 
-/mob/living/carbon/human/mob_has_gravity()
-	. = ..()
-	if(!.)
-		if(mob_negates_gravity())
-			. = 1
+/mob/living/carbon/human/has_gravity()
+	return ..() || mob_negates_gravity()
 
 /mob/living/carbon/human/mob_negates_gravity()
 	return ((shoes && shoes.negates_gravity()) || (dna.species.negates_gravity(src)))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -42,7 +42,7 @@
 			handle_environment(environment)
 
 		//Handle gravity
-		var/gravity = mob_has_gravity()
+		var/gravity = has_gravity()
 		update_gravity(gravity)
 
 		if(gravity > STANDARD_GRAVITY)

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -9,7 +9,7 @@
 	else //I'm not removing that shitton of tabs, unneeded as they are. -- Urist
 		//Being dead doesn't mean your temperature never changes
 
-		update_gravity(mob_has_gravity())
+		update_gravity(has_gravity())
 
 		handle_status_effects()
 

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -7,9 +7,9 @@
 	return FALSE
 
 /mob/living/silicon/robot/mob_negates_gravity()
-	return magpulse
+	return isspaceturf(get_turf(src)) ? FALSE : magpulse
 
-/mob/living/silicon/robot/mob_has_gravity()
+/mob/living/silicon/robot/has_gravity()
 	return ..() || mob_negates_gravity()
 
 /mob/living/silicon/robot/experience_pressure_difference(pressure_difference, direction)

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -7,9 +7,9 @@
 	return FALSE
 
 /mob/living/silicon/robot/mob_negates_gravity()
-	return isspaceturf(get_turf(src)) ? FALSE : magpulse
+	return isspaceturf(get_turf(src)) ? FALSE : magpulse //We don't mimick gravity on space turfs
 
-/mob/living/silicon/robot/has_gravity()
+/mob/living/silicon/robot/has_gravity(turf/T)
 	return ..() || mob_negates_gravity()
 
 /mob/living/silicon/robot/experience_pressure_difference(pressure_difference, direction)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -249,9 +249,9 @@
 		return ..()
 
 /mob/living/simple_animal/drone/mob_negates_gravity()
-	return 1
+	return !isspaceturf(get_turf(src))
 
-/mob/living/simple_animal/drone/mob_has_gravity()
+/mob/living/simple_animal/drone/has_gravity()
 	return ..() || mob_negates_gravity()
 
 /mob/living/simple_animal/drone/experience_pressure_difference(pressure_difference, direction)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -249,9 +249,9 @@
 		return ..()
 
 /mob/living/simple_animal/drone/mob_negates_gravity()
-	return !isspaceturf(get_turf(src))
+	return !isspaceturf(get_turf(src)) //We don't mimick gravity on space turfs
 
-/mob/living/simple_animal/drone/has_gravity()
+/mob/living/simple_animal/drone/has_gravity(turf/T)
 	return ..() || mob_negates_gravity()
 
 /mob/living/simple_animal/drone/experience_pressure_difference(pressure_difference, direction)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -322,14 +322,6 @@
 				. = AM
 
 /**
-  * Returns true if a mob has gravity
-  *
-  * I hate that this exists
-  */
-/mob/proc/mob_has_gravity()
-	return has_gravity()
-
-/**
   * Does this mob ignore gravity
   */
 /mob/proc/mob_negates_gravity()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -303,7 +303,7 @@
 			var/turf/turf = A
 			if(isspaceturf(turf))
 				continue
-			if(!turf.density && !mob_negates_gravity())
+			if(!turf.density)
 				continue
 			return A
 		else

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -301,8 +301,6 @@
 			continue
 		else if(isturf(A))
 			var/turf/turf = A
-			if(isspaceturf(turf))
-				continue
 			if(!turf.density)
 				continue
 			return A

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -365,7 +365,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 		var/mob/M = i
 		if(M.z != z && !(ztrait && SSmapping.level_trait(z, ztrait) && SSmapping.level_trait(M.z, ztrait)))
 			continue
-		M.update_gravity(M.mob_has_gravity())
+		M.update_gravity(M.has_gravity())
 		if(M.client)
 			shake_camera(M, 15, 1)
 			M.playsound_local(T, null, 100, 1, 0.5, S = alert_sound)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This soft-reverts tgstation/tgstation#20464 while avoiding tgstation/tgstation#20410. In short, this PR removes weird situations around gravity and movement code.

The magnetic boots have worked in a really weird manner; for example, `update_gravity()` depended on `mob_has_gravity()`, thus magboots could prevent *every* (incl. space; yes, magboots technically caused gravity to the wearer in space) non-gravity situations regarding warnings and float via `mob_negates_gravity()`... except when it comes to `Process_Spacemove()`. Magboots don't cause gravity here, since deep in the `Process_Spacemove()` family tree, `has_gravity()` is the one who checks the gravity; and  `has_gravity()` doesn't call `mob_negates_gravity()`.

So magboots prevent weightlessness when it comes to spacemove? Well, `mob/Process_Spacemove()` looks for backup! The backup finding process is code that is responsible for making you being able to spacewalk safely as long as you move near wall or lattice, and the proc is `get_spacemove_backup()` Magboots can flex its muscles via `mob_negates_gravity()` because it allows any non-space turfs to be its backup: so, as long as it isn't space all around, magboots let you walk!

This PR does a small refactor to remove this inconsistency, by removing `mob_has_gravity()` to make `mob_negates_gravity()` have influence on Spacemove and other stuffs properly; `has_gravity()` is used to check if something is on the floor (or can be on floor when the throwing ends) instead of floating above it, rather than denoting the actual state of weightlessness. But, we can't let magboots and other `mob_negates_gravity()` checks to cause spacewalking most of the time, so I included `isspaceturf()` checks (think the one at the current `get_spacemove_backup()`) in corresponding places to not repeat the mistake of tgstation/tgstation#20303 (i.e. tgstation/tgstation#20410)

I can further rewrite the gravity code to differentiate the gravity-mimicking behaviors and the real actual gravity, but, for now, I see no need for it, so I stop; in my humble opinion, full-blown rewriting of legacy code should be kept at minimum.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Y'know, I could've ignored this. However, while intermittently doing the dreaded `Life()` review, I learnt that a thin wrapper called `mob_has_gravity()` has been causing 10% additional overhead (I still have no idea why) even on cases where it does nothing but returning the return of `has_gravity()` (i.e. simple mobs calls `/mob/proc/mob_has_gravity()`). I decided to fix it.

This solution hopefully improves the movement and gravity code, and reduce overhead caused by `mob_has_gravity()`. This should reduce workload of the server a tiny bit considering `mob_has_gravity()` is quite busy code path.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: magboots no longer make you feel gravity in space
code: removed legacy mob_has_gravity() to reduce overhead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
