### PR TITLE
Meteor wave changes.

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1815,6 +1815,7 @@
 #include "code\modules\events\anomaly_grav.dm"
 #include "code\modules\events\anomaly_pyro.dm"
 #include "code\modules\events\anomaly_vortex.dm"
+#include "code\modules\events\asteroid_impact.dm"
 #include "code\modules\events\aurora_caelus.dm"
 #include "code\modules\events\blob.dm"
 #include "code\modules\events\brain_trauma.dm"

--- a/code/modules/events/asteroid_impact.dm
+++ b/code/modules/events/asteroid_impact.dm
@@ -8,7 +8,6 @@
 /datum/round_event/asteroid_impact
 	//Should be enough time to escape.
 	startWhen = 260
-	endWhen = 261
 	announceWhen = 1
 
 /datum/round_event/asteroid_impact/announce(fake)
@@ -22,8 +21,9 @@
 			if(SSshuttle.emergency.timer > world.time + 5 MINUTES)
 				SSshuttle.emergency.setTimer(5 MINUTES)
 
-/datum/round_event/asteroid_impact/tick()
+/datum/round_event/asteroid_impact/start()
 	for(var/mob/living/M in GLOB.mob_list)
-		if(is_station_level(M.z))
+		if(is_station_level(M.z) && !QDELETED(M))
 			explosion(M, 3, 4, 6, 0, FALSE)
+			qdel(M)
 			CHECK_TICK

--- a/code/modules/events/asteroid_impact.dm
+++ b/code/modules/events/asteroid_impact.dm
@@ -1,0 +1,29 @@
+
+/datum/round_event_control/asteroid_impact
+	name = "Asteroid Impact (End Round)"
+	typepath = /datum/round_event/asteroid_impact
+	weight = -1
+	max_occurrences = 0
+
+/datum/round_event/asteroid_impact
+	//Should be enough time to escape.
+	startWhen = 260
+	endWhen = 261
+	announceWhen = 1
+
+/datum/round_event/asteroid_impact/announce(fake)
+	priority_announce("A class-A asteroid has been detected on a collision course with the station. Destruction of the station is innevitable.")
+	if(!fake)
+		set_security_level(SEC_LEVEL_DELTA)
+		var/area/A = GLOB.areas_by_type[/area/centcom]
+		if(EMERGENCY_IDLE_OR_RECALLED)
+			SSshuttle.emergency.request(null, A, "Automatic Shuttle Call: Station destruction imminent.", TRUE)
+		else
+			if(SSshuttle.emergency.timer > world.time + 5 MINUTES)
+				SSshuttle.emergency.setTimer(5 MINUTES)
+
+/datum/round_event/asteroid_impact/tick()
+	for(var/mob/living/M in GLOB.mob_list)
+		if(is_station_level(M.z))
+			explosion(M, 3, 4, 6, 0, FALSE)
+			CHECK_TICK

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -48,10 +48,11 @@
 
 /datum/round_event/meteor_wave/announce(fake)
 	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: 10 MINUTES. Anti-meteor point defense is available for purchase via the station's cargo shuttle.", "Meteor Alert", 'sound/ai/meteors.ogg')
-	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat]
-	P.special_enabled = TRUE
-	P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat_control]
-	P.special_enabled = TRUE
+	if(!fake)
+		var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat]
+		P.special_enabled = TRUE
+		P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat_control]
+		P.special_enabled = TRUE
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -6,11 +6,11 @@
 	weight = 4
 	min_players = 15
 	max_occurrences = 3
-	earliest_start = 50 MINUTES
+	earliest_start = 30 MINUTES
 
 /datum/round_event/meteor_wave
-	startWhen		= 6
-	endWhen			= 66
+	startWhen		= 300
+	endWhen			= 360
 	announceWhen	= 1
 	var/list/wave_type
 	var/wave_name = "normal"
@@ -47,7 +47,11 @@
 			kill()
 
 /datum/round_event/meteor_wave/announce(fake)
-	priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg')
+	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: 10 MINUTES. Anti-meteor point defense is available for purchase via the station's cargo shuttle.", "Meteor Alert", 'sound/ai/meteors.ogg')
+	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat]
+	P.special_enabled = TRUE
+	P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat_control]
+	P.special_enabled = TRUE
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Meteors will now be warned of 10 minutes before they strike.
When meteors are detected on a collision course with the station, meteor shields will be unlocked.

## Why It's Good For The Game

Adds in an intense window to save yourself from the meteors, gives engineers and cargo an opportunity to cooperate and lessens the impact of meteors on longer rounds.

## Changelog
:cl:
tweak: Meteors now spawn 10 minutes after being announced.
tweak: Meteor wave event now unlocks meteor shields.
tweak: Meteor wave start time reduced from 50 minutes to 30 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
