### PR TITLE
Cyborgs get Ratvar laws upon conversion

### DIFF
--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -59,7 +59,7 @@
 /datum/antagonist/servant_of_ratvar/apply_innate_effects(mob/living/M)
 	. = ..()
 	owner.current.faction |= "ratvar"
-	owner.language_holder.grant_language(/datum/language/ratvar)
+	owner.language_holder.grant_language(/datum/language/ratvar, TRUE, TRUE, LANGUAGE_CULTIST)
 	transmit_spell = new()
 	transmit_spell.Grant(owner.current)
 	owner.current.throw_alert("clockinfo", /atom/movable/screen/alert/clockwork/clocksense)
@@ -71,7 +71,7 @@
 
 /datum/antagonist/servant_of_ratvar/remove_innate_effects(mob/living/M)
 	owner.current.faction -= "ratvar"
-	owner.language_holder.remove_language(/datum/language/ratvar)
+	owner.language_holder.remove_language(/datum/language/ratvar, TRUE, TRUE, LANGUAGE_CULTIST)
 	owner.current.clear_alert("clockinfo")
 	transmit_spell.Remove(transmit_spell.owner)
 	SSticker.mode.update_clockcult_icons_removed(owner)

--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -47,7 +47,6 @@
 			GLOB.cyborg_servants_of_ratvar |= owner
 	check_ark_status()
 	owner.announce_objectives()
-	owner.language_holder.grant_language(/datum/language/ratvar)
 
 /datum/antagonist/servant_of_ratvar/on_removal()
 	team.remove_member(owner)
@@ -60,6 +59,7 @@
 /datum/antagonist/servant_of_ratvar/apply_innate_effects(mob/living/M)
 	. = ..()
 	owner.current.faction |= "ratvar"
+	owner.language_holder.grant_language(/datum/language/ratvar)
 	transmit_spell = new()
 	transmit_spell.Grant(owner.current)
 	owner.current.throw_alert("clockinfo", /atom/movable/screen/alert/clockwork/clocksense)
@@ -71,6 +71,7 @@
 
 /datum/antagonist/servant_of_ratvar/remove_innate_effects(mob/living/M)
 	owner.current.faction -= "ratvar"
+	owner.language_holder.remove_language(/datum/language/ratvar)
 	owner.current.clear_alert("clockinfo")
 	transmit_spell.Remove(transmit_spell.owner)
 	SSticker.mode.update_clockcult_icons_removed(owner)
@@ -115,9 +116,6 @@
 //Grant access to the clockwork tools.
 //If AI, disconnect all active borgs and make it only able to control converted shells
 /datum/antagonist/servant_of_ratvar/proc/equip_silicon(mob/living/silicon/S)
-	S.laws = new /datum/ai_laws/ratvar
-	S.laws.associate(S)
-	S.show_laws()
 	if(isAI(S))
 		var/mob/living/silicon/ai/AI = S
 		AI.disconnect_shell()
@@ -129,6 +127,9 @@
 		var/mob/living/silicon/robot/R = S
 		R.connected_ai = null
 		R.SetRatvar(TRUE)
+	S.laws = new /datum/ai_laws/ratvar     //Laws down here so borgs don't instantly resync their laws
+	S.laws.associate(S)
+	S.show_laws()
 
 /datum/antagonist/servant_of_ratvar/proc/add_objectives()
 	objectives |= team.objectives


### PR DESCRIPTION
## About The Pull Request
Fixes #2353

Moves the law update inside the equip_silicon proc so borgs don't instantly resync their laws with the AI.

Also moves the grant_language to apply_innate_effects like bloodcult does it, adds a remove_language and adds a source to the language.

## Why It's Good For The Game

Cyborgs actually get the ratvar laws now. And the language thing is because of consistency and because the language never gets removed on deconversion.

## Changelog
:cl:
fix: Cyborgs now get the ratvar laws upon conversion
fix: Upon deconversion you now actually lose the ratvar language
/:cl: