### PR TITLE
Organ storage bag can insert organs into a smart organ storage

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -128,6 +128,28 @@
 				to_chat(user, "<span class='warning'>There is nothing in [O] to put in [src]!</span>")
 				return FALSE
 
+		if(istype(O, /obj/item/organ_storage))
+			var/obj/item/organ_storage/S = O
+			if(S.contents.len)
+				var/obj/item/I = S.contents[1]
+				if(accept_check(I))
+					load(I)
+					user.visible_message("[user] inserts \the [I] into \the [src].", \
+									 "<span class='notice'>You insert \the [I] into \the [src].</span>")
+					O.cut_overlays()
+					O.icon_state = "evidenceobj"
+					O.desc = "A container for holding body parts."
+					if(visible_contents)
+						update_icon()
+					updateUsrDialog()
+					return TRUE
+				else
+					to_chat(user, "<span class='warning'>[src] does not accept [I]!</span>")
+					return FALSE
+			else
+				to_chat(user, "<span class='warning'>There is nothing in [O] to put into [src]!</span>")
+				return FALSE
+
 	if(user.a_intent != INTENT_HARM)
 		to_chat(user, "<span class='warning'>\The [src] smartly refuses [O].</span>")
 		updateUsrDialog()

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -247,8 +247,6 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(!isitem(I))		//Check if it is an actual item
-		return
 	if(contents.len)
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -247,6 +247,8 @@
 	. = ..()
 	if(!proximity)
 		return
+	if(!isitem(I))		//Check if it is an actual item
+		return
 	if(contents.len)
 		to_chat(user, "<span class='notice'>[src] already has something inside it.</span>")
 		return


### PR DESCRIPTION
## About The Pull Request

Makes organ storage bags (from medical cyborgs) able to insert the organs they hold into a smart organ storage (organ smartfridge).

## Why It's Good For The Game

Medical cyborgs currently have no way to insert organs into the smart organ storage, this changes that.

## Changelog
:cl:
add: Medical cyborgs can insert organs with the organ storage bag into a smart organ storage
/:cl: