### PR TITLE
IPCs get pulled into body when revived

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -163,6 +163,8 @@ datum/species/ipc/on_species_loss(mob/living/carbon/C)
 			H.visible_message("[H]'s cooling system fans stutter and stall. There is a faint, yet rapid beeping coming from inside their chassis.")
 
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)
+	H.notify_ghost_cloning("You have been repaired!")
+	H.grab_ghost()
 	H.dna.features["ipc_screen"] = "BSOD"
 	H.update_body()
 	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")


### PR DESCRIPTION
For @FlamePrince

## About The Pull Request

When IPCs are repaired, the ghost for them gets yanked back in.
Closes #3898

## Changelog
:cl: FlamePrince, JJRcop
tweak: IPCs are pulled into their body when repaired.
/:cl:
