### PR TITLE
Fixes runtimes at wild west load

### DIFF
--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -154,9 +154,13 @@
 	var/corrupt_delay = 50
 	var/last_corrupt = 0
 
-/obj/structure/destructible/cult/pylon/New()
-	START_PROCESSING(SSfastprocess, src)
+/obj/structure/destructible/cult/pylon/Initialize()
 	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/destructible/cult/pylon/LateInitialize()
+	. = ..()
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/structure/destructible/cult/pylon/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR moves cult pylon's `START_PROCESSING` from `New` to `LateInitialize` because

1. Its `process` does tile corruption
2. which ultimately calls `ChangeTurf` on nearby non cult floor turfs
3. and tries to inherit gas of pre-existing turf's gasmixture
4. which should be initialized from `initial_gas_mix` at turf's `Initialize`

...and you know where this is going. As away mission loading might happen while processing subsystems are working busily, `/obj/structure/destructible/cult/pylon/process()` started at `New` has chance to call `ChangeTurf` on turfs before their `Initialize`, which will obviously fail since it tries to inherit nonexistent (and still hypothetical) gas mixtures. This PR prevents that error (and a few less prominent "pylon-working-on-uninitialized-turfs" error other than this), which happens around 300 times every time an admin loads Wild West away mission.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Wild West away mission runtimes at load have been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
