### PR TITLE
adds file cabinet to HoP's office on meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -36283,13 +36283,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bqB" = (
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/pen,
 /obj/structure/window/reinforced,
-/obj/structure/table/wood,
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bqC" = (
@@ -39267,9 +39264,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "bwm" = (
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
+/obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bwn" = (
@@ -39315,12 +39310,15 @@
 "bwp" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
-	pixel_x = -2;
+	pixel_x = 5;
 	pixel_y = 4
 	},
 /obj/item/stamp/hop{
-	pixel_x = -4;
-	pixel_y = 4
+	pixel_x = -6
+	},
+/obj/item/pen{
+	pixel_x = 5;
+	pixel_y = 6
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
it's the wheely variant so if you're a powergaming golden player you can actually drag the file cabinet which is kind of cool
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think sage will die without this 

The computer it replaced was moved up to his computer area, and a pen was moved so he had one. 

![image](https://user-images.githubusercontent.com/40812746/109414492-c26ea680-7978-11eb-9764-c9ff4dcf3ae2.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Froststahr
add: HoP now has a file cabinet on meta
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
