### PR TITLE
Remove duplicate var in teleportation.dm

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -252,7 +252,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 4
 	throw_range = 10
-	item_state = "electronic"
 
 	var/charges = 4
 	var/max_charges = 4


### PR DESCRIPTION
Also includes my CL entry for the teleporter because nobody has realized that it is in the game yet.

:cl:Qwertytoforty, imported by Cenrus
add: Adds the syndicate teleporter, a mobility item that syndicate agents can buy for 8 TC.
/:cl: