### PR TITLE
[BOUNTY] Mothpeople aren't vulnerable to flashes when wearing protection

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -123,7 +123,7 @@
 		if(I.sharpness)
 			dismemberthreshold = min(((affecting.max_damage * 2) - affecting.get_damage()), dismemberthreshold) //makes it so limbs wont become immune to being dismembered if the item is sharp
 			if(stat == DEAD)
-				dismemberthreshold = dismemberthreshold / 3 
+				dismemberthreshold = dismemberthreshold / 3
 		if(I.force >= dismemberthreshold && I.force >= 10)
 			if(affecting.dismember(I.damtype))
 				I.add_mob_blood(src)
@@ -325,7 +325,7 @@
 
 	. = ..()
 
-	var/damage = intensity - get_eye_protection()
+	var/damage = (intensity - get_eye_protection()) * eyes.damage_multiplier
 	if(.) // we've been flashed
 		if(visual)
 			return
@@ -333,15 +333,15 @@
 		if (damage == 1)
 			to_chat(src, "<span class='warning'>Your eyes sting a little.</span>")
 			if(prob(40))
-				eyes.applyOrganDamage(1)
+				eyes.applyOrganDamage(1 * eyes.damage_multiplier)
 
 		else if (damage == 2)
 			to_chat(src, "<span class='warning'>Your eyes burn.</span>")
-			eyes.applyOrganDamage(rand(2, 4))
+			eyes.applyOrganDamage(rand(2, 4) * eyes.damage_multiplier)
 
 		else if( damage >= 3)
 			to_chat(src, "<span class='warning'>Your eyes itch and burn severely!</span>")
-			eyes.applyOrganDamage(rand(12, 16))
+			eyes.applyOrganDamage(rand(12, 16) * eyes.damage_multiplier)
 
 		if(eyes.damage > 10)
 			blind_eyes(damage)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -25,6 +25,7 @@
 	var/eye_color = "" //set to a hex code to override a mob's eye color
 	var/eye_icon_state = "eyes"
 	var/old_eye_color = "fff"
+	var/damage_multiplier = 1
 	var/flash_protect = 0
 	var/see_invisible = SEE_INVISIBLE_LIVING
 	var/lighting_alpha
@@ -376,7 +377,7 @@
 /obj/item/organ/eyes/moth
 	name = "moth eyes"
 	desc = "These eyes seem to have increased sensitivity to bright light, with no improvement to low light vision."
-	flash_protect = -1
+	damage_multiplier = 2
 
 /obj/item/organ/eyes/snail
 	name = "snail eyes"


### PR DESCRIPTION
## About The Pull Request
Moth people are no longer vulnerable to flashes while behind sunglasses or other flash protection. You don't need to stack sunglasses and a welding helmet or swap eyes anymore.
In exchange, moths take double damage from all flashing sources while unprotected, as well as being blinded or blurred for twice as long. Number can be changed for balance.

## Why It's Good For The Game
Allows moths to effectively play as security or head roles without anyone with a flash ruining their day.
![image](https://user-images.githubusercontent.com/11001588/105674820-2e09c200-5f3c-11eb-9d09-b1d4ade03c02.png)

## Changelog
:cl: Aeder
balance: moths can no longer get flashed while behind protection, but take double damage if unprotected.
/:cl:
