### PR TITLE
Xenos now break firelock window shutters instead of opening them

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -422,6 +422,10 @@
 	heat_proof = FALSE
 	assemblytype = /obj/structure/firelock_frame/window
 
+/obj/machinery/door/firedoor/window/attack_alien(mob/living/carbon/alien/humanoid/user)
+	playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
+	return attack_generic(user, 60, BRUTE, "melee", 0)
+
 /obj/item/electronics/firelock
 	name = "firelock circuitry"
 	custom_price = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Xenos now break firelock window shutters instead of opening them. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Xenos should slash at the shutters instead of politely opening them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: xenomorphs now break firelock window shutters instead of opening them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
