### PR TITLE
Audits merge_type

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -68,6 +68,7 @@
 	novariants = TRUE
 	grind_results = list(/datum/reagent/bluespace = 20)
 	point_value = 30
+	merge_type = /obj/item/stack/sheet/bluespace_crystal
 	var/crystal_type = /obj/item/stack/ore/bluespace_crystal/refined
 
 /obj/item/stack/sheet/bluespace_crystal/fifty

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -7,6 +7,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	max_amount = 50
 	item_flags = NOBLUDGEON
+	merge_type = /obj/item/stack/telecrystal
 
 /obj/item/stack/telecrystal/attack(mob/target, mob/user)
 	if(target == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -122,14 +122,15 @@
 	name = "black carpet"
 	icon_state = "tile-carpet-black"
 	item_state = "tile-carpet-black"
+	merge_type = /obj/item/stack/tile/carpet/black
 	turf_type = /turf/open/floor/carpet/black
-
 	tableVariant = /obj/structure/table/wood/fancy/black
 
 /obj/item/stack/tile/carpet/blue
 	name = "blue carpet"
 	icon_state = "tile-carpet-blue"
 	item_state = "tile-carpet-blue"
+	merge_type = /obj/item/stack/tile/carpet/blue
 	turf_type = /turf/open/floor/carpet/blue
 	tableVariant = /obj/structure/table/wood/fancy/blue
 
@@ -137,6 +138,7 @@
 	name = "cyan carpet"
 	icon_state = "tile-carpet-cyan"
 	item_state = "tile-carpet-cyan"
+	merge_type = /obj/item/stack/tile/carpet/cyan
 	turf_type = /turf/open/floor/carpet/cyan
 	tableVariant = /obj/structure/table/wood/fancy/cyan
 
@@ -144,6 +146,7 @@
 	name = "green carpet"
 	icon_state = "tile-carpet-green"
 	item_state = "tile-carpet-green"
+	merge_type = /obj/item/stack/tile/carpet/green
 	turf_type = /turf/open/floor/carpet/green
 	tableVariant = /obj/structure/table/wood/fancy/green
 
@@ -151,6 +154,7 @@
 	name = "orange carpet"
 	icon_state = "tile-carpet-orange"
 	item_state = "tile-carpet-orange"
+	merge_type = /obj/item/stack/tile/carpet/orange
 	turf_type = /turf/open/floor/carpet/orange
 	tableVariant = /obj/structure/table/wood/fancy/orange
 
@@ -158,6 +162,7 @@
 	name = "purple carpet"
 	icon_state = "tile-carpet-purple"
 	item_state = "tile-carpet-purple"
+	merge_type = /obj/item/stack/tile/carpet/purple
 	turf_type = /turf/open/floor/carpet/purple
 	tableVariant = /obj/structure/table/wood/fancy/purple
 
@@ -165,6 +170,7 @@
 	name = "red carpet"
 	icon_state = "tile-carpet-red"
 	item_state = "tile-carpet-red"
+	merge_type = /obj/item/stack/tile/carpet/red
 	turf_type = /turf/open/floor/carpet/red
 	tableVariant = /obj/structure/table/wood/fancy/red
 
@@ -172,6 +178,7 @@
 	name = "royal black carpet"
 	icon_state = "tile-carpet-royalblack"
 	item_state = "tile-carpet-royalblack"
+	merge_type = /obj/item/stack/tile/carpet/royalblack
 	turf_type = /turf/open/floor/carpet/royalblack
 	tableVariant = /obj/structure/table/wood/fancy/royalblack
 
@@ -179,6 +186,7 @@
 	name = "royal blue carpet"
 	icon_state = "tile-carpet-royalblue"
 	item_state = "tile-carpet-royalblue"
+	merge_type = /obj/item/stack/tile/carpet/royalblue
 	turf_type = /turf/open/floor/carpet/royalblue
 	tableVariant = /obj/structure/table/wood/fancy/royalblue
 
@@ -187,6 +195,7 @@
 	singular_name = "retro floor tile"
 	desc = "A stack of floor tiles that remind you of simpler times.."
 	icon_state = "tile_eighties"
+	merge_type = /obj/item/stack/tile/eighties
 	turf_type = /turf/open/floor/eighties
 
 /obj/item/stack/tile/carpet/fifty
@@ -264,7 +273,7 @@
 	desc = "A high-traction floor tile. It feels rubbery in your hand."
 	icon_state = "tile_noslip_standard"
 	turf_type = /turf/open/floor/noslip/standard
-	merge_type = /obj/item/stack/tile/noslip
+	merge_type = /obj/item/stack/tile/noslip/standard
 
 /obj/item/stack/tile/noslip/white
 	name = "high-traction floor tile"
@@ -272,7 +281,7 @@
 	desc = "A high-traction floor tile. It feels rubbery in your hand."
 	icon_state = "tile_noslip_white"
 	turf_type = /turf/open/floor/noslip/white
-	merge_type = /obj/item/stack/tile/noslip
+	merge_type = /obj/item/stack/tile/noslip/white
 
 /obj/item/stack/tile/noslip/blue
 	name = "high-traction floor tile"
@@ -280,7 +289,7 @@
 	desc = "A high-traction floor tile. It feels rubbery in your hand."
 	icon_state = "tile_noslip_blue"
 	turf_type = /turf/open/floor/noslip/blue
-	merge_type = /obj/item/stack/tile/noslip
+	merge_type = /obj/item/stack/tile/noslip/blue
 
 /obj/item/stack/tile/noslip/darkblue
 	name = "high-traction floor tile"
@@ -288,7 +297,7 @@
 	desc = "A high-traction floor tile. It feels rubbery in your hand."
 	icon_state = "tile_noslip_darkblue"
 	turf_type = /turf/open/floor/noslip/darkblue
-	merge_type = /obj/item/stack/tile/noslip
+	merge_type = /obj/item/stack/tile/noslip/darkblue
 
 /obj/item/stack/tile/noslip/dark
 	name = "high-traction floor tile"
@@ -296,7 +305,7 @@
 	desc = "A high-traction floor tile. It feels rubbery in your hand."
 	icon_state = "tile_noslip_dark"
 	turf_type = /turf/open/floor/noslip/dark
-	merge_type = /obj/item/stack/tile/noslip
+	merge_type = /obj/item/stack/tile/noslip/dark
 
 /obj/item/stack/tile/noslip/vaporwave
 	name = "high-traction floor tile"
@@ -304,7 +313,7 @@
 	desc = "A high-traction floor tile. It feels rubbery in your hand."
 	icon_state = "tile_noslip_pinkblack"
 	turf_type = /turf/open/floor/noslip/vaporwave
-	merge_type = /obj/item/stack/tile/noslip
+	merge_type = /obj/item/stack/tile/noslip/vaporwave
 
 /obj/item/stack/tile/noslip/thirty
 	amount = 30

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -385,6 +385,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	max_amount = 30
 	singular_name = "conveyor belt"
 	w_class = WEIGHT_CLASS_BULKY
+	merge_type = /obj/item/stack/conveyor
 	///id for linking
 	var/id = ""
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Follow-up of #3814 

This audits `merge_type`s to ensure stacks that should merge each other actually merge and vice versa. This PR is four parts:

1. Conveyor belt stack merge between the main type and its `thirty` subtype
2. Bluespace polycrystals and telecrystals
3. Each of carpet type's `fifty` subtypes
4. High-traction tiles no longer cross-merge between colors

Please note that cable coil stacks cross-merging between colors is intentional.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better stack merging.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: telecrystal, bluespace polycrystal, conveyor belt, and carpet stacks now properly merge with its own respective subtypes
fix: high-traction floor tile stacks no longer merge between different colors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
