### PR TITLE
Insecure Crosscomms newscasters and small QoL

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1604,3 +1604,33 @@ config_setting should be one of the following:
 		if(-INFINITY to 0, 11 to INFINITY)
 			CRASH("Can't turn invalid directions!")
 	return turn(input_dir, 180)
+
+/**
+ * Sends a topic call to crosscomms servers.
+ *
+ * Params:
+ * sender - Name of the IC entity sending the message
+ * msg - Message text to send
+ * type - What handler the recieving server should use
+ * insecure - Send the messages to insecure servers
+*/
+/proc/comms_send(sender, msg, type, insecure = FALSE)
+	var/list/message = list()
+	message["message_sender"] = sender
+	message["message"] = msg
+	message["source"] = "([CONFIG_GET(string/cross_comms_name)])"
+	message += type
+
+	var/comms_key = CONFIG_GET(string/comms_key)
+	if(comms_key)
+		message["key"] = comms_key
+		var/list/servers = CONFIG_GET(keyed_list/cross_server)
+		for(var/I in servers)
+			world.Export("[servers[I]]?[list2params(message)]")
+
+	comms_key = CONFIG_GET(string/comms_key_insecure)
+	if(comms_key && insecure)
+		message["key"] = comms_key
+		var/list/servers = CONFIG_GET(keyed_list/insecure_cross_server)
+		for(var/I in servers)
+			world.Export("[servers[I]]?[list2params(message)]")

--- a/code/controllers/configuration/entries/comms.dm
+++ b/code/controllers/configuration/entries/comms.dm
@@ -44,6 +44,10 @@
 /datum/config_entry/keyed_list/insecure_cross_server/ValidateListEntry(key_name, key_value)
 	return key_value != "byond://address:port" && ..()
 
+/datum/config_entry/flag/insecure_announce
+
+/datum/config_entry/flag/insecure_newscaster
+
 /datum/config_entry/string/cross_comms_name
 
 /datum/config_entry/string/medal_hub_address

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -564,7 +564,7 @@ SUBSYSTEM_DEF(ticker)
 			news_message = "During routine evacuation procedures, the emergency shuttle of [station_name()] had its navigation protocols corrupted and went off course, but was recovered shortly after."
 
 	if(news_message)
-		comms_send(news_source, news_message, "News_Report", TRUE)
+		comms_send(news_source, news_message, "News_Report", CONFIG_GET(flag/insecure_newscaster))
 
 /datum/controller/subsystem/ticker/proc/GetTimeLeft()
 	if(isnull(SSticker.timeLeft))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -564,7 +564,7 @@ SUBSYSTEM_DEF(ticker)
 			news_message = "During routine evacuation procedures, the emergency shuttle of [station_name()] had its navigation protocols corrupted and went off course, but was recovered shortly after."
 
 	if(news_message)
-		send2otherserver(news_source, news_message,"News_Report")
+		comms_send(news_source, news_message, "News_Report", TRUE)
 
 /datum/controller/subsystem/ticker/proc/GetTimeLeft()
 	if(isnull(SSticker.timeLeft))

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -23,12 +23,12 @@
 	var/keyword
 	var/log = TRUE
 	var/key_valid
+	var/insecure_key = FALSE
 	var/require_comms_key = FALSE
 	var/permit_insecure = FALSE
 
 /datum/world_topic/proc/TryRun(list/input, addr)
 	key_valid = config && (CONFIG_GET(string/comms_key) == input["key"])
-	var/insecure_key = FALSE
 	if(!key_valid && permit_insecure)
 		key_valid = config && (CONFIG_GET(string/comms_key_insecure) == input["key"])
 		insecure_key = key_valid
@@ -97,6 +97,9 @@
 	permit_insecure = TRUE
 
 /datum/world_topic/comms_console/Run(list/input, addr)
+	if(insecure_key && !CONFIG_GET(flag/insecure_announce))
+		return
+
 	if(CHAT_FILTER_CHECK(input["message"])) // prevents any.. diplomatic incidents
 		minor_announce("In the interest of station productivity and mental hygiene, a message from [input["message_sender"]] was intercepted by the CCC and determined to be unfit for crew-level access.", "CentCom Communications Commission")
 		message_admins("Incomming cross-comms message from [input["message_sender"]] blocked: [input["message"]]")

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -111,8 +111,12 @@
 /datum/world_topic/news_report
 	keyword = "News_Report"
 	require_comms_key = TRUE
+	permit_insecure = TRUE
 
 /datum/world_topic/news_report/Run(list/input, addr)
+	if(insecure_key && !CONFIG_GET(flag/insecure_newscaster))
+		return
+
 	minor_announce(input["message"], "Breaking Update From [input["message_sender"]]")
 
 /datum/world_topic/adminmsg

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -475,8 +475,6 @@
 					cross_servers_count += length(CONFIG_GET(keyed_list/insecure_cross_server))
 					if(cross_servers_count)
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=crossserver'>Send a message to [cross_servers_count == 1 ? "an " : ""]allied station[cross_servers_count > 1 ? "s" : ""]</A> \]"
-						//if(cross_servers_count > 1)
-						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=targeted_crossserver'>Send a message to a specific allied station</A> \]"
 					if(SSmapping.config.allow_custom_shuttles)
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=purchase_menu'>Purchase Shuttle</A> \]"
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=changeseclevel'>Change Alert Level</A> \]"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -764,7 +764,7 @@
 			world.Export("[servers[I]]?[list2params(message)]")
 
 	comms_key = CONFIG_GET(string/comms_key_insecure)
