### PR TITLE
Reverts #1087: Autophagocytosis Zombie Threshold

### DIFF
--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -125,16 +125,6 @@ Bonus
 
 /datum/symptom/flesh_death/proc/Flesh_death(mob/living/M, datum/disease/advance/A)
 	var/get_damage = rand(6,10)
-	if(MOB_UNDEAD in M.mob_biotypes)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			var/S = H.dna.species
-			if(zombie && istype(S, /datum/species/zombie/infectious) && !istype(S, /datum/species/zombie/infectious/fast))
-				H.set_species(/datum/species/zombie/infectious/fast)
-				to_chat(M, "<span class='warning'>Your extraneous flesh sloughs off, giving you a boost of speed at the cost of a bit of padding!</span>")
-			else if(prob(base_message_chance))
-				to_chat(M, "<span class='warning'>Your body slowly decays... luckily, you're already dead!</span>")
-		return //this symptom wont work on the undead.
 	M.take_overall_damage(brute = get_damage, required_status = BODYPART_ORGANIC)
 	if(chems)
 		M.reagents.add_reagent_list(list(/datum/reagent/toxin/heparin = 2, /datum/reagent/toxin/lipolicide = 2))

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -84,7 +84,7 @@ Bonus
 /datum/symptom/flesh_death
 
 	name = "Autophagocytosis Necrosis"
-	desc = "The virus rapidly consumes infected cells, leading to heavy and widespread damage. Contains dormant prions- expert virologists believe it to be the precursor to Romerol, though the mechanism through which they are activated is largely unknown"
+	desc = "The virus rapidly consumes infected cells, leading to heavy and widespread damage."
 	stealth = -2
 	resistance = -2
 	stage_speed = 1
@@ -95,7 +95,6 @@ Bonus
 	symptom_delay_min = 3
 	symptom_delay_max = 6
 	var/chems = FALSE
-	var/zombie = FALSE
 	threshold_desc = "<b>Stage Speed 7:</b> Synthesizes Heparin and Lipolicide inside the host, causing increased bleeding and hunger.<br>\
 					  <b>Stealth 5:</b> The symptom remains hidden until active."
 
@@ -106,8 +105,6 @@ Bonus
 		suppress_warning = TRUE
 	if(A.properties["stage_rate"] >= 7) //bleeding and hunger
 		chems = TRUE
-	if((A.properties["stealth"] >= 2) && (A.properties["stage_rate"] >= 12))
-		zombie = TRUE
 
 /datum/symptom/flesh_death/Activate(datum/disease/advance/A)
 	if(!..())
@@ -125,7 +122,7 @@ Bonus
 				return
 			if(prob(base_message_chance / 2)) //reduce spam
 				to_chat(M, "<span class='userdanger'>[pick("You feel your muscles weakening.", "Some of your skin detaches itself.", "You feel sandy.")]</span>")
-		
+
 /datum/symptom/flesh_death/proc/Flesh_death(mob/living/M, datum/disease/advance/A)
 	var/get_damage = rand(6,10)
 	if(MOB_UNDEAD in M.mob_biotypes)
@@ -141,9 +138,4 @@ Bonus
 	M.take_overall_damage(brute = get_damage, required_status = BODYPART_ORGANIC)
 	if(chems)
 		M.reagents.add_reagent_list(list(/datum/reagent/toxin/heparin = 2, /datum/reagent/toxin/lipolicide = 2))
-	if(zombie)
-		if(ishuman(A.affected_mob))
-			if(!A.affected_mob.getorganslot(ORGAN_SLOT_ZOMBIE))
-				var/obj/item/organ/zombie_infection/ZI = new()
-				ZI.Insert(M)
 	return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts #1087

Listen, this wasn't and never has been remotely "secret". This is a way to avoiding the romerol tax, which exists for a reason. 
Doubly so since zombies can really derail a round when combined with a necrotic metabolism trifecta, making them harder to kill.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Listen, there is a reason why Romerol costs 25 TC. Making this possible sans uplink is a little silly.

I love virology(and tax evasion) as much as some of y'all. But man, there's just a few things that are just straight up wacky and uncharacteristic. Also I am working to get some more interesting new symptoms for virology, to counteract this one unfortunate outlier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
del: Reverts #1087
del: Removed Autophagocytosis Necrosis Zombie Threshold.
del: Removes most of the other Zombie Related Stuff from Zesko's PRs for this symptom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
