### PR TITLE
slimes no longer attack their master

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -553,7 +553,7 @@
 	GLOB.poi_list -= src
 
 /mob/living/simple_animal/slime/proc/make_master(mob/user)
-	Friends[user]++
+	Friends[user] += SLIME_FRIENDSHIP_ATTACK * 2
 	master = user
 
 /mob/living/simple_animal/slime/rainbow/Initialize(mapload, new_colour="rainbow", new_is_adult)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -552,5 +552,10 @@
 		LAZYREMOVE(GLOB.mob_spawners[spawner], src)
 	GLOB.poi_list -= src
 
+/mob/living/simple_animal/slime/make_master(mob/user)
+	Friends[user]++
+	S.master = user
+
 /mob/living/simple_animal/slime/rainbow/Initialize(mapload, new_colour="rainbow", new_is_adult)
 	. = ..(mapload, new_colour, new_is_adult)
+

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -554,7 +554,7 @@
 
 /mob/living/simple_animal/slime/proc/make_master(mob/user)
 	Friends[user]++
-	S.master = user
+	master = user
 
 /mob/living/simple_animal/slime/rainbow/Initialize(mapload, new_colour="rainbow", new_is_adult)
 	. = ..(mapload, new_colour, new_is_adult)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -552,7 +552,7 @@
 		LAZYREMOVE(GLOB.mob_spawners[spawner], src)
 	GLOB.poi_list -= src
 
-/mob/living/simple_animal/slime/make_master(mob/user)
+/mob/living/simple_animal/slime/proc/make_master(mob/user)
 	Friends[user]++
 	S.master = user
 

--- a/code/modules/research/xenobiology/crossbreeding/transformative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/transformative.dm
@@ -153,7 +153,7 @@ transformative extracts:
 /obj/item/slimecross/transformative/lightpink/do_effect(mob/living/simple_animal/slime/S, mob/user)
 	..()
 	GLOB.poi_list |= S
-	S.master = user
+	S.make_master(user)
 	LAZYADD(GLOB.mob_spawners["[S.master.real_name]'s slime"], S)
 
 /obj/item/slimecross/transformative/adamantine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

by applying a SLIME_EFFECT_LIGHT_PINK, slimes controlled by a player are not allowed to attack their master, now the slime will also not be able to attack him when it is not controlled by anyone.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

slimes should not attack their master.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: AI-controlled slimes that have a master no longer attack their master
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
