### PR TITLE
Cleans up a common mob helper proc

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -377,11 +377,10 @@
 		if(AM.Move(get_step(T, direction)))
 			break
 
-/proc/get_mob_by_key(key)
-	var/ckey = ckey(key)
-	for(var/i in GLOB.player_list)
-		var/mob/M = i
-		if(M.ckey == ckey)
+/proc/get_mob_by_ckey(key)
+	var/ckey = ckey(key) //just to be safe
+	for(var/mob/M as() in GLOB.player_list)
+		if(M?.ckey == ckey)
 			return M
 	return null
 

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -381,14 +381,6 @@ Turf and target are separate in case you want to teleport some distance from a t
 	// means that one unit is 1 kJ.
 	return DisplayJoules(units * SSmachines.wait * 0.1 / GLOB.CELLRATE)
 
-/proc/get_mob_by_ckey(key)
-	if(!key)
-		return
-	var/list/mobs = sortmobs()
-	for(var/mob/M in mobs)
-		if(M.ckey == key)
-			return M
-
 //Returns the atom sitting on the turf.
 //For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
 //Optional arg 'type' to stop once it reaches a specific type instead of a turf.

--- a/code/game/machinery/computer/arena.dm
+++ b/code/game/machinery/computer/arena.dm
@@ -187,7 +187,7 @@
 	to_chat(user,"[ckey] removed from [team] team.")
 
 /obj/machinery/computer/arena/proc/spawn_member(obj/machinery/arena_spawn/spawnpoint,ckey,team)
-	var/mob/oldbody = get_mob_by_key(ckey)
+	var/mob/oldbody = get_mob_by_ckey(ckey)
 	if(!isobserver(oldbody))
 		return
 	var/mob/living/carbon/human/M = new/mob/living/carbon/human(get_turf(spawnpoint))
@@ -217,7 +217,7 @@
 	. = list()
 	for(var/team in team_keys)
 		for(var/key in team_keys[team])
-			var/mob/M = get_mob_by_key(key)
+			var/mob/M = get_mob_by_ckey(key)
 			if(M)
 				. += M
 
@@ -336,7 +336,7 @@
 		dat += "<ul>"
 		for(var/ckey in team_keys[team])
 			var/player_status = "Not Present"
-			var/mob/M = get_mob_by_key(ckey)
+			var/mob/M = get_mob_by_ckey(ckey)
 			if(M)
 				//Should define waiting room upper/lower corner and check if they're there instead of generic live/dead check
 				if(isobserver(M))

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -288,7 +288,7 @@
 
 		var/where = "[AREACOORD(location)]"
 		if(carry.my_atom.fingerprintslast)
-			var/mob/M = get_mob_by_key(carry.my_atom.fingerprintslast)
+			var/mob/M = get_mob_by_ckey(carry.my_atom.fingerprintslast)
 			var/more = ""
 			if(M)
 				more = "[ADMIN_LOOKUPFLW(M)] "

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -216,7 +216,7 @@
 			admin_attachment_message = " with [attachment] attached by [attacher ? ADMIN_LOOKUPFLW(attacher) : "Unknown"]"
 			attachment_message = " with [attachment] attached by [attacher ? key_name_admin(attacher) : "Unknown"]"
 
-		var/mob/bomber = get_mob_by_key(fingerprintslast)
+		var/mob/bomber = get_mob_by_ckey(fingerprintslast)
 		var/admin_bomber_message
 		var/bomber_message
 		if(bomber)

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -245,7 +245,7 @@
 
 	if(pressure > TANK_FRAGMENT_PRESSURE)
 		if(!istype(src.loc, /obj/item/transfer_valve))
-			log_bomber(get_mob_by_key(fingerprintslast), "was last key to touch", src, "which ruptured explosively")
+			log_bomber(get_mob_by_ckey(fingerprintslast), "was last key to touch", src, "which ruptured explosively")
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react(src)
 		air_contents.react(src)

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -160,7 +160,7 @@
 	if(GLOB.total_cube_monkeys >= CONFIG_GET(number/max_cube_monkeys))
 		visible_message("<span class='warning'>[src] refuses to expand!</span>")
 		return
-	var/mob/spammer = get_mob_by_key(fingerprintslast)
+	var/mob/spammer = get_mob_by_ckey(fingerprintslast)
 	var/mob/living/bananas = new spawned_mob(drop_location(), TRUE, spammer)
 	if(faction)
 		bananas.faction = faction

--- a/code/modules/integrated_electronics/subtypes/text.dm
+++ b/code/modules/integrated_electronics/subtypes/text.dm
@@ -74,7 +74,7 @@
 
 	if(spamprotection >= max_string_length*1.75 && assembly)
 		if(assembly.fingerprintslast)
-			var/mob/M = get_mob_by_key(assembly.fingerprintslast)
+			var/mob/M = get_mob_by_ckey(assembly.fingerprintslast)
 			var/more = ""
 			if(M)
 				more = "[ADMIN_LOOKUPFLW(M)] "

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -18,7 +18,7 @@
 		var/lastkey = holder.my_atom.fingerprintslast
 		var/touch_msg = "N/A"
 		if(lastkey)
-			var/mob/toucher = get_mob_by_key(lastkey)
+			var/mob/toucher = get_mob_by_ckey(lastkey)
 			touch_msg = "[ADMIN_LOOKUPFLW(toucher)]"
 		if(!istype(holder.my_atom, /obj/machinery/plumbing)) //excludes standard plumbing equipment from spamming admins with this shit
 			message_admins("Reagent explosion reaction occurred at [ADMIN_VERBOSEJMP(T)][inside_msg]. Last Fingerprint: [touch_msg].")

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -443,7 +443,7 @@
 	var/lastkey = holder.my_atom.fingerprintslast
 	var/touch_msg = "N/A"
 	if(lastkey)
-		var/mob/toucher = get_mob_by_key(lastkey)
+		var/mob/toucher = get_mob_by_ckey(lastkey)
 		touch_msg = "[ADMIN_LOOKUPFLW(toucher)]."
 	message_admins("Slime Explosion reaction started at [ADMIN_VERBOSEJMP(T)]. Last Fingerprint: [touch_msg]")
 	log_game("Slime Explosion reaction started at [AREACOORD(T)]. Last Fingerprint: [lastkey ? lastkey : "N/A"].")
@@ -579,7 +579,7 @@
 	new /obj/effect/timestop(T, null, null, null)
 	if(istype(extract))
 		if(extract.Uses > 0)
-			var/mob/lastheld = get_mob_by_key(holder.my_atom.fingerprintslast)
+			var/mob/lastheld = get_mob_by_ckey(holder.my_atom.fingerprintslast)
 			if(lastheld && !lastheld.equip_to_slot_if_possible(extract, SLOT_HANDS, disable_warning = TRUE))
 				extract.forceMove(get_turf(lastheld))
 


### PR DESCRIPTION
Just look at the code.

## Changelog
:cl:
code: Optimized get_mob_by_ckey().
code: Removed get_mob_by_key().
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
