### PR TITLE
Area mood fixes

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -375,6 +375,8 @@
 
 /datum/component/mood/proc/check_area_mood(datum/source, var/area/A)
 	if(A.mood_bonus)
+		if(get_event("area"))
+			clear_event(null, "area")
 		add_event(null, "area", /datum/mood_event/area, list(A.mood_bonus, A.mood_message))
 	else
 		clear_event(null, "area")

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -375,7 +375,7 @@
 
 /datum/component/mood/proc/check_area_mood(datum/source, var/area/A)
 	if(A.mood_bonus)
-		if(get_event("area"))
+		if(get_event("area"))	//walking between areas that give mood bonus should first clear the bonus from the previous one
 			clear_event(null, "area")
 		add_event(null, "area", /datum/mood_event/area, list(A.mood_bonus, A.mood_message))
 	else

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -81,7 +81,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	ambient_effects = MAINTENANCE
 	valid_territory = FALSE
 	mood_bonus = -1
-	mood_message = "<span class='nicegreen'>It's kind of cramped in here!\n</span>"
+	mood_message = "<span class='warning'>It's kind of cramped in here!\n</span>"
 	lighting_colour_tube = "#ffe5cb"
 	lighting_colour_bulb = "#ffdbb4"
 
@@ -718,7 +718,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "morgue"
 	ambient_effects = SPOOKY
 	mood_bonus = -2
-	mood_message = "<span class='nicegreen'>It smells like death in here!\n</span>"
+	mood_message = "<span class='warning'>It smells like death in here!\n</span>"
 
 /area/medical/chemistry
 	name = "Chemistry"
@@ -770,7 +770,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Brig"
 	icon_state = "brig"
 	mood_bonus = -3
-	mood_message = "<span class='nicegreen'>I hate cramped brig cells.\n</span>"
+	mood_message = "<span class='warning'>I hate cramped brig cells.\n</span>"
 
 /area/security/courtroom
 	name = "Courtroom"
@@ -808,7 +808,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/execution
 	icon_state = "execution_room"
 	mood_bonus = -5
-	mood_message = "<span class='nicegreen'>I feel a sense of impending doom.\n</span>"
+	mood_message = "<span class='warning'>I feel a sense of impending doom.\n</span>"
 
 /area/security/execution/transfer
 	name = "Transfer Centre"
@@ -903,7 +903,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "janitor"
 	flags_1 = NONE
 	mood_bonus = -1
-	mood_message = "<span class='nicegreen'>It feels dirty in here!\n</span>"
+	mood_message = "<span class='warning'>It feels dirty in here!\n</span>"
 
 /area/hydroponics
 	name = "Hydroponics"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
First fix: Mood descriptions for areas with negative mood values (e.g. Reeducation Room or Morgue) are now written in red instead of green (when inspecting your moods).

Second fix: Until now walking between areas that give some mood value (like Medbay -> Morgue, Maint -> Bar, Jannie Closet -> Maint) wouldn't properly update changes, you'd be stuck with the mood given by the area you left and it would only reset upon entering an area that has a mood value of 0. Now after entering a new area it checks if the previous one was giving any mood value and if so, it clears it and properly adds new areas mood.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because it fixes it (or at least a very small part of it).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


## Changelog
:cl:
fix: Area mood description is now written in red if it gives you negative mood.
fix: Mood changes are now properly updated when walking between areas that alter it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
