### PR TITLE
Feline Symptom for Uplink: Viro Now Has A Meme TC Buy like the cool kids do

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -469,6 +469,7 @@
 #include "code\datums\diseases\advance\symptoms\confusion.dm"
 #include "code\datums\diseases\advance\symptoms\cough.dm"
 #include "code\datums\diseases\advance\symptoms\deafness.dm"
+#include "code\datums\diseases\advance\symptoms\feline.dm"
 #include "code\datums\diseases\advance\symptoms\fever.dm"
 #include "code\datums\diseases\advance\symptoms\fire.dm"
 #include "code\datums\diseases\advance\symptoms\flesh_eating.dm"

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -16,6 +16,15 @@
 	symptoms = list(new/datum/symptom/cough)
 	..()
 
+//Feline Symptom for Uplink
+/datum/disease/advance/feline
+	copy_type = /datum/disease/advance
+
+/datum/disease/feline/New()
+	name = "Assimilative Toxoplasmosis Derivative"
+	symptoms = list(new/datum/symptom/feline)
+	..()
+
 //Randomly generated Disease, for virus crates and events
 /datum/disease/advance/random
 	name = "Experimental Disease"

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -20,7 +20,7 @@
 /datum/disease/advance/feline
 	copy_type = /datum/disease/advance
 
-/datum/disease/feline/New()
+/datum/disease/advance/feline/New()
 	name = "Assimilative Toxoplasmosis Derivative"
 	symptoms = list(new/datum/symptom/feline)
 	..()

--- a/code/datums/diseases/advance/symptoms/feline.dm
+++ b/code/datums/diseases/advance/symptoms/feline.dm
@@ -1,3 +1,4 @@
+//I am actually going insane from a second project so I am writing a meme symptom for an uplink item to avoid burnout.
 /datum/symptom/feline
 	name = "Feline Minor Retrovirus"
 	desc = "A derivative of the fabled felinid virus"
@@ -6,12 +7,54 @@
 	stage_speed = 1
 	transmittable = 2
 	level = -1 //Uplink Symptom
-	severity = 5 //Class F Biohazard
-	symptom_delay_max = 10
+	severity = 3 //Class F Biohazard
+	symptom_delay_max = 20
 	symptom_delay_max = 60
 	var/nya_transmit = FALSE //Var that stores the transmission threshhold
-	var/full_Feline = FALSE //Var that checks the stage speed and resistance threshold
+	var/full_feline = FALSE //Var that checks the stage speed and resistance threshold
 	threshold_desc = "<b>Transmission 12:</b> Chance for virus to spread when nyaaa ing. <br>\
-	<b>Stage Speed 12 and Resistance 10:</b> Acts as the regular felinid retrovirus."
+	<b>Stage Speed 12 and Resistance 10:</b> Will mutate the species into felinid."
 
+/datum/symptom/feline/severityset(datum/disease/advance/A)
+	if(A.properties["transmittable"] >= 12)
+		severity+= 1
+	if(A.properties["stage_speed"] >= 12 && A.properties["resistance"] >= 10)
+		severity+= 99 //Sets Severity to a Custom Felinid Virus Biohazard Classification
+	..()
 
+/datum/symptom/feline/Start(datum/disease/advance/A)
+	if(!..())
+		return
+	if(A.properties["transmittable"] >= 12)
+		nya_transmit = TRUE
+	if(A.properties["stage_speed"] >= 12 && A.properties["resistance"] >= 10)
+		full_feline = TRUE //OH NYOOO WE NEED TO LYNCH THE VIWOLOGIST
+
+/datum/symptom/feline/Activate(datum/disease/advance/A)
+	if(!..())
+		return
+	var/mob/M = A.affected_mob
+	switch(A.stage)
+		if(2)
+			if(prob(40))
+				M.say(pick("Nya!", "Nya~", "~meow~", "N-nya"))
+			if(prob(40))
+				to_chat(M, "<span class='danger'>You feel [pick("catlike", "like eating chocolate isn't a good idea", "an urge to chase after lasers")].</span>")
+		if(3)
+			if(prob(45))
+				M.say(pick("Nya!", "Nya~", "~meow~", "N-nya", "MIAOW!", "N-NYAAAAA!", "NYAAAAAAA~"))
+			if(prob(45))
+				to_chat(M, "<span class='danger'>You feel [pick("very catlike", "like avoiding chocolate entirely", "a constant urge to chase after lasers")].</span>")
+		if(4, 5)
+			if(prob(50))
+				M.say(pick("Nya!", "Nya~", "~meow~", "N-nya", "MIAOW!", "N-NYAAAAA!", "NYAAAAAAA~", "Mew - NYAAAAAAA!~", "N- meow", "M- NYAAAA"))
+			if(prob(50))
+				to_chat(M, "<span class='danger'>You feel [pick("incredibly catlike", "like eating chocolate would kill you", "an insatiable urge to chase after lasers", "joining a metagang")].</span>")
+			if(A.stage == 5)
+				if(nya_transmit)
+					if(prob(15))
+						M.say(pick("Nya!", "Nya~", "~meow~", "N-nya", "MIAOW!", "N-NYAAAAA!", "NYAAAAAAA~", "Mew - NYAAAAAAA!~", "N- meow", "M- NYAAAA"))
+						A.spread(5)
+				if(full_feline)
+					if(ishuman(M))
+						M.reagents.add_reagent_list(list(/datum/reagent/mutationtoxin/felinid = 1, /datum/reagent/medicine/mutadone = 1))

--- a/code/datums/diseases/advance/symptoms/feline.dm
+++ b/code/datums/diseases/advance/symptoms/feline.dm
@@ -1,0 +1,17 @@
+/datum/symptom/feline
+	name = "Feline Minor Retrovirus"
+	desc = "A derivative of the fabled felinid virus"
+	stealth = -2
+	resistance = -2
+	stage_speed = 1
+	transmittable = 2
+	level = -1 //Uplink Symptom
+	severity = 5 //Class F Biohazard
+	symptom_delay_max = 10
+	symptom_delay_max = 60
+	var/nya_transmit = FALSE //Var that stores the transmission threshhold
+	var/full_Feline = FALSE //Var that checks the stage speed and resistance threshold
+	threshold_desc = "<b>Transmission 12:</b> Chance for virus to spread when nyaaa ing. <br>\
+	<b>Stage Speed 12 and Resistance 10:</b> Acts as the regular felinid retrovirus."
+
+

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -236,6 +236,10 @@
 	desc = "A small bottle. Contains H13N1 flu virion culture in synthblood medium."
 	spawned_disease = /datum/disease/advance/flu
 
+/obj/item/reagent_containers/glass/bottle/feline
+	name = "Assimilative Toxoplasmosis Derivative Culture Bottle"
+	desc = "A small bottle. Contains a weakened derivative of Assimilative Toxoplasmosis, the fabled Cat Virus, in synthblood medium."
+	spawned_disease = /datum/disease/advance/feline
 /obj/item/reagent_containers/glass/bottle/retrovirus
 	name = "Retrovirus culture bottle"
 	desc = "A small bottle. Contains a retrovirus culture in a synthblood medium."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1890,6 +1890,14 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	surplus = 0
 
+/datum/uplink_item/role_restricted/feline_symptom_bottle
+	name = "Assimilative Toxoplasmosis Derivative"
+	desc = "A culture bottle containing a weakened derivative of the fabled cat virus"
+	item = /obj/item/reagent_containers/glass/bottle/feline
+	cost = 20 //This is meant purely to be a meme pick.
+	restricted_roles = list("Virologist", "Chief Medical Officer")
+	surplus = 10
+
 /datum/uplink_item/role_restricted/ancient_jumpsuit
 	name = "Ancient Jumpsuit"
 	desc = "A tattered old jumpsuit that will provide absolutely no benefit to you. It fills the wearer with a strange compulsion to blurt out 'glorf'."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an Uplink Only Symptom and Bottle that contains a gimped version of the fabled cat virus.

Thresholds:
Transmission 12: Similar to Pierrot's Throat, you have a low chance to spread when force speeches.
Stage Speed 12 and Resistance 10: Full-fledged Cat Virus.(Both Must be met for this)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It gives Viro/CMO tots a nice funky but useless TC Buy, and I think having bragging rights TC buys that are role restricted are pretty fun. (Funny Cat Virus Still Go BRRRRR)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
add: Added A Feline Symptom, only obtainable through uplink
add: Added an Uplink Entry for the Culture Bottle, restricted to Viro and CMO
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
