### PR TITLE
A New Beneficial Viro Symptom: Neurological Overdrive

### DIFF
--- a/code/datums/diseases/advance/symptoms/neurological.dm
+++ b/code/datums/diseases/advance/symptoms/neurological.dm
@@ -2,9 +2,9 @@
 	name = "Neurological Overdrive"
 	desc = "The disease increases connectivity between the infected's nerves, reducing stuns."
 	stealth = 1
-	resistance = 0
-	stage_speed = 3
-	transmittable = 0
+	resistance = -1
+	stage_speed = 1
+	transmittable = -2
 	level = 9
 	severity = 0
 	symptom_delay_min = 1

--- a/code/datums/diseases/advance/symptoms/neurological.dm
+++ b/code/datums/diseases/advance/symptoms/neurological.dm
@@ -1,6 +1,6 @@
 /datum/symptom/nerve_overdrive
 	name = "Neurological Overdrive"
-	desc = "The disease increases connectivity between the infected's nerves, reducing stuns."
+	desc = "The disease increases connectivity between the infected's nerves, reducing stuns. Increased nerve connections however make burns far more painful."
 	stealth = 1
 	resistance = -1
 	stage_speed = 1
@@ -36,12 +36,16 @@
 	if(!..())
 		return
 	var/mob/living/carbon/C = A.affected_mob
+	if(is_human(C))
+		var/mob/living/carbon/human/H = C
+		for(var/obj/item/bodypart/B in H.bodyparts)
+			B.burn_reduction -= 2.5 //Burn Damage Increased. 2.5 burn reduction to avoid robusto clockwork disease breaking even on burn reduction
 	switch(A.stage)
 		if(2)
 			C.AdjustStun(-10, FALSE)
 			if(fastmover)
 				if(fastmover_activation < A.stage) //Checks if Modifier for the Stage was Added
-					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.25, blacklisted_movetypes=(FLYING|FLOATING))
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = -0.25, blacklisted_movetypes=(FLYING|FLOATING))
 					fastmover_activation = A.stage //Ensures Multiplier Not Added 2x
 		if(3)
 			if(super_reduction)
@@ -51,7 +55,7 @@
 			if(fastmover)
 				if(fastmover_activation < A.stage)//Checks if Modifier for Stage was Added
 					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
-					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.5, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = -0.5, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
 					fastmover_activation = A.stage
 		if(4)
 			if(super_reduction)
@@ -61,7 +65,7 @@
 			if(fastmover)
 				if(fastmover_activation < A.stage)//Checks if Modifier for Stage was Added
 					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
-					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.75, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = -0.75, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
 					fastmover_activation = A.stage
 		if(5)
 			if(super_reduction)
@@ -71,7 +75,7 @@
 			if(fastmover)
 				if(fastmover_activation < A.stage)//Checks if Modifier for Stage was Added
 					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
-					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 1, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = -1, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
 					fastmover_activation = A.stage
 		if(prob(10)) //Frequent Activation, would prefer not to Spam
 				to_chat(M, "<span class='notice'>[pick("You feel like you are thinking faster than ever.", "You feel like your limbs are more responsive.", "You feel like everything is slower than you remember.", "Your eyes adjust quickly to sudden changes in light", "You feel more aware of everything around you.")]</span>")

--- a/code/datums/diseases/advance/symptoms/neurological.dm
+++ b/code/datums/diseases/advance/symptoms/neurological.dm
@@ -1,0 +1,77 @@
+/datum/symptom/nerve_overdrive
+	name = "Neurological Overdrive"
+	desc = "The disease increases connectivity between the infected's nerves, reducing stuns."
+	stealth = 1
+	resistance = 0
+	stage_speed = 3
+	transmittable = 0
+	level = 9
+	severity = 0
+	symptom_delay_min = 1
+	symptom_delay_max = 1
+	var/fastmover = FALSE
+	var/list/fastmover_activation = list(FALSE, FALSE, FALSE, FALSE, FALSE) //Each of the Indexes Represents a Stage, When Activated, the Index is set to true
+	var/super_reduction = FALSE
+	threshold_desc = "<b>Stage Speed 12:</b>The virus overclocks the nervous system making the host move even faster than normal.<br>\
+                      <b>Stage Speed 15:</b>The virus tightens the synapses between nerves, allowing for even quicker recovery from stuns."
+
+/datum/symptom/nerve_overdrive/OnAdd(datum/disease/advance/A)
+	A.infectable_biotypes |= MOB_ROBOTIC //Robots don't have nerves.
+
+/datum/symptom/nerve_overdrive/severityset(datum/disease/advance/A)
+	. = ..()
+	if(A.properties["stage_rate"] >= 12)
+		severity -= 1
+	if(A.properties["stage_rate"] >= 15)
+		severity -= 1
+
+/datum/symptom/never_overdrive/Start(datum/disease/advance/A)
+	. = ..()
+	if(A.properties["stage_rate"] >= 12)
+		fastmover = TRUE
+	if(A.properties["stage_rate"] >= 15)
+		super_reduction = TRUE
+
+/datum/symptom/nerve_overdrive/Activate(datum/disease/advance/A)
+	if(!..())
+		return
+	var/mob/living/carbon/C = A.affected_mob
+	switch(A.stage)
+		if(2)
+			C.AdjustStun(-10, FALSE)
+			if(fastmover)
+				if(!fastmover_activation[A.stage]) //Checks if Modifier for the Stage was Added
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.25, blacklisted_movetypes=(FLYING|FLOATING))
+					fastmover_activation[A.stage] = TRUE //Ensures Multiplier Not Added 2x
+		if(3)
+			if(super_reduction)
+				C.AdjustStun(-20, FALSE)
+			else
+				C.AdjustStun(-15, FALSE)
+			if(fastmover)
+				if(!fastmover_activation[A.stage])//Checks if Modifier for Stage was Added
+					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.5, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
+					fastmover_activation[A.stage] = TRUE
+		if(4)
+			if(super_reduction)
+				C.adjustStun(-25, FALSE)
+			else
+				C.AdjustStun(-20, FALSE)
+			if(fastmover)
+				if(!fastmover_activation[A.stage])//Checks if Modifier for Stage was Added
+					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.75, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
+					fastmover_activation[A.stage] = TRUE
+		if(5)
+			if(super_reduction)
+				C.adjustStun(-30, FALSE)
+			else
+				C.AdjustStun(-25, FALSE)
+			if(fastmover)
+				if(!fastmover_activation[A.stage])//Checks if Modifier for Stage was Added
+					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
+					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 1, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
+					fastmover_activation[A.stage] = TRUE
+		if(prob(10)) //Frequent Activation, would prefer not to Spam
+				to_chat(M, "<span class='notice'>[pick("You feel like you are thinking faster than ever.", "You feel like your limbs are more responsive.", "You feel like everything is slower than you remember.", "Your eyes adjust quickly to sudden changes in light", "You feel more aware of everything around you.")]</span>")

--- a/code/datums/diseases/advance/symptoms/neurological.dm
+++ b/code/datums/diseases/advance/symptoms/neurological.dm
@@ -10,7 +10,7 @@
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/fastmover = FALSE
-	var/list/fastmover_activation = list(FALSE, FALSE, FALSE, FALSE, FALSE) //Each of the Indexes Represents a Stage, When Activated, the Index is set to true
+	var/fastmover_activation = 0 //Each of the Indexes Represents a Stage, When Activated, the Index is set to true
 	var/super_reduction = FALSE
 	threshold_desc = "<b>Stage Speed 12:</b>The virus overclocks the nervous system making the host move even faster than normal.<br>\
                       <b>Stage Speed 15:</b>The virus tightens the synapses between nerves, allowing for even quicker recovery from stuns."
@@ -40,38 +40,38 @@
 		if(2)
 			C.AdjustStun(-10, FALSE)
 			if(fastmover)
-				if(!fastmover_activation[A.stage]) //Checks if Modifier for the Stage was Added
+				if(fastmover_activation < A.stage) //Checks if Modifier for the Stage was Added
 					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.25, blacklisted_movetypes=(FLYING|FLOATING))
-					fastmover_activation[A.stage] = TRUE //Ensures Multiplier Not Added 2x
+					fastmover_activation = A.stage //Ensures Multiplier Not Added 2x
 		if(3)
 			if(super_reduction)
 				C.AdjustStun(-20, FALSE)
 			else
 				C.AdjustStun(-15, FALSE)
 			if(fastmover)
-				if(!fastmover_activation[A.stage])//Checks if Modifier for Stage was Added
+				if(fastmover_activation < A.stage)//Checks if Modifier for Stage was Added
 					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
 					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.5, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
-					fastmover_activation[A.stage] = TRUE
+					fastmover_activation = A.stage
 		if(4)
 			if(super_reduction)
 				C.adjustStun(-25, FALSE)
 			else
 				C.AdjustStun(-20, FALSE)
 			if(fastmover)
-				if(!fastmover_activation[A.stage])//Checks if Modifier for Stage was Added
+				if(fastmover_activation < A.stage)//Checks if Modifier for Stage was Added
 					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
 					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 0.75, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
-					fastmover_activation[A.stage] = TRUE
+					fastmover_activation = A.stage
 		if(5)
 			if(super_reduction)
 				C.adjustStun(-30, FALSE)
 			else
 				C.AdjustStun(-25, FALSE)
 			if(fastmover)
-				if(!fastmover_activation[A.stage])//Checks if Modifier for Stage was Added
+				if(fastmover_activation < A.stage)//Checks if Modifier for Stage was Added
 					C.remove_movespeed_modifier(type) //Removes Previous Stage Modifier
 					C.add_movespeed_modifier(type, TRUE, 100, multiplicative_slowdown = 1, blacklisted_movetypes=(FLYING|FLOATING)) //New Modifier
-					fastmover_activation[A.stage] = TRUE
+					fastmover_activation = A.stage
 		if(prob(10)) //Frequent Activation, would prefer not to Spam
 				to_chat(M, "<span class='notice'>[pick("You feel like you are thinking faster than ever.", "You feel like your limbs are more responsive.", "You feel like everything is slower than you remember.", "Your eyes adjust quickly to sudden changes in light", "You feel more aware of everything around you.")]</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a Symptom, Neurological Overdrive.

This is a level 9 beneficial, which provides stun reductions with the following thresholds:
Stage Speed 12: Faster Movement
Stage Speed 15: More stun reduction
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Virology, currently, feels lacking for non-antagonistic behavior(It's fairly easy to make any malicious disease). Beneficials however, seem to be lacking in some way. Some of the obvious beneficials either kinda suck(Superficial, Regen Coma), others have weird side effects(Pituitary, Organic Flux), are annoying to others(Necro Seed, Cornu), or annoying in other ways(ThermoStable, Regen Coma).

This new Symptom I am hoping will add to the list of virology beneficials in a way that doesn't involve spreading pink shit everywhere.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new Beneficial Virology Symptom, Neurological Overdrive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
