### PR TITLE
TBoH is no longer overwritten by the hammerspace admin spawn item

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -94,7 +94,7 @@
 	icon_state = "hammerspace"
 	w_class = WEIGHT_CLASS_GIGANTIC
 
-/obj/item/storage/bag/trash/bluespace/ComponentInitialize()
+/obj/item/storage/bag/trash/bluespace/hammerspace/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 1000

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -88,6 +88,7 @@
 	STR.max_combined_w_class = 60
 	STR.max_items = 60
 
+
 /obj/item/storage/bag/trash/bluespace/hammerspace
 	name = "hammerspace belt"
 	desc = "A belt that opens into a near infinite pocket of bluespace."
@@ -101,7 +102,7 @@
 	STR.max_items = 300
 	STR.max_w_class = WEIGHT_CLASS_GIGANTIC
 
-/obj/item/storage/bag/trash/bluespace/update_icon()
+/obj/item/storage/bag/trash/bluespace/hammerspace/update_icon()
 	if(contents.len == 0)
 		icon_state = "[initial(icon_state)]"
 	else icon_state = "[initial(icon_state)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes 
![image](https://user-images.githubusercontent.com/3241376/104836145-5bd27500-5871-11eb-81a5-2a0dbc171074.png)

The trash bag of holding is no longer better than the actual bag of holding.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Removes a bad meta item from the game and makes the TBoH actually useful for trash as it was intended to be


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a bug with the Trashbag of Holding where it was given the same storage as an admin spawn only item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
