### PR TITLE
Fixes a few rogue AIStatus usages

### DIFF
--- a/code/controllers/subsystem/idlenpcpool.dm
+++ b/code/controllers/subsystem/idlenpcpool.dm
@@ -32,8 +32,10 @@ SUBSYSTEM_DEF(idlenpcpool)
 	while(currentrun.len)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
 		--currentrun.len
-		if (!SA)
-			GLOB.simple_animals[AI_IDLE] -= SA
+
+		if(!SA)
+			stack_trace("Null entry found at GLOB.simple_animals\[AI_IDLE\]. Null entries will be purged. Yell at coderbus. Subsystem will try to continue.")
+			removeNullsFromList(GLOB.simple_animals[AI_IDLE])
 			continue
 
 		if(!SA.ckey)

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -23,6 +23,11 @@ SUBSYSTEM_DEF(npcpool)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
 		--currentrun.len
 
+		if(!SA)
+			stack_trace("Null entry found at GLOB.simple_animals\[AI_ON\]. Null entries will be purged. Yell at coderbus. Subsystem will try to continue.")
+			removeNullsFromList(GLOB.simple_animals[AI_ON])
+			continue
+
 		if(!SA.ckey && !SA.notransform)
 			if(SA.stat != DEAD)
 				SA.handle_automated_movement()

--- a/code/modules/mob/living/simple_animal/eldritch_demons.dm
+++ b/code/modules/mob/living/simple_animal/eldritch_demons.dm
@@ -158,7 +158,7 @@
 			current.icon_state = "armsy_mid"
 			current.icon_living = "armsy_mid"
 			current.front = src
-			current.AIStatus = AI_OFF
+			current.toggle_ai(AI_OFF)
 			back = current
 		else if(i < len)
 			current = new type(drop_location(),FALSE)
@@ -166,12 +166,12 @@
 			prev.icon_state = "armsy_mid"
 			prev.icon_living = "armsy_mid"
 			prev.front = next
-			prev.AIStatus = AI_OFF
+			prev.toggle_ai(AI_OFF)
 		else
 			prev.icon_state = "armsy_end"
 			prev.icon_living = "armsy_end"
 			prev.front = next
-			prev.AIStatus = AI_OFF
+			prev.toggle_ai(AI_OFF)
 		next = prev
 
 //we are literally a vessel of otherworldly destruction, we bring our own gravity unto this plane
@@ -233,7 +233,7 @@
 			prev.icon_state = "armsy_end"
 			prev.icon_living = "armsy_end"
 			prev.front = src
-			prev.AIStatus = AI_OFF
+			prev.toggle_ai(AI_OFF)
 			current_stacks = 0
 			return
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -145,13 +145,13 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 
 /mob/living/simple_animal/hostile/swarmer/ai/proc/StartAction(deci = 0)
 	stop_automated_movement = TRUE
-	AIStatus = AI_OFF
+	toggle_ai(AI_OFF)
 	addtimer(CALLBACK(src, .proc/EndAction), deci)
 
 
 /mob/living/simple_animal/hostile/swarmer/ai/proc/EndAction()
 	stop_automated_movement = FALSE
-	AIStatus = AI_ON
+	toggle_ai(AI_ON)
 
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -81,7 +81,7 @@
 	var/dextrous = FALSE //If the creature has, and can use, hands
 	var/dextrous_hud_type = /datum/hud/dextrous
 
-	var/AIStatus = AI_ON //The Status of our AI, can be set to AI_ON (On, usual processing), AI_IDLE (Will not process, but will return to AI_ON if an enemy comes near), AI_OFF (Off, Not processing ever), AI_Z_OFF (Temporarily off due to nonpresence of players)
+	var/AIStatus = AI_ON //The Status of our AI, can be changed via toggle_ai(togglestatus) to AI_ON (On, usual processing), AI_IDLE (Will not process, but will return to AI_ON if an enemy comes near), AI_OFF (Off, Not processing ever), AI_Z_OFF (Temporarily off due to nonpresence of players)
 	var/can_have_ai = TRUE //once we have become sentient, we can never go back
 
 	var/shouldwakeup = FALSE //convenience var for forcibly waking up an idling AI on next check.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes direct changes made to `AIStatus` to `toggle_ai` proc because former usage

1. Doesn't work
2. Will cause problems at GC
3. And break (idle)npcpool

This PR also includes null reference check that has already been in use at `idlenpcpool` subsystem to `npcpool` subsystem.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less broken legacy code, and prevent the `npcpool` subsystem from grinding to a halt.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Hardened npc subsystems so mobs are less prone to freeze completely and irreversibly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
