### PR TITLE
Allows nightmare's light eater to extinguish bonfires and people on fire

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -192,6 +192,11 @@
 			if(!borg.lamp_cooldown)
 				borg.update_headlamp(TRUE, INFINITY)
 				to_chat(borg, "<span class='danger'>Your headlamp is fried! You'll need a human to help replace it.</span>")
+
+		if(L.on_fire)
+			L.ExtinguishMob()
+			playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
+
 		else
 			for(var/obj/item/O in AM)
 				if(O.light_range && O.light_power)
@@ -202,6 +207,12 @@
 		var/obj/item/I = AM
 		if(I.light_range && I.light_power)
 			disintegrate(I)
+
+	else if(istype(AM, /obj/structure/bonfire))
+		var/obj/structure/bonfire/F = AM
+		if(F.burning)
+			F.extinguish()
+			playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
 
 /obj/item/light_eater/proc/disintegrate(obj/item/O)
 	if(istype(O, /obj/item/pda))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Light eater is meant to eat light. Fire produces light. Light eater should therefore be able to eat the fire.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: nightmare's light eater can now extinguish bonfires and people on fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
