### PR TITLE
Oozeling Tweak: Increase cost of limb regen, make limbs recede sooner

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -89,7 +89,7 @@
 				H.blood_volume += 15
 	if(H.blood_volume < BLOOD_VOLUME_OKAY && prob(5))
 		to_chat(H, "<span class='danger'>You feel drained!</span>")
-	if(H.blood_volume < BLOOD_VOLUME_BAD)
+	if(H.blood_volume < BLOOD_VOLUME_OKAY)
 		Cannibalize_Body(H)
 	if(regenerate_limbs)
 		regenerate_limbs.UpdateButtonIcon()
@@ -120,7 +120,7 @@
 	if(..())
 		var/mob/living/carbon/human/H = owner
 		var/list/limbs_to_heal = H.get_missing_limbs()
-		if(limbs_to_heal.len && H.blood_volume >= BLOOD_VOLUME_OKAY+40)
+		if(limbs_to_heal.len && H.blood_volume >= BLOOD_VOLUME_OKAY+80)
 			return TRUE
 		return FALSE
 
@@ -131,19 +131,21 @@
 		to_chat(H, "<span class='notice'>You feel intact enough as it is.</span>")
 		return
 	to_chat(H, "<span class='notice'>You focus intently on your missing [limbs_to_heal.len >= 2 ? "limbs" : "limb"]...</span>")
-	if(H.blood_volume >= 40*limbs_to_heal.len+BLOOD_VOLUME_OKAY)
+	if(H.blood_volume >= 80*limbs_to_heal.len+BLOOD_VOLUME_OKAY)
 		if(do_after(H, 60, target = H))
 			H.regenerate_limbs()
-			H.blood_volume -= 40*limbs_to_heal.len
+			H.blood_volume -= 80*limbs_to_heal.len
+			H.nutrition -= 20*limbs_to_heal.len
 			to_chat(H, "<span class='notice'>...and after a moment you finish reforming!</span>")
 		return
-	if(H.blood_volume >= 40)//We can partially heal some limbs
-		while(H.blood_volume >= BLOOD_VOLUME_OKAY+40 && LAZYLEN(limbs_to_heal))
+	if(H.blood_volume >= 80)//We can partially heal some limbs
+		while(H.blood_volume >= BLOOD_VOLUME_OKAY+80 && LAZYLEN(limbs_to_heal))
 			if(do_after(H, 30, target = H))
 				var/healed_limb = pick(limbs_to_heal)
 				H.regenerate_limb(healed_limb)
 				limbs_to_heal -= healed_limb
-				H.blood_volume -= 40
+				H.blood_volume -= 80
+				H.nutrition -= 20
 			to_chat(H, "<span class='warning'>...but there is not enough of you to fix everything! You must attain more blood volume to heal completely!</span>")
 		return
 	to_chat(H, "<span class='warning'>...but there is not enough of you to go around! You must attain more blood volume to heal!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**At first glance this PR looks like a heavy nerf, but I promise that in practice it will actually feel like a slight buff overall. Please read before you judge.**

** *

**Earlier limb receding**

When oozelings suffer from blood loss, the *intended* effect is for their limbs to recede in order to regain some of their blood volume back and survive... however, the trigger for receding limbs doesn't occur until blood volume is so low that suffocation is rapidly underway, so in practice Oozelings only start to lose limbs after they're almost guaranteed to die (40% blood volume) and the act of cannibalizing limbs is rarely enough of a bump to save them because you're still suffering heavy oxyloss at 54% blood volume.

With this change, Oozelings now cannibalize limbs at 60% blood volume, in the early stages of oxyloss from lacking blood instead of the late stages, which will actually result in a bit more longevity for oozelings, especially ones that are starving.

** *

**Increase cost of limb regen** (also slightly tweaked thresholds to regen)

This half on the other hand, is a straight nerf, and in my opinion, just fixing an oversight. A limb should not provide more sustenance than it costs to produce. If anything I may tweak these so that regeneration costs more, pending other opinions. 

Before change:
* Cannibalizing a limb added 80 blood (14%) and 20 nutrition to the Oozeling
* Regenerating a limb cost 40 blood

After Change:
* Cannibalizing a limb adds 80 blood and 20 nutrition
* Regenerating a limb costs 80 blood and 20 nutrition


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Oozelings should not be dying of blood loss while they still have limbs to cannibalize for blood restoration. Also limbs should cost *at least* as much to restore as they grant when cannibalized. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Oozeling limbs now recede at an earlier threshold, making it far more likely for them to survive when exposed to adverse conditions that result in blood loss.
fix: Oozeling regeneration now costs the same as the refund from limb recession.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
