### PR TITLE
Aligns lighting overlays to lighting fixtures on direction changes.

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -363,6 +363,12 @@
 			lighting_overlays["[base_state]-[light_power]-[light_color]-[dir]"] = LO
 		. += LO
 
+/obj/machinery/light/setDir(newdir)
+	var/olddir = dir
+	..()
+	if(olddir != dir)
+		update_icon() // A few things need to update their overlays when dir changes. This is one of them.
+
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(trigger = TRUE)
 	switch(status)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -354,20 +354,13 @@
 	if(on || emergency_mode)
 		if(!lighting_overlays)
 			lighting_overlays = list()
-		var/mutable_appearance/LO = lighting_overlays["[base_state]-[light_power]-[light_color]-[dir]"]
+		var/mutable_appearance/LO = lighting_overlays["[base_state]-[light_power]-[light_color]"]
 		if(!LO)
-			var/image/temp_image = image(overlayicon, null, base_state, layer, dir)
-			LO = new(temp_image)
+			LO = mutable_appearance(overlayicon, base_state, ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE)
 			LO.color = light_color
 			LO.alpha = clamp(light_power*255, 30, 200)
-			lighting_overlays["[base_state]-[light_power]-[light_color]-[dir]"] = LO
+			lighting_overlays["[base_state]-[light_power]-[light_color]"] = LO
 		. += LO
-
-/obj/machinery/light/setDir(newdir)
-	var/olddir = dir
-	..()
-	if(olddir != dir)
-		update_icon() // A few things need to update their overlays when dir changes. This is one of them.
 
 // update the icon_state and luminosity of the light depending on its state
 /obj/machinery/light/proc/update(trigger = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lighting overlays didn't rotate when lighting fixtures rotated. The bug was noticed when #3222 and #3085 was testmerged. The working theory is that #3222 made lighting overlays have its own directions, so BYOND didn't rotate them when the lighting fixture was rotated. This PR removes that direction baking to make BYOND rotate the overlays accordingly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This PR prevents this:

![Screenshot 2021-01-26 012218](https://user-images.githubusercontent.com/8010007/105739701-be1b2c00-5f7b-11eb-9b31-161f5e6075c1.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed lighting overlays decoupling with lighting fixtures when shuttle rotates for real.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
