### PR TITLE
Xenobiology Cargo Pack

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1641,13 +1641,19 @@ datum/supply_pack/medical/bruisekits
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
-/datum/supply_pack/critter/slime
-	name = "Grey Slime Crate"
-	desc = "In case a freak accident has rendered the xenobiology lab empty!"
-	cost = 5000
-	contains = list(/mob/living/simple_animal/slime)
-	crate_name = "slime crate"
-	group = "Science"
+/datum/supply_pack/science/xenobio
+	name = "Xenobiology Lab Crate"
+	desc = "In case a freak accident has rendered the xenobiology lab non-functional! Contains two grey slime extracts, some plasma, and the required circuit boards to set up your xenobiology lab up and running! Requires Xenobiology access to open."
+	cost = 20000
+	access = ACCESS_XENOBIOLOGY
+	contains = list(/obj/item/slime_extract/grey,
+					/obj/item/slime_extract/grey,
+					/obj/item/reagent_containers/syringe/plasma,
+					/obj/item/circuitboard/computer/xenobiology,
+					/obj/item/circuitboard/machine/monkey_recycler,
+					/obj/item/circuitboard/machine/processor/slime)
+	crate_name = "xenobiology starter crate"
+	crate_type = /obj/structure/closet/crate/secure/science
 
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Service //////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1644,7 +1644,7 @@ datum/supply_pack/medical/bruisekits
 /datum/supply_pack/science/xenobio
 	name = "Xenobiology Lab Crate"
 	desc = "In case a freak accident has rendered the xenobiology lab non-functional! Contains two grey slime extracts, some plasma, and the required circuit boards to set up your xenobiology lab up and running! Requires Xenobiology access to open."
-	cost = 20000
+	cost = 10000
 	access = ACCESS_XENOBIOLOGY
 	contains = list(/obj/item/slime_extract/grey,
 					/obj/item/slime_extract/grey,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1641,6 +1641,14 @@ datum/supply_pack/medical/bruisekits
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
+/datum/supply_pack/critter/slime
+	name = "Grey Slime Crate"
+	desc = "In case a freak accident has rendered the xenobiology lab empty!"
+	cost = 5000
+	contains = list(/mob/living/simple_animal/slime)
+	crate_name = "slime crate"
+	group = "Science"
+
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Service //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds xeno bio crate to cargo, containing extracts and boards to set up a xenobio lab.

## Why It's Good For The Game

Sometimes it happens that all slimes die (accident, sabotage) and makes xenobiology useless.

There's no reason for this not to exist.

Edit: also, you can do ghetto xenobiology without stealing slimes from xenobio now.

## Changelog
:cl:
add: Added Xenobiology Cargo Pack in Science
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
