### PR TITLE
Heretic Sickly Blade is a Summon Spell

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -30,35 +30,6 @@
 	if(target.stat == DEAD)
 		to_chat(user,"<span class='warning'>[target.real_name] is dead. Bring them onto a transmutation rune!</span>")
 
-/datum/action/innate/heretic_shatter
-	name = "Shattering Offer"
-	desc = "By breaking your blade you are noticed by the hill or rust and are granted an escape from a dire sitatuion. (Teleports you to a random safe z turf on your current z level but destroys your blade.)"
-	background_icon_state = "bg_ecult"
-	button_icon_state = "shatter"
-	icon_icon = 'icons/mob/actions/actions_ecult.dmi'
-	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN
-	var/mob/living/carbon/human/holder
-	var/obj/item/melee/sickly_blade/sword
-
-/datum/action/innate/heretic_shatter/Grant(mob/user, obj/object)
-	sword = object
-	holder = user
-	//i know what im doing
-	return ..()
-
-/datum/action/innate/heretic_shatter/IsAvailable()
-	if(IS_HERETIC(holder) || IS_HERETIC_MONSTER(holder))
-		return TRUE
-	else
-		return FALSE
-
-/datum/action/innate/heretic_shatter/Activate()
-	var/turf/safe_turf = find_safe_turf(zlevels = sword.z, extended_safety_checks = TRUE)
-	do_teleport(holder,safe_turf,forceMove = TRUE)
-	to_chat(holder,"<span class='warning'> You feel a gust of energy flow through your body, Rusted Hills heard your call...")
-	qdel(sword)
-
-
 /obj/item/melee/sickly_blade
 	name = "Sickly blade"
 	desc = "A sickly green crescent blade, decorated with an ornamental eye. You feel like you're being watched..."
@@ -71,17 +42,12 @@
 	inhand_y_dimension = 64
 	flags_1 = CONDUCT_1
 	sharpness = IS_SHARP
-	w_class = WEIGHT_CLASS_NORMAL
-	force = 24
+	w_class = WEIGHT_CLASS_BULKY
+	force = 21
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
-	var/datum/action/innate/heretic_shatter/linked_action
-
-/obj/item/melee/sickly_blade/Initialize()
-	. = ..()
-	linked_action = new(src)
-
+	
 /obj/item/melee/sickly_blade/attack(mob/living/M, mob/living/user)
 	if(!(IS_HERETIC(user) || IS_HERETIC_MONSTER(user)))
 		to_chat(user,"<span class='danger'>You feel a pulse of some alien intellect lash out at your mind!</span>")
@@ -89,14 +55,6 @@
 		human_user.AdjustParalyzed(5 SECONDS)
 		return FALSE
 	return ..()
-
-/obj/item/melee/sickly_blade/pickup(mob/user)
-	. = ..()
-	linked_action.Grant(user, src)
-
-/obj/item/melee/sickly_blade/dropped(mob/user, silent)
-	. = ..()
-	linked_action.Remove(user, src)
 
 /obj/item/melee/sickly_blade/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -228,7 +228,7 @@
 	name = "Break of dawn"
 	desc = "Starts your journey in the mansus. Allows you to select a target using a living heart on a transmutation rune."
 	gain_text = "Gates of mansus open up to your mind."
-	next_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh)
+	next_knowledge = list(/datum/eldritch_knowledge/spell/base_rust,/datum/eldritch_knowledge/spell/base_ash,/datum/eldritch_knowledge/spell/base_flesh)
 	cost = 0
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/touch/mansus_grasp
 	required_atoms = list(/obj/item/living_heart)

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -605,3 +605,19 @@
 	range = 10
 	invocation = "E'E'S"
 	action_background_icon_state = "bg_ecult"
+	
+/obj/effect/proc_holder/spell/targeted/conjure_item/heretic_blade
+	name = "Sickly blade"
+	desc = "Summons a sickly blade infused with the blessing of your gods, that has different effects depending on your path."
+	invocation_type = "none"
+	include_user = TRUE
+	range = -1
+	clothes_req = FALSE
+	item_type = /obj/item/melee/sickly_blade
+
+	school = "conjuration"
+	charge_max = 150
+	cooldown_min = 10
+	action_icon = 'icons/obj/eldritch.dmi'
+	action_icon_state = "eldritch_blade"
+	action_background_icon_state = "bg_ecult"

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -1,13 +1,17 @@
-/datum/eldritch_knowledge/base_ash
+/datum/eldritch_knowledge/spell/base_ash
 	name = "Nightwatcher's secret"
 	desc = "Opens up the path of ash to you. Allows you to transmute a match with a kitchen knife or it's derivatives into an ashen blade."
 	gain_text = "City guard knows their watch. If you ask them at night they may tell you about the ashy lantern."
