### PR TITLE
Implements a blacklist for problematic contractor dropoff points

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -954,9 +954,9 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/payout_bonus = 0
 	var/area/dropoff = null
 	var/static/list/area_blacklist = typecacheof(list(/area/ai_monitored/turret_protected,
-														/area/solar/,
-														/area/science/test_area/,
-														/area/shuttle/))
+														/area/solar,
+														/area/science/test_area,
+														/area/shuttle))
 	
 // Generate a random valid area on the station that the dropoff will happen.
 /datum/objective/contract/proc/generate_dropoff()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -953,13 +953,17 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/payout = 0
 	var/payout_bonus = 0
 	var/area/dropoff = null
-
+	var/static/list/area_blacklist = typecacheof(list(/area/ai_monitored/turret_protected,
+														/area/solar/,
+														/area/science/test_area/,
+														/area/shuttle/))
+	
 // Generate a random valid area on the station that the dropoff will happen.
 /datum/objective/contract/proc/generate_dropoff()
 	var/found = FALSE
 	while (!found)
 		var/area/dropoff_area = pick(GLOB.sortedAreas)
-		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors)
+		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !is_type_in_typecache(dropoff_area, area_blacklist))
 			dropoff = dropoff_area
 			found = TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -963,7 +963,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/found = FALSE
 	while (!found)
 		var/area/dropoff_area = pick(GLOB.sortedAreas)
-		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !is_type_in_typecache(dropoff_area, area_blacklist))
+		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !area_blacklist[dropoff_area.type])
 			dropoff = dropoff_area
 			found = TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -963,7 +963,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/found = FALSE
 	while (!found)
 		var/area/dropoff_area = pick(GLOB.sortedAreas)
-		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !area_blacklist[dropoff_area.type]
+		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !is_type_in_typecache(dropoff_area, area_blacklist))
 			dropoff = dropoff_area
 			found = TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -963,7 +963,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	var/found = FALSE
 	while (!found)
 		var/area/dropoff_area = pick(GLOB.sortedAreas)
-		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !is_type_in_typecache(dropoff_area, area_blacklist))
+		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !area_blacklist[dropoff_area.type]
 			dropoff = dropoff_area
 			found = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Blacklists the following areas from being valid contract dropoff locations:

External solars. Kills the target from lack of pressure and has no plating for the pod to land at.
Toxins test site, for being in space.
AI Upload, core and satellite for being excruciatingly hard and protected by turrets
Shuttles.

## Why It's Good For The Game

People dying from external dropoff locations isn't good, the point of contracting is that the victim is supposed to be sent up and return alive.

## Changelog
:cl:
add: Blacklisted solars, toxins test site, shuttles, and AI Upload/Sat from being contract dropoff locations.
/:cl: