### PR TITLE
Fixes some GC issues

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -107,19 +107,12 @@
 		return ..()
 
 /obj/structure/toilet/secret
-	var/obj/item/secret
 	var/secret_type = null
 
-/obj/structure/toilet/secret/Initialize(mapload)
+/obj/structure/toilet/secret/Initialize()
 	. = ..()
 	if (secret_type)
-		secret = new secret_type(src)
-		secret.desc += " It's a secret!"
-		w_items += secret.w_class
-		contents += secret
-
-
-
+		new secret_type(src)
 
 /obj/structure/urinal
 	name = "urinal"


### PR DESCRIPTION
Ports https://github.com/Citadel-Station-13/Citadel-Station-13/pull/13499

----

## About The Pull Request

See title. Whoever wrote toilet loot somehow didn't notice that they were using spawners, which delete themselves, and for some reason decided to keep a reference to the item spawned inside itself, which in this case is a loot spawner that instantly qdels itself. This was causing the description addition not to work at all (not that it was ever used) and to cause all the spawners to force hard del cause the toilets kept a reference to what the original code writer must have assumed would be the item spawned by the loot spawner but was actually the spawner itself. For no reason.
## Why It's Good For The Game

You may have noticed I typed a lot up there saying "why is this code like this". I'd rather it not be.
## Changelog

:cl:Putnam3145
fix: Toilet loot spawners don't lag the server on server start with forced hard dels.
/:cl: