### PR TITLE
Various GC fixes

### DIFF
--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -135,7 +135,7 @@
 	for(var/datum/mind/B in team.members)
 		if(B.current)
 			for(var/datum/action/innate/cult/mastervote/vote in B.current.actions)
-				vote.Remove(B.current)
+				qdel(vote)
 			if(!B.current.incapacitated())
 				to_chat(B.current,"<span class='cultlarge'>[Nominee] has won the cult's support and is now their master. Follow [Nominee.p_their()] orders to the best of your ability!</span>")
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -51,7 +51,7 @@
 	fixed_mut_color = rgb(128,128,128)
 	H.update_body()
 	var/datum/action/innate/squid_change/S = locate(/datum/action/innate/squid_change) in H.actions
-	S?.Remove(H)
+	qdel(S)
 
 /datum/action/innate/squid_change
 	name = "Color Change"

--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/slime/death(gibbed)
 	if(stat == DEAD)
 		return
+	remove_form_spawner_menu()
 	if(!gibbed)
 		if(is_adult)
 			var/mob/living/simple_animal/slime/M = new(loc, colour)
@@ -10,7 +11,7 @@
 			is_adult = FALSE
 			maxHealth = 150
 			for(var/datum/action/innate/slime/reproduce/R in actions)
-				R.Remove(src)
+				qdel(R)
 			var/datum/action/innate/slime/evolve/E = new
 			E.Grant(src)
 			revive(full_heal = 1)
@@ -41,4 +42,6 @@
 			X.stored_slimes -= src
 	if(stat != DEAD)
 		GLOB.total_slimes--
+	remove_form_spawner_menu()
+	master = null
 	return ..()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -142,7 +142,7 @@
 				maxHealth = round(maxHealth * 1.3)
 			amount_grown = 0
 			for(var/datum/action/innate/slime/evolve/E in actions)
-				E.Remove(src)
+				qdel(E)
 			regenerate_icons()
 			update_name()
 		else

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -110,14 +110,6 @@
 	. = ..()
 	set_nutrition(700)
 
-/mob/living/simple_animal/slime/Destroy()
-	for(var/A in actions)
-		var/datum/action/AC = A
-		AC.Remove(src)
-	remove_form_spawner_menu()
-	master = null
-	return ..()
-
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)
 	colour = new_colour
 	update_name()
@@ -549,15 +541,11 @@
 /mob/living/simple_animal/slime/get_spawner_flavour_text()
 	return "You are a slime born and raised in a laboratory.[master ? " Your duty is to follow the orders of [master.real_name].": ""]"
 
-/mob/living/simple_animal/slime/death(gibbed)
-	remove_form_spawner_menu()
-	. = ..()
-
 /mob/living/simple_animal/slime/ghostize(can_reenter_corpse = TRUE)
 	. = ..()
-	if(. && transformeffects & SLIME_EFFECT_LIGHT_PINK)
+	if(. && transformeffects & SLIME_EFFECT_LIGHT_PINK && stat != DEAD)
 		LAZYADD(GLOB.mob_spawners["[master.real_name]'s slime"], src)
-	GLOB.poi_list |= src
+		GLOB.poi_list |= src
 
 /mob/living/simple_animal/slime/proc/remove_form_spawner_menu()
 	for(var/spawner in GLOB.mob_spawners)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -37,6 +37,7 @@
 		qdel(cc)
 	client_colours = null
 	ghostize()
+	QDEL_LIST(actions)
 	return ..()
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a few problems around mob GC, especially slime harddel. `QDEL_LIST(actions)` (yes, actions should be qdeleted) is a catch-all handler for whatever `actions` added to a mob. This rather wild fix is because I deeply suspect a lot of mobs didn't handle `actions` properly on `Destroy` and things won't particularly improve in the future.

Just for the record, this PR is related to #3070.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

GC problems should be fixed as much as possible.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: mob GC is improved
del: slime harddels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
