### PR TITLE
Prevents GODMODE shades from hanging around

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -60,6 +60,17 @@
 		A.death()
 	return ..()
 
+/obj/item/soulstone/Exited(mob/living/simple_animal/shade/S, atom/newLoc)
+	..()
+	if(istype(S))
+		// Things that *really should always* happen when shade comes out go here.
+		S.status_flags &= ~GODMODE
+		S.mobility_flags = MOBILITY_FLAGS_DEFAULT
+		S.cancel_camera()
+		if(purified)
+			S.icon_state = "ghost1"
+			S.name = "Purified [initial(S.name)]"
+
 /obj/item/soulstone/proc/hot_potato(mob/living/user)
 	to_chat(user, "<span class='userdanger'>Holy magics residing in \the [src] burn your hand!</span>")
 	var/obj/item/bodypart/affecting = user.get_bodypart("[(user.active_hand_index % 2 == 0) ? "r" : "l" ]_arm")
@@ -106,14 +117,9 @@
 
 /obj/item/soulstone/proc/release_shades(mob/user)
 	for(var/mob/living/simple_animal/shade/A in src)
-		A.status_flags &= ~GODMODE
-		A.mobility_flags = MOBILITY_FLAGS_DEFAULT
 		A.forceMove(get_turf(user))
-		A.cancel_camera()
 		if(purified)
-			icon_state = "purified_soulstone"
-			A.icon_state = "ghost1"
-			A.name = "Purified [initial(A.name)]"
+			icon_state = "purified_soulstone"			
 		else
 			icon_state = "soulstone"
 		name = initial(name)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -63,7 +63,7 @@
 /obj/item/soulstone/Exited(mob/living/simple_animal/shade/S, atom/newLoc)
 	..()
 	if(istype(S))
-		// Things that *really should always* happen when shade comes out go here.
+		// Things that *really should always* happen to the shade when it comes out should go here.
 		S.status_flags &= ~GODMODE
 		S.mobility_flags = MOBILITY_FLAGS_DEFAULT
 		S.cancel_camera()
@@ -119,7 +119,7 @@
 	for(var/mob/living/simple_animal/shade/A in src)
 		A.forceMove(get_turf(user))
 		if(purified)
-			icon_state = "purified_soulstone"			
+			icon_state = "purified_soulstone"
 		else
 			icon_state = "soulstone"
 		name = initial(name)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sometimes, shades come out of shards without the help of `release_shades` proc. (e.g. Summon Cultist to a cultist shade) The problem here is, shades will stay `GODMODE` when it doesn't go through `release_shades`. With the help of `Exited`s ubiquity, it should prevent `GODMODE` shades.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game 

This PR was a Headmin request. And no more `GODMODE` shades, oh dear.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:park66665, PowerfulBacon
fix: No more GODMODE shades hanging around the station, terrorizing players and admins alike.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
