### PR TITLE
Small Airlock refactor and animation time changes for specific airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -91,7 +91,7 @@
 	var/mask_file = 'icons/obj/doors/airlocks/mask_32x32.dmi' // because filters aren't allowed to have icon_states :(
 	var/mask_x = 0
 	var/mask_y = 0
-	var/anim_parts = "left=-14,0;right=13,0"
+	var/anim_parts = "left=-14,0;right=13,0" //format is "left = open_px, open_py, move_start_time, move_end_time, aperture_angle" Important: move_end_time = 0 as example will not work in this case as its not an actual associ value
 	var/list/part_overlays
 	var/panel_attachment = "right"
 	var/note_attachment = "left"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -91,7 +91,7 @@
 	var/mask_file = 'icons/obj/doors/airlocks/mask_32x32.dmi' // because filters aren't allowed to have icon_states :(
 	var/mask_x = 0
 	var/mask_y = 0
-	var/anim_parts = "left=-14,0;right=13,0" //format is "left = open_px, open_py, move_start_time, move_end_time, aperture_angle" Important: move_end_time = 0 as example will not work in this case as its not an actual associ value
+	var/anim_parts = "left=-14,0;right=13,0" //format is "airlock_part = open_px, open_py, move_start_time, move_end_time, aperture_angle" Important: move_end_time = 0 as example will not work in this case as its not an actual associ value
 	var/list/part_overlays
 	var/panel_attachment = "right"
 	var/note_attachment = "left"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -562,7 +562,7 @@
 					part.transform = T
 				if(AIRLOCK_CLOSING)
 					part.transform = T
-					animate(part, transform = T, time = 3.5 - part.move_end_time, flags = ANIMATION_LINEAR_TRANSFORM)
+					animate(part, transform = T, time = initial(part.move_end_time) - part.move_end_time, flags = ANIMATION_LINEAR_TRANSFORM)
 					animate(transform = matrix(), time = part.move_end_time - part.move_start_time, flags = ANIMATION_LINEAR_TRANSFORM)
 				if(AIRLOCK_OPENING)
 					part.transform = matrix()
@@ -579,7 +579,7 @@
 				if(AIRLOCK_CLOSING)
 					part.pixel_x = part.open_px
 					part.pixel_y = part.open_py
-					animate(part, pixel_x = part.open_px, pixel_y = part.open_py, time = 3.5 - part.move_end_time)
+					animate(part, pixel_x = part.open_px, pixel_y = part.open_py, time = initial(part.move_end_time) - part.move_end_time)
 					animate(pixel_x = 0, pixel_y = 0, time = part.move_end_time - part.move_start_time)
 				if(AIRLOCK_OPENING)
 					part.pixel_x = 0

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -91,7 +91,7 @@
 	var/mask_file = 'icons/obj/doors/airlocks/mask_32x32.dmi' // because filters aren't allowed to have icon_states :(
 	var/mask_x = 0
 	var/mask_y = 0
-	var/anim_parts = "left=-14,0;right=13,0" //format is "airlock_part = open_px, open_py, move_start_time, move_end_time, aperture_angle" Important: move_end_time = 0 as example will not work in this case as its not an actual associ value
+	var/anim_parts = "left=-14,0;right=13,0" //format is "airlock_part=open_px,open_py,move_start_time,move_end_time,aperture_angle"
 	var/list/part_overlays
 	var/panel_attachment = "right"
 	var/note_attachment = "left"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -192,7 +192,7 @@
 		P.icon_state = part_id
 		P.name = name
 		door_time += P.move_end_time
-	open_speed = max(door_time) - 1 //calculates the open_speed directly out of the animation time
+	open_speed = max(door_time) //open_speed is max animation time
 	add_filter("mask_filter", 1, list(type="alpha",icon=mask_file,x=mask_x,y=mask_y))
 
 /obj/machinery/door/airlock/proc/update_other_id()
@@ -564,7 +564,7 @@
 					part.transform = T
 				if(AIRLOCK_CLOSING)
 					part.transform = T
-					animate(part, transform = T, time = initial(part.move_end_time) - part.move_end_time, flags = ANIMATION_LINEAR_TRANSFORM)
+					animate(part, transform = T, time = open_speed - part.move_end_time, flags = ANIMATION_LINEAR_TRANSFORM)
 					animate(transform = matrix(), time = part.move_end_time - part.move_start_time, flags = ANIMATION_LINEAR_TRANSFORM)
 				if(AIRLOCK_OPENING)
 					part.transform = matrix()
@@ -581,7 +581,7 @@
 				if(AIRLOCK_CLOSING)
 					part.pixel_x = part.open_px
 					part.pixel_y = part.open_py
-					animate(part, pixel_x = part.open_px, pixel_y = part.open_py, time = initial(part.move_end_time) - part.move_end_time)
+					animate(part, pixel_x = part.open_px, pixel_y = part.open_py, time = open_speed - part.move_end_time)
 					animate(pixel_x = 0, pixel_y = 0, time = part.move_end_time - part.move_start_time)
 				if(AIRLOCK_OPENING)
 					part.pixel_x = 0
@@ -1181,7 +1181,7 @@
 	sleep(1)
 	set_opacity(0)
 	update_freelook_sight()
-	sleep(open_speed)
+	sleep(open_speed - 1)
 	density = FALSE
 	air_update_turf(1)
 	sleep(1)
@@ -1231,7 +1231,7 @@
 	if(!air_tight)
 		density = TRUE
 		air_update_turf(1)
-	sleep(open_speed)
+	sleep(open_speed - 1)
 	if(!safe)
 		crush()
 	if(visible && !glass)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -51,7 +51,6 @@
 	assemblytype = /obj/structure/door_assembly
 	normalspeed = 1
 	explosion_block = 1
-	open_speed = 2.5
 	hud_possible = list(DIAG_AIRLOCK_HUD)
 	var/allow_repaint = TRUE //Set to FALSE if the airlock should not be allowed to be repainted.
 
@@ -174,6 +173,7 @@
 	else
 		part_overlays = list()
 	var/list/parts_desc = params2list(anim_parts)
+	var/list/door_time = list()
 	for(var/part_id in parts_desc)
 		var/obj/effect/overlay/airlock_part/P = new
 		P.side_id = part_id
@@ -191,6 +191,8 @@
 		P.icon = icon
 		P.icon_state = part_id
 		P.name = name
+		door_time += P.move_end_time
+	open_speed = max(door_time) - 1 //calculates the open_speed directly out of the animation time
 	add_filter("mask_filter", 1, list(type="alpha",icon=mask_file,x=mask_x,y=mask_y))
 
 /obj/machinery/door/airlock/proc/update_other_id()

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -400,7 +400,7 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_hatch
 	//anim_parts = "ul=-9,9;ur=9,9;dl=-9,-9;dr=9,-9"
-	anim_parts = "ul=-15,0,0,5,-90;ur=0,15,0,5,-90;dl=0,-15,0,5,-90;dr=15,0,0,5,-90"
+	anim_parts = "ul=-15,0,0,4,-90;ur=0,15,0,4,-90;dl=0,-15,0,4,-90;dr=15,0,0,4,-90"
 	note_attachment = "ul"
 	panel_attachment = "dr"
 	allow_repaint = FALSE
@@ -412,7 +412,7 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/hatch/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_mhatch
 	//anim_parts = "ul=-9,9;ur=9,9;dl=-9,-9;dr=9,-9"
-	anim_parts = "ul=-15,0,0,5,-90;ur=0,15,0,5,-90;dl=0,-15,0,5,-90;dr=15,0,0,5,-90"
+	anim_parts = "ul=-15,0,0,4,-90;ur=0,15,0,4,-90;dl=0,-15,0,4,-90;dr=15,0,0,4,-90"
 	note_attachment = "ul"
 	panel_attachment = "dr"
 	allow_repaint = FALSE
@@ -456,7 +456,7 @@
 	overlays_file = 'icons/obj/doors/airlocks/abductor/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_abductor
 	note_overlay_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
-	anim_parts="p1=0,40,0;p2=0,24,2;p3=0,-36,0.5;p4=0,16,3;p5=0,-40,0;p6=0,32,1;p7=0,-24,2" // the door has 7 fucking parts. SEVEN.
+	anim_parts="p1=0,40,0,5;p2=0,24,2,5;p3=0,-36,0.5,5;p4=0,16,3,5;p5=0,-40,0,5;p6=0,32,1,5;p7=0,-24,2,5" // the door has 7 fucking parts. SEVEN.
 	damage_deflection = 30
 	explosion_block = 3
 	hackProof = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR replaces some magic numbers in the animation code of the airlock and implements some changes that allow different airlock speeds for specific airlocks. Said animation speed now also directly effects the actual time you can pass trough an airlock. Also there are some changes to the animation time of the hatch and the abductor airlock.
For the hatch that one already overwrote the base animation speed defined in overlays.dm so it was kinda slower then intended so hatches got a bit sped up. Abductor airlocks on the other hand got their animation speed slowed to the original intended speed before the port as it has quite a lot of moving parts and looks honestly better with that speed. https://streamable.com/xpac6p
On a sidenote turns out survival pod airlocks also where still set to the original airlock animation speed and i do not think that should change as just like the alien airlocks they look better at the original speed due to all the moving parts.

Edit: I feel the part where i say some airlocks already have custom time and then say i make them possible is a bit misleading so let me clarify.
Originally the animation time for all airlocks was 5 thus the magic number inside the animation script was also 5 but i set it during the port to 3.5 now that number would get the end time substracted from in most cases that was also 3.5 however there are exceptions for that like the mining airlocks. As those airlocks had different times then expected the resulting animation speed could differ from what was expected(like in cases where it should have returned 0 it returned -1.5). But now that this magic number is actually gone and defined in a var that also gets set in another proc for that specific airlock this difference does not really matter anymore and all the airlock animations should act as expected.



## Why It's Good For The Game


## Changelog
:cl:

refractor: replaces magic number with actual var in set_airlock_overlays
refactor: changes open_speed to be defined as the max animation time taken from all airlock parts
tweak: Changes the animation time of the hatches and the abductor airlock
tweak: animation time now directly influences how long it takes until you can pass trough the airlock

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
