### PR TITLE
Small TGUI stat panel fixes

### DIFF
--- a/code/controllers/subsystem/stat.dm
+++ b/code/controllers/subsystem/stat.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(stat)
 			var/mob/M = C.mob
 			if(M)
 				//Handle listed turfs seperately
-				if(M.listed_turf?.name == C.selected_stat_tab)
+				if(sanitize(M.listed_turf?.name) == C.selected_stat_tab)
 					currentrun_listed += C
 				else
 					//Auto-update, not forced

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -320,7 +320,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	set name = "Adminverbs - Hide Most"
 	set category = "Admin"
 
-	remove_verb(list(/client/proc/hide_most_verbs, GLOB.admin_verbs_hideable))
+	remove_verb(list(/client/proc/hide_most_verbs) + GLOB.admin_verbs_hideable)
 	add_verb(/client/proc/show_verbs)
 
 	to_chat(src, "<span class='interface'>Most of your adminverbs have been hidden.</span>")

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -206,13 +206,13 @@ GLOBAL_LIST_EMPTY(dirty_vars)
 	if(!check_rights(R_DEBUG))
 		return
 	remove_verb(/client/proc/enable_debug_verbs)
-	add_verb(list(/client/proc/disable_debug_verbs, GLOB.admin_verbs_debug_mapping))
+	add_verb(list(/client/proc/disable_debug_verbs) + GLOB.admin_verbs_debug_mapping)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Enable Debug Verbs") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/disable_debug_verbs()
 	set category = "Debug"
 	set name = "Debug verbs - Disable"
-	remove_verb(list(/client/proc/disable_debug_verbs, GLOB.admin_verbs_debug_mapping))
+	remove_verb(list(/client/proc/disable_debug_verbs) + GLOB.admin_verbs_debug_mapping)
 	add_verb(/client/proc/enable_debug_verbs)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Disable Debug Verbs") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -47,7 +47,7 @@
 		else
 			// ===== NON CONSTANT TABS (Tab names which can change) =====
 			// ===== LISTEDS TURFS =====
-			if(listed_turf && listed_turf.name == selected_tab)
+			if(listed_turf && sanitize(listed_turf.name) == selected_tab)
 				client.stat_update_mode = STAT_MEDIUM_UPDATE
 				var/list/overrides = list()
 				for(var/image/I in client.images)
@@ -173,7 +173,7 @@
 		if(!TurfAdjacent(listed_turf))
 			listed_turf = null
 		else
-			tabs |= listed_turf.name
+			tabs |= sanitize(listed_turf.name)
 	//Add spells
 	var/list/spells = mob_spell_list
 	if(mind)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #3500
Fixes mapping debug verbs from not being shown

This PR fixes minuscule bugs at TGUI stat panel. Please let me know if you have a bug that you really want to see fixed. I *might* be able to fix it.

Space not being alt-click-able was because TGUI stat panel knowing space panel as `space` while BYOND knowing it as `\improper space`. So BYOND tries to find `space` panel given by TGUI player input while it only has `\improper space`, thereby locking space panel from being opened. This PR unites misconceptions to `space`. (and any other future turf names with text macro)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Players should be able to Alt-click the space, and debuggers should be able to use every debug verbs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: you can now see space tiles' panel
fix: admins (or people with perms) can now use mapping debug verbs that requires enabling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
