### PR TITLE
[Bounty] Camera Implant

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1021,6 +1021,7 @@
 #include "code\game\objects\items\implants\implant.dm"
 #include "code\game\objects\items\implants\implant_abductor.dm"
 #include "code\game\objects\items\implants\implant_bb.dm"
+#include "code\game\objects\items\implants\implant_camera.dm"
 #include "code\game\objects\items\implants\implant_chem.dm"
 #include "code\game\objects\items\implants\implant_clown.dm"
 #include "code\game\objects\items\implants\implant_exile.dm"

--- a/code/game/objects/items/implants/implant_camera.dm
+++ b/code/game/objects/items/implants/implant_camera.dm
@@ -14,8 +14,7 @@
 
 /obj/item/implant/camera/on_implanted(mob/user)
 	camera = new (user)		//Insert the camera directly into the mob so the camera actually shows what it sees
-	var/rand_number = rand(1, 1000)
-	camera.c_tag = "IMPLANT #[rand_number]"
+	camera.c_tag = "IMPLANT #[rand(1, 999)]"
 	camera.network = list("ss13")
 	camera.internal_light = FALSE		//No AI camera light
 

--- a/code/game/objects/items/implants/implant_camera.dm
+++ b/code/game/objects/items/implants/implant_camera.dm
@@ -1,0 +1,36 @@
+/obj/item/implant/camera
+	name = "camera implant"
+	desc = "Watchful eye inside you."
+	activated = FALSE
+	var/obj/machinery/camera/camera = null
+
+/obj/item/implant/camera/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Camera Implant<BR>
+				<b>Life:</b> 24 hours after death of host<BR>
+				<b>Implant Details:</b> <BR>
+				<b>Function:</b> Remote surveillance of implanted subject."}
+	return dat
+
+/obj/item/implant/camera/on_implanted(mob/user)
+	camera = new (src)
+	var/rand_number = rand(1, 1000)
+	camera.c_tag = "IMPLANT #[rand_number]"
+	camera.network = list("ss13")
+	camera.internal_light = FALSE		//No AI camera light
+
+/obj/item/implant/camera/removed(mob/living/source, silent, special)
+	. = ..()
+	if(.)
+		QDEL_NULL(camera)
+		return TRUE
+	return FALSE
+
+/obj/item/implanter/camera
+	name = "implanter (camera)"
+	imp_type = /obj/item/implant/camera
+
+/obj/item/implantcase/camera
+	name = "implant case - 'Camera'"
+	desc = "A glass case containing a camera implant."
+	imp_type = /obj/item/implant/camera

--- a/code/game/objects/items/implants/implant_camera.dm
+++ b/code/game/objects/items/implants/implant_camera.dm
@@ -2,7 +2,7 @@
 	name = "camera implant"
 	desc = "Watchful eye inside you."
 	activated = FALSE
-	var/obj/machinery/camera/camera = null
+	var/obj/machinery/camera/camera
 
 /obj/item/implant/camera/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>

--- a/code/game/objects/items/implants/implant_camera.dm
+++ b/code/game/objects/items/implants/implant_camera.dm
@@ -13,7 +13,7 @@
 	return dat
 
 /obj/item/implant/camera/on_implanted(mob/user)
-	camera = new (src)
+	camera = new (user)		//Insert the camera directly into the mob so the camera actually shows what it sees
 	var/rand_number = rand(1, 1000)
 	camera.c_tag = "IMPLANT #[rand_number]"
 	camera.network = list("ss13")


### PR DESCRIPTION
## About The Pull Request

Bounty: https://github.com/BeeStation/BeeStation-Hornet/issues/3689
Adds a camera implant to the game which is currently only available through admin tools.
Available in VV (as shown in video) or as a spawnable item as implanter/implantcase.
(Does not follow players automatically at the moment so it kinda relies on https://github.com/BeeStation/BeeStation-Hornet/pull/3727 being merged)

Closes #3689 

<details>
<summary>
In-Game
</summary>

https://user-images.githubusercontent.com/53494785/108930152-aa7be780-7645-11eb-8d2b-af8d6bff6621.mp4

</details>

## Why It's Good For The Game

A new way for admins to spy on people.

## Changelog
:cl:
add: Camera implant which inserts a camera into you. Admin only at the moment.
/:cl: