### PR TITLE
Remove runed metal from station library

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -15661,9 +15661,7 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "aQs" = (
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /obj/item/clothing/under/suit/red,
 /obj/item/book/codex_gigas,
 /turf/open/floor/engine/cult,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -15661,7 +15661,9 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "aQs" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /obj/item/clothing/under/suit/red,
 /obj/item/book/codex_gigas,
 /turf/open/floor/engine/cult,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -76500,7 +76500,9 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cyc" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /obj/item/book/codex_gigas,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -76500,9 +76500,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cyc" = (
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /obj/item/book/codex_gigas,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -16128,9 +16128,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "aLP" = (
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /obj/item/book/codex_gigas,
 /turf/open/floor/engine/cult,
 /area/library)

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -16128,7 +16128,9 @@
 /turf/open/floor/carpet,
 /area/library)
 "aLP" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /obj/item/book/codex_gigas,
 /turf/open/floor/engine/cult,
 /area/library)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -47140,9 +47140,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/book/codex_gigas{
 	pixel_x = -4;

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -47140,7 +47140,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/book/codex_gigas{
 	pixel_x = -4;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48911,7 +48911,9 @@
 /turf/open/floor/wood,
 /area/library)
 "bPV" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48911,9 +48911,7 @@
 /turf/open/floor/wood,
 /area/library)
 "bPV" = (
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53704,9 +53704,7 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAT" = (
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAU" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53704,7 +53704,9 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAT" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAU" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6450,7 +6450,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "pO" = (
-/obj/structure/destructible/cult/tome/library,
+/obj/structure/destructible/cult/tome,
 /obj/item/book/codex_gigas,
 /obj/machinery/airalarm{
 	dir = 8;

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6450,7 +6450,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "pO" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /obj/item/book/codex_gigas,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -10830,7 +10832,9 @@
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "zo" = (
-/obj/structure/destructible/cult/tome,
+/obj/structure/destructible/cult/tome{
+	debris = null
+	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "zp" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10830,7 +10830,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "zo" = (
-/obj/structure/destructible/cult/tome/library,
+/obj/structure/destructible/cult/tome,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "zp" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6450,9 +6450,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/centcom/ferry)
 "pO" = (
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /obj/item/book/codex_gigas,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -10832,9 +10830,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "zo" = (
-/obj/structure/destructible/cult/tome{
-	debris = null
-	},
+/obj/structure/destructible/cult/tome/library,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "zp" = (

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -258,6 +258,9 @@
 			new N(get_turf(src))
 			to_chat(user, "<span class='cultitalic'>You summon the [choice] from the archives!</span>")
 
+/obj/structure/destructible/cult/tome/library //library archive
+	debris = null
+
 /obj/effect/gateway
 	name = "gateway"
 	desc = "You're pretty sure that abyss is staring back."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since the new crossbreeds for xenobio that also introduced a way to dublicate materials easily runed metal from the library can now be used to easily make runic golems every round.
Now this PR does not intend to completly remove runed golems in non cult rounds just the one guranteed way  to get it every round.
You will still be able to get it from ruines and random rooms like normal just not from library.
Also i decided against var editing the original object and just defined a new sub object all together its in my opinion a bit cleaner.

## Why It's Good For The Game

While creating runed golems is not a bad thing in itself those golems have quite the ammount of abilites and should not be that easily available.

## Changelog
:cl:
del: removes runed metal debris from the cult archive in station library
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
