### PR TITLE
Patient Zero - Midround Event

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1846,6 +1846,7 @@
 #include "code\modules\events\mice_migration.dm"
 #include "code\modules\events\nightmare.dm"
 #include "code\modules\events\operative.dm"
+#include "code\modules\events\patient_zero.dm"
 #include "code\modules\events\pirates.dm"
 #include "code\modules\events\portal_storm.dm"
 #include "code\modules\events\prison_break.dm"

--- a/code/modules/events/patient_zero.dm
+++ b/code/modules/events/patient_zero.dm
@@ -1,0 +1,56 @@
+/datum/round_event_control/patient_zero
+	name = "Patient Zero"
+	typepath = /datum/round_event/ghost_role/patient_zero
+	weight = 5
+
+	min_players = 10
+
+/datum/round_event/ghost_role/patient_zero
+	announceWhen	= 400
+
+	minimum_required = 1
+	role_name = "patient zero"
+
+	// 50% chance of being incremented by one
+	var/spawncount = 1
+	fakeable = TRUE
+
+/datum/round_event/ghost_role/patient_zero/announce(fake)
+	priority_announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", 'sound/ai/aliens.ogg')
+
+/datum/round_event/ghost_role/patient_zero/spawn_role()
+	var/list/candidates = get_candidates(ROLE_ALIEN, null, ROLE_ALIEN)
+	if(!candidates.len)
+		return NOT_ENOUGH_PLAYERS
+
+	var/mob/dead/selected = pick(candidates)
+
+	var/list/spawn_locs = list()
+	for(var/obj/effect/landmark/carpspawn/C in GLOB.landmarks_list)
+		spawn_locs += (C.loc)
+	if(!spawn_locs.len)
+		message_admins("No valid spawn locations found, aborting...")
+		return MAP_ERROR
+	
+	var/mob/living/carbon/human/patient = new(pick(spawn_locs))
+	var/datum/mind/Mind = new /datum/mind(selected.key)
+	Mind.assigned_role = "Patient Zero"
+	Mind.special_role = "Patient Zero"
+	Mind.active = TRUE
+	Mind.transfer_to(patient)
+	patient.set_species(/datum/species/zombie/infectious)
+	patient.equipOutfit(/datum/outfit/pzero)
+	patient.dna.update_dna_identity()
+	
+	var/turf/T = locate(125,125,2)
+	patient.throw_at(T, 2, 2)
+	
+	message_admins("[ADMIN_LOOKUPFLW(patient)] has been spawned as Romerol Zombie by an event.")
+	spawned_mobs += patient
+	return SUCCESSFUL_SPAWN
+	
+/datum/outfit/pzero
+	name = "Patient Zero"
+	uniform = /obj/item/clothing/under/rank/security/detective
+	ears = /obj/item/radio/headset
+	suit = /obj/item/clothing/suit/jacket/miljacket

--- a/code/modules/events/patient_zero.dm
+++ b/code/modules/events/patient_zero.dm
@@ -2,17 +2,14 @@
 	name = "Patient Zero"
 	typepath = /datum/round_event/ghost_role/patient_zero
 	weight = 5
-
-	min_players = 10
+	max_occurrences = 1
+	min_players = 20
+	earliest_start = 50 MINUTES
 
 /datum/round_event/ghost_role/patient_zero
-	announceWhen	= 400
-
+	announceWhen	= 500
 	minimum_required = 1
 	role_name = "patient zero"
-
-	// 50% chance of being incremented by one
-	var/spawncount = 1
 	fakeable = TRUE
 
 /datum/round_event/ghost_role/patient_zero/announce(fake)

--- a/code/modules/events/patient_zero.dm
+++ b/code/modules/events/patient_zero.dm
@@ -42,8 +42,7 @@
 	patient.equipOutfit(/datum/outfit/pzero)
 	patient.dna.update_dna_identity()
 	
-	var/turf/T = locate(125,125,2)
-	patient.throw_at(T, 2, 2)
+	patient.throw_at(SSmapping.get_station_center(), 2, 2)
 	
 	message_admins("[ADMIN_LOOKUPFLW(patient)] has been spawned as Romerol Zombie by an event.")
 	spawned_mobs += patient


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rare midround game-ending event: Patient Zero.
Hurls a solo romerol zombie at the station.

## Why It's Good For The Game

* People like zombies
* Zombies are not very common
* Zombies are easy to deal with and quite easy to manage
* Not such a threat lategame, if people are organized, but otherwise can be devastating
* Not as serious as benos/blob, but still threatening

## Changelog
:cl:
add: Patient zero mid-round event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
