### PR TITLE
creates a new serviceborg beaker upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -732,7 +732,32 @@
 		var/obj/item/borg/apparatus/beaker/extra/E = locate() in R.module.modules
 		if (E)
 			R.module.remove_module(E, TRUE)
+			
+/obj/item/borg/upgrade/service_beaker_app
+	name = "beaker storage apparatus"
+	desc = "A supplementary beaker storage apparatus for service cyborgs."
+	icon_state = "cyborg_upgrade3"
+	require_module = TRUE
+	module_type = /obj/item/robot_module/butler
 
+/obj/item/borg/upgrade/service_beaker_app/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		var/obj/item/borg/apparatus/beaker/extra/E = locate() in R.module.modules
+		if(E)
+			to_chat(user, "<span class='warning'>This unit has no room for additional beaker storage.</span>")
+			return FALSE
+
+		E = new(R.module)
+		R.module.basic_modules += E
+		R.module.add_module(E, FALSE, TRUE)
+
+/obj/item/borg/upgrade/service_beaker_app/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		var/obj/item/borg/apparatus/beaker/extra/E = locate() in R.module.modules
+		if (E)
+			R.module.remove_module(E, TRUE)
 
 /obj/item/borg/upgrade/speciality
 	name = "Speciality Module"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -708,7 +708,7 @@
 			R.module.remove_module(C, TRUE)
 
 /obj/item/borg/upgrade/beaker_app
-	name = "beaker storage apparatus"
+	name = "Medical cyborg beaker storage apparatus"
 	desc = "A supplementary beaker storage apparatus for medical cyborgs."
 	icon_state = "cyborg_upgrade3"
 	require_module = TRUE
@@ -734,7 +734,7 @@
 			R.module.remove_module(E, TRUE)
 			
 /obj/item/borg/upgrade/service_beaker_app
-	name = "beaker storage apparatus"
+	name = "Service cyborg beaker storage apparatus"
 	desc = "A supplementary beaker storage apparatus for service cyborgs."
 	icon_state = "cyborg_upgrade3"
 	require_module = TRUE

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -777,10 +777,19 @@
 	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_beaker_app
-	name = "Cyborg Upgrade (Beaker Storage)"
+	name = "Cyborg Upgrade (Medical Beaker Storage)"
 	id = "borg_upgrade_beakerapp"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/beaker_app
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 2250) //Need glass for the new beaker too
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+	
+/datum/design/borg_upgrade_service_beaker_app
+	name = "Cyborg Upgrade (Service Beaker Storage)"
+	id = "borg_upgrade_servicebeakerapp"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/service_beaker_app
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 2250) //Need glass for the new beaker too
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -370,9 +370,9 @@
 /datum/techweb_node/cyborg_upg_service
 	id = "cyborg_upg_service"
 	display_name = "Cyborg Upgrades: Service"
-	description = "Allows service borgs to specialize with various modules."
+	description = "Allows service borgs to specialize and upgrade with various modules."
 	prereq_ids = list("cyborg_upg_util")
-	design_ids = list("borg_upgrade_casino", "borg_upgrade_kitchen", "borg_upgrade_botany", "borg_upgrade_party")
+	design_ids = list("borg_upgrade_casino", "borg_upgrade_kitchen", "borg_upgrade_botany", "borg_upgrade_party", "borg_upgrade_servicebeakerapp")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 	export_price = 1000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

basically the current medical cyborg supplementary beaker upgrade has been duplicated but for serviceborgs and under the service cyborg upgrade in the techweb, 

## Why It's Good For The Game

Sometimes as a service cyborg you want to get some "special ingredients" from chemistry but you still need somewhere to mix drinks before dispensing them into a glass. This solves that issue. 

## Changelog
:cl:
add: adds a new beaker upgrade for serviceborgs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
