### PR TITLE
[Mapping] Moves Boxstation cargo autolathe behind shutters and moves box science autolathe into Science

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25355,13 +25355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bty" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "public_autolathe";
-	name = "public autolathe shutters"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "btz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -25543,15 +25536,6 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bud" = (
-/obj/machinery/button/door{
-	id = "public_autolathe";
-	name = "Autolathe Shutters Control";
-	pixel_x = 28;
-	req_access_txt = "31"
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bue" = (
@@ -48339,6 +48323,15 @@
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"fFT" = (
+/obj/machinery/button/door{
+	id = "public_autolathe";
+	name = "Autolathe Shutters Control";
+	pixel_x = 28;
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "fGe" = (
 /obj/machinery/light{
 	dir = 4
@@ -51525,6 +51518,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jJh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jJw" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -52104,6 +52101,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kvF" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "kwh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -56194,10 +56196,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"pqP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "pqQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -61088,11 +61086,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
-"vBt" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "vBU" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -62072,6 +62065,13 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port/aft)
+"wyR" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "public_autolathe";
+	name = "public autolathe shutters"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "wzO" = (
 /obj/effect/spawner/room/threexthree,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -86583,7 +86583,7 @@ bnG
 bnz
 bpA
 wDF
-bud
+fFT
 bbR
 biv
 eyM
@@ -86842,7 +86842,7 @@ bfm
 wQP
 sdX
 iiH
-vBt
+kvF
 bwe
 bwd
 bwY
@@ -87098,7 +87098,7 @@ boR
 bqs
 wDF
 bbR
-bty
+wyR
 bqs
 bwd
 bvL
@@ -87355,7 +87355,7 @@ bbR
 hKl
 vaL
 btu
-pqP
+jJh
 bqs
 bwd
 ccR
@@ -87612,7 +87612,7 @@ bbR
 bqt
 cBq
 bbR
-pqP
+jJh
 bqs
 bwd
 bxC
@@ -87869,7 +87869,7 @@ bbR
 bbR
 bbR
 bbR
-bty
+wyR
 bqs
 bwd
 byM

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25355,6 +25355,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"bty" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "public_autolathe";
+	name = "public autolathe shutters"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "btz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -25536,6 +25543,15 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"bud" = (
+/obj/machinery/button/door{
+	id = "public_autolathe";
+	name = "Autolathe Shutters Control";
+	pixel_x = 28;
+	req_access_txt = "31"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bue" = (
@@ -50374,6 +50390,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"iiH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/space)
 "ijc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -51051,13 +51071,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"jfg" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "public_autolathe";
-	name = "public autolathe shutters"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "jfI" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4;
@@ -51116,10 +51129,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"jjd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "jjq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52870,15 +52879,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"lnC" = (
-/obj/machinery/button/door{
-	id = "public_autolathe";
-	name = "Autolathe Shutters Control";
-	pixel_x = 28;
-	req_access_txt = "31"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "loO" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/effect/turf_decal/stripes/line,
@@ -54249,11 +54249,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"mHl" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "mHx" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -56199,6 +56194,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"pqP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "pqQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -60202,10 +60201,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"uxP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/space)
 "uxV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -61094,17 +61089,10 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
 "vBt" = (
-/obj/machinery/door/window/southright{
-	name = "Research and Development Desk";
-	req_one_access_txt = "7;29"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "research lab shutters"
-	},
+/obj/effect/turf_decal/stripes/box,
 /obj/machinery/autolathe,
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "vBU" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86595,7 +86583,7 @@ bnG
 bnz
 bpA
 wDF
-lnC
+bud
 bbR
 biv
 eyM
@@ -86853,8 +86841,8 @@ boS
 bfm
 wQP
 sdX
-uxP
-mHl
+iiH
+vBt
 bwe
 bwd
 bwY
@@ -87110,7 +87098,7 @@ boR
 bqs
 wDF
 bbR
-jfg
+bty
 bqs
 bwd
 bvL
@@ -87367,7 +87355,7 @@ bbR
 hKl
 vaL
 btu
-jjd
+pqP
 bqs
 bwd
 ccR
@@ -87624,7 +87612,7 @@ bbR
 bqt
 cBq
 bbR
-jjd
+pqP
 bqs
 bwd
 bxC
@@ -87881,7 +87869,7 @@ bbR
 bbR
 bbR
 bbR
-jfg
+bty
 bqs
 bwd
 byM
@@ -110744,7 +110732,7 @@ aYV
 aXq
 sYn
 bfX
-vBt
+bhC
 biU
 pDJ
 blI

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -51051,6 +51051,13 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"jfg" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "public_autolathe";
+	name = "public autolathe shutters"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jfI" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4;
@@ -51109,6 +51116,10 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jjd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jjq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -52859,6 +52870,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"lnC" = (
+/obj/machinery/button/door{
+	id = "public_autolathe";
+	name = "Autolathe Shutters Control";
+	pixel_x = 28;
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "loO" = (
 /obj/machinery/atmospherics/pipe/simple,
 /obj/effect/turf_decal/stripes/line,
@@ -60182,6 +60202,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"uxP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/space)
 "uxV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -86571,7 +86595,7 @@ bnG
 bnz
 bpA
 wDF
-bbR
+lnC
 bbR
 biv
 eyM
@@ -86828,8 +86852,8 @@ bfm
 boS
 bfm
 wQP
-bfm
-bbR
+sdX
+uxP
 mHl
 bwe
 bwd
@@ -87086,8 +87110,8 @@ boR
 bqs
 wDF
 bbR
-bbR
-bbR
+jfg
+bqs
 bwd
 bvL
 byI
@@ -87343,8 +87367,8 @@ bbR
 hKl
 vaL
 btu
-bbR
-bbR
+jjd
+bqs
 bwd
 ccR
 byK
@@ -87600,8 +87624,8 @@ bbR
 bqt
 cBq
 bbR
-bbR
-bbR
+jjd
+bqs
 bwd
 bxC
 byL
@@ -87857,8 +87881,8 @@ bbR
 bbR
 bbR
 bbR
-bbR
-bbR
+jfg
+bqs
 bwd
 byM
 bAd

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25355,13 +25355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bty" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "public_autolathe";
-	name = "public autolathe shutters"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "btz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -25543,15 +25536,6 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bud" = (
-/obj/machinery/button/door{
-	id = "public_autolathe";
-	name = "Autolathe Shutters Control";
-	pixel_x = 28;
-	req_access_txt = "31"
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bue" = (
@@ -49140,6 +49124,10 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"gxZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "gyH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -56194,10 +56182,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"pqP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "pqQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -56235,6 +56219,11 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"pvX" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "pwf" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -56782,6 +56771,13 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"qbk" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "public_autolathe";
+	name = "public autolathe shutters"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "qbp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -59737,6 +59733,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"tTj" = (
+/obj/machinery/button/door{
+	id = "public_autolathe";
+	name = "Autolathe Shutters Control";
+	pixel_x = 28;
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "tUd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -61088,11 +61093,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
-"vBt" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "vBU" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86583,7 +86583,7 @@ bnG
 bnz
 bpA
 wDF
-bud
+tTj
 bbR
 biv
 eyM
@@ -86842,7 +86842,7 @@ bfm
 wQP
 sdX
 iiH
-vBt
+pvX
 bwe
 bwd
 bwY
@@ -87098,7 +87098,7 @@ boR
 bqs
 wDF
 bbR
-bty
+qbk
 bqs
 bwd
 bvL
@@ -87355,7 +87355,7 @@ bbR
 hKl
 vaL
 btu
-pqP
+gxZ
 bqs
 bwd
 ccR
@@ -87612,7 +87612,7 @@ bbR
 bqt
 cBq
 bbR
-pqP
+gxZ
 bqs
 bwd
 bxC
@@ -87869,7 +87869,7 @@ bbR
 bbR
 bbR
 bbR
-bty
+qbk
 bqs
 bwd
 byM

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21671,12 +21671,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bhV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/lab)
 "bhW" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
@@ -23067,7 +23061,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "blL" = (
@@ -46664,6 +46657,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"duB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/science/lab)
 "duJ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -47589,6 +47589,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"eFn" = (
+/obj/machinery/button/door{
+	id = "public_autolathe";
+	name = "Autolathe Shutters Control";
+	pixel_x = 28;
+	req_access_txt = "31"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "eGg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -48320,15 +48329,6 @@
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"fFT" = (
-/obj/machinery/button/door{
-	id = "public_autolathe";
-	name = "Autolathe Shutters Control";
-	pixel_x = 28;
-	req_access_txt = "31"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "fGe" = (
 /obj/machinery/light{
 	dir = 4
@@ -50958,6 +50958,13 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"iXQ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "public_autolathe";
+	name = "public autolathe shutters"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "iXS" = (
 /obj/effect/spawner/room/threexthree,
 /turf/open/floor/plating,
@@ -51515,10 +51522,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"jJh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "jJw" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -52098,11 +52101,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kvF" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "kwh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -54174,6 +54172,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"mCK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "mDL" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -58785,6 +58787,11 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"szz" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "szT" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62065,13 +62072,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port/aft)
-"wyR" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "public_autolathe";
-	name = "public autolathe shutters"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "wzO" = (
 /obj/effect/spawner/room/threexthree,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -86583,7 +86583,7 @@ bnG
 bnz
 bpA
 wDF
-fFT
+eFn
 bbR
 biv
 eyM
@@ -86842,7 +86842,7 @@ bfm
 wQP
 sdX
 iiH
-kvF
+szz
 bwe
 bwd
 bwY
@@ -87098,7 +87098,7 @@ boR
 bqs
 wDF
 bbR
-wyR
+iXQ
 bqs
 bwd
 bvL
@@ -87355,7 +87355,7 @@ bbR
 hKl
 vaL
 btu
-jJh
+mCK
 bqs
 bwd
 ccR
@@ -87612,7 +87612,7 @@ bbR
 bqt
 cBq
 bbR
-jJh
+mCK
 bqs
 bwd
 bxC
@@ -87869,7 +87869,7 @@ bbR
 bbR
 bbR
 bbR
-wyR
+iXQ
 bqs
 bwd
 byM
@@ -110991,7 +110991,7 @@ sYn
 bfX
 bhD
 biV
-bhV
+blK
 bnp
 bnp
 bng
@@ -111248,7 +111248,7 @@ sYn
 bgb
 bhC
 biU
-blK
+duB
 blJ
 bno
 boA

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25355,6 +25355,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"bty" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "public_autolathe";
+	name = "public autolathe shutters"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "btz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -25536,6 +25543,15 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"bud" = (
+/obj/machinery/button/door{
+	id = "public_autolathe";
+	name = "Autolathe Shutters Control";
+	pixel_x = 28;
+	req_access_txt = "31"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bue" = (
@@ -49124,10 +49140,6 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"gxZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "gyH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -56182,6 +56194,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"pqP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "pqQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -56219,11 +56235,6 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"pvX" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "pwf" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -56771,13 +56782,6 @@
 /obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"qbk" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "public_autolathe";
-	name = "public autolathe shutters"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "qbp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
@@ -59733,15 +59737,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"tTj" = (
-/obj/machinery/button/door{
-	id = "public_autolathe";
-	name = "Autolathe Shutters Control";
-	pixel_x = 28;
-	req_access_txt = "31"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "tUd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -61093,6 +61088,11 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
+"vBt" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "vBU" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -86583,7 +86583,7 @@ bnG
 bnz
 bpA
 wDF
-tTj
+bud
 bbR
 biv
 eyM
@@ -86842,7 +86842,7 @@ bfm
 wQP
 sdX
 iiH
-pvX
+vBt
 bwe
 bwd
 bwY
@@ -87098,7 +87098,7 @@ boR
 bqs
 wDF
 bbR
-qbk
+bty
 bqs
 bwd
 bvL
@@ -87355,7 +87355,7 @@ bbR
 hKl
 vaL
 btu
-gxZ
+pqP
 bqs
 bwd
 ccR
@@ -87612,7 +87612,7 @@ bbR
 bqt
 cBq
 bbR
-gxZ
+pqP
 bqs
 bwd
 bxC
@@ -87869,7 +87869,7 @@ bbR
 bbR
 bbR
 bbR
-qbk
+bty
 bqs
 bwd
 byM

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21672,8 +21672,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bhV" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/science/lab)
 "bhW" = (
 /obj/machinery/door/poddoor/shutters{
@@ -23055,15 +23057,9 @@
 /area/science/research)
 "blI" = (
 /obj/machinery/rnd/destructive_analyzer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "blJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/rnd/production/protolathe/department/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
@@ -23071,6 +23067,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "blL" = (
@@ -56365,7 +56362,10 @@
 /obj/machinery/computer/cargo/request{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/science/lab)
 "pDL" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
@@ -110991,8 +110991,8 @@ sYn
 bfX
 bhD
 biV
-biW
-blK
+bhV
+bnp
 bnp
 bng
 bpZ
@@ -111248,7 +111248,7 @@ sYn
 bgb
 bhC
 biU
-biW
+blK
 blJ
 bno
 boA
@@ -111505,7 +111505,7 @@ sYn
 rYy
 bgc
 biX
-bhV
+bka
 bka
 bka
 bnk

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25355,12 +25355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bty" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "btz" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -25542,15 +25536,6 @@
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"bud" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/sign/departments/minsky/supply/mining{
-	pixel_x = 32
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bue" = (
@@ -47508,6 +47493,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/sign/departments/minsky/supply/mining{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "eyO" = (
@@ -50386,15 +50374,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"iiH" = (
-/obj/machinery/autolathe,
-/obj/machinery/door/window/westleft{
-	name = "Cargo Desk";
-	req_access_txt = "31"
-	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "ijc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -54250,6 +54229,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"mHl" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "mHx" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -56195,15 +56179,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"pqP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "pqQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -86598,7 +86573,7 @@ bpA
 wDF
 bbR
 bbR
-bud
+biv
 eyM
 kSb
 bAZ
@@ -86854,8 +86829,8 @@ boS
 bfm
 wQP
 bfm
-iiH
-sdX
+bbR
+mHl
 bwe
 bwd
 bwY
@@ -87881,9 +87856,9 @@ bnJ
 bbR
 bbR
 bbR
-bty
-bty
-pqP
+bbR
+bbR
+bbR
 bwd
 byM
 bAd

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55210,59 +55210,29 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccV" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccW" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Internal Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"ccX" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+/obj/machinery/door/airlock/atmos/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8
 	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
+/turf/open/floor/plasteel/dark,
+/area/space)
+"ccX" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ccZ" = (
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	name = "glass door";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "glass door";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel/dark,
+/area/space)
 "cda" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -56841,23 +56811,13 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "cgD" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/falsewall/reinforced,
+/turf/open/space/basic,
+/area/space)
 "cgE" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "cgF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57599,19 +57559,15 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "chW" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/space/basic,
+/area/space)
 "chX" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/space/basic,
+/area/space)
 "chY" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -58247,28 +58203,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cjl" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
-"cjm" = (
-/obj/machinery/door/airlock/atmos/glass{
-	heat_proof = 1;
-	name = "Auxiliary Chamber";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"cjn" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
-"cjo" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/starboard)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -58840,22 +58774,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"ckK" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
-"ckL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
-"ckM" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/maintenance/starboard)
 "ckT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -59415,15 +59333,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"cme" = (
-/obj/item/stack/rods{
-	amount = 25
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
-"cmf" = (
-/turf/open/floor/plating/airless,
-/area/maintenance/starboard)
 "cmk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -82529,12 +82438,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"fGw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82722,10 +82625,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
 "gkP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/atmos/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/space/basic,
 /area/engine/atmos)
 "gnd" = (
 /turf/closed/wall,
@@ -84093,14 +83995,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"lxw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -84570,13 +84464,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"nBD" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "nCn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -84970,12 +84857,6 @@
 "pcn" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"pco" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "peG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -85370,12 +85251,6 @@
 /mob/living/simple_animal/bot/cleanbot/medbay,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"qze" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "qzv" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -86067,13 +85942,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"tEj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -86427,9 +86295,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"vox" = (
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86741,18 +86606,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "wxc" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/plating,
-/area/engine/atmos)
+/turf/open/floor/plasteel/dark,
+/area/space)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -86922,11 +86780,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/solars/starboard/fore)
-"xjM" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/space,
-/area/space/nearstation)
 "xkS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -131623,15 +131476,15 @@ bYB
 bKG
 bKG
 ccV
-pco
-eUG
-eUG
-eUG
-eUG
-eUG
-eUG
-lxw
-eUG
+bxc
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 ggI
 ggI
 dkZ
@@ -131880,17 +131733,17 @@ bxc
 bxc
 bxc
 ccW
-qze
-aaf
+bxc
 aaa
 aaa
-aaf
-aaa
-aaf
-tEj
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132137,17 +131990,17 @@ aaf
 aaf
 bxc
 ccX
-fGw
-xjM
-xjM
-xjM
-xjM
-xjM
-xjM
-nBD
-aaf
-aaf
-aaf
+bxc
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132395,17 +132248,17 @@ aaf
 bxc
 wxc
 gkP
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
+chW
+chX
 aaa
 aaa
-aai
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132649,19 +132502,19 @@ bVN
 bXr
 bAR
 aaf
-aMr
-apc
-bBb
-aaf
+cgD
+ccZ
 aaa
-aaf
-atm
-cjo
-ckM
-cmf
-cmf
 aaa
-bKK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132906,19 +132759,19 @@ ajl
 bUJ
 bAR
 aaf
-aMq
-apc
-bgo
-aTQ
 cgD
-chW
-cjl
-ckK
-vox
-vox
-ckM
-aaf
-bKK
+ccZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133163,20 +133016,20 @@ bVP
 bXs
 bAR
 aaf
-aMr
-apc
-apc
-apc
-apc
-apc
-cjm
-vox
-cme
-vox
-cjo
+cgD
+cgE
 aaa
-bKK
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133420,19 +133273,19 @@ bAR
 bAR
 bAR
 aaf
-aMq
-apc
-aVk
-aNC
-cgE
-chX
-cjn
-ckL
-vox
-vox
-atm
-aaf
-aai
+cgD
+ccZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133677,20 +133530,20 @@ aaf
 aaf
 aaf
 aaf
-aMr
+cgD
 ccZ
-bBb
-aaf
 aaa
-aaf
-cjo
-ckM
-cmf
-ckM
-cjo
 aaa
-aaf
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -133934,20 +133787,20 @@ aaa
 aaa
 aaa
 aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
+cgD
+cgE
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134191,18 +134044,18 @@ bzj
 bzj
 bzj
 bJe
-bzj
-aai
-bzj
-aaf
-aaf
-aai
-bzj
-aai
-bzj
-bzj
-aaf
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134451,17 +134304,17 @@ aaf
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
 aaa
-aaf
 aaa
-aac
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134705,10 +134558,10 @@ bzi
 bzi
 bzi
 bJf
-aaf
-aaf
-aaf
-aaf
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134964,7 +134817,7 @@ aaa
 aaf
 aaa
 aaa
-aaf
+aaa
 aaa
 aaa
 aaa
@@ -135219,9 +135072,9 @@ bzj
 bzj
 bzj
 bKK
-bzj
-bzj
-anS
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55210,29 +55210,59 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccW" = (
-/obj/machinery/door/airlock/atmos/glass,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_access_txt = "24"
 	},
-/turf/open/floor/plasteel/dark,
-/area/space)
-"ccX" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"ccX" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 8
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "ccZ" = (
-/turf/open/floor/plasteel/dark,
-/area/space)
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "glass door";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "glass door";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cda" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -56811,13 +56841,23 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "cgD" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cgE" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/open/floor/plasteel/dark,
-/area/space)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cgF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57559,15 +57599,19 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "chW" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/space/basic,
-/area/space)
-"chX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"chX" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "chY" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -58203,6 +58247,28 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"cjl" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard)
+"cjm" = (
+/obj/machinery/door/airlock/atmos/glass{
+	heat_proof = 1;
+	name = "Auxiliary Chamber";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
+"cjn" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard)
+"cjo" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/starboard)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -58774,6 +58840,22 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"ckK" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/starboard)
+"ckL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/starboard)
+"ckM" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/maintenance/starboard)
 "ckT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -59333,6 +59415,15 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"cme" = (
+/obj/item/stack/rods{
+	amount = 25
+	},
+/turf/open/floor/engine/vacuum,
+/area/maintenance/starboard)
+"cmf" = (
+/turf/open/floor/plating/airless,
+/area/maintenance/starboard)
 "cmk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -82438,6 +82529,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"fGw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82625,9 +82722,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
 "gkP" = (
-/obj/machinery/door/airlock/atmos/glass,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "gnd" = (
 /turf/closed/wall,
@@ -83995,6 +84093,14 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"lxw" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -84464,6 +84570,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"nBD" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "nCn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -84857,6 +84970,12 @@
 "pcn" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"pco" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "peG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -85251,6 +85370,12 @@
 /mob/living/simple_animal/bot/cleanbot/medbay,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"qze" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "qzv" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -85942,6 +86067,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"tEj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -86295,6 +86427,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vox" = (
+/turf/open/floor/engine/vacuum,
+/area/maintenance/starboard)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86606,11 +86741,18 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "wxc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/atmos)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -86780,6 +86922,11 @@
 	},
 /turf/closed/wall,
 /area/maintenance/solars/starboard/fore)
+"xjM" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/space,
+/area/space/nearstation)
 "xkS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -131476,15 +131623,15 @@ bYB
 bKG
 bKG
 ccV
-bxc
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pco
+eUG
+eUG
+eUG
+eUG
+eUG
+eUG
+lxw
+eUG
 ggI
 ggI
 dkZ
@@ -131733,17 +131880,17 @@ bxc
 bxc
 bxc
 ccW
-bxc
+qze
+aaf
 aaa
 aaa
+aaf
+aaa
+aaf
+tEj
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -131990,17 +132137,17 @@ aaf
 aaf
 bxc
 ccX
-bxc
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fGw
+xjM
+xjM
+xjM
+xjM
+xjM
+xjM
+nBD
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -132248,17 +132395,17 @@ aaf
 bxc
 wxc
 gkP
-chW
-chX
+aaf
+aaa
+aaf
+aaa
+aaf
+aaa
+aaf
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aai
+aaf
 aaa
 aaa
 aaa
@@ -132502,19 +132649,19 @@ bVN
 bXr
 bAR
 aaf
-cgD
-ccZ
+aMr
+apc
+bBb
+aaf
 aaa
+aaf
+atm
+cjo
+ckM
+cmf
+cmf
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bKK
 aaa
 aaa
 aaa
@@ -132759,19 +132906,19 @@ ajl
 bUJ
 bAR
 aaf
+aMq
+apc
+bgo
+aTQ
 cgD
-ccZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+chW
+cjl
+ckK
+vox
+vox
+ckM
+aaf
+bKK
 aaa
 aaa
 aaa
@@ -133016,20 +133163,20 @@ bVP
 bXs
 bAR
 aaf
-cgD
-cgE
+aMr
+apc
+apc
+apc
+apc
+apc
+cjm
+vox
+cme
+vox
+cjo
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bKK
+aaf
 aaa
 aaa
 aaa
@@ -133273,19 +133420,19 @@ bAR
 bAR
 bAR
 aaf
-cgD
-ccZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aMq
+apc
+aVk
+aNC
+cgE
+chX
+cjn
+ckL
+vox
+vox
+atm
+aaf
+aai
 aaa
 aaa
 aaa
@@ -133530,20 +133677,20 @@ aaf
 aaf
 aaf
 aaf
-cgD
+aMr
 ccZ
+bBb
+aaf
 aaa
+aaf
+cjo
+ckM
+cmf
+ckM
+cjo
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -133787,20 +133934,20 @@ aaa
 aaa
 aaa
 aaf
-cgD
-cgE
+aaa
+aaf
+aaa
+aaf
+aaa
+aaf
+aaa
+aaf
+aaa
+aaf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -134044,18 +134191,18 @@ bzj
 bzj
 bzj
 bJe
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bzj
+aai
+bzj
+aaf
+aaf
+aai
+bzj
+aai
+bzj
+bzj
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -134304,17 +134451,17 @@ aaf
 aaa
 aaa
 aaa
+aaf
 aaa
 aaa
 aaa
+aaf
 aaa
 aaa
 aaa
+aaf
 aaa
-aaa
-aaa
-aaa
-aaa
+aac
 aaa
 aaa
 aaa
@@ -134558,10 +134705,10 @@ bzi
 bzi
 bzi
 bJf
-aaa
-aaa
-aaa
-aaa
+aaf
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -134817,7 +134964,7 @@ aaa
 aaf
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -135072,9 +135219,9 @@ bzj
 bzj
 bzj
 bKK
-aaa
-aaa
-aaa
+bzj
+bzj
+anS
 aaa
 aaa
 aaa


### PR DESCRIPTION

## About The Pull Request

Inspired by: https://github.com/tgstation/tgstation/pull/41613
![image](https://user-images.githubusercontent.com/3241376/108715468-8b177a00-74e0-11eb-87ef-907a0b9b13a4.png)

![image](https://user-images.githubusercontent.com/3241376/108715652-c619ad80-74e0-11eb-9982-f013f6773c38.png)


## Changelog
:cl:
add: Boxstation cargo has a gated autolathe
tweak: moves box science autolathe into Science
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
