### PR TITLE
Synthflesh unhusk change

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -420,8 +420,8 @@
 			if(show_message)
 				to_chat(M, "<span class='danger'>You feel your burns and bruises healing! It stings like hell!</span>")
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
-			//Has to be at less than THRESHOLD_UNHUSK burn damage and have 100 synthflesh before unhusking. Corpses dont metabolize.
-			if(HAS_TRAIT_FROM(M, TRAIT_HUSK, "burn") && M.getFireLoss() < THRESHOLD_UNHUSK && M.reagents.has_reagent(/datum/reagent/medicine/synthflesh, 100))
+			//Has to be at less than THRESHOLD_UNHUSK burn damage and have at least 100 synthflesh (currently inside the body + amount now being applied). Corpses dont metabolize.
+			if(HAS_TRAIT_FROM(M, TRAIT_HUSK, "burn") && M.getFireLoss() < THRESHOLD_UNHUSK && (M.reagents.get_reagent_amount(/datum/reagent/medicine/synthflesh) + reac_volume) >= 100)
 				M.cure_husk("burn")
 				M.visible_message("<span class='nicegreen'>You successfully replace most of the burnt off flesh of [M].")
 	..()


### PR DESCRIPTION
## About The Pull Request

Basically unhusking with synthflesh is unintuitive, the corpse might have 99u of synthflesh, you add another 100u  and it doesn't unhusk (even though the stated threshold is 100u), but add another 1u and it finally unhusks the body. The change is about checking if the current amount of synth + amount to be added is greater or equal to 100, and if that's true then unhusk, so if the body currently has 50u of synth and you add another 50u, it will be unhusked.

## Why It's Good For The Game

Unhusking with synthflesh is more intuitive.

## Changelog
:cl:
tweak: Synthflesh unhusking is more intuitive: if current amount in the body + amount being applied is  >=100, unhusk.
/:cl:


