### PR TITLE
Adds the Syndicate Authentication Device

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -285,3 +285,18 @@ effective or pretty fucking useless.
 	else
 		GLOB.active_jammers -= src
 	update_icon()
+
+/obj/item/faction_aligner_syndicate
+	name = "Syndicate Authentication Device"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gangtool-red"
+	item_state = "radio"
+	desc = "Used to temporarily grant individuals elite Syndicate authentication."
+	var/used_up = FALSE
+
+/obj/item/faction_aligner_syndicate/attack_self(mob/living/user)
+	if(used_up)
+	else
+		to_chat(user, "You are temporarily added to the elite Syndicate authentication database. Syndicate turrets will no longer attack you.")
+		user.faction |= "Syndicate"
+		used_up = TRUE

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1737,6 +1737,15 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	item = /obj/item/clothing/glasses/thermal/syndi
 	cost = 3
 
+/datum/uplink_item/device_tools/syndi_auth
+	name = "Syndicate Authentication Device"
+	desc = "This device grants an individual temporary authentication to Syndicate networks, preventing them being marked as hostile by turrets and other technology."
+	item = /obj/item/faction_aligner_syndicate
+	cost = 1
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
+
+
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"


### PR DESCRIPTION
## About The Pull Request

Adds the Syndicate Authentication Device to the nuke op uplink, a one-use 1 TC item which grants the individual the Syndicate faction, which mainly means Syndicate turrets won't shoot them. 

## Why It's Good For The Game

Allows various Syndicate or other antagonists to work together with nuke ops during dynamic, which adds more opportunity for variety than all antags being forced to fight nukies because they otherwise are unlikely to escape alive. 

## Changelog
:cl:
add: Adds the Syndicate Authentication Device to the nuke op uplink, which prevents an individual from being targeted by Syndicate turrets. 
/:cl: