### PR TITLE
Fire Extinguisher is no longer lethal for oozelings

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -221,7 +221,12 @@
 			M.adjustStaminaLoss(25, 0)
 			to_chat(M, "<span class='warning'>You struggle to maintain your form!</span>")
 		else
-			M.blood_volume -= 10
+			if (M.blood_volume<BLOOD_VOLUME_OKAY)
+				metabolization_rate = 10 * REAGENTS_METABOLISM
+			else
+				metabolization_rate = REAGENTS_METABOLISM
+			M.blood_volume -= 30
+			
 			to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
 		return
 	if(method == TOUCH)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -221,7 +221,7 @@
 			M.adjustStaminaLoss(25, 0)
 			to_chat(M, "<span class='warning'>You struggle to maintain your form!</span>")
 		else
-			M.blood_volume -= 30
+			M.blood_volume -= 10
 			to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
 		return
 	if(method == TOUCH)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -217,8 +217,12 @@
 	if(!istype(M))
 		return
 	if(isoozeling(M))
-		M.blood_volume -= 30
-		to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
+		if (method == TOUCH)
+			M.adjustStaminaLoss(25, 0)
+			to_chat(M, "<span class='warning'>You struggle to maintain your form!</span>")
+		else
+			M.blood_volume -= 30
+			to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
 		return
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oozelings now only take stamina damage when splashed with water, as opposed to losing fatal amounts of blood.

Also made it so they expel water when low on blood.

## Why It's Good For The Game

Fire Extinguisher is no longer a deadly weapon against oozelings. It's stupid. 

You're on fire? Someone splases you with water? You're dead.
Chaplain splashes hallways with holy water? You are fully dressed and he cannot tell you're an oozeling? You are now dead.

Water is way too common for it to be this deadly. It may make sense lore wise, but it's not really so fun to do when something as little as a wall mounted fire extinguisher is enough to take you out for good.

Made it so they expel water when they are low on blood. This change is so that there's a chance for them to be revived when suffering waterdeath. IIRC blood filtering doesn't remove water and this can mean an oozeling will stay dead with 50u of water inside of them and no way to recover for a long period of time.

## Changelog
:cl:
add: oozelings now only recieve stamina damage when splashed by water, instead of losing blood
add: oozelings rapidly expel water when their blood volume is too low
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
