### PR TITLE
Removes ancient synth

### DIFF
--- a/_maps/RandomZLevels/TheFactory.dmm
+++ b/_maps/RandomZLevels/TheFactory.dmm
@@ -61,7 +61,7 @@
 /turf/open/floor/plating/asteroid,
 /area/awaymission/factory/secret)
 "afB" = (
-/obj/item/soundsynth/ancient,
+/obj/item/soundsynth,
 /obj/effect/light_emitter{
 	light_power = 2;
 	light_range = 2

--- a/code/modules/awaymissions/mission_code/TheFactory.dm
+++ b/code/modules/awaymissions/mission_code/TheFactory.dm
@@ -218,33 +218,9 @@
 	hud_type = list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_DIAGNOSTIC_BASIC, DATA_HUD_MEDICAL_ADVANCED)
 	hud_trait = list(TRAIT_SECURITY_HUD, TRAIT_MEDICAL_HUD)
 
-/obj/item/soundsynth/ancient//the original soundsynth code says it was ported from /vg/station. I guess I should mention it or I'll be sent to Brazil. https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/game/objects/items/devices/sound_synth.dm
-	name = "ancient sound synthesizer"
-	desc = "A device that is able to create sounds. This one is an ancient relic and has no restrictions."
-	shiftpitch = 0
-	sound_list = list()
-
 /obj/item/soundsynth/examine(mob/user)
 	. = ..()
 	. += "<span class='info'>Alt+Click on it to change volume.</span>"
-
-/obj/item/soundsynth/ancient/pick_sound(S as sound)
-	set category = "Object"
-	set name = "Select Sound Playback"
-	selected_sound = S
-	to_chat(usr, "Sound playback set to: [selected_sound]!")
-	if(!selected_sound)
-		return
-
-/obj/item/soundsynth/ancient/AltClick(mob/living/carbon/user)
-	volume = input(usr, "What volume would you like the sound to play at?",, 100) as null|num
-	if(!volume)
-		return
-
-/obj/item/soundsynth/ancient/attack_self(mob/user as mob)
-	if(spam_flag + 2 SECONDS < world.timeofday)
-		playsound(src, selected_sound, volume, 0, 0)
-		spam_flag = world.timeofday
 
 /obj/item/soundsynth/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
 	if(spam_flag + 2 SECONDS < world.timeofday)

--- a/code/modules/awaymissions/mission_code/TheFactory.dm
+++ b/code/modules/awaymissions/mission_code/TheFactory.dm
@@ -218,15 +218,6 @@
 	hud_type = list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_DIAGNOSTIC_BASIC, DATA_HUD_MEDICAL_ADVANCED)
 	hud_trait = list(TRAIT_SECURITY_HUD, TRAIT_MEDICAL_HUD)
 
-/obj/item/soundsynth/examine(mob/user)
-	. = ..()
-	. += "<span class='info'>Alt+Click on it to change volume.</span>"
-
-/obj/item/soundsynth/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
-	if(spam_flag + 2 SECONDS < world.timeofday)
-		M.playsound_local(get_turf(src), selected_sound, volume, shiftpitch)
-		spam_flag = world.timeofday
-
 //MOBS//
 
 /mob/living/simple_animal/hostile/proc/summon_backup_nosound(distance, exact_faction_match)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the ancient sound synth, a broken item that allows users to play ANY sound from their PC. ANY FUCKING SOUND!

## Why It's Good For The Game

uhhh... you can probably tell why.

Also, if an admin wants to play custom sounds they can edit the base one in varedit so that potential isn't removed.

## Changelog
:cl:
del: Ancient sound synth.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
