### PR TITLE
Makes automatic shotguns heavy weapons

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -60,6 +60,9 @@
 
 // Automatic Shotguns//
 
+/obj/item/gun/ballistic/shotgun/automatic
+	weapon_weight = WEAPON_HEAVY
+
 /obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)
 	..()
 	rack()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes shotguns weapon weight heavy.

## Why It's Good For The Game

Makes it so you need 2 hands to fire automatic shotgun. In tern fixes a bug where if you fire the combat shotgun with something in your other hand it doesn't rack without making it completely bypass the 2 hand check..

## Changelog
:cl:
tweak: Automatic shotguns need 2 hands to be fired, fixing a bug that would break automatic shotguns if you had an item in your inactive hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
