### PR TITLE
Makes sunHUDs need advanced sunglasses to be crafted.

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -56,13 +56,13 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/security = 1,
-				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/clothing/glasses/sunglasses/advanced = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunsecremoval
 	name = "Security HUD removal"
-	result = /obj/item/clothing/glasses/sunglasses
+	result = /obj/item/clothing/glasses/sunglasses/advanced
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/security/sunglasses = 1)
@@ -74,13 +74,13 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health = 1,
-				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/clothing/glasses/sunglasses/advanced = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunmedremoval
 	name = "Medical HUD removal"
-	result = /obj/item/clothing/glasses/sunglasses
+	result = /obj/item/clothing/glasses/sunglasses/advanced
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/health/sunglasses = 1)
@@ -92,13 +92,13 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic = 1,
-				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/clothing/glasses/sunglasses/advanced = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsundiagremoval
 	name = "Diagnostic HUD removal"
-	result = /obj/item/clothing/glasses/sunglasses
+	result = /obj/item/clothing/glasses/sunglasses/advanced
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/hud/diagnostic/sunglasses = 1)
@@ -110,7 +110,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/science = 1,
-				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/clothing/glasses/sunglasses/advanced = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
@@ -120,7 +120,7 @@
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/science = 1,
-				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/clothing/glasses/sunglasses/advanced = 1,
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 

--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -126,7 +126,7 @@
 
 /datum/crafting_recipe/beergogglesremoval
 	name = "Beer Goggles removal"
-	result = /obj/item/clothing/glasses/sunglasses
+	result = /obj/item/clothing/glasses/sunglasses/advanced
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	reqs = list(/obj/item/clothing/glasses/sunglasses/advanced/reagent = 1)


### PR DESCRIPTION
## About The Pull Request
Changes sunHUDs crafting recipe from being able to use normal (not flash-proof) sunglasses to advanced sunglasses and its subtypes.

## Why It's Good For The Game
Using the normal sunglasses in the sunhud crafting recipes allows you to get flash protection in less than 1 minute from roundstart by gathering the 2 tools required, 5 cable coil and buying sunglasses from the clothes vendor in dorms, you can skip the buying sunglasses step completely by buying sunglasses in the beecoin shop so you spawn with them roundstart. I don't consider being able to craft a flashproof item with stuff as easy to get as this very good.

## Changelog
:cl:
balance: HUD Sunglasses now need advanced sunglasses or its subtypes to be crafted instead of normal sunglasses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
