### PR TITLE
Emags now unbolt external airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -95,6 +95,7 @@
 	var/list/part_overlays
 	var/panel_attachment = "right"
 	var/note_attachment = "left"
+	var/emag_unbolt = FALSE
 
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
@@ -1339,6 +1340,8 @@
 		operating = TRUE
 		update_icon(AIRLOCK_EMAG, 1)
 		sleep(6)
+		if(emag_unbolt)
+			unbolt()
 		if(QDELETED(src))
 			return
 		operating = FALSE

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -340,6 +340,7 @@
 	anim_parts = "top=0,16;bottom=0,-16"
 	note_attachment = "bottom"
 	panel_attachment = "bottom"
+	emag_unbolt = TRUE
 
 /obj/machinery/door/airlock/arrivals_external
 	name = "arrivals airlock"


### PR DESCRIPTION
## About The Pull Request

External airlocks now unbolt when emagged. Normal airlock emag behaviour is unchanged.

## Why It's Good For The Game

External airlocks being bolted by default now means it's currently much slower and detectable for a nukie to enter the station (and emags are now far less useful for them), and prevents traitors easily making a quick escape to space. 

## Changelog
:cl:
balance: Emags now unbolt external airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
