### PR TITLE
Fixes issue examining modular computer with a printer

### DIFF
--- a/code/modules/modular_computers/computers/_modular_computer_shared.dm
+++ b/code/modules/modular_computers/computers/_modular_computer_shared.dm
@@ -61,4 +61,4 @@
 	if(printer_slot)
 		. += "It has a printer installed."
 		if(user_is_adjacent)
-			. += "The printer's paper levels are at: [printer_slot.stored_paper]/[printer_slot.max_paper].</span>]"
+			. += "The printer's paper levels are at: [printer_slot.stored_paper]/[printer_slot.max_paper].</span>"


### PR DESCRIPTION
:cl:
fix: removed a rogue closing square bracket from modular computer examine
/:cl: