### PR TITLE
Fixes a bug/exploit with cloning

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -436,7 +436,7 @@
 	connected.updateUsrDialog()
 	return TRUE
 
-/obj/machinery/clonepod/proc/go_out()
+/obj/machinery/clonepod/proc/go_out(move = TRUE)
 	countdown.stop()
 	var/mob/living/mob_occupant = occupant
 	var/turf/T = get_turf(src)
@@ -469,7 +469,8 @@
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
 		mob_occupant.flash_act()
 
-	occupant.forceMove(T)
+	if(move)
+		occupant.forceMove(T)
 	icon_state = "pod_0"
 	mob_occupant.domutcheck(1) //Waiting until they're out before possible monkeyizing. The 1 argument forces powers to manifest.
 	for(var/fl in unattached_flesh)
@@ -478,6 +479,13 @@
 
 	occupant = null
 	clonemind = null
+
+// Guess they moved out on their own, remove any clone status effects
+// If the occupant var is null, welp what can we do
+/obj/machinery/clonepod/Exited(atom/movable/AM, atom/newloc)
+	if(AM == occupant)
+		go_out(FALSE)
+	. = ..()
 
 /obj/machinery/clonepod/proc/malfunction()
 	var/mob/living/mob_occupant = occupant


### PR DESCRIPTION
## About The Pull Request
Basically, if you teleport out of cloning early due to adminbus, or (mainly) a *certain* mutation, you're stuck in a limbo state, being mute, unable to emote, while *also* having a suite of buffs, such as nobreath, stable heart and liver, as well as *no crit damage*, because the game didn't handle you leaving the cloner.
This would take some effort to pull off, along with a buddy helping, but if you don't mind basically only being able to communicate by pointing and writing on paper, you can get some strong buffs.

## Why It's Good For The Game
Squashes a *really* annoying bug, and potentially a quite broken exploit.

## Changelog
:cl: MCterra
fix: fixed a bug with teleporting out of the cloner not updating status properly.
/:cl: