### PR TITLE
Prevents Die of Fate spam

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -170,6 +170,7 @@
 	microwave_riggable = FALSE
 	var/reusable = TRUE
 	var/used = FALSE
+	var/roll_in_progress = FALSE
 
 /obj/item/dice/d20/fate/stealth
 	name = "d20"
@@ -192,6 +193,10 @@
 
 /obj/item/dice/d20/fate/diceroll(mob/user)
 	. = ..()
+	if(roll_in_progress)
+		to_chat(user, "<span class='warning'>The dice is already channeling its power! Be patient!</span>")
+		return
+
 	if(!used)
 		if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
 			to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
@@ -199,10 +204,9 @@
 
 		if(!reusable)
 			used = TRUE
-
+		roll_in_progress = TRUE
 		var/turf/T = get_turf(src)
 		T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
-
 		addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
 
 /obj/item/dice/d20/fate/equipped(mob/user, slot)
@@ -213,6 +217,7 @@
 
 /obj/item/dice/d20/fate/proc/effect(var/mob/living/carbon/human/user,roll)
 	var/turf/T = get_turf(src)
+
 	switch(roll)
 		if(1)
 			//Dust
@@ -338,6 +343,9 @@
 			//Free wizard!
 			T.visible_message("<span class='userdanger'>Magic flows out of [src] and into [user]!</span>")
 			user.mind.make_Wizard()
+	//roll is completed, allow others players to roll the dice
+	roll_in_progress = FALSE
+
 
 /datum/outfit/butler
 	name = "Butler"

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -170,7 +170,6 @@
 	microwave_riggable = FALSE
 	var/reusable = TRUE
 	var/used = FALSE
-	var/roll_in_progress = FALSE
 
 /obj/item/dice/d20/fate/stealth
 	name = "d20"
@@ -193,10 +192,6 @@
 
 /obj/item/dice/d20/fate/diceroll(mob/user)
 	. = ..()
-	if(roll_in_progress)
-		to_chat(user, "<span class='warning'>The dice is already channeling its power! Be patient!</span>")
-		return
-
 	if(!used)
 		if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
 			to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
@@ -204,9 +199,10 @@
 
 		if(!reusable)
 			used = TRUE
-		roll_in_progress = TRUE
+
 		var/turf/T = get_turf(src)
 		T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
+
 		addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
 
 /obj/item/dice/d20/fate/equipped(mob/user, slot)
@@ -217,7 +213,6 @@
 
 /obj/item/dice/d20/fate/proc/effect(var/mob/living/carbon/human/user,roll)
 	var/turf/T = get_turf(src)
-
 	switch(roll)
 		if(1)
 			//Dust
@@ -343,9 +338,6 @@
 			//Free wizard!
 			T.visible_message("<span class='userdanger'>Magic flows out of [src] and into [user]!</span>")
 			user.mind.make_Wizard()
-	//roll is completed, allow others players to roll the dice
-	roll_in_progress = FALSE
-
 
 /datum/outfit/butler
 	name = "Butler"

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -170,6 +170,8 @@
 	microwave_riggable = FALSE
 	var/reusable = TRUE
 	var/used = FALSE
+	/// So you can't roll the die 20 times in a second and stack a bunch of effects that might conflict
+	COOLDOWN_DECLARE(roll_cd)
 
 /obj/item/dice/d20/fate/stealth
 	name = "d20"
@@ -191,19 +193,26 @@
 	rigged_value = 1
 
 /obj/item/dice/d20/fate/diceroll(mob/user)
+	if(!COOLDOWN_FINISHED(src, roll_cd))
+		to_chat(user, "<span class='warning'>Hold on, [src] isn't caught up with your last roll!</span>")
+		return
+
 	. = ..()
-	if(!used)
-		if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
-			to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
-			return
+	if(used)
+		return
 
-		if(!reusable)
-			used = TRUE
+	if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
+		to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
+		return
 
-		var/turf/T = get_turf(src)
-		T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
+	if(!reusable)
+		used = TRUE
 
-		addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
+	var/turf/T = get_turf(src)
+	T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
+
+	addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
+	COOLDOWN_START(src, roll_cd, 2.5 SECONDS)
 
 /obj/item/dice/d20/fate/equipped(mob/user, slot)
 	if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -170,8 +170,6 @@
 	microwave_riggable = FALSE
 	var/reusable = TRUE
 	var/used = FALSE
-	/// So you can't roll the die 20 times in a second and stack a bunch of effects that might conflict
-	COOLDOWN_DECLARE(roll_cd)
 
 /obj/item/dice/d20/fate/stealth
 	name = "d20"
@@ -193,26 +191,19 @@
 	rigged_value = 1
 
 /obj/item/dice/d20/fate/diceroll(mob/user)
-	if(!COOLDOWN_FINISHED(src, roll_cd))
-		to_chat(user, "<span class='warning'>Hold on, [src] isn't caught up with your last roll!</span>")
-		return
-
 	. = ..()
-	if(used)
-		return
+	if(!used)
+		if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
+			to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
+			return
 
-	if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))
-		to_chat(user, "<span class='warning'>You feel the magic of the dice is restricted to ordinary humans!</span>")
-		return
+		if(!reusable)
+			used = TRUE
 
-	if(!reusable)
-		used = TRUE
+		var/turf/T = get_turf(src)
+		T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
 
-	var/turf/T = get_turf(src)
-	T.visible_message("<span class='userdanger'>[src] flares briefly.</span>")
-
-	addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
-	COOLDOWN_START(src, roll_cd, 2.5 SECONDS)
+		addtimer(CALLBACK(src, .proc/effect, user, .), 1 SECONDS)
 
 /obj/item/dice/d20/fate/equipped(mob/user, slot)
 	if(!ishuman(user) || !user.mind || (user.mind in SSticker.mode.wizards))


### PR DESCRIPTION
## About The Pull Request

The Die of Fate has a 1 second delay from rolling to actually taking effect. This means that you can spam roll it and only get the good effects before the bad effects catch up with you. You can easily cheese wizard this way.

![image](https://user-images.githubusercontent.com/3241376/109194045-a5f72200-775e-11eb-9b35-704d194ca5e6.png)

This adds a variable onto the Die that locks you out from rolling it until the effect is processed.

## Why It's Good For The Game

Prevents cheesing die of fate
![image](https://user-images.githubusercontent.com/3241376/109194086-aee7f380-775e-11eb-9d61-b787f268c921.png)

Unknown if this fix meets code quality, or if https://github.com/tgstation/tgstation/pull/56174 should be used instead

## Changelog
:cl:
fix: You can no longer roll a Die of Fate multiple times before the first roll takes effect
/:cl:


