### PR TITLE
Cap slimepeople duping

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -433,6 +433,8 @@
 	config_entry_value = 100
 /datum/config_entry/number/max_slimes
 	config_entry_value = 100
+/datum/config_entry/number/max_slimeperson_bodies
+	config_entry_value = 10
 
 //Maximum citation fine
 /datum/config_entry/number/maxfine

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -192,6 +192,13 @@
 	if(!isslimeperson(H))
 		return
 	CHECK_DNA_AND_SPECIES(H)
+
+	//Prevent one person from creating 100 bodies.
+	var/datum/species/jelly/slime/species = H.dna.species
+	if(length(species.bodies) > CONFIG_GET(number/max_slimeperson_bodies))
+		to_chat(H, "<span class='warning'>Your mind is spread too thin! You have too many bodies already.</span>")
+		return
+
 	H.visible_message("<span class='notice'>[owner] gains a look of \
 		concentration while standing perfectly still.</span>",
 		"<span class='notice'>You focus intently on moving your body while \

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -608,6 +608,9 @@ RANDOMIZE_SHIFT_TIME
 ## A cap on how many monkeys may be created via monkey cubes
 MONKEYCAP 100
 
+## Max amount of bodies allowed to slimepeople. Has balance considerations as well as technical ones.
+MAX_SLIMEPERSON_BODIES 10
+
 ## Maximum fine for a citation
 MAXFINE 2000
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -615,6 +615,10 @@ MAX_CUBE_MONKEYS 150
 MAX_CHICKENS 100
 MAX_SLIMES 100
 
+## Max amount of bodies allowed to slimepeople. Has balance considerations as well as technical ones.
+MAX_SLIMEPERSON_BODIES 10
+
+
 ## Uncomment to restrict suiciding. Adds an additional confirmation dialogue, additional logging, and prevents suicide within the first 15 minutes of the round.
 #RESTRICTED_SUICIDE
 


### PR DESCRIPTION
Prevents building up 100s of worthless carbons.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cap slimepeople duplication at 10. Prevents runaway duplication from plasma chambers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

having a pile of utterly worthless carbon mobs isn't a great thing for performance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Slimepeople are only allowed to have 10 total bodies, for performance reasons.
config: This can be configured.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
