### PR TITLE
[PORT] Vending machine costs

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5547,8 +5547,8 @@
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
-/obj/item/multitool,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "alO" = (
@@ -6222,7 +6222,6 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/item/multitool,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "aoj" = (
@@ -9130,7 +9129,6 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayS" = (
@@ -10759,10 +10757,6 @@
 /obj/item/assembly/signaler,
 /obj/item/radio/intercom{
 	pixel_y = 20
-	},
-/obj/item/multitool,
-/obj/item/multitool{
-	pixel_x = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -23436,9 +23430,6 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
-/obj/item/multitool{
-	pixel_x = 3
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bnj" = (
@@ -25666,7 +25657,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buH" = (
@@ -29952,7 +29942,6 @@
 /obj/machinery/cell_charger{
 	pixel_y = 5
 	},
-/obj/item/multitool,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bGw" = (
@@ -30347,7 +30336,6 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/multitool,
 /obj/item/clothing/glasses/meson,
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -31670,7 +31658,6 @@
 	},
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/t_scanner,
-/obj/item/multitool,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bLC" = (
@@ -54730,6 +54717,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"npS" = (
+/obj/item/clothing/gloves/color/fyellow,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nqZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -79122,7 +79113,7 @@ ayl
 aNi
 ayl
 ayl
-ayl
+npS
 aSf
 czK
 czK

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -31668,7 +31668,7 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/t_scanner,
 /obj/item/multitool,
 /turf/open/floor/plating,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -52129,7 +52129,7 @@
 /area/storage/primary)
 "bKt" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -54663,7 +54663,7 @@
 /area/hallway/primary/port)
 "bOl" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/storage/toolbox/electrical,
 /obj/item/multitool,
 /obj/machinery/light{

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -23987,7 +23987,6 @@
 "aTQ" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
-/obj/item/multitool,
 /obj/item/pen/red,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -55064,7 +55063,6 @@
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
-/obj/item/multitool,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
@@ -55964,7 +55962,6 @@
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer,
 /obj/item/assembly/timer,
-/obj/item/multitool,
 /obj/item/multitool,
 /obj/machinery/light,
 /obj/effect/turf_decal/bot,

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -6321,13 +6321,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "apY" = (
+/obj/item/clothing/gloves/color/yellow{
+	pixel_x = 2;
+	pixel_y = 4
+	},
 /obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus{
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/item/clothing/gloves/color/yellow,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -17734,7 +17738,7 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/t_scanner,
 /obj/item/multitool,
 /turf/open/floor/plating,

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -7491,10 +7491,6 @@
 	pixel_x = -30
 	},
 /obj/item/t_scanner,
-/obj/item/multitool{
-	pixel_x = 4
-	},
-/obj/item/multitool,
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel,
 /area/storage/tools)
@@ -8849,7 +8845,6 @@
 	pixel_x = -2;
 	pixel_y = -1
 	},
-/obj/item/multitool,
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -9329,7 +9324,6 @@
 "awC" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
-/obj/item/multitool,
 /obj/item/stack/cable_coil/random/five,
 /turf/open/floor/plating,
 /area/solar/starboard)
@@ -16178,7 +16172,6 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/construction)
 "aLY" = (
@@ -17740,7 +17733,6 @@
 	},
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/t_scanner,
-/obj/item/multitool,
 /turf/open/floor/plating,
 /area/storage/tech)
 "aPE" = (
@@ -17749,7 +17741,6 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/multitool,
 /obj/item/clothing/glasses/meson{
 	pixel_x = -2;
 	pixel_y = -2
@@ -28474,9 +28465,6 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
-/obj/item/multitool{
-	pixel_x = 3
-	},
 /obj/machinery/airalarm{
 	pixel_y = 25
 	},
@@ -38238,7 +38226,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/item/multitool,
 /obj/item/screwdriver,
 /obj/machinery/camera{
 	c_tag = "Cargo - Main 1";
@@ -44894,10 +44881,6 @@
 	},
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/item/multitool{
-	pixel_x = 1;
-	pixel_y = -2
-	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/scanning_module,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -24174,7 +24174,6 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "aKe" = (
@@ -56968,7 +56967,6 @@
 "bDD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
-/obj/item/multitool,
 /turf/open/floor/engine,
 /area/storage/tech)
 "bDE" = (
@@ -63519,7 +63517,6 @@
 	},
 /obj/item/pickaxe,
 /obj/item/pickaxe,
-/obj/item/multitool,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -87559,7 +87556,6 @@
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/folder,
-/obj/item/multitool,
 /obj/item/pen/red,
 /obj/machinery/airalarm{
 	pixel_y = 22

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -75289,7 +75289,6 @@
 /area/security/brig)
 "cdS" = (
 /obj/structure/sign/warning/securearea,
-/obj/item/multitool,
 /turf/closed/wall/r_wall,
 /area/security/nuke_storage)
 "cdT" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -56973,7 +56973,7 @@
 /area/storage/tech)
 "bDE" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/electronics/apc,
 /obj/item/electronics/airlock{
 	pixel_y = 6
@@ -98542,7 +98542,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/head/welding{
 	pixel_y = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -22012,7 +22012,7 @@
 	dir = 4;
 	pixel_x = 27
 	},
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -26093,7 +26093,7 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/t_scanner,
 /obj/item/multitool,
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19486,10 +19486,6 @@
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/item/multitool,
-/obj/item/multitool{
-	pixel_x = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
@@ -28436,7 +28432,6 @@
 	},
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
-/obj/item/multitool,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -29413,7 +29408,6 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/multitool,
 /obj/item/clothing/glasses/meson,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
@@ -32001,7 +31995,6 @@
 /obj/item/clipboard,
 /obj/item/folder/yellow,
 /obj/item/folder/yellow,
-/obj/item/multitool,
 /obj/item/pen/red,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -43678,7 +43678,7 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/fyellow,
 /obj/item/t_scanner,
 /obj/effect/turf_decal/tile/green{
 	dir = 1

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12632,8 +12632,6 @@
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/item/multitool,
-/obj/item/multitool,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -26,6 +26,7 @@
 	throw_speed = 3
 	materials = list(/datum/material/iron=50, /datum/material/glass=20)
 	var/obj/machinery/buffer // simple machine buffer for device linkage
+	custom_premium_price = 450
 	toolspeed = 1
 	usesound = 'sound/weapons/empty.ogg'
 	var/mode = 0

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -7,6 +7,8 @@
 	permeability_coefficient = 0.05
 	item_color="yellow"
 	resistance_flags = NONE
+	custom_premium_price = PAYCHECK_COMMAND * 6
+
 
 /obj/item/clothing/gloves/color/fyellow                             //Cheap Chinese Crap
 	desc = "These gloves are cheap knockoffs of the coveted ones - no way this can end badly."

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -8,7 +8,6 @@
 		            /obj/item/crowbar = 5,
 		            /obj/item/weldingtool = 3,
 		            /obj/item/wirecutters = 5,
-					/obj/item/multitool = 5,
 		            /obj/item/wrench = 5,
 		            /obj/item/analyzer = 5,
 		            /obj/item/t_scanner = 5,
@@ -19,9 +18,10 @@
 		            /obj/item/clothing/ears/earmuffs = 1)
 	contraband = list(/obj/item/clothing/gloves/color/fyellow = 2)
 	premium = list(/obj/item/storage/belt/utility = 2,
-		           /obj/item/weldingtool/hugetank = 2,
-		           /obj/item/clothing/head/welding = 2,
-		           /obj/item/clothing/gloves/color/yellow = 1)
+					/obj/item/multitool = 2,
+		           	/obj/item/weldingtool/hugetank = 2,
+		           	/obj/item/clothing/head/welding = 2,
+		           	/obj/item/clothing/gloves/color/yellow = 1)
 	refill_canister = /obj/item/vending_refill/tool
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION


## About The Pull Request
- Ports some parts of https://github.com/tgstation/tgstation/pull/48856
- makes insulated gloves expensive in vending machines
- makes multitools more expensive from vending machines
## Why It's Good For The Game

Free insulated gloves in a static location means that the first person to rush item at the start of the round gets a very limited and expensive item.
Along these lines, multitools and insulated gloves are both extremely inexpensive from vending machines. Giving away tiding tools for essentially free doesn't encourage players to interact with each other, and makes any attempt at an economy laughable.

This PR is a draft until review requested

## Changelog
:cl:
balance: Tool storage multitools removed, two added to the youtool premium section at 450cr each.
balance: Insulated gloves in vending machines have a price scaled by command paycheck
/:cl:
