### PR TITLE
Crematorium qdel fix

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -260,6 +260,11 @@ GLOBAL_LIST_EMPTY(crematoriums)
 		locked = TRUE
 		update_icon()
 
+		for(var/obj/O in conts)
+			if(O.resistance_flags & INDESTRUCTIBLE)
+				O.forceMove(src) // in case an item in container should be spared
+				conts -= O
+		
 		for(var/mob/living/M in conts)
 			if (M.stat != DEAD)
 				M.emote("scream")
@@ -267,11 +272,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 				log_combat(user, M, "cremated")
 			else
 				M.log_message("was cremated", LOG_ATTACK)
-
-			for(var/obj/item/I in M)
-				if(I.resistance_flags & INDESTRUCTIBLE)
-					M.dropItemToGround(I, TRUE)
-
 			M.death(1)
 			if(M) //some animals get automatically deleted on death.
 				M.ghostize()
@@ -279,9 +279,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 
 		for(var/obj/O in conts) //conts defined above, ignores crematorium and tray
 			CHECK_TICK
-			if(O.resistance_flags & INDESTRUCTIBLE)
-				O.forceMove(src) // in case an item in container should be spared
-				continue
 			log_game("[key_name(user)] has cremated [O.name] ([O.type]) at [AREACOORD(src)].")
 			if(user)
 				user.log_message("cremated [O.name] ([O.type]) at [AREACOORD(src)]", LOG_ATTACK) //Logged in their attack log for consistency with mobs, see above


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hotfix for #3534

#3534 was merged before my review was properly addressed, and my concern of incomplete indestructible obj exemption became reality. This PR is a hotfix for it.

There are 2 ways on how objects are qdeleted at cremation:

1. At `/atom/movable/Destroy`, contents are qdeleted on `Destroy`.
2. Every object and mob in the crematorium at the point of activation, *recursively* (`GetAllContents` minus the tray itself), is included in the `conts` list, and `qdel` is called on each of them. This may seem redundant, but it is necessary for being thorough and complete logging.

Which means, the fix presented at #3534 isn't sufficient for indestructible objects residing deeper than mobs' direct `contents` and the crematorium's direct `contents`; indestructible objects don't get qdeleted at cremation code, but it is qdeleted at qdeleted container's `/atom/movable/Destroy`, for those containers are qdeleted at cremation before the exemption can happen. Those includes things like station blueprints in a cremated CE's backpack, and medal of captaincy attached to captain's jumpsuit.

![Screenshot 2021-03-02 235633](https://user-images.githubusercontent.com/8010007/109669202-3c8b6f00-7bb5-11eb-9a66-6f8e934e21e2.png)
_Fig 1. Nuclear Authentication Disk in cremated captain's backpack being destroyed despite of #3534; local testing._

In order to prevent both  causes of cremation, this PR does two things:

1. It moves indestructible objects to crematorium, so it won't be qdeleted by cause 1 of above list.
2. It removes indestructible objects from `conts` list, so it won't be qdeleted by cause 2 of above list.

![Screenshot 2021-03-03 000406](https://user-images.githubusercontent.com/8010007/109669896-ecf97300-7bb5-11eb-8492-6c7bbd51e659.png)
_Fig 2. An example of desired outcome; local testing._

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This PR fully implements what #3534 tried to achieve.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

Not needed.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
