### PR TITLE
Adds vault door to gulag

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -5179,16 +5179,16 @@
 /area/mine/science)
 "KZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Monitoring";
-	req_access_txt = "2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/vault{
+	name = "Labor Camp Monitoring";
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)


### PR DESCRIPTION
## About The Pull Request

<strike>I have no idea when or why the vault door between gulag and security/mining was removed (or if it was even intentional)</strike>, but it made escaping ridiculously easy. <strike>Re-</strike>adds the labor camp monitoring vault door

## Why It's Good For The Game

Above, gulag should be at least _somewhat_ challenging to escape.

## Changelog
:cl:
add: adds the labor camp monitoring vault door
/:cl:

