### PR TITLE
CBZ 2: Tokyo Drift

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -478,13 +478,6 @@
 					/obj/item/clothing/suit/armor/bulletproof)
 	crate_name = "bulletproof armor crate"
 
-/datum/supply_pack/security/armory/cling_test
-	name = "Changeling Testing Kit"
-	desc = "Contains a single bottle of concentrated BZ, used for detecting and incapacitating changelings. Due to the rarity of this chemical, the cost is extortionate, and security personnel are recommended to visit their local chemistry department instead if possible. Requires Armory access to open."
-	cost = 10000
-	contains = list(/obj/item/reagent_containers/glass/bottle/concentrated_bz)
-	crate_name = "Changeling testing kit crate"
-
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -478,6 +478,13 @@
 					/obj/item/clothing/suit/armor/bulletproof)
 	crate_name = "bulletproof armor crate"
 
+/datum/supply_pack/security/armory/cling_test
+	name = "Changeling Testing Kit"
+	desc = "Contains a single bottle of concentrated BZ, used for detecting and incapacitating changelings. Due to the rarity of this chemical, the cost is extortionate, and security personnel are recommended to visit their local chemistry department instead if possible. Requires Armory access to open."
+	cost = 10000
+	contains = list(/obj/item/reagent_containers/glass/bottle/concentrated_bz)
+	crate_name = "Changeling testing kit crate"
+
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1923,15 +1923,16 @@
 	if(L.mind)
 		var/datum/antagonist/changeling/changeling = L.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling)
-			changeling.chem_charges = max(changeling.chem_charges-2, 0)
 			if(prob(30))
-				L.losebreath += 1
-				L.adjustOxyLoss(3,5)
-				L.emote("gasp")
-				to_chat(L, "<font size=3 color=red><b>You can't breathe!</b></font>")
-
-		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
-	return ..()
+				L.adjustStaminaLoss(3,5)
+				L.emote("scream")
+				to_chat(L, "<font size=3 color=red><b>The chemicals burn our senses!</b></font>")
+				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+		else
+			L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 200)
+			if(prob(30))
+				to_chat(L, "<font size=3 color=red><b>Your head feels like it's on fire!</b></font>")
+	..()
 
 /datum/reagent/fake_cbz
 	name = "Concentrated BZ"
@@ -1941,9 +1942,17 @@
 	random_unrestricted = FALSE
 
 /datum/reagent/fake_cbz/on_mob_life(mob/living/L)
-	L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
-	if(prob(15))
-		to_chat(L, "You don't feel much of anything")
+	if(L.mind)
+		var/datum/antagonist/changeling/changeling = L.mind.has_antag_datum(/datum/antagonist/changeling)
+		if(changeling)
+			L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+			if(prob(30))
+				to_chat(L, "<font size=3 color=red><b>We feel a little sore, but nothing too bad.</b></font>")
+		else
+			L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 200)
+			if(prob(30))
+				to_chat(L, "<font size=3 color=red><b>Your head feels like it's on fire!</b></font>")
+	..()
 
 /datum/reagent/pax/peaceborg
 	name = "Synthpax"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1904,6 +1904,47 @@
 			changeling.chem_charges = max(changeling.chem_charges-2, 0)
 	return ..()
 
+/datum/reagent/concentrated_bz
+	name = "Concentrated BZ"
+	description = "A hyperconcentrated liquid form of BZ gas, known to cause an extremely adverse reaction to changelings. Also causes minor brain damage."
+	color = "#FAFF00"
+	taste_description = "acrid cinnamon"
+	random_unrestricted = FALSE
+
+/datum/reagent/concentrated_bz/on_mob_metabolize(mob/living/L)
+	..()
+	ADD_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
+
+/datum/reagent/concentrated_bz/on_mob_end_metabolize(mob/living/L)
+	..()
+	REMOVE_TRAIT(L, CHANGELING_HIVEMIND_MUTE, type)
+
+/datum/reagent/concentrated_bz/on_mob_life(mob/living/L)
+	if(L.mind)
+		var/datum/antagonist/changeling/changeling = L.mind.has_antag_datum(/datum/antagonist/changeling)
+		if(changeling)
+			changeling.chem_charges = max(changeling.chem_charges-2, 0)
+			if(prob(30))
+				L.losebreath += 1
+				L.adjustOxyLoss(3,5)
+				L.emote("gasp")
+				to_chat(L, "<font size=3 color=red><b>You can't breathe!</b></font>")
+
+		L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+	return ..()
+
+/datum/reagent/fake_cbz
+	name = "Concentrated BZ"
+	description = "A hyperconcentrated liquid form of BZ gas, known to cause an extremely adverse reaction to changelings. Also causes minor brain damage."
+	color = "#FAFF00"
+	taste_description = "acrid cinnamon"
+	random_unrestricted = FALSE
+
+/datum/reagent/fake_cbz/on_mob_life(mob/living/L)
+	L.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 50)
+	if(prob(15))
+		to_chat(L, "You don't feel much of anything")
+
 /datum/reagent/pax/peaceborg
 	name = "Synthpax"
 	description = "A colorless liquid that suppresses violent urges in its subjects. Cheaper to synthesize than normal Pax, but wears off faster."

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -37,6 +37,18 @@
 	results = list(/datum/reagent/impedrezene = 2)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/oxygen = 1, /datum/reagent/consumable/sugar = 1)
 
+/datum/chemical_reaction/concentrated_bz
+	name = "Concentrated BZ"
+	id = "Concentrated BZ"
+	results = list(/datum/reagent/concentrated_bz = 10)
+	required_reagents = list(/datum/reagent/toxin/plasma = 40, /datum/reagent/nitrous_oxide = 10)
+
+/datum/chemical_reaction/fake_cbz
+	name = "Fake CBZ"
+	id = "Fake CBZ"
+	results = list(/datum/reagent/fake_cbz = 1)
+	required_reagents = list(/datum/reagent/concentrated_bz = 1, /datum/reagent/medicine/neurine = 3)
+
 /datum/chemical_reaction/cryptobiolin
 	name = "Cryptobiolin"
 	id = /datum/reagent/cryptobiolin

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -40,7 +40,7 @@
 /datum/chemical_reaction/concentrated_bz
 	name = "Concentrated BZ"
 	id = "Concentrated BZ"
-	results = list(/datum/reagent/concentrated_bz = 10)
+	results = list(/datum/reagent/concentrated_bz = 1)
 	required_reagents = list(/datum/reagent/toxin/plasma = 4, /datum/reagent/nitrous_oxide = 1, /datum/reagent/toxin/anacea = 1)
 
 /datum/chemical_reaction/fake_cbz

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -41,7 +41,7 @@
 	name = "Concentrated BZ"
 	id = "Concentrated BZ"
 	results = list(/datum/reagent/concentrated_bz = 10)
-	required_reagents = list(/datum/reagent/toxin/plasma = 40, /datum/reagent/nitrous_oxide = 10)
+	required_reagents = list(/datum/reagent/toxin/plasma = 4, /datum/reagent/nitrous_oxide = 1, /datum/reagent/toxin/anacea = 1)
 
 /datum/chemical_reaction/fake_cbz
 	name = "Fake CBZ"

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -82,6 +82,11 @@
 	desc = "A small bottle of cryostylane. It feels cold to the touch"
 	list_reagents = list(/datum/reagent/cryostylane = 30)
 
+/obj/item/reagent_containers/glass/bottle/concentrated_bz
+	name = "concentrated BZ bottle"
+	desc = "A small bottle of concentrated BZ"
+	list_reagents = list(/datum/reagent/concentrated_bz = 30)
+
 /obj/item/reagent_containers/glass/bottle/ammonia
 	name = "ammonia bottle"
 	desc = "A small bottle of ammonia."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Readds CBZ and nerfs it to prevent people abusing it to mass check on ling rounds.

CBZ now uses a much harder chemical recipe (4u plasma, 1u N2O, 1u Anacea -> 1u CBZ) and cannot be ordered from cargo anymore.

CBZ no longer causes oxygen damage to lings, instead doing very minor stamina and brain damage, and making them scream. Non-lings are affected differently, taking massive, potentially fatal, brain damage. This prevents sec from injecting everyone in sight with the stuff to flush out changelings.

Fake CBZ also does this massive brain damage, but only to non-lings. Lings take minor brain damage to mask the fact that they are lings.

## Why It's Good For The Game

Speedmerging a poorly thought out removal and completely ignoring the consensus of the maintainers is dumb.

Encouraging sec players to abuse a code oversight to find changelings is dumb.

Spamming everyone who gets arrested with CBZ to find the lings is dumb.

## Changelog
:cl:
add: Added CBZ, again
add: CBZ and fake CBZ now do massive brain damage to non-lings, and minor brain damage to lings. Be very careful not to test an innocent person!
del: Removed CBZ cargo crate
balance: CBZ recipe now requires anacea
balance: CBZ now does not suffocate lings, making them scream instead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
