### PR TITLE
Updates contractor baton

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -401,7 +401,7 @@
 //Contractor Baton
 /obj/item/melee/classic_baton/contractor_baton
 	name = "contractor baton"
-	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electrical shocks to targets."
+	desc = "A compact, specialised baton assigned to Syndicate contractors. Applies light electric shocks that can resonate with a specific targets brain frequency causing significant stunning effects."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "contractor_baton_0"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
@@ -414,6 +414,9 @@
 	force = 5
 	on = FALSE
 	var/knockdown_time_carbon = (1.5 SECONDS) // Knockdown length for carbons.
+	var/stamina_damage_non_target = 55
+	var/stamina_damage_target = 85
+	var/target_confusion = 4 SECONDS
 
 	stamina_damage = 85
 	affect_silicon = TRUE
@@ -428,7 +431,7 @@
 	force_off = 5
 	weight_class_on = WEIGHT_CLASS_NORMAL
 
-
+	var/datum/antagonist/traitor/owner_data = null
 
 /obj/item/melee/classic_baton/contractor_baton/get_wait_description()
 	return "<span class='danger'>The baton is still charging!</span>"
@@ -463,6 +466,11 @@
 /obj/item/melee/classic_baton/contractor_baton/attack(mob/living/target, mob/living/user)
 	if(!on)
 		return ..()
+
+	if(!owner_data || owner_data?.owner?.current != user)
+		return ..()
+
+	var/is_target = owner_data.contractor_hub?.current_contract?.contract?.target == target.mind
 
 	add_fingerprint(user)
 	if((HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
@@ -520,9 +528,15 @@
 				user.do_attack_animation(target)
 
 			playsound(get_turf(src), on_stun_sound, 75, 1, -1)
-			target.Knockdown(knockdown_time_carbon)
-			target.drop_all_held_items()
-			target.adjustStaminaLoss(stamina_damage)
+			if(is_target)
+				target.Knockdown(knockdown_time_carbon)
+				target.drop_all_held_items()
+				target.adjustStaminaLoss(stamina_damage)
+				if(target.confused < 6 SECONDS)
+					target.confused = min(target.confused + target_confusion, 6 SECONDS)
+			else
+				target.Knockdown(knockdown_time_carbon)
+				target.adjustStaminaLoss(stamina_damage_non_target)
 			additional_effects_carbon(target, user)
 
 			log_combat(user, target, "stunned", src)
@@ -539,6 +553,14 @@
 			var/wait_desc = get_wait_description()
 			if (wait_desc)
 				to_chat(user, wait_desc)
+
+/obj/item/melee/classic_baton/contractor_baton/pickup(mob/user)
+	. = ..()
+	if(!owner_data)
+		var/datum/antagonist/traitor/traitor_data = user.mind.has_antag_datum(/datum/antagonist/traitor)
+		if(traitor_data)
+			owner_data = traitor_data
+			to_chat(user, "<span class='notice'>[src] scans your genetic data as you pick it up, creating an uplink with the syndicate database. Attacking your current target will stun and mute them, however the baton is weak against non-targets.</span>")
 
 // Supermatter Sword
 /obj/item/melee/supermatter_sword


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the contractor baton more effective against targets, less effective against non-targets and inoperable for non-contractor.

## Why It's Good For The Game

The batong is very strong since its made for kidnapping. The problem comes when it's used to just stun and take out everyone you come across. Additionally, it's super strong when out of the contractor's hands and generally isn't as fun to be taken down by a sec wielding it.

Also I haven't died to this in the last 24 hours or like ever, but I've seen combinations of murderboning contractors and sec running around with the baton that sparked this PR. Go abduct people rather than try and take them out the game.

## Changelog
:cl:
tweak: Contractor baton now only works with the assigned contractor.
tweak: Contractor baton no longer causes non-targets to drop their held items.
tweak: Contractor baton causes the contract target to have 4 seconds of confusion when hit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
