### PR TITLE
Fixes IAA message being the wrong way around

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -248,7 +248,7 @@
 
 	to_chat(owner.current, "<span class='userdanger'>Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them.</span>")
 	owner.announce_objectives()
-	owner.current.client?.tgui_panel?.give_antagonist_popup("[syndicate ? "Internal Affairs" : "External Affairs"]",
+	owner.current.client?.tgui_panel?.give_antagonist_popup("[syndicate ? "External Affairs" : "Internal Affairs"]",
 		"[syndicate?"Eliminate your target and cause as much damage to Nanotrasen property as you see fit."\
 		: "Eliminate your target without drawing too much attention to yourself, but watch your back since somebody is after you."]")
 


### PR DESCRIPTION
## Changelog
:cl:
fix: IAA agents are reported on the stat as EAA agents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
