### PR TITLE
Miscellaneous fixes (2021-02-15)

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -133,17 +133,18 @@ RLD
 		update_icon()
 		return TRUE
 	else
+		var/list/matlist = list(getmaterialref(/datum/material/iron) = 500)
 		if(silo_mats.on_hold())
 			if(user)
 				to_chat(user, "Mineral access is on hold, please contact the quartermaster.")
 			return FALSE
-		if(!silo_mats.mat_container.has_materials(list(/datum/material/iron = 500), amount))
+		if(!silo_mats.mat_container.has_materials(matlist, amount))
 			if(user)
 				to_chat(user, no_ammo_message)
 			return FALSE
 
-		silo_mats.mat_container.use_materials(list(/datum/material/iron = 500), amount)
-		silo_mats.silo_log(src, "consume", -amount, "build", list(/datum/material/iron = 500))
+		silo_mats.mat_container.use_materials(matlist, amount)
+		silo_mats.silo_log(src, "consume", -amount, "build", matlist)
 		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)
@@ -154,7 +155,7 @@ RLD
 			if(user)
 				to_chat(user, "Mineral access is on hold, please contact the quartermaster.")
 			return FALSE
-		. = silo_mats.mat_container.has_materials(list(/datum/material/iron = 500), amount)
+		. = silo_mats.mat_container.has_materials(list(getmaterialref(/datum/material/iron) = 500), amount)
 	if(!. && user)
 		to_chat(user, no_ammo_message)
 		if(has_ammobar)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -312,7 +312,7 @@ Code:
 //would be to use <span style="width: NNNpx; overflow: none;">[A.area.name]</span>
 					for(var/obj/machinery/power/apc/A in L)
 						menu += copytext_char(add_trailing(A.area.name, 30, " "), 1, 30)
-						menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_leading(DisplayPower(A.lastused_total), 6, " ")]  [A.cell ? "[add_leading(round(A.cell.percent()), 3, " ")]% [chg[A.charging+1]]" : "  N/C"]<BR>"
+						menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_leading(DisplayPower(A.lastused_total), 6, " ")]  [A.cell ? "[add_leading("[round(A.cell.percent())]", 3, " ")]% [chg[A.charging+1]]" : "  N/C"]<BR>"
 
 				menu += "</FONT></PRE>"
 

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -201,8 +201,8 @@
 	var/denied_type = /obj/item/crusher_trophy
 
 /obj/item/crusher_trophy/examine(mob/living/user)
-	..()
-	to_chat(user, "<span class='notice'>Causes [effect_desc()] when attached to a kinetic crusher.</span>")
+	. = ..()
+	. += "<span class='notice'>Causes [effect_desc()] when attached to a kinetic crusher.</span>"
 
 /obj/item/crusher_trophy/proc/effect_desc()
 	return "errors"

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -96,15 +96,15 @@
 	return tab_data
 
 /mob/proc/get_all_verbs()
-	var/list/all_verbs = list()
+	var/list/all_verbs = deepCopyList(sorted_verbs)
 	//An annoying thing to mention:
 	// list A [A: ["b", "c"]] +  (list B) [A: ["c", "d"]] will only have A from list B
-	all_verbs += sorted_verbs
 	for(var/i in client.sorted_verbs)
 		if(i in all_verbs)
 			all_verbs[i] += client.sorted_verbs[i]
 		else
-			all_verbs[i] = client.sorted_verbs[i]
+			var/list/verbs_to_copy = client.sorted_verbs[i]
+			all_verbs[i] = verbs_to_copy.Copy()
 	for(var/atom/A as() in contents)
 		//As an optimisation we will make it so all verbs on objects will go into the object tab.
 		//If you don't want this to happen change this.

--- a/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -52,7 +52,7 @@
 			H.gib()
 			obj_integrity = min(obj_integrity + max_integrity*0.05,max_integrity)//restores 5% hp of tendril
 			for(var/mob/living/L in view(src, 5))
-				if(L.mind.has_antag_datum(/datum/antagonist/ashwalker))
+				if(L.mind?.has_antag_datum(/datum/antagonist/ashwalker))
 					SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "oogabooga", /datum/mood_event/sacrifice_good)
 				else
 					SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "oogabooga", /datum/mood_event/sacrifice_bad)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a few bugs.

The most notable of them is the bug at `/mob/proc/get_all_verbs()` which caused mob's `sorted_verb`'s sublists to balloon indefinitely (generally in tens of thousands as the round goes on) and possibly lag the server a bit(?). It is caused by refs being passed indiscriminately; at the composition of `all_verbs` list, the sublists themselves, rather than their contents, are added to the `all_verbs`. As the proc adds client's verbs to the corresponding sublists of `all_verbs`, the mob's `sorted_verb`'s sublists indefinitely balloons every time the `/mob/proc/get_all_verbs()` gets called.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less bugs and memory leaks, better code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Engineering PDA catridge's APC monitors power percentage display
fix: Crusher trophy's examine text is now sane
fix: RCDs with a silo link now work properly
fix: Ash walker tendril now applies mood properly
fix: Fixed a memory leak related to TGUI Stat panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
