### PR TITLE
[PORT] Cryotube reagent fix, tweaks and Extinguishes mob on fire

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,4 +1,5 @@
 #define CRYOMOBS 'icons/obj/cryo_mobs.dmi'
+///Max temperature allowed inside the cryotube, should break before reaching this heat
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	name = "cryo cell"
@@ -179,6 +180,8 @@
 		return
 
 	var/mob/living/mob_occupant = occupant
+	if(mob_occupant.on_fire)
+		mob_occupant.ExtinguishMob()
 	if(!check_nap_violations())
 		return
 	if(mob_occupant.stat == DEAD) // We don't bother with dead people.

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,4 +1,6 @@
 #define CRYOMOBS 'icons/obj/cryo_mobs.dmi'
+#define CRYO_MULTIPLY_FACTOR 25 // Multiply factor is used with efficiency to multiply Tx quantity and how much extra is transfered to occupant magically.
+#define CRYO_TX_QTY 0.5 // Tx quantity is how much volume should be removed from the cell's beaker - multiplied by delta_time
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	name = "cryo cell"
@@ -25,7 +27,6 @@
 	var/conduction_coefficient = 0.3
 
 	var/obj/item/reagent_containers/glass/beaker = null
-	var/reagent_transfer = 0
 
 	var/obj/item/radio/radio
 	var/radio_key = /obj/item/encryptionkey/headset_med
@@ -166,7 +167,7 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/nap_violation(mob/violator)
 	open_machine()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/process()
+/obj/machinery/atmospherics/components/unary/cryo_cell/process(delta_time)
 	..()
 
 	if(!on)
@@ -201,21 +202,15 @@
 
 	if(air1.total_moles())
 		if(mob_occupant.bodytemperature < T0C) // Sleepytime. Why? More cryo magic.
-			mob_occupant.Sleeping((mob_occupant.bodytemperature * sleep_factor) * 2000)
-			mob_occupant.Unconscious((mob_occupant.bodytemperature * unconscious_factor) * 2000)
-		if(beaker)
-			if(reagent_transfer == 0) // Magically transfer reagents. Because cryo magic.
-				beaker.reagents.trans_to(occupant, 1, efficiency * 25) // Transfer reagents.
-				beaker.reagents.reaction(occupant, VAPOR)
-				air1.adjust_moles(/datum/gas/oxygen, -max(0,air1.get_moles(/datum/gas/oxygen) - 2 / efficiency)) //Let's use gas for this
-			if(++reagent_transfer >= 10 * efficiency) // Throttle reagent transfer (higher efficiency will transfer the same amount but consume less from the beaker).
-				reagent_transfer = 0
-
+			mob_occupant.Sleeping((mob_occupant.bodytemperature * sleep_factor) * 1000 * delta_time)//delta_time is roughly ~2 seconds
+			mob_occupant.Unconscious((mob_occupant.bodytemperature * unconscious_factor) * 1000 * delta_time)
+		if(beaker)//How much to transfer. As efficiency is increased, less reagent from the beaker is used and more is magically transferred to occupant
+			beaker.reagents.trans_to(occupant, (CRYO_TX_QTY / (efficiency * CRYO_MULTIPLY_FACTOR)) * delta_time, efficiency * CRYO_MULTIPLY_FACTOR, method = VAPOR)
 		use_power(1000 * efficiency)
 
 	return 1
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos()
+/obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos(delta_time)
 	..()
 
 	if(!on)
@@ -242,8 +237,8 @@
 
 			var/heat = ((1 - cold_protection) * 0.1 + conduction_coefficient) * temperature_delta * (air_heat_capacity * heat_capacity / (air_heat_capacity + heat_capacity))
 
-			air1.set_temperature(max(air1.return_temperature() - heat / air_heat_capacity, TCMB))
-			mob_occupant.adjust_bodytemperature(heat / heat_capacity, TCMB)
+			air1.set_temperature(max(air1.return_temperature() - heat * delta_time/ air_heat_capacity, TCMB))
+			mob_occupant.adjust_bodytemperature(heat * delta_time / heat_capacity, TCMB)
 
 		air1.set_moles(/datum/gas/oxygen, max(0,air1.get_moles(/datum/gas/oxygen) - 0.5 / efficiency)) // Magically consume gas? Why not, we run on cryo magic.
 
@@ -266,7 +261,6 @@
 			L.update_mobility()
 	occupant = null
 	flick("pod-open-anim", src)
-	reagent_transfer = efficiency * 10 - 5 // wait before injecting the next occupant
 	..()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/close_machine(mob/living/carbon/user)
@@ -474,3 +468,5 @@
 		SSair.add_to_rebuild_queue(src)
 
 #undef CRYOMOBS
+#undef CRYO_MULTIPLY_FACTOR
+#undef CRYO_TX_QTY

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,6 +1,6 @@
 #define CRYOMOBS 'icons/obj/cryo_mobs.dmi'
 #define CRYO_MULTIPLY_FACTOR 1.5 // Multiply factor is used with efficiency to multiply Tx quantity and how much extra is transfered to occupant magically.
-#define CRYO_TX_QTY 0.6 // Tx quantity is how much volume should be removed from the cell's beaker - multiplied by delta_time
+#define CRYO_TX_QTY 0.4 // Tx quantity is how much volume should be removed from the cell's beaker - multiplied by delta_time
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	name = "cryo cell"

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,6 +1,6 @@
 #define CRYOMOBS 'icons/obj/cryo_mobs.dmi'
-#define CRYO_MULTIPLY_FACTOR 25 // Multiply factor is used with efficiency to multiply Tx quantity and how much extra is transfered to occupant magically.
-#define CRYO_TX_QTY 6 // Tx quantity is how much volume should be removed from the cell's beaker - multiplied by delta_time
+#define CRYO_MULTIPLY_FACTOR 1.5 // Multiply factor is used with efficiency to multiply Tx quantity and how much extra is transfered to occupant magically.
+#define CRYO_TX_QTY 0.6 // Tx quantity is how much volume should be removed from the cell's beaker - multiplied by delta_time
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	name = "cryo cell"

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -230,7 +230,7 @@
 
 	var/datum/gas_mixture/air1 = airs[1]
 
-	if(!nodes[1] || !airs[1] || air1.get_moles(/datum/gas/oxygen) < 5) // Turn off if the machine won't work, it will not have enough moles to operate.
+	if(!nodes[1] || !airs[1] || air1.get_moles(/datum/gas/oxygen) < 5) // Turn off if the machine won't work due to not having enough moles to operate.
 		on = FALSE
 		update_icon()
 		var/msg = "Aborting. Not enough gas present to operate."

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -233,7 +233,7 @@
 	if(!nodes[1] || !airs[1] || air1.get_moles(/datum/gas/oxygen) < 5) // Turn off if the machine won't work, it will not have enough moles to operate.
 		on = FALSE
 		update_icon()
-		var/msg = "Aborting. Not enough moles of gas present to operate."
+		var/msg = "Aborting. Not enough gas present to operate."
 		radio.talk_into(src, msg, radio_channel)
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -205,7 +205,7 @@
 			mob_occupant.Sleeping((mob_occupant.bodytemperature * sleep_factor) * 1000 * delta_time)//delta_time is roughly ~2 seconds
 			mob_occupant.Unconscious((mob_occupant.bodytemperature * unconscious_factor) * 1000 * delta_time)
 		if(beaker)//How much to transfer. As efficiency is increased, less reagent from the beaker is used and more is magically transferred to occupant
-			beaker.reagents.trans_to(occupant, (CRYO_TX_QTY / (efficiency * CRYO_MULTIPLY_FACTOR)) * delta_time, (efficiency * CRYO_MULTIPLY_FACTOR)*(efficiency*0.05), method = VAPOR)
+			beaker.reagents.trans_to(occupant, (CRYO_TX_QTY / (efficiency * CRYO_MULTIPLY_FACTOR)) * delta_time, efficiency * CRYO_MULTIPLY_FACTOR, method = VAPOR) // Transfer reagents.
 		use_power(1000 * efficiency)
 
 	return 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -203,7 +203,7 @@
 			mob_occupant.Unconscious((mob_occupant.bodytemperature * unconscious_factor) * 2000)
 		if(beaker)
 			if(reagent_transfer == 0) // Magically transfer reagents. Because cryo magic.
-				beaker.reagents.trans_to(occupant, 1, efficiency * 0.25) // Transfer reagents.
+				beaker.reagents.trans_to(occupant, 1, efficiency * 25) // Transfer reagents.
 				beaker.reagents.reaction(occupant, VAPOR)
 				air1.adjust_moles(/datum/gas/oxygen, -max(0,air1.get_moles(/datum/gas/oxygen) - 2 / efficiency)) //Let's use gas for this
 			if(++reagent_transfer >= 10 * efficiency) // Throttle reagent transfer (higher efficiency will transfer the same amount but consume less from the beaker).
@@ -264,6 +264,7 @@
 			L.update_mobility()
 	occupant = null
 	flick("pod-open-anim", src)
+	reagent_transfer = efficiency * 10 - 5 // wait before injecting the next occupant
 	..()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/close_machine(mob/living/carbon/user)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -176,11 +176,23 @@
 		on = FALSE
 		update_icon()
 		return
-	if(!occupant)
+
+	if(!occupant)//Won't operate unless there's an occupant.
+		on = FALSE
+		update_icon()
+		var/msg = "Aborting. No occupant detected."
+		radio.talk_into(src, msg, radio_channel)
+		return
+
+	if(!beaker || !beaker.reagents.reagent_list.len) //No beaker or beaker without reagents with stop the machine from running.
+		on = FALSE
+		update_icon()
+		var/msg = "Aborting. No beaker or chemicals installed."
+		radio.talk_into(src, msg, radio_channel)
 		return
 
 	var/mob/living/mob_occupant = occupant
-	if(mob_occupant.on_fire) //Extinguish occupant, happens after the occupant is healed and ejected
+	if(mob_occupant.on_fire) //Extinguish occupant, happens after the occupant is healed and ejected.
 		mob_occupant.ExtinguishMob()
 	if(!check_nap_violations())
 		return
@@ -214,13 +226,6 @@
 	..()
 
 	if(!on)
-		return
-
-	if(!beaker || !beaker.reagents.reagent_list.len) //No beaker or beaker without reagents with stop the machine from running.
-		on = FALSE
-		update_icon()
-		var/msg = "Aborting. No beaker or chemicals installed."
-		radio.talk_into(src, msg, radio_channel)
 		return
 
 	var/datum/gas_mixture/air1 = airs[1]

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,5 +1,4 @@
 #define CRYOMOBS 'icons/obj/cryo_mobs.dmi'
-///Max temperature allowed inside the cryotube, should break before reaching this heat
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	name = "cryo cell"
@@ -180,7 +179,7 @@
 		return
 
 	var/mob/living/mob_occupant = occupant
-	if(mob_occupant.on_fire)
+	if(mob_occupant.on_fire) //Extinguish occupant, happens after the occupant is healed and ejected
 		mob_occupant.ExtinguishMob()
 	if(!check_nap_violations())
 		return

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,6 +1,6 @@
 #define CRYOMOBS 'icons/obj/cryo_mobs.dmi'
 #define CRYO_MULTIPLY_FACTOR 25 // Multiply factor is used with efficiency to multiply Tx quantity and how much extra is transfered to occupant magically.
-#define CRYO_TX_QTY 0.5 // Tx quantity is how much volume should be removed from the cell's beaker - multiplied by delta_time
+#define CRYO_TX_QTY 6 // Tx quantity is how much volume should be removed from the cell's beaker - multiplied by delta_time
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	name = "cryo cell"
@@ -205,7 +205,7 @@
 			mob_occupant.Sleeping((mob_occupant.bodytemperature * sleep_factor) * 1000 * delta_time)//delta_time is roughly ~2 seconds
 			mob_occupant.Unconscious((mob_occupant.bodytemperature * unconscious_factor) * 1000 * delta_time)
 		if(beaker)//How much to transfer. As efficiency is increased, less reagent from the beaker is used and more is magically transferred to occupant
-			beaker.reagents.trans_to(occupant, (CRYO_TX_QTY / (efficiency * CRYO_MULTIPLY_FACTOR)) * delta_time, efficiency * 15, method = VAPOR)
+			beaker.reagents.trans_to(occupant, (CRYO_TX_QTY / (efficiency * CRYO_MULTIPLY_FACTOR)) * delta_time, (efficiency * CRYO_MULTIPLY_FACTOR)*(efficiency*0.05), method = VAPOR)
 		use_power(1000 * efficiency)
 
 	return 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -184,7 +184,7 @@
 		radio.talk_into(src, msg, radio_channel)
 		return
 