-	if(comms_key)
+	if(comms_key && CONFIG_GET(flag/insecure_announce))
 		message["key"] = comms_key
 		var/list/servers = CONFIG_GET(keyed_list/insecure_cross_server)
 		for(var/I in servers)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -138,7 +138,7 @@
 					return
 				CM.lastTimeUsed = world.time
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-				cross_server(input)
+				comms_send(station_name(), input, "Comms_Console", CONFIG_GET(flag/insecure_announce))
 				minor_announce(input, title = "Outgoing message to allied station")
 				usr.log_talk(input, LOG_SAY, tag="message to the other server")
 				message_admins("[ADMIN_LOOKUPFLW(usr)] has sent a message to the other server.")
@@ -475,6 +475,8 @@
 					cross_servers_count += length(CONFIG_GET(keyed_list/insecure_cross_server))
 					if(cross_servers_count)
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=crossserver'>Send a message to [cross_servers_count == 1 ? "an " : ""]allied station[cross_servers_count > 1 ? "s" : ""]</A> \]"
+						//if(cross_servers_count > 1)
+						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=targeted_crossserver'>Send a message to a specific allied station</A> \]"
 					if(SSmapping.config.allow_custom_shuttles)
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=purchase_menu'>Purchase Shuttle</A> \]"
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=changeseclevel'>Change Alert Level</A> \]"
@@ -748,27 +750,6 @@
 
 /obj/machinery/computer/communications/proc/add_message(datum/comm_message/new_message)
 	messages += new_message
-
-/obj/machinery/computer/communications/proc/cross_server(msg)
-	var/list/message = list()
-	message["message_sender"] = station_name()
-	message["message"] = msg
-	message["source"] = "([CONFIG_GET(string/cross_comms_name)])"
-	message += "Comms_Console"
-
-	var/comms_key = CONFIG_GET(string/comms_key)
-	if(comms_key)
-		message["key"] = comms_key
-		var/list/servers = CONFIG_GET(keyed_list/cross_server)
-		for(var/I in servers)
-			world.Export("[servers[I]]?[list2params(message)]")
-
-	comms_key = CONFIG_GET(string/comms_key_insecure)
-	if(comms_key && CONFIG_GET(flag/insecure_announce))
-		message["key"] = comms_key
-		var/list/servers = CONFIG_GET(keyed_list/insecure_cross_server)
-		for(var/I in servers)
-			world.Export("[servers[I]]?[list2params(message)]")
 
 /datum/comm_message
 	var/title

--- a/config/Sage/comms.txt
+++ b/config/Sage/comms.txt
@@ -19,7 +19,7 @@ INSECURE_TOPIC_COOLDOWN 300
 ## Note: Servers should be either secure (normal) or insecure, but NOT both at the same time.
 #INSECURE_CROSS_SERVER ServerName byond://address:port
 
-## Toggles for different features on insecure crosscomms. Allows for modularity with different features enabled.
+## Toggles for different features on insecure crosscomms. Allows for modularity, with different features enabled at a time.
 ## Crosscomms announcements, mainly the comms console
 #INSECURE_ANNOUNCE
 ## Newscaster reports, for evacuation reports etc

--- a/config/Sage/comms.txt
+++ b/config/Sage/comms.txt
@@ -19,6 +19,12 @@ INSECURE_TOPIC_COOLDOWN 300
 ## Note: Servers should be either secure (normal) or insecure, but NOT both at the same time.
 #INSECURE_CROSS_SERVER ServerName byond://address:port
 
+## Toggles for different features on insecure crosscomms. Allows for modularity with different features enabled.
+## Crosscomms announcements, mainly the comms console
+#INSECURE_ANNOUNCE
+## Newscaster reports, for evacuation reports etc
+#INSECURE_NEWSCASTER
+
 ## Name that the server calls itself in communications
 #CROSS_COMMS_NAME
 

--- a/config/comms.txt
+++ b/config/comms.txt
@@ -19,6 +19,12 @@ INSECURE_TOPIC_COOLDOWN 300
 ## Note: Servers should be either secure (normal) or insecure, but NOT both at the same time.
 #INSECURE_CROSS_SERVER ServerName byond://address:port
 
+## Toggles for different features on insecure crosscomms. Allows for modularity with different features enabled.
+## Crosscomms announcements, mainly the comms console
+#INSECURE_ANNOUNCE
+## Newscaster reports, for evacuation reports etc
+#INSECURE_NEWSCASTER
+
 ## Name that the server calls itself in communications
 #CROSS_COMMS_NAME
 


### PR DESCRIPTION
## About The Pull Request
"Insecure" comms support for newscasters. Also small QoL where I put stuff in config so servers can choose what's sent and received through the "insecure" crosscomms system, though I don't expect too much else to get added to this with the coming bee API, that I might rework everything into anyway, depending.

## Why It's Good For The Game
"Highly configurable. Infinitely variable"
More config options. Station evacuation messages.

## Changelog
:cl: MCterra
add: Newscasters join the insecure comms family
server: More config options for insecure comms
/:cl:
