### PR TITLE
[Port] Fixes railings

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -66,20 +66,22 @@
 	return TRUE
 
 /obj/structure/railing/CanPass(atom/movable/mover, turf/target)
-	..()
+	. = ..()
 	if(get_dir(loc, target) & dir)
-		return !density
+		var/checking = FLYING | FLOATING
+		return . || mover.movement_type & checking
 	return TRUE
 
 /obj/structure/railing/corner/CanPass()
 	..()
 	return TRUE
 
-/obj/structure/railing/CheckExit(atom/movable/O, turf/target)
+/obj/structure/railing/CheckExit(atom/movable/mover, turf/target)
 	..()
 	if(get_dir(loc, target) & dir)
-		return 0
-	return 1
+		var/checking = UNSTOPPABLE | FLYING | FLOATING
+		return !density || mover.movement_type & checking || mover.move_force >= MOVE_FORCE_EXTREMELY_STRONG
+	return TRUE
 
 /obj/structure/railing/corner/CheckExit()
 	return 1


### PR DESCRIPTION
## About The Pull Request

Port from [Fixes railings #52068](https://github.com/tgstation/tgstation/pull/52068) and in the Things to port list https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-41715352.  
Fixes railings blocking bullets, thrown items, lasers and immovable rods from a certain direction.

## Why It's Good For The Game
Railings shouldn't block bullets, lasers, thrown items and immovable rods. 
## Changelog
:cl: Melbert
fix: Fixes railings blocking bullets and immovable rods from a certain direction.
/:cl: