### PR TITLE
Bluespace Miners Nerf

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -760,10 +760,10 @@
 	icon_state = "science"
 	build_path = /obj/machinery/mineral/bluespace_miner
 	req_components = list(
-		/obj/item/stock_parts/matter_bin = 2,
-		/obj/item/stock_parts/micro_laser = 1,
-		/obj/item/stock_parts/manipulator = 1,
-		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/matter_bin = 4,
+		/obj/item/stock_parts/micro_laser = 2,
+		/obj/item/stock_parts/manipulator = 4,
+		/obj/item/stock_parts/scanning_module = 2,
 		/obj/item/stack/ore/bluespace_crystal = 5)
 	needs_anchored = FALSE
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -760,11 +760,11 @@
 	icon_state = "science"
 	build_path = /obj/machinery/mineral/bluespace_miner
 	req_components = list(
-		/obj/item/stock_parts/matter_bin = 3,
+		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/stock_parts/micro_laser = 1,
-		/obj/item/stock_parts/manipulator = 3,
+		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stock_parts/scanning_module = 1,
-		/obj/item/stack/ore/bluespace_crystal = 3)
+		/obj/item/stack/ore/bluespace_crystal = 5)
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/circuit_imprinter/department/science

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -39,41 +39,19 @@
 	var/efficiency = 0	
 	for(var/obj/item/stock_parts/P in component_parts)
 		efficiency += P.rating
-	
-	switch (efficiency)
-		if (19 to 28)
-			ore_rates = list(
-				/datum/material/iron = 0.6, 
-				/datum/material/glass = 0.6,
-				/datum/material/copper = 0.2, 
-				/datum/material/silver = 0.1, 
-			)
-		if (29 to 38)
-			ore_rates = list(
-				/datum/material/iron = 0.6, 
-				/datum/material/glass = 0.6,
-				/datum/material/copper = 0.4, 
-				/datum/material/silver = 0.2, 
-				/datum/material/gold = 0.1, 
-				/datum/material/plasma = 0.2,
-			)
-		if (39 to INFINITY)	//and beyond
-			ore_rates = list(
-				/datum/material/iron = 0.6, 
-				/datum/material/glass = 0.6, 
-				/datum/material/copper = 0.4, 
-				/datum/material/silver = 0.2, 
-				/datum/material/gold = 0.1, 
-				/datum/material/plasma = 0.2,
-				/datum/material/titanium = 0.1, 
-				/datum/material/uranium = 0.1, 
-				/datum/material/diamond = 0.1
-			)
-		else 
-			ore_rates = list(
-				/datum/material/iron = 0.6, 
-				/datum/material/glass = 0.6,
-			)
+	efficiency /= 40
+		
+	ore_rates = list(
+				/datum/material/iron = 0.2 + 0.6 * efficiency, 
+				/datum/material/glass = 0.2 + 0.6 * efficiency, 
+				/datum/material/copper = 0.2 + 0.3 * efficiency, 
+				/datum/material/silver = 0.1 + 0.2 * efficiency, 
+				/datum/material/plasma = 0.1 + 0.2 * efficiency,
+				/datum/material/gold = 0.05 + 0.1 * efficiency, 
+				/datum/material/titanium = 0.05 + 0.1 * efficiency, 
+				/datum/material/uranium = 0.05 + 0.1 * efficiency, 
+				/datum/material/diamond = 0.05 + 0.1 * efficiency
+		)
 
 /obj/machinery/mineral/bluespace_miner/process()
 	if(!materials?.silo || materials?.on_hold())
@@ -82,4 +60,4 @@
 	if(!mat_container || panel_open || !powered())
 		return
 	var/datum/material/ore = pick(ore_rates)
-	mat_container.insert_amount_mat((ore_rates[ore] * rand (200,400)), ore)
+	mat_container.insert_amount_mat((ore_rates[ore] * rand (300,500)), ore)

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -6,12 +6,13 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/bluespace_miner
 	layer = BELOW_OBJ_LAYER
-	var/list/ore_rates = list(/datum/material/iron = 0.6, /datum/material/glass = 0.6, /datum/material/copper = 0.4, /datum/material/plasma = 0.2,  /datum/material/silver = 0.2, /datum/material/gold = 0.1, /datum/material/titanium = 0.1, /datum/material/uranium = 0.1, /datum/material/diamond = 0.1)
+	var/list/ore_rates = list(/datum/material/iron = 1, /datum/material/glass = 1)
 	var/datum/component/remote_materials/materials
 
 /obj/machinery/mineral/bluespace_miner/Initialize(mapload)
 	. = ..()
 	materials = AddComponent(/datum/component/remote_materials, "bsm", mapload)
+	revise_mat_rates()
 
 /obj/machinery/mineral/bluespace_miner/Destroy()
 	materials = null
@@ -30,11 +31,56 @@
 	else if(materials?.on_hold())
 		. += "<span class='warning'>Ore silo access is on hold, please contact the quartermaster.</span>"
 
+/obj/machinery/mineral/bluespace_miner/exchange_parts(mob/living/user,obj/item/tool)
+	..()
+	revise_mat_rates()
+
+/obj/machinery/mineral/bluespace_miner/proc/revise_mat_rates()
+	var/efficiency = 0	
+	for(var/obj/item/stock_parts/P in component_parts)
+		efficiency += P.rating
+	
+	switch (efficiency)
+		if (5 to 10)
+			ore_rates = list(
+				/datum/material/iron = 1, 
+				/datum/material/glass = 1,
+				/datum/material/copper = 0.5, 
+				/datum/material/silver = 0.2, 
+			)
+		if (10 to 15)
+			ore_rates = list(
+				/datum/material/iron = 1, 
+				/datum/material/glass = 1,
+				/datum/material/copper = 0.4, 
+				/datum/material/silver = 0.3, 
+				/datum/material/gold = 0.2, 
+				/datum/material/plasma = 0.2,
+			)
+		if (15 to INFINITY)	//and beyond
+			ore_rates = list(
+				/datum/material/iron = 1, 
+				/datum/material/glass = 1, 
+				/datum/material/copper = 0.6, 
+				/datum/material/silver = 0.4, 
+				/datum/material/gold = 0.33, 
+				/datum/material/plasma = 0.33,
+				/datum/material/titanium = 0.25, 
+				/datum/material/uranium = 0.25, 
+				/datum/material/diamond = 0.25
+			)
+		else 
+			ore_rates = list(
+				/datum/material/iron = 1, 
+				/datum/material/glass = 1,
+			)
+
 /obj/machinery/mineral/bluespace_miner/process()
 	if(!materials?.silo || materials?.on_hold())
 		return
 	var/datum/component/material_container/mat_container = materials.mat_container
 	if(!mat_container || panel_open || !powered())
 		return
-	var/datum/material/ore = pick(ore_rates)
-	mat_container.insert_amount_mat((ore_rates[ore] * 1000), ore)
+	if (prob(33))
+		var/datum/material/ore = pick(ore_rates)
+		mat_container.insert_amount_mat((ore_rates[ore] * 1000), ore)

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -43,10 +43,10 @@
 	switch (efficiency)
 		if (19 to 28)
 			ore_rates = list(
-				/datum/material/iron = .6, 
-				/datum/material/glass = .6,
-				/datum/material/copper = .2, 
-				/datum/material/silver = .1, 
+				/datum/material/iron = 0.6, 
+				/datum/material/glass = 0.6,
+				/datum/material/copper = 0.2, 
+				/datum/material/silver = 0.1, 
 			)
 		if (29 to 38)
 			ore_rates = list(

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -41,38 +41,38 @@
 		efficiency += P.rating
 	
 	switch (efficiency)
-		if (10 to 19)
+		if (19 to 28)
 			ore_rates = list(
-				/datum/material/iron = 3, 
-				/datum/material/glass = 3,
-				/datum/material/copper = 2, 
-				/datum/material/silver = 1, 
+				/datum/material/iron = .6, 
+				/datum/material/glass = .6,
+				/datum/material/copper = .2, 
+				/datum/material/silver = .1, 
 			)
-		if (20 to 29)
+		if (29 to 38)
 			ore_rates = list(
-				/datum/material/iron = 6, 
-				/datum/material/glass = 6,
-				/datum/material/copper = 4, 
-				/datum/material/silver = 2, 
-				/datum/material/gold = 1, 
-				/datum/material/plasma = 2,
+				/datum/material/iron = 0.6, 
+				/datum/material/glass = 0.6,
+				/datum/material/copper = 0.4, 
+				/datum/material/silver = 0.2, 
+				/datum/material/gold = 0.1, 
+				/datum/material/plasma = 0.2,
 			)
-		if (30 to INFINITY)	//and beyond
+		if (39 to INFINITY)	//and beyond
 			ore_rates = list(
-				/datum/material/iron = 6, 
-				/datum/material/glass = 6, 
-				/datum/material/copper = 4, 
-				/datum/material/silver = 2, 
-				/datum/material/gold = 1, 
-				/datum/material/plasma = 2,
-				/datum/material/titanium = 1, 
-				/datum/material/uranium = 1, 
-				/datum/material/diamond = 1
+				/datum/material/iron = 0.6, 
+				/datum/material/glass = 0.6, 
+				/datum/material/copper = 0.4, 
+				/datum/material/silver = 0.2, 
+				/datum/material/gold = 0.1, 
+				/datum/material/plasma = 0.2,
+				/datum/material/titanium = 0.1, 
+				/datum/material/uranium = 0.1, 
+				/datum/material/diamond = 0.1
 			)
 		else 
 			ore_rates = list(
-				/datum/material/iron = 1, 
-				/datum/material/glass = 1,
+				/datum/material/iron = 0.6, 
+				/datum/material/glass = 0.6,
 			)
 
 /obj/machinery/mineral/bluespace_miner/process()

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -43,28 +43,28 @@
 	switch (efficiency)
 		if (10 to 19)
 			ore_rates = list(
-				/datum/material/iron = 5, 
-				/datum/material/glass = 5,
-				/datum/material/copper = 3, 
+				/datum/material/iron = 3, 
+				/datum/material/glass = 3,
+				/datum/material/copper = 2, 
 				/datum/material/silver = 1, 
 			)
 		if (20 to 29)
 			ore_rates = list(
-				/datum/material/iron = 5, 
-				/datum/material/glass = 5,
-				/datum/material/copper = 3, 
+				/datum/material/iron = 6, 
+				/datum/material/glass = 6,
+				/datum/material/copper = 4, 
 				/datum/material/silver = 2, 
 				/datum/material/gold = 1, 
-				/datum/material/plasma = 1,
+				/datum/material/plasma = 2,
 			)
 		if (30 to INFINITY)	//and beyond
 			ore_rates = list(
-				/datum/material/iron = 4, 
-				/datum/material/glass = 4, 
-				/datum/material/copper = 2.4, 
-				/datum/material/silver = 1.6, 
-				/datum/material/gold = 1.2, 
-				/datum/material/plasma = 1.2,
+				/datum/material/iron = 6, 
+				/datum/material/glass = 6, 
+				/datum/material/copper = 4, 
+				/datum/material/silver = 2, 
+				/datum/material/gold = 1, 
+				/datum/material/plasma = 2,
 				/datum/material/titanium = 1, 
 				/datum/material/uranium = 1, 
 				/datum/material/diamond = 1

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -41,33 +41,33 @@
 		efficiency += P.rating
 	
 	switch (efficiency)
-		if (5 to 10)
+		if (10 to 19)
 			ore_rates = list(
-				/datum/material/iron = 1, 
-				/datum/material/glass = 1,
-				/datum/material/copper = 0.5, 
-				/datum/material/silver = 0.2, 
+				/datum/material/iron = 5, 
+				/datum/material/glass = 5,
+				/datum/material/copper = 3, 
+				/datum/material/silver = 1, 
 			)
-		if (10 to 15)
+		if (20 to 29)
 			ore_rates = list(
-				/datum/material/iron = 1, 
-				/datum/material/glass = 1,
-				/datum/material/copper = 0.4, 
-				/datum/material/silver = 0.3, 
-				/datum/material/gold = 0.2, 
-				/datum/material/plasma = 0.2,
+				/datum/material/iron = 5, 
+				/datum/material/glass = 5,
+				/datum/material/copper = 3, 
+				/datum/material/silver = 2, 
+				/datum/material/gold = 1, 
+				/datum/material/plasma = 1,
 			)
-		if (15 to INFINITY)	//and beyond
+		if (30 to INFINITY)	//and beyond
 			ore_rates = list(
-				/datum/material/iron = 1, 
-				/datum/material/glass = 1, 
-				/datum/material/copper = 0.6, 
-				/datum/material/silver = 0.4, 
-				/datum/material/gold = 0.33, 
-				/datum/material/plasma = 0.33,
-				/datum/material/titanium = 0.25, 
-				/datum/material/uranium = 0.25, 
-				/datum/material/diamond = 0.25
+				/datum/material/iron = 4, 
+				/datum/material/glass = 4, 
+				/datum/material/copper = 2.4, 
+				/datum/material/silver = 1.6, 
+				/datum/material/gold = 1.2, 
+				/datum/material/plasma = 1.2,
+				/datum/material/titanium = 1, 
+				/datum/material/uranium = 1, 
+				/datum/material/diamond = 1
 			)
 		else 
 			ore_rates = list(
@@ -81,6 +81,5 @@
 	var/datum/component/material_container/mat_container = materials.mat_container
 	if(!mat_container || panel_open || !powered())
 		return
-	if (prob(33))
-		var/datum/material/ore = pick(ore_rates)
-		mat_container.insert_amount_mat((ore_rates[ore] * 1000), ore)
+	var/datum/material/ore = pick(ore_rates)
+	mat_container.insert_amount_mat((ore_rates[ore] * rand (200,400)), ore)


### PR DESCRIPTION
## About The Pull Request

Bluespace miners are a little slower, and they now farm rarer mats, depending on the current tier parts they are equipt with.

## Why It's Good For The Game

Nerfs bluespace miners while not making them completely obsolete. Miners are still required to upgrade them and make them efficient, and they cannot completely replace miners anymore, especially not at T1.

## Changelog
:cl:
tweak: changed the parts required to make bluespace miners, and they now require 5 BSC
tweak: bluespace miners are a bit slower, and can only generate rare mats with higher tear parts.
/:cl: