### PR TITLE
Atropine/Hepanephrodaxon fix

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -827,7 +827,7 @@
 	overdose_threshold = 15
 
 /datum/reagent/medicine/atropine/on_mob_life(mob/living/carbon/M)
-	if(M.health <= 80)
+	if(M.health <= 20)
 		M.adjustToxLoss(-4*REM, 0)
 		M.adjustBruteLoss(-4*REM, 0)
 		M.adjustFireLoss(-4*REM, 0)
@@ -1203,7 +1203,7 @@
 	taste_description = "glue"
 	reagent_state = LIQUID
 	color = "#D2691E"
-	metabolization_rate = REM * 1.5
+	metabolization_rate = REM * 3.75
 	overdose_threshold = 10
 
 /datum/reagent/medicine/hepanephrodaxon/on_mob_life(var/mob/living/carbon/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
While going over things for an upcoming overhaul PR, I happened upon a **major** oversight with Atropine and a rather minor one with Hepanephrodaxon. Atropine is supposed to stop working at 20 HP per https://github.com/BeeStation/BeeStation-Hornet/pull/2995 but instead was coded to stop working at 80 HP. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Atropine now stops working at 20 HP as intended
fix: Hepanephrodaxon now has its correct metabolization rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
