### PR TITLE
Energy katana gets deleted when the ninja dies.

### DIFF
--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -18,7 +18,7 @@
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	sharpness = IS_SHARP
 	max_integrity = 200
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE
 	var/datum/effect_system/spark_spread/spark_system
 	var/datum/action/innate/dash/ninja/jaunt
 	var/dash_toggled = TRUE

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -82,7 +82,9 @@ Contents:
 	qdel(n_gloves)
 	qdel(n_shoes)
 	qdel(src)
-
+	if(energyKatana)
+		energyKatana.visible_message("<span class='warning'>[src] flares and then turns to dust!</span>")
+		qdel(energyKatana)
 
 //Randomizes suit parameters.
 /obj/item/clothing/suit/space/space_ninja/proc/randomize_param()

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -81,10 +81,10 @@ Contents:
 	qdel(n_hood)
 	qdel(n_gloves)
 	qdel(n_shoes)
-	qdel(src)
 	if(energyKatana)
 		energyKatana.visible_message("<span class='warning'>[src] flares and then turns to dust!</span>")
 		qdel(energyKatana)
+	qdel(src)
 
 //Randomizes suit parameters.
 /obj/item/clothing/suit/space/space_ninja/proc/randomize_param()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Destroys the energy katana when the ninja dies.
Makes the energy katana indestructible.

## Why It's Good For The Game

Energy katana is one of the most overpowered items in the game, if the ninja manages to die then literally nothing stands a chance against security wielding it.
Also makes it indestructible, so its always in play while the ninja is in play and then out of play when the ninja is out of play.

## Changelog
:cl:
tweak: Energy katana is now indestructible.
tweak: Energy katana is destroyed when its attached ninja is destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
