### PR TITLE
Block abductors from AI sat

### DIFF
--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -1,6 +1,7 @@
 /area/ai_monitored
 	name = "AI Monitored Area"
 	clockwork_warp_allowed = FALSE
+	abductor_warp_allowed = FALSE
 	var/list/obj/machinery/camera/motioncameras = list()
 	var/list/datum/weakref/motionTargets = list()
 

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -1,7 +1,6 @@
 /area/ai_monitored
 	name = "AI Monitored Area"
 	clockwork_warp_allowed = FALSE
-	abductor_warp_allowed = FALSE
 	var/list/obj/machinery/camera/motioncameras = list()
 	var/list/datum/weakref/motionTargets = list()
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -20,8 +20,6 @@
 	var/blob_allowed = TRUE // Does it count for blobs score? By default, all areas count.
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?
 	var/clockwork_warp_fail = "The structure there is too dense for warping to pierce. (This is normal in high-security areas.)"
-	var/abductor_warp_allowed = TRUE // Similar to above, for abductors! Mostly to protect the AI.
-	var/abductor_warp_fail = "This area is coated in bluespace interference, it's not possible to warp here safely!"
 
 	var/fire = null
 	var/atmos = TRUE

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -20,6 +20,8 @@
 	var/blob_allowed = TRUE // Does it count for blobs score? By default, all areas count.
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?
 	var/clockwork_warp_fail = "The structure there is too dense for warping to pierce. (This is normal in high-security areas.)"
+	var/abductor_warp_allowed = TRUE // Similar to above, for abductors! Mostly to protect the AI.
+	var/abductor_warp_fail = "This area is coated in bluespace interference, it's not possible to warp here safely!"
 
 	var/fire = null
 	var/atmos = TRUE

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -104,7 +104,7 @@
 	var/target_loc = get_turf(remote_eye)
 
 	if(istype(get_area(target_loc), /area/ai_monitored))
-		to_chat(owner, "<span class=warning>Due to significant interference, this area cannot be warped to!</span>")
+		to_chat(owner, "<span class='warning'>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -72,7 +72,7 @@
 	var/target_loc = get_turf(remote_eye)
 
 	if(istype(get_area(target_loc), /area/ai_monitored))
-		to_chat(owner, "<span class=warning>Due to significant interference, this area cannot be warped to!</span>")
+		to_chat(owner, "<span class='warning'>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -72,7 +72,7 @@
 	var/target_loc = get_turf(remote_eye)
 
 	if(istype(get_area(target_loc), /area/ai_monitored))
-		to_chat(owner, "<span class=warning>This area is coated in bluespace interference, it's not possible to warp here safely!</span>")
+		to_chat(owner, "<span class=warning>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
@@ -104,7 +104,7 @@
 	var/target_loc = get_turf(remote_eye)
 
 	if(istype(get_area(target_loc), /area/ai_monitored))
-		to_chat(owner, "<span class=warning>This area is coated in bluespace interference, it's not possible to warp here safely!</span>")
+		to_chat(owner, "<span class=warning>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -71,8 +71,8 @@
 	var/obj/machinery/abductor/pad/P = target
 	var/target_loc = get_turf(remote_eye)
 
-	if(!get_area(target_loc).abductor_warp_allowed)
-		to_chat(owner, "<span class=warning>[get_area(target_loc).abductor_warp_fail]</span>")
+	if(istype(get_area(target_loc), /area/ai_monitored))
+		to_chat(owner, "<span class=warning>This area is coated in bluespace interference, it's not possible to warp here safely!</span>")
 		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
@@ -103,8 +103,8 @@
 	var/obj/machinery/abductor/pad/P = target
 	var/target_loc = get_turf(remote_eye)
 
-	if(!get_area(target_loc).abductor_warp_allowed)
-		to_chat(owner, "<span class=warning>[get_area(target_loc).abductor_warp_fail]</span>")
+	if(istype(get_area(target_loc), /area/ai_monitored))
+		to_chat(owner, "<span class=warning>This area is coated in bluespace interference, it's not possible to warp here safely!</span>")
 		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))

--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -69,6 +69,11 @@
 	var/mob/living/carbon/human/C = owner
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
 	var/obj/machinery/abductor/pad/P = target
+	var/target_loc = get_turf(remote_eye)
+
+	if(!get_area(target_loc).abductor_warp_allowed)
+		to_chat(owner, "<span class=warning>[get_area(target_loc).abductor_warp_fail]</span>")
+		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
 		P.PadToLoc(remote_eye.loc)
@@ -96,6 +101,11 @@
 	var/mob/living/carbon/human/C = owner
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
 	var/obj/machinery/abductor/pad/P = target
+	var/target_loc = get_turf(remote_eye)
+
+	if(!get_area(target_loc).abductor_warp_allowed)
+		to_chat(owner, "<span class=warning>[get_area(target_loc).abductor_warp_fail]</span>")
+		return
 
 	if(GLOB.cameranet.checkTurfVis(remote_eye.loc))
 		P.MobToLoc(remote_eye.loc,C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blocks abductors from TPing to AI sat using a mechanism akin to what blocks clockies from areas. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
cringe, unbalanced, and unfun for a midround to be able to just card the AI for free
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Abductors can no longer teleport into the AI satellite. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
