### PR TITLE
Fixes weapon circuit runtime and some slightly logging changes 

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -132,7 +132,7 @@
 	//Shooting Code:
 	A.preparePixelProjectile(target, src)
 	A.ignore_source_check = TRUE //needed else writing into firer will mess with the projectile collision
-	A.firer = usr == null ? "[assembly]/[REF(assembly)] circuit made by [assembly.creator]" : "[usr.ckey]/[usr] trough [assembly]/[REF(assembly)] circuit made by [assembly.creator]"
+	A.firer = !usr ? "[assembly]/[REF(assembly)] circuit made by [assembly.creator]" : "[usr.ckey]/[usr] trough [assembly]/[REF(assembly)] circuit made by [assembly.creator]"
 	A.log_override = TRUE //Only resoves a runtime that would be caused on call.
 	A.fire()
 	log_attack("[assembly] [REF(assembly)] made by [assembly.creator] has fired [installed_gun].")

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -132,7 +132,7 @@
 	//Shooting Code:
 	A.preparePixelProjectile(target, src)
 	A.ignore_source_check = TRUE //needed else writing into firer will mess with the projectile collision
-	A.firer = !usr ? "[assembly]/[REF(assembly)] circuit made by [assembly.creator]" : "[usr.ckey]/[usr] trough [assembly]/[REF(assembly)] circuit made by [assembly.creator]"
+	A.firer = !usr ? "[assembly]/[REF(assembly)] circuit made by [assembly.creator]" : "[assembly]/[REF(assembly)] circuit activated by [usr.ckey]/[usr] and made by [assembly.creator]"
 	A.log_override = TRUE //Only resoves a runtime that would be caused on call.
 	A.fire()
 	log_attack("[assembly] [REF(assembly)] made by [assembly.creator] has fired [installed_gun].")

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -132,9 +132,10 @@
 	//Shooting Code:
 	A.preparePixelProjectile(target, src)
 	A.ignore_source_check = TRUE //needed else writing into firer will mess with the projectile collision
-	A.firer = "[usr.ckey]/[usr] trough [assembly]/[REF(assembly)] circuit"
+	A.firer = usr == null ? "[assembly]/[REF(assembly)] circuit made by [assembly.creator]" : "[usr.ckey]/[usr] trough [assembly]/[REF(assembly)] circuit made by [assembly.creator]"
+	A.log_override = TRUE //Only resoves a runtime that would be caused on call.
 	A.fire()
-	log_attack("[assembly] [REF(assembly)] has fired [installed_gun].")
+	log_attack("[assembly] [REF(assembly)] made by [assembly.creator] has fired [installed_gun].")
 	return A
 
 /obj/item/integrated_circuit/manipulation/locomotion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a runtime that occured for logging when it tried to call usr if the action was actually not called by a player like with a timer also fixes yet another runtime that occured when it tried to write into the non existing combat log of the assembly. This also includes a sligthly change to the gun circuit logging as the log message now includes the circuit creator too.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Runtimes bad. 
Runtimes that freeze the projectile in the air cause someone(me) forgot to consider timers as the action source of a weapon circuit firing are even worse.
## Changelog
:cl:
fix: weapon circuit runtime
tweak: adds creator to weapon circuit logging
/:cl:
 
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
