### PR TITLE
Improves mulligan antagonist conversion

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -182,6 +182,11 @@
 	min_val = 0
 	max_val = 1
 
+/datum/config_entry/number/midround_antag_conversion_time
+	config_entry_value = 180
+	integer = FALSE
+	min_val = 0
+
 /datum/config_entry/number/shuttle_refuel_delay
 	config_entry_value = 12000
 	integer = FALSE

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -205,7 +205,7 @@ SUBSYSTEM_DEF(ticker)
 			mode.process(wait * 0.1)
 			check_queue()
 			check_maprotate()
-			if(!mode.check_round_conversion() && !roundend_check_paused && mode.check_finished(force_ending) || force_ending)
+			if(mode.check_round_conversion() && !roundend_check_paused && mode.check_finished(force_ending) || force_ending)
 				current_state = GAME_STATE_FINISHED
 				toggle_ooc(TRUE) // Turn it on
 				toggle_dooc(TRUE)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -205,8 +205,7 @@ SUBSYSTEM_DEF(ticker)
 			mode.process(wait * 0.1)
 			check_queue()
 			check_maprotate()
-
-			if(!roundend_check_paused && mode.check_finished(force_ending) || force_ending)
+			if(!mode.check_round_conversion() && !roundend_check_paused && mode.check_finished(force_ending) || force_ending)
 				current_state = GAME_STATE_FINISHED
 				toggle_ooc(TRUE) // Turn it on
 				toggle_dooc(TRUE)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -359,6 +359,7 @@
 
 //Checks if we can convert the round type
 //Checks if antagonists are in brig to convert the roundtype to something else.
+//Returns TRUE if the end game checks should run
 /datum/game_mode/proc/check_round_conversion()
 	//Run checks
 	if(!SSticker.setup_done || !gamemode_ready)
@@ -429,7 +430,7 @@
 
 	//Check for living antagonists
 	round_converted = convert_roundtype()
-	return round_converted
+	return TRUE
 
 /datum/game_mode/proc/check_win() //universal trigger to be called at mob death, nuke explosion, etc. To be called from everywhere.
 	return 0

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -179,6 +179,7 @@
 	name = "Abductee"
 	roundend_category = "abductees"
 	antagpanel_category = "Abductee"
+	delay_roundend = FALSE
 
 /datum/antagonist/abductee/on_gain()
 	give_objective()

--- a/code/modules/antagonists/greentext/greentext.dm
+++ b/code/modules/antagonists/greentext/greentext.dm
@@ -2,6 +2,7 @@
 	name = "winner"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE //Not that it will be there for long
+	delay_roundend = FALSE
 
 /datum/antagonist/greentext/proc/forge_objectives()
 	var/datum/objective/O = new /datum/objective("Succeed")

--- a/code/modules/antagonists/guardian/guardian.dm
+++ b/code/modules/antagonists/guardian/guardian.dm
@@ -5,6 +5,7 @@
 	show_in_antagpanel = FALSE
 	var/datum/guardian_stats/stats
 	var/datum/mind/summoner
+	delay_roundend = FALSE
 
 /datum/antagonist/guardian/roundend_report()
 	var/list/parts = list()

--- a/code/modules/antagonists/official/official.dm
+++ b/code/modules/antagonists/official/official.dm
@@ -6,6 +6,7 @@
 	var/datum/team/ert/ert_team
 	can_hijack = HIJACK_PREVENT
 	show_to_ghosts = TRUE
+	delay_roundend = FALSE
 
 /datum/antagonist/official/greet()
 	to_chat(owner, "<B><font size=3 color=red>You are a CentCom Official.</font></B>")

--- a/code/modules/antagonists/santa/santa.dm
+++ b/code/modules/antagonists/santa/santa.dm
@@ -3,6 +3,7 @@
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
+	delay_roundend = FALSE
 
 /datum/antagonist/santa/on_gain()
 	. = ..()

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -3,6 +3,7 @@
 	roundend_category = "valentines" //there's going to be a ton of them so put them in separate category
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
+	delay_roundend = FALSE
 	var/datum/mind/date
 
 /datum/antagonist/valentine/proc/forge_objectives()

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -154,16 +154,26 @@ CONTINUOUS SECRET_EXTENDED
 ## In modes that are continuous, if all antagonists should die then a new set of antagonists will be created.
 
 MIDROUND_ANTAG TRAITOR
-MIDROUND_ANTAG INCURSION
-#MIDROUND_ANTAG TRAITORBRO
+#MIDROUND_ANTAG CULT
+#MIDROUND_ANTAG DYNAMIC
+MIDROUND_ANTAG HERESY
+#MIDROUND_ANTAG NUCLEAR
 MIDROUND_ANTAG TRAITORCHAN
-MIDROUND_ANTAG INTERNAL_AFFAIRS
-#MIDROUND_ANTAG  NUCLEAR
-#MIDROUND_ANTAG  REVOLUTION
-MIDROUND_ANTAG CULT
 MIDROUND_ANTAG CHANGELING
-MIDROUND_ANTAG WIZARD
-#MIDROUND_ANTAG  MONKEY
+MIDROUND_ANTAG INCURSION
+#MIDROUND_ANTAG REVOLUTION
+MIDROUND_ANTAG INTERNAL_AFFAIRS
+MIDROUND_ANTAG TRAITORBRO
+#MIDROUND_ANTAG WIZARD
+#MIDROUND_ANTAG CLOWNOPS
+#MIDROUND_ANTAG CLOCKCULT
+#MIDROUND_ANTAG MONKEY
+#MIDROUND_ANTAG GANG
+#MIDROUND_ANTAG METEOR
+#MIDROUND_ANTAG EXTENDED
+#MIDROUND_ANTAG SECRET_EXTENDED
+MIDROUND_ANTAG DEVIL
+MIDROUND_ANTAG DEVIL_AGENTS
 
 ## Uncomment these for overrides of the minimum / maximum number of players in a round type.
 ## If you set any of these occasionally check to see if you still need them as the modes
@@ -530,6 +540,9 @@ MIDROUND_ANTAG_TIME_CHECK 60
 
 ## A ratio of living to total crew members, the lower this is, the more people will have to die in order for midround antag to be skipped
 MIDROUND_ANTAG_LIFE_CHECK 0.7
+
+## The amount of time is takes after all antagonists either die, enter brig or become borg before the round gets converted.
+MIDROUND_ANTAG_CONVERSION_TIME 180
 
 ##Limit Spell Choices##
 ## Uncomment to disallow wizards from using certain spells that may be too chaotic/fun for your playerbase

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -154,16 +154,26 @@ CONTINUOUS SECRET_EXTENDED
 ## In modes that are continuous, if all antagonists should die then a new set of antagonists will be created.
 
 MIDROUND_ANTAG TRAITOR
-#MIDROUND_ANTAG INCURSION
-#MIDROUND_ANTAG TRAITORBRO
+#MIDROUND_ANTAG CULT
+#MIDROUND_ANTAG DYNAMIC
+MIDROUND_ANTAG HERESY
+#MIDROUND_ANTAG NUCLEAR
 MIDROUND_ANTAG TRAITORCHAN
-MIDROUND_ANTAG INTERNAL_AFFAIRS
-#MIDROUND_ANTAG  NUCLEAR
-#MIDROUND_ANTAG  REVOLUTION
-MIDROUND_ANTAG CULT
 MIDROUND_ANTAG CHANGELING
-MIDROUND_ANTAG WIZARD
-#MIDROUND_ANTAG  MONKEY
+MIDROUND_ANTAG INCURSION
+#MIDROUND_ANTAG REVOLUTION
+MIDROUND_ANTAG INTERNAL_AFFAIRS
+MIDROUND_ANTAG TRAITORBRO
+#MIDROUND_ANTAG WIZARD
+#MIDROUND_ANTAG CLOWNOPS
+#MIDROUND_ANTAG CLOCKCULT
+#MIDROUND_ANTAG MONKEY
+#MIDROUND_ANTAG GANG
+#MIDROUND_ANTAG METEOR
+#MIDROUND_ANTAG EXTENDED
+#MIDROUND_ANTAG SECRET_EXTENDED
+MIDROUND_ANTAG DEVIL
+MIDROUND_ANTAG DEVIL_AGENTS
 
 ## Uncomment these for overrides of the minimum / maximum number of players in a round type.
 ## If you set any of these occasionally check to see if you still need them as the modes
@@ -526,6 +536,9 @@ MIDROUND_ANTAG_TIME_CHECK 60
 
 ## A ratio of living to total crew members, the lower this is, the more people will have to die in order for midround antag to be skipped
 MIDROUND_ANTAG_LIFE_CHECK 0.7
+
+## The amount of time is takes after all antagonists either die, enter brig or become borg before the round gets converted.
+MIDROUND_ANTAG_CONVERSION_TIME 180
 
 ##Limit Spell Choices##
 ## Uncomment to disallow wizards from using certain spells that may be too chaotic/fun for your playerbase


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds additional checks for round conversion in gamemode conversion.
Will convert the gamemode if
 - All antagonists die
 - All antagonists are silicons
 - All antagonists are in security
 - 
Since obviously an antag could walk into sec for 1 second and convert the roundtype, these checks require 180 seconds between running for it to take effect.

## Why It's Good For The Game

More interesting rounds, security dominating roundstart wont leave the round just running on extended when it really should end (stops assuming sec executes all traitors).

## Changelog
:cl:
fix: Gamemode conversion no longer assumes security execute all traitors and will now convert the gamemode if traitors are in brig or borgs.
fix: Heretics now allows for roundtype conversion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
