### PR TITLE
fixes crate animation breaking at closing

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -73,7 +73,7 @@
 	for(var/I in 0 to num_steps)
 		var/door_state = I == 0 || (I == num_steps && closing) ? "[icon_door || icon_state]_door" : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
 		var/door_layer = I == 0 || (I == num_steps && closing) ? ABOVE_MOB_LAYER : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/matrix/M = get_door_transform(I==0 || (I == num_steps && closing) ? 0 : animation_math_list[closing ? num_steps - I : I], I==0 || (I == num_steps && closing) ? 1 : animation_math_list[closing ?  2 * num_steps - I : num_steps + I])
+		var/matrix/M = get_door_transform(I == 0 || (I == num_steps && closing) ? 0 : animation_math_list[closing ? num_steps - I : I], I == 0 || (I == num_steps && closing) ? 1 : animation_math_list[closing ?  2 * num_steps - I : num_steps + I])
 		if(I == 0)
 			door_obj.transform = M
 			door_obj.icon_state = door_state

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -71,9 +71,9 @@
 	var/num_steps = door_anim_time / world.tick_lag
 	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
-		var/door_state = animation_math_list[closing ? 3 * num_steps + I + 1 : num_steps + I + 1] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
-		var/door_layer = animation_math_list[closing ? 3 * num_steps + I + 1 : num_steps + I + 1] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps * 2 + I + 1 : I + 1], animation_math_list[closing ?  num_steps * 3 + I + 1 : num_steps + I + 1])
+		var/door_state = I == 0 ? "[icon_door || icon_state]_door" : animation_math_list[closing ? 3 * num_steps + I : num_steps + I] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
+		var/door_layer = I == 0 ? ABOVE_MOB_LAYER : animation_math_list[closing ? 3 * num_steps + I : num_steps + I] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
+		var/matrix/M = get_door_transform(I==0 ? 0 : animation_math_list[closing ? num_steps * 2 + I : I], I==0 ? 0 : animation_math_list[closing ?  num_steps * 3 + I : num_steps + I])
 		if(I == 0)
 			door_obj.transform = M
 			door_obj.icon_state = door_state
@@ -99,8 +99,8 @@
 
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	var/num_steps_1 = door_anim_time / world.tick_lag
-	var/list/new_animation_math_sublist[num_steps_1 * 4 + 1]
-	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
+	var/list/new_animation_math_sublist[num_steps_1 * 4]
+	for(var/I in 1 to num_steps_1) //loop to save the animation values into the lists
 		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
 		var/angle_2 = I == 0 ? 0 : door_anim_angle * (1 - (I / num_steps_1))
 		var/polar_angle = abs(arcsin(cos(angle_1)))
@@ -109,10 +109,10 @@
 		var/polar_angle_2 = abs(arcsin(cos(angle_2)))
 		var/azimuth_angle_2 = angle_2 >= 90 ? azimuth_angle_3 : 0
 		var/radius_cr_2 = angle_2 >= 90 ? radius_2 : 1
-		new_animation_math_sublist[I + 1] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
-		new_animation_math_sublist[num_steps_1 + I + 1] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
-		new_animation_math_sublist[num_steps_1 * 2 + I + 1] = -sin(polar_angle_2) * sin(azimuth_angle_2) * radius_cr_2
-		new_animation_math_sublist[num_steps_1 * 3 + I + 1] = cos(azimuth_angle_2) * sin(polar_angle_2) * radius_cr_2
+		new_animation_math_sublist[I] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
+		new_animation_math_sublist[num_steps_1 + I] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
+		new_animation_math_sublist[num_steps_1 * 2 + I] = -sin(polar_angle_2) * sin(azimuth_angle_2) * radius_cr_2
+		new_animation_math_sublist[num_steps_1 * 3 + I] = cos(azimuth_angle_2) * sin(polar_angle_2) * radius_cr_2
 	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
 
 /obj/structure/closet/crate/attack_hand(mob/user)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -21,7 +21,7 @@
 	open_sound_volume = 35
 	close_sound_volume = 50
 	drag_slowdown = 0
-	var/azimuth_angle_3 = 138 //in this context the azimuth angle for over 90 degree
+	var/azimuth_angle_2 = 138 //in this context the azimuth angle for over 90 degree
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
 	var/static/list/animation_math //assoc list with pre calculated values
@@ -30,7 +30,7 @@
 	. = ..()
 	if(animation_math == null) //checks if there is already a list for animation_math if not creates one to avoid runtimes
 		animation_math = new/list()
-	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"])
+	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"])
 		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
@@ -69,11 +69,11 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
-	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"]
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
-		var/door_state = I == 0 ? "[icon_door || icon_state]_door" : animation_math_list[closing ? 3 * num_steps + I : num_steps + I] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
-		var/door_layer = I == 0 ? ABOVE_MOB_LAYER : animation_math_list[closing ? 3 * num_steps + I : num_steps + I] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/matrix/M = get_door_transform(I==0 ? 0 : animation_math_list[closing ? num_steps * 2 + I : I], I==0 ? 0 : animation_math_list[closing ?  num_steps * 3 + I : num_steps + I])
+		var/door_state = I == 0 || (I == num_steps && closing) ? "[icon_door || icon_state]_door" : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
+		var/door_layer = I == 0 || (I == num_steps && closing) ? ABOVE_MOB_LAYER : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
+		var/matrix/M = get_door_transform(I==0 || (I == num_steps && closing) ? 0 : animation_math_list[closing ? num_steps - I : I], I==0 || (I == num_steps && closing) ? 1 : animation_math_list[closing ?  2 * num_steps - I : num_steps + I])
 		if(I == 0)
 			door_obj.transform = M
 			door_obj.icon_state = door_state
@@ -99,21 +99,15 @@
 
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	var/num_steps_1 = door_anim_time / world.tick_lag
-	var/list/new_animation_math_sublist[num_steps_1 * 4]
+	var/list/new_animation_math_sublist[num_steps_1 * 2]
 	for(var/I in 1 to num_steps_1) //loop to save the animation values into the lists
-		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
-		var/angle_2 = I == 0 ? 0 : door_anim_angle * (1 - (I / num_steps_1))
+		var/angle_1 = door_anim_angle * (I / num_steps_1)
 		var/polar_angle = abs(arcsin(cos(angle_1)))
-		var/azimuth_angle = angle_1 >= 90 ? azimuth_angle_3 : 0
+		var/azimuth_angle = angle_1 >= 90 ? azimuth_angle_2 : 0
 		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
-		var/polar_angle_2 = abs(arcsin(cos(angle_2)))
-		var/azimuth_angle_2 = angle_2 >= 90 ? azimuth_angle_3 : 0
-		var/radius_cr_2 = angle_2 >= 90 ? radius_2 : 1
 		new_animation_math_sublist[I] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
 		new_animation_math_sublist[num_steps_1 + I] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
-		new_animation_math_sublist[num_steps_1 * 2 + I] = -sin(polar_angle_2) * sin(azimuth_angle_2) * radius_cr_2
-		new_animation_math_sublist[num_steps_1 * 3 + I] = cos(azimuth_angle_2) * sin(polar_angle_2) * radius_cr_2
-	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
+	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
 
 /obj/structure/closet/crate/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -13,7 +13,7 @@
 	climb_time = 10 //real fast, because let's be honest stepping into or onto a crate is easy
 	climb_stun = 0 //climbing onto crates isn't hard, guys
 	delivery_icon = "deliverycrate"
-	door_anim_time = 2
+	door_anim_time = 3
 	door_anim_angle = 210
 	door_hinge = 3.5
 	open_sound = 'sound/machines/crate_open.ogg'
@@ -71,9 +71,9 @@
 	var/num_steps = door_anim_time / world.tick_lag
 	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
-		var/door_state = I == 0 || (I == num_steps && closing) ? "[icon_door || icon_state]_door" : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
-		var/door_layer = I == 0 || (I == num_steps && closing) ? ABOVE_MOB_LAYER : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/matrix/M = get_door_transform(I == 0 || (I == num_steps && closing) ? 0 : animation_math_list[closing ? num_steps - I : I], I == 0 || (I == num_steps && closing) ? 1 : animation_math_list[closing ?  2 * num_steps - I : num_steps + I])
+		var/door_state = I == (closing ? num_steps : 0) ? "[icon_door || icon_state]_door" : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
+		var/door_layer = I == (closing ? num_steps : 0) ? ABOVE_MOB_LAYER : animation_math_list[closing ? 2 * num_steps - I : num_steps + I] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
+		var/matrix/M = get_door_transform(I == (closing ? num_steps : 0) ? 0 : animation_math_list[closing ? num_steps - I : I], I == (closing ? num_steps : 0) ? 1 : animation_math_list[closing ?  2 * num_steps - I : num_steps + I])
 		if(I == 0)
 			door_obj.transform = M
 			door_obj.icon_state = door_state

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -21,7 +21,7 @@
 	open_sound_volume = 35
 	close_sound_volume = 50
 	drag_slowdown = 0
-	var/azimuth_angle_2 = 138 //in this context the azimuth angle for over 90 degree
+	var/azimuth_angle_3 = 138 //in this context the azimuth angle for over 90 degree
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 	var/radius_2 = 1.35
 	var/static/list/animation_math //assoc list with pre calculated values
@@ -30,7 +30,7 @@
 	. = ..()
 	if(animation_math == null) //checks if there is already a list for animation_math if not creates one to avoid runtimes
 		animation_math = new/list()
-	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"])
+	if(!door_anim_time == 0 && !animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"])
 		animation_list()
 
 /obj/structure/closet/crate/CanPass(atom/movable/mover, turf/target)
@@ -69,12 +69,11 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
-	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
-		var/angle = door_anim_angle * (closing ? 1 - (I/num_steps) : (I/num_steps))
-		var/door_state = angle >= 90 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
-		var/door_layer = angle >= 90 ? FLOAT_LAYER : ABOVE_MOB_LAYER
-		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps + 1 - I : I + 1], animation_math_list[closing ? 2 * num_steps + 1 - I : num_steps + I + 1])
+		var/door_state = animation_math_list[closing ? 3 * num_steps + I + 1 : num_steps + I + 1] <= 0 ? "[icon_door_override ? icon_door : icon_state]_back" : "[icon_door || icon_state]_door"
+		var/door_layer = animation_math_list[closing ? 3 * num_steps + I + 1 : num_steps + I + 1] <= 0 ? FLOAT_LAYER : ABOVE_MOB_LAYER
+		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps * 2 + I + 1 : I + 1], animation_math_list[closing ?  num_steps * 3 + I + 1 : num_steps + I + 1])
 		if(I == 0)
 			door_obj.transform = M
 			door_obj.icon_state = door_state
@@ -100,15 +99,21 @@
 
 /obj/structure/closet/crate/proc/animation_list() //pre calculates a list of values for the crate animation cause byond not like math
 	var/num_steps_1 = door_anim_time / world.tick_lag
-	var/list/new_animation_math_sublist[num_steps_1 * 2 + 1]
+	var/list/new_animation_math_sublist[num_steps_1 * 4 + 1]
 	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
 		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
+		var/angle_2 = I == 0 ? 0 : door_anim_angle * (1 - (I / num_steps_1))
 		var/polar_angle = abs(arcsin(cos(angle_1)))
-		var/azimuth_angle = angle_1 >= 90 ? azimuth_angle_2 : 0
+		var/azimuth_angle = angle_1 >= 90 ? azimuth_angle_3 : 0
 		var/radius_cr = angle_1 >= 90 ? radius_2 : 1
-		new_animation_math_sublist[I+1] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
-		new_animation_math_sublist[num_steps_1+I+1] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
-	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
+		var/polar_angle_2 = abs(arcsin(cos(angle_2)))
+		var/azimuth_angle_2 = angle_2 >= 90 ? azimuth_angle_3 : 0
+		var/radius_cr_2 = angle_2 >= 90 ? radius_2 : 1
+		new_animation_math_sublist[I + 1] = -sin(polar_angle) * sin(azimuth_angle) * radius_cr
+		new_animation_math_sublist[num_steps_1 + I + 1] = cos(azimuth_angle) * sin(polar_angle) * radius_cr
+		new_animation_math_sublist[num_steps_1 * 2 + I + 1] = -sin(polar_angle_2) * sin(azimuth_angle_2) * radius_cr_2
+		new_animation_math_sublist[num_steps_1 * 3 + I + 1] = cos(azimuth_angle_2) * sin(polar_angle_2) * radius_cr_2
+	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
 
 /obj/structure/closet/crate/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -15,7 +15,7 @@
 	var/obj/item/tank/internals/emergency_oxygen/tank
 	door_hinge = 5.5
 	door_anim_angle = 90
-	azimuth_angle_3 = 0.35
+	azimuth_angle_2 = 0.35
 
 /obj/structure/closet/crate/critter/Initialize()
 	. = ..()
@@ -41,7 +41,7 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
-	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"]
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
 		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps + 1 - I : I + 1], animation_math_list[closing ? 2 * num_steps + 1 - I : num_steps + I + 1])
 
@@ -84,5 +84,5 @@
 	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
 		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
 		new_animation_math_sublist[I+1] = cos(angle_1)
-		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * azimuth_angle_3
-	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
+		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * azimuth_angle_2
+	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"] = new_animation_math_sublist

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -43,7 +43,7 @@
 	var/num_steps = door_anim_time / world.tick_lag
 	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
-		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps + 1 - I : I + 1], animation_math_list[closing ? 2 * num_steps + 1 - I : num_steps + I + 1])
+		var/matrix/M = get_door_transform(I == 0 || (I == num_steps && closing) ? 1 : animation_math_list[closing ? num_steps - I : I], I == 0 || (I == num_steps && closing) ? 0 : animation_math_list[closing ? 2 * num_steps - I : num_steps + I])
 
 		if(I == 0)
 			door_obj.transform = M
@@ -81,8 +81,8 @@
 /obj/structure/closet/crate/critter/animation_list()
 	var/num_steps_1 = door_anim_time / world.tick_lag
 	var/list/new_animation_math_sublist[num_steps_1 * 2 + 1]
-	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
-		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
-		new_animation_math_sublist[I+1] = cos(angle_1)
-		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * azimuth_angle_2
+	for(var/I in 1 to num_steps_1) //loop to save the animation values into the lists
+		var/angle_1 = door_anim_angle * (I / num_steps_1)
+		new_animation_math_sublist[I] = cos(angle_1)
+		new_animation_math_sublist[num_steps_1+I] = sin(angle_1) * azimuth_angle_2
 	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"] = new_animation_math_sublist

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -43,7 +43,7 @@
 	var/num_steps = door_anim_time / world.tick_lag
 	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
-		var/matrix/M = get_door_transform(I == 0 || (I == num_steps && closing) ? 1 : animation_math_list[closing ? num_steps - I : I], I == 0 || (I == num_steps && closing) ? 0 : animation_math_list[closing ? 2 * num_steps - I : num_steps + I])
+		var/matrix/M = get_door_transform(I == (closing ? num_steps : 0) ? 1 : animation_math_list[closing ? num_steps - I : I], I == (closing ? num_steps : 0) ? 0 : animation_math_list[closing ? 2 * num_steps - I : num_steps + I])
 
 		if(I == 0)
 			door_obj.transform = M
@@ -80,7 +80,7 @@
 
 /obj/structure/closet/crate/critter/animation_list()
 	var/num_steps_1 = door_anim_time / world.tick_lag
-	var/list/new_animation_math_sublist[num_steps_1 * 2 + 1]
+	var/list/new_animation_math_sublist[num_steps_1 * 2]
 	for(var/I in 1 to num_steps_1) //loop to save the animation values into the lists
 		var/angle_1 = door_anim_angle * (I / num_steps_1)
 		new_animation_math_sublist[I] = cos(angle_1)

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -15,7 +15,7 @@
 	var/obj/item/tank/internals/emergency_oxygen/tank
 	door_hinge = 5.5
 	door_anim_angle = 90
-	azimuth_angle_2 = 0.35
+	azimuth_angle_3 = 0.35
 
 /obj/structure/closet/crate/critter/Initialize()
 	. = ..()
@@ -41,7 +41,7 @@
 	door_obj.icon_state = "[icon_door || icon_state]_door"
 	is_animating_door = TRUE
 	var/num_steps = door_anim_time / world.tick_lag
-	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"]
+	var/list/animation_math_list = animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"]
 	for(var/I in 0 to num_steps)
 		var/matrix/M = get_door_transform(animation_math_list[closing ? num_steps + 1 - I : I + 1], animation_math_list[closing ? 2 * num_steps + 1 - I : num_steps + I + 1])
 
@@ -84,5 +84,5 @@
 	for(var/I in 0 to num_steps_1) //loop to save the animation values into the lists
 		var/angle_1 = I == 0 ? 0 : door_anim_angle * (I / num_steps_1)
 		new_animation_math_sublist[I+1] = cos(angle_1)
-		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * azimuth_angle_2
-	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_2]-[radius_2]-[door_hinge]"] = new_animation_math_sublist
+		new_animation_math_sublist[num_steps_1+I+1] = sin(angle_1) * azimuth_angle_3
+	animation_math["[door_anim_time]-[door_anim_angle]-[azimuth_angle_3]-[radius_2]-[door_hinge]"] = new_animation_math_sublist


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reason for the small blip in the crate animation was that originally i assumed the animation parameter would be inverted mathematically indifferent but that was not the case cause of a missmatching index that happened trough this was solveable with some additional logic checks so the list size stays the same actually shrinks cause i also fixed another issue that had me add one additional index to avoid a runtime.
## Why It's Good For The Game

Fixes bumping crate animation

## Changelog
:cl:
fix: crate animation at closing
refractor: decreases crate list size by 1 deleting an unused index
tweak: changing crate animation time from 2 to 3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