-	if(!beaker || !beaker.reagents.reagent_list.len) //No beaker or beaker without reagents with stop the machine from running.
+	if(!beaker?.reagents?.reagent_list.len) //No beaker or beaker without reagents with stop the machine from running.
 		on = FALSE
 		update_icon()
 		var/msg = "Aborting. No beaker or chemicals installed."

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -149,7 +149,7 @@
 		M.adjustCloneLoss(-power, 0)
 		REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC) //fixes common causes for disfiguration
 		. = 1
-	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (M.bodytemperature ** 2) + 0.5)
+	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (M.bodytemperature ** 2) + 0.5)//Metabolism rate is reduced in colder body temps making it more effective
 	..()
 
 /datum/reagent/medicine/clonexadone
@@ -164,7 +164,7 @@
 		M.adjustCloneLoss(0.00006 * (M.bodytemperature ** 2) - 6, 0)
 		REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 		. = 1
-	metabolization_rate = REAGENTS_METABOLISM * (0.000015 * (M.bodytemperature ** 2) + 0.75)
+	metabolization_rate = REAGENTS_METABOLISM * (0.000015 * (M.bodytemperature ** 2) + 0.75)//Metabolism rate is reduced in colder body temps making it more effective
 	..()
 
 /datum/reagent/medicine/pyroxadone
@@ -175,6 +175,7 @@
 
 /datum/reagent/medicine/pyroxadone/on_mob_life(mob/living/carbon/M)
 	if(M.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT)
+		metabolization_rate = 0.2 // It metabolises effectively when the body is taking heat damage
 		var/power = 0
 		switch(M.bodytemperature)
 			if(BODYTEMP_HEAT_DAMAGE_LIMIT to 400)
@@ -193,6 +194,8 @@
 		M.adjustCloneLoss(-power, 0)
 		REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 		. = 1
+	else //If not the right temperature for pyroxadone to work
+		metabolization_rate = REAGENTS_METABOLISM
 	..()
 
 /datum/reagent/medicine/rezadone


### PR DESCRIPTION
## About The Pull Request
Ports [Makes cryo handle reagent transfer better. #56755](https://github.com/tgstation/tgstation/pull/56755) from TG to fix [#3595](https://github.com/BeeStation/BeeStation-Hornet/issues/3595). It's tweaked. Reagents are now injected every **2 seconds** rather than waiting x amount of time. 

Ports part of [#51092](https://github.com/tgstation/tgstation/pull/51092). Adds the ability for Cryotubes to extinguish a burning corpse when they have been healed. It will eject the occupant when they are fully healed THEN extinguish the person so you can be on fire and cryo-ed no problems.~~Works well with hot cryo~~ on_fire buff doesn't work in the Cryotube.

Pyroxadone metabolism rate is variable now, 0.4u in normal/cold temps and  0.2u in body damaging temperatures. I wanted it to work similar to Cryoxadone but instead gave it a flat rate as cryo works between 3-273k and pyro works above 360.15K with no roof. 

Cryotubes now alert medical when there's no moles of gas to being operation.

Another alert is for when there's no beaker or or reagents are present in the tube and it is turned on. This stops the operation. It will alert medical if either conditions met with a warning. 

Fixed and wrote some more comments.

## Why It's Good For The Game

1. Bug fix, more consistent and faster healing. Less excess chemicals after the operation is finished

2. Burning bodies in Cryotubes is not good as it increases the temperature of the tube, unless it's pyro which is why the extinguishing happens at the end. 

3. This is to balance with the Cryotubes and in general. Speaks for itself. 

4. It didn't before and no one ever analyses the pipes.

5. Stops Cryotubes from working without a beaker/reagents. Warns medical on radio. Also acts as a limiting factor, you shouldn't be in a turned on cryotube (unupgraded) forever

6. Housekeeping 
## Changelog
:cl: Cheesus, ShizCalev, coiax
add: Cryotube extinguishes a burning occupant when they are ejected by the machine. 
code: Comments around cryo cell code
add: Cyrotubes now alerts and stops when the tube has no beaker, reagents or enough moles. 
tweak: changed how much is used and how much is magically transferred to the occupant
tweak: Pyroxadone's metabolization rate is now variable, dependant on heat. 
removed: Outdated cryo reagent injection system
fix: fixed reagents not being injected into an occupant properly.
/:cl:
