### PR TITLE
Fixes AI tracking not working near roundstart

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -169,7 +169,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 
 /datum/cameranet/proc/checkTurfVis(turf/position)
-	var/datum/camerachunk/chunk = chunkGenerated(position.x, position.y, position.z)
+	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z)
 	if(chunk)
 		if(chunk.changed)
 			chunk.hasChanged(1) // Update now, no matter if it's visible or not.


### PR DESCRIPTION
## About The Pull Request

Port of: https://github.com/tgstation/tgstation/pull/52138

Saw it on Things to Port and decided to port it over.
https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-41692761

Tested it on a local server and seems to work like intended.

Original description:

> Replaces a `chunkGenerated` which only returns a chunk if it has already been generated with `getCameraChunk` which generates a chunk if it doesn't already exist.

## Why It's Good For The Game

Fixes something that is a bit annoying roundstart as AI.

## Changelog
:cl: YPOQ
fix: Fixed an issue that prevented AIs from tracking players in areas they have not yet viewed.
/:cl: