### PR TITLE
[Port] Security (SecHUD) Arrest Permissions \ Detective SecHUD Changes 

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -52463,7 +52463,7 @@
 	pixel_x = 3
 	},
 /obj/item/lighter,
-/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "kSp" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -123866,7 +123866,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "pGt" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -84765,7 +84765,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "ozV" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13556,7 +13556,7 @@
 	pixel_y = 2
 	},
 /obj/item/storage/fancy/cigarettes,
-/obj/item/clothing/glasses/hud/security/sunglasses,
+/obj/item/clothing/glasses/sunglasses,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aEo" = (

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -15,7 +15,7 @@
 	use_power = IDLE_POWER_USE				//this turret uses and requires power
 	idle_power_usage = 100		//when inactive, this turret takes up constant 50 Equipment power
 	active_power_usage = 600	//when active, this turret takes up constant 300 Equipment power
-	req_access = list(ACCESS_SEC_DOORS)
+	req_access = list(ACCESS_SECURITY)
 	power_channel = AREA_USAGE_EQUIP	//drains power from the EQUIPMENT channel
 
 	var/base_icon_state = "standard"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -402,7 +402,7 @@
 			else //Implant and standard glasses check access
 				if(H.wear_id)
 					var/list/access = H.wear_id.GetAccess()
-					if(ACCESS_SEC_DOORS in access)
+					if(ACCESS_SECURITY in access)
 						allowed_access = H.get_authentification_name()
 
 			if(!allowed_access)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- [x] https://github.com/tgstation/tgstation/pull/51600

Arrest option through SecHUDs is now only available to people with Security access (instead of Brig access), restricting it roundstart to Captain, HoS, HoP and Security Officers. Previously, roles such as Lawyer, CMO, Detective, etc; could set arrest status through SecHUDs.

Additionally, Security access is now also required to operate portable turrets (from Brig access).

---
~~Future: Give the Detective some nice gimmick items to use instead of SecHUDs~~
- [x] ~~https://github.com/tgstation/tgstation/pull/46891 - Add SpyGlasses~~
- [x] ~~https://github.com/tgstation/tgstation/pull/56883 - Turn the camera into an accessory~~
- [x] ~~https://github.com/tgstation/tgstation/pull/53355 - Merge the Det's Sunglasses into their Spy Glasses~~

See https://github.com/BeeStation/BeeStation-Hornet/pull/3973
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 
del: Detective gets roundstart normal sunglasses instead of SecHUDs ~~at PubbyStation~~.
balance: Balanced access to arrest option through SecHUDs, now requiring Security access instead of Brig access.
balance: Balanced access to portable turrets, now requiring Security access instead of Brig access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
