### PR TITLE
Removes AI/cyborg upload from techweb

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -25,7 +25,7 @@
 	starting_node = TRUE
 	display_name = "Cyborg Construction"
 	description = "Sapient robots with preloaded tool modules and programmable laws."
-	design_ids = list("robocontrol", "sflash", "borg_suit", "borg_head", "borg_chest", "borg_r_arm", "borg_l_arm", "borg_r_leg", "borg_l_leg", "borgupload",
+	design_ids = list("robocontrol", "sflash", "borg_suit", "borg_head", "borg_chest", "borg_r_arm", "borg_l_arm", "borg_r_leg", "borg_l_leg",
 	"cyborgrecharger", "borg_upgrade_restart", "borg_upgrade_rename")
 
 /datum/techweb_node/mech
@@ -383,7 +383,7 @@
 	prereq_ids = list("robotics", "posibrain")
 	design_ids = list("aifixer", "aicore", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module",
 	"reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "paladin_module", "tyrant_module", "overlord_module", "corporate_module",
-	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "aiupload", "intellicard")
+	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "intellicard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes the AI and Cyborg upload modules from the techweb, meaning they cannot be printed on circuit imprinters (unless you have a design disk with aforementioned designs) as they are no longer possible to research.

## Why It's Good For The Game

The fact anyone with access to a circuit imprinter can easily acquire an AI or Cyborg upload board makes it far too easy to subvert silicons. It doesn't make much sense from an in-universe perspective that literally anyone with R&D/engineering access (or who can perform the very trivial task of breaking in) can print AI upload boards when the AI upload chamber is so heavily secured and the only spare board is in secure tech storage. It also doesn't make sense from a gameplay perspective that AI is so easy to subvert. Just walk (or break) into RnD (for upgrades if anyone asks), print freeform + ai upload, and you're done. You can subvert AI at your leisure with a computer in maint that you may or may not bother to destroy after. 

This PR forces people who want to subvert AI to actually do some legwork and break into secure tech storage or even the AI upload chamber itself. It also makes emagging borgs a lot more interesting since going the route of subverting the AI first is actually difficult. Some players might even choose to subvert borgs without subverting the AI especially if the AI upload board was stolen/taken by RD at shiftstart (along with the hand tele in the teleporter room) like they're supposed to.

It also leaves open the possibility of having a traitor item with an upload design disk; perhaps making it a bundle along with the hacked AI upload module. It also doesn't prevent the printing of AI modules in RnD, meaning it's still not that hard to subvert the AI.

## Changelog
:cl:
del: Removed AI and cyborg upload board from the techweb. Go steal it from secure tech storage you lazy bastards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
