### PR TITLE
Oozlings now use Slime sprites instead of the current Jelly ones

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -17,7 +17,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_factions = list("slime")
 	species_language_holder = /datum/language_holder/oozeling
-	limbs_id = "jelly"
+	limbs_id = "slime"
 
 /datum/species/oozeling/random_name(gender,unique,lastname)
 	if(unique)


### PR DESCRIPTION
## About The Pull Request
Changes the sprite for the Oozlings to the slime person one instead of the Jellyperson one.

also if the this pr is fucked in anyway tell me literally never used github before!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it is better than the one currently used, and has less clipping
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Updated Oozlings to use the same sprites as slime people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
