### PR TITLE
Buffs the chaplain's null rod

### DIFF
--- a/_maps/RandomRooms/10x5/sk_rdm011_barbershop.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm011_barbershop.dmm
@@ -82,7 +82,6 @@
 	amount = 2
 	},
 /obj/item/stack/sheet/iron/ten,
-/obj/item/twohanded/required/chainsaw,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/clothing/head/wig/random,
 /obj/item/reagent_containers/medspray/spraytan,


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

-removed the barber's roundstart snowflake weapon

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
-reduces powergame potential of random maint spawns
-buffs the value of the chaplain's null rod
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: made the chaplain's nullrod more valuable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
