### PR TITLE
Poppy pin removal fix

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -945,5 +945,6 @@
 	name = "Poppy Pin Removal"
 	result = /obj/item/reagent_containers/food/snacks/grown/poppy
 	time = 5
-	reqs = /obj/item/clothing/accessory/poppy_pin
+	reqs = list(/obj/item/clothing/accessory/poppy_pin = 1)
+	
 	category = CAT_MISC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/3551


## Changelog
:cl:
fix: Poppies can no longer be freely generated from poppy pin crafting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
