### PR TITLE
Fix Changeling Absorbtion Bug

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -192,6 +192,9 @@
 	if(!ishuman(owner.current))
 		to_chat(owner.current, "<span class='danger'>We can't remove our evolutions in this form!</span>")
 		return
+	if(isabsorbing)
+		to_chat(owner.current, "<span class='danger'>We cannot readapt right now!</span>")
+		return
 	if(canrespec)
 		to_chat(owner.current, "<span class='notice'>We have removed our evolutions from this form, and are now ready to readapt.</span>")
 		reset_powers()

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -11,14 +11,15 @@
 		return
 	var/mob/living/carbon/target = user.pulling
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	if(!target || !iscarbon(target))
+		to_chat(user, "<span class='warning'>We must be grabbing a creature to absorb them!</span>")
+		changeling.isabsorbing = FALSE
+		return
 	if(changeling.isabsorbing)
 		to_chat(user, "<span class='warning'>We are already absorbing!</span>")
 		return
 	if(HAS_TRAIT(target, TRAIT_NODEATH))
 		to_chat(user, "<span class='warning'>We can't absorb this creature.</span>")
-		return
-	if(!user.pulling || !iscarbon(user.pulling))
-		to_chat(user, "<span class='warning'>We must be grabbing a creature to absorb them!</span>")
 		return
 	if(user.grab_state <= GRAB_NECK)
 		to_chat(user, "<span class='warning'>We must have a tighter grip to absorb this creature!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #3468

Changelings cannot readapt while absorbing.
Failsafe: Absorb always resets absorbing to false if there is no target.

## Changelog
:cl:
fix: a changeling related fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
