### PR TITLE
Temporary fix for Warping gold crossbreed

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -614,25 +614,15 @@ GLOBAL_DATUM(blue_storage, /obj/item/storage/backpack/holding/bluespace)
 		/obj/item/gun/energy/laser/retro/old,
 		/obj/item/storage/toolbox/mechanical/old,
 		/obj/item/storage/toolbox/emergency/old,
-		/obj/effect/mob_spawn/teratomamonkey,
-		/obj/effect/mob_spawn/human/ash_walker,
 		/obj/effect/spawner/lootdrop/three_course_meal,
 		/mob/living/simple_animal/pet/dog/corgi/puppy/void,
 		/obj/structure/closet/crate/necropolis,
-		/obj/item/grenade/gluon,
 		/obj/item/card/emagfake,
-		/obj/item/gun/ballistic/revolver/reverse,
 		/obj/item/flashlight/flashdark,
-		/mob/living/simple_animal/slime/rainbow,
-		/obj/item/storage/belt/sabre,
-		/obj/item/drone_shell,
-		/obj/item/sharpener,
 		/mob/living/simple_animal/hostile/cat_butcherer
 	)
 
 	var/static/list/rare_items = list(
-		/obj/effect/mob_spawn/human/syndicate/battlecruiser/captain,
-		/obj/structure/spawner/skeleton,
 		/obj/effect/spawner/lootdrop/armory_contraband,
 		/obj/effect/spawner/lootdrop/teratoma/major
 	)
@@ -654,7 +644,7 @@ GLOBAL_DATUM(blue_storage, /obj/item/storage/backpack/holding/bluespace)
 		switch(rand(1,100))
 			if(1 to 80)
 				path = pick(common_items)
-			if(80 to 95)
+			if(80 to 99)
 				path = pick(uncommon_items)
 			else
 				path = pick(rare_items)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About the Pull request

Removes most of the good/harmful loot from the Warping Gold table until an agreeable list is merged, and also fixes the "rare" table's spawn chance to the 1% rate it was supposed to be. Gamer loot should never have a high enough chance for the rune to be worthwhile to grind for it - it should be an occasional surprise to someone expecting overpriced toys and oddities. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because people don't like Syndicate Battlecruiser Captains murdering them apparently or some shit. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Warping Gold Crossbreeds have temporarily had their loot table neutered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
