### PR TITLE
Heretics' Mansus Grasp Lays Runes

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -8,8 +8,6 @@
 	var/mob/living/last_user
 	///how many charges do we have?
 	var/charge = 1
-	///Where we cannot create the rune?
-	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava))
 	///Is it in use?
 	var/in_use = FALSE
 
@@ -32,12 +30,8 @@
 	if(!proximity_flag || !IS_HERETIC(user) || in_use)
 		return
 	in_use = TRUE
-	if(istype(target,/obj/effect/eldritch))
-		remove_rune(target,user)
 	if(istype(target,/obj/effect/reality_smash))
 		get_power_from_influence(target,user)
-	if(istype(target,/turf/open))
-		draw_rune(target,user)
 	in_use = FALSE
 
 ///Gives you a charge and destroys a corresponding influence
@@ -47,28 +41,6 @@
 	if(do_after(user,10 SECONDS,FALSE,RS))
 		qdel(RS)
 		charge += 1
-
-///Draws a rune on a selected turf
-/obj/item/forbidden_book/proc/draw_rune(atom/target,mob/user)
-
-	for(var/turf/T in range(1,target))
-		if(is_type_in_typecache(T, blacklisted_turfs))
-			to_chat(target, "<span class='warning'>The terrain doesn't support runes!</span>")
-			return
-	var/A = get_turf(target)
-	to_chat(user, "<span class='danger'>You start drawing a rune...</span>")
-
-	if(do_after(user,30 SECONDS,FALSE,A))
-
-		new /obj/effect/eldritch/big(A)
-
-
-///Removes runes from the selected turf
-/obj/item/forbidden_book/proc/remove_rune(atom/target,mob/user)
-
-	to_chat(user, "<span class='danger'>You start removing a rune...</span>")
-	if(do_after(user,2 SECONDS,user))
-		qdel(target)
 
 
 /obj/item/forbidden_book/ui_interact(mob/user, datum/tgui/ui = null)

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -87,15 +87,13 @@
 
 	for(var/turf/T in range(1,user))
 		if(is_type_in_typecache(T, blacklisted_turfs))
-			to_chat(user, "<span class='warning'>The terrain doesn't support runes!</span>")
+			to_chat(user, "<span class='warning'>The targeted terrain doesn't support runes!</span>")
 			return
 	var/A = get_turf(user)
 	to_chat(user, "<span class='danger'>You start drawing a rune...</span>")
 
 	if(do_after(user,30 SECONDS,FALSE,A))
-
 		new /obj/effect/eldritch/big(A)
-
 
 ///Removes runes from the selected turf
 /obj/item/melee/touch_attack/mansus_fist/proc/remove_rune(atom/target,mob/user)

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -46,10 +46,15 @@
 	icon_state = "mansus_grasp"
 	item_state = "mansus_grasp"
 	catchphrase = "R'CH T'H TR'TH"
+	///Where we cannot create the rune?
+	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava))
 
 /obj/item/melee/touch_attack/mansus_fist/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!proximity_flag || target == user)
-		return
+		return FALSE
+	if(istype(target,/obj/effect/eldritch))
+		remove_rune(target,user)
+		return FALSE
 	playsound(user, 'sound/items/welder.ogg', 75, TRUE)
 	if(ishuman(target))
 		var/mob/living/carbon/human/tar = target
@@ -76,6 +81,27 @@
 			use_charge = TRUE
 	if(use_charge)
 		return ..()
+
+///Draws a rune on a selected turf
+/obj/item/melee/touch_attack/mansus_fist/attack_self(mob/user)
+
+	for(var/turf/T in range(1,user))
+		if(is_type_in_typecache(T, blacklisted_turfs))
+			to_chat(user, "<span class='warning'>The terrain doesn't support runes!</span>")
+			return
+	var/A = get_turf(user)
+	to_chat(user, "<span class='danger'>You start drawing a rune...</span>")
+
+	if(do_after(user,30 SECONDS,FALSE,A))
+
+		new /obj/effect/eldritch/big(A)
+
+
+///Removes runes from the selected turf
+/obj/item/melee/touch_attack/mansus_fist/proc/remove_rune(atom/target,mob/user)
+	to_chat(user, "<span class='danger'>You start removing a rune...</span>")
+	if(do_after(user,2 SECONDS,user))
+		qdel(target)
 
 /obj/effect/proc_holder/spell/aoe_turf/rust_conversion
 	name = "Aggressive Spread"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows heretics to place and remove runes with their mansus grasp instead of the book.

## Why It's Good For The Game

Empowers heretics:
* They no longer need to carry the book around to be able to lay runes.
* They cannot be rendered useless by taking their book away
* They can no longer accidentally lay a rune instead of harvesting a reality tear

## Changelog
:cl:
balance: Heretics no longer require the Codex to lay runes, instead they can lay runes using their Mansus empowered hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
