### PR TITLE
Temporarily removes code ownership for config/tgs files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,18 +5,17 @@
 # to the same file or dir, add them to the end under Multiple Owners
 
 # crossedfall
+# On-leave
 
 .dockerignore @crossedfall
 .github @crossedfall
-.travis.yml @crossedfall
-appveyor.yml @crossedfall
-/code/modules/tgs @crossedfall
-/config @crossedfall
+#/code/modules/tgs @crossedfall
+#/config @crossedfall
 dependencies.sh @crossedfall
 Dockerfile @crossedfall
 /SQL @crossedfall
 TGS3.json @crossedfall
-/tools @crossedfall
+#/tools @crossedfall
 
 
 # ike709

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@ dependencies.sh @crossedfall
 Dockerfile @crossedfall
 /SQL @crossedfall
 TGS3.json @crossedfall
-#/tools @crossedfall
+/tools @crossedfall
 
 
 # ike709


### PR DESCRIPTION
Allows maintainers to handle some of the more common stuff I normally oversee.

_TGS3.json is left as is because it could require box access to process._