### PR TITLE
Fixes shields getting damaged by stamina.

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -21,7 +21,7 @@
 			var/obj/item/projectile/P = hitby
 			if(P.damage_type != STAMINA)// disablers dont do shit to shields
 				attackforce = (P.damage / 2)
-		if(isitem(hitby))
+		else if(isitem(hitby))
 			var/obj/item/I = hitby
 			attackforce = damage
 			if(!I.damtype == BRUTE)


### PR DESCRIPTION
## About The Pull Request
`if(P.damage_type != STAMINA)// disablers dont do shit to shields`
Yeah not really, shields were able to take damage from all stamina dealing projectiles because after they are set to deal 0 damage it passes another check becase no `else` and it's damage gets changed.

## Why It's Good For The Game
fix

## Changelog
:cl:
fix: Shields can't take stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
