### PR TITLE
Xenobiology: Buffs /datum/status_effect/in_love

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -70,7 +70,9 @@
 /datum/status_effect/in_love/tick()
 	if(date)
 		new /obj/effect/temp_visual/love_heart/invisible(get_turf(date.loc), owner)
-
+		if(get_dist(get_turf(owner), get_turf(date)) < 7)
+			owner.heal_overall_damage(1, 1)
+			date.heal_overall_damage(1, 1)
 
 /datum/status_effect/throat_soothed
 	id = "throat_soothed"

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -71,8 +71,8 @@
 	if(date)
 		new /obj/effect/temp_visual/love_heart/invisible(get_turf(date.loc), owner)
 		if(get_dist(get_turf(owner), get_turf(date)) < 7)
-			owner.heal_overall_damage(1, 1)
-			date.heal_overall_damage(1, 1)
+			owner.heal_overall_damage(1, 1, BODYPART_ORGANIC)
+			date.heal_overall_damage(1, 1, BODYPART_ORGANIC)
 
 /datum/status_effect/throat_soothed
 	id = "throat_soothed"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs /datum/status_effect/in_love to heal 1 brute and 1 burn every tick when near your date.

## Why It's Good For The Game

For the amount of work the love potion requires, you get nothing out of it but some cringey RP potential. Buffs it so that when you are near your love you get decent healing.

## Changelog
:cl:
balance: Love potion now heals when near your date.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
