### PR TITLE
Fixes a few runtimes

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -197,7 +197,7 @@
 			C.process_endround_metacoin()
 
 			if(CONFIG_GET(flag/allow_crew_objectives))
-				var/mob/M = C.mob
+				var/mob/M = C ? C.mob : null
 				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives))
 					for(var/datum/objective/crew/CO in M.mind.crew_objectives)
 						if(!C) //Yes, the client can be null here. BYOND moment.

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -193,11 +193,11 @@
 	for(var/client/C in GLOB.clients)
 		if(C)
 
-			C.playtitlemusic(40)
-			C.process_endround_metacoin()
+			C?.process_endround_metacoin()
+			C?.playtitlemusic(40)
 
 			if(CONFIG_GET(flag/allow_crew_objectives))
-				var/mob/M = C.mob
+				var/mob/M = C?.mob
 				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives))
 					for(var/datum/objective/crew/CO in M.mind.crew_objectives)
 						if(!C) //Yes, the client can be null here. BYOND moment.

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -197,7 +197,7 @@
 			C.process_endround_metacoin()
 
 			if(CONFIG_GET(flag/allow_crew_objectives))
-				var/mob/M = C ? C.mob : null
+				var/mob/M = C.mob
 				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives))
 					for(var/datum/objective/crew/CO in M.mind.crew_objectives)
 						if(!C) //Yes, the client can be null here. BYOND moment.

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -200,7 +200,7 @@
 				var/mob/M = C.mob
 				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives))
 					for(var/datum/objective/crew/CO in M.mind.crew_objectives)
-						if(CO.check_completion())
+						if(C && CO.check_completion()) //Yes, the client can be null here. BYOND moment.
 							C.inc_metabalance(METACOIN_CO_REWARD, reason="Completed your crew objective!")
 							break
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -200,8 +200,10 @@
 				var/mob/M = C.mob
 				if(M?.mind?.current && LAZYLEN(M.mind.crew_objectives))
 					for(var/datum/objective/crew/CO in M.mind.crew_objectives)
-						if(C && CO.check_completion()) //Yes, the client can be null here. BYOND moment.
-							C.inc_metabalance(METACOIN_CO_REWARD, reason="Completed your crew objective!")
+						if(!C) //Yes, the client can be null here. BYOND moment.
+							break
+						if(CO.check_completion())
+							C?.inc_metabalance(METACOIN_CO_REWARD, reason="Completed your crew objective!")
 							break
 
 	to_chat(world, "<BR><BR><BR><span class='big bold'>The round has ended.</span>")

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -71,5 +71,5 @@ SUBSYSTEM_DEF(ambience)
 	var/area/A = get_area(M)
 
 	if (length(A.ambient_effects) && (M.client.prefs.toggles & SOUND_AMBIENCE) && M.can_hear_ambience() && (world.time - M.client.ambient_effect_last_played) > AMBIENT_EFFECT_COOLDOWN && prob(5) && !M.client.channel_in_use(CHANNEL_AMBIENT_EFFECTS)) // 1/20 chance to play every second after cooldown
-		SEND_SOUND(M, sound(pick(A.ambient_effects), repeat = 0, wait = 0, volume = AMBIENT_EFFECTS_VOLUME, channel = CHANNEL_AMBIENT_EFFECTS))
 		M?.client?.ambient_effect_last_played = world.time
+		SEND_SOUND(M, sound(pick(A.ambient_effects), repeat = 0, wait = 0, volume = AMBIENT_EFFECTS_VOLUME, channel = CHANNEL_AMBIENT_EFFECTS))

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -70,6 +70,6 @@ SUBSYSTEM_DEF(ambience)
 /datum/controller/subsystem/ambience/proc/update_effects(mob/M) // Effect, random sounds that will play at random times, IC (requires the user to be able to hear)
 	var/area/A = get_area(M)
 
-	if (A.ambient_effects && (M.client.prefs.toggles & SOUND_AMBIENCE) && M.can_hear_ambience() && (world.time - M.client.ambient_effect_last_played) > AMBIENT_EFFECT_COOLDOWN && prob(5) && !M.client.channel_in_use(CHANNEL_AMBIENT_EFFECTS)) // 1/20 chance to play every second after cooldown
+	if (length(A.ambient_effects) && (M.client.prefs.toggles & SOUND_AMBIENCE) && M.can_hear_ambience() && (world.time - M.client.ambient_effect_last_played) > AMBIENT_EFFECT_COOLDOWN && prob(5) && !M.client.channel_in_use(CHANNEL_AMBIENT_EFFECTS)) // 1/20 chance to play every second after cooldown
 		SEND_SOUND(M, sound(pick(A.ambient_effects), repeat = 0, wait = 0, volume = AMBIENT_EFFECTS_VOLUME, channel = CHANNEL_AMBIENT_EFFECTS))
 		M.client.ambient_effect_last_played = world.time

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -70,6 +70,6 @@ SUBSYSTEM_DEF(ambience)
 /datum/controller/subsystem/ambience/proc/update_effects(mob/M) // Effect, random sounds that will play at random times, IC (requires the user to be able to hear)
 	var/area/A = get_area(M)
 
-	if (length(A.ambient_effects) && (M.client.prefs.toggles & SOUND_AMBIENCE) && M.can_hear_ambience() && (world.time - M.client.ambient_effect_last_played) > AMBIENT_EFFECT_COOLDOWN && prob(5) && !M.client.channel_in_use(CHANNEL_AMBIENT_EFFECTS)) // 1/20 chance to play every second after cooldown
-		M?.client?.ambient_effect_last_played = world.time
+	if (length(A.ambient_effects) && (M.client?.prefs.toggles & SOUND_AMBIENCE) && M.can_hear_ambience() && (world.time - M.client?.ambient_effect_last_played) > AMBIENT_EFFECT_COOLDOWN && prob(5) && !M.client?.channel_in_use(CHANNEL_AMBIENT_EFFECTS)) // 1/20 chance to play every second after cooldown
+		M.client?.ambient_effect_last_played = world.time
 		SEND_SOUND(M, sound(pick(A.ambient_effects), repeat = 0, wait = 0, volume = AMBIENT_EFFECTS_VOLUME, channel = CHANNEL_AMBIENT_EFFECTS))

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -72,4 +72,4 @@ SUBSYSTEM_DEF(ambience)
 
 	if (length(A.ambient_effects) && (M.client.prefs.toggles & SOUND_AMBIENCE) && M.can_hear_ambience() && (world.time - M.client.ambient_effect_last_played) > AMBIENT_EFFECT_COOLDOWN && prob(5) && !M.client.channel_in_use(CHANNEL_AMBIENT_EFFECTS)) // 1/20 chance to play every second after cooldown
 		SEND_SOUND(M, sound(pick(A.ambient_effects), repeat = 0, wait = 0, volume = AMBIENT_EFFECTS_VOLUME, channel = CHANNEL_AMBIENT_EFFECTS))
-		M.client.ambient_effect_last_played = world.time
+		M?.client?.ambient_effect_last_played = world.time

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -258,7 +258,7 @@
 	var/turf/position = get_turf(src)
 	for(var/obj/item/jammer/jammer in GLOB.active_jammers)
 		var/turf/jammer_turf = get_turf(jammer)
-		if(position && position.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
+		if(position?.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
 			return
 
 	// Determine the identity information which will be attached to the signal.

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -258,7 +258,7 @@
 	var/turf/position = get_turf(src)
 	for(var/obj/item/jammer/jammer in GLOB.active_jammers)
 		var/turf/jammer_turf = get_turf(jammer)
-		if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
+		if(position && position.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
 			return
 
 	// Determine the identity information which will be attached to the signal.

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -13,6 +13,9 @@
 	var/last_man_standing = FALSE
 	var/list/datum/mind/targets_stolen
 
+/datum/antagonist/traitor/internal_affairs/New()
+	..()
+	targets_stolen = list()
 
 /datum/antagonist/traitor/internal_affairs/proc/give_pinpointer()
 	if(owner?.current)


### PR DESCRIPTION
Runtimes bad.

## Changelog
:cl:
fix: Null clients are now less likely to completely break roundend.
fix: Fixed some internal affairs objective code just... not working.
fix: Fixed two ambience runtimes.
fix: Radios will no longer runtime when we can't get their turf.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
