### PR TITLE
Crystallized cerulean tweaks

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -323,9 +323,7 @@ Slimecrossing Items
 	var/obj/item/stack/stack_item = target
 
 	if(istype(stack_item,/obj/item/stack/telecrystal))
-		var/mob/living/carbon/carbie = user
-		to_chat(user,"<span class='big red'>You will pay for your hubris!</span>")
-		carbie.gain_trauma(/datum/brain_trauma/special/beepsky,TRAUMA_RESILIENCE_ABSOLUTE)
+		to_chat(user,"<span class='notice'>The crystal disappears!</span>")
 		qdel(src)
 		return
 

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -341,10 +341,9 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	var/max_stage = 5
 	var/datum/weakref/pylon
 
-/obj/structure/cerulean_slime_crystal/Initialize()
+/obj/structure/cerulean_slime_crystal/Initialize(mapload, obj/structure/slime_crystal/cerulean/master_pylon)
 	. = ..()
-	var/obj/structure/slime_crystal/cerulean/master_pylon = locate(/obj/structure/slime_crystal/cerulean) in range(2, get_turf(src))
-	if(master_pylon)
+	if(istype(master_pylon))
 		pylon = WEAKREF(master_pylon)
 	transform *= 1/(max_stage-1)
 	stage_growth()
@@ -377,6 +376,8 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		if(C)
 			C.crystals--
 			C.spawn_crystal()
+		else
+			pylon = null
 	return ..()
 
 /obj/structure/slime_crystal/cerulean
@@ -398,7 +399,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		var/obj/structure/cerulean_slime_crystal/CSC = locate() in range(1,T)
 		if(CSC)
 			continue
-		new /obj/structure/cerulean_slime_crystal(T)
+		new /obj/structure/cerulean_slime_crystal(T, src)
 		crystals++
 		return
 

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -339,9 +339,13 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	max_integrity = 5
 	var/stage = 0
 	var/max_stage = 5
+	var/datum/weakref/pylon
 
 /obj/structure/cerulean_slime_crystal/Initialize()
 	. = ..()
+	var/obj/structure/slime_crystal/cerulean/master_pylon = locate(/obj/structure/slime_crystal/cerulean) in range(2, get_turf(src))
+	if(master_pylon)
+		pylon = WEAKREF(master_pylon)
 	transform *= 1/(max_stage-1)
 	stage_growth()
 
@@ -357,20 +361,37 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	var/matrix/M = new
 	M.Scale(1/max_stage * stage)
 
-	animate(src, transform = M, time = 60 SECONDS)
+	animate(src, transform = M, time = 120 SECONDS)
 
-	addtimer(CALLBACK(src, .proc/stage_growth), 60 SECONDS)
+	addtimer(CALLBACK(src, .proc/stage_growth), 120 SECONDS)
 
 /obj/structure/cerulean_slime_crystal/Destroy()
-	if(stage > 1)
+	if(stage > 3)
 		var/obj/item/cerulean_slime_crystal/crystal = new(get_turf(src))
-		crystal.amt = stage
+		if(stage == 5)
+			crystal.amt = rand(1,3)
+		else
+			crystal.amt = 1
+	if(pylon)
+		var/obj/structure/slime_crystal/cerulean/C = pylon.resolve()
+		if(C)
+			C.crystals--
+			C.spawn_crystal()
 	return ..()
 
 /obj/structure/slime_crystal/cerulean
 	colour = "cerulean"
+	uses_process = FALSE
+	var/crystals = 0
 
-/obj/structure/slime_crystal/cerulean/process()
+/obj/structure/slime_crystal/cerulean/Initialize()
+	. = ..()
+	while(crystals < 3)
+		spawn_crystal()
+
+/obj/structure/slime_crystal/cerulean/proc/spawn_crystal()
+	if(crystals >= 3)
+		return
 	for(var/turf/T as() in RANGE_TURFS(2,src))
 		if(is_blocked_turf(T) || isspaceturf(T)  || T == get_turf(src) || prob(50))
 			continue
@@ -378,6 +399,8 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		if(CSC)
 			continue
 		new /obj/structure/cerulean_slime_crystal(T)
+		crystals++
+		return
 
 /obj/structure/slime_crystal/pyrite
 	colour = "pyrite"

--- a/code/modules/research/xenobiology/crossbreeding/crystalized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/crystalized.dm
@@ -3,6 +3,7 @@
 	desc = "It's crystalline,"
 	effect = "crystalline"
 	icon_state = "crystalline"
+	effect_desc = "Use to place a pylon."
 	var/obj/structure/slime_crystal/crystal_type
 
 /obj/item/slimecross/crystalline/attack_self(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Crystallized cerulean only spawns 3 crystals.
Each crystal's grow time is doubled (from 60 to 120).
Each crystal now drops the crystal (yes) after it reaches stage 4.
Stage 4 crystals adds 1 of the materials, stage 5 adds rand(1,3).
Brain trauma from dupping tc is gone.
Crystalized crossbread no longer say null upon inspecting.

Pylon no longer uses `process()` instead the `spawn_crystal()` is triggered on initialize and then every time one crystal is destroyed.

## Why It's Good For The Game

It was too good + fixes a bug

## Changelog
:cl:
tweak: Crystalized cerulean pylon only spawns 3 crystals at the time.
tweak: Each crystal takes twice as long to grow than before.
tweak: Each crystal only drops poly-crystal upon reaching state 4 (only 1 amt) or 5 (randomly chosen between 1 ~ 3 amt).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
