### PR TITLE
Adds an atmosbot to the mining base and fixes up outpost access

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1366,6 +1366,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/mob/living/simple_animal/bot/atmosbot{
+	name = "Officer Fastmosky"
+	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "fi" = (
@@ -3178,7 +3181,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
-	req_access_txt = "29"
+	req_access_txt = "47,54,29"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -4640,11 +4643,8 @@
 /area/mine/living_quarters)
 "Fe" = (
 /obj/structure/table/wood/bar,
-/obj/item/storage/box/donkpockets{
-	pixel_x = -2;
-	pixel_y = 5
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/carpet/black,
 /area/mine/science)
 "Fi" = (
@@ -5321,7 +5321,7 @@
 /obj/structure/barricade/wooden/crude,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
+	req_access_txt = "47,54,29"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -5839,6 +5839,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
+	},
+/obj/item/bot_assembly/atmosbot{
+	created_name = "Fastmosky Senior";
+	name = "old atmosbot assembly"
 	},
 /turf/open/floor/plasteel,
 /area/mine/science)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The lavaland base may sometimes have a small fuckup, incase this ever happens we got officer fastmosky for the job, the science outpost also had some weird access doors so i fixed em up, also added an atmosbot assembly for the outpost eva
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Miners may sometimes have a small fuckup, incase this ever happens we got Officer Fastmosky for the job, also the outpost had a CHEMISTRY DOOR,  BEHIND A FUCKING ROBOTICS DOOR
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
add: Added Officer Fastmosky to the lavaland base
tweak: Made the robotics and chemistry doors at the science outpost now only require basic science access and not chemistry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
