### PR TITLE
Overhaul Bluespace Miners

### DIFF
--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -38,6 +38,14 @@
 		for(var/mob/living/simple_animal/hostile/megafauna/chonker in GLOB.mob_living_list)
 			lavaland_mobs += chonker
 		if(!length(lavaland_mobs))
+			for(var/mob/living/simple_animal/hostile/lesser_chonk in GLOB.mob_living_list)
+				if(istype(lesser_chonk, /area/lavaland/surface/outdoors))
+					lavaland_mobs += lesser_chonk
+		if(!length(lavaland_mobs))
+			for(var/mob/living/carbon/human/H in GLOB.mob_living_list)
+				if(H.job == "Shaft Miner")
+					lavaland_mobs += H
+		if(!length(lavaland_mobs))
 			return
 		chosen_mob = pick(lavaland_mobs)
 		chosen_mob.adjustBruteLoss(2500)

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -6,6 +6,9 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/bluespace_miner
 	layer = BELOW_OBJ_LAYER
+	var/mob/living/simple_animal/hostile/megafauna/chosen_mob
+	var/damage_buffer
+	var/list/lavaland_mobs = list()
 	var/list/ore_rates = list(/datum/material/iron = 0.6, /datum/material/glass = 0.6, /datum/material/copper = 0.4, /datum/material/plasma = 0.2,  /datum/material/silver = 0.2, /datum/material/gold = 0.1, /datum/material/titanium = 0.1, /datum/material/uranium = 0.1, /datum/material/diamond = 0.1)
 	var/datum/component/remote_materials/materials
 
@@ -31,10 +34,16 @@
 		. += "<span class='warning'>Ore silo access is on hold, please contact the quartermaster.</span>"
 
 /obj/machinery/mineral/bluespace_miner/process()
-	if(!materials?.silo || materials?.on_hold())
-		return
-	var/datum/component/material_container/mat_container = materials.mat_container
-	if(!mat_container || panel_open || !powered())
-		return
-	var/datum/material/ore = pick(ore_rates)
-	mat_container.insert_amount_mat((ore_rates[ore] * 1000), ore)
+	if(damage_buffer >= 1000)
+		for(var/mob/living/simple_animal/hostile/megafauna/chonker in GLOB.mob_living_list)
+			lavaland_mobs += chonker
+		if(!length(lavaland_mobs))
+			return
+		chosen_mob = pick(lavaland_mobs)
+		chosen_mob.adjustBruteLoss(2500)
+		chosen_mob.gib()
+		lavaland_mobs.Cut()
+		damage_buffer = 0
+		visible_message("<span class='notice'>[src] has automatically slain [chosen_mob]!</span>")
+	else
+		damage_buffer += 50

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -48,8 +48,8 @@
 		if(!length(lavaland_mobs))
 			return
 		chosen_mob = pick(lavaland_mobs)
-		chosen_mob.adjustBruteLoss(2500)
-		chosen_mob.gib()
+		chosen_mob.adjustBruteLoss(5000)
+		chosen_mob.adjustFireLoss(5000)
 		lavaland_mobs.Cut()
 		damage_buffer = 0
 		visible_message("<span class='notice'>[src] has automatically slain [chosen_mob]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bluespace miners were originally invented to replace shaft miners, but I think that they failed to do so, only generating passive materials instead. There are people still on lavaland doing "something", so I think a rework is needed.

Bluespace miners now slowly generate a damage buffer which it unleashes upon an random, unsuspecting megafauna, ultimately gibbing it for good measure. When it is out of megafauna, it starts killing goliaths. Then, miners. For balance.

To balance this, bluespace miners no longer generate materials.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Miners will now have plenty of time to shoot at rocky bits
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Challenge
tweak: Miners no longer die to megafauna
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
