### PR TITLE
Changeling last resort spawns the headcrab instantly instead of being delayed by 0.8 seconds.

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -39,7 +39,6 @@
 		cp.Remove(user)
 	user.gib()
 	. = TRUE
-	sleep(8) // So it's not killed in explosion
 	var/mob/living/simple_animal/hostile/headcrab/crab = new(turf)
 	for(var/obj/item/organ/I in organs)
 		I.forceMove(crab)


### PR DESCRIPTION
## About The Pull Request
Last resort doesn't cause an explosion anymore after #1561 but for whatever reason the `sleep(8)` meant to protect the headcrab from being killed by the explosion was never removed so you just have to wait 0.8 seconds after being gibbed.

## Why It's Good For The Game
A bit awkward having to wait 0.8 seconds AFTER stuns apply only to be greeted by people ready to murder you once you actually spawn.

## Changelog
:cl:
tweak: Changeling last resort ability no longer takes 0.8 seconds after use to actually spawn the headcrab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
