### PR TITLE
Fixes rainbow slimes

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -228,12 +228,12 @@
 /mob/living/simple_animal/slime/proc/make_baby(drop_loc, new_adult, new_nutrition, new_powerlevel, force_original_colour=FALSE, step_away=TRUE,datum/component/nanites/original_nanites=null)
 	var/child_colour = colour
 	if(!force_original_colour)
-		if(prob(mutation_chance))
+		if(mutation_chance >= 100)
+			child_colour = "rainbow"
+		else if(prob(mutation_chance))
 			if(transformeffects & SLIME_EFFECT_PYRITE)
 				slime_mutation = mutation_table(pick(slime_colours - list("rainbow")))
-			else if(mutation_chance >= 100)
-				child_colour = "rainbow"
-			child_colour = slime_mutation[rand(1,4)]
+			child_colour = slime_mutation[rand(1,4)]				
 		else
 			child_colour = colour
 	var/mob/living/simple_animal/slime/M = new(drop_loc, child_colour, new_adult)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#3070 made rainbow slime impossible. This PR fixes it by making `child_colour` less shitty.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Xenobio people can now sleep soundly knowing xenobio is not very broken.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: rainbow slimes can now exist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
