### PR TITLE
Moves spare to safe located in bridge, acting captain gets codes to it

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16785,6 +16785,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = 6;
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aTT" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -45650,22 +45650,9 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/mining_voucher,
-/turf/open/floor/plasteel/dark,
-/area/bridge)
-"bBG" = (
-/obj/item/radio/intercom{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = 6;
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -164001,7 +163988,7 @@ aaa
 bwS
 byg
 bzM
-bBG
+bzP
 bDB
 bFi
 bGU

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33093,15 +33093,16 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bkD" = (
-/obj/item/radio/intercom{
-	pixel_y = 29
-	},
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = 6;
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -8510,6 +8510,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/storage/secure/safe/caps_spare{
+	pixel_x = 6;
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "atQ" = (

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -462,3 +462,5 @@
 	min_val = 0
 
 /datum/config_entry/flag/bsminer_researchable
+
+/datum/config_entry/flag/spare_enforce_coc

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1,9 +1,3 @@
-/// Defines for locations of items being added to your inventory on spawn
-#define LOCATION_LPOCKET "in your left pocket"
-#define LOCATION_RPOCKET "in your right pocket"
-#define LOCATION_BACKPACK "in your backpack"
-#define LOCATION_HANDS "in your hands"
-
 SUBSYSTEM_DEF(job)
 	name = "Jobs"
 	init_order = INIT_ORDER_JOBS
@@ -738,10 +732,10 @@ obj/item/paper/fluff/spare_id_safe_code
 
 	var/paper = new /obj/item/paper/fluff/spare_id_safe_code()
 	var/list/slots = list(
-		LOCATION_LPOCKET = SLOT_L_STORE,
-		LOCATION_RPOCKET = SLOT_R_STORE,
-		LOCATION_BACKPACK = ITEM_SLOT_BACKPACK,
-		LOCATION_HANDS = ITEM_SLOT_HANDS
+		LOCATION_LPOCKET = "in your left pocket",
+		LOCATION_RPOCKET = "in your right pocket",
+		LOCATION_BACKPACK = "in your backpack",
+		LOCATION_HANDS = "in your hands"
 	)
 	var/where = H.equip_in_one_of_slots(paper, slots, FALSE) || "at your feet"
 
@@ -755,8 +749,3 @@ obj/item/paper/fluff/spare_id_safe_code
 		var/obj/item/card/id/id_card = H.wear_id
 		if(!(ACCESS_HEADS in id_card.access))
 			LAZYADD(id_card.access, ACCESS_HEADS)
-
-#undef LOCATION_LPOCKET
-#undef LOCATION_RPOCKET
-#undef LOCATION_BACKPACK
-#undef LOCATION_HANDS

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1,3 +1,9 @@
+/// Defines for locations of items being added to your inventory on spawn
+#define LOCATION_LPOCKET "in your left pocket"
+#define LOCATION_RPOCKET "in your right pocket"
+#define LOCATION_BACKPACK "in your backpack"
+#define LOCATION_HANDS "in your hands"
+
 SUBSYSTEM_DEF(job)
 	name = "Jobs"
 	init_order = INIT_ORDER_JOBS
@@ -16,6 +22,16 @@ SUBSYSTEM_DEF(job)
 
 	var/list/level_order = list(JP_HIGH,JP_MEDIUM,JP_LOW)
 
+	var/spare_id_safe_code = ""
+
+	var/list/chain_of_command = list(
+		"Captain" = 1,				//Not used yet but captain is first in chain_of_command
+		"Head of Personnel" = 2,
+		"Research Director" = 3,
+		"Chief Engineer" = 4,
+		"Chief Medical Officer" = 5,
+		"Head of Security" = 6)
+
 /datum/controller/subsystem/job/Initialize(timeofday)
 	SSmapping.HACK_LoadMapConfig()
 	if(!occupations.len)
@@ -24,6 +40,9 @@ SUBSYSTEM_DEF(job)
 		LoadJobs()
 	generate_selectable_species()
 	set_overflow_role(CONFIG_GET(string/overflow_job))
+
+	spare_id_safe_code = "[rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)]"
+
 	return ..()
 
 /datum/controller/subsystem/job/proc/set_overflow_role(new_overflow_role)
@@ -699,3 +718,45 @@ SUBSYSTEM_DEF(job)
 
 /datum/controller/subsystem/job/proc/JobDebug(message)
 	log_job_debug(message)
+
+obj/item/paper/fluff/spare_id_safe_code
+	name = "Nanotrasen-Approved Spare ID Safe Code"
+	desc = "Proof that you have been approved for Captaincy, with all its glory and all its horror."
+
+/obj/item/paper/fluff/spare_id_safe_code/Initialize()
+	. = ..()
+	var/id_safe_code = SSjob.spare_id_safe_code
+	info = "Captain's Spare ID safe code combination: [id_safe_code ? id_safe_code : "\[REDACTED\]"]<br><br>The spare ID can be found in its dedicated safe on the bridge."
+
+/datum/controller/subsystem/job/proc/promote_to_captain(var/mob/dead/new_player/new_captain, acting_captain = FALSE)
+	var/mob/living/carbon/human/H = new_captain.new_character
+	if(!new_captain)
+		CRASH("Cannot promote [new_captain.ckey], there is no new_character attached to him.")
+
+	if(!spare_id_safe_code)
+		CRASH("Cannot promote [H.real_name] to Captain, there is no spare_id_safe_code.")
+
+	var/paper = new /obj/item/paper/fluff/spare_id_safe_code()
+	var/list/slots = list(
+		LOCATION_LPOCKET = SLOT_L_STORE,
+		LOCATION_RPOCKET = SLOT_R_STORE,
+		LOCATION_BACKPACK = ITEM_SLOT_BACKPACK,
+		LOCATION_HANDS = ITEM_SLOT_HANDS
+	)
+	var/where = H.equip_in_one_of_slots(paper, slots, FALSE) || "at your feet"
+
+	if(acting_captain)
+		to_chat(new_captain, "<span class='notice'>Due to your position in the chain of command, you have been granted access to captain's spare ID. You can find in important note about this [where].</span>")
+	else
+		to_chat(new_captain, "<span class='notice'>You can find the code to obtain your spare ID from the secure safe on the Bridge [where].</span>")
+
+	// Force-give their ID card bridge access.
+	if(H.wear_id?.GetID())
+		var/obj/item/card/id/id_card = H.wear_id
+		if(!(ACCESS_HEADS in id_card.access))
+			LAZYADD(id_card.access, ACCESS_HEADS)
+
+#undef LOCATION_LPOCKET
+#undef LOCATION_RPOCKET
+#undef LOCATION_BACKPACK
+#undef LOCATION_HANDS

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -50,7 +50,7 @@
 			if(l_hacking)
 				to_chat(user, "<span class='danger'>This safe is already being hacked.</span>")
 				return
-			if(open == TRUE)
+			if(open)
 				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")
 				l_hacking = TRUE
 				if (W.use_tool(src, user, 400))

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -211,7 +211,6 @@ There appears to be a small amount of surface corrosion. It doesn't look like it
 
 /obj/item/storage/secure/safe/caps_spare/Initialize()
 	. = ..()
-
 	l_code = SSjob.spare_id_safe_code
 	l_set = TRUE
 	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SET_LOCKSTATE, TRUE)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -21,6 +21,7 @@
 	var/l_setshort = 0
 	var/l_hacking = 0
 	var/open = FALSE
+	var/can_hack_open = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	desc = "This shouldn't exist. If it does, create an issue report."
 
@@ -32,33 +33,34 @@
 
 /obj/item/storage/secure/examine(mob/user)
 	. = ..()
-	. += "The service panel is currently <b>[open ? "unscrewed" : "screwed shut"]</b>."
+	if(can_hack_open)
+		. += "The service panel is currently <b>[open ? "unscrewed" : "screwed shut"]</b>."
 
 /obj/item/storage/secure/attackby(obj/item/W, mob/user, params)
-	if(SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED))
+	if(can_hack_open && SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED))
 		if (W.tool_behaviour == TOOL_SCREWDRIVER)
 			if (W.use_tool(src, user, 20))
-				open =! open
+				open = !open
 				to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>")
 			return
 		if (W.tool_behaviour == TOOL_WIRECUTTER)
 			to_chat(user, "<span class='danger'>[src] is protected from this sort of tampering, yet it appears the internal memory wires can still be <b>pulsed</b>.</span>")
-		if ((W.tool_behaviour == TOOL_MULTITOOL) && (!l_hacking))
-			if(open == 1)
+			return
+		if ((W.tool_behaviour == TOOL_MULTITOOL))
+			if(l_hacking)
+				to_chat(user, "<span class='danger'>This safe is already being hacked.</span>")
+				return
+			if(open == TRUE)
 				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")
-				l_hacking = 1
+				l_hacking = TRUE
 				if (W.use_tool(src, user, 400))
 					to_chat(user, "<span class='danger'>Internal memory reset - lock has been disengaged.</span>")
-					l_set = 0
-					l_hacking = 0
-				else
-					l_hacking = 0
-			else
-				to_chat(user, "<span class='notice'>You must <b>unscrew</b> the service panel before you can pulse the wiring.</span>")
+					l_set = FALSE
+
+				l_hacking = FALSE
+				return
+			to_chat(user, "<span class='notice'>You must <b>unscrew</b> the service panel before you can pulse the wiring.</span>")
 			return
-		//At this point you have exhausted all the special things to do when locked
-		// ... but it's still locked.
-		return
 
 	// -> storage/attackby() what with handle insertion, etc
 	return ..()
@@ -187,3 +189,35 @@
 
 /obj/item/storage/secure/safe/HoS
 	name = "head of security's safe"
+
+/**
+ * This safe is meant to be damn robust. To break in, you're supposed to get creative, or use acid or an explosion.
+ *
+ * This makes the safe still possible to break in for someone who is prepared and capable enough, either through
+ * chemistry, botany or whatever else.
+ *
+ * The safe is also weak to explosions, so spending some early TC could allow an antag to blow it upen if they can
+ * get access to it.
+ */
+/obj/item/storage/secure/safe/caps_spare
+	name = "captain's spare ID safe"
+	desc = "In case of emergency, do not break glass. All Captains and Acting Captains are provided with codes to access this safe. \
+It is made out of the same material as the station's Black Box and is designed to resist all conventional weaponry. \
+There appears to be a small amount of surface corrosion. It doesn't look like it could withstand much of an explosion."
+	can_hack_open = FALSE
+	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
+	max_integrity = 300
+	color = "#ffdd33"
+
+/obj/item/storage/secure/safe/caps_spare/Initialize()
+	. = ..()
+
+	l_code = SSjob.spare_id_safe_code
+	l_set = TRUE
+	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SET_LOCKSTATE, TRUE)
+
+/obj/item/storage/secure/safe/caps_spare/PopulateContents()
+	new /obj/item/card/id/captains_spare(src)
+
+/obj/item/storage/secure/safe/caps_spare/rust_heretic_act()
+	take_damage(damage_amount = 100, damage_type = BRUTE, damage_flag = "melee", armour_penetration = 100)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -33,7 +33,6 @@
 	new /obj/item/storage/belt/sabre(src)
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/door_remote/captain(src)
-	new /obj/item/card/id/captains_spare(src)
 	new /obj/item/storage/photo_album/Captain(src)
 	new /obj/item/card/id/departmental_budget/civ(src)
 

--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -632,3 +632,6 @@ ROUNDSTART_BLUESPACE_MINERS 0
 
 ## Enable the bluespace miner research node?
 #BSMINER_RESEARCHABLE
+
+## Do we want all the heads to get codes to spare safe, or just one highest in CoC?
+SPARE_ENFORCE_COC

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -632,3 +632,6 @@ ROUNDSTART_BLUESPACE_MINERS 2
 
 ## Enable the bluespace miner research node?
 #BSMINER_RESEARCHABLE
+
+## Do we want all the heads to get codes to spare safe, or just one highest in CoC?
+#SPARE_ENFORCE_COC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Spare has been moved from caps locker to safe located in bridge.
Paper with codes to that safe is given to captain, if there is one roundstart.
If there is no captain and if `SPARE_ENFORCE_COC` config entry is uncommented it will give the codes to the head highest in CoC. If the `SPARE_ENFORCE_COC` is not enabled it will give the codes to every head present on roundstart.

some code and general idea of keeping spare in safe taken from: https://github.com/tgstation/tgstation/pull/56910

Current chain of command:
1. Captain
2. HoP
3. RD
4. CE
5. CMO
6. HoS

SPARE_ENFORCE_COC is enabled on sage and not enabled on golden.

closes: #3832
alternative to and closes: #3855

## Why It's Good For The Game

No more breaking into the locker with fireaxe roundstart.

## Changelog
:cl:
add: Spare has been moved to safe located in bridge.
add: Captain gets code to that safe.
config: New config entry SPARE_ENFORCE_COC.
config: If there is no captain and SPARE_ENFORCE_COC is enabled code will be given to head highest in CoC.
config: If there is no captain and SPARE_ENFORCE_COC is not enabled code will be given to all of roundstart heads.
/:cl: