### PR TITLE
Adds emagging to mechs

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -466,6 +466,19 @@
 				speech_bubble_recipients.Add(M.client)
 		INVOKE_ASYNC(GLOBAL_PROC, /proc/flick_overlay, image('icons/mob/talk.dmi', src, "machine[say_test(raw_message)]",MOB_LAYER+1), speech_bubble_recipients, 30)
 
+/obj/mecha/emag_act()
+	. = ..()
+	if(obj_flags & EMAGGED)
+		to_chat(user, "<span class='warning'>The mech suit's internal controls are damaged beyond repair!</span>")
+		return
+	obj_flags |= EMAGGED
+	playsound(src, "sparks", 100, 1)
+	to_chat(user, "<span class='warning'>You short out the mech suit's internal controls.</span>")
+	dna_lock = null
+	equipment_disabled = TRUE
+	log_message("System emagged detected", LOG_MECHA, color="red")
+	addtimer(CALLBACK(src, /obj/mecha/proc/restore_equipment), 15 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+
 ////////////////////////////
 ///// Action processing ////
 ////////////////////////////

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -466,7 +466,7 @@
 				speech_bubble_recipients.Add(M.client)
 		INVOKE_ASYNC(GLOBAL_PROC, /proc/flick_overlay, image('icons/mob/talk.dmi', src, "machine[say_test(raw_message)]",MOB_LAYER+1), speech_bubble_recipients, 30)
 
-/obj/mecha/emag_act()
+/obj/mecha/emag_act(mob/user)
 	. = ..()
 	if(obj_flags & EMAGGED)
 		to_chat(user, "<span class='warning'>The mech suit's internal controls are damaged beyond repair!</span>")

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -391,6 +391,9 @@
 
 	//Turns on the DNA lock
 	if(href_list["dna_lock"])
+		if(obj_flags & EMAGGED)
+			occupant_message("The control console lights up red, failing to bind to your DNA.")
+			return
 		if(!iscarbon(occupant) || !occupant.dna)
 			occupant_message("The controls console flashes brightly, binding to your DNA.")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows mechs to be emagged.
Emagging will disable a mechs equipment for 15 seconds and prevent it from being DNA locked (also unlocking DNA locked mechs).

## Why It's Good For The Game

Adds emaggability to something that should really have it. Allows traitors to counter validhunting mechs by disabling them for 15 seconds and destroying it, or allows them to hijack unpiloted, unprotected mechs.

## Changelog
:cl:
add: Allows mechs to be emagged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
