### PR TITLE
Adds Chess Crates and a Maints Chess Room

### DIFF
--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -16,7 +16,7 @@
 /area/template_noop)
 "e" = (
 /obj/structure/table/wood,
-/obj/item/clothing/hat/festive,
+/obj/item/clothing/head/festive,
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "f" = (

--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -36,83 +36,83 @@
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "i" = (
-/obj/item/cardboard_cutout/adaptive/black/rook,
+/obj/item/cardboard_cutout/adaptive/chess/black/rook,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "j" = (
-/obj/item/cardboard_cutout/adaptive/black/knight,
+/obj/item/cardboard_cutout/adaptive/chess/black/knight,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "k" = (
-/obj/item/cardboard_cutout/adaptive/black/bishop,
+/obj/item/cardboard_cutout/adaptive/chess/black/bishop,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "l" = (
-/obj/item/cardboard_cutout/adaptive/black/queen,
+/obj/item/cardboard_cutout/adaptive/chess/black/queen,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "m" = (
-/obj/item/cardboard_cutout/adaptive/black/king,
+/obj/item/cardboard_cutout/adaptive/chess/black/king,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "n" = (
-/obj/item/cardboard_cutout/adaptive/black/bishop,
+/obj/item/cardboard_cutout/adaptive/chess/black/bishop,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "o" = (
-/obj/item/cardboard_cutout/adaptive/black/knight,
+/obj/item/cardboard_cutout/adaptive/chess/black/knight,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "p" = (
-/obj/item/cardboard_cutout/adaptive/black/rook,
+/obj/item/cardboard_cutout/adaptive/chess/black/rook,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "q" = (
-/obj/item/cardboard_cutout/adaptive/black/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "r" = (
-/obj/item/cardboard_cutout/adaptive/black/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "s" = (
-/obj/item/cardboard_cutout/adaptive/white/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/pawn,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "t" = (
-/obj/item/cardboard_cutout/adaptive/white/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/pawn,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "u" = (
-/obj/item/cardboard_cutout/adaptive/white/rook,
+/obj/item/cardboard_cutout/adaptive/chess/rook,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "v" = (
-/obj/item/cardboard_cutout/adaptive/white/knight,
+/obj/item/cardboard_cutout/adaptive/chess/knight,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "w" = (
-/obj/item/cardboard_cutout/adaptive/white/bishop,
+/obj/item/cardboard_cutout/adaptive/chess/bishop,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "x" = (
-/obj/item/cardboard_cutout/adaptive/white/queen,
+/obj/item/cardboard_cutout/adaptive/chess/queen,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "y" = (
-/obj/item/cardboard_cutout/adaptive/white/king,
+/obj/item/cardboard_cutout/adaptive/chess/king,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "z" = (
-/obj/item/cardboard_cutout/adaptive/white/bishop,
+/obj/item/cardboard_cutout/adaptive/chess/bishop,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "A" = (
-/obj/item/cardboard_cutout/adaptive/white/knight,
+/obj/item/cardboard_cutout/adaptive/chess/knight,
 /turf/open/floor/monotile/dark,
 /area/template_noop)
 "B" = (
-/obj/item/cardboard_cutout/adaptive/white/rook,
+/obj/item/cardboard_cutout/adaptive/chess/rook,
 /turf/open/floor/monotile/light,
 /area/template_noop)
 "C" = (

--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -10,7 +10,7 @@
 /area/template_noop)
 "d" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/carpet/orange,
 /area/template_noop)
@@ -117,6 +117,7 @@
 /area/template_noop)
 "C" = (
 /obj/structure/table/wood,
+/obj/item/storage/crayons,
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "D" = (
@@ -132,9 +133,6 @@
 "F" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
-	pixel_y = -3
-},
-/obj/item/reagent_containers/food/drinks/soda_cans/tonic{
 	pixel_x = -3;
 	pixel_y = 3
 },
@@ -142,12 +140,12 @@
 	pixel_x = 3;
 	pixel_y = 3
 },
+/obj/item/reagent_containers/food/drinks/soda_cans/tonic{
+	pixel_y = -3
+},
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "G" = (
-/obj/item/reagent_containers/food/snacks/nachos{
-	pixel_y = -3
-},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/nachos{
 	pixel_x = -3;
@@ -156,6 +154,9 @@
 /obj/item/reagent_containers/food/snacks/nachos {
 	pixel_x = 3;
 	pixel_y = 3
+},
+/obj/item/reagent_containers/food/snacks/nachos{
+	pixel_y = -3
 },
 /turf/open/floor/carpet/orange,
 /area/template_noop)

--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -31,7 +31,7 @@
 /area/template_noop)
 "h" = (
 /obj/machinery/light/small{
-	dir = 2
+	dir = 1
 	},
 /turf/open/floor/carpet/orange,
 /area/template_noop)
@@ -135,14 +135,14 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
 	pixel_x = -3;
 	pixel_y = 3
-},
+	},
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
 	pixel_x = 3;
 	pixel_y = 3
-},
+	},
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
 	pixel_y = -3
-},
+	},
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "G" = (
@@ -150,26 +150,26 @@
 /obj/item/reagent_containers/food/snacks/nachos{
 	pixel_x = -3;
 	pixel_y = 3
-},
-/obj/item/reagent_containers/food/snacks/nachos {
+	},
+/obj/item/reagent_containers/food/snacks/nachos{
 	pixel_x = 3;
 	pixel_y = 3
-},
+	},
 /obj/item/reagent_containers/food/snacks/nachos{
 	pixel_y = -3
-},
+	},
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 
 (1,1,1) = {"
 a
 a
-h
+d
 a
 a
 a
 a
-h
+d
 C
 D
 "}
@@ -186,7 +186,7 @@ u
 E
 "}
 (3,1,1) = {"
-d
+h
 j
 r
 c
@@ -246,7 +246,7 @@ z
 a
 "}
 (8,1,1) = {"
-d
+h
 o
 q
 b

--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -134,12 +134,10 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
 	pixel_y = -3
 },
-/obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
 	pixel_x = -3,
 	pixel_y = 3
 },
-/obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
 	pixel_x = 3,
 	pixel_y = 3
@@ -147,7 +145,6 @@
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "G" = (
-/obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/nachos{
 	pixel_y = -3
 },
@@ -156,7 +153,6 @@
 	pixel_x = -3,
 	pixel_y = 3
 },
-/obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/nachos {
 	pixel_x = 3,
 	pixel_y = 3

--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -1,0 +1,286 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"b" = (
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"c" = (
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"d" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"e" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/syndie_kit/cutouts,
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"f" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"g" = (
+/obj/machinery/light/small,
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"h" = (
+/obj/machinery/light/small{
+	dir = 2
+	},
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"i" = (
+/obj/item/cardboard_cutout/adaptive/black/rook,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"j" = (
+/obj/item/cardboard_cutout/adaptive/black/knight,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"k" = (
+/obj/item/cardboard_cutout/adaptive/black/bishop,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"l" = (
+/obj/item/cardboard_cutout/adaptive/black/queen,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"m" = (
+/obj/item/cardboard_cutout/adaptive/black/king,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"n" = (
+/obj/item/cardboard_cutout/adaptive/black/bishop,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"o" = (
+/obj/item/cardboard_cutout/adaptive/black/knight,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"p" = (
+/obj/item/cardboard_cutout/adaptive/black/rook,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"q" = (
+/obj/item/cardboard_cutout/adaptive/black/pawn,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"r" = (
+/obj/item/cardboard_cutout/adaptive/black/pawn,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"s" = (
+/obj/item/cardboard_cutout/adaptive/white/pawn,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"t" = (
+/obj/item/cardboard_cutout/adaptive/white/pawn,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"u" = (
+/obj/item/cardboard_cutout/adaptive/white/rook,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"v" = (
+/obj/item/cardboard_cutout/adaptive/white/knight,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"w" = (
+/obj/item/cardboard_cutout/adaptive/white/bishop,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"x" = (
+/obj/item/cardboard_cutout/adaptive/white/queen,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"y" = (
+/obj/item/cardboard_cutout/adaptive/white/king,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"z" = (
+/obj/item/cardboard_cutout/adaptive/white/bishop,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"A" = (
+/obj/item/cardboard_cutout/adaptive/white/knight,
+/turf/open/floor/monotile/dark,
+/area/template_noop)
+"B" = (
+/obj/item/cardboard_cutout/adaptive/white/rook,
+/turf/open/floor/monotile/light,
+/area/template_noop)
+"C" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"D" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/cardboard/fifty,
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"E" = (
+/obj/structure/table/wood,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"F" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/tonic{
+	pixel_y = -3
+},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/tonic{
+	pixel_x = -3,
+	pixel_y = 3
+},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/tonic{
+	pixel_x = 3,
+	pixel_y = 3
+},
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+"G" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/nachos{
+	pixel_y = -3
+},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/nachos{
+	pixel_x = -3,
+	pixel_y = 3
+},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/nachos {
+	pixel_x = 3,
+	pixel_y = 3
+},
+/turf/open/floor/carpet/orange,
+/area/template_noop)
+
+(1,1,1) = {"
+a
+a
+h
+a
+a
+a
+a
+h
+C
+D
+"}
+(2,1,1) = {"
+a
+i
+q
+b
+c
+b
+c
+s
+u
+E
+"}
+(3,1,1) = {"
+d
+j
+r
+c
+b
+c
+b
+t
+v
+g
+"}
+(4,1,1) = {"
+a
+k
+q
+b
+c
+b
+c
+s
+w
+a
+"}
+(5,1,1) = {"
+a
+l
+r
+c
+b
+c
+b
+t
+x
+a
+"}
+(6,1,1) = {"
+a
+m
+q
+b
+c
+b
+c
+s
+y
+a
+"}
+(7,1,1) = {"
+a
+n
+r
+c
+b
+c
+b
+t
+z
+a
+"}
+(8,1,1) = {"
+d
+o
+q
+b
+c
+b
+c
+s
+A
+g
+"}
+(9,1,1) = {"
+e
+p
+r
+c
+b
+c
+b
+t
+B
+a
+"}
+(10,1,1) = {"
+F
+G
+f
+a
+a
+a
+a
+f
+a
+a
+"}

--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -16,7 +16,7 @@
 /area/template_noop)
 "e" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/syndie_kit/cutouts,
+/obj/item/clothing/hat/festive,
 /turf/open/floor/carpet/orange,
 /area/template_noop)
 "f" = (

--- a/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm157_chess.dmm
@@ -135,11 +135,11 @@
 	pixel_y = -3
 },
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
-	pixel_x = -3,
+	pixel_x = -3;
 	pixel_y = 3
 },
 /obj/item/reagent_containers/food/drinks/soda_cans/tonic{
-	pixel_x = 3,
+	pixel_x = 3;
 	pixel_y = 3
 },
 /turf/open/floor/carpet/orange,
@@ -150,11 +150,11 @@
 },
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/nachos{
-	pixel_x = -3,
+	pixel_x = -3;
 	pixel_y = 3
 },
 /obj/item/reagent_containers/food/snacks/nachos {
-	pixel_x = 3,
+	pixel_x = 3;
 	pixel_y = 3
 },
 /turf/open/floor/carpet/orange,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1347,43 +1347,27 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/refuel)
 "dH" = (
-/obj/item/cardboard_cutout/adaptive{
-	color = "#9999BB";
-	icon_state = "cutout_viva";
-	name = "Black Rook"
-	},
+/obj/item/cardboard_cutout/adaptive/black/rook,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "dI" = (
-/obj/item/cardboard_cutout/adaptive{
-	color = "#9999BB";
-	icon_state = "cutout_mime";
-	name = "Black Queen"
-	},
+/obj/item/cardboard_cutout/adaptive/black/queen,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "dJ" = (
-/obj/item/cardboard_cutout/adaptive{
-	color = "#9999BB";
-	icon_state = "cutout_clown";
-	name = "Black King"
-	},
+/obj/item/cardboard_cutout/adaptive/black/king,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "dK" = (
-/obj/item/cardboard_cutout/adaptive{
-	color = "#9999BB";
-	icon_state = "cutout_ian";
-	name = "Black Knight"
-	},
+/obj/item/cardboard_cutout/adaptive/black/knight,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -1536,21 +1520,13 @@
 	},
 /area/holodeck/rec_center/firingrange)
 "ed" = (
-/obj/item/cardboard_cutout/adaptive{
-	color = "#9999BB";
-	icon_state = "cutout_greytide";
-	name = "Black Pawn"
-	},
+/obj/item/cardboard_cutout/adaptive/black/pawn,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "ee" = (
-/obj/item/cardboard_cutout/adaptive{
-	color = "#9999BB";
-	icon_state = "cutout_greytide";
-	name = "Black Pawn"
-	},
+/obj/item/cardboard_cutout/adaptive/black/pawn,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
@@ -1842,20 +1818,14 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
 "eW" = (
-/obj/item/cardboard_cutout/adaptive{
-	icon_state = "cutout_greytide";
-	name = "White Pawn"
-	},
+/obj/item/cardboard_cutout/adaptive/white/pawn,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "eX" = (
-/obj/item/cardboard_cutout/adaptive{
-	icon_state = "cutout_greytide";
-	name = "White Pawn"
-	},
+/obj/item/cardboard_cutout/adaptive/white/pawn,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -1972,38 +1942,26 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
 "fj" = (
-/obj/item/cardboard_cutout/adaptive{
-	icon_state = "cutout_viva";
-	name = "White Rook"
-	},
+/obj/item/cardboard_cutout/adaptive/white/rook,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "fk" = (
-/obj/item/cardboard_cutout/adaptive{
-	icon_state = "cutout_mime";
-	name = "White Queen"
-	},
+/obj/item/cardboard_cutout/adaptive/white/queen,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "fl" = (
-/obj/item/cardboard_cutout/adaptive{
-	icon_state = "cutout_clown";
-	name = "White King"
-	},
+/obj/item/cardboard_cutout/adaptive/white/king,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "fm" = (
-/obj/item/cardboard_cutout/adaptive{
-	icon_state = "cutout_ian";
-	name = "White Knight"
-	},
+/obj/item/cardboard_cutout/adaptive/white/knight,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1347,27 +1347,27 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/refuel)
 "dH" = (
-/obj/item/cardboard_cutout/adaptive/black/rook,
+/obj/item/cardboard_cutout/adaptive/chess/black/rook,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "dI" = (
-/obj/item/cardboard_cutout/adaptive/black/queen,
+/obj/item/cardboard_cutout/adaptive/chess/black/queen,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "dJ" = (
-/obj/item/cardboard_cutout/adaptive/black/king,
+/obj/item/cardboard_cutout/adaptive/chess/black/king,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "dK" = (
-/obj/item/cardboard_cutout/adaptive/black/knight,
+/obj/item/cardboard_cutout/adaptive/chess/black/knight,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -1520,13 +1520,13 @@
 	},
 /area/holodeck/rec_center/firingrange)
 "ed" = (
-/obj/item/cardboard_cutout/adaptive/black/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "ee" = (
-/obj/item/cardboard_cutout/adaptive/black/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
@@ -1818,14 +1818,14 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
 "eW" = (
-/obj/item/cardboard_cutout/adaptive/white/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/pawn,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "eX" = (
-/obj/item/cardboard_cutout/adaptive/white/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/pawn,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -1942,26 +1942,26 @@
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
 "fj" = (
-/obj/item/cardboard_cutout/adaptive/white/rook,
+/obj/item/cardboard_cutout/adaptive/chess/rook,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "fk" = (
-/obj/item/cardboard_cutout/adaptive/white/queen,
+/obj/item/cardboard_cutout/adaptive/chess/queen,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "fl" = (
-/obj/item/cardboard_cutout/adaptive/white/king,
+/obj/item/cardboard_cutout/adaptive/chess/king,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "fm" = (
-/obj/item/cardboard_cutout/adaptive/white/knight,
+/obj/item/cardboard_cutout/adaptive/chess/knight,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1346,32 +1346,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/refuel)
-"dH" = (
-/obj/item/cardboard_cutout/adaptive/chess/black/rook,
-/turf/open/floor/holofloor{
-	dir = 8;
-	icon_state = "dark"
-	},
-/area/holodeck/rec_center/spacechess)
-"dI" = (
-/obj/item/cardboard_cutout/adaptive/chess/black/queen,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
-/area/holodeck/rec_center/spacechess)
-"dJ" = (
-/obj/item/cardboard_cutout/adaptive/chess/black/king,
-/turf/open/floor/holofloor{
-	dir = 8;
-	icon_state = "dark"
-	},
-/area/holodeck/rec_center/spacechess)
-"dK" = (
-/obj/item/cardboard_cutout/adaptive/chess/black/knight,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
-/area/holodeck/rec_center/spacechess)
 "dL" = (
 /turf/open/floor/holofloor/grass,
 /area/holodeck/rec_center/thunderdome1218)
@@ -1520,16 +1494,16 @@
 	},
 /area/holodeck/rec_center/firingrange)
 "ed" = (
-/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
-/area/holodeck/rec_center/spacechess)
-"ee" = (
-/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/black/king,
 /turf/open/floor/holofloor{
 	dir = 8;
 	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
+"ee" = (
+/obj/item/cardboard_cutout/adaptive/chess/black/queen,
+/turf/open/floor/holofloor{
+	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "ef" = (
@@ -1818,16 +1792,16 @@
 /turf/open/floor/holofloor/plating,
 /area/holodeck/rec_center/kobayashi)
 "eW" = (
-/obj/item/cardboard_cutout/adaptive/chess/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/rook,
 /turf/open/floor/holofloor{
-	dir = 8;
-	icon_state = "dark"
+	icon_state = "white"
 	},
 /area/holodeck/rec_center/spacechess)
 "eX" = (
-/obj/item/cardboard_cutout/adaptive/chess/pawn,
+/obj/item/cardboard_cutout/adaptive/chess/knight,
 /turf/open/floor/holofloor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "dark"
 	},
 /area/holodeck/rec_center/spacechess)
 "eY" = (
@@ -1941,32 +1915,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
-"fj" = (
-/obj/item/cardboard_cutout/adaptive/chess/rook,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
-/area/holodeck/rec_center/spacechess)
-"fk" = (
-/obj/item/cardboard_cutout/adaptive/chess/queen,
-/turf/open/floor/holofloor{
-	dir = 8;
-	icon_state = "dark"
-	},
-/area/holodeck/rec_center/spacechess)
-"fl" = (
-/obj/item/cardboard_cutout/adaptive/chess/king,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
-/area/holodeck/rec_center/spacechess)
-"fm" = (
-/obj/item/cardboard_cutout/adaptive/chess/knight,
-/turf/open/floor/holofloor{
-	dir = 8;
-	icon_state = "dark"
-	},
-/area/holodeck/rec_center/spacechess)
 "fn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -2440,6 +2388,12 @@
 /obj/item/folder/red,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"he" = (
+/obj/item/cardboard_cutout/adaptive/chess/bishop,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
 "hh" = (
 /turf/closed/indestructible/rock/snow,
 /area/syndicate_mothership)
@@ -2494,6 +2448,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"hQ" = (
+/obj/item/cardboard_cutout/adaptive/chess/black/knight,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
 "hS" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line,
@@ -12653,6 +12613,12 @@
 "Di" = (
 /turf/closed/indestructible/riveted,
 /area/ai_multicam_room)
+"Dn" = (
+/obj/item/cardboard_cutout/adaptive/chess/pawn,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
 "Dp" = (
 /obj/structure/trap/ctf/red,
 /obj/effect/turf_decal/tile/red,
@@ -16801,6 +16767,12 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/holding)
+"MH" = (
+/obj/item/cardboard_cutout/adaptive/chess/king,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
 "MI" = (
 /obj/machinery/light{
 	dir = 1
@@ -17103,6 +17075,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Oz" = (
+/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
 "OD" = (
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
@@ -17226,6 +17205,13 @@
 /obj/structure/barricade/security/ctf,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"PH" = (
+/obj/item/cardboard_cutout/adaptive/chess/queen,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
 "PI" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
@@ -17404,6 +17390,13 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"QB" = (
+/obj/item/cardboard_cutout/adaptive/chess/pawn,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
 "QH" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -17934,6 +17927,13 @@
 /obj/machinery/door/window/eastright,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"TE" = (
+/obj/item/cardboard_cutout/adaptive/chess/black/bishop,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
 "TF" = (
 /obj/structure/barricade/security/ctf,
 /turf/open/floor/plasteel/dark,
@@ -18124,6 +18124,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ctf)
+"Vd" = (
+/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
+/turf/open/floor/holofloor{
+	icon_state = "white"
+	},
+/area/holodeck/rec_center/spacechess)
 "Vk" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18216,6 +18222,13 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
+"VK" = (
+/obj/item/cardboard_cutout/adaptive/chess/black/rook,
+/turf/open/floor/holofloor{
+	dir = 8;
+	icon_state = "dark"
+	},
+/area/holodeck/rec_center/spacechess)
 "VP" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -75110,14 +75123,14 @@ bm
 bl
 bj
 dn
-dH
+dn
 ed
+Vd
 ev
 ew
-ev
-ew
+QB
 eW
-fj
+dn
 dn
 fx
 aa
@@ -75367,14 +75380,14 @@ cK
 ca
 bj
 dn
-dI
+dn
 ee
+Oz
 ew
 ev
-ew
-ev
+Dn
 eX
-fk
+dn
 dn
 fx
 aa
@@ -75624,14 +75637,14 @@ cM
 bl
 bj
 dn
-dJ
-ed
+dn
+TE
+Vd
 ev
 ew
-ev
-ew
-eW
-fl
+QB
+he
+dn
 dn
 fx
 aa
@@ -75881,14 +75894,14 @@ cK
 bn
 bj
 dn
-dK
-ee
+dn
+hQ
+Oz
 ew
 ev
-ew
-ev
-eX
-fm
+Dn
+PH
+dn
 dn
 fx
 ab
@@ -76138,14 +76151,14 @@ cW
 bl
 bj
 dn
-dH
-ed
+dn
+VK
+Vd
 ev
 ew
-ev
-ew
-eW
-fj
+QB
+MH
+dn
 dn
 fx
 ab

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -199,11 +199,11 @@
 
 /obj/item/cardboard_cutout/adaptive/white/queen
 	name = "White Queen"
-	icon_state = "cutout_deathsquad";
+	icon_state = "cutout_clown";
 
 /obj/item/cardboard_cutout/adaptive/white/rook
 	name = "White Rook"
-	icon_state = "cutout_ntsec";
+	icon_state = "cutout_deathsquad";
 
 /obj/item/cardboard_cutout/adaptive/white/knight
 	name = "White Knight"
@@ -211,7 +211,7 @@
 
 /obj/item/cardboard_cutout/adaptive/white/bishop
 	name = "White Bishop"
-	icon_state = "cutout_clown";
+	icon_state = "cutout_ntsec";
 	
 /obj/item/cardboard_cutout/adaptive/white/pawn
 	name = "White Pawn"

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -228,11 +228,11 @@
 
 /obj/item/cardboard_cutout/adaptive/chess/black/queen
 	name = "Black Queen"
-	icon_state = "cutout_fluke";
+	icon_state = "cutout_traitor";
 
 /obj/item/cardboard_cutout/adaptive/chess/black/rook
 	name = "Black Rook"
-	icon_state = "cutout_traitor";
+	icon_state = "cutout_cultist";
 
 /obj/item/cardboard_cutout/adaptive/chess/black/knight
 	name = "Black Knight"
@@ -240,7 +240,7 @@
 
 /obj/item/cardboard_cutout/adaptive/chess/black/bishop
 	name = "Black Bishop"
-	icon_state = "cutout_cultist";
+	icon_state = "cutout_fluke";
 	
 /obj/item/cardboard_cutout/adaptive/chess/black/pawn
 	name = "Black Pawn"

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -222,26 +222,26 @@
 /obj/item/cardboard_cutout/adaptive/chess/black
 	color = "#9999BB";
 
-/obj/item/cardboard_cutout/adaptive/black/king
+/obj/item/cardboard_cutout/adaptive/chess/black/king
 	name = "Black King"
 	icon_state = "cutout_wizard";
 
-/obj/item/cardboard_cutout/adaptive/black/queen
+/obj/item/cardboard_cutout/adaptive/chess/black/queen
 	name = "Black Queen"
 	icon_state = "cutout_fluke";
 
-/obj/item/cardboard_cutout/adaptive/black/rook
+/obj/item/cardboard_cutout/adaptive/chess/black/rook
 	name = "Black Rook"
 	icon_state = "cutout_traitor";
 
-/obj/item/cardboard_cutout/adaptive/black/knight
+/obj/item/cardboard_cutout/adaptive/chess/black/knight
 	name = "Black Knight"
 	icon_state = "cutout_fukken_xeno";
 
-/obj/item/cardboard_cutout/adaptive/black/bishop
+/obj/item/cardboard_cutout/adaptive/chess/black/bishop
 	name = "Black Bishop"
 	icon_state = "cutout_cultist";
 	
-/obj/item/cardboard_cutout/adaptive/black/pawn
+/obj/item/cardboard_cutout/adaptive/chess/black/pawn
 	name = "Black Pawn"
 	icon_state = "cutout_shadowling";

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -185,3 +185,63 @@
 
 /obj/item/cardboard_cutout/adaptive //Purchased by Syndicate agents, these cutouts are indistinguishable from normal cutouts but aren't discolored when their appearance is changed
 	deceptive = TRUE
+	
+//	--- CHESS PIECES ---
+
+// WHITE
+
+/obj/item/cardboard_cutout/adaptive/white
+	color = "#FFFFFF";
+
+/obj/item/cardboard_cutout/adaptive/white/king
+	name = "White King"
+	icon_state = "cutout_ian";
+
+/obj/item/cardboard_cutout/adaptive/white/queen
+	name = "White Queen"
+	icon_state = "cutout_deathsquad";
+
+/obj/item/cardboard_cutout/adaptive/white/rook
+	name = "White Rook"
+	icon_state = "cutout_ntsec";
+
+/obj/item/cardboard_cutout/adaptive/white/knight
+	name = "White Knight"
+	icon_state = "cutout_lusty";
+
+/obj/item/cardboard_cutout/adaptive/white/bishop
+	name = "White Bishop"
+	icon_state = "cutout_clown";
+	
+/obj/item/cardboard_cutout/adaptive/white/pawn
+	name = "White Pawn"
+	icon_state = "cutout_greytide";
+
+// BLACK
+
+/obj/item/cardboard_cutout/adaptive/black
+	color = "#9999BB";
+
+/obj/item/cardboard_cutout/adaptive/black/king
+	name = "Black King"
+	icon_state = "cutout_wizard";
+
+/obj/item/cardboard_cutout/adaptive/black/queen
+	name = "Black Queen"
+	icon_state = "cutout_fluke";
+
+/obj/item/cardboard_cutout/adaptive/black/rook
+	name = "Black Rook"
+	icon_state = "cutout_traitor";
+
+/obj/item/cardboard_cutout/adaptive/black/knight
+	name = "Black Knight"
+	icon_state = "cutout_fukken_xeno";
+
+/obj/item/cardboard_cutout/adaptive/black/bishop
+	name = "Black Bishop"
+	icon_state = "cutout_cultist";
+	
+/obj/item/cardboard_cutout/adaptive/black/pawn
+	name = "Black Pawn"
+	icon_state = "cutout_shadowling";

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -190,36 +190,36 @@
 
 // WHITE
 
-/obj/item/cardboard_cutout/adaptive/white
-	color = "#FFFFFF";
+/obj/item/cardboard_cutout/adaptive/chess
+	desc = "A large cardboard cutout resembling a chess piece."
 
-/obj/item/cardboard_cutout/adaptive/white/king
+/obj/item/cardboard_cutout/adaptive/chess/king
 	name = "White King"
 	icon_state = "cutout_ian";
 
-/obj/item/cardboard_cutout/adaptive/white/queen
+/obj/item/cardboard_cutout/adaptive/chess/queen
 	name = "White Queen"
 	icon_state = "cutout_clown";
 
-/obj/item/cardboard_cutout/adaptive/white/rook
+/obj/item/cardboard_cutout/adaptive/chess/rook
 	name = "White Rook"
 	icon_state = "cutout_deathsquad";
 
-/obj/item/cardboard_cutout/adaptive/white/knight
+/obj/item/cardboard_cutout/adaptive/chess/knight
 	name = "White Knight"
 	icon_state = "cutout_lusty";
 
-/obj/item/cardboard_cutout/adaptive/white/bishop
+/obj/item/cardboard_cutout/adaptive/chess/bishop
 	name = "White Bishop"
 	icon_state = "cutout_ntsec";
 	
-/obj/item/cardboard_cutout/adaptive/white/pawn
+/obj/item/cardboard_cutout/adaptive/chess/pawn
 	name = "White Pawn"
 	icon_state = "cutout_greytide";
 
 // BLACK
 
-/obj/item/cardboard_cutout/adaptive/black
+/obj/item/cardboard_cutout/adaptive/chess/black
 	color = "#9999BB";
 
 /obj/item/cardboard_cutout/adaptive/black/king

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -133,12 +133,18 @@
 	turf_type = /turf/open/floor/carpet/blue
 	tableVariant = /obj/structure/table/wood/fancy/blue
 
+/obj/item/stack/tile/carpet/blue/thirtytwo
+	amount = 32
+
 /obj/item/stack/tile/carpet/cyan
 	name = "cyan carpet"
 	icon_state = "tile-carpet-cyan"
 	item_state = "tile-carpet-cyan"
 	turf_type = /turf/open/floor/carpet/cyan
 	tableVariant = /obj/structure/table/wood/fancy/cyan
+
+/obj/item/stack/tile/carpet/cyan/thirtytwo
+	amount = 32
 
 /obj/item/stack/tile/carpet/green
 	name = "green carpet"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2510,7 +2510,7 @@ datum/supply_pack/medical/bruisekits
 
 /datum/supply_pack/costumes_toys/chess_white
 	name = "White Chess Piece Crate"
-	desc = "Look at you, playing a nerd's game within a nerd's game!"
+	desc = "Look at you, playing a nerd game within a nerd game!"
 	cost = 500
 	contains = list(
 		/obj/item/cardboard_cutout/adaptive/chess/king,
@@ -2534,7 +2534,7 @@ datum/supply_pack/medical/bruisekits
 
 /datum/supply_pack/costumes_toys/chess_black
 	name = "Black Chess Piece Crate"
-	desc = "Look at you, playing a nerd's game within a nerd's game!"
+	desc = "Look at you, playing a nerd game within a nerd game!"
 	cost = 500
 	contains = list(
 		/obj/item/cardboard_cutout/adaptive/chess/black/king,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2508,6 +2508,58 @@ datum/supply_pack/medical/bruisekits
 		var/item = pick_n_take(L)
 		new item(C)
 
+/datum/supply_pack/costumes_toys/chess_white
+	name = "White Chess Piece Crate"
+	desc = "Look at you, playing a nerd's game within a nerd's game!"
+	cost = 500
+	contains = list(
+		/obj/item/cardboard_cutout/adaptive/chess/king,
+		/obj/item/cardboard_cutout/adaptive/chess/queen,
+		/obj/item/cardboard_cutout/adaptive/chess/rook,
+		/obj/item/cardboard_cutout/adaptive/chess/rook,
+		/obj/item/cardboard_cutout/adaptive/chess/knight,
+		/obj/item/cardboard_cutout/adaptive/chess/knight,
+		/obj/item/cardboard_cutout/adaptive/chess/bishop,	
+		/obj/item/cardboard_cutout/adaptive/chess/bishop,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/pawn,
+	)
+	crate_type = /obj/structure/closet/crate/wooden
+
+/datum/supply_pack/costumes_toys/chess_black
+	name = "Black Chess Piece Crate"
+	desc = "Look at you, playing a nerd's game within a nerd's game!"
+	cost = 500
+	contains = list(
+		/obj/item/cardboard_cutout/adaptive/chess/black/king,
+		/obj/item/cardboard_cutout/adaptive/chess/black/queen,
+		/obj/item/cardboard_cutout/adaptive/chess/black/rook,
+		/obj/item/cardboard_cutout/adaptive/chess/black/rook,
+		/obj/item/cardboard_cutout/adaptive/chess/black/knight,
+		/obj/item/cardboard_cutout/adaptive/chess/black/knight,
+		/obj/item/cardboard_cutout/adaptive/chess/black/bishop,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/bishop,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,	
+		/obj/item/cardboard_cutout/adaptive/chess/black/pawn,
+	)
+	crate_type = /obj/structure/closet/crate/wooden
+
+//////////////////////////////////////////////////////////////////////////////
+///////////////////////// Wardrobe Resupplies ////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
 /datum/supply_pack/costumes_toys/wardrobes/autodrobe
 	name = "Autodrobe Supply Crate"
 	desc = "Autodrobe missing your favorite dress? Solve that issue today with this autodrobe refill."

--- a/code/modules/mapping/random_rooms.dm
+++ b/code/modules/mapping/random_rooms.dm
@@ -1341,3 +1341,11 @@
 	template_width = 10
 	weight = 4
 	stock = 2
+
+/datum/map_template/random_room/sk_rdm157
+	name = "Space Chess"
+	room_id = "sk_rdm157_chess"
+	mappath = "_maps/RandomRooms/10x10/sk_rdm157_chess.dmm"
+	centerspawner = FALSE
+	template_height = 10
+	template_width = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Standardizes chess pieces (for holodeck too), adds chess crates at cargo and a chance for a 10x10 space chess room to spawn in maints.

![image](https://user-images.githubusercontent.com/26130695/109359724-8ee22e00-784b-11eb-9a55-9b63dd9d978c.png)


## Why It's Good For The Game

Adds people more minigames/stuff to do.
Added crates so I can add them to the changelog.

## Changelog
:cl:
add: Standardized space chess, added space chess cargo crates
/:cl: