### PR TITLE
Fixes bluespace tear nullspacing issue

### DIFF
--- a/code/modules/power/singularity/boh_tear.dm
+++ b/code/modules/power/singularity/boh_tear.dm
@@ -19,7 +19,7 @@
 
 /obj/singularity/boh_tear/Initialize()
 	. = ..()
-	old_loc = loc
+	old_loc = get_turf(src)
 	addtimer(CALLBACK(src, /atom/movable.proc/moveToNullspace), 5 SECONDS) // vanishes after 5 seconds
 	QDEL_IN(src, 10 MINUTES)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PowerfulBaconToday at 12:45
I think if the BOH was made inside something then the loc would have been an object. However the object was consumed by the BOH so the old_loc is now inside the BOH bag (in nullspace). This means that when the mobs are moved back to their old position they are transfered to null space

## Why It's Good For The Game

Fixes BOH nullspacing issue.

## Changelog
:cl:
fix: BOH nullspacing bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
