### PR TITLE
Standarizes coldroom tiles, removes roundstart cold tile.

### DIFF
--- a/_maps/RandomRooms/5x4/sk_rdm124_oldcryoroom.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm124_oldcryoroom.dmm
@@ -3,13 +3,13 @@
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "b" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "c" = (
 /obj/effect/turf_decal/stripes/line{
@@ -17,7 +17,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "d" = (
 /obj/structure/showcase/machinery/cloning_pod,
@@ -29,11 +29,11 @@
 /obj/effect/turf_decal/bot_red,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "f" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "g" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -46,7 +46,7 @@
 "h" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trap/reusable,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "i" = (
 /obj/item/wrench/medical,
@@ -59,18 +59,18 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "k" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/effect/turf_decal/stripes/end{
-	icon_state = "warn_end";
-	dir = 4
+	dir = 4;
+	icon_state = "warn_end"
 	},
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "l" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -78,7 +78,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "m" = (
 /obj/machinery/stasis,
@@ -95,26 +95,26 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "o" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "p" = (
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "q" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/template_noop)
 "r" = (
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/RandomZLevels/TheFactory.dmm
+++ b/_maps/RandomZLevels/TheFactory.dmm
@@ -1268,9 +1268,7 @@
 	health = 150;
 	zombiejob = "Janitor"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "bjM" = (
 /obj/item/stack/ore/bananium,
@@ -1938,9 +1936,7 @@
 /obj/item/chair,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "bTM" = (
 /obj/structure/bed,
@@ -2465,9 +2461,7 @@
 	icon_state = "floor3-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "cvq" = (
 /obj/structure/table/wood/poker,
@@ -4080,9 +4074,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "dRE" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4493,9 +4485,7 @@
 	icon_state = "floor2"
 	},
 /obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "enI" = (
 /obj/machinery/camera{
@@ -4598,9 +4588,7 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "esd" = (
 /obj/structure/window/reinforced/spawner,
@@ -5485,9 +5473,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "fbF" = (
 /obj/structure/table,
@@ -5900,18 +5886,14 @@
 /obj/effect/decal/cleanable/chem_pile,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "ftR" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fum" = (
 /obj/effect/decal/cleanable/blood,
@@ -5939,9 +5921,7 @@
 	icon_state = "floor5-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fvv" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide{
@@ -6005,9 +5985,7 @@
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "fzg" = (
 /obj/item/clothing/shoes/sandal,
@@ -6030,9 +6008,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "fzH" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide{
@@ -6050,9 +6026,7 @@
 	icon_state = "floor2-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fAc" = (
 /obj/effect/rune/narsie{
@@ -6063,9 +6037,7 @@
 	icon_state = "floor3-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fBb" = (
 /obj/structure/kitchenspike,
@@ -6077,9 +6049,7 @@
 	icon_state = "floor2-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fBf" = (
 /obj/machinery/portable_atmospherics/canister/bz{
@@ -6169,9 +6139,7 @@
 	icon_state = "bubblegumfoot"
 	},
 /obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "fEE" = (
 /obj/item/clothing/head/helmet/skull,
@@ -6192,9 +6160,7 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor3"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "fEZ" = (
 /obj/effect/decal/cleanable/vomit,
@@ -6220,9 +6186,7 @@
 "fGa" = (
 /obj/item/bodypart/chest,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "fGp" = (
 /obj/structure/table/wood,
@@ -6266,9 +6230,7 @@
 	icon_state = "ert";
 	name = "\proper level three access ID card"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fIh" = (
 /obj/structure/closet/crate/bin,
@@ -6287,9 +6249,7 @@
 	icon_state = "floor3-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fKS" = (
 /obj/structure/closet/body_bag{
@@ -6439,9 +6399,7 @@
 	icon_state = "floor2"
 	},
 /obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "fRJ" = (
 /obj/structure/reagent_dispensers/plumbed,
@@ -6550,9 +6508,7 @@
 	icon_state = "floor5-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fWU" = (
 /obj/structure/chair/noose,
@@ -6562,9 +6518,7 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor3"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "fWZ" = (
 /obj/structure/kitchenspike,
@@ -6573,9 +6527,7 @@
 	icon_state = "floor2-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "fXb" = (
 /obj/item/clothing/glasses/science/sciencesun,
@@ -6679,9 +6631,7 @@
 	wander = 0;
 	zombiejob = "Assistant"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "gdS" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -6733,9 +6683,7 @@
 /area/awaymission/factory/secret)
 "gfm" = (
 /obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "gfu" = (
 /obj/item/clothing/glasses/science/sciencesun,
@@ -6812,9 +6760,7 @@
 	icon_state = "floor4-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "gkt" = (
 /obj/item/shard{
@@ -6831,9 +6777,7 @@
 	icon_state = "floor2-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "gkS" = (
 /obj/machinery/power/floodlight{
@@ -7045,9 +6989,7 @@
 /obj/item/organ/tongue/lizard,
 /obj/item/organ/tongue,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "gvi" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -7055,9 +6997,7 @@
 	},
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "gvo" = (
 /obj/item/ammo_casing/shotgun/buckshot{
@@ -7206,9 +7146,7 @@
 	icon_state = "floor3"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "gBo" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -7243,9 +7181,7 @@
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "gEB" = (
 /obj/structure/chair/wood/normal,
@@ -7271,9 +7207,7 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "gFD" = (
 /obj/machinery/vending/cola/random,
@@ -7813,9 +7747,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "heB" = (
 /turf/open/floor/plasteel/dark,
@@ -8879,9 +8811,7 @@
 /obj/item/bodypart/r_leg,
 /obj/item/bodypart/l_leg,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "hTA" = (
 /obj/structure/closet,
@@ -10768,9 +10698,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "jwr" = (
 /obj/structure/table/reinforced,
@@ -12108,9 +12036,7 @@
 "kLN" = (
 /obj/item/bodypart/chest,
 /obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "kMo" = (
 /obj/machinery/door/airlock/freezer,
@@ -12144,9 +12070,7 @@
 "kOr" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/three_course_meal,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "kOv" = (
 /obj/structure/closet/crate/coffin,
@@ -12312,18 +12236,14 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/camera,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "kVd" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor5-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "kVo" = (
 /obj/machinery/light,
@@ -12489,17 +12409,13 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor2"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lfb" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor2"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lfh" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -12520,16 +12436,12 @@
 /area/awaymission/factory/factoryafter/down/maint)
 "lfE" = (
 /obj/machinery/camera,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lgl" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lgG" = (
 /obj/structure/cable{
@@ -12739,18 +12651,14 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/chair/noose,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lpp" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lpM" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -12760,9 +12668,7 @@
 /obj/structure/chair/noose,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lpT" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -12771,9 +12677,7 @@
 /obj/structure/chair/noose,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lqW" = (
 /obj/effect/decal/remains/human,
@@ -12813,9 +12717,7 @@
 /obj/structure/chair/noose,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lsB" = (
 /obj/structure/stone_tile/burnt,
@@ -12855,9 +12757,7 @@
 "lww" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lwC" = (
 /obj/structure/cable,
@@ -13021,9 +12921,7 @@
 /area/awaymission/factory/factoryafter/down/levelthree)
 "lCp" = (
 /obj/structure/chair/noose,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lCs" = (
 /mob/living/simple_animal/hostile/zombie{
@@ -13034,9 +12932,7 @@
 	wander = 0;
 	zombiejob = "Cook"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lCT" = (
 /obj/item/circuitboard/computer/prototype_cloning,
@@ -13051,9 +12947,7 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor3"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lDg" = (
 /obj/structure/chair/noose,
@@ -13061,9 +12955,7 @@
 /obj/effect/decal/cleanable/blood{
 	icon_state = "floor2"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lDK" = (
 /turf/closed/wall/mineral/wood/nonmetal,
@@ -13265,23 +13157,17 @@
 "lKD" = (
 /obj/item/bodypart/l_arm,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lKP" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/item/chair,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lKZ" = (
 /obj/item/bodypart/l_arm,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lLK" = (
 /obj/structure/chair/wood{
@@ -13291,9 +13177,7 @@
 /area/awaymission/factory/villageduring/house)
 "lLZ" = (
 /obj/item/chair,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lMk" = (
 /obj/item/chair{
@@ -13329,13 +13213,6 @@
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
-	},
-/area/awaymission/factory/factoryafter/down/leveltwo)
-"lNE" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "lNP" = (
@@ -13397,9 +13274,7 @@
 "lQY" = (
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lRf" = (
 /obj/structure/closet/firecloset/full,
@@ -13477,9 +13352,7 @@
 	icon_state = "floor5-old"
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "lTn" = (
 /obj/structure/table/wood,
@@ -13788,9 +13661,7 @@
 /area/awaymission/factory/villageduring/house)
 "mhD" = (
 /obj/effect/gibspawner/human,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "mib" = (
 /obj/item/clothing/gloves/color/brown/cargo,
@@ -15507,9 +15378,7 @@
 "nzJ" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "nzT" = (
 /obj/structure/spawner/nether{
@@ -16118,9 +15987,7 @@
 	icon_state = "floor4-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "nZb" = (
 /obj/item/pen,
@@ -17048,11 +16915,6 @@
 	},
 /turf/open/floor/circuit/off,
 /area/awaymission/factory/factoryafter/down/levelthree)
-"oIg" = (
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
-/area/awaymission/factory/factoryduring/down/leveltwo)
 "oIn" = (
 /obj/item/ammo_casing/c45{
 	caliber = null;
@@ -17703,9 +17565,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "peL" = (
 /obj/effect/decal/cleanable/crayon{
@@ -18235,9 +18095,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "pwP" = (
 /obj/structure/table/reinforced,
@@ -20283,12 +20141,6 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/open/floor/plasteel,
 /area/awaymission/factory/factoryduring/down/leveltwo)
-"qZa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
-/area/awaymission/factory/factoryafter/down/leveltwo)
 "qZc" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/ballistic/automatic/pistol/m1911,
@@ -21815,9 +21667,7 @@
 /turf/open/floor/circuit/off,
 /area/awaymission/factory/factoryafter/down/levelthree/engine)
 "sjE" = (
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "sjV" = (
 /obj/machinery/shower{
@@ -22131,9 +21981,7 @@
 	dir = 4
 	},
 /obj/effect/gibspawner/human,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "syL" = (
 /obj/structure/sink{
@@ -22304,9 +22152,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "sCO" = (
 /obj/effect/decal/remains/robot,
@@ -22806,9 +22652,7 @@
 /obj/structure/chair/noose,
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "sTu" = (
 /obj/structure/lattice/catwalk/over,
@@ -23607,9 +23451,7 @@
 	icon_state = "floor2-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "tBm" = (
 /obj/structure/table,
@@ -24148,9 +23990,7 @@
 "uef" = (
 /obj/machinery/gibber,
 /obj/effect/gibspawner/human,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo)
 "ueo" = (
 /obj/structure/table/wood,
@@ -25833,9 +25673,7 @@
 /area/awaymission/factory/villageafter/house/ritual)
 "vpP" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "vqq" = (
 /turf/closed/wall/rust,
@@ -26012,9 +25850,7 @@
 	icon_state = "floor3"
 	},
 /obj/effect/decal/cleanable/chem_pile,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryduring/down/leveltwo/ritual)
 "vyk" = (
 /obj/structure/table,
@@ -26426,9 +26262,7 @@
 	icon_state = "floor3-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "vJa" = (
 /obj/structure/mineral_door/wood,
@@ -28301,9 +28135,7 @@
 /obj/effect/decal/cleanable/blood/gibs/torso,
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "xnl" = (
 /obj/structure/frame/computer,
@@ -28358,9 +28190,7 @@
 	icon_state = "floor5-old"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo/ritual)
 "xrD" = (
 /obj/structure/table,
@@ -28679,9 +28509,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/item/reagent_containers/food/snacks/meat/slab,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor{
-	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
-	},
+/turf/open/floor/plasteel/freezer,
 /area/awaymission/factory/factoryafter/down/leveltwo)
 "xEA" = (
 /turf/open/floor/plating/ashplanet/wateryrock{
@@ -36279,7 +36107,7 @@ qvG
 jCC
 bVd
 kMo
-qZa
+irG
 lpp
 hTt
 hdN
@@ -37053,7 +36881,7 @@ bwJ
 kUZ
 lsr
 lKD
-lNE
+lxQ
 hdI
 iFI
 qKh
@@ -37310,7 +37138,7 @@ kMo
 kVd
 lww
 lKP
-qZa
+irG
 hdI
 iFI
 qKh
@@ -37567,7 +37395,7 @@ bwJ
 xEo
 bTn
 tBh
-qZa
+irG
 hdI
 iFI
 phj
@@ -66607,7 +66435,7 @@ tor
 nBY
 fbB
 fWU
-oIg
+tcn
 mhD
 nBY
 ubo

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13639,7 +13639,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aKD" = (
 /obj/structure/disposalpipe/segment,
@@ -13768,7 +13768,7 @@
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aKV" = (
 /obj/machinery/door/window/southleft{
@@ -14222,7 +14222,7 @@
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aMm" = (
 /obj/machinery/firealarm{
@@ -14342,7 +14342,7 @@
 /area/crew_quarters/bar)
 "aMD" = (
 /obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aME" = (
 /obj/structure/disposalpipe/segment{
@@ -14357,7 +14357,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMF" = (
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aMG" = (
 /obj/structure/closet/crate/hydroponics,
@@ -14725,14 +14725,14 @@
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aNM" = (
 /obj/structure/kitchenspike,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aNN" = (
 /obj/machinery/door/airlock/public/glass{
@@ -14759,7 +14759,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aNP" = (
 /obj/structure/disposalpipe/segment,
@@ -15032,7 +15032,7 @@
 /area/crew_quarters/theatre)
 "aOI" = (
 /obj/structure/kitchenspike,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aOJ" = (
 /obj/structure/window/reinforced,
@@ -15060,7 +15060,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aON" = (
 /obj/structure/disposalpipe/segment,
@@ -15068,7 +15068,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aOO" = (
 /obj/machinery/door/airlock{
@@ -15107,7 +15107,7 @@
 /area/library)
 "aOT" = (
 /obj/machinery/gibber,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aOU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -15559,7 +15559,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aQm" = (
 /obj/effect/turf_decal/tile/green{
@@ -49472,7 +49472,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "gRK" = (
 /obj/machinery/door/airlock/command/glass{
@@ -50843,7 +50843,7 @@
 "iNn" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/machinery/camera/autoname,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "iRx" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -57818,7 +57818,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "ryW" = (
 /obj/structure/cable/yellow{
@@ -59595,7 +59595,7 @@
 /area/tcommsat/computer)
 "tMl" = (
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "tMn" = (
 /obj/structure/cable/yellow{

--- a/_maps/map_files/Donutstation/Donutstation.dmm
+++ b/_maps/map_files/Donutstation/Donutstation.dmm
@@ -25774,7 +25774,7 @@
 /area/security/main)
 "bgp" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bgq" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -25808,13 +25808,13 @@
 	name = "Kitchen Cold Room";
 	req_access_txt = "28"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bgu" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bgv" = (
 /obj/effect/turf_decal/tile/bar{
@@ -25840,7 +25840,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bgy" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -25965,7 +25965,7 @@
 /obj/machinery/airalarm/kitchen_cold_room{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bgK" = (
 /obj/structure/table/wood,
@@ -26148,14 +26148,14 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bhf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /obj/machinery/icecream_vat,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bhg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26167,7 +26167,7 @@
 /area/engine/atmos)
 "bhi" = (
 /obj/machinery/gibber,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bhj" = (
 /obj/machinery/power/apc{
@@ -26312,7 +26312,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
 	dir = 4
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bhy" = (
 /obj/structure/chair/stool,
@@ -26679,7 +26679,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bik" = (
 /obj/structure/disposalpipe/segment,
@@ -26706,7 +26706,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bio" = (
 /obj/structure/lattice/catwalk,
@@ -26740,7 +26740,7 @@
 	pixel_y = -32
 	},
 /obj/structure/kitchenspike,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "bis" = (
 /obj/structure/cable/yellow{
@@ -31594,7 +31594,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/maintenance/port/aft)
 "brz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -51059,11 +51059,11 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 4
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "dwg" = (
 /obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "dxJ" = (
 /obj/structure/closet/wardrobe/science_white,
@@ -51332,7 +51332,7 @@
 "esU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "etl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -51743,7 +51743,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "fzV" = (
 /obj/machinery/button/door{
@@ -53398,7 +53398,7 @@
 /area/engine/engine_room)
 "lEx" = (
 /obj/machinery/chem_master/condimaster,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "lEO" = (
 /obj/structure/cable/yellow{
@@ -53948,7 +53948,7 @@
 /area/medical/medbay/central)
 "nuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "nvs" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -54158,7 +54158,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "nUo" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -54688,7 +54688,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "pBI" = (
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "pGQ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -54964,7 +54964,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "qBm" = (
 /obj/structure/table,
@@ -56775,7 +56775,7 @@
 	dir = 2;
 	pixel_y = -28
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "wtu" = (
 /obj/structure/bed,
@@ -57089,7 +57089,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/coldroom)
 "xyU" = (
 /obj/structure/window/reinforced{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -47780,15 +47780,15 @@
 	pixel_x = -27
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bNF" = (
 /obj/machinery/gibber,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bNG" = (
 /obj/structure/kitchenspike,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bNI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48410,7 +48410,7 @@
 /area/crew_quarters/kitchen)
 "bOX" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bOY" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -48429,13 +48429,13 @@
 	name = "CondiMaster Neo";
 	pixel_x = -4
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bPa" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bPb" = (
 /obj/structure/table/wood,
@@ -49185,11 +49185,11 @@
 /area/crew_quarters/kitchen)
 "bQI" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bQJ" = (
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bQN" = (
 /obj/machinery/airalarm{
@@ -49766,7 +49766,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bRY" = (
 /obj/structure/disposalpipe/segment{
@@ -49783,7 +49783,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bRZ" = (
 /obj/structure/disposalpipe/segment{
@@ -49796,7 +49796,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bSa" = (
 /obj/structure/disposalpipe/segment{
@@ -49805,7 +49805,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bSd" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -50235,7 +50235,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/kitchen_coldroom,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bSY" = (
 /obj/structure/disposalpipe/segment,
@@ -50248,7 +50248,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/kitchen_coldroom,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bSZ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -50895,7 +50895,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/kitchen_coldroom,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bUq" = (
 /obj/structure/disposalpipe/segment{
@@ -50907,7 +50907,7 @@
 	req_access_txt = "28"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/kitchen_coldroom,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bUr" = (
 /obj/machinery/navbeacon{
@@ -53348,7 +53348,7 @@
 "bZx" = (
 /obj/machinery/icecream_vat,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bZy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -56731,7 +56731,7 @@
 	},
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "cgG" = (
 /obj/structure/closet/emcloset/anchored,
@@ -82354,7 +82354,7 @@
 	name = "old sink";
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "fBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -85498,7 +85498,7 @@
 /turf/open/floor/plating,
 /area/science/shuttledock)
 "rFZ" = (
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "rHt" = (
 /obj/effect/spawner/structure/window/reinforced,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -19652,14 +19652,14 @@
 	name = "CondiMaster Neo";
 	pixel_x = -4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aSJ" = (
 /obj/machinery/gibber,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aSK" = (
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aSL" = (
 /obj/machinery/navbeacon{
@@ -19674,30 +19674,10 @@
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "aSM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/maintenance/department/crew_quarters/bar)
 "aSN" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -20244,7 +20224,7 @@
 /obj/structure/kitchenspike,
 /obj/item/assembly/mousetrap,
 /obj/item/reagent_containers/food/snacks/deadmouse,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aTY" = (
 /obj/structure/cable/yellow{
@@ -20253,7 +20233,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aTZ" = (
 /obj/machinery/camera{
@@ -20268,7 +20248,7 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aUa" = (
 /obj/structure/extinguisher_cabinet{
@@ -20276,7 +20256,7 @@
 	},
 /obj/item/crowbar,
 /obj/item/wrench,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aUb" = (
 /obj/structure/plasticflaps/opaque,
@@ -20730,23 +20710,23 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aUY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aUZ" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aVa" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aVb" = (
 /obj/machinery/light{
@@ -20757,7 +20737,7 @@
 	pixel_x = 23
 	},
 /obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aVc" = (
 /obj/machinery/door/window/southleft{
@@ -21209,7 +21189,7 @@
 /area/hydroponics)
 "aVW" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aVX" = (
 /obj/machinery/power/apc{
@@ -21218,13 +21198,13 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aVY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aVZ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -21233,7 +21213,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aWa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -21671,17 +21651,17 @@
 /area/hydroponics)
 "aWU" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aWV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aWW" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aWX" = (
 /obj/structure/disposalpipe/segment{
@@ -22181,7 +22161,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aYb" = (
 /obj/machinery/door/airlock{

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -161,7 +161,6 @@
 #define TCOMMS_ATMOS				"n2=100;TEMP=80" //-193,15°C telecommunications. also used for xenobiology slime killrooms
 #define AIRLESS_ATMOS				"TEMP=2.7" //space
 #define FROZEN_ATMOS				"o2=22;n2=82;TEMP=180" //-93.15°C snow and ice turfs
-#define KITCHEN_COLDROOM_ATMOS		"o2=25;n2=96;TEMP=253.15" //-20°C kitchen coldroom; higher amount of mol to reach about 101.3 kpA
 #define BURNMIX_ATMOS				"o2=100;plasma=200;TEMP=370" //used in the holodeck burn test program
 
 //ATMOSPHERICS DEPARTMENT GAS TANK TURFS

--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -88,14 +88,6 @@
 	initial_gas_mix = AIRLESS_ATMOS
 
 
-/turf/open/floor/plasteel/kitchen_coldroom
-	name = "cold room floor"
-	initial_gas_mix = KITCHEN_COLDROOM_ATMOS
-
-/turf/open/floor/plasteel/kitchen_coldroom/freezerfloor
-	icon_state = "freezerfloor"
-
-
 /turf/open/floor/plasteel/grimy
 	icon_state = "grimy"
 	tiled_dirt = FALSE

--- a/code/modules/antagonists/clock_cult/scriptures/hateful_manacles.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/hateful_manacles.dm
@@ -8,7 +8,7 @@
 	button_icon_state = "Hateful Manacles"
 	power_cost = 25
 	invokation_time = 15
-	invokation_text = list("Shackle the heretic...", "...Break them in body and spirit!")
+	invokation_text = list("Shackle the heretic...", "... Break them in body and spirit!")
 	slab_overlay = "hateful_manacles"
 	use_time = 200
 	cogs_required = 0

--- a/code/modules/antagonists/clock_cult/scriptures/hateful_manacles.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/hateful_manacles.dm
@@ -8,7 +8,7 @@
 	button_icon_state = "Hateful Manacles"
 	power_cost = 25
 	invokation_time = 15
-	invokation_text = list("Shackle the heretic...", "... Break them in body and spirit!")
+	invokation_text = list("Shackle the heretic...", "...Break them in body and spirit!")
 	slab_overlay = "hateful_manacles"
 	use_time = 200
 	cogs_required = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All coldrooms have the same tiles (/freezer).
Removes roundstart cold tiles and replaces them on all of the maps that were using them (donut too).

## Why It's Good For The Game

No more space wind and air alarms freaking out.

## Changelog
:cl:
tweak: Replaced tiles in metastation freezer room with less cold ones.
del: Removed roundstart cold tiles and replaced them with /freezer tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
