### PR TITLE
Reworking Zombie Powder into a unique toxin

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -171,21 +171,19 @@
 	silent_toxin = TRUE
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
-	toxpwr = 0.5
+	toxpwr = 0
 	taste_description = "death"
 
-/datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/L)
+/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/carbon/M)
+	if(current_cycle >= 10) // delayed activation for toxin
+		M.adjustStaminaLoss((current_cycle - 5)*REM, 0)
+	if(M.getStaminaLoss() >= 145) // fake death tied to stamina for interesting interactions - 23 ticks to fake death with pure ZP
+		M.fakedeath(type)
 	..()
-	L.fakedeath(type)
 
 /datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/L)
 	L.cure_fakedeath(type)
 	..()
-
-/datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/carbon/M)
-	M.adjustOxyLoss(0.5*REM, 0)
-	..()
-	. = 1
 
 /datum/reagent/toxin/ghoulpowder
 	name = "Ghoul Powder"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR turns zombie powder into a unique toxin that retains the same original flavor without being an absurdly over powered instant stun when utilized mid-combat. 

**Before:**
Zombie powder would trigger a fake death in whatever consumed it, not only functioning as an instant hardstun in combat, but also disguising a victim as a corpse for relatively inconspicuous transport. 

**Now:**
Zombie powder is a stealthy toxin which does nothing at first when it is metabolized, allowing for very effective drive-by deliveries via sleepypen or hypospray. After a little while, the toxin begins to take effect, gradually and then rapidly draining stamina. When stamina damage exceeds a certain value (after stamcrit), the fake death is triggered.

**Detailed breakdown:**
9 ticks - do nothing, no signs of poisoning at all
tick 10+ - ramping stamina damage (5, 6, 7, 8...) with stamcrit at tick 20 
145+ stamina damage (tick 23*) - fake death kicks in and lasts until reagent processing ends, where you wake up in stamcrit.

*Since the fake death is tied to stamina damage and not tick count, it may trigger earlier or later depending on outside conditions - most notably triggering instantly if forced on someone in deep stamcrit, or being delayed if the target is using stamina-regen drugs. Since the stamina damage is exponential, it will *eventually* overcome any form of regen though. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instant stuns are very feelsbad, and the game has only one other delayed activation toxin.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Zombie powder is now a delayed activation stamina toxin that triggers a fake death once the victim is in a deep stamcrit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
