### PR TITLE
[Mapping] Gives metastation a fusion room in Atmos

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56813,10 +56813,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"cgE" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "cgF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57557,14 +57553,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"chW" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/space/basic,
-/area/engine/atmos)
-"chX" = (
-/obj/machinery/door/airlock/external/glass,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "chY" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -58200,25 +58188,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cjl" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"cjm" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
-"cjn" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"cjo" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -58790,17 +58759,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"ckK" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"ckL" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil/random,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "ckM" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -59364,22 +59322,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"cme" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"cmf" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #1";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cmk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -77126,6 +77068,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"dac" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "dap" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/chair{
@@ -82312,6 +82261,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"ffe" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "ffD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -82485,10 +82438,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"fGw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82796,6 +82745,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gFJ" = (
+/obj/machinery/advanced_airlock_controller/directional/north,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "gHh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83196,6 +83149,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"itb" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "ixU" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -83235,6 +83193,15 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/janitor)
+"iAt" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #1";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iAI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83811,6 +83778,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kAz" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "kAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -84046,11 +84017,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"lxw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -84352,6 +84318,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"mLy" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "mLO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84533,6 +84505,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"nFY" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/space/basic,
+/area/engine/atmos)
 "nHj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84750,6 +84726,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"orM" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil/random,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "osb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -84918,12 +84899,6 @@
 "pcn" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"pco" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "peG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -85318,11 +85293,6 @@
 /mob/living/simple_animal/bot/cleanbot/medbay,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"qze" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "qzv" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -85611,6 +85581,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"sbj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "sdi" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -85968,6 +85942,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"tii" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -86020,6 +85998,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tHI" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "tIm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -86142,6 +86127,11 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
+"uoq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -86164,6 +86154,10 @@
 "urv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
+"urF" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "usN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -87083,6 +87077,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
+"xHS" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "xJp" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/blue,
@@ -132075,7 +132075,7 @@ bxc
 ccX
 bxc
 xjM
-cgE
+urF
 bCi
 bCi
 bCi
@@ -132332,12 +132332,12 @@ bxc
 wxc
 gkP
 bKG
-cme
+dac
 bCi
 bCi
 bCi
 bCi
-cmf
+iAt
 bza
 aaa
 aaa
@@ -132585,11 +132585,11 @@ bVN
 bXr
 bAR
 aaf
-chW
+nFY
 ccQ
 bxc
 ccQ
-cgE
+urF
 bCi
 bCi
 bCi
@@ -132842,11 +132842,11 @@ ajl
 bUJ
 bAR
 aaf
-chW
+nFY
 ccQ
 bxc
-cjn
-cgE
+tHI
+urF
 bCi
 bCi
 bCi
@@ -133099,11 +133099,11 @@ bVP
 bXs
 bAR
 aaf
-chW
-chX
+nFY
+kAz
 bxc
-cjo
-cgE
+ffe
+urF
 bCi
 bCi
 bCi
@@ -133356,18 +133356,18 @@ bAR
 bAR
 bAR
 aaf
-chW
-cjl
+nFY
+gFJ
 bxc
-ckK
-cgE
+mLy
+urF
 bCi
 bCi
 bCi
 vox
-fGw
-lxw
-pco
+sbj
+uoq
+xHS
 aaa
 lMJ
 aaa
@@ -133613,11 +133613,11 @@ aaf
 aaf
 aaf
 aaf
-chW
+nFY
 ccZ
 bxc
-ckL
-cgE
+orM
+urF
 bCi
 bCi
 bCi
@@ -133870,8 +133870,8 @@ aaa
 aaa
 aaa
 aaf
-chW
-chX
+nFY
+kAz
 bxc
 bxc
 bza
@@ -134128,7 +134128,7 @@ bzj
 bzj
 bJe
 aaa
-cjm
+tii
 aaa
 vLD
 aaa
@@ -134385,7 +134385,7 @@ aaa
 aaa
 aaf
 aaa
-cjm
+tii
 aaa
 vLD
 aaa
@@ -134654,7 +134654,7 @@ lMJ
 lMJ
 lMJ
 lMJ
-qze
+itb
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -82034,10 +82034,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"dZR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ecs" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -83448,13 +83444,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -84345,14 +84334,25 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mSZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
+"mTx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"mTx" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
 "mTW" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -85069,11 +85069,6 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"pPS" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "pRi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -85258,6 +85253,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"qow" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qqg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -85532,10 +85531,10 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "rPH" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85574,8 +85573,9 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "sbj" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sdi" = (
 /obj/structure/window/reinforced{
@@ -85934,6 +85934,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"tfj" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "tii" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -86120,7 +86125,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "uoq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uoA" = (
@@ -86276,7 +86281,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "uYt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vcK" = (
@@ -86349,11 +86354,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vox" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -86493,11 +86495,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vRM" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vUC" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -86675,6 +86678,10 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"wyr" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -87070,9 +87077,11 @@
 /turf/open/floor/plating,
 /area/science/shuttledock)
 "xHS" = (
-/obj/structure/sign/warning/nosmoking/circle,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "xJp" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/blue,
@@ -100709,7 +100718,7 @@ bXt
 bYC
 vZU
 xgg
-aaa
+iGZ
 aaa
 aaf
 aaa
@@ -100966,8 +100975,8 @@ bXu
 bYD
 hvP
 jyQ
+mSZ
 cda
-cej
 cfz
 cED
 chY
@@ -101223,7 +101232,7 @@ bXv
 mKD
 jmO
 iGZ
-aaa
+iGZ
 aaa
 aaf
 aaa
@@ -103809,7 +103818,7 @@ aob
 aob
 aob
 alK
-dZR
+qow
 cwg
 dux
 ack
@@ -129248,7 +129257,7 @@ aaf
 bzi
 aaa
 aaa
-pPS
+tfj
 aaa
 aaa
 aaa
@@ -130019,7 +130028,7 @@ aaa
 aai
 aaa
 aaa
-pPS
+tfj
 aaa
 aaa
 aaa
@@ -130533,7 +130542,7 @@ aaa
 bzj
 aaf
 aaa
-pPS
+tfj
 aaa
 aaa
 aaa
@@ -131047,7 +131056,7 @@ aaa
 bJf
 aaf
 aaa
-pPS
+tfj
 aaa
 aaa
 aaa
@@ -131820,7 +131829,7 @@ aaa
 lMJ
 aaa
 aaa
-mTx
+rPH
 aaa
 aaa
 aaa
@@ -132077,7 +132086,7 @@ aaa
 lMJ
 aaa
 aaa
-mTx
+rPH
 aaa
 aaa
 aaa
@@ -132323,7 +132332,7 @@ wxc
 gkP
 bKG
 dac
-sbj
+uoq
 bCi
 bKD
 bCi
@@ -132591,7 +132600,7 @@ aaa
 lMJ
 aaa
 aaa
-mTx
+rPH
 aaa
 aaa
 aaa
@@ -133362,7 +133371,7 @@ auv
 lMJ
 aaa
 aaa
-mTx
+rPH
 aaa
 aaa
 aaa
@@ -133605,21 +133614,21 @@ aaf
 aaf
 nFY
 ccZ
-mSZ
+mTx
 orM
-rPH
-uoq
-uoq
-uoq
+sbj
 uYt
+uYt
+uYt
+vox
 ckM
-xHS
+wyr
 auv
 auv
 lMJ
 aaa
 aaa
-mTx
+rPH
 aaa
 aaa
 aaa
@@ -133868,7 +133877,7 @@ bza
 bza
 bza
 bza
-vox
+vRM
 bxc
 bxc
 auv
@@ -134125,7 +134134,7 @@ auv
 auv
 auv
 auv
-vRM
+xHS
 auv
 auv
 auv
@@ -134133,7 +134142,7 @@ aaa
 fwb
 aaa
 aaa
-mTx
+rPH
 aaa
 aaa
 aaa
@@ -134390,7 +134399,7 @@ aaa
 fwb
 aaa
 aaa
-mTx
+rPH
 aaa
 aaa
 aaa
@@ -135405,16 +135414,16 @@ aaa
 aaa
 lrF
 dkZ
-mTx
-mTx
-mTx
+rPH
+rPH
+rPH
 dkZ
 lrF
-mTx
-mTx
+rPH
+rPH
 lrF
-mTx
-mTx
+rPH
+rPH
 lrF
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58200,6 +58200,10 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"cjo" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -59334,6 +59338,10 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"cmf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cmk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -77077,13 +77085,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"dac" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "dap" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/chair{
@@ -80551,11 +80552,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"dkZ" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "dlI" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -82096,6 +82092,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"elk" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"eml" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #1";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ems" = (
 /obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/reinforced,
@@ -82206,12 +82216,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"eOg" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "eTL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes{
@@ -82264,13 +82268,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"ffe" = (
-/obj/structure/closet/radiation,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "ffD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -82406,6 +82403,10 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
+"fyI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "fBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -82444,6 +82445,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"fFR" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82704,6 +82712,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"gwU" = (
+/obj/structure/closet/radiation,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "gyr" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -82727,6 +82742,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/aisat)
+"gBP" = (
+/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "gCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -82749,13 +82771,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"gFJ" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "gHh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82997,19 +83012,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hTw" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"hVd" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
 "hWr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83154,11 +83156,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"itb" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "ixU" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -83198,15 +83195,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/janitor)
-"iAt" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #1";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "iAI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83415,6 +83403,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
+"jqX" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -83424,6 +83416,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"jrF" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "jsu" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -83662,6 +83660,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"klD" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "koT" = (
 /obj/machinery/light_switch{
 	pixel_x = -25
@@ -83775,16 +83777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kAz" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "kAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -83952,6 +83944,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ldY" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lhb" = (
 /obj/item/clothing/head/festive,
 /turf/open/floor/plating,
@@ -83963,6 +83959,11 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"lkl" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "lnO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -83975,10 +83976,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"lrF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "lvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84236,6 +84233,12 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/port/aft)
+"msg" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "mvj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -84311,12 +84314,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"mLy" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "mLO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84345,16 +84342,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"mSZ" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
-"mTx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "mTW" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -84495,10 +84482,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"nFY" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/space/basic,
-/area/engine/atmos)
 "nHj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84716,12 +84699,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"orM" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "osb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -84890,6 +84867,13 @@
 "pcn" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"pel" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "peG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -85347,6 +85331,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"qDn" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "qEn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile/purple{
@@ -85483,6 +85472,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"rAm" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "rBU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85528,10 +85524,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"rPH" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85569,10 +85561,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"sbj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "sdi" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -85930,10 +85918,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
-"tii" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -85986,13 +85970,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"tHI" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "tIm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -86115,10 +86092,12 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
-"uoq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+"ulS" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -86141,10 +86120,6 @@
 "urv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
-"urF" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "usN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -86178,6 +86153,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
+"uxm" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "uyu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -86218,6 +86203,12 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
 /area/space/nearstation)
+"uGo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "uGW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -86271,12 +86262,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"uYt" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "vcK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -86346,10 +86331,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"vox" = (
-/obj/structure/sign/warning/nosmoking/circle,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86408,6 +86389,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"vHK" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/space/basic,
+/area/engine/atmos)
 "vHO" = (
 /obj/machinery/door/airlock/research{
 	name = "Shuttle dock";
@@ -86487,11 +86472,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"vRM" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "vUC" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -86564,6 +86544,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wfk" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "wgp" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -86633,6 +86618,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wog" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "wps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -87073,6 +87063,16 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
+"xPe" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"xPr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xQk" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -126668,7 +126668,7 @@ cgz
 cpN
 crd
 ack
-tii
+klD
 aaa
 aaa
 aaa
@@ -126925,7 +126925,7 @@ cgz
 cgz
 cre
 auv
-tii
+klD
 aaa
 aaa
 aaa
@@ -127182,7 +127182,7 @@ cNw
 cOa
 crf
 auv
-tii
+klD
 aaa
 aaa
 aaa
@@ -127439,7 +127439,7 @@ cgz
 cgz
 cre
 auv
-tii
+klD
 aaa
 aaa
 aaa
@@ -127696,7 +127696,7 @@ cgz
 cpP
 ack
 ack
-tii
+klD
 aaa
 aaa
 aaa
@@ -129238,7 +129238,7 @@ aaf
 bzi
 aaa
 aaa
-vRM
+lkl
 aaa
 aaa
 aaa
@@ -130009,7 +130009,7 @@ aaa
 aai
 aaa
 aaa
-vRM
+lkl
 aaa
 aaa
 aaa
@@ -130523,7 +130523,7 @@ aaa
 bzj
 aaf
 aaa
-vRM
+lkl
 aaa
 aaa
 aaa
@@ -131037,7 +131037,7 @@ aaa
 bJf
 aaf
 aaa
-vRM
+lkl
 aaa
 aaa
 aaa
@@ -131550,7 +131550,7 @@ lMJ
 auv
 ggI
 aaa
-dkZ
+wfk
 aaf
 aaf
 aaf
@@ -131810,7 +131810,7 @@ aaa
 lMJ
 aaa
 aaa
-mSZ
+qDn
 aaa
 aaa
 aaa
@@ -132055,7 +132055,7 @@ bxc
 ccX
 bxc
 xjM
-urF
+jqX
 bCi
 bCi
 bCi
@@ -132067,7 +132067,7 @@ aaa
 lMJ
 aaa
 aaa
-mSZ
+qDn
 aaa
 aaa
 aaa
@@ -132312,19 +132312,19 @@ bxc
 wxc
 gkP
 bKG
-dac
-rPH
+pel
+ldY
 bCi
 bKD
 bCi
-iAt
+eml
 bza
 auv
 aaa
 lMJ
 vLD
 vLD
-hVd
+ulS
 aaa
 aaa
 aaa
@@ -132565,11 +132565,11 @@ bVN
 bXr
 bAR
 aaf
-nFY
-eOg
+vHK
+uGo
 bxc
 ccQ
-urF
+jqX
 bCi
 bCi
 bCi
@@ -132581,7 +132581,7 @@ aaa
 lMJ
 aaa
 aaa
-mSZ
+qDn
 aaa
 aaa
 aaa
@@ -132822,11 +132822,11 @@ ajl
 bUJ
 bAR
 aaf
-nFY
+vHK
 ccU
 bxc
-tHI
-urF
+rAm
+jqX
 bCi
 bCi
 bCi
@@ -132838,7 +132838,7 @@ aaa
 lMJ
 aaa
 aaa
-dkZ
+wfk
 aaa
 aaa
 aaa
@@ -133079,11 +133079,11 @@ bVP
 bXs
 bAR
 aaf
-nFY
-kAz
+vHK
+uxm
 bxc
-ffe
-urF
+gwU
+jqX
 bCi
 bCi
 bCi
@@ -133095,7 +133095,7 @@ auv
 lMJ
 vLD
 vLD
-hVd
+ulS
 aaa
 aaa
 aaa
@@ -133336,11 +133336,11 @@ bAR
 bAR
 bAR
 aaf
-nFY
-gFJ
+vHK
+gBP
 bxc
-mLy
-urF
+xPe
+jqX
 bCi
 bCi
 bCi
@@ -133352,7 +133352,7 @@ auv
 lMJ
 aaa
 aaa
-mSZ
+qDn
 aaa
 aaa
 aaa
@@ -133593,23 +133593,23 @@ aaf
 aaf
 aaf
 aaf
-nFY
+vHK
 ccZ
-lrF
-orM
-mTx
-sbj
-sbj
-sbj
-uoq
+fyI
+msg
+elk
+xPr
+xPr
+xPr
+cmf
 ckM
-vox
+cjo
 auv
 auv
 lMJ
 aaa
 aaa
-mSZ
+qDn
 aaa
 aaa
 aaa
@@ -133850,8 +133850,8 @@ aaa
 aaa
 aaa
 aaf
-nFY
-hTw
+vHK
+fFR
 bxc
 bxc
 bza
@@ -133866,7 +133866,7 @@ aaa
 fwb
 vLD
 vLD
-hVd
+ulS
 aaa
 aaa
 aaa
@@ -134108,14 +134108,14 @@ bzj
 bzj
 bJe
 auv
-tii
+klD
 auv
 lMJ
 auv
 auv
 auv
 auv
-uYt
+jrF
 auv
 auv
 auv
@@ -134123,7 +134123,7 @@ aaa
 fwb
 aaa
 aaa
-mSZ
+qDn
 aaa
 aaa
 aaa
@@ -134365,7 +134365,7 @@ aaa
 aaa
 aaf
 aaa
-tii
+klD
 aaa
 lMJ
 aaa
@@ -134380,7 +134380,7 @@ aaa
 fwb
 aaa
 aaa
-mSZ
+qDn
 aaa
 aaa
 aaa
@@ -134634,10 +134634,10 @@ lMJ
 fwb
 fwb
 fwb
-itb
+wog
 vLD
 vLD
-hVd
+ulS
 aaa
 aaa
 aaa
@@ -134894,7 +134894,7 @@ aaa
 vLD
 aaa
 aaa
-dkZ
+wfk
 aaa
 aaa
 aaa
@@ -135393,19 +135393,19 @@ aaa
 aaa
 aaa
 aaa
-hVd
-dkZ
-mSZ
-mSZ
-mSZ
-dkZ
-hVd
-mSZ
-mSZ
-hVd
-mSZ
-mSZ
-hVd
+ulS
+wfk
+qDn
+qDn
+qDn
+wfk
+ulS
+qDn
+qDn
+ulS
+qDn
+qDn
+ulS
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9664,8 +9664,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "arF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/secondary)
@@ -55222,17 +55222,29 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8
 	},
+/obj/structure/sign/warning/vacuum{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccX" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 33
+	},
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccZ" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -63050,9 +63062,6 @@
 	dir = 4;
 	network = list("turbine");
 	use_power = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /obj/structure/lattice,
 /turf/open/space,
@@ -80543,13 +80552,10 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "dkZ" = (
-/obj/structure/grille,
+/obj/structure/grille/broken,
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/turf/open/space/basic,
+/area/space)
 "dlI" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -82201,14 +82207,11 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "eOg" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "eTL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes{
@@ -82263,6 +82266,9 @@
 /area/engine/engineering)
 "ffe" = (
 /obj/structure/closet/radiation,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ffD" = (
@@ -82567,10 +82573,8 @@
 /turf/closed/wall,
 /area/janitor)
 "ggI" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
 /area/space/nearstation)
 "ghU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82747,6 +82751,9 @@
 /area/maintenance/starboard/aft)
 "gFJ" = (
 /obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "gHh" = (
@@ -82850,8 +82857,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
 "gXY" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -82991,20 +82998,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hTw" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "hVd" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "hWr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83404,13 +83409,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port)
-"joQ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "jpP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -83727,7 +83725,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kwL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel,
@@ -83780,6 +83777,12 @@
 /area/hallway/secondary/exit/departure_lounge)
 "kAz" = (
 /obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "kAX" = (
@@ -83973,12 +83976,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "lrF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84220,13 +84220,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"mpB" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/space,
-/area/space/nearstation)
 "mrv" = (
 /obj/machinery/door/airlock/wood{
 	doorClose = 'sound/effects/doorcreaky.ogg';
@@ -84353,18 +84346,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mSZ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/space,
-/area/space/nearstation)
-"mTx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/structure/lattice,
+/obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/area/space)
+"mTx" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "mTW" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -84729,6 +84719,7 @@
 "orM" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "osb" = (
@@ -85538,12 +85529,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "rPH" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85582,7 +85570,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "sbj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sdi" = (
@@ -85945,7 +85933,7 @@
 "tii" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -86128,9 +86116,8 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "uoq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -86285,13 +86272,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "uYt" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/space)
 "vcK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -86362,8 +86347,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vox" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -86503,9 +86488,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vRM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/secondary)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "vUC" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -86676,10 +86662,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "wxc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -87077,12 +87063,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
-"xHS" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "xJp" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/blue,
@@ -126168,12 +126148,12 @@ apX
 amV
 bZC
 arF
-vRM
-vRM
-vRM
-osW
-osW
-osW
+ovj
+ovj
+ovj
+auv
+auv
+auv
 ctl
 nYJ
 nYJ
@@ -126431,7 +126411,7 @@ cmc
 cpM
 crc
 aaf
-lrF
+auv
 aaa
 aaa
 nYJ
@@ -126688,7 +126668,7 @@ cgz
 cpN
 crd
 ack
-mpB
+tii
 aaa
 aaa
 aaa
@@ -126944,8 +126924,8 @@ atF
 cgz
 cgz
 cre
-aaa
-mpB
+auv
+tii
 aaa
 aaa
 aaa
@@ -127201,8 +127181,8 @@ cne
 cNw
 cOa
 crf
-aaa
-mpB
+auv
+tii
 aaa
 aaa
 aaa
@@ -127458,8 +127438,8 @@ cnf
 cgz
 cgz
 cre
-aaa
-mpB
+auv
+tii
 aaa
 aaa
 aaa
@@ -127710,13 +127690,13 @@ pOP
 pOP
 pOP
 gXY
-mTx
+cgz
 cng
 cgz
 cpP
 ack
-mSZ
-joQ
+ack
+tii
 aaa
 aaa
 aaa
@@ -127967,12 +127947,12 @@ aaf
 aaf
 aaf
 aaf
-rPH
-hVd
+lMJ
+lMJ
 aaa
 aaf
 aaa
-viG
+aaa
 aaa
 aaa
 aaa
@@ -128225,11 +128205,11 @@ bAR
 bAR
 bAR
 bAR
-aLw
+lMJ
 aaa
 aai
 aaf
-viG
+aaa
 aaa
 aaa
 aaa
@@ -128482,11 +128462,11 @@ chN
 cjc
 cjc
 bAR
-aLw
+lMJ
 aaa
 bzi
 aaa
-hTw
+aaa
 aaa
 aaa
 aaa
@@ -128739,11 +128719,11 @@ chO
 ajO
 ckG
 bAR
-aLw
+lMJ
 aaa
 bzi
-aaa
-uYt
+vLD
+vLD
 aaf
 aaf
 aaf
@@ -128996,12 +128976,12 @@ chP
 cje
 cjc
 bAR
-aLw
+lMJ
 aaa
 bzi
 aaa
-uYt
 aaa
+vLD
 aaa
 aaa
 aac
@@ -129253,12 +129233,12 @@ bAR
 bAR
 bAR
 bAR
-aLw
+lMJ
 aaf
 bzi
 aaa
-uYt
-aaf
+aaa
+vRM
 aaa
 aaa
 aaa
@@ -129510,12 +129490,12 @@ chQ
 cjf
 cjf
 bAR
-aLw
+lMJ
 aaa
 bzi
 aaa
-hTw
 aaa
+vLD
 aaa
 aaa
 aaa
@@ -129767,12 +129747,12 @@ chR
 amu
 ckH
 bAR
-aLw
+lMJ
 aaa
 bzi
 aaa
-uYt
 aaa
+vLD
 aaa
 aaa
 aaa
@@ -130024,12 +130004,12 @@ chS
 cjh
 cjf
 bAR
-aLw
+lMJ
 aaa
 aai
 aaa
-uYt
-aaf
+aaa
+vRM
 aaa
 aaa
 aaa
@@ -130281,12 +130261,12 @@ bAR
 bAR
 bAR
 bAR
-aLw
+lMJ
 aaf
 bzi
 aaa
-uYt
 aaa
+vLD
 aaa
 aaa
 aaa
@@ -130538,12 +130518,12 @@ chT
 cji
 ckI
 bAR
-aLw
+lMJ
 aaa
 bzj
 aaf
-hTw
-aaf
+aaa
+vRM
 aaa
 aaa
 aaa
@@ -130795,12 +130775,12 @@ chU
 cjj
 ckJ
 bAR
-aLw
+lMJ
 aaa
 bzi
 aaa
-uYt
 aaa
+vLD
 aaa
 aaa
 aaa
@@ -131052,12 +131032,12 @@ chV
 cjk
 ckI
 bAR
-aLw
+lMJ
 aaa
 bJf
 aaf
-eOg
-aaf
+aaa
+vRM
 aaa
 aaa
 aaa
@@ -131309,12 +131289,12 @@ bAR
 bAR
 bAR
 bAR
-aLw
+lMJ
 aaa
 aaf
 aaa
-uYt
 aaa
+vLD
 aaa
 aaa
 aaf
@@ -131560,16 +131540,16 @@ bKG
 bKG
 ccV
 bxc
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+auv
+auv
+auv
+auv
+auv
+auv
+lMJ
+auv
 ggI
-ggI
+aaa
 dkZ
 aaf
 aaf
@@ -131825,12 +131805,12 @@ bza
 bza
 bxc
 bxc
-aaa
+auv
 aaa
 lMJ
 aaa
 aaa
-aaa
+mSZ
 aaa
 aaa
 aaa
@@ -132082,12 +132062,12 @@ bCi
 bCi
 nBD
 bxc
-aaa
+auv
 aaa
 lMJ
 aaa
 aaa
-aaa
+mSZ
 aaa
 aaa
 aaa
@@ -132333,18 +132313,18 @@ wxc
 gkP
 bKG
 dac
+rPH
 bCi
-bCi
-bCi
+bKD
 bCi
 iAt
 bza
-aaa
+auv
 aaa
 lMJ
-aaa
-aaa
-aaa
+vLD
+vLD
+hVd
 aaa
 aaa
 aaa
@@ -132586,7 +132566,7 @@ bXr
 bAR
 aaf
 nFY
-ccQ
+eOg
 bxc
 ccQ
 urF
@@ -132596,12 +132576,12 @@ bCi
 bCi
 bCi
 bza
-aaa
+auv
 aaa
 lMJ
 aaa
 aaa
-aaa
+mSZ
 aaa
 aaa
 aaa
@@ -132843,7 +132823,7 @@ bUJ
 bAR
 aaf
 nFY
-ccQ
+ccU
 bxc
 tHI
 urF
@@ -132853,12 +132833,12 @@ bCi
 bCi
 bCi
 bza
-aaa
+auv
 aaa
 lMJ
 aaa
 aaa
-aaa
+dkZ
 aaa
 aaa
 aaa
@@ -133110,12 +133090,12 @@ bCi
 bCi
 bCi
 bza
-aaa
-aaa
+auv
+auv
 lMJ
-aaa
-aaa
-aaa
+vLD
+vLD
+hVd
 aaa
 aaa
 aaa
@@ -133364,15 +133344,15 @@ urF
 bCi
 bCi
 bCi
-vox
-sbj
-uoq
-xHS
+bAC
+bCi
+bza
 aaa
+auv
 lMJ
 aaa
 aaa
-aaa
+mSZ
 aaa
 aaa
 aaa
@@ -133615,21 +133595,21 @@ aaf
 aaf
 nFY
 ccZ
-bxc
+lrF
 orM
-urF
-bCi
-bCi
-bCi
-bCi
+mTx
+sbj
+sbj
+sbj
+uoq
 ckM
-bxc
-aaa
-aaa
+vox
+auv
+auv
 lMJ
 aaa
 aaa
-aaa
+mSZ
 aaa
 aaa
 aaa
@@ -133871,7 +133851,7 @@ aaa
 aaa
 aaf
 nFY
-kAz
+hTw
 bxc
 bxc
 bza
@@ -133881,12 +133861,12 @@ bza
 bza
 bxc
 bxc
+auv
 aaa
-aaa
-lMJ
-aaa
-aaa
-aaa
+fwb
+vLD
+vLD
+hVd
 aaa
 aaa
 aaa
@@ -134127,23 +134107,23 @@ bzj
 bzj
 bzj
 bJe
-aaa
+auv
 tii
-aaa
-vLD
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+auv
 lMJ
+auv
+auv
+auv
+auv
+uYt
+auv
+auv
+auv
+aaa
+fwb
 aaa
 aaa
-aaa
+mSZ
 aaa
 aaa
 aaa
@@ -134387,20 +134367,20 @@ aaf
 aaa
 tii
 aaa
-vLD
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 lMJ
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+fwb
+aaa
+aaa
+mSZ
 aaa
 aaa
 aaa
@@ -134651,13 +134631,13 @@ lMJ
 lMJ
 lMJ
 lMJ
-lMJ
-lMJ
-lMJ
+fwb
+fwb
+fwb
 itb
-aaa
-aaa
-aaa
+vLD
+vLD
+hVd
 aaa
 aaa
 aaa
@@ -134899,22 +134879,22 @@ aaa
 aaa
 aaf
 aaa
+vLD
 aaa
 aaa
+vLD
 aaa
 aaa
+vLD
 aaa
 aaa
+vLD
 aaa
 aaa
+vLD
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dkZ
 aaa
 aaa
 aaa
@@ -135156,19 +135136,19 @@ bzj
 bzj
 bKK
 aaa
+vLD
 aaa
 aaa
+vLD
 aaa
 aaa
+vLD
 aaa
 aaa
+vLD
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -135413,19 +135393,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hVd
+dkZ
+mSZ
+mSZ
+mSZ
+dkZ
+hVd
+mSZ
+mSZ
+hVd
+mSZ
+mSZ
+hVd
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2044,11 +2044,16 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aef" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/port/fore)
 "aeg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -40130,6 +40135,13 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
+"bxR" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "bxS" = (
 /obj/item/cigbutt,
 /obj/machinery/power/apc/highcap/five_k{
@@ -56250,6 +56262,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cfB" = (
@@ -58182,6 +58200,10 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
+"cjo" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -59316,6 +59338,10 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"cmf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cmk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -64548,18 +64574,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"cwg" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cwh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -77064,13 +77078,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"dac" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "dap" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/chair{
@@ -80538,11 +80545,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"dkZ" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "dlI" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -82083,6 +82085,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ekV" = (
+/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "ems" = (
 /obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/reinforced,
@@ -82193,17 +82202,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"eOg" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
 "eTL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes{
@@ -82256,13 +82254,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"ffe" = (
-/obj/structure/closet/radiation,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "ffD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -82528,6 +82519,16 @@
 /obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"fTp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"fUe" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "fUt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -82628,6 +82629,11 @@
 "gnd" = (
 /turf/closed/wall,
 /area/maintenance/department/science/central)
+"gnP" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "gnZ" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -82707,11 +82713,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"gzs" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "gzP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -82746,13 +82747,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"gFJ" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "gHh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82840,6 +82834,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"gOi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space)
 "gUT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -82859,13 +82859,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"gYL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "heM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -82950,6 +82943,11 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating/airless,
 /area/science/shuttledock)
+"hFa" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "hFV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -83001,25 +82999,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hTw" = (
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13,8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"hVd" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat Space Access Airlock";
-	req_access_txt = "32"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/break_room)
 "hWr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83041,6 +83020,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"idj" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "ieV" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/stripes/line{
@@ -83161,11 +83145,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"itb" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "ixU" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -83205,15 +83184,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/janitor)
-"iAt" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #1";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "iAI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83458,6 +83428,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -83525,6 +83502,19 @@
 	},
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
+"jNC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"jNL" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "jSj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -83551,12 +83541,6 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
-"jXu" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "jXK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -83781,16 +83765,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kAz" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "kAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -83854,6 +83828,12 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"kJf" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "kKE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -83981,12 +83961,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"lrF" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "lvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84052,6 +84026,12 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"lGQ" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -84098,6 +84078,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lPf" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lRd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84319,12 +84303,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"mLy" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "mLO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84353,19 +84331,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"mSZ" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"mTx" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
+"mTq" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mTW" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -84442,6 +84411,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"nqx" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "nqY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -84506,10 +84482,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"nFY" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/space/basic,
-/area/engine/atmos)
 "nHj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84555,6 +84527,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"nLo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "nLv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -84567,10 +84546,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"nMk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "nTf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -84731,12 +84706,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"orM" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "osb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -84964,6 +84933,10 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"prt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -85323,6 +85296,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"qAy" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "qBh" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -85392,6 +85371,15 @@
 /obj/item/storage/photo_album,
 /turf/open/floor/engine/cult,
 /area/library)
+"qRA" = (
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13,8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qVR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -85469,6 +85457,12 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rpg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rrB" = (
 /turf/closed/wall,
 /area/vacant_room/commissary)
@@ -85485,6 +85479,10 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"rzr" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "rzX" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -85543,22 +85541,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"rPH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85596,10 +85578,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"sbj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "sdi" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -85650,6 +85628,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"shX" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "siF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -85845,9 +85833,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"sJO" = (
-/obj/structure/sign/warning/nosmoking/circle,
-/turf/closed/wall/r_wall,
+"sJT" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -85954,6 +85943,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"tcw" = (
+/obj/structure/closet/radiation,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "tcM" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/purple{
@@ -85961,10 +85957,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
-"tii" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -85975,6 +85967,11 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"tmD" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -86017,13 +86014,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"tHI" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "tIm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -86143,11 +86133,6 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
-"uoq" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -86170,10 +86155,6 @@
 "urv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
-"urF" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "usN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -86201,6 +86182,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/secondary)
+"uuP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uvc" = (
 /obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_x = 32
@@ -86300,11 +86285,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"uYt" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "vcK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -86374,10 +86354,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"vox" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86428,6 +86404,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"vDO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "vEv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -86515,10 +86500,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"vRM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "vUC" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -86527,6 +86508,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"vVZ" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #1";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vWK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -87090,14 +87080,20 @@
 	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
-"xHS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xJp" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/blue,
 /area/bridge)
+"xKp" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Space Access Airlock";
+	req_access_txt = "32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/break_room)
 "xKV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -87108,6 +87104,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"xUB" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/space/basic,
+/area/engine/atmos)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -100986,8 +100986,8 @@ bVR
 bXu
 bYD
 hvP
+vDO
 jyQ
-rPH
 cda
 cfz
 cED
@@ -103830,8 +103830,8 @@ aob
 aob
 aob
 alK
-nMk
-cwg
+prt
+cfA
 dux
 ack
 aaa
@@ -104088,7 +104088,7 @@ aob
 aob
 alK
 bXE
-cfA
+rpg
 iLz
 tLf
 eUG
@@ -106053,8 +106053,8 @@ aaf
 aaf
 acU
 aak
-eOg
 aef
+gOi
 ojC
 afE
 agC
@@ -126699,7 +126699,7 @@ cgz
 cpN
 crd
 ack
-tii
+mTq
 aaa
 aaa
 aaa
@@ -126956,7 +126956,7 @@ cgz
 cgz
 cre
 auv
-tii
+mTq
 aaa
 aaa
 aaa
@@ -127213,7 +127213,7 @@ cNw
 cOa
 crf
 auv
-tii
+mTq
 aaa
 aaa
 aaa
@@ -127470,7 +127470,7 @@ cgz
 cgz
 cre
 auv
-tii
+mTq
 aaa
 aaa
 aaa
@@ -127727,7 +127727,7 @@ cgz
 cpP
 ack
 ack
-tii
+mTq
 aaa
 aaa
 aaa
@@ -128164,7 +128164,7 @@ aaf
 aaa
 aaf
 dnh
-hTw
+qRA
 dnh
 dnS
 dnS
@@ -129269,7 +129269,7 @@ aaf
 bzi
 aaa
 aaa
-gzs
+tmD
 aaa
 aaa
 aaa
@@ -130040,7 +130040,7 @@ aaa
 aai
 aaa
 aaa
-gzs
+tmD
 aaa
 aaa
 aaa
@@ -130554,7 +130554,7 @@ aaa
 bzj
 aaf
 aaa
-gzs
+tmD
 aaa
 aaa
 aaa
@@ -131068,7 +131068,7 @@ aaa
 bJf
 aaf
 aaa
-gzs
+tmD
 aaa
 aaa
 aaa
@@ -131290,7 +131290,7 @@ aaf
 uGa
 aaf
 aaa
-hVd
+xKp
 bxc
 bzg
 bAP
@@ -131581,7 +131581,7 @@ lMJ
 auv
 ggI
 aaa
-dkZ
+hFa
 aaf
 aaf
 aaf
@@ -131841,7 +131841,7 @@ aaa
 lMJ
 aaa
 aaa
-uoq
+idj
 aaa
 aaa
 aaa
@@ -132086,7 +132086,7 @@ bxc
 ccX
 bxc
 xjM
-urF
+rzr
 bCi
 bCi
 bCi
@@ -132098,7 +132098,7 @@ aaa
 lMJ
 aaa
 aaa
-uoq
+idj
 aaa
 aaa
 aaa
@@ -132343,19 +132343,19 @@ bxc
 wxc
 gkP
 bKG
-dac
-vox
+jNC
+lPf
 bCi
 bKD
 bCi
-iAt
+vVZ
 bza
 auv
 aaa
 lMJ
 vLD
 vLD
-mTx
+jNL
 aaa
 aaa
 aaa
@@ -132596,11 +132596,11 @@ bVN
 bXr
 bAR
 aaf
-nFY
-lrF
+xUB
+kJf
 bxc
 ccQ
-urF
+rzr
 bCi
 bCi
 bCi
@@ -132612,7 +132612,7 @@ aaa
 lMJ
 aaa
 aaa
-uoq
+idj
 aaa
 aaa
 aaa
@@ -132853,11 +132853,11 @@ ajl
 bUJ
 bAR
 aaf
-nFY
+xUB
 ccU
 bxc
-tHI
-urF
+nqx
+rzr
 bCi
 bCi
 bCi
@@ -132869,7 +132869,7 @@ aaa
 lMJ
 aaa
 aaa
-dkZ
+hFa
 aaa
 aaa
 aaa
@@ -133110,11 +133110,11 @@ bVP
 bXs
 bAR
 aaf
-nFY
-kAz
+xUB
+shX
 bxc
-ffe
-urF
+tcw
+rzr
 bCi
 bCi
 bCi
@@ -133126,7 +133126,7 @@ auv
 lMJ
 vLD
 vLD
-mTx
+jNL
 aaa
 aaa
 aaa
@@ -133367,11 +133367,11 @@ bAR
 bAR
 bAR
 aaf
-nFY
-gFJ
+xUB
+ekV
 bxc
-mLy
-urF
+fUe
+rzr
 bCi
 bCi
 bCi
@@ -133383,7 +133383,7 @@ auv
 lMJ
 aaa
 aaa
-uoq
+idj
 aaa
 aaa
 aaa
@@ -133624,23 +133624,23 @@ aaf
 aaf
 aaf
 aaf
-nFY
+xUB
 ccZ
-sbj
-orM
-uYt
-vRM
-vRM
-vRM
-xHS
+fTp
+lGQ
+sJT
+uuP
+uuP
+uuP
+cmf
 ckM
-sJO
+cjo
 auv
 auv
 lMJ
 aaa
 aaa
-uoq
+idj
 aaa
 aaa
 aaa
@@ -133881,15 +133881,15 @@ aaa
 aaa
 aaa
 aaf
-nFY
-mSZ
+xUB
+bxR
 bxc
 bxc
 bza
 bza
 bza
 bza
-gYL
+nLo
 bxc
 bxc
 auv
@@ -133897,7 +133897,7 @@ aaa
 fwb
 vLD
 vLD
-mTx
+jNL
 aaa
 aaa
 aaa
@@ -134139,14 +134139,14 @@ bzj
 bzj
 bJe
 auv
-tii
+mTq
 auv
 lMJ
 auv
 auv
 auv
 auv
-jXu
+qAy
 auv
 auv
 auv
@@ -134154,7 +134154,7 @@ aaa
 fwb
 aaa
 aaa
-uoq
+idj
 aaa
 aaa
 aaa
@@ -134396,7 +134396,7 @@ aaa
 aaa
 aaf
 aaa
-tii
+mTq
 aaa
 lMJ
 aaa
@@ -134411,7 +134411,7 @@ aaa
 fwb
 aaa
 aaa
-uoq
+idj
 aaa
 aaa
 aaa
@@ -134665,10 +134665,10 @@ lMJ
 fwb
 fwb
 fwb
-itb
+gnP
 vLD
 vLD
-mTx
+jNL
 aaa
 aaa
 aaa
@@ -134925,7 +134925,7 @@ aaa
 vLD
 aaa
 aaa
-dkZ
+hFa
 aaa
 aaa
 aaa
@@ -135424,19 +135424,19 @@ aaa
 aaa
 aaa
 aaa
-mTx
-dkZ
-uoq
-uoq
-uoq
-dkZ
-mTx
-uoq
-uoq
-mTx
-uoq
-uoq
-mTx
+jNL
+hFa
+idj
+idj
+idj
+hFa
+jNL
+idj
+idj
+jNL
+idj
+idj
+jNL
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2044,16 +2044,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aef" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/area/space)
 "aeg" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -82200,14 +82195,15 @@
 /area/engine/break_room)
 "eOg" = (
 /obj/machinery/door/airlock/external{
-	name = "MiniSat Space Access Airlock";
-	req_access_txt = "32"
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/break_room)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "eTL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes{
@@ -82711,6 +82707,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"gzs" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "gzP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -82858,6 +82859,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"gYL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "heM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -82994,18 +83002,24 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hTw" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13,8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "hVd" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Space Access Airlock";
+	req_access_txt = "32"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/break_room)
 "hWr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83537,6 +83551,12 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
+"jXu" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "jXK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -83962,11 +83982,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "lrF" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "lvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84334,25 +84354,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mSZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
-"mTx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"mTx" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "mTW" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -84554,6 +84567,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"nMk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nTf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -85253,10 +85270,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"qow" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "qqg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -85531,10 +85544,21 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "rPH" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85573,9 +85597,8 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "sbj" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "sdi" = (
 /obj/structure/window/reinforced{
@@ -85822,6 +85845,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sJO" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
@@ -85934,11 +85961,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
-"tfj" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "tii" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -86104,11 +86126,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ujJ" = (
-/obj/machinery/door/airlock/external{
-	req_one_access_txt = "13,8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -86125,9 +86144,10 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "uoq" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -86281,8 +86301,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "uYt" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "vcK" = (
 /obj/structure/cable/yellow{
@@ -86354,7 +86375,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vox" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vpJ" = (
@@ -86495,11 +86516,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vRM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "vUC" = (
 /obj/structure/window/reinforced,
@@ -86678,10 +86696,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"wyr" = (
-/obj/structure/sign/warning/nosmoking/circle,
-/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -87077,11 +87091,9 @@
 /turf/open/floor/plating,
 /area/science/shuttledock)
 "xHS" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xJp" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/blue,
@@ -100975,7 +100987,7 @@ bXu
 bYD
 hvP
 jyQ
-mSZ
+rPH
 cda
 cfz
 cED
@@ -103818,7 +103830,7 @@ aob
 aob
 aob
 alK
-qow
+nMk
 cwg
 dux
 ack
@@ -105784,7 +105796,7 @@ aaa
 aaa
 acT
 aaa
-aaf
+aee
 aee
 nCn
 vXa
@@ -106041,7 +106053,7 @@ aaf
 aaf
 acU
 aak
-aak
+eOg
 aef
 ojC
 afE
@@ -106298,7 +106310,7 @@ aaa
 aaa
 aaf
 aaa
-aaf
+aee
 aee
 mco
 siK
@@ -128151,8 +128163,8 @@ aaa
 aaf
 aaa
 aaf
-aaa
-xmR
+dnh
+hTw
 dnh
 dnS
 dnS
@@ -129257,7 +129269,7 @@ aaf
 bzi
 aaa
 aaa
-tfj
+gzs
 aaa
 aaa
 aaa
@@ -130028,7 +130040,7 @@ aaa
 aai
 aaa
 aaa
-tfj
+gzs
 aaa
 aaa
 aaa
@@ -130542,7 +130554,7 @@ aaa
 bzj
 aaf
 aaa
-tfj
+gzs
 aaa
 aaa
 aaa
@@ -131056,7 +131068,7 @@ aaa
 bJf
 aaf
 aaa
-tfj
+gzs
 aaa
 aaa
 aaa
@@ -131278,7 +131290,7 @@ aaf
 uGa
 aaf
 aaa
-eOg
+hVd
 bxc
 bzg
 bAP
@@ -131829,7 +131841,7 @@ aaa
 lMJ
 aaa
 aaa
-rPH
+uoq
 aaa
 aaa
 aaa
@@ -132086,7 +132098,7 @@ aaa
 lMJ
 aaa
 aaa
-rPH
+uoq
 aaa
 aaa
 aaa
@@ -132332,7 +132344,7 @@ wxc
 gkP
 bKG
 dac
-uoq
+vox
 bCi
 bKD
 bCi
@@ -132343,7 +132355,7 @@ aaa
 lMJ
 vLD
 vLD
-lrF
+mTx
 aaa
 aaa
 aaa
@@ -132585,7 +132597,7 @@ bXr
 bAR
 aaf
 nFY
-hTw
+lrF
 bxc
 ccQ
 urF
@@ -132600,7 +132612,7 @@ aaa
 lMJ
 aaa
 aaa
-rPH
+uoq
 aaa
 aaa
 aaa
@@ -133114,7 +133126,7 @@ auv
 lMJ
 vLD
 vLD
-lrF
+mTx
 aaa
 aaa
 aaa
@@ -133371,7 +133383,7 @@ auv
 lMJ
 aaa
 aaa
-rPH
+uoq
 aaa
 aaa
 aaa
@@ -133614,21 +133626,21 @@ aaf
 aaf
 nFY
 ccZ
-mTx
-orM
 sbj
+orM
 uYt
-uYt
-uYt
-vox
+vRM
+vRM
+vRM
+xHS
 ckM
-wyr
+sJO
 auv
 auv
 lMJ
 aaa
 aaa
-rPH
+uoq
 aaa
 aaa
 aaa
@@ -133870,14 +133882,14 @@ aaa
 aaa
 aaf
 nFY
-hVd
+mSZ
 bxc
 bxc
 bza
 bza
 bza
 bza
-vRM
+gYL
 bxc
 bxc
 auv
@@ -133885,7 +133897,7 @@ aaa
 fwb
 vLD
 vLD
-lrF
+mTx
 aaa
 aaa
 aaa
@@ -134134,7 +134146,7 @@ auv
 auv
 auv
 auv
-xHS
+jXu
 auv
 auv
 auv
@@ -134142,7 +134154,7 @@ aaa
 fwb
 aaa
 aaa
-rPH
+uoq
 aaa
 aaa
 aaa
@@ -134399,7 +134411,7 @@ aaa
 fwb
 aaa
 aaa
-rPH
+uoq
 aaa
 aaa
 aaa
@@ -134656,7 +134668,7 @@ fwb
 itb
 vLD
 vLD
-lrF
+mTx
 aaa
 aaa
 aaa
@@ -135412,19 +135424,19 @@ aaa
 aaa
 aaa
 aaa
-lrF
+mTx
 dkZ
-rPH
-rPH
-rPH
+uoq
+uoq
+uoq
 dkZ
-lrF
-rPH
-rPH
-lrF
-rPH
-rPH
-lrF
+mTx
+uoq
+uoq
+mTx
+uoq
+uoq
+mTx
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55210,59 +55210,32 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccV" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccW" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Internal Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"ccX" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+/obj/machinery/door/airlock/atmos/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8
 	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"ccX" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccZ" = (
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	name = "glass door";
-	req_access_txt = "24"
+/obj/structure/sign/warning/vacuum{
+	pixel_y = -32
 	},
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "glass door";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "cda" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -56840,24 +56813,10 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"cgD" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "cgE" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "cgF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -57599,19 +57558,13 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "chW" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/falsewall/reinforced,
+/turf/open/space/basic,
+/area/engine/atmos)
 "chX" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "chY" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -58248,27 +58201,24 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "cjl" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
-"cjm" = (
-/obj/machinery/door/airlock/atmos/glass{
-	heat_proof = 1;
-	name = "Auxiliary Chamber";
-	req_access_txt = "24"
-	},
-/turf/open/floor/plating,
+/obj/machinery/advanced_airlock_controller/directional/north,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"cjm" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "cjn" = (
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/structure/closet/radiation,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "cjo" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/starboard)
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -58841,21 +58791,20 @@
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "ckK" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "ckL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
+/obj/structure/table,
+/obj/item/stack/cable_coil/random,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "ckM" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/maintenance/starboard)
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ckT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -59416,14 +59365,21 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "cme" = (
-/obj/item/stack/rods{
-	amount = 25
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "cmf" = (
-/turf/open/floor/plating/airless,
-/area/maintenance/starboard)
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #1";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cmk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -82530,10 +82486,8 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "fGw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/scrubbers,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82722,10 +82676,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
 "gkP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/atmos/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "gnd" = (
 /turf/closed/wall,
@@ -84094,13 +84047,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "lxw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "lzk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -84571,12 +84521,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "nBD" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nCn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -84971,11 +84919,11 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "pco" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/turf/open/floor/plating/airless,
+/area/space)
 "peG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -85371,11 +85319,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "qze" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "qzv" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -86067,13 +86014,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"tEj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -86428,8 +86368,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vox" = (
-/turf/open/floor/engine/vacuum,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86741,17 +86682,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "wxc" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -86923,10 +86860,9 @@
 /turf/closed/wall,
 /area/maintenance/solars/starboard/fore)
 "xjM" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "xkS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -131623,15 +131559,15 @@ bYB
 bKG
 bKG
 ccV
-pco
-eUG
-eUG
-eUG
-eUG
-eUG
-eUG
-lxw
-eUG
+bxc
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 ggI
 ggI
 dkZ
@@ -131880,18 +131816,18 @@ bxc
 bxc
 bxc
 ccW
-qze
-aaf
+bxc
+bxc
+bza
+bza
+bza
+bza
+bza
+bxc
+bxc
 aaa
 aaa
-aaf
-aaa
-aaf
-tEj
-aaa
-aaa
-aaf
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -132137,18 +132073,18 @@ aaf
 aaf
 bxc
 ccX
-fGw
+bxc
 xjM
-xjM
-xjM
-xjM
-xjM
-xjM
+cgE
+bCi
+bCi
+bCi
+bCi
 nBD
-aaf
-aaf
-aaf
+bxc
 aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -132395,17 +132331,17 @@ aaf
 bxc
 wxc
 gkP
-aaf
+bKG
+cme
+bCi
+bCi
+bCi
+bCi
+cmf
+bza
 aaa
-aaf
 aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aai
-aaf
+lMJ
 aaa
 aaa
 aaa
@@ -132649,20 +132585,20 @@ bVN
 bXr
 bAR
 aaf
-aMr
-apc
-bBb
-aaf
+chW
+ccQ
+bxc
+ccQ
+cgE
+bCi
+bCi
+bCi
+bCi
+bCi
+bza
 aaa
-aaf
-atm
-cjo
-ckM
-cmf
-cmf
 aaa
-bKK
-aaa
+lMJ
 aaa
 aaa
 aaa
@@ -132906,20 +132842,20 @@ ajl
 bUJ
 bAR
 aaf
-aMq
-apc
-bgo
-aTQ
-cgD
 chW
-cjl
-ckK
-vox
-vox
-ckM
-aaf
-bKK
+ccQ
+bxc
+cjn
+cgE
+bCi
+bCi
+bCi
+bCi
+bCi
+bza
 aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -133163,20 +133099,20 @@ bVP
 bXs
 bAR
 aaf
-aMr
-apc
-apc
-apc
-apc
-apc
-cjm
-vox
-cme
-vox
+chW
+chX
+bxc
 cjo
+cgE
+bCi
+bCi
+bCi
+bCi
+bCi
+bza
 aaa
-bKK
-aaf
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -133420,20 +133356,20 @@ bAR
 bAR
 bAR
 aaf
-aMq
-apc
-aVk
-aNC
+chW
+cjl
+bxc
+ckK
 cgE
-chX
-cjn
-ckL
+bCi
+bCi
+bCi
 vox
-vox
-atm
-aaf
-aai
+fGw
+lxw
+pco
 aaa
+lMJ
 aaa
 aaa
 aaa
@@ -133677,20 +133613,20 @@ aaf
 aaf
 aaf
 aaf
-aMr
+chW
 ccZ
-bBb
-aaf
-aaa
-aaf
-cjo
+bxc
+ckL
+cgE
+bCi
+bCi
+bCi
+bCi
 ckM
-cmf
-ckM
-cjo
+bxc
 aaa
-aaf
-aaf
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -133934,20 +133870,20 @@ aaa
 aaa
 aaa
 aaf
+chW
+chX
+bxc
+bxc
+bza
+bza
+bza
+bza
+bza
+bxc
+bxc
 aaa
-aaf
 aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
+lMJ
 aaa
 aaa
 aaa
@@ -134191,20 +134127,20 @@ bzj
 bzj
 bzj
 bJe
-bzj
-aai
-bzj
-aaf
-aaf
-aai
-bzj
-aai
-bzj
-bzj
-aaf
-aaf
+aaa
+cjm
+aaa
+vLD
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -134449,19 +134385,19 @@ aaa
 aaa
 aaf
 aaa
+cjm
 aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
+vLD
 aaa
 aaa
 aaa
-aaf
 aaa
-aac
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -134705,20 +134641,20 @@ bzi
 bzi
 bzi
 bJf
-aaf
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+qze
 aaa
 aaa
 aaa
@@ -134964,7 +134900,7 @@ aaa
 aaf
 aaa
 aaa
-aaf
+aaa
 aaa
 aaa
 aaa
@@ -135219,9 +135155,9 @@ bzj
 bzj
 bzj
 bKK
-bzj
-bzj
-anS
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56255,12 +56255,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cfB" = (
@@ -64563,9 +64557,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cwh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82035,6 +82034,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dZR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ecs" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -83089,9 +83092,6 @@
 /area/science/misc_lab/range)
 "ioR" = (
 /obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
 /obj/machinery/advanced_airlock_controller{
 	dir = 8;
 	pixel_x = 24
@@ -83960,11 +83960,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
-"lnp" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "lnO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -85074,6 +85069,11 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"pPS" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "pRi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -103552,7 +103552,7 @@ aob
 aob
 aob
 ate
-auv
+ack
 cwf
 ack
 aaf
@@ -103809,9 +103809,9 @@ aob
 aob
 aob
 alK
-ack
+dZR
 cwg
-ack
+dux
 ack
 aaa
 aaa
@@ -104066,7 +104066,7 @@ aob
 aob
 aob
 alK
-dux
+bXE
 cfA
 iLz
 tLf
@@ -129248,7 +129248,7 @@ aaf
 bzi
 aaa
 aaa
-lnp
+pPS
 aaa
 aaa
 aaa
@@ -130019,7 +130019,7 @@ aaa
 aai
 aaa
 aaa
-lnp
+pPS
 aaa
 aaa
 aaa
@@ -130533,7 +130533,7 @@ aaa
 bzj
 aaf
 aaa
-lnp
+pPS
 aaa
 aaa
 aaa
@@ -131047,7 +131047,7 @@ aaa
 bJf
 aaf
 aaa
-lnp
+pPS
 aaa
 aaa
 aaa
@@ -131268,7 +131268,7 @@ aaa
 aaf
 uGa
 aaf
-bhT
+aaa
 eOg
 bxc
 bzg

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55228,14 +55228,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "ccX" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = 33
 	},
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -58200,10 +58200,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cjo" = (
-/obj/structure/sign/warning/nosmoking/circle,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "cjr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -59338,10 +59334,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"cmf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cmk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -77085,6 +77077,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"dac" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "dap" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/chair{
@@ -80552,6 +80551,11 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"dkZ" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "dlI" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -82092,20 +82096,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"elk" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"eml" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #1";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ems" = (
 /obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/reinforced,
@@ -82216,6 +82206,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"eOg" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "eTL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes{
@@ -82268,6 +82264,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"ffe" = (
+/obj/structure/closet/radiation,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "ffD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -82403,10 +82406,6 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
-"fyI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "fBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -82445,13 +82444,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"fFR" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82712,13 +82704,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
-"gwU" = (
-/obj/structure/closet/radiation,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "gyr" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -82742,13 +82727,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/aisat)
-"gBP" = (
-/obj/machinery/advanced_airlock_controller/directional/north,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "gCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -82771,6 +82749,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gFJ" = (
+/obj/machinery/advanced_airlock_controller/directional/north,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "gHh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83012,6 +82997,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"hTw" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"hVd" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
 "hWr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83156,6 +83154,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"itb" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "ixU" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -83195,6 +83198,15 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/janitor)
+"iAt" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #1";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iAI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83403,10 +83415,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
-"jqX" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -83416,12 +83424,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"jrF" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "jsu" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -83660,10 +83662,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"klD" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "koT" = (
 /obj/machinery/light_switch{
 	pixel_x = -25
@@ -83777,6 +83775,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kAz" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "kAX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -83944,10 +83952,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ldY" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lhb" = (
 /obj/item/clothing/head/festive,
 /turf/open/floor/plating,
@@ -83959,11 +83963,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
-"lkl" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "lnO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -83976,6 +83975,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"lrF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84233,12 +84236,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/port/aft)
-"msg" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "mvj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -84314,6 +84311,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"mLy" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/twenty,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "mLO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84342,6 +84345,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"mSZ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space)
+"mTx" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "mTW" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -84482,6 +84495,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"nFY" = (
+/obj/structure/falsewall/reinforced,
+/turf/open/space/basic,
+/area/engine/atmos)
 "nHj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84699,6 +84716,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"orM" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil/random,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "osb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -84867,13 +84890,6 @@
 "pcn" = (
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
-"pel" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "peG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -85331,11 +85347,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"qDn" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
 "qEn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile/purple{
@@ -85472,13 +85483,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"rAm" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "rBU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85524,6 +85528,10 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"rPH" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85561,6 +85569,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"sbj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "sdi" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -85918,6 +85930,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"tii" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
@@ -85970,6 +85986,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tHI" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "tIm" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -86092,12 +86115,10 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
-"ulS" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
+"uoq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -86120,6 +86141,10 @@
 "urv" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
+"urF" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "usN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -86153,16 +86178,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
-"uxm" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "uyu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -86203,12 +86218,6 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/open/space,
 /area/space/nearstation)
-"uGo" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "uGW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -86262,6 +86271,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"uYt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vcK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -86331,6 +86347,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vox" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86389,10 +86411,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"vHK" = (
-/obj/structure/falsewall/reinforced,
-/turf/open/space/basic,
-/area/engine/atmos)
 "vHO" = (
 /obj/machinery/door/airlock/research{
 	name = "Shuttle dock";
@@ -86472,6 +86490,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vRM" = (
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "vUC" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -86544,11 +86566,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wfk" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "wgp" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -86618,11 +86635,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wog" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "wps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -87053,6 +87065,11 @@
 	},
 /turf/open/floor/plating,
 /area/science/shuttledock)
+"xHS" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "xJp" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/blue,
@@ -87063,16 +87080,6 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
-"xPe" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/twenty,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"xPr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xQk" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -126668,7 +126675,7 @@ cgz
 cpN
 crd
 ack
-klD
+tii
 aaa
 aaa
 aaa
@@ -126925,7 +126932,7 @@ cgz
 cgz
 cre
 auv
-klD
+tii
 aaa
 aaa
 aaa
@@ -127182,7 +127189,7 @@ cNw
 cOa
 crf
 auv
-klD
+tii
 aaa
 aaa
 aaa
@@ -127439,7 +127446,7 @@ cgz
 cgz
 cre
 auv
-klD
+tii
 aaa
 aaa
 aaa
@@ -127696,7 +127703,7 @@ cgz
 cpP
 ack
 ack
-klD
+tii
 aaa
 aaa
 aaa
@@ -129238,7 +129245,7 @@ aaf
 bzi
 aaa
 aaa
-lkl
+xHS
 aaa
 aaa
 aaa
@@ -130009,7 +130016,7 @@ aaa
 aai
 aaa
 aaa
-lkl
+xHS
 aaa
 aaa
 aaa
@@ -130523,7 +130530,7 @@ aaa
 bzj
 aaf
 aaa
-lkl
+xHS
 aaa
 aaa
 aaa
@@ -131037,7 +131044,7 @@ aaa
 bJf
 aaf
 aaa
-lkl
+xHS
 aaa
 aaa
 aaa
@@ -131550,7 +131557,7 @@ lMJ
 auv
 ggI
 aaa
-wfk
+dkZ
 aaf
 aaf
 aaf
@@ -131810,7 +131817,7 @@ aaa
 lMJ
 aaa
 aaa
-qDn
+mSZ
 aaa
 aaa
 aaa
@@ -132055,7 +132062,7 @@ bxc
 ccX
 bxc
 xjM
-jqX
+urF
 bCi
 bCi
 bCi
@@ -132067,7 +132074,7 @@ aaa
 lMJ
 aaa
 aaa
-qDn
+mSZ
 aaa
 aaa
 aaa
@@ -132312,19 +132319,19 @@ bxc
 wxc
 gkP
 bKG
-pel
-ldY
+dac
+rPH
 bCi
 bKD
 bCi
-eml
+iAt
 bza
 auv
 aaa
 lMJ
 vLD
 vLD
-ulS
+hVd
 aaa
 aaa
 aaa
@@ -132565,11 +132572,11 @@ bVN
 bXr
 bAR
 aaf
-vHK
-uGo
+nFY
+eOg
 bxc
 ccQ
-jqX
+urF
 bCi
 bCi
 bCi
@@ -132581,7 +132588,7 @@ aaa
 lMJ
 aaa
 aaa
-qDn
+mSZ
 aaa
 aaa
 aaa
@@ -132822,11 +132829,11 @@ ajl
 bUJ
 bAR
 aaf
-vHK
+nFY
 ccU
 bxc
-rAm
-jqX
+tHI
+urF
 bCi
 bCi
 bCi
@@ -132838,7 +132845,7 @@ aaa
 lMJ
 aaa
 aaa
-wfk
+dkZ
 aaa
 aaa
 aaa
@@ -133079,11 +133086,11 @@ bVP
 bXs
 bAR
 aaf
-vHK
-uxm
+nFY
+kAz
 bxc
-gwU
-jqX
+ffe
+urF
 bCi
 bCi
 bCi
@@ -133095,7 +133102,7 @@ auv
 lMJ
 vLD
 vLD
-ulS
+hVd
 aaa
 aaa
 aaa
@@ -133336,11 +133343,11 @@ bAR
 bAR
 bAR
 aaf
-vHK
-gBP
+nFY
+gFJ
 bxc
-xPe
-jqX
+mLy
+urF
 bCi
 bCi
 bCi
@@ -133352,7 +133359,7 @@ auv
 lMJ
 aaa
 aaa
-qDn
+mSZ
 aaa
 aaa
 aaa
@@ -133593,23 +133600,23 @@ aaf
 aaf
 aaf
 aaf
-vHK
+nFY
 ccZ
-fyI
-msg
-elk
-xPr
-xPr
-xPr
-cmf
+lrF
+orM
+mTx
+sbj
+sbj
+sbj
+uoq
 ckM
-cjo
+vRM
 auv
 auv
 lMJ
 aaa
 aaa
-qDn
+mSZ
 aaa
 aaa
 aaa
@@ -133850,15 +133857,15 @@ aaa
 aaa
 aaa
 aaf
-vHK
-fFR
+nFY
+hTw
 bxc
 bxc
 bza
 bza
 bza
 bza
-bza
+uYt
 bxc
 bxc
 auv
@@ -133866,7 +133873,7 @@ aaa
 fwb
 vLD
 vLD
-ulS
+hVd
 aaa
 aaa
 aaa
@@ -134108,14 +134115,14 @@ bzj
 bzj
 bJe
 auv
-klD
+tii
 auv
 lMJ
 auv
 auv
 auv
 auv
-jrF
+vox
 auv
 auv
 auv
@@ -134123,7 +134130,7 @@ aaa
 fwb
 aaa
 aaa
-qDn
+mSZ
 aaa
 aaa
 aaa
@@ -134365,7 +134372,7 @@ aaa
 aaa
 aaf
 aaa
-klD
+tii
 aaa
 lMJ
 aaa
@@ -134380,7 +134387,7 @@ aaa
 fwb
 aaa
 aaa
-qDn
+mSZ
 aaa
 aaa
 aaa
@@ -134634,10 +134641,10 @@ lMJ
 fwb
 fwb
 fwb
-wog
+itb
 vLD
 vLD
-ulS
+hVd
 aaa
 aaa
 aaa
@@ -134894,7 +134901,7 @@ aaa
 vLD
 aaa
 aaa
-wfk
+dkZ
 aaa
 aaa
 aaa
@@ -135393,19 +135400,19 @@ aaa
 aaa
 aaa
 aaa
-ulS
-wfk
-qDn
-qDn
-qDn
-wfk
-ulS
-qDn
-qDn
-ulS
-qDn
-qDn
-ulS
+hVd
+dkZ
+mSZ
+mSZ
+mSZ
+dkZ
+hVd
+mSZ
+mSZ
+hVd
+mSZ
+mSZ
+hVd
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -39254,15 +39254,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bwl" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat Space Access Airlock";
-	req_access_txt = "32"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
@@ -82207,11 +82200,15 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "eOg" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/door/airlock/external{
+	name = "MiniSat Space Access Airlock";
+	req_access_txt = "32"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/atmos)
+/area/engine/break_room)
 "eTL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes{
@@ -82998,18 +82995,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "hTw" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"hVd" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"hVd" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space)
 "hWr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83963,6 +83960,11 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"lnp" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "lnO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -83976,9 +83978,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "lrF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice,
+/obj/structure/lattice,
+/obj/structure/grille,
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/space)
 "lvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -84346,15 +84350,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mSZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
+"mTx" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/space)
-"mTx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "mTW" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -85529,8 +85532,9 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "rPH" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "rQK" = (
 /obj/structure/cable/yellow{
@@ -85570,7 +85574,7 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "sbj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sdi" = (
@@ -86116,7 +86120,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "uoq" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uoA" = (
@@ -86272,11 +86276,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
 "uYt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "vcK" = (
 /obj/structure/cable/yellow{
@@ -86348,11 +86349,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vox" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/atmos)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86491,9 +86493,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vRM" = (
-/obj/structure/sign/warning/nosmoking/circle,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "vUC" = (
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
@@ -87066,10 +87070,9 @@
 /turf/open/floor/plating,
 /area/science/shuttledock)
 "xHS" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/sign/warning/nosmoking/circle,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "xJp" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/blue,
@@ -129245,7 +129248,7 @@ aaf
 bzi
 aaa
 aaa
-xHS
+lnp
 aaa
 aaa
 aaa
@@ -130016,7 +130019,7 @@ aaa
 aai
 aaa
 aaa
-xHS
+lnp
 aaa
 aaa
 aaa
@@ -130530,7 +130533,7 @@ aaa
 bzj
 aaf
 aaa
-xHS
+lnp
 aaa
 aaa
 aaa
@@ -131044,7 +131047,7 @@ aaa
 bJf
 aaf
 aaa
-xHS
+lnp
 aaa
 aaa
 aaa
@@ -131265,8 +131268,8 @@ aaa
 aaf
 uGa
 aaf
-aaf
-ack
+bhT
+eOg
 bxc
 bzg
 bAP
@@ -131817,7 +131820,7 @@ aaa
 lMJ
 aaa
 aaa
-mSZ
+mTx
 aaa
 aaa
 aaa
@@ -132074,7 +132077,7 @@ aaa
 lMJ
 aaa
 aaa
-mSZ
+mTx
 aaa
 aaa
 aaa
@@ -132320,7 +132323,7 @@ wxc
 gkP
 bKG
 dac
-rPH
+sbj
 bCi
 bKD
 bCi
@@ -132331,7 +132334,7 @@ aaa
 lMJ
 vLD
 vLD
-hVd
+lrF
 aaa
 aaa
 aaa
@@ -132573,7 +132576,7 @@ bXr
 bAR
 aaf
 nFY
-eOg
+hTw
 bxc
 ccQ
 urF
@@ -132588,7 +132591,7 @@ aaa
 lMJ
 aaa
 aaa
-mSZ
+mTx
 aaa
 aaa
 aaa
@@ -133102,7 +133105,7 @@ auv
 lMJ
 vLD
 vLD
-hVd
+lrF
 aaa
 aaa
 aaa
@@ -133359,7 +133362,7 @@ auv
 lMJ
 aaa
 aaa
-mSZ
+mTx
 aaa
 aaa
 aaa
@@ -133602,21 +133605,21 @@ aaf
 aaf
 nFY
 ccZ
-lrF
+mSZ
 orM
-mTx
-sbj
-sbj
-sbj
+rPH
 uoq
+uoq
+uoq
+uYt
 ckM
-vRM
+xHS
 auv
 auv
 lMJ
 aaa
 aaa
-mSZ
+mTx
 aaa
 aaa
 aaa
@@ -133858,14 +133861,14 @@ aaa
 aaa
 aaf
 nFY
-hTw
+hVd
 bxc
 bxc
 bza
 bza
 bza
 bza
-uYt
+vox
 bxc
 bxc
 auv
@@ -133873,7 +133876,7 @@ aaa
 fwb
 vLD
 vLD
-hVd
+lrF
 aaa
 aaa
 aaa
@@ -134122,7 +134125,7 @@ auv
 auv
 auv
 auv
-vox
+vRM
 auv
 auv
 auv
@@ -134130,7 +134133,7 @@ aaa
 fwb
 aaa
 aaa
-mSZ
+mTx
 aaa
 aaa
 aaa
@@ -134387,7 +134390,7 @@ aaa
 fwb
 aaa
 aaa
-mSZ
+mTx
 aaa
 aaa
 aaa
@@ -134644,7 +134647,7 @@ fwb
 itb
 vLD
 vLD
-hVd
+lrF
 aaa
 aaa
 aaa
@@ -135400,19 +135403,19 @@ aaa
 aaa
 aaa
 aaa
-hVd
+lrF
 dkZ
-mSZ
-mSZ
-mSZ
+mTx
+mTx
+mTx
 dkZ
-hVd
-mSZ
-mSZ
-hVd
-mSZ
-mSZ
-hVd
+lrF
+mTx
+mTx
+lrF
+mTx
+mTx
+lrF
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tries to steal this
![image](https://user-images.githubusercontent.com/3241376/108721657-dc773780-74e7-11eb-89d0-529d0a88809c.png)

https://github.com/tgstation/tgstation/blob/master/_maps/map_files/MetaStation/MetaStation.dmm

- [x] Add airlock controller
- [ ] Subarea(?)
- [x] Air alarm
- [ ] Playtest
- [ ] Stub some piping to make it easer for atmos to hook in?
- [ ] setup the space zones
- [ ] Space lattice

## Why It's Good For The Game
- WIP

## Changelog
:cl:
add: Added a fusion room to Metastation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
