### PR TITLE
adds GPS signals to various space ruins

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -466,6 +466,9 @@
 "bm" = (
 /obj/structure/closet/wardrobe/science_white,
 /obj/structure/disposalpipe/segment,
+/obj/item/gps/science{
+	gpstag = "Zoo"
+	},
 /turf/open/floor/plasteel/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "bn" = (
@@ -911,6 +914,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
+"Qb" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/gps/mining,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/abandonedzoo)
 "VW" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Bio Containment";
@@ -1081,7 +1098,7 @@ ax
 aG
 aN
 aV
-ay
+Qb
 tP
 bh
 bm

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -123,9 +123,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/gps{
-	gpstag = "Emergency Blackbox GPS"
-	},
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -328,6 +325,10 @@
 /area/ruin/unpowered)
 "dc" = (
 /obj/item/shard,
+/turf/template_noop,
+/area/template_noop)
+"dA" = (
+/obj/machinery/computer/shuttle/caravan/pirate,
 /turf/template_noop,
 /area/template_noop)
 "dD" = (
@@ -3484,7 +3485,7 @@ aa
 aa
 aa
 aa
-aa
+dA
 hm
 hQ
 io

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -16,8 +16,8 @@
 /area/template_noop)
 "ae" = (
 /obj/structure/fluff/broken_flooring{
-	icon_state = "plating";
-	dir = 4
+	dir = 4;
+	icon_state = "plating"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -66,8 +66,8 @@
 "an" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
-	icon_state = "plating";
-	dir = 4
+	dir = 4;
+	icon_state = "plating"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -78,8 +78,8 @@
 "ap" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
-	icon_state = "pile";
-	dir = 8
+	dir = 8;
+	icon_state = "pile"
 	},
 /turf/template_noop,
 /area/template_noop)
@@ -123,6 +123,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/gps{
+	gpstag = "Emergency Blackbox GPS"
+	},
 /turf/open/floor/plasteel/dark{
 	initial_gas_mix = "TEMP=2.7"
 	},
@@ -133,8 +136,8 @@
 /area/template_noop)
 "aE" = (
 /obj/structure/fluff/broken_flooring{
-	icon_state = "pile";
-	dir = 4
+	dir = 4;
+	icon_state = "pile"
 	},
 /turf/template_noop,
 /area/template_noop)

--- a/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
@@ -51,6 +51,10 @@
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
+/obj/item/gps/engineering{
+	color = "#FFFF00";
+	gpstag = "HONK"
+	},
 /turf/open/floor/mineral/bananium/airless,
 /area/ruin/unpowered)
 "l" = (

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -32,6 +32,9 @@
 "i" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gps{
+	gpstag = "Emergency Blackbox GPS"
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/space/has_grav/powered/mechtransport)
 "j" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


adds a couple gps signals to some space ruins:
abandoned zoo: aka the one with the medical suit and a crab
caravan ambush: aka the one with the nukies and pirates that you die on
crashed clown ship: aka the one where HONK
mechtransport: aka the one thats useless

caravan amnush and mechtransport both use the same GPS signal name so you cant really tell which one is which until you go there (is it anti-meta/power-gaming or am i just uncreative? who knows)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
due to lack of space ruin budget people rarely find spaceruins, so adding a couple to the man-made spaceruins would seem quite nice

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Jimmy Brickets
add: a couple spaceruins now have GPS signals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
