### PR TITLE
Audits do_after calls at heretics code

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -99,7 +99,7 @@
 ///Removes runes from the selected turf
 /obj/item/melee/touch_attack/mansus_fist/proc/remove_rune(atom/target,mob/user)
 	to_chat(user, "<span class='danger'>You start removing a rune...</span>")
-	if(do_after(user,2 SECONDS,user))
+	if(do_after(user,2 SECONDS,target = user))
 		qdel(target)
 
 /obj/effect/proc_holder/spell/aoe_turf/rust_conversion
@@ -581,7 +581,7 @@
 
 	to_chat(originator, "<span class='notice'>You begin linking [target]'s mind to yours...</span>")
 	to_chat(target, "<span class='warning'>You feel your mind being pulled... connected... intertwined with the very fabric of reality...</span>")
-	if(!do_after(originator, 6 SECONDS, target))
+	if(!do_after(originator, 6 SECONDS, target = target))
 		return
 	if(!originator.link_mob(target))
 		to_chat(originator, "<span class='warning'>You can't seem to link [target]'s mind...</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a problem described at #3771; rune removing having no progressbar. This ordeal ultimately comes from the difference where tg's `do_after` having `target` as the third argument while Bee's one having it as the fourth, which got kinda looked over at porting it: #2347.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Progressbars for `do_after`s!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed progress bar not showing up when removing transmutation rune
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
