### PR TITLE
Dynamic: Fixes a division by zero runtime (tg#56728)

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -430,17 +430,17 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	message_admins("[GLOB.dynamic_forced_roundstart_ruleset.len] rulesets being forced. Will now attempt to draft players for them.")
 	log_game("DYNAMIC: [GLOB.dynamic_forced_roundstart_ruleset.len] rulesets being forced. Will now attempt to draft players for them.")
 	for (var/datum/dynamic_ruleset/roundstart/rule in GLOB.dynamic_forced_roundstart_ruleset)
+		configure_ruleset(rule)
 		message_admins("Drafting players for forced ruleset [rule.name].")
 		log_game("DYNAMIC: Drafting players for forced ruleset [rule.name].")
-		configure_ruleset(rule)
 		rule.mode = src
-		rule.acceptable(roundstart_pop_ready, threat_level)	// Assigns some vars in the modes, running it here for consistency
+		rule.acceptable(roundstart_pop_ready, threat_level) // Assigns some vars in the modes, running it here for consistency
 		rule.candidates = candidates.Copy()
 		rule.trim_candidates()
 		if (rule.ready(roundstart_pop_ready, TRUE))
 			var/cost = rule.cost
 			var/scaled_times = 0
-			if (!(rule.flags & LONE_RULESET))
+			if (rule.scaling_cost)
 				scaled_times = round(max(round_start_budget - cost, 0) / rule.scaling_cost)
 				cost += rule.scaling_cost * scaled_times
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/56728

This PR was missed in the dynamic update PR. Forcing roundstart rulesets should work again

:cl: Mothblocks
fix: Forcing roundstart rulesets should now work properly.
/:cl: