### PR TITLE
You can now tuck plushies and nuke disks into bed

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -501,6 +501,7 @@
 #include "code\datums\diseases\advance\symptoms\wizarditis.dm"
 #include "code\datums\diseases\advance\symptoms\youth.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\bed_tucking.dm"
 #include "code\datums\elements\bsa_blocker.dm"
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\decal.dm"

--- a/code/datums/elements/bed_tucking.dm
+++ b/code/datums/elements/bed_tucking.dm
@@ -1,0 +1,58 @@
+/// Tucking element, for things that can be tucked into bed.
+/datum/element/bed_tuckable
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+	id_arg_index = 2
+	/// our pixel_x offset - how much the item moves x when in bed (+x is closer to the pillow)
+	var/x_offset = 0
+	/// our pixel_y offset - how much the item move y when in bed (-y is closer to the middle)
+	var/y_offset = 0
+	/// our rotation degree - how much the item turns when in bed (+degrees turns it more parallel)
+	var/rotation_degree = 0
+
+/datum/element/bed_tuckable/Attach(obj/target, x = 0, y = 0, rotation = 0)
+	. = ..()
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+
+	x_offset = x
+	y_offset = y
+	rotation_degree = rotation
+	RegisterSignal(target, COMSIG_ITEM_ATTACK_OBJ, .proc/tuck_into_bed)
+
+/datum/element/bed_tuckable/Detach(obj/target)
+	. = ..()
+	UnregisterSignal(target, list(COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_PICKUP))
+
+/**
+ * Tuck our object into bed.
+ *
+ * tucked - the object being tucked
+ * target_bed - the bed we're tucking them into
+ * tucker - the guy doing the tucking
+ */
+/datum/element/bed_tuckable/proc/tuck_into_bed(obj/item/tucked, obj/structure/bed/target_bed, mob/living/tucker)
+
+	if(!istype(target_bed))
+		return
+
+	if(!tucker.transferItemToLoc(tucked, target_bed.drop_location()))
+		return
+
+	to_chat(tucker, "<span class='notice'>You lay [tucked] out on [target_bed].</span>")
+	tucked.pixel_x = x_offset
+	tucked.pixel_y = y_offset
+	if(rotation_degree)
+		tucked.transform = turn(tucked.transform, rotation_degree)
+		RegisterSignal(tucked, COMSIG_ITEM_PICKUP, .proc/untuck)
+
+	return COMPONENT_NO_AFTERATTACK
+
+/**
+ * If we rotate our object, then we need to un-rotate it when it's picked up
+ *
+ * tucked - the object that is tucked
+ */
+/datum/element/bed_tuckable/proc/untuck(obj/item/tucked)
+
+	tucked.transform = turn(tucked.transform, -rotation_degree)
+	UnregisterSignal(tucked, COMSIG_ITEM_PICKUP)

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -36,6 +36,7 @@
 /obj/item/toy/plush/Initialize()
 	. = ..()
 	AddComponent(/datum/component/squeak, squeak_override)
+	AddElement(/datum/element/bed_tuckable, 6, -5, 90)
 
 	//have we decided if Pinocchio goes in the blue or pink aisle yet?
 	if(gender == NEUTER)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -22,6 +22,10 @@ LINEN BINS
 	dog_fashion = /datum/dog_fashion/head/ghost
 	var/list/dream_messages = list("white")
 
+/obj/item/bedsheet/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/bed_tuckable, 0, 0, 0)
+
 /obj/item/bedsheet/attack(mob/living/M, mob/user)
 	if(!attempt_initiate_surgery(src, M, user))
 		..()

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -652,7 +652,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001)
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -644,8 +644,6 @@ This is here to make the tiles around the station mininuke change when it's arme
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
 	var/turf/newturf = get_turf(src)
 	if(newturf && lastlocation == newturf)
-		/// Probability of ticking up lone op weight
-		var/lone_op_prob = 0.0001
 		/// How comfy is our disk?
 		var/disk_comfort_level = 0
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -623,9 +623,11 @@ This is here to make the tiles around the station mininuke change when it's arme
 	var/fake = FALSE
 	var/turf/lastlocation
 	var/last_disk_move
+	var/process_tick = 0
 
 /obj/item/disk/nuclear/Initialize()
 	. = ..()
+	AddElement(/datum/element/bed_tuckable, 6, -6, 0)
 	if(!fake)
 		GLOB.poi_list |= src
 		last_disk_move = world.time
@@ -636,16 +638,30 @@ This is here to make the tiles around the station mininuke change when it's arme
 	AddComponent(/datum/component/stationloving, !fake)
 
 /obj/item/disk/nuclear/process()
+	++process_tick
 	if(fake)
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
 	var/turf/newturf = get_turf(src)
 	if(newturf && lastlocation == newturf)
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
+		/// Probability of ticking up lone op weight
+		var/lone_op_prob = 0.0001
+		/// How comfy is our disk?
+		var/disk_comfort_level = 0
+
+		//Go through and check for items that make disk comfy
+		for(var/obj/comfort_item in loc)
+			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
+				disk_comfort_level++
+
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*lone_op_prob))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1
 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
+					if(disk_comfort_level >= 2)
+						if((process_tick % 30) == 0)
+							visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -652,7 +652,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*lone_op_prob))
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001)
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -650,7 +650,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 		var/disk_comfort_level = 0
 
 		//Go through and check for items that make disk comfy
-		for(var/obj/comfort_item in loc)
+		for(var/comfort_item in loc)
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -659,9 +659,8 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1
 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
-					if(disk_comfort_level >= 2)
-						if((process_tick % 30) == 0)
-							visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
+					if(disk_comfort_level >= 2 && (process_tick % 30) == 0)
+						visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#3304 resuscitated | Ports: tgstation/tgstation#55940

## Why It's Good For The Game

Very Important PR

## Changelog
:cl: Melbert
add: You can now make beds with blankets.
add: You can now tuck plushes into bed.
add: You can also tuck the nuclear authentication disk into bed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
