### PR TITLE
Fix Crystalline Gold Crossbreed

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -513,7 +513,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/human_mob = user
-	var/mob/living/simple_animal/pet/chosen_pet = pick(/mob/living/simple_animal/pet/dog/corgi,/mob/living/simple_animal/pet/dog/pug,/mob/living/simple_animal/pet/dog/bullterrier,/mob/living/simple_animal/pet/fox,/mob/living/simple_animal/pet/cat/kitten,/mob/living/simple_animal/pet/cat/space,/mob/living/simple_animal/pet/penguin)
+	var/mob/living/simple_animal/pet/chosen_pet = pick(/mob/living/simple_animal/pet/dog/corgi,/mob/living/simple_animal/pet/dog/pug,/mob/living/simple_animal/pet/dog/bullterrier,/mob/living/simple_animal/pet/fox,/mob/living/simple_animal/pet/cat/kitten,/mob/living/simple_animal/pet/cat/space,/mob/living/simple_animal/pet/penguin/emperor)
 	chosen_pet = new chosen_pet(get_turf(human_mob))
 	human_mob.forceMove(chosen_pet)
 	human_mob.mind.transfer_to(chosen_pet)

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -99,6 +99,15 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		on_mob_leave(M)
 		affected_mobs -= M
 
+/obj/structure/slime_crystal/gold/process()
+	if(!uses_process)
+		return PROCESS_KILL
+
+	var/list/current_mobs = view_or_range(3, src, range_type)
+	for(var/M in affected_mobs - current_mobs)
+		on_mob_leave(M)
+		affected_mobs -= M
+
 /obj/structure/slime_crystal/proc/master_crystal_destruction()
 	qdel(src)
 
@@ -518,16 +527,10 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	human_mob.forceMove(chosen_pet)
 	human_mob.mind.transfer_to(chosen_pet)
 	ADD_TRAIT(human_mob, TRAIT_NOBREATH, type)
+	affected_mobs += chosen_pet
 
 /obj/structure/slime_crystal/gold/on_mob_leave(mob/living/affected_mob)
-	if(!istype(affected_mob,/mob/living/simple_animal/pet))
-		return
-
 	var/mob/living/carbon/human/human_mob = locate() in affected_mob
-
-	if(!human_mob)
-		return
-
 	affected_mob.mind.transfer_to(human_mob)
 	human_mob.forceMove(get_turf(affected_mob))
 	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, type)

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -110,8 +110,9 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 
 	for(var/mob/living/M in affected_mobs)
 		if(M.health <= 0)
-			on_mob_death(M)
+			on_mob_leave(M)
 			affected_mobs -= M
+
 /obj/structure/slime_crystal/proc/master_crystal_destruction()
 	qdel(src)
 
@@ -122,9 +123,6 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	return
 
 /obj/structure/slime_crystal/proc/on_mob_leave(mob/living/affected_mob)
-	return
-
-/obj/structure/slime_crystal/proc/on_mob_death(mob/living/affected_mob)
 	return
 
 /obj/structure/slime_crystal/grey
@@ -539,19 +537,11 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 /obj/structure/slime_crystal/gold/on_mob_leave(mob/living/affected_mob)
 	var/mob/living/carbon/human/human_mob = locate() in affected_mob
 	affected_mob.mind.transfer_to(human_mob)
+	human_mob.grab_ghost()
 	human_mob.forceMove(get_turf(affected_mob))
 	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, type)
 	qdel(affected_mob)
 
-/obj/structure/slime_crystal/gold/on_mob_death(mob/living/affected_mob)
-	var/mob/living/carbon/human/human_mob = locate() in affected_mob
-	affected_mob.mind.transfer_to(human_mob)
-	human_mob.forceMove(get_turf(affected_mob))
-	human_mob.grab_ghost()
-	human_mob.adjustStaminaLoss(affected_mob.maxHealth)
-	human_mob.Knockdown(affected_mob.maxHealth)
-	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, type)
-	qdel(affected_mob)
 /obj/structure/slime_crystal/oil
 	colour = "oil"
 

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -100,9 +100,6 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		affected_mobs -= M
 
 /obj/structure/slime_crystal/gold/process()
-	if(!uses_process)
-		return PROCESS_KILL
-
 	var/list/current_mobs = view_or_range(3, src, range_type)
 	for(var/M in affected_mobs - current_mobs)
 		on_mob_leave(M)

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -517,7 +517,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	chosen_pet = new chosen_pet(get_turf(human_mob))
 	human_mob.forceMove(chosen_pet)
 	human_mob.mind.transfer_to(chosen_pet)
-	ADD_TRAIT(human_mob, TRAIT_NOBREATH, MAGIC_TRAIT)
+	ADD_TRAIT(human_mob, TRAIT_NOBREATH, type)
 
 /obj/structure/slime_crystal/gold/on_mob_leave(mob/living/affected_mob)
 	if(!istype(affected_mob,/mob/living/simple_animal/pet))
@@ -530,7 +530,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 
 	affected_mob.mind.transfer_to(human_mob)
 	human_mob.forceMove(get_turf(affected_mob))
-	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, MAGIC_TRAIT)
+	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, type)
 	qdel(affected_mob)
 
 /obj/structure/slime_crystal/oil

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -108,6 +108,10 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		on_mob_leave(M)
 		affected_mobs -= M
 
+	for(var/mob/living/M in affected_mobs)
+		if(M.health <= 0)
+			on_mob_death(M)
+			affected_mobs -= M
 /obj/structure/slime_crystal/proc/master_crystal_destruction()
 	qdel(src)
 
@@ -118,6 +122,9 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	return
 
 /obj/structure/slime_crystal/proc/on_mob_leave(mob/living/affected_mob)
+	return
+
+/obj/structure/slime_crystal/proc/on_mob_death(mob/living/affected_mob)
 	return
 
 /obj/structure/slime_crystal/grey
@@ -536,6 +543,15 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, type)
 	qdel(affected_mob)
 
+/obj/structure/slime_crystal/gold/on_mob_death(mob/living/affected_mob)
+	var/mob/living/carbon/human/human_mob = locate() in affected_mob
+	affected_mob.mind.transfer_to(human_mob)
+	human_mob.forceMove(get_turf(affected_mob))
+	human_mob.grab_ghost()
+	human_mob.adjustStaminaLoss(affected_mob.maxHealth)
+	human_mob.Knockdown(affected_mob.maxHealth)
+	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, type)
+	qdel(affected_mob)
 /obj/structure/slime_crystal/oil
 	colour = "oil"
 

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 		affected_mobs -= M
 
 	for(var/mob/living/M in affected_mobs)
-		if(M.health <= 0)
+		if(M.stat == DEAD)
 			on_mob_leave(M)
 			affected_mobs -= M
 

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -517,6 +517,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	chosen_pet = new chosen_pet(get_turf(human_mob))
 	human_mob.forceMove(chosen_pet)
 	human_mob.mind.transfer_to(chosen_pet)
+	ADD_TRAIT(human_mob, TRAIT_NOBREATH, MAGIC_TRAIT)
 
 /obj/structure/slime_crystal/gold/on_mob_leave(mob/living/affected_mob)
 	if(!istype(affected_mob,/mob/living/simple_animal/pet))
@@ -529,6 +530,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 
 	affected_mob.mind.transfer_to(human_mob)
 	human_mob.forceMove(get_turf(affected_mob))
+	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, MAGIC_TRAIT)
 	qdel(affected_mob)
 
 /obj/structure/slime_crystal/oil

--- a/code/modules/research/xenobiology/crossbreeding/_structures.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_structures.dm
@@ -513,7 +513,7 @@ GLOBAL_LIST_EMPTY(bluespace_slime_crystals)
 	if(!ishuman(user))
 		return
 	var/mob/living/carbon/human/human_mob = user
-	var/mob/living/simple_animal/pet/chosen_pet = pick(/mob/living/simple_animal/pet/dog/corgi,/mob/living/simple_animal/pet/dog/pug,/mob/living/simple_animal/pet/dog/bullterrier,/mob/living/simple_animal/pet/fox,/mob/living/simple_animal/pet/cat/kitten,/mob/living/simple_animal/pet/cat/space,/mob/living/simple_animal/pet,/mob/living/simple_animal/pet/penguin)
+	var/mob/living/simple_animal/pet/chosen_pet = pick(/mob/living/simple_animal/pet/dog/corgi,/mob/living/simple_animal/pet/dog/pug,/mob/living/simple_animal/pet/dog/bullterrier,/mob/living/simple_animal/pet/fox,/mob/living/simple_animal/pet/cat/kitten,/mob/living/simple_animal/pet/cat/space,/mob/living/simple_animal/pet/penguin)
 	chosen_pet = new chosen_pet(get_turf(human_mob))
 	human_mob.forceMove(chosen_pet)
 	human_mob.mind.transfer_to(chosen_pet)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes a bug where your original body would sufficate while beeing transformed as a pet.
Also includes an extra processing to transform you back on death of the simplemob so you are not stuck inside the corpse of the pet until someone destroys the pylon or drags you out of its range.
Next this also changes the processing proc for the golden slime pylon specifically the way affected_mobs are defined before that define would happen during processing causing some problems.
This specifically caused a bug where the mob might have already left the range of the slime pylon means it never got added to the affected_mob list thus it also does not get transformed back after leaving the range of the pillar.
This also allowed to remove the checks in on_mob_leave as it would not get called for every single mob inside its range.
Now new mobs get added during attack_hands to affected_mobs this also removes the in_range check that got called every processing.
## Why It's Good For The Game

Fixes some bugs and makes some small improvements to the processing of golden slime pylons.

## Changelog
:cl:
tweak: Transforms you back on death when you are transformed trough a golden slime pylon
fix: Fixes the old body suffocating while inside the content list of the simple mob while being transformed by golden slime pylon
fix: Fixes another bug with golden slime pylon that could lead to you not transforming back after leaving its range
refactor: Changes the processing code a bit to remove a redundant loop for golden slime pylon and some redundant checks
fix: Gold slime pylon transforming someone into an invisible animal
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
