### PR TITLE
Fix Airlock Painter icon bug as well as a possible cult airlock exploid with airlock painter

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1268,63 +1268,124 @@
 		if("Standard")
 			icon = 'icons/obj/doors/airlocks/station/public.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Public")
 			icon = 'icons/obj/doors/airlocks/station2/glass.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station2/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_public
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Engineering")
 			icon = 'icons/obj/doors/airlocks/station/engineering.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_eng
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Atmospherics")
 			icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_atmo
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Security")
 			icon = 'icons/obj/doors/airlocks/station/security.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_sec
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Command")
 			icon = 'icons/obj/doors/airlocks/station/command.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_com
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Medical")
 			icon = 'icons/obj/doors/airlocks/station/medical.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_med
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Research")
 			icon = 'icons/obj/doors/airlocks/station/research.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_research
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Freezer")
 			icon = 'icons/obj/doors/airlocks/station/freezer.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_fre
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Science")
 			icon = 'icons/obj/doors/airlocks/station/science.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_science
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Virology")
 			icon = 'icons/obj/doors/airlocks/station/virology.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_viro
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Mining")
 			icon = 'icons/obj/doors/airlocks/station/mining.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_min
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("Maintenance")
 			icon = 'icons/obj/doors/airlocks/station/maintenance.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_mai
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
 		if("External")
 			icon = 'icons/obj/doors/airlocks/external/external.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_ext
+			anim_parts = "top=0,16;bottom=0,-16"
+			note_attachment = "bottom"
+			panel_attachment = "bottom"
 		if("External Maintenance")
 			icon = 'icons/obj/doors/airlocks/station/maintenanceexternal.dmi'
 			overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
+			note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 			assemblytype = /obj/structure/door_assembly/door_assembly_extmai
+			anim_parts = "left=-14,0;right=13,0"
+			panel_attachment = "right"
+			note_attachment = "left"
+	rebuild_parts()
 	update_icon()
 
 /obj/machinery/door/airlock/CanAStarPass(obj/item/card/id/ID)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -53,6 +53,7 @@
 	explosion_block = 1
 	open_speed = 2.5
 	hud_possible = list(DIAG_AIRLOCK_HUD)
+	var/allow_repaint = TRUE
 
 	FASTDMM_PROP(\
 		pinned_vars = list("req_access_txt", "req_one_access_txt", "name")\
@@ -1252,7 +1253,7 @@
 
 
 /obj/machinery/door/airlock/proc/change_paintjob(obj/item/airlock_painter/W, mob/user)
-	if(!W.can_use(user))
+	if(!W.can_use(user) || !allow_repaint)
 		return
 
 	var/list/optionlist

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -479,6 +479,7 @@
 	var/openingoverlaytype = /obj/effect/temp_visual/cult/door
 	var/friendly = FALSE
 	var/stealthy = FALSE
+	allow_repaint = FALSE
 
 /obj/machinery/door/airlock/cult/Initialize()
 	. = ..()
@@ -589,6 +590,7 @@
 	assemblytype = null
 	glass = TRUE
 	bound_width = 64 // 2x1
+	allow_repaint = FALSE
 
 /obj/machinery/door/airlock/glass_large/narsie_act()
 	return

--- a/code/modules/antagonists/clock_cult/clockwork_turfs.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_turfs.dm
@@ -348,6 +348,7 @@
 	air_tight = FALSE
 	CanAtmosPass = ATMOS_PASS_YES
 	var/construction_state = GEAR_SECURE //Pinion airlocks have custom deconstruction
+	allow_repaint = FALSE
 
 /obj/machinery/door/airlock/clockwork/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR is an alternative to Porting https://github.com/yogstation13/Yogstation/pull/10935 from Yogstation.
It fixes a Bug that would turn a repainted maint hatches invisible and another bug overlooked by the yogstation coder that would mess up the external airlock repaint.
I am aware that i could have reduced the ammount of additional code needed in here by simply using another check for the single exception but i decided to instead override it in every single condition in the switch function to stay consitant and make it overal less confusing.
Just to clarify this is not a Port but it got inspired by the PR mentioned above.

Edit: Just found a exploid cult could use to repaint their cult airlocks to look like normal ones so fixed that too and disallowed the repaint of large airlocks.

## Why It's Good For The Game

Fixes an icon bug that has been introduced with the smooth airlock port.
Also fixes an exploid you could use to disguise cult airlocks.

## Changelog
:cl:
fix: Repainted hatches/maint hatches turning invisible.
fix: External Airlock repaint missing the moving parts.
fix: hatch position and note position in all cases above.
fix: Exploid allowing cult to disguise their airlocks with airlock painter
tweak: Disallowing repaint of large airlock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
