### PR TITLE
Removes the assistants' maint access on Sage

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -352,7 +352,7 @@ MINIMAL_ACCESS_THRESHOLD 20
 #JOBS_HAVE_MINIMAL_ACCESS
 
 ## Uncomment to give assistants maint access.
-ASSISTANTS_HAVE_MAINT_ACCESS
+#ASSISTANTS_HAVE_MAINT_ACCESS
 
 ## Uncoment to give security maint access. Note that if you dectivate JOBS_HAVE_MINIMAL_ACCESS security already gets maint from that.
 SECURITY_HAS_MAINT_ACCESS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes assistant maintenance access on Sage
on Golden assistants will still have maint access.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/22380218/110623549-49075d00-819d-11eb-8749-8e7f86c3f429.png)

## Changelog
:cl:
config: Assistants don't have maintenance access on Sage anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
