### PR TITLE
Removes CBZ

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -478,13 +478,6 @@
 					/obj/item/clothing/suit/armor/bulletproof)
 	crate_name = "bulletproof armor crate"
 
-/datum/supply_pack/security/armory/cling_test
-	name = "Changeling Testing Kit"
-	desc = "Contains a single bottle of concentrated BZ, used for detecting and incapacitating changelings. Due to the rarity of this chemical, the cost is extortionate, and security personnel are recommended to visit their local chemistry department instead if possible. Requires Armory access to open."
-	cost = 10000
-	contains = list(/obj/item/reagent_containers/glass/bottle/concentrated_bz)
-	crate_name = "Changeling testing kit crate"
-
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1904,47 +1904,6 @@
 			changeling.chem_charges = max(changeling.chem_charges-2, 0)
 	return ..()
 
-/datum/reagent/concentrated_bz
-	name = "Concentrated BZ"
-	description = "A hyperconcentrated liquid form of BZ gas, known to cause an extremely adverse reaction to changelings. Also causes minor brain damage."
-	color = "#FAFF00"
-	taste_description = "acrid cinnamon"
-	random_unrestricted = FALSE
-
-/datum/reagent/concentrated_bz/on_mob_metabolize(mob/living/L)
-	..()
-	ADD_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
-
-/datum/reagent/concentrated_bz/on_mob_end_metabolize(mob/living/L)
-	..()
-	REMOVE_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
-
-/datum/reagent/concentrated_bz/on_mob_life(mob/living/L)
-	if(L.mind)
-		var/datum/antagonist/changeling/changeling = L.mind.has_antag_datum(/datum/antagonist/changeling)
-		if(changeling)
-			changeling.chem_charges = max(changeling.chem_charges-2, 0)
-			if(prob(30))
-				L.losebreath += 1
-				L.adjustOxyLoss(3,5)
-				L.emote("gasp")
-				to_chat(L, "<font size=3 color=red><b>You can't breathe!</b></font>")
-
-		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
-	return ..()
-
-/datum/reagent/fake_cbz
-	name = "Concentrated BZ"
-	description = "A hyperconcentrated liquid form of BZ gas, known to cause an extremely adverse reaction to changelings. Also causes minor brain damage."
-	color = "#FAFF00"
-	taste_description = "acrid cinnamon"
-	random_unrestricted = FALSE
-
-/datum/reagent/fake_cbz/on_mob_life(mob/living/L)
-	L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
-	if(prob(15))
-		to_chat(L, "You don't feel much of anything")
-
 /datum/reagent/pax/peaceborg
 	name = "Synthpax"
 	description = "A colorless liquid that suppresses violent urges in its subjects. Cheaper to synthesize than normal Pax, but wears off faster."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -37,18 +37,6 @@
 	results = list(/datum/reagent/impedrezene = 2)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 
-/datum/chemical_reaction/concentrated_bz
-	name = "Concentrated BZ"
-	id = "Concentrated BZ"
-	results = list(/datum/reagent/concentrated_bz = 10)
-	required_reagents = list(/datum/reagent/toxin/plasma = 40, /datum/reagent/nitrous_oxide = 10)
-
-/datum/chemical_reaction/fake_cbz
-	name = "Fake CBZ"
-	id = "Fake CBZ"
-	results = list(/datum/reagent/fake_cbz = 1)
-	required_reagents = list(/datum/reagent/concentrated_bz = 1, /datum/reagent/medicine/neurine = 3)
-
 /datum/chemical_reaction/cryptobiolin
 	name = "Cryptobiolin"
 	id = /datum/reagent/cryptobiolin

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -82,11 +82,6 @@
 	desc = "A small bottle of cryostylane. It feels cold to the touch"
 	list_reagents = list(/datum/reagent/cryostylane = 30)
 
-/obj/item/reagent_containers/glass/bottle/concentrated_bz
-	name = "concentrated BZ bottle"
-	desc = "A small bottle of concentrated BZ"
-	list_reagents = list(/datum/reagent/concentrated_bz = 30)
-
 /obj/item/reagent_containers/glass/bottle/ammonia
 	name = "ammonia bottle"
 	desc = "A small bottle of ammonia."


### PR DESCRIPTION
## About The Pull Request

Removes CBZ. Reverts #1412.

## Why It's Good For The Game

There shouldn't be a easily obtainable, large supply of "expose antag" formula.

Especially for lings; a weak stealth antag who's only defense is hiding in maints.

## Changelog
:cl:
del: cbz, fake cbz and changeling test crates are no more
/:cl:
