### PR TITLE
Now is time to sanitize pickweight

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -261,13 +261,14 @@
 			L[item] = 1
 		total += L[item]
 
-	total = rand(1, total)
+	total *= rand()
 	for (item in L)
 		total -=L [item]
 		if (total <= 0)
 			return item
 
-	return null
+	// Emergency pick()
+	return pick(L)
 
 /proc/pickweightAllowZero(list/L) //The original pickweight proc will sometimes pick entries with zero weight.  I'm not sure if changing the original will break anything, so I left it be.
 	var/total = 0
@@ -277,13 +278,13 @@
 			L[item] = 0
 		total += L[item]
 
-	total = rand(0, total)
+	total *= rand()
 	for (item in L)
 		total -=L [item]
 		if (total <= 0 && L[item])
 			return item
 
-	return null
+	return pick(L)
 
 /// Pick a random element from the list and remove it from the list.
 /proc/pick_n_take(list/L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #2908 
fixes #3462

`pickweight` is a 9-year-old helper that can't handle non-integer weights. As BYOND's `rand(X,Y)` can actually return numbers *roughly* between `round(X)` and `round(Y) + 1`, when the calculated `total` at `pickweight` is non-integer, the line `total = rand(1, total)` *can* set `total` to be higher than the weights' total. In that case, `pickweight`'s logic can't pick an entry and return `null` (and may break shit once in a while) as `total` will never go below 0. This has been the cause of #2908 (which is the same bug as #3462) since weights *can* be non-integer as rooms get spawned and templates' weights are halved.

This PR uses `rand()`, which returns random non-integer number between 0 and 1, so that the logic of `pickweight` can handle non-integer weights, therefore making it more accurate and safe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better code, but, honestly, when can we achieve it?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed weighted picking logic, so various codes utilizing weighted pick is now a bit more safe and correct
fix: The most prominent of such cases would be preventing random maint rooms from not spawning once in a while
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
