### PR TITLE
[Port] Fixes the atmos subsystem locking up on rare occasions

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -88,6 +88,8 @@ SUBSYSTEM_DEF(air)
 		var/list/pipenet_rebuilds = pipenets_needing_rebuilt
 		for(var/thing in pipenet_rebuilds)
 			var/obj/machinery/atmospherics/AT = thing
+			if(!thing) //If a null somehow shows up here, this next line runtimes and the subsystem dies
+				continue
 			AT.build_network()
 		cost_rebuilds = MC_AVERAGE(cost_rebuilds, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 		pipenets_needing_rebuilt.Cut()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -86,9 +86,8 @@ SUBSYSTEM_DEF(air)
 
 	if(currentpart == SSAIR_REBUILD_PIPENETS)
 		var/list/pipenet_rebuilds = pipenets_needing_rebuilt
-		for(var/thing in pipenet_rebuilds)
-			var/obj/machinery/atmospherics/AT = thing
-			if(!thing) //If a null somehow shows up here, this next line runtimes and the subsystem dies
+		for(var/obj/machinery/atmospherics/AT as() in pipenet_rebuilds)
+			if(!AT) //If a null somehow shows up here, this next line runtimes and the subsystem dies
 				continue
 			AT.build_network()
 		cost_rebuilds = MC_AVERAGE(cost_rebuilds, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
port https://github.com/tgstation/tgstation/pull/56556

> Because pipenets_needing_rebuilt are not handled in a separate proc, and don't have a sanity check, if a null somehow gets in, the whole atmospherics system will lock up. forever.

> I don't like the current implementation, but I can deal with that later.

Dunno if this is/has been an issue on Bee, but I like my GBP

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: [Port[ Fixes a bug that could cause the atmos system to lock up permanently
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
