### PR TITLE
Fixed naming issues with some pet beacons

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -344,7 +344,7 @@
 	mob_choice = /mob/living/simple_animal/pet/cat
 
 /obj/item/choice_beacon/pet/mouse
-	name = "cat delivery beacon"
+	name = "mouse delivery beacon"
 	default_name = "Jerry"
 	mob_choice = /mob/living/simple_animal/mouse
 	
@@ -354,12 +354,12 @@
 	mob_choice = /mob/living/simple_animal/pet/dog/corgi
 	
 /obj/item/choice_beacon/pet/hamster
-	name = "corgi delivery beacon"
+	name = "hamster delivery beacon"
 	default_name = "Doctor"
 	mob_choice = /mob/living/simple_animal/pet/hamster
 	
 /obj/item/choice_beacon/pet/pug
-	name = "corgi delivery beacon"
+	name = "pug delivery beacon"
 	default_name = "Silvestro"
 	mob_choice = /mob/living/simple_animal/pet/dog/pug
 	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixed the names of some pet beacons.

## Why It's Good For The Game

Oops.

## Changelog
:cl:
fix: pet beacons are named properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
