### PR TITLE
Shove cuff bad

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -61,7 +61,7 @@
 								"<span class='userdanger'>[user] is trying to put [src.name] on you!</span>")
 
 			playsound(loc, cuffsound, 30, 1, -2)
-			if(do_mob(user, C, 30) && (C.get_num_arms(FALSE) >= 2 || C.get_arm_ignore()))
+			if(do_mob(user, C, 50) && (C.get_num_arms(FALSE) >= 2 || C.get_arm_ignore()))
 				if(iscyborg(user))
 					apply_cuffs(C, user, TRUE)
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases cuff time from 3 seconds to 5 seconds, to prevent shovestun cuffing

## Why It's Good For The Game

Currently, one shove paralyze gives you enough time to handcuff someone before they have the opportunity to get back up. 
It can actually be faster to detain someone via shoving than a baton or disabler.. 

## Changelog
:cl:
balance: Changes cuff time from 3 seconds to 5 seconds 
/:cl:

