### PR TITLE
Fixes some mob sprites and corpse loot not matching each other

### DIFF
--- a/code/modules/mob/living/simple_animal/corpse.dm
+++ b/code/modules/mob/living/simple_animal/corpse.dm
@@ -22,7 +22,7 @@
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset
-	mask = /obj/item/clothing/mask/gas
+	mask = /obj/item/clothing/mask/gas/old
 	head = /obj/item/clothing/head/helmet/swat
 	back = /obj/item/storage/backpack
 	id = /obj/item/card/id/syndicate
@@ -110,7 +110,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	head = /obj/item/clothing/head/bearpelt
 	gloves = /obj/item/clothing/gloves/color/black
-	mask = /obj/item/clothing/mask/gas
+	mask = /obj/item/clothing/mask/gas/old
 
 
 


### PR DESCRIPTION

## About The Pull Request

When coder/spriter added new gasmasks, they forgot that some mobs still got old one and that result in some uncomfortable stuff.
When those two alive they look like this:
![1](https://user-images.githubusercontent.com/65843722/104768938-0d55a580-57a1-11eb-9c58-7af857aae3f0.png)

But when they die they look like this:
![2](https://user-images.githubusercontent.com/65843722/104769000-28c0b080-57a1-11eb-8147-07f73e54c925.png)

As you can see their gasmasks magically changed from old sprite to new because someone forgot to add /old to the corpse outfit.

## Why It's Good For The Game

Immersion Ruined™ is gone.

## Changelog
:cl:
fix: some simple mob corpses got back their old gasmasks.
/:cl:

