### PR TITLE
Removes botany's superior chem dispenser

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13436,7 +13436,6 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aJN" = (
-/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aJO" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -125467,7 +125467,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "vhb" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55005,7 +55005,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ccv" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -63688,7 +63688,6 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "ucI" = (
-/obj/machinery/chem_dispenser/mutagensaltpetersmall,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "uek" = (

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -606,18 +606,6 @@
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
 	needs_anchored = FALSE
 
-/obj/item/circuitboard/machine/chem_dispenser/botany				//probably should be generic but who cares
-	name = "minor botanical chem dispenser (Machine Board)"
-	build_path = /obj/machinery/chem_dispenser/mutagensaltpetersmall
-	req_components = list(
-		/obj/item/stock_parts/matter_bin = 2,
-		/obj/item/stock_parts/capacitor = 1,
-		/obj/item/stock_parts/manipulator = 1,
-		/obj/item/stack/sheet/glass = 1,
-		/obj/item/stock_parts/cell = 1)
-	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
-	needs_anchored = FALSE
-
 /obj/item/circuitboard/machine/chem_heater
 	name = "chemical heater (Machine Board)"
 	icon_state = "medical"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1928,6 +1928,17 @@ datum/supply_pack/medical/bruisekits
 	crate_name = "beekeeping starter crate"
 	crate_type = /obj/structure/closet/crate/hydroponics
 
+/datum/supply_pack/organic/hydroponics/chemical_refill
+	name = "Botanical Reagent Crate"
+	desc = ""
+	cost = 800
+	contains = list(/obj/item/reagent_containers/glass/bottle/mutagen,
+					/obj/item/reagent_containers/glass/bottle/mutagen,
+					/obj/item/reagent_containers/glass/bottle/mutagen,
+					/obj/item/reagent_containers/glass/bottle/diethylamine)
+	crate_name = "beekeeper suits"
+	crate_type = /obj/structure/closet/crate/hydroponics
+
 /datum/supply_pack/organic/randomized/chef
 	name = "Excellent Meat Crate"
 	desc = "The best cuts in the whole galaxy."

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -591,31 +591,6 @@
 	component_parts += new /obj/item/stock_parts/cell/bluespace(null)
 	RefreshParts()
 
-/obj/machinery/chem_dispenser/mutagensaltpetersmall
-	name = "minor botanical chemical dispenser"
-	desc = "A botanical chemical dispenser on a budget."
-	icon_state = "minidispenser"
-	working_state = "minidispenser_working"
-	nopower_state = "minidispenser_nopower"
-	circuit = /obj/item/circuitboard/machine/chem_dispenser/botany
-	dispensable_reagents = list(
-		/datum/reagent/toxin/mutagen,
-		/datum/reagent/saltpetre,
-		/datum/reagent/water)
-	upgrade_reagents = list(
-		/datum/reagent/toxin/plantbgone,
-		/datum/reagent/toxin/plantbgone/weedkiller,
-		/datum/reagent/toxin/pestkiller,
-		/datum/reagent/diethylamine)
-
-/obj/machinery/chem_dispenser/mutagensaltpetersmall/display_beaker()
-	var/mutable_appearance/b_o = beaker_overlay || mutable_appearance(icon, "disp_beaker")
-	b_o.pixel_y = -4
-	b_o.pixel_x = -4
-	return b_o
-
-
-
 /obj/machinery/chem_dispenser/fullupgrade //fully ugpraded stock parts, emagged
 	desc = "Creates and dispenses chemicals. This model has had its safeties shorted out."
 	obj_flags = CAN_BE_HIT | EMAGGED


### PR DESCRIPTION
## About The Pull Request

- Removes botany's chem dispenser from the game
- reverts https://github.com/BeeStation/BeeStation-Hornet/pull/1560
## Why It's Good For The Game

Departments need to depend on each other. Progression is meant to take time, and is reduced when departments work together.

This item was created since rounds were short, and botany _needed to get their endgame faster_. 

>The problem: Beestation rounds are SHORT. Like, 25 minutes short at times. An effective Botanist has to speed run tech storage or chemistry to steal a dispenser (optimally) in order to get chemicals needed to mutate plants and increase yield.

However, this has caused Botany to no longer depend on the rest of the station to reach their endgame. No longer does Botany need to ask chemists for materials, or suffer when no chemists or doctors are around to press buttons.

Rounds should be longer, not optimized for a rush to the end.
---

Why ask a chemist for anything, when your private dispenser is outright **better** than theirs?

![image](https://user-images.githubusercontent.com/3241376/108586237-ba788c00-7312-11eb-8aa3-4df8d4a86be5.png)

![image](https://user-images.githubusercontent.com/3241376/108586248-d2e8a680-7312-11eb-82c3-50d1d0c20ccc.png)


## Changelog
:cl:
del: Removed botany's specific chem dispenser.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
