### PR TITLE
Removes some stupid admin only / nuke op / unbalanced things from the goldspace rune.

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -609,7 +609,6 @@ GLOBAL_DATUM(blue_storage, /obj/item/storage/backpack/holding/bluespace)
 	)
 
 	var/static/list/uncommon_items = list(
-		/obj/item/clothing/head/speedwagon/cursed,
 		/obj/item/clothing/suit/space/hardsuit/ancient,
 		/obj/item/gun/energy/laser/retro/old,
 		/obj/item/storage/toolbox/mechanical/old,
@@ -618,21 +617,15 @@ GLOBAL_DATUM(blue_storage, /obj/item/storage/backpack/holding/bluespace)
 		/obj/effect/mob_spawn/human/ash_walker,
 		/obj/effect/spawner/lootdrop/three_course_meal,
 		/mob/living/simple_animal/pet/dog/corgi/puppy/void,
-		/obj/structure/closet/crate/necropolis,
-		/obj/item/grenade/gluon,
 		/obj/item/card/emagfake,
 		/obj/item/gun/ballistic/revolver/reverse,
-		/obj/item/flashlight/flashdark,
 		/mob/living/simple_animal/slime/rainbow,
 		/obj/item/storage/belt/sabre,
-		/obj/item/drone_shell,
 		/obj/item/sharpener,
 		/mob/living/simple_animal/hostile/cat_butcherer
 	)
 
 	var/static/list/rare_items = list(
-		/obj/effect/mob_spawn/human/syndicate/battlecruiser/captain,
-		/obj/structure/spawner/skeleton,
 		/obj/effect/spawner/lootdrop/armory_contraband,
 		/obj/effect/spawner/lootdrop/teratoma/major
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes some stupid admin only / nuke op / unbalanced things from the goldspace rune.

## Why It's Good For The Game

Removes some stupid admin only / nuke op / unbalanced things from the goldspace rune.

## Changelog
:cl:
del: Removes some stupid admin only / nuke op / unbalanced things from the goldspace rune.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
