### PR TITLE
Another New Beneficial Viro Symptom: Night Vision Symptom

### DIFF
--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -83,7 +83,7 @@ Bonus
 	resistance = -2
 	stage_speed = -2
 	transmittable = 0
-	level = 7
+	level = 9
 	severity = 0
 	base_message_chance = 50
 	symptom_delay_min = 15
@@ -97,7 +97,7 @@ Bonus
 	threshold_desc = "<b>Resistance 10:</b> Vision in the dark is even better.<br>\
 					  <b>Resistance 14:</b> The host will grow a pair of NVGs.<br>\
 					  <b>Stage Speed 10:</b> The host's eyes are able to percieve infrared radiation.<br>\
-					  <b>Stage Speed 14:</b> The host's eyes are able to percieve xray radiation. This overrides the thermal vision threshhold."
+					  <b>Stage Speed 18:</b> The host's eyes are able to percieve xray radiation. This overrides the thermal vision threshhold."
 
 /datum/symptom/ocularsensitivity/severityset(datum/disease/advance/A)
 	. = ..()
@@ -107,7 +107,7 @@ Bonus
 		severity += 2 //Disregards the decrease from other resistance threshold, in fact is probably borderline antagonistic.
 	if(A.properties["stage_rate"] >= 10) //Thermal Vision
 		severity -= 1
-	if(A.properties["stage_rate"] >= 14) //Xray Vision
+	if(A.properties["stage_rate"] >= 18) //Xray Vision
 		severity -= 2
 
 /datum/symptom/ocularsensitivity/Start(datum/disease/advance/A)
@@ -118,7 +118,7 @@ Bonus
 		nvgs = TRUE
 	if(A.properties["stage_rate"] >= 10) //Thermal Vision
 		thermal = TRUE
-	if(A.properties["stage_rate"] >= 14) //Xray Vision
+	if(A.properties["stage_rate"] >= 18) //Xray Vision
 		xray = TRUE
 
 /datum/symptom/ocularsensitivity/Activate(datum/disease/advance/A)
@@ -128,13 +128,13 @@ Bonus
 	switch(A.stage)
 		if(4)
 			if(!nvision_buff)
-				to_chat(M, "<span class='userdanger'>Your vision becomes better!</span>")
+				to_chat(L, "<span class='userdanger'>Your vision becomes better!</span>")
 				if(better_vis)
 					L.see_in_dark += 4
-					vision_buff_tracker = TRUE
+					nvision_buff = TRUE
 				else
 					L.see_in_dark += 2
-					vision_buff_tracker = TRUE
+					nvision_buff = TRUE
 			if(thermal && !xray && !other_buff)
 				ADD_TRAIT(L, TRAIT_THERMAL_VISION, DISEASE_TRAIT)
 			if(xray && !other_buff)
@@ -143,7 +143,7 @@ Bonus
 			if(nvgs)
 				giveNVGS(A)
 
-/datum/symptop/ocularsensitivity/proc/giveNVGS(datum/disease/advance/A)
+/datum/symptom/ocularsensitivity/proc/giveNVGS(datum/disease/advance/A)
 	if(ishuman(A.affected_mob))
 		var/mob/living/carbon/human/M = A.affected_mob
 		if(!istype(M.glasses, /obj/item/clothing/glasses/night))

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -124,12 +124,11 @@ Bonus
 		if(4)
 			if(!thresholds["nvision_buff"])
 				to_chat(L, "<span class='userdanger'>Your vision becomes better!</span>")
+				thresholds["nvision_buff"] = TRUE // So this won't happen again
 				if(thresholds["better_vis"])
 					L.see_in_dark += 4
-					thresholds["nvision_buff"] = TRUE
 				else
 					L.see_in_dark += 2
-					thresholds["nvision_buff"] = TRUE
 			if(thresholds["thermal"] && !thresholds["xray"] && !thresholds["other_buff"])
 				ADD_TRAIT(L, TRAIT_THERMAL_VISION, DISEASE_TRAIT)
 				thresholds["other_buff"] = TRUE

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -88,12 +88,14 @@ Bonus
 	base_message_chance = 50
 	symptom_delay_min = 15
 	symptom_delay_max = 50
-	var/better_vis = FALSE
-	var/nvgs = FALSE
-	var/thermal = FALSE
-	var/xray = FALSE
-	var/nvision_buff = FALSE //Toggles TRUE when the Night Vision Buffs are Applied
-	var/other_buff = FALSE //Toggles TRUE when Thermal/Xray is applied
+	var/list/thresholds = list()//An Associative List of Threshhold related vars. ["better_vis"], ["nvgs"], ["thermal"], ["xray"], ["nvision_buff"], ["other_buff"] are the indexes.
+	//Associative Index Initialization
+	thresholds["better_vis"] = FALSE
+	thresholds["nvgs"] = FALSE
+	thresholds["thermal"] = FALSE
+	thresholds["xray"] = FALSE
+	thresholds["nvision_buff"] = FALSE //Toggles TRUE when the Night Vision Buffs are Applied
+	thresholds["other_buff"] = FALSE //Toggles TRUE when Thermal/Xray is applied
 	threshold_desc = "<b>Resistance 10:</b> Vision in the dark is even better.<br>\
 					  <b>Resistance 14:</b> The host will grow a pair of NVGs.<br>\
 					  <b>Stage Speed 10:</b> The host's eyes are able to percieve infrared radiation.<br>\
@@ -113,13 +115,13 @@ Bonus
 /datum/symptom/ocularsensitivity/Start(datum/disease/advance/A)
 	. = ..()
 	if(A.properties["resistance"] >= 10) //Better Night Vision
-		better_vis = TRUE
+		thresholds["better_vis"] = TRUE
 	if(A.properties["resistance"] >= 14) //Grow a pair of NVGS
-		nvgs = TRUE
+		thresholds["nvgs"] = TRUE
 	if(A.properties["stage_rate"] >= 10) //Thermal Vision
-		thermal = TRUE
+		thresholds["thermal"] = TRUE
 	if(A.properties["stage_rate"] >= 18) //Xray Vision
-		xray = TRUE
+		thresholds["xray"] = TRUE
 
 /datum/symptom/ocularsensitivity/Activate(datum/disease/advance/A)
 	if(!..())
@@ -127,20 +129,22 @@ Bonus
 	var/mob/living/L = A.affected_mob
 	switch(A.stage)
 		if(4)
-			if(!nvision_buff)
+			if(!thresholds["nvision_buff"])
 				to_chat(L, "<span class='userdanger'>Your vision becomes better!</span>")
-				if(better_vis)
+				if(thresholds["better_vis"])
 					L.see_in_dark += 4
-					nvision_buff = TRUE
+					thresholds["nvision_buff"] = TRUE
 				else
 					L.see_in_dark += 2
-					nvision_buff = TRUE
-			if(thermal && !xray && !other_buff)
+					thresholds["nvision_buff"] = TRUE
+			if(thresholds["thermal"] && !thresholds["xray"] && !thresholds["other_buff"])
 				ADD_TRAIT(L, TRAIT_THERMAL_VISION, DISEASE_TRAIT)
-			if(xray && !other_buff)
+				thresholds["other_buff"] = TRUE
+			if(thresholds["xray"] && thresholds["other_buff"])
 				ADD_TRAIT(L, TRAIT_XRAY_VISION, DISEASE_TRAIT)
+				thresholds["other_buff"] = TRUE
 		if(5)
-			if(nvgs)
+			if(thresholds["nvgs"])
 				giveNVGS(A)
 
 /datum/symptom/ocularsensitivity/proc/giveNVGS(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -88,7 +88,7 @@ Bonus
 	base_message_chance = 50
 	symptom_delay_min = 15
 	symptom_delay_max = 50
-	var/list/thresholds = list()//An Associative List of Threshhold related vars. ["better_vis"], ["nvgs"], ["thermal"], ["xray"], ["nvision_buff"], ["other_buff"] are the indexes.
+	thresholds = list()//An Associative List of Threshhold related vars. ["better_vis"], ["nvgs"], ["thermal"], ["xray"], ["nvision_buff"], ["other_buff"] are the indexes.
 	//Associative Index Initialization
 	thresholds["better_vis"] = FALSE
 	thresholds["nvgs"] = FALSE

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -88,14 +88,7 @@ Bonus
 	base_message_chance = 50
 	symptom_delay_min = 15
 	symptom_delay_max = 50
-	thresholds = list()//An Associative List of Threshhold related vars. ["better_vis"], ["nvgs"], ["thermal"], ["xray"], ["nvision_buff"], ["other_buff"] are the indexes.
-	//Associative Index Initialization
-	thresholds["better_vis"] = FALSE
-	thresholds["nvgs"] = FALSE
-	thresholds["thermal"] = FALSE
-	thresholds["xray"] = FALSE
-	thresholds["nvision_buff"] = FALSE //Toggles TRUE when the Night Vision Buffs are Applied
-	thresholds["other_buff"] = FALSE //Toggles TRUE when Thermal/Xray is applied
+	thresholds = list()//An Associative List of Threshhold related vars. ["better_vis"], ["nvgs"], ["thermal"], ["xray"], ["nvision_buff"], ["other_buff"] are the indexes
 	threshold_desc = "<b>Resistance 10:</b> Vision in the dark is even better.<br>\
 					  <b>Resistance 14:</b> The host will grow a pair of NVGs.<br>\
 					  <b>Stage Speed 10:</b> The host's eyes are able to percieve infrared radiation.<br>\
@@ -161,13 +154,13 @@ Bonus
 /datum/symptom/ocularsensitivity/End(datum/disease/advance/A)
 	..()
 	var/mob/living/L = A.affected_mob
-	if(better_vis)
+	if(thresholds["better_vis"])
 		L.see_in_dark -= 4
 	else
 		L.see_in_dark -= 2
-	if(thermal && !xray)
+	if(thresholds["thermal"] && !thresholds["xray"])
 		REMOVE_TRAIT(L, TRAIT_THERMAL_VISION, DISEASE_TRAIT)
-	if(xray)
+	if(thresholds["xray"])
 		REMOVE_TRAIT(L, TRAIT_XRAY_VISION, DISEASE_TRAIT)
 	if(ishuman(A.affected_mob))
 		var/mob/living/carbon/human/M = A.affected_mob

--- a/code/datums/diseases/advance/symptoms/vision.dm
+++ b/code/datums/diseases/advance/symptoms/vision.dm
@@ -97,7 +97,7 @@ Bonus
 	threshold_desc = "<b>Resistance 10:</b> Vision in the dark is even better.<br>\
 					  <b>Resistance 14:</b> The host will grow a pair of NVGs.<br>\
 					  <b>Stage Speed 10:</b> The host's eyes are able to percieve infrared radiation.<br>\
-					  <b>Stage Speed 14:</b> The host's eyes are able to percieve xray radiation."
+					  <b>Stage Speed 14:</b> The host's eyes are able to percieve xray radiation. This overrides the thermal vision threshhold."
 
 /datum/symptom/ocularsensitivity/severityset(datum/disease/advance/A)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a Symptom, Ocular Hyper-reception.

This is a level 9 beneficial, which provides better vision in the dark with the following thresholds:
Resistance 10: Better Night Vision
Resistance 14: Grow a Pair of NVGs(a la Pierrot's)
Stage Speed 10: Thermal Vision
Stage Speed 18: Xray Vision(overrides thermal vision)

Stats: stealth = 1, resistance = -2, stage speed = -2, transmission = 0
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Virology, currently, feels lacking for non-antagonistic behavior(It's fairly easy to make any malicious disease). Beneficials however, seem to be lacking in some way. Some of the obvious beneficials either kinda suck(Superficial, Regen Coma), others have weird side effects(Pituitary, Organic Flux), are annoying to others(Necro Seed, Cornu), or annoying in other ways(ThermoStable, Regen Coma).

This new Symptom I am hoping will add to the list of virology beneficials in a way that doesn't involve spreading pink shit everywhere.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds Ocular Hyper-reception Symptom, for vision enhancements
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
