### PR TITLE
Adds the Snake Operative Kit

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1700,6 +1700,7 @@
 #include "code\modules\client\verbs\who.dm"
 #include "code\modules\clothing\chameleon.dm"
 #include "code\modules\clothing\clothing.dm"
+#include "code\modules\clothing\snakeop.dm"
 #include "code\modules\clothing\ears\_ears.dm"
 #include "code\modules\clothing\glasses\_glasses.dm"
 #include "code\modules\clothing\glasses\engine_goggles.dm"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -279,3 +279,4 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define BATTLE_ROYALE_TRAIT "battleroyale_trait"
 #define MADE_UNCLONEABLE "made-uncloneable"
 #define TRAIT_JAWS_OF_LIFE "jaws-of-life"
+#define TRAIT_SNAKEOP "snake-op"

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -192,7 +192,8 @@
 			if(I && D.temporarilyRemoveItemFromInventory(I))
 				A.put_in_hands(I)
 			D.Jitter(2)
-			D.apply_damage(5, A.dna.species.attack_type, blocked = def_check)
+			if(!HAS_TRAIT(A, TRAIT_PACIFISM))
+				D.apply_damage(5, A.dna.species.attack_type, blocked = def_check)
 	else
 		D.visible_message("<span class='danger'>[A] fails to disarm [D]!</span>", \
 							"<span class='userdanger'>[A] fails to disarm you!</span>", null, COMBAT_MESSAGE_RANGE)
@@ -221,6 +222,7 @@
 	to_chat(usr, "<span class='notice'>CQC Kick</span>: Harm Harm. Knocks opponent away. Knocks out stunned or knocked down opponents.")
 	to_chat(usr, "<span class='notice'>Restrain</span>: Grab Grab. Locks opponents into a restraining position, disarm to knock them out with a chokehold.")
 	to_chat(usr, "<span class='notice'>Pressure</span>: Disarm Grab. Decent stamina damage.")
+	to_chat(usr, "<span class='notice'>Chokehold</span>: Grab Grab Disarm. Puts your opponent to sleep.")
 	to_chat(usr, "<span class='notice'>Consecutive CQC</span>: Disarm Disarm Harm. Mainly offensive move, huge damage and decent stamina damage.")
 
 	to_chat(usr, "<b><i>In addition, by having your throw mode on when being attacked, you enter an active defense mode where you have a chance to block and sometimes even counter attacks done to you.</i></b>")

--- a/code/modules/clothing/snakeop.dm
+++ b/code/modules/clothing/snakeop.dm
@@ -1,0 +1,77 @@
+/obj/item/snake_op_transform
+	name = "Snake Operative Device"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gangtool-red"
+	item_state = "radio"
+	desc = "Pacifies you and grants you all the gear of a true stealth agent. Instant clotheswap not at all reverse-engineered from magical girl animes."
+	var/used_up = FALSE
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/snake_op_transform/attack_self(mob/user)
+	if(used_up)
+	else
+		to_chat(user,"<span class='notice'>You activate the Snake Operative Device. You've been given fast-track access to elite Syndicate technology, good luck out there soldier.</span>")
+		var/mob/living/carbon/human/H = user
+		if(ishuman(user))
+			ADD_TRAIT(user, TRAIT_PACIFISM, TRAIT_SNAKEOP)
+			ADD_TRAIT(user, TRAIT_ALWAYS_CLEAN, TRAIT_SNAKEOP)
+
+			user.dropItemToGround(H.w_uniform)
+			user.dropItemToGround(H.wear_mask)
+			user.dropItemToGround(H.glasses)
+			user.dropItemToGround(H.gloves)
+			user.dropItemToGround(H.shoes)
+			user.dropItemToGround(H.belt)
+			user.dropItemToGround(H.shoes)
+			user.dropItemToGround(H.wear_id)
+			user.dropItemToGround(H.back)
+			user.equip_to_slot_or_del(new /obj/item/clothing/under/syndicate/combat/snake(user), SLOT_W_UNIFORM)
+			user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/syndicate/snake(user), SLOT_WEAR_MASK)
+			user.equip_to_slot_or_del(new /obj/item/clothing/glasses/night(user), SLOT_GLASSES)
+			user.equip_to_slot_or_del(new /obj/item/clothing/gloves/combat/snake(user), SLOT_GLOVES)
+			user.equip_to_slot_or_del(new /obj/item/clothing/shoes/combat/snake(user), SLOT_SHOES)
+			user.equip_to_slot_or_del(new /obj/item/storage/belt/military/assault(user), SLOT_BELT)
+			user.equip_to_slot_or_del(new /obj/item/card/id/syndicate(user), SLOT_WEAR_ID)
+			user.equip_to_slot_or_del(new /obj/item/storage/backpack/duffelbag/syndie/snake(user), SLOT_BACK)
+			user.equip_to_slot_or_del(new /obj/item/book/granter/martial/cqc(user), SLOT_IN_BACKPACK)
+			user.equip_to_slot_or_del(new /obj/item/chameleon(user), SLOT_IN_BACKPACK)
+			user.equip_to_slot_or_del(new /obj/item/storage/box/syndie_kit/space(user), SLOT_IN_BACKPACK)
+
+			used_up = TRUE
+
+/obj/item/clothing/under/syndicate/combat/snake
+    resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/item/clothing/under/syndicate/combat/snake/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_SNAKEOP)
+
+/obj/item/clothing/mask/gas/syndicate/snake
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	flags_cover = MASKCOVERSEYES //can eat through it
+	visor_flags_cover = MASKCOVERSEYES //unnecessary?
+
+/obj/item/clothing/mask/gas/syndicate/snake/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_SNAKEOP)
+
+/obj/item/clothing/gloves/combat/snake
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/item/clothing/gloves/combat/snake/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_SNAKEOP)
+
+/obj/item/clothing/shoes/combat/snake
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/item/clothing/shoes/combat/snake/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_SNAKEOP)
+
+/obj/item/storage/backpack/duffelbag/syndie/snake
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/item/storage/backpack/duffelbag/syndie/snake/Initialize()
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, TRAIT_SNAKEOP)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -261,6 +261,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/bundles_TC/snake_op
+	name = "Snake Operative Kit"
+	desc = "Exclusive access to everything you need to be a Snake Operative including CQC Manual, Chameleon Projector, Space Suit and a full Syndicate outfit. \
+			Warning: in exchange for this fast-track access you'll be forbidden from using these elite techniques to kill anyone (which is enforced through pacification), \
+			and you won't be allowed to remove several clothing items. Make your mark and don't let them see you coming!"
+	item = /obj/item/snake_op_transform
+	cost = 20
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
 /datum/uplink_item/bundles_TC/surplus
 	name = "Syndicate Surplus Crate"
 	desc = "A dusty crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \


### PR DESCRIPTION
## About The Pull Request

Wasn't sure whether to put this under Badassery or Bundles categories.

The 20 TC Snake Operative Kit is intended to make you feel like a badass Solid Snake at taking down opponents - with a cost. 

The first and most notable weakness is if you get this kit you will be pacified. The second is that several of the outfit pieces are no-drop, and highly obvious Syndicate gear. These downsides are to limit how robust this kit is, and make it more of a hardmode which requires a certain style of play. 

**Included in this kit is:**
- CQC Manual (you'll basically only be able to use the Chokehold)
- Chameleon Projector
- Syndicate Space Suit box
- Agent ID
- *No-drop clothing pieces:* combat uniform, syndicate mask, combat gloves, combat boots and syndicate duffel bag.
- *Removable clothing:* night vision goggles and assault belt.

All in all you'll be forced to look like a validman at all times, but with the NVGs, chameleon projector and CQC you'll be a superb ambusher and able to quickly knock out any Assistant validhunting you. Good for those who are very patient, or alternatively for those who want to show off how robust they are. 

![](https://i.imgur.com/ZDY79Wb.png)

## Why It's Good For The Game

New kit forces an interesting style of stealth antag which is fairly lacking at the moment, and also gives a way for the most robust to show off just how they good they are by being pacified and looking like a valid always. 

## Changelog
:cl:
add: Adds the Snake Operative Kit for 20 TC. Includes CQC, a cham projector and a number of other items, however you are also pacified and several clothing items are no-drop. 
/:cl:
