### PR TITLE
Stops sofas from turning into chairs

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -3,6 +3,7 @@
 	icon_state = "sofamiddle"
 	icon = 'icons/obj/sofa.dmi'
 	buildstackamount = 1
+	item_chair = null
 
 /obj/structure/chair/sofa/left
 	icon_state = "sofaend_left"


### PR DESCRIPTION
## About The Pull Request
Fixes being able to drag a sofa on your sprite and turning it into a normal chair, probably fixes other stuff about it but this is all i noticed.

## Why It's Good For The Game
Fix good

## Changelog
:cl:
fix: Sofas won't turn into chairs when dragged on your sprite
/:cl: