### PR TITLE
Removes BZ from lavaland

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -12,7 +12,6 @@
 		/datum/gas/carbon_dioxide=10,
 	)
 	restricted_gases = list(
-		/datum/gas/bz=10,
 		/datum/gas/plasma=0.1,
 		/datum/gas/water_vapor=0.1,
 	)


### PR DESCRIPTION
Prevents lavaland from generating an infinite supply of BZ for cargo to sell off.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes an infinite money pit in the form of (economically) exploiting lavaland's atmos.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Work for your cash.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Lavaland no longer produces BZ.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
