### PR TITLE
[Port] tgui: RCD Access Control

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -2,10 +2,14 @@
 	name = "airlock electronics"
 	req_access = list(ACCESS_MAINT_TUNNELS)
 	custom_price = 5
-
+	/// A list of all granted accesses
 	var/list/accesses = list()
+	/// If the airlock should require ALL or only ONE of the listed accesses
 	var/one_access = 0
-	var/unres_sides = 0 //unrestricted sides, or sides of the airlock that will open regardless of access
+	/// Unrestricted sides, or sides of the airlock that will open regardless of access
+	var/unres_sides = 0
+	/// A holder of the electronics, in case of them working as an integrated part
+	var/holder
 
 /obj/item/electronics/airlock/examine(mob/user)
 	. = ..()
@@ -47,7 +51,6 @@
 	data["accesses"] = accesses
 	data["oneAccess"] = one_access
 	data["unres_direction"] = unres_sides
-
 	return data
 
 /obj/item/electronics/airlock/ui_act(action, params)
@@ -87,3 +90,8 @@
 				return
 			accesses -= get_region_accesses(region)
 			. = TRUE
+
+/obj/item/electronics/airlock/ui_host()
+	if(holder)
+		return holder
+	return src

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -199,10 +199,10 @@ RLD
 	var/airlock_glass = FALSE // So the floor's rcd_act knows how much ammo to use
 	var/window_type = /obj/structure/window/fulltile
 	var/advanced_airlock_setting = 1 //Set to 1 if you want more paintjobs available
-	var/list/conf_access = null
-	var/use_one_access = 0 //If the airlock should require ALL or only ONE of the listed accesses.
 	var/delay_mod = 1
 	var/canRturf = FALSE //Variable for R walls to deconstruct them
+	/// Integrated airlock electronics for setting access to a newly built airlocks
+	var/obj/item/electronics/airlock/airlock_electronics
 
 /obj/item/construction/rcd/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] sets the RCD to 'Wall' and points it down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide..</span>")
@@ -235,77 +235,6 @@ RLD
 		to_chat(user, "<span class='notice'>You change \the [src]'s storage link state: [silo_link ? "ON" : "OFF"].</span>")
 	else
 		to_chat(user, "<span class='warning'>\the [src] dont have remote storage connection.</span>")
-
-
-/obj/item/construction/rcd/proc/change_airlock_access(mob/user)
-	if (!ishuman(user) && !user.has_unlimited_silicon_privilege)
-		return
-
-	var/t1 = ""
-
-	if(use_one_access)
-		t1 += "Restriction Type: <a href='?src=[REF(src)];access=one'>At least one access required</a><br>"
-	else
-		t1 += "Restriction Type: <a href='?src=[REF(src)];access=one'>All accesses required</a><br>"
-
-	t1 += "<a href='?src=[REF(src)];access=all'>Remove All</a><br>"
-
-	var/accesses = ""
-	accesses += "<div align='center'><b>Access</b></div>"
-	accesses += "<table style='width:100%'>"
-	accesses += "<tr>"
-	for(var/i = 1; i <= 7; i++)
-		accesses += "<td style='width:14%'><b>[get_region_accesses_name(i)]:</b></td>"
-	accesses += "</tr><tr>"
-	for(var/i = 1; i <= 7; i++)
-		accesses += "<td style='width:14%' valign='top'>"
-		for(var/A in get_region_accesses(i))
-			if(A in conf_access)
-				accesses += "<a href='?src=[REF(src)];access=[A]'><font color=\"red\">[replacetext(get_access_desc(A), " ", "&nbsp")]</font></a> "
-			else
-				accesses += "<a href='?src=[REF(src)];access=[A]'>[replacetext(get_access_desc(A), " ", "&nbsp")]</a> "
-			accesses += "<br>"
-		accesses += "</td>"
-	accesses += "</tr></table>"
-	t1 += "<tt>[accesses]</tt>"
-
-	t1 += "<p><a href='?src=[REF(src)];close=1'>Close</a></p>\n"
-
-	var/datum/browser/popup = new(user, "rcd_access", "Access Control", 900, 500)
-	popup.set_content(t1)
-	popup.open()
-	onclose(user, "rcd_access")
-
-/obj/item/construction/rcd/Topic(href, href_list)
-	..()
-	if (usr.stat || usr.restrained())
-		return
-
-	if (href_list["close"])
-		usr << browse(null, "window=rcd_access")
-		return
-
-	if (href_list["access"])
-		toggle_access(href_list["access"])
-		change_airlock_access(usr)
-
-/obj/item/construction/rcd/proc/toggle_access(acc)
-	if (acc == "all")
-		conf_access = null
-	else if(acc == "one")
-		use_one_access = !use_one_access
-	else
-		var/req = text2num(acc)
-
-		if (conf_access == null)
-			conf_access = list()
-
-		if (!(req in conf_access))
-			conf_access += req
-		else
-			conf_access -= req
-			if (!conf_access.len)
-				conf_access = null
 
 /obj/item/construction/rcd/proc/get_airlock_image(airlock_type)
 	var/obj/machinery/door/airlock/proto = airlock_type
@@ -494,9 +423,13 @@ RLD
 
 /obj/item/construction/rcd/Initialize()
 	. = ..()
+	airlock_electronics = new(src)
+	airlock_electronics.name = "Access Control"
+	airlock_electronics.holder = src
 	GLOB.rcd_list += src
 
 /obj/item/construction/rcd/Destroy()
+	QDEL_NULL(airlock_electronics)
 	GLOB.rcd_list -= src
 	. = ..()
 
@@ -548,7 +481,7 @@ RLD
 			mode = RCD_LADDER
 			return
 		if("Change Access")
-			change_airlock_access(user)
+			airlock_electronics.ui_interact(user)
 			return
 		if("Change Airlock Type")
 			change_airlock_setting(user)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -268,7 +268,6 @@
 				return FALSE
 			to_chat(user, "<span class='notice'>You build an airlock.</span>")
 			var/obj/machinery/door/airlock/A = new the_rcd.airlock_type(src)
-
 			A.electronics = new /obj/item/electronics/airlock(A)
 			if(the_rcd.airlock_electronics)
 				A.electronics.accesses = the_rcd.airlock_electronics.accesses.Copy()

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -269,16 +269,17 @@
 			to_chat(user, "<span class='notice'>You build an airlock.</span>")
 			var/obj/machinery/door/airlock/A = new the_rcd.airlock_type(src)
 
-			A.electronics = new/obj/item/electronics/airlock(A)
-
-			if(the_rcd.conf_access)
-				A.electronics.accesses = the_rcd.conf_access.Copy()
-			A.electronics.one_access = the_rcd.use_one_access
-
+			A.electronics = new /obj/item/electronics/airlock(A)
+			if(the_rcd.airlock_electronics)
+				A.electronics.accesses = the_rcd.airlock_electronics.accesses.Copy()
+				A.electronics.one_access = the_rcd.airlock_electronics.one_access
+				A.electronics.unres_sides = the_rcd.airlock_electronics.unres_sides
 			if(A.electronics.one_access)
 				A.req_one_access = A.electronics.accesses
 			else
 				A.req_access = A.electronics.accesses
+			if(A.electronics.unres_sides)
+				A.unres_sides = A.electronics.unres_sides
 			A.autoclose = TRUE
 			return TRUE
 		if(RCD_DECONSTRUCT)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -280,6 +280,7 @@
 			if(A.electronics.unres_sides)
 				A.unres_sides = A.electronics.unres_sides
 			A.autoclose = TRUE
+			A.update_icon()
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			if(ScrapeAway(flags = CHANGETURF_INHERIT_AIR) == src)


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/50600

Makes the RCD use the airlock electronis UI to change the access for airlocks.

I tested this and it seems to work like it should.

Original description: 

> This PR brings a new UI for the RCD Access Control using an already existing Airlock Electronics UI made originally by actioninja.
> 
> RCDs now have an integrated airlock electronics system via which they set accesses for a newly built airlocks. This behaves the very same way as it used to with the old UI, with one addition of now also being able to set unrestricted access from a certain direction.

<details>
  <summary>Old UI
</summary>

![old ui](https://user-images.githubusercontent.com/53494785/107667454-df745b80-6c8f-11eb-849f-27a1579b2149.png)

</details>

<details>
  <summary>New UI
</summary>

![new ui](https://user-images.githubusercontent.com/53494785/107667537-f1ee9500-6c8f-11eb-90db-fc6c05c2858f.png)

</details>

## Why It's Good For The Game

Better UI. And it doesn't use the whole screen for it.

## Changelog
:cl: Arkatos and actioninja
add: RCD Access Control now uses tgui.
tweak: RCDs are now able to set unrestricted directional access for newly built airlocks.
/:cl: