### PR TITLE
Xenobiology: Nerfs /obj/item/slimepotion/speed

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -857,10 +857,10 @@
 		return
 	if(isitem(C))
 		var/obj/item/I = C
-		if(I.slowdown <= 0 || I.obj_flags & IMMUTABLE_SLOW)
+		if(I.slowdown != initial(I.slowdown) || I.obj_flags & IMMUTABLE_SLOW)
 			to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
 			return ..()
-		I.slowdown = 0
+		I.slowdown = initial(I.slowdown) * 0.5
 
 	if(istype(C, /obj/vehicle))
 		var/obj/vehicle/V = C


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

/obj/item/slimepotion/speed now reduces the speed of suits by 50% instead of 100%

## Why It's Good For The Game

Very commonly used xenobiology item, most suits use slowdown as a method to balance good armour stats, however you can simply bypass them 100%. While still useful, there is a reason not to wear a suit the whole round.

## Changelog
:cl:
balance: Makes /obj/item/slimepotion/speed only reduce speed by 50%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
