### PR TITLE
Fix morph becoming invisible and unclickable if it disguises as an airlock

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -218,8 +218,7 @@
 		for(var/I in 1 to length(target.vis_contents))
 			var/obj/p = target.vis_contents[I]
 			icon = p.icon
-			add_overlay(p.icon_state)
-			add_overlay(p.overlays)
+			add_overlay(list(p.icon_state, p.overlays))
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)
 	pixel_y = initial(pixel_y)

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -217,6 +217,7 @@
 	if(target.vis_contents)
 		for(var/I in 1 to length(target.vis_contents))
 			var/obj/p = target.vis_contents[I]
+			icon = p.icon
 			add_overlay(p.icon_state)
 			add_overlay(p.overlays)
 	alpha = max(alpha, 150)	//fucking chameleons

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -214,6 +214,9 @@
 					"<span class='notice'>You twist your body and assume the form of [target].</span>")
 	appearance = target.appearance
 	copy_overlays(target)
+	vis_contents.Cut()
+	if(target.vis_contents)
+		vis_contents += target.vis_contents
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)
 	pixel_y = initial(pixel_y)
@@ -253,6 +256,8 @@
 	icon = initial(icon)
 	icon_state = initial(icon_state)
 	cut_overlays()
+	if(vis_contents)
+		vis_contents.Cut()
 
 	//Baseline stats
 	melee_damage = initial(melee_damage)

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -214,8 +214,7 @@
 					"<span class='notice'>You twist your body and assume the form of [target].</span>")
 	appearance = target.appearance
 	copy_overlays(target)
-	vis_contents.Cut()
-	if(target.vis_contents)
+	if(target.vis_contents && !istype(target, /obj/machinery/computer))
 		vis_contents += target.vis_contents
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -213,12 +213,10 @@
 	visible_message("<span class='warning'>[src] suddenly twists and changes shape, becoming a copy of [target]!</span>", \
 					"<span class='notice'>You twist your body and assume the form of [target].</span>")
 	appearance = target.appearance
-	copy_overlays(target)
-	if(target.vis_contents)
-		for(var/I in 1 to length(target.vis_contents))
-			var/obj/p = target.vis_contents[I]
-			icon = p.icon
-			add_overlay(list(p.icon_state, p.overlays))
+	copy_overlays(target, TRUE)
+	if(length(target.vis_contents))
+		for(var/atom/A as() in target.vis_contents)
+			add_overlay(A)
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)
 	pixel_y = initial(pixel_y)

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -213,7 +213,6 @@
 	visible_message("<span class='warning'>[src] suddenly twists and changes shape, becoming a copy of [target]!</span>", \
 					"<span class='notice'>You twist your body and assume the form of [target].</span>")
 	appearance = target.appearance
-	copy_overlays(target)
 	if(length(target.vis_contents))
 		add_overlay(target.vis_contents)
 	alpha = max(alpha, 150)	//fucking chameleons

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -214,8 +214,11 @@
 					"<span class='notice'>You twist your body and assume the form of [target].</span>")
 	appearance = target.appearance
 	copy_overlays(target)
-	if(target.vis_contents && !istype(target, /obj/machinery/computer))
-		vis_contents += target.vis_contents
+	if(target.vis_contents)
+		for(var/I in 1 to length(target.vis_contents))
+			var/obj/p = target.vis_contents[I]
+			add_overlay(p.icon_state)
+			add_overlay(p.overlays)
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)
 	pixel_y = initial(pixel_y)
@@ -255,8 +258,6 @@
 	icon = initial(icon)
 	icon_state = initial(icon_state)
 	cut_overlays()
-	if(vis_contents)
-		vis_contents.Cut()
 
 	//Baseline stats
 	melee_damage = initial(melee_damage)

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -213,7 +213,7 @@
 	visible_message("<span class='warning'>[src] suddenly twists and changes shape, becoming a copy of [target]!</span>", \
 					"<span class='notice'>You twist your body and assume the form of [target].</span>")
 	appearance = target.appearance
-	copy_overlays(target, TRUE)
+	copy_overlays(target)
 	if(length(target.vis_contents))
 		add_overlay(target.vis_contents)
 	alpha = max(alpha, 150)	//fucking chameleons

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -215,8 +215,7 @@
 	appearance = target.appearance
 	copy_overlays(target, TRUE)
 	if(length(target.vis_contents))
-		for(var/atom/A as() in target.vis_contents)
-			add_overlay(A)
+		add_overlay(target.vis_contents)
 	alpha = max(alpha, 150)	//fucking chameleons
 	transform = initial(transform)
 	pixel_y = initial(pixel_y)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug that would cause the morph to become invisible and unclickable if it tries to use an airlock as an disguise.
Also fixes screens not showing in disguise for computers or apc's.
I basically just convert the icons of the vis_content list objects into overlays.
closes #3376

## Why It's Good For The Game

Invisible Morph that cannot be hit is bad

## Changelog
:cl:
fix: Fixes morph becoming invisible and unclickable if it tries to disguise as an airlock
fix: Fixes computer screen and apc screen not showing in disguise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
