### PR TITLE
Eminence now has it's special move that lets it pass clockwalls

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -276,6 +276,7 @@
 #define INCORPOREAL_MOVE_BASIC 1
 #define INCORPOREAL_MOVE_SHADOW 2 //!  leaves a trail of shadows
 #define INCORPOREAL_MOVE_JAUNT 3 //! is blocked by holy water/salt
+#define INCORPOREAL_MOVE_EMINENCE 4 //! same as jaunt, but lets eminence pass clockwalls
 
 //Secbot and ED209 judgment criteria bitflag values
 #define JUDGE_EMAGGED		(1<<0)

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/effects/clockwork_effects.dmi'
 	icon_state = "eminence"
 	mob_biotypes = list(MOB_SPIRIT)
-	incorporeal_move = INCORPOREAL_MOVE_JAUNT
+	incorporeal_move = INCORPOREAL_MOVE_EMINENCE
 	invisibility = INVISIBILITY_OBSERVER
 	health = INFINITY
 	maxHealth = INFINITY

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -194,9 +194,11 @@
   * * INCORPOREAL_MOVE_BASIC - forceMoved to the next tile with no stop
   * * INCORPOREAL_MOVE_SHADOW  - the same but leaves a cool effect path
   * * INCORPOREAL_MOVE_JAUNT - the same but blocked by holy tiles
+  * * INCORPOREAL_MOVE_EMINCENCE - was invented so that only Eminence can pass through clockwalls
   *
   * You'll note this is another mob living level proc living at the client level
   */
+
 /client/proc/Process_Incorpmove(direct)
 	var/turf/mobloc = get_turf(mob)
 	if(!isliving(mob))
@@ -263,14 +265,28 @@
 				if(stepTurf.flags_1 & NOJAUNT_1)
 					to_chat(L, "<span class='warning'>Some strange aura is blocking the way.</span>")
 					return
-				if (locate(/obj/effect/blessing, stepTurf))
+				if(locate(/obj/effect/blessing, stepTurf))
 					to_chat(L, "<span class='warning'>Holy energies block your path!</span>")
 					return
+				L.forceMove(stepTurf)
+			L.setDir(direct)
 
+		if(INCORPOREAL_MOVE_EMINENCE) //Incorporeal move for emincence. Blocks move like Jaunt but lets it pass through clockwalls
+			var/turf/open/floor/stepTurf = get_step(L, direct)
+			if(stepTurf)
+				for(var/obj/effect/decal/cleanable/food/salt/S in stepTurf)
+					to_chat(L, "<span class='warning'>[S] bars your passage!</span>")
+					return
+				if(stepTurf.flags_1 & NOJAUNT_1)
+					if(!(stepTurf.contents[1].name == "clockwork wall"))
+						to_chat(L, "<span class='warning'>Some strange aura is blocking the way.</span>")
+						return
+				if(locate(/obj/effect/blessing, stepTurf))
+					to_chat(L, "<span class='warning'>Holy energies block your path!</span>")
+					return
 				L.forceMove(stepTurf)
 			L.setDir(direct)
 	return TRUE
-
 
 /**
   * Handles mob/living movement in space (or no gravity)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -273,12 +273,13 @@
 
 		if(INCORPOREAL_MOVE_EMINENCE) //Incorporeal move for emincence. Blocks move like Jaunt but lets it pass through clockwalls
 			var/turf/open/floor/stepTurf = get_step(L, direct)
+			var/turf/loccheck = get_turf(stepTurf)
 			if(stepTurf)
 				for(var/obj/effect/decal/cleanable/food/salt/S in stepTurf)
 					to_chat(L, "<span class='warning'>[S] bars your passage!</span>")
 					return
 				if(stepTurf.flags_1 & NOJAUNT_1)
-					if(!(stepTurf.contents[1].name == "clockwork wall"))
+					if(!is_reebe(loccheck.z))
 						to_chat(L, "<span class='warning'>Some strange aura is blocking the way.</span>")
 						return
 				if(locate(/obj/effect/blessing, stepTurf))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Resolves #3718 by adding an INCORPOREAL_MOVE_EMINENCE. 
It shares the same logic as jaunt, but makes sure there are no issues if 30 Runic golems try to pass clock walls. Otherwise it is also blocked by salt and holy water 


## Why It's Good For The Game
It allows Eminence to travel inside the Rebee like it is supposed to

## Changelog
:cl:
add: INCORPOREAL_MOVE_EMINENCE to mob_movement.dm, eminence.dm and __DEFINES/mobs.dm
/:cl:
