### PR TITLE
Adds missing stuff back to autodrobe

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -113,6 +113,8 @@
 					/obj/item/clothing/head/cueball = 1,
 					/obj/item/clothing/under/costume/joker = 2,
 					/obj/item/clothing/suit/joker = 2,
+					/obj/item/clothing/under/dress/sailor = 1,
+        			/obj/item/clothing/head/wig/random = 3,
 					/obj/item/clothing/head/delinquent = 1,
 					/obj/item/clothing/ears/headphones = 2)
 	contraband = list(/obj/item/clothing/suit/judgerobe = 1,


### PR DESCRIPTION
adds wig and sailor outfit back to the autodrobe vendor because I removed them on accident in #1707

## Why it's good for the game

Reverts an unintended change

## Changelog

:cl:
fix: Returned wig and sailor outfit to the autodrobe
/:cl: