### PR TITLE
balances bluespace miners

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -765,7 +765,7 @@
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stock_parts/manipulator/femto = 3,
 		/obj/item/stock_parts/scanning_module = 1,
-		/obj/item/stack/ore/bluespace_crystal = 10)
+		/obj/item/stack/ore/bluespace_crystal = 11)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/circuit_imprinter/department/science

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -760,11 +760,12 @@
 	icon_state = "science"
 	build_path = /obj/machinery/mineral/bluespace_miner
 	req_components = list(
+		/obj/item/stock_parts/capacitor/quadratic = 1,
 		/obj/item/stock_parts/matter_bin = 3,
 		/obj/item/stock_parts/micro_laser = 1,
-		/obj/item/stock_parts/manipulator = 3,
+		/obj/item/stock_parts/manipulator/femto = 3,
 		/obj/item/stock_parts/scanning_module = 1,
-		/obj/item/stack/ore/bluespace_crystal = 3)
+		/obj/item/stack/ore/bluespace_crystal = 10)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/circuit_imprinter/department/science

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -481,7 +481,7 @@
 	id = "bluespace_miner"
 	build_path = /obj/item/circuitboard/machine/bluespace_miner
 	category = list ("Misc. Machinery")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/board/mining_equipment_vendor
 	name = "Machine Design (Mining Rewards Vendor Board)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The current meta is for science to get the AI to give them access to the teleporter, where an enterprising Scientist will destroy the machine in order to get at the bluespace crystals within. Then Bluespace miners will be tech rushed, and bluespace miners will soon fill every square meter of the station.

![image](https://user-images.githubusercontent.com/3241376/103961530-45fadc80-511a-11eb-8d8d-6ea44ff1fee9.png)


This PR makes Bluespace miners a late game item by tweaking their cost, and moves them to being a cargo only item, since neither Science nor Engineering are in the business of harvesting materials for the station.

This should also discourage the current meta of players deconstructing the teleporters roundstart for their bluespace crystals in order to build a bluespace miner, which is detrimental to several other mechanics (like actually using the teleporter network).

Screenshot taken from a High-Population MRP round: 
![image](https://user-images.githubusercontent.com/3241376/104157339-90958680-53b0-11eb-969f-de2c21d8d9a5.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

machines that generate infinite resources shouldn't be possible to create at the start of the round by stealing bluespace crystals from the teleporter

It is not the job of science or engineering to get materials for the station

End game machines should only be possible mid to late round

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced bluespace miner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
