### PR TITLE
Protects Heads From Being Antags on Golden

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -254,7 +254,7 @@ PROTECT_ROLES_FROM_ANTAGONIST
 #PROTECT_ASSISTANT_FROM_ANTAGONIST
 
 ## Uncomment to prohibit head roles from becoming most antagonists.
-#PROTECT_HEADS_FROM_ANTAGONIST
+PROTECT_HEADS_FROM_ANTAGONIST
 
 ## If non-human species are barred from joining as a head of staff
 #ENFORCE_HUMAN_AUTHORITY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes Head of Staff antag eligibility on Golden

## Why It's Good For The Game

Our new rules require staff to trust Heads of Staff and we also rely on Heads helping to teach newer players. Having antag Heads makes it harder to do either.

## Changelog
:cl:
config: Heads of Staff can no longer be antags on Golden
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
