### PR TITLE
Buffs the negative effects of nullcrates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -186,6 +186,16 @@
 	dangerous = TRUE
 	var/beepsky_chance = -1
 	var/level = 1
+	var/hijacking_chance = 0
+	var/list/possible_hijackers = list(
+		/mob/living/simple_animal/hostile/syndicate/space,
+		/mob/living/simple_animal/hostile/syndicate/space/stormtrooper,
+		/mob/living/simple_animal/hostile/syndicate/melee/space,
+		/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper,
+		/mob/living/simple_animal/hostile/syndicate/ranged/space/stormtrooper,
+		/mob/living/simple_animal/hostile/syndicate/ranged/shotgun/space/stormtrooper,
+		/mob/living/simple_animal/hostile/syndicate/ranged/smg/space/stormtrooper
+	)
 
 /datum/supply_pack/emergency/syndicate/fill(obj/structure/closet/crate/C)
 	var/crate_value = 30
@@ -206,11 +216,24 @@
 			continue
 		crate_value -= I.cost
 		new I.item(C)
+	//Lone op chance increase
 	var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 	if(istype(loneop))
-		loneop.weight += 7
+		loneop.weight += 15
 		message_admins("a NULL_ENTRY crate has shipped, increasing the weight of the Lone Operative event to [loneop.weight]")
 		log_game("a NULL_ENTRY crate has shipped, increasing the weight of the Lone Operative event to [loneop.weight]")
+	hijacking_chance += 10
+	if(prob(hijacking_chance))
+		//Shuttle hijacking
+		hijack_ship(C)
+		message_admins("a NULL_ENTRY crate has shipped, the cargo ship has been hijacked")
+
+/datum/supply_pack/emergency/syndicate/proc/hijack_ship(obj/structure/closet/crate/C)
+	hijacking_chance = 0
+	for(var/i in 1 to rand(3, 7))
+		//Spawn random mobs
+		var/type = pick(possible_hijackers)
+		new type(get_turf(C))
 
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nullcrates now provide a large increase to the loneop event.
Nullcrates now have a chance for the cargo shuttle to be hijacked, since well it is a Nanotrasen ship going straight into syndicate command.

Upon hijacking 3 to 7 random syndicate mobs will spawn, however the loot will still be in the ship; if you want it you gotta work for it. Or you know, be a syndie.

## Why It's Good For The Game

Significantly increases the downsides for non-syndicates buying nullcrates.

## Changelog
:cl:
tweak: Null entry orders can now cause the cargo shuttle to be hijacked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
