### PR TITLE
[PORT] Removes rad immunity trait from IPCs and gives them NSV's radiation interaction

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -104,6 +104,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_RESISTHIGHPRESSURE	"resist_high_pressure"
 #define TRAIT_RESISTLOWPRESSURE	"resist_low_pressure"
 #define TRAIT_RADIMMUNE			"rad_immunity"
+#define TRAIT_MUTATEIMMUNE		"mutate_immune" // makes IPCs immune to mutations
+#define TRAIT_IPCRADBRAINDAMAGE	"rad_brain_damage" // causes IPCs to take brain damage when irradiated
 #define TRAIT_VIRUSIMMUNE		"virus_immunity"
 #define TRAIT_PIERCEIMMUNE		"pierce_immunity"
 #define TRAIT_NODISMEMBER		"dismember_immunity"

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -33,7 +33,7 @@
 	if(prob(40))
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			if(H.dna && !HAS_TRAIT(H, TRAIT_RADIMMUNE))
+			if(H.dna && !(HAS_TRAIT(H, TRAIT_RADIMMUNE) || HAS_TRAIT(H, TRAIT_MUTATEIMMUNE))) // don't add mutations to species that are immune, IPCs
 				if(prob(max(0,100-resist)))
 					H.randmuti()
 					if(prob(50))
@@ -42,6 +42,28 @@
 						else
 							H.easy_randmut(POSITIVE)
 						H.domutcheck()
+				if(HAS_TRAIT(H, TRAIT_IPCRADBRAINDAMAGE)) // instead, give IPCs brain damage
+					if(prob(max(0,100-resist)))
+						if(prob(50))
+							var/trauma_type = pickweight(list(
+								BRAIN_TRAUMA_MILD = 65,
+								BRAIN_TRAUMA_SEVERE = 30,
+								BRAIN_TRAUMA_SPECIAL = 5
+							))
+							var/resistance = pick(
+								50;TRAUMA_RESILIENCE_BASIC,
+								30;TRAUMA_RESILIENCE_SURGERY,
+								15;TRAUMA_RESILIENCE_LOBOTOMY,
+								5;TRAUMA_RESILIENCE_MAGIC
+							)
+							H.gain_trauma_type(trauma_type,resistance)
+
+							var/emote_type = pickweight(list(
+								"beep" = 34,
+								"buzz" = 34,
+								"buzz2" = 34,
+							))
+							H.emote(emote_type)
 		L.rad_act(20)
 
 /datum/weather/rad_storm/end()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1182,14 +1182,37 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		to_chat(H, "<span class='danger'>You feel weak.</span>")
 
 	if(radiation > RAD_MOB_VOMIT && prob(RAD_MOB_VOMIT_PROB))
-		H.vomit(10, TRUE)
+		var/obj/item/organ/stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+		if(!(H.getorgan(/obj/item/organ/stomach) && stomach.organ_flags == ORGAN_SYNTHETIC)) // synthetics can't vomit
+			H.vomit(10, TRUE)
 
-	if(radiation > RAD_MOB_MUTATE)
+	if(!HAS_TRAIT(H, TRAIT_MUTATEIMMUNE) && radiation > RAD_MOB_MUTATE) // ipcs will get brain damage rather than mutations when exposed to radiation
 		if(prob(1))
 			to_chat(H, "<span class='danger'>You mutate!</span>")
 			H.easy_randmut(NEGATIVE+MINOR_NEGATIVE)
 			H.emote("gasp")
 			H.domutcheck()
