### PR TITLE
Prevents guardians from teleporting things while in scout mode.

### DIFF
--- a/code/modules/guardian/abilities/major/scout.dm
+++ b/code/modules/guardian/abilities/major/scout.dm
@@ -17,6 +17,7 @@
 		guardian.alpha = 45
 		guardian.range = 255
 		guardian.do_the_cool_invisible_thing = FALSE
+		guardian.can_use_abilities = FALSE
 	else
 		guardian.ranged = initial(guardian.ranged)
 		guardian.melee_damage = initial(guardian.melee_damage)
@@ -26,6 +27,7 @@
 		guardian.range = initial(guardian.range)
 		guardian.do_the_cool_invisible_thing = initial(guardian.do_the_cool_invisible_thing)
 		guardian.stats.Apply(guardian)
+		guardian.can_use_abilities = initial(guardian.can_use_abilities)
 
 /datum/guardian_ability/major/scout/Manifest()
 	if(mode)

--- a/code/modules/guardian/abilities/minor/snares.dm
+++ b/code/modules/guardian/abilities/minor/snares.dm
@@ -17,7 +17,7 @@
 	set category = "Guardian"
 	set desc = "Set an invisible snare that will alert you when living creatures walk over it. Max of 5"
 	if(!can_use_abilities)
-		to_chat(G, "<span class='danger'><B>You can't do that right now!</span></B>")
+		to_chat(src, "<span class='danger'><B>You can't do that right now!</span></B>")
 		return
 	if(snares.len <6)
 		var/turf/snare_loc = get_turf(src.loc)

--- a/code/modules/guardian/abilities/minor/snares.dm
+++ b/code/modules/guardian/abilities/minor/snares.dm
@@ -16,6 +16,9 @@
 	set name = "Set Surveillance Snare"
 	set category = "Guardian"
 	set desc = "Set an invisible snare that will alert you when living creatures walk over it. Max of 5"
+	if(!can_use_abilities)
+		to_chat(G, "<span class='danger'><B>You can't do that right now!</span></B>")
+		return
 	if(snares.len <6)
 		var/turf/snare_loc = get_turf(src.loc)
 		var/obj/effect/snare/S = new /obj/effect/snare(snare_loc)

--- a/code/modules/guardian/abilities/minor/teleport.dm
+++ b/code/modules/guardian/abilities/minor/teleport.dm
@@ -27,6 +27,9 @@
 	if(!G.is_deployed())
 		to_chat(G, "<span class='danger'><B>You must be manifested to warp a target!</span></B>")
 		return
+	if(!G.can_use_abilities)
+		to_chat(G, "<span class='danger'><B>You can't do that right now!</span></B>")
+		return
 	if(!G.beacon)
 		to_chat(G, "<span class='danger'><B>You need a beacon placed to warp things!</span></B>")
 		return

--- a/code/modules/guardian/guardian.dm
+++ b/code/modules/guardian/guardian.dm
@@ -64,6 +64,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	var/beacon_cooldown = 0
 	var/list/pocket_dim
 	var/transforming = FALSE
+	var/can_use_abilities = TRUE
 
 /mob/living/simple_animal/hostile/guardian/Initialize(mapload, theme, guardiancolor)
 	GLOB.parasites += src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Didnt really want to make more PRs but this one is critical.

## Why It's Good For The Game

Guardians can teleport things in scout mode, from anywhere on the map.

## Changelog
:cl:
fix: Scout guardians can no longer teleport things while scouted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
