### PR TITLE
Implements Captain's spare bridge safe from TGStation

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -16,6 +16,27 @@ SUBSYSTEM_DEF(job)
 
 	var/list/level_order = list(JP_HIGH,JP_MEDIUM,JP_LOW)
 
+		/**
+	 * Keys should be assigned job roles. Values should be >= 1.
+	 * Represents the chain of command on the station. Lower numbers mean higher priority.
+	 * Used to give the Cap's Spare safe code to a an appropriate player.
+	 * Assumed Captain is always the highest in the chain of command.
+	 * See [/datum/controller/subsystem/ticker/proc/equip_characters]
+	 */
+	var/list/chain_of_command = list(
+		"Captain" = 1,
+		"Head of Personnel" = 2,
+		"Research Director" = 3,
+		"Chief Engineer" = 4,
+		"Chief Medical Officer" = 5,
+		"Head of Security" = 6,
+		"Quartermaster" = 7)
+
+	/// If TRUE, some player has been assigned Captaincy or Acting Captaincy at some point during the shift and has been given the spare ID safe code.
+	var/assigned_captain = FALSE
+	/// If TRUE, the "Captain" job will always be given the code to the spare ID safe and always have a "Captain on deck!" announcement.
+	var/always_promote_captain_job = TRUE
+
 /datum/controller/subsystem/job/Initialize(timeofday)
 	SSmapping.HACK_LoadMapConfig()
 	if(!occupations.len)
@@ -407,7 +428,7 @@ SUBSYSTEM_DEF(job)
 		message_admins(message)
 		RejectPlayer(player)
 //Gives the player the stuff he should have with his rank
-/datum/controller/subsystem/job/proc/EquipRank(mob/M, rank, joined_late = FALSE)
+/datum/controller/subsystem/job/proc/EquipRank(mob/M, rank, joined_late = FALSE, is_captain = FALSE)
 	var/mob/dead/new_player/newplayer
 	var/mob/living/living_mob
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -36,6 +36,9 @@ SUBSYSTEM_DEF(job)
 	var/assigned_captain = FALSE
 	/// If TRUE, the "Captain" job will always be given the code to the spare ID safe and always have a "Captain on deck!" announcement.
 	var/always_promote_captain_job = TRUE
+	/// The roundstart generated code for the spare ID safe. This is given to the Captain on shift start. If there's no Captain, it's given to the HoP. If there's no HoP
+	var/spare_id_safe_code = ""
+	/// Is this a good place to put this? No, but Bee doesn't (yet?) have the id_access subsystem, so...
 
 /datum/controller/subsystem/job/Initialize(timeofday)
 	SSmapping.HACK_LoadMapConfig()
@@ -45,6 +48,7 @@ SUBSYSTEM_DEF(job)
 		LoadJobs()
 	generate_selectable_species()
 	set_overflow_role(CONFIG_GET(string/overflow_job))
+	spare_id_safe_code = "[rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)][rand(0,9)]"
 	return ..()
 
 /datum/controller/subsystem/job/proc/set_overflow_role(new_overflow_role)
@@ -467,7 +471,7 @@ SUBSYSTEM_DEF(job)
 		living_mob.mind.assigned_role = rank
 	to_chat(M, "<b>You are the [rank].</b>")
 	if(job)
-		var/new_mob = job.equip(living_mob, null, null, joined_late , null, M.client)
+		var/new_mob = job.equip(living_mob, null, null, joined_late , null, M.client, is_captain) //silicons override this proc to return a mob
 		if(ismob(new_mob))
 			living_mob = new_mob
 			if(!joined_late)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -374,7 +374,7 @@ SUBSYSTEM_DEF(ticker)
 
 
 /datum/controller/subsystem/ticker/proc/equip_characters()
-	var/captainless=1
+	var/captainless=TRUE
 	for(var/mob/dead/new_player/N in GLOB.player_list)
 		var/mob/living/carbon/human/player = N.new_character
 		if(istype(player) && player.mind && player.mind.assigned_role)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -45,7 +45,7 @@
 		if (W.tool_behaviour == TOOL_WIRECUTTER)
 			to_chat(user, "<span class='danger'>[src] is protected from this sort of tampering, yet it appears the internal memory wires can still be <b>pulsed</b>.</span>")
 			return
-		if ((W.tool_behaviour == TOOL_MULTITOOL)
+		if (W.tool_behaviour == TOOL_MULTITOOL)
 			if(!l_hacking)
 				to_chat(user, "<span class='danger'>This safe is already being hacked.</span>")
 				return
@@ -204,7 +204,7 @@
 It is made out of the same material as the station's Black Box and is designed to resist all conventional weaponry. \
 There appears to be a small amount of surface corrosion. It doesn't look like it could withstand much of an explosion."
 	can_hack_open = FALSE
-	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 70, BIO = 100, RAD = 100, FIRE = 80, ACID = 70)
+	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 70, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
 	max_integrity = 300
 	color = "#ffdd33"
 
@@ -219,4 +219,5 @@ There appears to be a small amount of surface corrosion. It doesn't look like it
 	new /obj/item/card/id/captains_spare(src)
 
 /obj/item/storage/secure/safe/caps_spare/rust_heretic_act()
-	take_damage(damage_amount = 100, damage_type = BRUTE, damage_flag = MELEE, armour_penetration = 100)
+	take_damage(damage_amount = 100, damage_type = BRUTE, damage_flag = BRUTE, armour_penetration = 100)
+	///obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -17,10 +17,11 @@
 	var/icon_opened = "secure0"
 	var/code = ""
 	var/l_code = null
-	var/l_set = 0
-	var/l_setshort = 0
-	var/l_hacking = 0
+	var/l_set = FALSE
+	var/l_setshort = FALSE
+	var/l_hacking = FALSE
 	var/open = FALSE
+	var/can_hack_open = TRUE
 	w_class = WEIGHT_CLASS_NORMAL
 	desc = "This shouldn't exist. If it does, create an issue report."
 
@@ -35,30 +36,30 @@
 	. += "The service panel is currently <b>[open ? "unscrewed" : "screwed shut"]</b>."
 
 /obj/item/storage/secure/attackby(obj/item/W, mob/user, params)
-	if(SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED))
+	if(can_hack_open && SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED))
 		if (W.tool_behaviour == TOOL_SCREWDRIVER)
 			if (W.use_tool(src, user, 20))
-				open =! open
+				open = !open
 				to_chat(user, "<span class='notice'>You [open ? "open" : "close"] the service panel.</span>")
 			return
 		if (W.tool_behaviour == TOOL_WIRECUTTER)
 			to_chat(user, "<span class='danger'>[src] is protected from this sort of tampering, yet it appears the internal memory wires can still be <b>pulsed</b>.</span>")
-		if ((W.tool_behaviour == TOOL_MULTITOOL) && (!l_hacking))
-			if(open == 1)
+			return
+		if ((W.tool_behaviour == TOOL_MULTITOOL)
+			if(!l_hacking)
+				to_chat(user, "<span class='danger'>This safe is already being hacked.</span>")
+				return
+			if(open == TRUE)
 				to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")
-				l_hacking = 1
+				l_hacking = TRUE
 				if (W.use_tool(src, user, 400))
 					to_chat(user, "<span class='danger'>Internal memory reset - lock has been disengaged.</span>")
-					l_set = 0
-					l_hacking = 0
-				else
-					l_hacking = 0
-			else
-				to_chat(user, "<span class='notice'>You must <b>unscrew</b> the service panel before you can pulse the wiring.</span>")
+					l_set = FALSE
+
+				l_hacking = FALSE
+				return
+			to_chat(user, "<span class='notice'>You must <b>unscrew</b> the service panel before you can pulse the wiring.</span>")
 			return
-		//At this point you have exhausted all the special things to do when locked
-		// ... but it's still locked.
-		return
 
 	// -> storage/attackby() what with handle insertion, etc
 	return ..()
@@ -187,3 +188,35 @@
 
 /obj/item/storage/secure/safe/HoS
 	name = "head of security's safe"
+
+/**
+ * This safe is meant to be damn robust. To break in, you're supposed to get creative, or use acid or an explosion.
+ *
+ * This makes the safe still possible to break in for someone who is prepared and capable enough, either through
+ * chemistry, botany or whatever else.
+ *
+ * The safe is also weak to explosions, so spending some early TC could allow an antag to blow it upen if they can
+ * get access to it.
+ */
+/obj/item/storage/secure/safe/caps_spare
+	name = "captain's spare ID safe"
+	desc = "In case of emergency, do not break glass. All Captains and Acting Captains are provided with codes to access this safe. \
+It is made out of the same material as the station's Black Box and is designed to resist all conventional weaponry. \
+There appears to be a small amount of surface corrosion. It doesn't look like it could withstand much of an explosion."
+	can_hack_open = FALSE
+	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 70, BIO = 100, RAD = 100, FIRE = 80, ACID = 70)
+	max_integrity = 300
+	color = "#ffdd33"
+
+/obj/item/storage/secure/safe/caps_spare/Initialize()
+	. = ..()
+
+	l_code = SSid_access.spare_id_safe_code
+	l_set = TRUE
+	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SET_LOCKSTATE, TRUE)
+
+/obj/item/storage/secure/safe/caps_spare/PopulateContents()
+	new /obj/item/card/id/advanced/gold/captains_spare(src)
+
+/obj/item/storage/secure/safe/caps_spare/rust_heretic_act()
+	take_damage(damage_amount = 100, damage_type = BRUTE, damage_flag = MELEE, armour_penetration = 100)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -211,12 +211,12 @@ There appears to be a small amount of surface corrosion. It doesn't look like it
 /obj/item/storage/secure/safe/caps_spare/Initialize()
 	. = ..()
 
-	l_code = SSid_access.spare_id_safe_code
+	l_code = SSjob.spare_id_safe_code
 	l_set = TRUE
 	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SET_LOCKSTATE, TRUE)
 
 /obj/item/storage/secure/safe/caps_spare/PopulateContents()
-	new /obj/item/card/id/advanced/gold/captains_spare(src)
+	new /obj/item/card/id/captains_spare(src)
 
 /obj/item/storage/secure/safe/caps_spare/rust_heretic_act()
 	take_damage(damage_amount = 100, damage_type = BRUTE, damage_flag = MELEE, armour_penetration = 100)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -33,7 +33,6 @@
 	new /obj/item/storage/belt/sabre(src)
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/door_remote/captain(src)
-	new /obj/item/card/id/captains_spare(src)
 	new /obj/item/storage/photo_album/Captain(src)
 	new /obj/item/card/id/departmental_budget/civ(src)
 


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/56910
https://github.com/tgstation/tgstation/pull/57460

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a safe in the Bridge for the captain's spare. It cannot be destroyed, except by explosion or acid. Heads of Staff are given the code to it at the start of the round.
add: Adds a chain of succession enforced via code for Acting Captain
remove: Removes the captain's spare from the locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