+	if(HAS_TRAIT(H, TRAIT_IPCRADBRAINDAMAGE) && radiation > RAD_MOB_MUTATE)
+		if(prob(1))
+			to_chat(H, "<span class='danger'>Your system produces an error!</span>")
+			var/trauma_type = pickweight(list(
+				BRAIN_TRAUMA_MILD = 65,
+				BRAIN_TRAUMA_SEVERE = 30,
+				BRAIN_TRAUMA_SPECIAL = 5
+			))
+			var/resistance = pick(
+				50;TRAUMA_RESILIENCE_BASIC,
+				30;TRAUMA_RESILIENCE_SURGERY,
+				15;TRAUMA_RESILIENCE_LOBOTOMY,
+				5;TRAUMA_RESILIENCE_MAGIC
+			)
+			H.gain_trauma_type(trauma_type, resistance)
+			var/emote_type = pickweight(list(
+				"beep" = 34,
+				"buzz" = 34,
+				"buzz2" = 34,
+			))
+			H.emote(emote_type)
 
 	if(radiation > RAD_MOB_HAIRLOSS)
 		if(prob(15) && !(H.hair_style == "Bald") && (HAIR in species_traits))

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -4,7 +4,7 @@
 	say_mod = "states" //inherited from a user's real species
 	sexes = 0
 	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,TRAIT_EASYDISMEMBER,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH) //all of these + whatever we inherit from the real species
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE)
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE,TRAIT_MUTATEIMMUNE,TRAIT_IPCRADBRAINDAMAGE,TRAIT_TOXIMMUNE)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutant_brain = /obj/item/organ/brain/positron
 	mutanteyes = /obj/item/organ/eyes/robotic

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -4,7 +4,7 @@
 	say_mod = "states" //inherited from a user's real species
 	sexes = 0
 	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,TRAIT_EASYDISMEMBER,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH) //all of these + whatever we inherit from the real species
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE)
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutant_brain = /obj/item/organ/brain/positron
 	mutanteyes = /obj/item/organ/eyes/robotic

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -379,7 +379,7 @@
 				dna.remove_mutation(HM.type)
 
 	radiation -= min(radiation, RAD_LOSS_PER_TICK)
-	if(radiation > RAD_MOB_SAFE)
+	if(!(TRAIT_TOXIMMUNE in dna.species.inherent_traits) && radiation > RAD_MOB_SAFE) // don't deal tox damage if they're immune
 		adjustToxLoss(log(radiation-RAD_MOB_SAFE)*RAD_TOX_COEFFICIENT)
 
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -487,6 +487,19 @@
 			C.cure_trauma_type(BRAIN_TRAUMA_MILD)
 	..()
 
+/datum/reagent/medicine/radioactive_disinfectant
+	name = "Radioactive Disinfectant"
+	description = "Removes irradiation in synthetics."
+	color = "#806F42"
+	taste_description = "metallic"
+	process_flags = SYNTHETIC
+
+/datum/reagent/medicine/radioactive_disinfectant/on_mob_life(mob/living/carbon/M)
+	// potassium iodide for synthetics
+	if(M.radiation > 0)
+		M.radiation -= min(M.radiation, 8)
+	..()
+
 /datum/reagent/medicine/omnizine
 	name = "Omnizine"
 	description = "Slowly heals all damage types. Overdose will cause damage in all types instead."

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -298,6 +298,12 @@
 	required_temp = 370
 	mix_message = "The mixture becomes a metallic slurry."
 
+/datum/chemical_reaction/radioactive_disinfectant
+	name = "Radioactive Disinfectant"
+	id = /datum/reagent/medicine/radioactive_disinfectant
+	results = list(/datum/reagent/medicine/radioactive_disinfectant = 5)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 5, /datum/reagent/phenol = 1, /datum/reagent/iodine = 1, /datum/reagent/water = 1)
+
 /datum/chemical_reaction/carthatoline
 	name = "Carthatoline"
 	id = "carthatoline"

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -15,7 +15,6 @@ endmap
 map boxstation
 	maxplayers 60
 	votable
-	disabled
 endmap
 
 map metastation

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -15,6 +15,7 @@ endmap
 map boxstation
 	maxplayers 60
 	votable
+	disabled
 endmap
 
 map metastation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports [#1144](https://github.com/BeeStation/NSV13/pull/1144) from NSV
for whatever reason, IPCs are the only "silicon" type mob that are immune to rads. Not even borgs, drones, or AIs are immune. Why the hell are IPCs rad immune? Kinda dumb.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Means IPCs can't just tank massive radiation and shrug it off. Makes more sense mechanically as they're just borgs with hands and more freedom.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
port: adds IPC radiation interaction from NSV
balance: removed IPC's rad-immune trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
