### PR TITLE
Add turret control panel to the syndicate shuttle

### DIFF
--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -167,13 +167,13 @@
 	},
 /obj/machinery/turretid{
 	ailock = 1;
-	dir = 1;
+	desc = "Used to control the shuttle's automated defenses.";
 	icon_state = "control_kill";
 	lethal = 1;
-	name = "Infiltrator turret controls";
+	name = "infiltrator turret controls";
 	pixel_y = -30;
 	req_access = null;
-	req_access_txt = "150"
+	req_access_txt = "151"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/bridge)

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -173,7 +173,7 @@
 	name = "infiltrator turret controls";
 	pixel_y = -30;
 	req_access = null;
-	req_access_txt = "151"
+	req_access_txt = "150"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/bridge)

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -11,12 +11,6 @@
 "ac" = (
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/bridge)
-"ad" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
-	dir = 10
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/hallway)
 "ae" = (
 /obj/structure/window/plastitanium,
 /obj/machinery/door/poddoor/shutters{
@@ -167,11 +161,22 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/bridge)
 "aw" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/eva)
+/obj/machinery/turretid{
+	ailock = 1;
+	dir = 1;
+	icon_state = "control_kill";
+	lethal = 1;
+	name = "Infiltrator turret controls";
+	pixel_y = -30;
+	req_access = null;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/syndicate/bridge)
 "ax" = (
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/eva)
@@ -264,18 +269,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/hallway)
-"aF" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/armory)
-"aG" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
-	dir = 9
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/medical)
 "aH" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4;
@@ -1173,7 +1166,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/armory)
+/area/shuttle/syndicate/bridge)
 "pd" = (
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 5
@@ -1185,18 +1178,12 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/eva)
-"In" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
-	dir = 6
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/hallway)
 "MJ" = (
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/medical)
+/area/shuttle/syndicate/bridge)
 
 (1,1,1) = {"
 aa
@@ -1212,7 +1199,7 @@ aa
 aa
 aa
 aa
-aG
+ab
 aJ
 aJ
 aJ
@@ -1231,7 +1218,7 @@ aa
 aa
 aa
 aa
-aw
+ab
 ax
 ax
 ax
@@ -1329,7 +1316,7 @@ ag
 an
 at
 ac
-ad
+dp
 aa
 ax
 aN
@@ -1427,7 +1414,7 @@ aa
 ae
 ak
 ap
-at
+aw
 ac
 aA
 aE
@@ -1479,7 +1466,7 @@ am
 as
 at
 ac
-In
+MJ
 aa
 aB
 aO
@@ -1581,7 +1568,7 @@ aa
 aa
 aa
 aa
-aF
+pd
 aB
 aB
 aY
@@ -1612,7 +1599,7 @@ aa
 aa
 aa
 aa
-aF
+pd
 bm
 bm
 bm

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -572,7 +572,7 @@
 	if(controllock)
 		return
 	src.on = on
-	if(!on)
+	if(!on && !always_up)
 		popDown()
 	src.mode = mode
 	power_change()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -887,7 +887,7 @@
 	locked = FALSE
 
 /obj/machinery/turretid/attack_robot(mob/user)
-	if(!ailock || IsAdminGhost(user))
+	if(!ailock)
 		return attack_hand(user)
 	else
 		to_chat(user, "<span class='notice'>There seems to be a firewall preventing you from accessing this device.</span>")

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -715,7 +715,6 @@
 	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 80, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 
 /obj/machinery/porta_turret/syndicate/shuttle/target(atom/movable/target)
-	..()
 	if(target)
 		setDir(get_dir(base, target))//even if you can't shoot, follow the target
 		shootAt(target)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -715,6 +715,7 @@
 	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 80, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 
 /obj/machinery/porta_turret/syndicate/shuttle/target(atom/movable/target)
+	..()
 	if(target)
 		setDir(get_dir(base, target))//even if you can't shoot, follow the target
 		shootAt(target)
@@ -809,7 +810,7 @@
 	var/locked = TRUE
 	 /// An area in which linked turrets are located, it can be an area name, path or nothing
 	var/control_area = null
-	 /// AI is unable to use this machine if set to TRUE
+	 /// Silicons are unable to use this machine if set to TRUE
 	var/ailock = FALSE
 	/// Variable dictating if linked turrets will shoot cyborgs
 	var/shoot_cyborgs = FALSE
@@ -885,6 +886,12 @@
 	to_chat(user, "<span class='danger'>You short out the turret controls' access analysis module.</span>")
 	obj_flags |= EMAGGED
 	locked = FALSE
+
+/obj/machinery/turretid/attack_robot(mob/user)
+	if(!ailock || IsAdminGhost(user))
+		return attack_hand(user)
+	else
+		to_chat(user, "<span class='notice'>There seems to be a firewall preventing you from accessing this device.</span>")
 
 /obj/machinery/turretid/attack_ai(mob/user)
 	if(!ailock || IsAdminGhost(user))


### PR DESCRIPTION
## About The Pull Request

The syndicate shuttle now has a turret control panel, allowing the nuke team to control their turrets. It is locked behind syndicate access (150) and can't be deactivated by robots. Turrets  start on by default, so there is no gameplay change if you ignore it entirely.

## Why It's Good For The Game

Allows you to invite the captain onto your ominous armoured battleship for a pleasant tea party

## Changelog
:cl:
add: Added a turret control panel to the nuclear shuttle
/:cl: