### PR TITLE
Goliath children from the Broodmother no longer explode

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -188,6 +188,11 @@
 	if(get_dist(src, target) <= 7)//Screen range check, so it can't attack people off-screen
 		visible_message("<span class='warning'>[src] digs one of its tentacles under [target]!</span>")
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother(tturf, src)
+	
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/death()
+	. = ..()
+	if(mother != null)
+		mother.children_list -= src
 
 //Tentacles have less stun time compared to regular variant, to balance being able to use them much more often.  Also, 10 more damage.
 /obj/effect/temp_visual/goliath_tentacle/broodmother/trip()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -189,14 +189,6 @@
 		visible_message("<span class='warning'>[src] digs one of its tentacles under [target]!</span>")
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother(tturf, src)
 
-/mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/death()
-	. = ..()
-	if(mother != null)
-		mother.children_list -= src
-	visible_message("<span class='warning'>[src] explodes!</span>")
-	explosion(get_turf(loc),0,0,0,flame_range = 3, adminlog = FALSE)
-	gib()
-
 //Tentacles have less stun time compared to regular variant, to balance being able to use them much more often.  Also, 10 more damage.
 /obj/effect/temp_visual/goliath_tentacle/broodmother/trip()
 	var/latched = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -188,7 +188,6 @@
 	if(get_dist(src, target) <= 7)//Screen range check, so it can't attack people off-screen
 		visible_message("<span class='warning'>[src] digs one of its tentacles under [target]!</span>")
 		new /obj/effect/temp_visual/goliath_tentacle/broodmother(tturf, src)
-	
 /mob/living/simple_animal/hostile/asteroid/elite/broodmother_child/death()
 	. = ..()
 	if(mother != null)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is my first PR so if ive done any mistakes corrections would be appriciated.

This removes the goliath childrens ability to explode after death.

## Why It's Good For The Game

Anyone who has fought the goliath broodmother from the pulsating tumour have experienced the frustration of fighting one. Ever since fastmos was introduced has the goliathbroodmother been borderline unbeatable if a player who knows how to use it gets in controll of it.  

The mayor reason as to why the goliath broodmother is a hard opponenet is not due to any of its abilities, but rather the small childrens ability to explode upon death. The explosion is small and causes little to no damage, but flings you across the map as if you got launched from a mass driver. Most of the time this fight is just the goliath brood mother spawning the children, kiting away from the miner constantly knowing that if you kill one of the children you got flinged into a obstacle or a child and gets stunned, surrounded, and then die. The broodmother is strong enough without this ability, and does not need this at all to be a challange to the player. 

## Changelog
:cl:

del: Removes Post-death explosion on goliath children

/:cl:

