### PR TITLE
Stops qdeleted pipes from building pipeline

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -24,7 +24,7 @@
 	return ..()
 
 /datum/pipeline/proc/build_pipeline(obj/machinery/atmospherics/base)
-	if(src != null && base != null)
+	if(!QDELETED(base))
 		var/volume = 0
 		if(istype(base, /obj/machinery/atmospherics/pipe))
 			var/obj/machinery/atmospherics/pipe/E = base


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rarely, qdeleted (but not GCed) pipes get into pipenet rebuilding queue, probably because a pipe can be added twice to that queue while dequeuing on the `Destroy` only can handle being on the queue once. This causes harddel of said pipe. However, qdeleting or null pipenet won't *ever* initiate `build_pipeline`. I didn't bundle this fix into a daily(?) fix PR because this is atmos.

And, oh dear, pipeline code is a house of cards, really.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less harddels, faster code.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a cause of pipe harddels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
