### PR TITLE
Adds chameleon lightweight duffel bags

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -204,13 +204,13 @@
 			new /obj/item/melee/transforming/energy/sword/saber/blue(src) //see see it fits the theme bc its blue and ice is blue
 
 
-/obj/item/storage/box/contractor/kit
+/obj/item/storage/box/syndie_kit/contractor/kit
 	name = "Contract Kit"
 	desc = "Supplied to Syndicate contractors."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
-/obj/item/storage/box/contractor/essentials
+/obj/item/storage/box/syndie_kit/contractor/essentials
 	name = "Contractor Essentials"
 	desc = "Supplied to Syndicate contractors, providing their specialised space suit, radio jammer and chameleon uniform."
 	icon_state = "syndiebox"
@@ -262,7 +262,7 @@
 
 	return ..()
 
-/obj/item/storage/box/contractor/essentials/PopulateContents()
+/obj/item/storage/box/syndie_kit/contractor/essentials/PopulateContents()
 	new /obj/item/clothing/head/helmet/space/syndicate/contract(src)
 	new /obj/item/clothing/suit/space/syndicate/contract(src)
 	new /obj/item/clothing/under/chameleon(src)
@@ -272,9 +272,9 @@
 	new /obj/item/lighter(src)
 	new /obj/item/jammer(src)
 
-/obj/item/storage/box/contractor/kit/PopulateContents()
+/obj/item/storage/box/syndie_kit/contractor/kit/PopulateContents()
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
-	new /obj/item/storage/box/contractor/essentials(src)
+	new /obj/item/storage/box/syndie_kit/contractor/essentials(src)
 	new /obj/item/melee/classic_baton/contractor_baton(src)
 	new /obj/item/storage/backpack/chameleon/duffelbag(src)
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -275,6 +275,7 @@
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
 	new /obj/item/storage/box/syndicate/contractor_loadout(src)
 	new /obj/item/melee/classic_baton/contractor_baton(src)
+	new /obj/item/storage/backpack/chameleon/duffelbag(src)
 
 	// All about 4 TC or less - some nukeops only items, but fit nicely to the theme.
 	var/list/item_list = list(

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -203,15 +203,16 @@
 			new /obj/item/gun/energy/temperature/security(src)
 			new /obj/item/melee/transforming/energy/sword/saber/blue(src) //see see it fits the theme bc its blue and ice is blue
 
-/obj/item/storage/box/syndicate/contract_kit
+
+/obj/item/storage/box/contractor/kit
 	name = "Contract Kit"
 	desc = "Supplied to Syndicate contractors."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
-/obj/item/storage/box/syndicate/contractor_loadout
-	name = "Standard Loadout"
-	desc = "Supplied to Syndicate contractors, providing their specialised space suit and chameleon uniform."
+/obj/item/storage/box/contractor/essentials
+	name = "Contractor Essentials"
+	desc = "Supplied to Syndicate contractors, providing their specialised space suit, radio jammer and chameleon uniform."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
@@ -261,7 +262,7 @@
 
 	return ..()
 
-/obj/item/storage/box/syndicate/contractor_loadout/PopulateContents()
+/obj/item/storage/box/contractor/essentials/PopulateContents()
 	new /obj/item/clothing/head/helmet/space/syndicate/contract(src)
 	new /obj/item/clothing/suit/space/syndicate/contract(src)
 	new /obj/item/clothing/under/chameleon(src)
@@ -271,9 +272,9 @@
 	new /obj/item/lighter(src)
 	new /obj/item/jammer(src)
 
-/obj/item/storage/box/syndicate/contract_kit/PopulateContents()
+/obj/item/storage/box/contractor/kit/PopulateContents()
 	new /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink(src)
-	new /obj/item/storage/box/syndicate/contractor_loadout(src)
+	new /obj/item/storage/box/contractor/essentials(src)
 	new /obj/item/melee/classic_baton/contractor_baton(src)
 	new /obj/item/storage/backpack/chameleon/duffelbag(src)
 

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -146,7 +146,7 @@
 /datum/contractor_item/fulton_extraction_kit
 	name = "Fulton Extraction Kit"
 	desc = "For getting your target across the station to those difficult dropoffs. Place the beacon somewhere secure, and link the pack. Activating the pack on your target in space will send them over to the beacon - make sure they're not just going to run away though!"
-	item = /obj/item/storage/box/contractor/fulton_extraction
+	item = /obj/item/storage/box/contractor_fulton_extraction
 	item_icon = "parachute-box"
 	limited = 1
 	cost = 1
@@ -281,12 +281,12 @@
 	has_owner = TRUE
 	ignore_suit_sensor_level = TRUE
 
-/obj/item/storage/box/contractor/fulton_extraction
+/obj/item/storage/box/contractor_fulton_extraction
 	name = "Fulton Extraction Kit"
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
-/obj/item/storage/box/contractor/fulton_extraction/PopulateContents()
+/obj/item/storage/box/contractor_fulton_extraction/PopulateContents()
 	new /obj/item/extraction_pack(src)
 	new /obj/item/fulton_core(src)
 

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -146,7 +146,7 @@
 /datum/contractor_item/fulton_extraction_kit
 	name = "Fulton Extraction Kit"
 	desc = "For getting your target across the station to those difficult dropoffs. Place the beacon somewhere secure, and link the pack. Activating the pack on your target in space will send them over to the beacon - make sure they're not just going to run away though!"
-	item = /obj/item/storage/box/contractor/fulton_extraction
+	item = /obj/item/storage/box/syndie_kit/contractor/fulton_extraction
 	item_icon = "parachute-box"
 	limited = 1
 	cost = 1
@@ -281,12 +281,12 @@
 	has_owner = TRUE
 	ignore_suit_sensor_level = TRUE
 
-/obj/item/storage/box/contractor/fulton_extraction
+/obj/item/storage/box/syndie_kit/contractor/fulton_extraction
 	name = "Fulton Extraction Kit"
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
-/obj/item/storage/box/contractor/fulton_extraction/PopulateContents()
+/obj/item/storage/box/syndie_kit/contractor/fulton_extraction/PopulateContents()
 	new /obj/item/extraction_pack(src)
 	new /obj/item/fulton_core(src)
 

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -146,7 +146,7 @@
 /datum/contractor_item/fulton_extraction_kit
 	name = "Fulton Extraction Kit"
 	desc = "For getting your target across the station to those difficult dropoffs. Place the beacon somewhere secure, and link the pack. Activating the pack on your target in space will send them over to the beacon - make sure they're not just going to run away though!"
-	item = /obj/item/storage/box/contractor_fulton_extraction
+	item = /obj/item/storage/box/contractor/fulton_extraction
 	item_icon = "parachute-box"
 	limited = 1
 	cost = 1
@@ -281,12 +281,12 @@
 	has_owner = TRUE
 	ignore_suit_sensor_level = TRUE
 
-/obj/item/storage/box/contractor_fulton_extraction
+/obj/item/storage/box/contractor/fulton_extraction
 	name = "Fulton Extraction Kit"
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
-/obj/item/storage/box/contractor_fulton_extraction/PopulateContents()
+/obj/item/storage/box/contractor/fulton_extraction/PopulateContents()
 	new /obj/item/extraction_pack(src)
 	new /obj/item/fulton_core(src)
 

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -581,6 +581,18 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
+/obj/item/storage/backpack/chameleon/duffelbag
+	name = "duffel bag"
+	desc = "A large duffel bag for holding extra things."
+	icon_state = "duffel"
+	item_state = "duffel"
+	resistance_flags = FIRE_PROOF
+
+/obj/item/storage/backpack/chameleon/duffelbag/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = 30
+
 /obj/item/storage/belt/chameleon
 	name = "toolbelt"
 	desc = "Holds tools."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			you'll be granted your own contract uplink embedded within the supplied tablet computer. Additionally, you'll be granted \
 			standard contractor gear to help with your mission - comes supplied with the tablet, specialised space suit, chameleon jumpsuit and mask, \
 			agent card, specialised contractor baton, and three randomly selected low cost items. Can include otherwise unobtainable items."
-	item = /obj/item/storage/box/syndicate/contract_kit
+	item = /obj/item/storage/box/contractor/kit
 	cost = 20
 	player_minimum = 15
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/incursion)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			you'll be granted your own contract uplink embedded within the supplied tablet computer. Additionally, you'll be granted \
 			standard contractor gear to help with your mission - comes supplied with the tablet, specialised space suit, chameleon jumpsuit and mask, \
 			agent card, specialised contractor baton, and three randomly selected low cost items. Can include otherwise unobtainable items."
-	item = /obj/item/storage/box/contractor/kit
+	item = /obj/item/storage/box/syndie_kit/contractor/kit
 	cost = 20
 	player_minimum = 15
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/incursion)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1389,11 +1389,11 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	item = /obj/item/clothing/gloves/chameleon/combat
 	cost = 1
 
-/datum/uplink_item/stealthy_tools/jammer
-	name = "Radio Jammer"
-	desc = "This device will disrupt any nearby outgoing radio communication when activated. Does not affect binary chat."
-	item = /obj/item/jammer
-	cost = 3
+/datum/uplink_item/stealthy_tools/chamduffel
+	name = "Chameleon Lightweight Duffel Bag"
+	desc = "A duffel bag which holds more items than a backpack but has no additional slowdown, enhanced with chameleon disguise technology."
+	item = /obj/item/storage/backpack/chameleon/duffelbag
+	cost = 2
 
 /datum/uplink_item/stealthy_tools/smugglersatchel
 	name = "Smuggler's Satchel"
@@ -1402,6 +1402,12 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	item = /obj/item/storage/backpack/satchel/flat/with_tools
 	cost = 1
 	surplus = 30
+
+/datum/uplink_item/stealthy_tools/jammer
+	name = "Radio Jammer"
+	desc = "This device will disrupt any nearby outgoing radio communication when activated. Does not affect binary chat."
+	item = /obj/item/jammer
+	cost = 3
 
 //Space Suits and Hardsuits
 /datum/uplink_item/suits


### PR DESCRIPTION
## About The Pull Request

Syndicate duffel bags have no slowdown and are now available in a chameleon version in the uplink for 2 TC (they hold 3 extra normal items over a backpack/satchel). Also adds them to contract kit.

## Why It's Good For The Game

Additional cheap useful traitor items. Also contractors are overburdened with stuff (radio jammer, standard loadout box, up to 3 normal-sized random items) so this helps massively with inventory management. 

## Changelog
:cl:
add: Adds chameleon lightweight duffel bags to traitor uplinks and contract kit.
code: Standardises the contractor box types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
