### PR TITLE
[PORT] 2 PRs from Project>Features, missed file change

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57239,6 +57239,11 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"qCe" = (
+/obj/effect/turf_decal/tile/blue,
+/mob/living/simple_animal/bot/cleanbot/medbay,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qDU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -98566,7 +98571,7 @@ bqV
 bEe
 bBL
 bwA
-xQL
+qCe
 cfZ
 clh
 ctp

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90011,17 +90011,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"cWw" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/mob/living/simple_animal/bot/cleanbot{
-	name = "C.L.E.A.N.";
-	trash = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "cWx" = (
 /obj/machinery/light_switch{
 	pixel_x = 26;
@@ -124825,6 +124814,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"sTA" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/mob/living/simple_animal/bot/cleanbot/medbay,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "sTI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -173297,7 +173294,7 @@ cPF
 cRh
 cSU
 cRh
-cWw
+sTA
 cSS
 smY
 dbt

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -39330,23 +39330,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"beQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/mob/living/simple_animal/bot/cleanbot{
-	name = "Scrubs, MD";
-	on = 0
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/storage)
 "beR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -100587,6 +100570,20 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
+"uJN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/mob/living/simple_animal/bot/cleanbot/medbay,
+/turf/open/floor/plasteel/dark,
+/area/medical/storage)
 "wLw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -117936,7 +117933,7 @@ aPA
 aPa
 aON
 aQm
-beQ
+uJN
 aOV
 aQn
 aUL

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56462,23 +56462,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"cfN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/mob/living/simple_animal/bot/cleanbot{
-	name = "Scrubs, MD";
-	trash = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/storage)
 "cfO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue,
@@ -85373,6 +85356,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"qsO" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/mob/living/simple_animal/bot/cleanbot/medbay,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "qze" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -110297,7 +110294,7 @@ cab
 cbN
 cdt
 cex
-cfN
+qsO
 cgV
 cim
 cjM

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35292,13 +35292,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/medical/virology)
-"bBb" = (
-/obj/effect/turf_decal/stripes/line,
-/mob/living/simple_animal/bot/cleanbot{
-	name = "McSweepsky"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "bBc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -56387,6 +56380,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"hjz" = (
+/obj/effect/turf_decal/stripes/line,
+/mob/living/simple_animal/bot/cleanbot/medbay,
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "hjR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/brown{
@@ -93170,7 +93168,7 @@ bwH
 rAZ
 bzR
 bzR
-bBb
+hjz
 bDr
 bEx
 bkh

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -137,7 +137,7 @@
 	return primary_mat
 
 /// Proc for putting a stack inside of the container
-/datum/component/material_container/proc/insert_stack(obj/item/stack/S, amt, multiplier = 1) 
+/datum/component/material_container/proc/insert_stack(obj/item/stack/S, amt, multiplier = 1)
 	if(isnull(amt))
 		amt = S.amount
 
@@ -160,7 +160,7 @@
 	return amt
 
 /// For inserting an amount of material
-/datum/component/material_container/proc/insert_amount_mat(amt, var/datum/material/mat) 
+/datum/component/material_container/proc/insert_amount_mat(amt, var/datum/material/mat)
 	if(!istype(mat))
 		mat = getmaterialref(mat)
 	if(amt > 0 && has_space(amt))
@@ -175,7 +175,7 @@
 	return FALSE
 
 /// Uses an amount of a specific material, effectively removing it.
-/datum/component/material_container/proc/use_amount_mat(amt, var/datum/material/mat) 
+/datum/component/material_container/proc/use_amount_mat(amt, var/datum/material/mat)
 	if(!istype(mat))
 		mat = getmaterialref(mat)
 	var/amount = materials[mat]
@@ -187,7 +187,7 @@
 	return FALSE
 
 /// Proc for transfering materials to another container.
-/datum/component/material_container/proc/transer_amt_to(var/datum/component/material_container/T, amt, var/datum/material/mat) 
+/datum/component/material_container/proc/transer_amt_to(var/datum/component/material_container/T, amt, var/datum/material/mat)
 	if(!istype(mat))
 		mat = getmaterialref(mat)
 	if((amt==0)||(!T)||(!mat))
@@ -216,7 +216,7 @@
 /datum/component/material_container/proc/use_materials(list/mats, multiplier=1)
 	if(!mats || !length(mats))
 		return FALSE
-	
+
 	var/list/mats_to_remove = list() //Assoc list MAT | AMOUNT
 
 	for(var/x in mats) //Loop through all required materials
@@ -230,7 +230,7 @@
 			return FALSE //Can't afford it
 		mats_to_remove[req_mat] += amount_required //Add it to the assoc list of things to remove
 		continue
-		
+
 	var/total_amount_save = total_amount
 
 	for(var/i in mats_to_remove)
@@ -239,7 +239,7 @@
 	return total_amount_save - total_amount
 
 /// For spawning mineral sheets at a specific location. Used by machines to output sheets.
-/datum/component/material_container/proc/retrieve_sheets(sheet_amt, var/datum/material/M, target = null) 
+/datum/component/material_container/proc/retrieve_sheets(sheet_amt, var/datum/material/M, target = null)
 	if(!M.sheet_type)
 		return 0 //Add greyscale sheet handling here later
 	if(sheet_amt <= 0)
@@ -263,7 +263,7 @@
 
 
 /// Proc to get all the materials and dump them as sheets
-/datum/component/material_container/proc/retrieve_all(target = null) 
+/datum/component/material_container/proc/retrieve_all(target = null)
 	var/result = 0
 	for(var/MAT in materials)
 		var/amount = materials[MAT]
@@ -286,18 +286,18 @@
 				req_mat = getmaterialref(req_mat) //Get the ref
 
 			else // Its a category. (For example MAT_CATEGORY_RIGID)
-				if(!has_enough_of_category(req_mat, mats[req_mat], multiplier)) //Do we have enough of this category?
+				if(!has_enough_of_category(req_mat, mats[x], multiplier)) //Do we have enough of this category?
 					return FALSE
 				else
 					continue
 
-		if(!has_enough_of_material(req_mat, mats[req_mat], multiplier))//Not a category, so just check the normal way
+		if(!has_enough_of_material(req_mat, mats[x], multiplier))//Not a category, so just check the normal way
 			return FALSE
 
 	return TRUE
 
 /// Returns all the categories in a recipe.
-/datum/component/material_container/proc/get_categories(list/mats) 
+/datum/component/material_container/proc/get_categories(list/mats)
 	var/list/categories = list()
 	for(var/x in mats) //Loop through all required materials
 		if(!istext(x)) //This means its not a category
@@ -307,12 +307,12 @@
 
 
 /// Returns TRUE if you have enough of the specified material.
-/datum/component/material_container/proc/has_enough_of_material(var/datum/material/req_mat, amount, multiplier=1) 
+/datum/component/material_container/proc/has_enough_of_material(var/datum/material/req_mat, amount, multiplier=1)
 	if(!materials[req_mat]) //Do we have the resource?
 		return FALSE //Can't afford it
 	var/amount_required = amount * multiplier
 	if(materials[req_mat] >= amount_required) // do we have enough of the resource?
-		return TRUE 
+		return TRUE
 	return FALSE //Can't afford it
 
 /// Returns TRUE if you have enough of a specified material category (Which could be multiple materials)
@@ -324,7 +324,7 @@
 	return FALSE
 
 /// Turns a material amount into the amount of sheets it should output
-/datum/component/material_container/proc/amount2sheet(amt) 
+/datum/component/material_container/proc/amount2sheet(amt)
 	if(amt >= MINERAL_MATERIAL_AMOUNT)
 		return round(amt / MINERAL_MATERIAL_AMOUNT)
 	return FALSE
@@ -346,7 +346,7 @@
 	return material_amount
 
 /// Returns the amount of a specific material in this container.
-/datum/component/material_container/proc/get_material_amount(var/datum/material/mat) 
+/datum/component/material_container/proc/get_material_amount(var/datum/material/mat)
 	if(!istype(mat))
 		mat = getmaterialref(mat)
 	return(materials[mat])

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -50,11 +50,11 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/toy/eldrich_book = 1,
 		/obj/item/storage/belt/military/snack = 2,
 		/obj/item/choice_beacon/pet/cat = 1,
-		/obj/item/choice_beacon/pet/mouse = 1,	
+		/obj/item/choice_beacon/pet/mouse = 1,
 		/obj/item/choice_beacon/pet/corgi = 1,
-		/obj/item/choice_beacon/pet/hamster = 1,	
-		/obj/item/choice_beacon/pet/pug = 1,		
-		/obj/item/choice_beacon/pet/pingu = 1,	
+		/obj/item/choice_beacon/pet/hamster = 1,
+		/obj/item/choice_beacon/pet/pug = 1,
+		/obj/item/choice_beacon/pet/pingu = 1,
 		/obj/item/choice_beacon/pet/clown = 1))
 
 /obj/machinery/computer/arcade
