### PR TITLE
The View Audit Hotfix 3

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -38,7 +38,7 @@
 	var/list/knowledge = cultie.get_all_knowledge()
 	var/list/atoms_in_range = list()
 
-	for(var/atom/atom_in_range as mob|obj in range(1, src))
+	for(var/atom/atom_in_range as() in range(1, src))
 		if(isliving(atom_in_range))
 			var/mob/living/living_in_range = atom_in_range
 			if(living_in_range.stat != DEAD || living_in_range == user) // we only accept corpses, no living beings allowed.

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -180,7 +180,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/morph/proc/allowed(atom/movable/A) // make it into property/proc ? not sure if worth it
-	return !is_type_in_typecache(A, blacklist_typecache)
+	return !is_type_in_typecache(A, blacklist_typecache) && (isobj(A) || ismob(A))
 
 /mob/living/simple_animal/hostile/morph/proc/eat(atom/movable/A)
 	if(morphed && !eat_while_disguised)
@@ -197,7 +197,7 @@
 		if(A == src)
 			restore()
 			return
-		if((ismob(A) || isobj(A)) && allowed(A))
+		if(allowed(A))
 			assume(A)
 	else
 		to_chat(src, "<span class='warning'>Your chameleon skin is still repairing itself!</span>")
@@ -292,7 +292,7 @@
 	. = ..()
 	if(.)
 		var/list/things = list()
-		for(var/atom/movable/A as mob|obj in view(src))
+		for(var/atom/A as() in view(src))
 			if(allowed(A))
 				things += A
 		var/atom/movable/T = pick(things)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Continuation of #3654

`as mob|obj` doesn't work as documented (or expected). `as mob|obj` isn't a check for `/mob` and `/obj`, but, actually, is a `atom/movable` check.

The culprit seems to be `as obj`. It seems that BYOND internal `as` typechecking interprets `obj` not as `/obj`, *but as any `/atom/movable` that isn't `/mob`.* That means it is going to think lighting objects as `obj`.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AI controlled morphs should no longer disguise as light itself and be un-click-able.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