-	banned_knowledge = list(/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/final/rust_final,/datum/eldritch_knowledge/final/flesh_final)
+	banned_knowledge = list(/datum/eldritch_knowledge/spell/base_rust,/datum/eldritch_knowledge/spell/base_flesh,/datum/eldritch_knowledge/final/rust_final,/datum/eldritch_knowledge/final/flesh_final)
 	next_knowledge = list(/datum/eldritch_knowledge/ashen_grasp)
-	required_atoms = list(/obj/item/kitchen/knife,/obj/item/match)
-	result_atoms = list(/obj/item/melee/sickly_blade/ash)
+	spell_to_add = /obj/effect/proc_holder/spell/targeted/conjure_item/heretic_blade/ash
 	cost = 1
 	route = PATH_ASH
+	
+/obj/effect/proc_holder/spell/targeted/conjure_item/heretic_blade/ash
+	name = "Ashen Blade"
+	item_type = /obj/item/melee/sickly_blade/ash
+	action_icon_state = "flesh_blade"
 
 /datum/eldritch_knowledge/spell/ashen_shift
 	name = "Ashen Shift"

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -1,13 +1,17 @@
-/datum/eldritch_knowledge/base_flesh
+/datum/eldritch_knowledge/spell/base_flesh
 	name = "Principle of Hunger"
 	desc = "Opens up the path of flesh to you. Allows you to transmute a pool of blood with a kitchen knife into a Flesh Blade"
 	gain_text = "Hundred's of us starved, but I.. I found the strength in my greed."
-	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_rust,/datum/eldritch_knowledge/final/ash_final,/datum/eldritch_knowledge/final/rust_final)
+	banned_knowledge = list(/datum/eldritch_knowledge/spell/base_ash,/datum/eldritch_knowledge/spell/base_rust,/datum/eldritch_knowledge/final/ash_final,/datum/eldritch_knowledge/final/rust_final)
 	next_knowledge = list(/datum/eldritch_knowledge/flesh_grasp)
-	required_atoms = list(/obj/item/kitchen/knife,/obj/effect/decal/cleanable/blood)
-	result_atoms = list(/obj/item/melee/sickly_blade/flesh)
+	spell_to_add = /obj/effect/proc_holder/spell/targeted/conjure_item/heretic_blade/flesh
 	cost = 1
 	route = PATH_FLESH
+	
+/obj/effect/proc_holder/spell/targeted/conjure_item/heretic_blade/flesh
+	name = "Flesh Blade"
+	item_type = /obj/item/melee/sickly_blade/flesh
+	action_icon_state = "flesh_blade"
 
 /datum/eldritch_knowledge/flesh_ghoul
 	name = "Imperfect Ritual"

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -1,13 +1,17 @@
-/datum/eldritch_knowledge/base_rust
+/datum/eldritch_knowledge/spell/base_rust
 	name = "Blacksmith's Tale"
 	desc = "Opens up the path of rust to you. Allows you to transmute a knife with any trash item into a Rusty Blade."
 	gain_text = "Let me tell you a story, blacksmith said as he glazed into his rusty blade."
-	banned_knowledge = list(/datum/eldritch_knowledge/base_ash,/datum/eldritch_knowledge/base_flesh,/datum/eldritch_knowledge/final/ash_final,/datum/eldritch_knowledge/final/flesh_final)
+	banned_knowledge = list(/datum/eldritch_knowledge/spell/base_ash,/datum/eldritch_knowledge/spell/base_flesh,/datum/eldritch_knowledge/final/ash_final,/datum/eldritch_knowledge/final/flesh_final)
 	next_knowledge = list(/datum/eldritch_knowledge/rust_fist)
-	required_atoms = list(/obj/item/kitchen/knife,/obj/item/trash)
-	result_atoms = list(/obj/item/melee/sickly_blade/rust)
+	spell_to_add = /obj/effect/proc_holder/spell/targeted/conjure_item/heretic_blade/rust
 	cost = 1
 	route = PATH_RUST
+	
+/obj/effect/proc_holder/spell/targeted/conjure_item/heretic_blade/rust
+	name = "Rusty Blade"
+	item_type = /obj/item/melee/sickly_blade/rust
+	action_icon_state = "rust_blade"
 
 /datum/eldritch_knowledge/rust_fist
 	name = "Grasp of rust"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks the heretic blades to be a summon spell, instead of craftable items. How it works, you can summon and unsummon the blade via spell.
Nerfed the blade; it's large and deals less damage.

## Why It's Good For The Game

Heretic blade is easy to craft and not particularly interesting. Also it's very obvious and hard to hide.

This is just an idea. Open to feedback.

## Changelog
:cl:
add: Heretics can seathe/unseathe their blade with a spell; it is no longer a craftable item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
