### PR TITLE
Adds credit cost to printing items from the autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -18,6 +18,7 @@
 	var/hack_wire
 	var/disable_wire
 	var/shock_wire
+	var/price_factor = 50
 
 	//Security modes
 	var/security_interface_locked = TRUE
@@ -120,12 +121,12 @@
 			
 			for(var/material_id in D.materials)
 				if(material_id != "rigid material")
-					price += ore_values["[material_id]"] * D.materials[material_id] / 50 // also multiplied by 2000, since there are 2000 mat units in a sheet
+					price += ore_values["[material_id]"] * D.materials[material_id] / price_factor // also multiplied by 2000, since there are 2000 mat units in a sheet
 					material_cost += list(list(
 						"name" = material_id,
 						"amount" = D.materials[material_id] / MINERAL_MATERIAL_AMOUNT,))
 				else
-					price += D.materials[material_id] / 50
+					price += D.materials[material_id] / price_factor
 
 			if(price < 10) //To ensure the price isnt too low.
 				price += 10
@@ -452,7 +453,7 @@
 
 	var/price = 0 
 	for(var/MAT in being_built.materials)
-		price += ore_values["[MAT]"] * being_built.materials[MAT] / 50
+		price += ore_values["[MAT]"] * being_built.materials[MAT] / price_factor
 		var/datum/material/used_material = MAT
 		var/amount_needed = being_built.materials[MAT] * coeff * multiplier
 		if(istext(used_material)) //This means its a category

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -101,7 +101,7 @@
 	var/list/data = list()	
 	data["acceptsDisk"] = TRUE
 
-	var/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
+	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
 
 	//Items
 	data["items"] = list()
@@ -121,12 +121,12 @@
 			
 			for(var/material_id in D.materials)
 				if(material_id != "rigid material")
-					price += ore_values["[material_id]"] * D.materials[material_id] / price_factor // also multiplied by 2000, since there are 2000 mat units in a sheet
+					price += round(ore_values["[material_id]"] * D.materials[material_id] / price_factor) // also multiplied by 2000, since there are 2000 mat units in a sheet
 					material_cost += list(list(
 						"name" = material_id,
 						"amount" = D.materials[material_id] / MINERAL_MATERIAL_AMOUNT,))
 				else
-					price += D.materials[material_id] / price_factor
+					price += round(D.materials[material_id] / price_factor)
 
 			if(price < 10) //To ensure the price isnt too low.
 				price += 10
@@ -449,11 +449,11 @@
 	var/list/materials_used = list()
 	var/list/custom_materials = list() //These will apply their material effect, This should usually only be one.
 
-	var/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
+	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
 
 	var/price = 0 
 	for(var/MAT in being_built.materials)
-		price += ore_values["[MAT]"] * being_built.materials[MAT] / price_factor
+		price += round(ore_values["[MAT]"] * being_built.materials[MAT] / price_factor)
 		var/datum/material/used_material = MAT
 		var/amount_needed = being_built.materials[MAT] * coeff * multiplier
 		if(istext(used_material)) //This means its a category
@@ -520,13 +520,14 @@
 		autolathe_failure(1)
 
 /obj/machinery/autolathe/proc/autolathe_failure(failure) 
-	if(failure == 1)
-		failure = "bank credentials"
-	else if (failure == 2)
-		failure = "materials"
-		wants_operate = TRUE
-	else if (failure == 3)
-		failure = "credits"
+	switch(failure)
+		if(1)
+			failure = "bank credentials"
+		if(2)
+			failure = "materials"
+			wants_operate = TRUE
+		if(3)
+			failure = "credits"
 	say("Insufficient [failure], operation will proceed when sufficient [failure] are made available.")
 	operating = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a credit cost to printing items from the auto-lathe. Auto-lathes bill to your ID/budget if you have it, otherwise you stink. Emagged auto-lathes don't require credits to be payed, though NT wont like that. Auto-lathes off-station will be set to this setting. Silicons using the auto-lathe will bill to the civilian budget. Pretty pictures with some stats in the comments. These are all solely based off their existing material costs, so lots of the costs don't make sense and I am going to fix them.

## Why It's Good For The Game

Credits have almost no value and by extension budget cards. Get them nerds to spend their hard earned money which accumulates in their IDs, untouched, unwanted. :(

## This shit is blowing off, here's my soundcloud

https://github.com/austation/austation/pull/3092

CERTIFIED AUSTATION CLASSIC

## Changelog
:cl:
add: Added a credit cost to building items in the autolathe, circumvented by emagging
/:cl:
