### PR TITLE
Fixes firelocks and window doors not updating atmos properly on destroy and keeping pressure

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -66,6 +66,8 @@
 			LAZYREMOVE(A.firedoors, src)
 
 /obj/machinery/door/firedoor/Destroy()
+	density = FALSE
+	air_update_turf(1)
 	remove_from_areas()
 	affecting_areas.Cut()
 	return ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -66,8 +66,6 @@
 			LAZYREMOVE(A.firedoors, src)
 
 /obj/machinery/door/firedoor/Destroy()
-	density = FALSE
-	air_update_turf(1)
 	remove_from_areas()
 	affecting_areas.Cut()
 	return ..()
@@ -325,6 +323,11 @@
 	flags_1 = ON_BORDER_1
 	CanAtmosPass = ATMOS_PASS_PROC
 	assemblytype = /obj/structure/firelock_frame/border
+
+/obj/machinery/door/firedoor/border_only/Destroy()
+	density = FALSE
+	air_update_turf(1)
+	return ..()
 
 /obj/machinery/door/firedoor/border_only/closed
 	icon_state = "door_closed"

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -42,6 +42,7 @@
 
 /obj/machinery/door/window/Destroy()
 	density = FALSE
+	air_update_turf(1)
 	QDEL_LIST(debris)
 	if(obj_integrity == 0)
 		playsound(src, "shatter", 70, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Firelocks and window doors had a problem where they would not update atmos when destroyed and thus still keep pressure this PR fixes this.
closes #3594 
closes #2109 

## Why It's Good For The Game

Fixes a rather annoying bug

## Changelog
:cl:
fix: border firelocks holding Pressure after destroy
fix: window doors holding Pressure after destroy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
