### PR TITLE
More hallucinations

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -692,6 +692,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		feedback_details += "Type: Talk, Source: [person.real_name], Message: [message]"
 		to_chat(target, message)
 		if(target.client)
+			animate_chat(person, message, understood_language, null, list(target.client), 50)
 			target.client.images |= speech_overlay
 			sleep(30)
 			target.client.images.Remove(speech_overlay)
@@ -826,7 +827,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	..()
 	var/turf/source = random_far_turf()
 	if(!sound_type)
-		sound_type = pick("phone","hallelujah","highlander","laughter","hyperspace","game over","creepy","tesla")
+		sound_type = pick("phone","hallelujah","highlander","laughter","hyperspace","game over","creepy","tesla","clockcult")
 	feedback_details += "Type: [sound_type]"
 	//Strange audio
 	switch(sound_type)
@@ -860,6 +861,8 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			target.playsound_local(source, 'sound/magic/lightningbolt.ogg', 65, 1)
 			sleep(30)
 			target.playsound_local(source, 'sound/magic/lightningbolt.ogg', 100, 1)
+		if("clockcult")
+			target.playsound_local(source, pick('sound/magic/magic_missile.ogg', 'sound/magic/mm_hit.ogg', 'sound/machines/clockcult/integration_cog_install.ogg', 'sound/magic/staff_animation.ogg'), 50, 1)
 
 	qdel(src)
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -771,7 +771,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	..()
 	var/turf/source = random_far_turf()
 	if(!sound_type)
-		sound_type = pick("airlock","airlock pry","console","explosion","far explosion","mech","glass","alarm","beepsky","mech","wall decon","door hack")
+		sound_type = pick("airlock","airlock pry","console","explosion","far explosion","mech","glass","alarm","beepsky","mech","wall decon","door hack","clockcult")
 	feedback_details += "Type: [sound_type]"
 	//Strange audio
 	switch(sound_type)
@@ -818,6 +818,9 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			target.playsound_local(source, 'sound/items/screwdriver.ogg', 50, 1)
 			sleep(rand(40,80))
 			target.playsound_local(source, 'sound/machines/airlockforced.ogg', 30, 1)
+		//Clockcult effects
+		if("clockcult")
+			target.playsound_local(source, pick('sound/magic/magic_missile.ogg', 'sound/magic/mm_hit.ogg', 'sound/machines/clockcult/integration_cog_install.ogg', 'sound/magic/staff_animation.ogg'), 50, 1)
 	qdel(src)
 
 /datum/hallucination/weird_sounds
@@ -827,7 +830,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	..()
 	var/turf/source = random_far_turf()
 	if(!sound_type)
-		sound_type = pick("phone","hallelujah","highlander","laughter","hyperspace","game over","creepy","tesla","clockcult")
+		sound_type = pick("phone","hallelujah","highlander","laughter","hyperspace","game over","creepy","tesla")
 	feedback_details += "Type: [sound_type]"
 	//Strange audio
 	switch(sound_type)
@@ -861,8 +864,6 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			target.playsound_local(source, 'sound/magic/lightningbolt.ogg', 65, 1)
 			sleep(30)
 			target.playsound_local(source, 'sound/magic/lightningbolt.ogg', 100, 1)
-		if("clockcult")
-			target.playsound_local(source, pick('sound/magic/magic_missile.ogg', 'sound/magic/mm_hit.ogg', 'sound/machines/clockcult/integration_cog_install.ogg', 'sound/magic/staff_animation.ogg'), 50, 1)
 
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hallucinated messages will now show overhead.
Clockcult sounds added to hallucinations.

## Why It's Good For The Game

Harder to distinguish hallucinations, clockcult hallucinations.

## Changelog
:cl:
add: Clockcult hallucinations
add: Say hallucination has overhead chat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
