### PR TITLE
Buffs shotgun slugs

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	damage = 60
-	armour_penetration = -60
+	armour_penetration = -20
 
 /obj/item/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs shotgun slugs.

## Why It's Good For The Game

-60 was way too much, they do essentially 0 damage to armoured targets.

## Changelog
:cl:
balance: Buffed shotgun slugs to -20 armour penetration instead of -60
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
