### PR TITLE
Fix of a surgery runtime for cyborgs

### DIFF
--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -83,24 +83,34 @@
 
 /proc/attempt_cancel_surgery(datum/surgery/S, obj/item/I, mob/living/M, mob/user)
 	var/selected_zone = user.zone_selected
+
 	if(S.status == 1)
 		M.surgeries -= S
 		user.visible_message("[user] removes [I] from [M]'s [parse_zone(selected_zone)].", \
 			"<span class='notice'>You remove [I] from [M]'s [parse_zone(selected_zone)].</span>")
 		qdel(S)
-	else if(S.can_cancel)
+		return
+
+	if(S.can_cancel)
 		var/required_tool_type = TOOL_CAUTERY
 		var/obj/item/close_tool = user.get_inactive_held_item()
 		var/is_robotic = S.requires_bodypart_type == BODYPART_ROBOTIC
+
 		if(is_robotic)
 			required_tool_type = TOOL_SCREWDRIVER
-		if(close_tool?.tool_behaviour == required_tool_type || iscyborg(user))
-			M.surgeries -= S
-			user.visible_message("[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].", \
-				"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")
-			qdel(S)
-		else
+
+		if(iscyborg(user))
+			close_tool = locate(/obj/item/cautery) in user.held_items
+			if(!close_tool)
+				to_chat(user, "<span class='warning'>You need to equip a cautery in an inactive slot to stop [M]'s surgery!</span>")
+				return
+		else if(close_tool?.tool_behaviour != required_tool_type)
 			to_chat(user, "<span class='warning'>You need to hold a [is_robotic ? "screwdriver" : "cautery"] in your inactive hand to stop [M]'s surgery!</span>")
+			return
+		M.surgeries -= S
+		user.visible_message("[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].", \
+			"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")
+		qdel(S)
 
 /proc/get_location_accessible(mob/M, location)
 	var/covered_locations = 0	//based on body_parts_covered

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -108,7 +108,7 @@
 			to_chat(user, "<span class='warning'>You need to hold a [is_robotic ? "screwdriver" : "cautery"] in your inactive hand to stop [M]'s surgery!</span>")
 			return
 		M.surgeries -= S
-		user.visible_message("[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].", \
+		user.visible_message("<span class='notice'>[user] closes [M]'s [parse_zone(selected_zone)] with [close_tool] and removes [I].</span>", \
 			"<span class='notice'>You close [M]'s [parse_zone(selected_zone)] with [close_tool] and remove [I].</span>")
 		qdel(S)
 


### PR DESCRIPTION
## About The Pull Request

Ports: https://github.com/tgstation/tgstation/pull/48588

Fixes a runtime where cyborgs cannot cancel a surgery if it is past the first step.

Runtime:

```
runtime error: Cannot read 0.tool_behaviour
 - proc name: attempt cancel surgery (/proc/attempt_cancel_surgery)
 -   source file: helpers.dm,97
 -   usr: Medical Cyborg-119 (/mob/living/silicon/robot)
 -   src: null
 -   usr.loc: the floor (133,124,2) (/turf/open/floor/plasteel/white)
 -   call stack:
 - attempt cancel surgery(Tend Wounds (Burn, Basic) (/datum/surgery/healing/burn/basic), the surgical drapes (/obj/item/surgical_drapes), Ciara Tilton (/mob/living/carbon/human), Medical Cyborg-119 (/mob/living/silicon/robot))
 - attempt initiate surgery(the surgical drapes (/obj/item/surgical_drapes), Ciara Tilton (/mob/living/carbon/human), Medical Cyborg-119 (/mob/living/silicon/robot))
 - the surgical drapes (/obj/item/surgical_drapes): attack(Ciara Tilton (/mob/living/carbon/human), Medical Cyborg-119 (/mob/living/silicon/robot))
```
So apparently `var/obj/item/close_tool = user.get_inactive_held_item()` returns `0` for cyborgs and `0` has no `tool_behaviour` and therefore runtimes.

## Why It's Good For The Game

Cyborgs should be able to cancel surgeries.

## Changelog
:cl: Thebleh, Sarchutar
fix: Cyborgs can cancel surgeries, which are past the first step, with drapes and a cautery again. (They have to be on harm intent to do it)
/:cl: