### PR TITLE
Fixed Necropolis seed stealth 8 threshold and virology pda

### DIFF
--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -112,15 +112,17 @@
 		M.visible_message("<span class='danger'>An unearthly roar shakes the ground as [M] explodes into a shower of gore, leaving behind an ominous, fleshy chest.</span>")
 		playsound(M.loc,'sound/effects/tendril_destroyed.ogg', 200, 0, 50, 1, 1)
 		M.hellbound = TRUE
-		M.gib()
 		if(ishuman(M)) //We don't NEED them to be human. However, I want to avoid people making teratoma-farms for necrochests
 			var/mob/living/carbon/human/H = M
 			var/S = H.dna.species
 			if(istype(S, /datum/species/golem) || istype(S, /datum/species/jelly)) //nope. sorry, xenobio.
+				M.gib()
 				return
 		else
+			M.gib()
 			return
 		new /obj/structure/closet/crate/necropolis/tendril(M.loc)
+		M.gib()
 
 /obj/effect/temp_visual/goliath_tentacle/necro
 	name = "fledgling necropolis tendril"

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -38,3 +38,4 @@
 	backpack = /obj/item/storage/backpack/virology
 	satchel = /obj/item/storage/backpack/satchel/vir
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
+	pda_slot = SLOT_R_STORE


### PR DESCRIPTION
## About The Pull Request
Closes #2427
Closes #3589
Closes #3728
Makes the virologist PDA start registered with your account, it used to just start as "Virology PDA" and makes the necro seed stealth 8 threshold actually drop a chest, turns out that because you get gibbed before spawning the chest it couldn't find the location where it's supposed to spawn so it just did nothing.
## Why It's Good For The Game
fix
## Changelog
:cl:
fix: Virologist PDA starts registered with your account.
fix: Necropolis seed stealth 8 threshold actually drops a chest and doesn't just gib you.
/:cl: