### PR TITLE
Bumping into grilles damages them

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -84,6 +84,7 @@
 		return
 	var/mob/M = AM
 	shock(M, 70)
+	take_damage(rand(0,1), BRUTE, "melee", FALSE)
 
 /obj/structure/grille/attack_animal(mob/user)
 	. = ..()
@@ -252,7 +253,6 @@
 			var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 			s.set_up(3, 1, src)
 			s.start()
-			take_damage(rand(0,1), BRUTE, "melee", FALSE)
 			return TRUE
 		else
 			return FALSE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -252,6 +252,7 @@
 			var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 			s.set_up(3, 1, src)
 			s.start()
+			take_damage(rand(0,1), BRUTE, "melee", FALSE)
 			return TRUE
 		else
 			return FALSE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -84,7 +84,8 @@
 		return
 	var/mob/M = AM
 	shock(M, 70)
-	take_damage(rand(0,1), BRUTE, "melee", FALSE)
+	if(prob(50))
+		take_damage(1, BRUTE, "melee", FALSE)
 
 /obj/structure/grille/attack_animal(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deals 0-1 damage every time a grille is bumbed. Will take an average of 100 bumps to fully destroy a grille.

## Why It's Good For The Game

Prevents using them to drain all power from a network and creating server lag by conveyoring mobs into them.

## Changelog
:cl:
tweak: Grilles now take damage when a mob bumps into them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
