### PR TITLE
Revert "Removes the assistants' maint access on Sage"

### DIFF
--- a/config/Sage/game_options.txt
+++ b/config/Sage/game_options.txt
@@ -352,7 +352,7 @@ MINIMAL_ACCESS_THRESHOLD 20
 #JOBS_HAVE_MINIMAL_ACCESS
 
 ## Uncomment to give assistants maint access.
-#ASSISTANTS_HAVE_MAINT_ACCESS
+ASSISTANTS_HAVE_MAINT_ACCESS
 
 ## Uncoment to give security maint access. Note that if you dectivate JOBS_HAVE_MINIMAL_ACCESS security already gets maint from that.
 SECURITY_HAS_MAINT_ACCESS


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#3849

Assistants are not new player characters. If you think that you are not playing the game. This is cringe and unnecessary + was speedmerged for literally no reason.

:cl:
config: Reverts assistant changes on sage.
/:cl: