### PR TITLE
nerfs sepchems

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -90,7 +90,7 @@
 	lifespan = 30
 	endurance = 25
 	mutatelist = list()
-	genes = list(/datum/plant_gene/trait/glow/berry, /datum/plant_gene/trait/noreact, /datum/plant_gene/trait/repeated_harvest)
+	genes = list(/datum/plant_gene/trait/glow/berry, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/uranium = 0.25, /datum/reagent/iodine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -15,10 +15,8 @@
 /obj/item/seeds/random/Initialize()
 	. = ..()
 	randomize_stats()
-	if(prob(60))
-		add_random_reagents(1, 3)
-	if(prob(50))
-		add_random_traits(1, 2)
+	add_random_reagents(1, 3)
+	add_random_traits(2, 3)
 	add_random_plant_type(35)
 
 /obj/item/reagent_containers/food/snacks/grown/random

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -15,8 +15,9 @@
 /obj/item/seeds/random/Initialize()
 	. = ..()
 	randomize_stats()
-	add_random_reagents(1, 3)
-	add_random_traits(2, 3)
+	if(prob(60)
+		add_random_reagents(1, 3)
+	add_random_traits(1, 2)
 	add_random_plant_type(35)
 
 /obj/item/reagent_containers/food/snacks/grown/random

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -17,7 +17,8 @@
 	randomize_stats()
 	if(prob(60)
 		add_random_reagents(1, 3)
-	add_random_traits(1, 2)
+	if(prob(50))
+		add_random_traits(2, 3)
 	add_random_plant_type(35)
 
 /obj/item/reagent_containers/food/snacks/grown/random

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -15,7 +15,7 @@
 /obj/item/seeds/random/Initialize()
 	. = ..()
 	randomize_stats()
-	if(prob(60)
+	if(prob(60))
 		add_random_reagents(1, 3)
 	if(prob(50))
 		add_random_traits(2, 3)

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -87,7 +87,7 @@
 	name = "Pack of Strange Seeds"
 	id = "random"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 5000)
+	materials = list(/datum/material/biomass = 2500)
 	build_path = /obj/item/seeds/random
 	category = list("initial", "Food")
 

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -87,7 +87,7 @@
 	name = "Pack of Strange Seeds"
 	id = "random"
 	build_type = BIOGENERATOR
-	materials = list(/datum/material/biomass = 2500)
+	materials = list(/datum/material/biomass = 5000)
 	build_path = /obj/item/seeds/random
 	category = list("initial", "Food")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

you can no longer get sepchems from glowberries. 

## Why It's Good For The Game

see: breaching rocket wheats

## Changelog
:cl:
balance: can only get sepchems from strangeseeds now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
