### PR TITLE
Floorbot Fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -430,13 +430,14 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 		return
 	var/list/adjacent = T.GetAtmosAdjacentTurfs(1)
 	var/atom/final_result
+	var/static/list/turf_typecache = typecacheof(/turf)
 	if(shuffle)	//If we were on the same tile as another bot, let's randomize our choices so we dont both go the same way
 		adjacent = shuffle(adjacent)
 		shuffle = FALSE
 	for(var/turf/scan as() in adjacent)//Let's see if there's something right next to us first!
 		if(check_bot(scan))	//Is there another bot there? Then let's just skip it
 			continue
-		if(isturf(scan_type))	//If we're lookeing for a turf we can just run the checks directly!
+		if(turf_typecache[scan_type])	//If we're lookeing for a turf we can just run the checks directly!
 			if(!istype(scan, scan_type))
 				continue
 			final_result = checkscan(scan,old_target)
@@ -455,7 +456,7 @@ Pass the desired type path itself, declaring a temporary var beforehand is not r
 		if(!(RT in adjacent))
 			wider_search_list += RT
 	wider_search_list = shuffle(wider_search_list) // Do we *really* need shuffles? Future coders should decide this.
-	if(isturf(scan_type))
+	if(turf_typecache[scan_type])
 		for(var/turf/scan as() in wider_search_list)
 			if(!istype(scan, scan_type))
 				continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a few problems around floorbot.

Our very old `isturf(scan_type)` check wasn't functional, yet it didn't get caught in #3431 and lived through a refactor. This patch should reduce the incidence of floorbot failing to work and the CPU usage caused by floorbots.

Another patch was floorbot causing duplicate tile, i.e. tile upon tile. It shouldn't happen, but such phenomenon shouldn't a cause of a big problem... except when the superfluous tile is of the same type of preexisting tile. `ChangeTurf` called by `ScrapeAway` in such cases (i.e. `ChangeTurf` called to change the turf to the same type, for the turf type right below the turf being `ScrapeAway`ed is the same.) won't work and let the turf live without resolving `a tile upon the same tile` situation even though `make_plating` already has created the tile item.

The reason why floorbots causing this was a lack of check after `sleep(50)` at `/mob/living/simple_animal/bot/floorbot/proc/repair`; floorbot will call `PlaceOnTop` no matter whether someone placed a tile the bot is working on.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Floorbots no longer be stuck or a cause of infinite tile duplication.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: floorbots no longer cause an infinite source of removed tiles
fix: floorbots is a bit less dumb
fix: CPU usage of floorbots has been reduced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
