### PR TITLE
removes ghostbuster glasses from curator kit, replaces them with ghost seeing camera

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -109,7 +109,7 @@
 	name = "Spectre Inspector - 1980's."
 
 /obj/item/storage/box/hero/ghostbuster/PopulateContents()
-	new /obj/item/clothing/glasses/welding/ghostbuster(src)
+	new /obj/item/camera/spooky(src)
 	new /obj/item/storage/belt/fannypack/bustin(src)
 	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/clothing/shoes/jackboots(src)
@@ -346,32 +346,32 @@
 	name = "mouse delivery beacon"
 	default_name = "Jerry"
 	mob_choice = /mob/living/simple_animal/mouse
-	
+
 /obj/item/choice_beacon/pet/corgi
 	name = "corgi delivery beacon"
 	default_name = "Tosha"
 	mob_choice = /mob/living/simple_animal/pet/dog/corgi
-	
+
 /obj/item/choice_beacon/pet/hamster
 	name = "hamster delivery beacon"
 	default_name = "Doctor"
 	mob_choice = /mob/living/simple_animal/pet/hamster
-	
+
 /obj/item/choice_beacon/pet/pug
 	name = "pug delivery beacon"
 	default_name = "Silvestro"
 	mob_choice = /mob/living/simple_animal/pet/dog/pug
-	
+
 /obj/item/choice_beacon/pet/ems
 	name = "emotional support animal delivery beacon"
 	default_name = "Hugsie"
 	mob_choice = /mob/living/simple_animal/pet/cat/kitten
-	
+
 /obj/item/choice_beacon/pet/pingu
 	name = "penguin delivery beacon"
 	default_name = "Pingu"
 	mob_choice = /mob/living/simple_animal/pet/penguin/baby
-	
+
 /obj/item/choice_beacon/pet/clown
 	name = "living lube delivery beacon"
 	default_name = "Offensive"


### PR DESCRIPTION
## About The Pull Request

removes ghostbuster glasses from curator kit, replaces them with ghost seeing camera

## Why It's Good For The Game

Giving the curator a live view of all ghosts on the map was a terrible idea. It leads to validhunting, and cunning ghosts can even send messages across the death meta barrier by changing their name.

In terms of balance, the ghost goggles were leagues better than the traitor 8-ball item, and the curator gets them for free.

## Changelog
:cl:
add: Adds spooky camera to the curator ghost busting kit
del: Removed ecto glasses from the curator ghost busting kit


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
