### PR TITLE
Fixes being able to flash genetically blind people.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -309,7 +309,8 @@
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
 	if(!eyes) //can't flash what can't see!
 		return
-
+	if(HAS_TRAIT(src, TRAIT_BLIND)	// Ditto
+		return
 	. = ..()
 
 	var/damage = intensity - get_eye_protection()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -309,7 +309,7 @@
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
 	if(!eyes) //can't flash what can't see!
 		return
-	if(HAS_TRAIT(src, TRAIT_BLIND)	// Ditto
+	if(HAS_TRAIT(src, TRAIT_BLIND))	// Ditto
 		return
 	. = ..()
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -307,7 +307,7 @@
 	if(NOFLASH in dna?.species?.species_traits)
 		return
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
-	if(!eyes) //can't flash what can't see!
+	if(!eyes || HAS_TRAIT(src, TRAIT_BLIND)) //can't flash what can't see!
 		return
 	if(HAS_TRAIT(src, TRAIT_BLIND))	// Ditto
 		return

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -309,8 +309,6 @@
 	var/obj/item/organ/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
 	if(!eyes || HAS_TRAIT(src, TRAIT_BLIND)) //can't flash what can't see!
 		return
-	if(HAS_TRAIT(src, TRAIT_BLIND))	// Ditto
-		return
 	. = ..()
 
 	var/damage = intensity - get_eye_protection()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Flash considers if someone is missing eyes, however does not consider if the eyes can actually see. This makes flashes unable to blind blind people.

## Why It's Good For The Game

Fixes a small inconsistency in flashes.

## Changelog
:cl:
fix: You can no longer flash blind people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
