### PR TITLE
Clockwork cult changes and fixes for brass manacles

### DIFF
--- a/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_slab.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_INIT(clockwork_slabs, list())
 	name = "Clockwork Slab"
 	desc = "A mechanical-looking device filled with intricate cogs that swirl to their own accord."
 	clockwork_desc = "A beautiful work of art, harnessing mechanical energy for a variety of useful powers."
+	item_flags = NOBLUDGEON
 	icon_state = "dread_ipad"
 	lefthand_file = 'icons/mob/inhands/antag/clockwork_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/clockwork_righthand.dmi'

--- a/code/modules/antagonists/clock_cult/scriptures/hateful_manacles.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/hateful_manacles.dm
@@ -4,7 +4,7 @@
 /datum/clockcult/scripture/slab/hateful_manacles
 	name = "Hateful Manacles"
 	desc = "Forms replicant manacles around a target's wrists that function like handcuffs, restraining the target."
-	tip = "Handcuff a target at close range."
+	tip = "Handcuff a target at close range to subdue them for conversion or vitality extraction."
 	button_icon_state = "Hateful Manacles"
 	power_cost = 25
 	invokation_time = 15
@@ -24,14 +24,19 @@
 	if(M.handcuffed)
 		to_chat(invoker, "<span class='brass'>[M] is already restrained!</span>")
 		return FALSE
-	playsound(src, 'sound/weapons/cablecuff.ogg', 30, TRUE, -2)
+	playsound(M, 'sound/weapons/handcuffs.ogg', 30, TRUE, -2)
 	M.visible_message("<span class='danger'>[invoker] forms a well of energy around [M], brass appearing at their wrists!</span>",\
 						"<span class='userdanger'>[invoker] is trying to restrain you!</span>")
-	if(do_after(invoker, 50, target=M))
+	if(do_after(invoker, 30, target=M))
 		if(M.handcuffed)
 			return FALSE
-		//Todo, update with custom cuffs
-		M.handcuffed = new /obj/item/restraints/handcuffs/cable/zipties/used(M)
+		M.handcuffed = new /obj/item/restraints/handcuffs/clockwork(M)
 		M.update_handcuffed()
 		return TRUE
 	return FALSE
+
+/obj/item/restraints/handcuffs/clockwork
+	name = "replicant manacles"
+	desc = "Heavy manacles made out of freezing-cold metal. It looks like brass, but feels much more solid."
+	icon_state = "brass_manacles"
+	item_flags = DROPDEL

--- a/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
+++ b/code/modules/antagonists/clock_cult/servant_of_ratvar.dm
@@ -109,10 +109,7 @@
 	H.put_in_hands(slab)
 	slab.pickup(H)
 	//Remove cuffs
-	if(H.handcuffed)
-		H.handcuffed.forceMove(get_turf(H))
-		H.handcuffed = null
-		H.update_handcuffed()
+	H.uncuff()
 	return FALSE
 
 //Grant access to the clockwork tools.


### PR DESCRIPTION
## About The Pull Request

Adjusts some minor things with CWC, listed below

* Clockwork Slab now has NOBLUDGEON because I thought physically whacking people with the slab looked weird.

* Sigil of submission now uses the uncuff proc

* Hateful manacles now uses real brass manacles instead of used zipties

* Hateful manacles now takes 3 seconds to cuff, in line with all other cuffs (previously 5 seconds)

* Fixes the handcuff sound that plays when invoking hateful manacles, previously it didn't work.

## Why It's Good For The Game

Very minor polishing, should make the manacles spell more useful

## Changelog
:cl:
fix: Hateful Manacles sound effect works properly
tweak: NOBLUDGEON added to Clockwork Slab
tweak: Hateful Manacles now takes 3 seconds to cuff (Previously 5)
/:cl: