### PR TITLE
Oozelings die in the pool

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -18,6 +18,7 @@
 	inherent_factions = list("slime")
 	species_language_holder = /datum/language_holder/oozeling
 	limbs_id = "ooze"
+	swimming_component = /datum/component/swimming/dissolve
 
 /datum/species/oozeling/random_name(gender,unique,lastname)
 	if(unique)

--- a/code/modules/pool/components/swimming_dissolve.dm
+++ b/code/modules/pool/components/swimming_dissolve.dm
@@ -22,6 +22,10 @@
 		var/obj/item/organ/brain = L.getorgan(/obj/item/organ/brain)
 		brain.Remove(L)	//Maybe making them completely unrecoverable is too far
 		brain.forceMove(get_turf(L))
+		//Force all items to the ground to not delete anything important.
+		for(var/obj/item/W in L)
+			L.dropItemToGround(W, TRUE)
+		//Delete the body.
 		qdel(L)
 
 /datum/component/swimming/dissolve/exit_pool()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oozelings were made after pools so weren't added in.
Makes oozelings dissolve into the pool.

## Why It's Good For The Game

Brings them up to date.

## Changelog
:cl:
add: Oozelings dissolve into the pool
fix: Items are dropped from people who dissolve in the pool.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
