### PR TITLE
Changes heresy minimum required pop to 25

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -223,6 +223,9 @@ MAX_POP INCURSION -1
 MIN_POP CLOCKCULT 32
 MAX_POP CLOCKCULT -1
 
+MIN_POP HERESY 25
+MAX_POP HERESY -1
+
 ## The amount of time it takes for the emergency shuttle to be called, from round start.
 SHUTTLE_REFUEL_DELAY 12000
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -223,6 +223,9 @@ MAX_POP INCURSION -1
 MIN_POP CLOCKCULT 32
 MAX_POP CLOCKCULT -1
 
+MIN_POP HERESY 25
+MAX_POP HERESY -1
+
 ## The amount of time it takes for the emergency shuttle to be called, from round start.
 SHUTTLE_REFUEL_DELAY 12000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heresy is not designed for low pop. Heretics are given a heavy incentive to murder people in order to gain powers and ascend.
On low pop it usually ends up in heretics murderboning the whole 7 people station.
Heresy requires 25 minimum pop now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Heretics wont wipe the whole lowpop station now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Heresy requires 25 minimum pop now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