@@ -351,6 +351,15 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 // *** THE ORION TRAIL ** //
 
+/obj/item/gamer_pamphlet
+	name = "pamphlet - \'Violent Video Games and You\'"
+	desc = "A pamphlet encouraging the reader to maintain a balanced lifestyle and take care of their mental health, while still enjoying video games in a healthy way. You probably don't need this..."
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "pamphlet"
+	item_state = "paper"
+	w_class = WEIGHT_CLASS_TINY
+
+
 #define ORION_TRAIL_WINTURN		9
 
 //Orion Trail Events
@@ -407,6 +416,16 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	var/gameStatus = ORION_STATUS_START
 	var/canContinueEvent = 0
 
+	var/obj/item/radio/Radio
+	var/list/gamers = list()
+	var/killed_crew = 0
+
+
+/obj/machinery/computer/arcade/orion_trail/Initialize()
+	. = ..()
+	Radio = new /obj/item/radio(src)
+	Radio.listening = 0
+
 /obj/machinery/computer/arcade/orion_trail/kobayashi
 	name = "Kobayashi Maru control computer"
 	desc = "A test for cadets"
@@ -448,11 +467,44 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	event = null
 	gameStatus = ORION_STATUS_NORMAL
 	lings_aboard = 0
+	killed_crew = 0
 
 	//spaceport junk
 	spaceport_raided = 0
 	spaceport_freebie = 0
 	last_spaceport_action = ""
+
+/obj/machinery/computer/arcade/orion_trail/proc/report_player(mob/gamer)
+	if(gamers[gamer] == -2)
+		return // enough harassing them
+
+	if(gamers[gamer] == -1)
+		say("WARNING: Continued antisocial behavior detected: Dispensing self-help literature.")
+		new /obj/item/gamer_pamphlet(get_turf(src))
+		gamers[gamer]--
+		return
+
+	if(!(gamer in gamers))
+		gamers[gamer] = 0
+
+	gamers[gamer]++ // How many times the player has 'prestiged' (massacred their crew)
+
+	if(gamers[gamer] > 2 && prob(20 * gamers[gamer]))
+
+		Radio.set_frequency(FREQ_SECURITY)
+		Radio.talk_into(src, "SECURITY ALERT: Crewmember [gamer] recorded displaying antisocial tendencies in [get_area(src)]. Please watch for violent behavior.", FREQ_SECURITY)
+
+		Radio.set_frequency(FREQ_MEDICAL)
+		Radio.talk_into(src, "PSYCH ALERT: Crewmember [gamer] recorded displaying antisocial tendencies in [get_area(src)]. Please schedule psych evaluation.", FREQ_MEDICAL)
+
+		gamers[gamer] = -1
+
+		if(!isnull(GLOB.data_core.general))
+			for(var/datum/data/record/R in GLOB.data_core.general)
+				if(R.fields["name"] == gamer.name)
+					R.fields["m_stat"] = "*Unstable*"
+					return
+
 
 /obj/machinery/computer/arcade/orion_trail/ui_interact(mob/user)
 	. = ..()
