### PR TITLE
Cargo can no longer sell BZ via cargo.

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -141,7 +141,6 @@
 	var/obj/machinery/portable_atmospherics/canister/C = O
 	var/worth = 10
 
-	worth += C.air_contents.get_moles(/datum/gas/bz)*4
 	worth += C.air_contents.get_moles(/datum/gas/stimulum)*100
 	worth += C.air_contents.get_moles(/datum/gas/hypernoblium)*1000
 	worth += C.air_contents.get_moles(/datum/gas/miasma)*10


### PR DESCRIPTION
NT no longer buys BZ from the station.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

it's infinite and so easy to mine, why would NT pay you for it when they can just mine it themselves.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Solves the infinite farming problem without balance implications.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: NT no longer buys a gas they can just mine themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
