### PR TITLE
Sec borg and peacemaker improvement

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -328,6 +328,7 @@
 		for(var/mob/living/carbon/M in hearers(9, user))
 			if(M.get_ear_protection() == FALSE)
 				M.confused += 6
+				M.Stun(1)
 		audible_message("<font color='red' size='7'>HUMAN HARM</font>")
 		playsound(get_turf(src), 'sound/ai/harmalarm.ogg', 70, 3)
 		cooldown = world.time + 200
@@ -969,3 +970,4 @@
 	. = ..()
 	if(stored)
 		. += "You are currently holding [stored]."
+

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -294,7 +294,7 @@
 
 /obj/item/harmalarm
 	name = "\improper Sonic Harm Prevention Tool"
-	desc = "Releases a harmless blast that confuses most organics. For when the harm is JUST TOO MUCH."
+	desc = "Releases a harmless blast that knocks down most organics. For when the harm is JUST TOO MUCH."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "megaphone"
 	var/cooldown = 0
@@ -327,8 +327,7 @@
 			"<span class='danger'>The siren pierces your hearing!</span>")
 		for(var/mob/living/carbon/M in hearers(9, user))
 			if(M.get_ear_protection() == FALSE)
-				M.confused += 6
-				M.Stun(1)
+				M.Knockdown(3 SECONDS)
 		audible_message("<font color='red' size='7'>HUMAN HARM</font>")
 		playsound(get_turf(src), 'sound/ai/harmalarm.ogg', 70, 3)
 		cooldown = world.time + 200

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -87,3 +87,22 @@
 /obj/item/storage/box/evidence/PopulateContents()
 	for(var/i in 1 to 6)
 		new /obj/item/evidencebag(src)
+
+/obj/item/evidencebag/proc/Remove()
+	if(contents.len)
+		var/obj/item/Contents = contents[1]
+		var/obj/item/TR = get_turf(src)
+		Contents.forceMove(TR)
+		cut_overlays()
+		w_class = WEIGHT_CLASS_TINY
+		icon_state = "evidenceobj"
+		desc = "An empty evidence bag."
+
+/obj/item/evidencebag/CtrlShiftClick(mob/user)
+	Remove()
+
+/obj/item/evidencebag/cyborg
+	name = "cyborg evidence bag"
+
+/obj/item/evidencebag/cyborg/Destroy()
+	Remove()

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -105,4 +105,9 @@
 	name = "cyborg evidence bag"
 
 /obj/item/evidencebag/cyborg/Destroy()
+	. = ..()
+	Remove()
+
+/obj/item/evidencebag/cyborg/emp_act()
+	. = ..()
 	Remove()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -378,7 +378,11 @@
 		/obj/item/borg/charger,
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg,
-		/obj/item/extinguisher/mini)
+		/obj/item/extinguisher/mini,
+		/obj/item/holosign_creator/security,
+		/obj/item/detective_scanner,
+		/obj/item/reagent_containers/spray/pepper,
+		/obj/item/evidencebag)
 	emag_modules = list(/obj/item/gun/energy/laser/cyborg)
 	ratvar_modules = list(
 		/obj/item/clock_module/abscond,

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -382,7 +382,7 @@
 		/obj/item/holosign_creator/security,
 		/obj/item/detective_scanner,
 		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/evidencebag)
+		/obj/item/evidencebag/cyborg)
 	emag_modules = list(/obj/item/gun/energy/laser/cyborg)
 	ratvar_modules = list(
 		/obj/item/clock_module/abscond,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Secborg has a very poor amount of tools in their disposal compaired to other borgs. This pr fixes it.
Adds security holobarrier projector, forensic scanner, pepper spray and evidence bag to secborg.
Items will drop out of evidence bag if borg module is reset or borg is destroyed or if it was emped.

Peacekeeper harmalarm is in a bad place atm. It confuses people causing them to wallslam which is human harm and against the whole point of peaceborg.
Peacekeeper harmalarm will no longer confuse but knockdown people for 3 seconds.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Secborg has a wider array of tools and can investigate and collect evidence now.
Peacemaker's harmalarm is a bit better at preventing harm and doesnt cause human harm now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added security holobarrier projector, forensic scanner, pepper spray and evidence bag to secborg.
tweak: Peacekeeper harmalarm will knockdown people for 3 seconds instead of confusing them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