@@ -685,6 +737,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		if(gameStatus == ORION_STATUS_NORMAL || event == ORION_TRAIL_LING)
 			var/sheriff = remove_crewmember() //I shot the sheriff
 			playsound(loc,'sound/weapons/gunshot.ogg', 100, 1)
+			killed_crew++
 
 			if(settlers.len == 0 || alive == 0)
 				say("The last crewmember [sheriff], shot themselves, GAME OVER!")
@@ -693,6 +746,11 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 					obj_flags &= EMAGGED
 				gameStatus = ORION_STATUS_GAMEOVER
 				event = null
+
+
+				if(killed_crew >= 4)
+					report_player(usr)
+
 			else if(obj_flags & EMAGGED)
 				if(usr.name == sheriff)
 					say("The crew of the ship chose to kill [usr.name]!")
@@ -700,6 +758,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 
 			if(event == ORION_TRAIL_LING) //only ends the ORION_TRAIL_LING event, since you can do this action in multiple places
 				event = null
+				killed_crew-- // the kill was valid
 
 	//Spaceport specific interactions
 	//they get a header because most of them don't reset event (because it's a shop, you leave when you want to)
@@ -712,6 +771,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 				fuel -= 10
 				food -= 10
 				event()
+				killed_crew-- // I mean not really but you know
 
 	else if(href_list["sellcrew"]) //sell a crewmember
 		if(gameStatus == ORION_STATUS_MARKET)

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -417,7 +417,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	var/canContinueEvent = 0
 
 	var/obj/item/radio/Radio
-	var/list/gamers = list()
+	var/static/list/gamers = list()
 	var/killed_crew = 0
 
 

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -274,6 +274,11 @@
 	do_sparks(3, TRUE, src)
 	..()
 
+/mob/living/simple_animal/bot/cleanbot/medbay
+	name = "Scrubs, MD"
+	bot_core_type = /obj/machinery/bot_core/cleanbot/medbay
+	on = FALSE
+
 /obj/machinery/bot_core/cleanbot
 	req_one_access = list(ACCESS_JANITOR, ACCESS_ROBOTICS)
 
@@ -309,3 +314,6 @@ Maintenance panel panel is [open ? "opened" : "closed"]"})
 				drawn = !drawn
 		get_targets()
 		update_controls()
+
+/obj/machinery/bot_core/cleanbot/medbay
+	req_one_access = list(ACCESS_JANITOR, ACCESS_ROBOTICS, ACCESS_MEDICAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Didn't think they warranted 3 separate PRs. 

Ports from Things to Port:
1 .[Reports problematic video game behaviour to the authorities](https://github.com/tgstation/tgstation/pull/47426)
2. [Doctors can interact with Scrubs, MD](https://github.com/tgstation/tgstation/pull/48471)
1.https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29397952
2.https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-31064949

Missed file change for the ore silo linking:
3. [[PORT] RCD ore silo link](https://github.com/BeeStation/BeeStation-Hornet/pull/762) form original pr [Silo link RCD upgrade](https://github.com/tgstation/tgstation/pull/45607)

## Why It's Good For The Game

Projects > Bugfixes/Code Improvements
## Changelog
:cl: cacogen, Ryll/Shaps, Moccha-Bee, Dennok, 
del: Old medbay clean bots
add: Scrubs MD added to Meta, box, donut, pubby, kilo and delta
add: Scrubs MD now give doctors access to it.
tweak: The station's new Orion Trail arcade machines now detect certain antisocial behaviors and can warn security and medical personnel about unhinged gamers.
tweak: Updated material_container.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
