### PR TITLE
Removes objective inheritance from IAA.

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -144,6 +144,7 @@
 				new_objective.owner = owner
 				new_objective.target = objective.target
 				new_objective.update_explanation_text()
+				new_objective.stolen = TRUE
 				add_objective(new_objective)
 				targets_stolen += objective.target
 				var/status_text = objective.check_completion() ? "neutralised" : "active"
@@ -157,6 +158,7 @@
 				new_objective.owner = owner
 				new_objective.target = objective.target
 				new_objective.update_explanation_text()
+				new_objective.stolen = TRUE
 				add_objective(new_objective)
 				targets_stolen += objective.target
 				var/status_text = objective.check_completion() ? "neutralised" : "active"
@@ -201,7 +203,6 @@
 						reinstate_escape_objective(owner)
 						last_man_standing = FALSE
 					to_chat(owner.current, fail_msg)
-					objective.stolen = FALSE
 
 /datum/antagonist/traitor/internal_affairs/proc/forge_iaa_objectives()
 	if(SSticker.mode.target_list.len && SSticker.mode.target_list[owner]) // Is a double agent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Recently a bug was fixed with IAA that made objective inheritance work for IAA.
This means that the only way to succeed in IAA is to kill every single IAA agent and then kill yourself.

## Why It's Good For The Game

The gamemode has gone from kill 1 target and survive against your own target to the battle royale murderbone-fest. Objective inheritance is completely broken, poorly communicated and fundamentally flawed, which is why I am removing it instead of fixing it.

## Changelog
:cl:
del: Removes objective inheritance from IAA.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
