### PR TITLE
Improves throw mode

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -119,8 +119,8 @@
 		return
 
 	if(in_throw_mode)
-		throw_item(A)
-		return
+		if(throw_item(A))
+			return
 
 	var/obj/item/W = get_active_held_item()
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -118,7 +118,7 @@
 		RestrainedClickOn(A)
 		return
 
-	if(in_throw_mode)
+	if(in_throw_mode && throw_item(A))
 		if(throw_item(A))
 			return
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -119,8 +119,7 @@
 		return
 
 	if(in_throw_mode && throw_item(A))
-		if(throw_item(A))
-			return
+		return
 
 	var/obj/item/W = get_active_held_item()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -119,15 +119,15 @@
 
 /mob/proc/throw_item(atom/target)
 	SEND_SIGNAL(src, COMSIG_MOB_THROW, target)
-	return
+	return TRUE
 
 /mob/living/carbon/throw_item(atom/target)
 	. = ..()
 	throw_mode_off()
 	if(!target || !isturf(loc))
-		return
+		return FALSE
 	if(istype(target, /atom/movable/screen))
-		return
+		return FALSE
 
 	var/atom/movable/thrown_thing
 	var/obj/item/I = get_active_held_item()
@@ -151,7 +151,7 @@
 
 		if(HAS_TRAIT(src, TRAIT_PACIFISM) && I.throwforce)
 			to_chat(src, "<span class='notice'>You set [I] down gently on the ground.</span>")
-			return
+			return TRUE
 
 	if(thrown_thing)
 		visible_message("<span class='danger'>[src] throws [thrown_thing].</span>", \
@@ -159,6 +159,8 @@
 		log_message("has thrown [thrown_thing]", LOG_ATTACK)
 		newtonian_move(get_dir(target, src))
 		thrown_thing.safe_throw_at(target, thrown_thing.throw_range, thrown_thing.throw_speed, src, null, null, null, move_force)
+		return TRUE
+	return FALSE
 
 /mob/living/carbon/restrained(ignore_grab)
 	. = (handcuffed || (!ignore_grab && pulledby && pulledby.grab_state >= GRAB_NECK))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Improves throw mode by making it not block clicks if you have an empty hand. This can be very annoying if you are trying to catch items/block shots in CQC since if you have throw mode on all clicks are blocked, even if you have an empty hand and nothing to throw.

This makes it so while you are in throw mode you can still pick up items and attack people.

## Why It's Good For The Game

Throw mode blocking all clicks even if you don't throw anything is very annoying and leads to many situations where it feels like the game isn't registering your clicks (because it isn't).

## Changelog
:cl:
tweak: You can now click on things while in throw mode if you aren't actually throwing anything
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
