### PR TITLE
space ruins but they don't destroy themselves by a random spessman that just opened a door

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
@@ -141,7 +141,6 @@
 "aF" = (
 /obj/item/toy/figure/chaplain,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -158,7 +157,6 @@
 "aH" = (
 /obj/item/toy/figure/assistant,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -170,7 +168,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "aJ" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -206,7 +203,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "aR" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -307,7 +303,6 @@
 /obj/item/toy/figure/clown,
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -328,7 +323,6 @@
 /obj/item/toy/figure/mime,
 /obj/effect/decal/cleanable/food/salt,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -379,7 +373,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "bw" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -398,7 +391,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "bz" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -532,7 +524,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "ca" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/item/toy/figure/geneticist,
@@ -559,7 +550,6 @@
 "ce" = (
 /obj/item/toy/figure/janitor,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /obj/item/toy/plush/lizardplushie,
@@ -569,7 +559,6 @@
 /obj/item/toy/figure/qm,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/food/salt,
@@ -624,7 +613,6 @@
 "cp" = (
 /obj/item/toy/figure/botanist,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -648,7 +636,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/food/pie_smudge,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -820,7 +807,6 @@
 "cW" = (
 /obj/item/toy/figure/lawyer,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -828,7 +814,6 @@
 "cX" = (
 /obj/item/toy/figure/secofficer,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -841,7 +826,6 @@
 "cZ" = (
 /obj/item/toy/figure/cargotech,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -853,7 +837,6 @@
 /obj/item/toy/sword,
 /obj/effect/decal/cleanable/food/tomato_smudge,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/food/salt,
@@ -935,6 +918,7 @@
 /area/ruin/space/has_grav/powered/macspace)
 "dr" = (
 /obj/machinery/door/airlock/silver,
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium,
 /area/ruin/space/has_grav/powered/macspace)
 "ds" = (
@@ -947,7 +931,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "dx" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/item/toy/toy_xeno,
@@ -956,7 +939,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "dy" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /obj/item/toy/plush/slimeplushie,
@@ -965,7 +947,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "dz" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/item/toy/figure/scientist,
@@ -980,7 +961,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "dB" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /obj/item/toy/talking/AI,
@@ -989,7 +969,6 @@
 "dC" = (
 /obj/item/toy/figure/botanist,
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /obj/item/toy/plush/beeplushie,
@@ -997,7 +976,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "dD" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/item/toy/figure/roboticist,
@@ -1012,7 +990,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "dF" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 1
 	},
 /obj/item/toy/plush/nukeplushie,
@@ -1029,7 +1006,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "ea" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/item/toy/figure/cmo,
@@ -1037,7 +1013,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "iO" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /obj/item/toy/figure/md,
@@ -1051,7 +1026,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "rA" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 4
 	},
 /obj/item/toy/figure/chemist,
@@ -1059,7 +1033,6 @@
 /area/ruin/space/has_grav/powered/macspace)
 "uO" = (
 /obj/structure/chair/wood/wings{
-	icon_state = "wooden_chair_wings";
 	dir = 8
 	},
 /obj/item/toy/figure/virologist,

--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -187,6 +187,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "I" = (
+/obj/structure/fans/tiny,
 /obj/machinery/door/airlock/highsecurity{
 	req_access = 207
 	},

--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -87,6 +87,7 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "s" = (
+/obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "goonwizship1"
 	},

--- a/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
+++ b/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
@@ -10,10 +10,6 @@
 "c" = (
 /turf/closed/indestructible/oldshuttle,
 /area/ruin/powered)
-"d" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/oldshuttle,
-/area/ruin/powered)
 "e" = (
 /turf/closed/indestructible/oldshuttle/corner,
 /area/ruin/powered)
@@ -381,7 +377,7 @@ a
 a
 a
 e
-d
+J
 h
 g
 g

--- a/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
+++ b/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
@@ -54,14 +54,12 @@
 /area/ruin/powered)
 "m" = (
 /obj/structure/chair/old{
-	icon_state = "chairold";
 	dir = 1
 	},
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
 "n" = (
 /obj/structure/chair/old{
-	icon_state = "chairold";
 	dir = 1
 	},
 /obj/item/crowbar/large{
@@ -73,7 +71,6 @@
 /area/ruin/powered)
 "o" = (
 /obj/structure/chair/old{
-	icon_state = "chairold";
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/retaliate/spaceman,
@@ -98,6 +95,11 @@
 "x" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/template_noop,
+/area/ruin/powered)
+"J" = (
+/obj/machinery/door/airlock/public/glass,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/oldshuttle,
 /area/ruin/powered)
 
 (1,1,1) = {"
@@ -141,7 +143,7 @@ a
 a
 a
 b
-d
+J
 f
 g
 g
@@ -163,7 +165,7 @@ g
 g
 g
 b
-d
+J
 l
 w
 a
@@ -254,7 +256,7 @@ g
 c
 "}
 (10,1,1) = {"
-d
+J
 g
 g
 g
@@ -268,7 +270,7 @@ c
 t
 g
 g
-d
+J
 "}
 (11,1,1) = {"
 c
@@ -367,7 +369,7 @@ g
 g
 g
 e
-d
+J
 l
 v
 a

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -1,46 +1,55 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/template_noop,
-/area/template_noop)
-"b" = (
-/turf/closed/wall/mineral/titanium,
-/area/ruin/space/has_grav/whiteship/box)
-"c" = (
+"aE" = (
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"d" = (
-/obj/structure/shuttle/engine/propulsion/left{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/whiteship/box)
-"e" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"f" = (
-/obj/structure/table,
-/obj/item/screwdriver,
-/obj/structure/light_construct{
+"bc" = (
+/obj/structure/light_construct/small{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/whiteship/box)
-"g" = (
-/obj/machinery/computer/pod{
-	dir = 8;
-	id = "oldship_ruin_gun"
+"bg" = (
+/obj/machinery/door/poddoor{
+	id = "oldship_ruin_gun";
+	name = "pod bay door"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"bW" = (
+/obj/structure/light_construct{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"h" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 8
+"eP" = (
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	name = "Broken Computer"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"i" = (
+"ff" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"fs" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"fS" = (
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"gu" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
@@ -49,121 +58,66 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/whiteship/box)
-"j" = (
-/turf/closed/wall/mineral/titanium/interior,
+"iw" = (
+/turf/closed/wall/mineral/titanium,
 /area/ruin/space/has_grav/whiteship/box)
-"k" = (
+"kK" = (
+/obj/structure/table,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"mk" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/medical,
 /obj/item/clothing/mask/breath,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"l" = (
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/whiteship/box)
-"m" = (
-/obj/item/stock_parts/cell{
-	charge = 100;
-	maxcharge = 15000
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"n" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"o" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/whiteship/box)
-"p" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "oldship_ruin_gun"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/whiteship/box)
-"q" = (
-/obj/machinery/door/poddoor{
-	id = "oldship_ruin_gun";
-	name = "pod bay door"
-	},
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/whiteship/box)
-"r" = (
-/obj/structure/shuttle/engine/propulsion/right{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/whiteship/box)
-"s" = (
-/obj/structure/light_construct/small,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/whiteship/box)
-"t" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/whiteship/box)
-"u" = (
-/obj/structure/frame/computer{
-	anchored = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"v" = (
-/obj/machinery/computer{
-	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
-	name = "Broken Computer"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"w" = (
-/obj/machinery/door/airlock/titanium,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"x" = (
+"mU" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"y" = (
-/obj/item/shard{
-	icon_state = "medium"
+"ns" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"nz" = (
+/obj/machinery/computer{
+	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
+	dir = 8;
+	name = "Broken Computer"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"z" = (
-/obj/structure/light_construct,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"A" = (
-/obj/structure/light_construct{
+"oG" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"B" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/whiteship/box)
-"C" = (
-/obj/structure/table,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"D" = (
-/obj/machinery/door/window,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/whiteship/box)
-"E" = (
+"oQ" = (
+/obj/structure/shuttle/engine/propulsion/right{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"qV" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"qY" = (
+/obj/structure/light_construct{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"sQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/structure/window/reinforced,
@@ -172,125 +126,41 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/whiteship/box)
-"F" = (
-/obj/structure/table,
-/obj/item/gun/energy/laser/retro,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"G" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"H" = (
-/obj/structure/light_construct{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"I" = (
-/obj/structure/light_construct/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"J" = (
-/obj/structure/light_construct{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"K" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/decal/remains/human,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"L" = (
-/obj/machinery/computer{
-	desc = "A computer long since rendered non-functional due to lack of maintenance. Spitting out error messages.";
-	dir = 8;
-	name = "Broken Computer"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"M" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"N" = (
-/obj/structure/light_construct/small{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"O" = (
-/obj/structure/table,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"P" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"Q" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/space/has_grav/whiteship/box)
-"R" = (
-/obj/machinery/door/window/northright,
-/obj/effect/decal/remains/human,
-/turf/open/floor/mineral/titanium/purple,
-/area/ruin/space/has_grav/whiteship/box)
-"S" = (
-/obj/item/multitool,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"T" = (
-/obj/structure/light_construct/small{
-	dir = 1
-	},
+"tY" = (
+/obj/structure/light_construct/small,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/whiteship/box)
-"U" = (
-/obj/structure/chair,
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"V" = (
-/obj/structure/frame/computer{
-	anchored = 1;
+"uY" = (
+/obj/structure/light_construct{
 	dir = 1
 	},
-/obj/structure/light_construct,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"W" = (
-/obj/item/scalpel,
-/turf/open/floor/mineral/titanium/white,
+"wW" = (
+/obj/machinery/door/window,
+/turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/whiteship/box)
-"X" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/ruin/space/has_grav/whiteship/box)
-"Y" = (
-/obj/structure/frame/computer{
-	anchored = 1;
+"ys" = (
+/obj/structure/light_construct/small{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
-"Z" = (
+"yC" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Bk" = (
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"BE" = (
+/obj/structure/table,
+/obj/item/screwdriver,
+/obj/structure/light_construct{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"DK" = (
 /obj/machinery/sleeper{
 	dir = 8
 	},
@@ -298,809 +168,944 @@
 /obj/structure/light_construct,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
+"EM" = (
+/obj/item/multitool,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Ff" = (
+/obj/structure/light_construct,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Fs" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"FI" = (
+/obj/structure/table,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Gk" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Hx" = (
+/obj/machinery/computer/pod{
+	dir = 8;
+	id = "oldship_ruin_gun"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Iv" = (
+/turf/template_noop,
+/area/template_noop)
+"Iy" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Kq" = (
+/obj/structure/light_construct/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"NH" = (
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "oldship_ruin_gun"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Ob" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Pd" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Ph" = (
+/obj/item/stock_parts/cell{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"QS" = (
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/obj/structure/light_construct,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"RN" = (
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"RU" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"TF" = (
+/obj/structure/shuttle/engine/propulsion/left{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"Vq" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/ruin/space/has_grav/whiteship/box)
+"VU" = (
+/obj/structure/chair,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Wi" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/whiteship/box)
+"Wt" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Xh" = (
+/obj/machinery/door/airlock/titanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/whiteship/box)
+"Yh" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser/retro,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
+"Yr" = (
+/obj/machinery/door/window/northright,
+/obj/effect/decal/remains/human,
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/space/has_grav/whiteship/box)
+"Yz" = (
+/obj/item/scalpel,
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-b
-t
-b
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+iw
+fS
+iw
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (2,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-j
-c
-j
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Vq
+Bk
+Vq
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (3,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-c
-c
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+Bk
+Bk
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (4,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-c
-c
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+Bk
+Bk
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (5,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-c
-c
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+Bk
+Bk
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (6,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-c
-z
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+Bk
+Ff
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (7,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-c
-c
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+Bk
+Bk
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (8,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-c
-c
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+Bk
+Bk
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (9,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-c
-M
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+Bk
+qV
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (10,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-j
-c
-j
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Vq
+Bk
+Vq
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (11,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-b
-w
-b
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+iw
+Wt
+iw
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (12,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-b
-c
-b
-a
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+Bk
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (13,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-b
-b
-w
-b
-b
-a
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+iw
+Wt
+iw
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (14,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-b
-b
-j
-c
-j
-b
-b
-a
-a
-a
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+iw
+iw
+Vq
+Bk
+Vq
+iw
+iw
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
+Iv
 "}
 (15,1,1) = {"
-b
-d
-h
-h
-h
-r
-a
-b
-j
-c
-c
-c
-j
-b
-a
-d
-h
-h
-h
-r
-b
+iw
+TF
+Wi
+Wi
+Wi
+oQ
+Iv
+iw
+Vq
+Bk
+Bk
+Bk
+Vq
+iw
+Iv
+TF
+Wi
+Wi
+Wi
+oQ
+iw
 "}
 (16,1,1) = {"
-b
-b
-i
-i
-i
-b
-b
-b
-A
-c
-c
-c
-z
-b
-b
-b
-i
-i
-i
-b
-b
+iw
+iw
+gu
+gu
+gu
+iw
+iw
+iw
+uY
+Bk
+Bk
+Bk
+Ff
+iw
+iw
+iw
+gu
+gu
+gu
+iw
+iw
 "}
 (17,1,1) = {"
-a
-b
-j
-l
-l
-j
-b
-j
-c
-c
-c
-c
-c
-j
-b
-j
-l
-l
-j
-b
-a
+Iv
+iw
+Vq
+yC
+yC
+Vq
+iw
+Vq
+Bk
+Bk
+Bk
+Bk
+Bk
+Vq
+iw
+Vq
+yC
+yC
+Vq
+iw
+Iv
 "}
 (18,1,1) = {"
-a
-a
-b
-j
-l
-s
-b
-c
-c
-c
-c
-c
-c
-P
-b
-T
-l
-j
-b
-a
-a
+Iv
+Iv
+iw
+Vq
+yC
+tY
+iw
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+aE
+iw
+bc
+yC
+Vq
+iw
+Iv
+Iv
 "}
 (19,1,1) = {"
-a
-a
-a
-b
-b
-t
-b
-b
-b
-B
-G
-B
-b
-b
-b
-t
-b
-b
-a
-a
-a
+Iv
+Iv
+Iv
+iw
+iw
+Xh
+iw
+iw
+iw
+Pd
+RU
+Pd
+iw
+iw
+iw
+Xh
+iw
+iw
+Iv
+Iv
+Iv
 "}
 (20,1,1) = {"
-a
-a
-a
-b
-b
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-b
-b
-a
-a
-a
+Iv
+Iv
+Iv
+iw
+iw
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+iw
+iw
+Iv
+Iv
+Iv
 "}
 (21,1,1) = {"
-a
-a
-b
-b
-j
-m
-c
-c
-c
-c
-H
-c
-c
-c
-c
-c
-b
-b
-b
-a
-a
+Iv
+Iv
+iw
+iw
+Vq
+Ph
+Bk
+Bk
+Bk
+Bk
+bW
+Bk
+Bk
+Bk
+Bk
+Bk
+iw
+iw
+iw
+Iv
+Iv
 "}
 (22,1,1) = {"
-a
-b
-b
-j
-c
-c
-c
-c
-b
-b
-b
-b
-b
-b
-c
-c
-b
-b
-b
-b
-a
+Iv
+iw
+iw
+Vq
+Bk
+Bk
+Bk
+Bk
+iw
+iw
+iw
+iw
+iw
+iw
+Bk
+Bk
+iw
+iw
+iw
+iw
+Iv
 "}
 (23,1,1) = {"
-b
-b
-b
-b
-b
-b
-j
-c
-b
-D
-c
-N
-c
-w
-c
-c
-w
-c
-j
-b
-a
+iw
+iw
+iw
+iw
+iw
+iw
+Vq
+Bk
+iw
+wW
+Bk
+ys
+Bk
+Wt
+Bk
+Bk
+Wt
+Bk
+Vq
+iw
+Iv
 "}
 (24,1,1) = {"
-t
-c
-c
-k
-k
-j
-b
-z
-b
-E
-c
-O
-Q
-b
-A
-c
-b
-c
-X
-b
-b
+fS
+Bk
+Bk
+mk
+mk
+Vq
+iw
+Ff
+iw
+sQ
+Bk
+FI
+oG
+iw
+uY
+Bk
+iw
+Bk
+fs
+iw
+iw
 "}
 (25,1,1) = {"
-b
-c
-c
-c
-c
-n
-b
-c
-w
-c
-I
-c
-R
-b
-c
-c
-b
-c
-c
-j
-b
+iw
+Bk
+Bk
+Bk
+Bk
+Iy
+iw
+Bk
+Wt
+Bk
+Kq
+Bk
+Yr
+iw
+Bk
+Bk
+iw
+Bk
+Bk
+Vq
+iw
 "}
 (26,1,1) = {"
-b
-e
-c
-c
-c
-c
-b
-c
-b
-b
-b
-b
-b
-b
-c
-m
-B
-W
-c
-c
-b
+iw
+ns
+Bk
+Bk
+Bk
+Bk
+iw
+Bk
+iw
+iw
+iw
+iw
+iw
+iw
+Bk
+Ph
+Pd
+Yz
+Bk
+Bk
+iw
 "}
 (27,1,1) = {"
-b
-f
-c
-c
-c
-c
-w
-c
-c
-c
-J
-c
-c
-c
-c
-c
-B
-c
-c
-Z
-b
+iw
+BE
+Bk
+Bk
+Bk
+Bk
+Wt
+Bk
+Bk
+Bk
+qY
+Bk
+Bk
+Bk
+Bk
+Bk
+Pd
+Bk
+Bk
+DK
+iw
 "}
 (28,1,1) = {"
-b
-c
-c
-c
-c
-c
-b
-j
-c
-c
-c
-c
-c
-c
-c
-S
-B
-c
-c
-c
-b
+iw
+Bk
+Bk
+Bk
+Bk
+Bk
+iw
+Vq
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+EM
+Pd
+Bk
+Bk
+Bk
+iw
 "}
 (29,1,1) = {"
-b
-c
-c
-c
-c
-j
-b
-b
-b
-B
-G
-B
-b
-b
-b
-b
-b
-c
-c
-c
-b
+iw
+Bk
+Bk
+Bk
+Bk
+Vq
+iw
+iw
+iw
+Pd
+RU
+Pd
+iw
+iw
+iw
+iw
+iw
+Bk
+Bk
+Bk
+iw
 "}
 (30,1,1) = {"
-b
-c
-c
-c
-j
-b
-j
-c
-c
-c
-c
-c
-c
-C
-C
-C
-b
-c
-c
-j
-b
+iw
+Bk
+Bk
+Bk
+Vq
+iw
+Vq
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+kK
+kK
+kK
+iw
+Bk
+Bk
+Vq
+iw
 "}
 (31,1,1) = {"
-t
-c
-g
-c
-b
-j
-c
-c
-c
-c
-c
-c
-c
-c
-c
-c
-j
-j
-Y
-b
-a
+fS
+Bk
+Hx
+Bk
+iw
+Vq
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Vq
+Vq
+Ob
+iw
+Iv
 "}
 (32,1,1) = {"
-b
-b
-b
-o
-b
-u
-x
-c
-c
-c
-c
-c
-c
-c
-c
-U
-V
-b
-b
-b
-a
+iw
+iw
+iw
+Gk
+iw
+RN
+mU
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+Bk
+VU
+QS
+iw
+iw
+iw
+Iv
 "}
 (33,1,1) = {"
-a
-a
-b
-p
-b
-v
-x
-c
-c
-C
-K
-C
-c
-c
-c
-c
-j
-b
-b
-a
-a
+Iv
+Iv
+iw
+NH
+iw
+eP
+mU
+Bk
+Bk
+kK
+ff
+kK
+Bk
+Bk
+Bk
+Bk
+Vq
+iw
+iw
+Iv
+Iv
 "}
 (34,1,1) = {"
-a
-a
-b
-q
-b
-j
-y
-c
-c
-F
-L
-C
-c
-c
-c
-j
-b
-b
-a
-a
-a
+Iv
+Iv
+iw
+bg
+iw
+Vq
+Fs
+Bk
+Bk
+Yh
+nz
+kK
+Bk
+Bk
+Bk
+Vq
+iw
+iw
+Iv
+Iv
+Iv
 "}
 (35,1,1) = {"
-a
-a
-a
-a
-b
-b
-b
-B
-B
-B
-B
-B
-B
-B
-b
-b
-b
-a
-a
-a
-a
+Iv
+Iv
+Iv
+Iv
+iw
+iw
+iw
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+Pd
+iw
+iw
+iw
+Iv
+Iv
+Iv
+Iv
 "}


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You know every space ruin (on the moment of this PR) was made before the fastmos striked in. Mapperdudes didn't expect atmosphere being changing so fast and this result in some uncomfortable moments like going into a space fastfood building and spacing all the food and yourself because fastmos moment. Or going somewhere else, opening a door and flying through the 3-4 z-levels next 5 seconds because air farted in your face that strong upon opening a door.

This PR adds tiny fans on some space ruins (and invisible tiny fans on shuttle relic) where it fits good and also on those ruins where there is no way to open a door without depressurizing the rest of the ruin. I didn't put fans on the ruins that look like a part of a station or a ship (like cloning facility with experimental cloner), because it doesn't fit logically (like random medbay room that got separated and turned into a space ruin have no reason to have a tiny fan under it's airlock).

also it looks like white ship ruin wasn't saved in TGM format before.

Also this PR clears some unnecessary var strings on the maps affected.

## Why It's Good For The Game

You can now watch the ruins from inside without that bright blue filter in your eyes and floor tiles everywhere.

## Changelog
:cl:
tweak: Added tiny fans on some space ruins.
/:cl:
