### PR TITLE
add mediborg amputation adventure to illegal tech

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -21,6 +21,14 @@
 	build_path = /obj/item/circuitboard/computer/arcade/orion_trail
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_ALL
+	
+/datum/design/board/amputation_adventure
+	name = "Computer Design (Mediborg's Amputation Adventure)"
+	desc = "Allows for the construction of circuit boards used to build a new Mediborg's Amputation Adventure machine."
+	id = "arcade_amputation"
+	build_path = /obj/item/circuitboard/computer/arcade/amputation
+	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_ALL
 
 /datum/design/board/seccamera
 	name = "Computer Design (Security Camera)"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1129,7 +1129,7 @@
 	display_name = "Illegal Technology"
 	description = "Dangerous research used to create dangerous objects."
 	prereq_ids = list("adv_engi", "adv_weaponry", "explosive_weapons")
-	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill", "advanced_camera")
+	design_ids = list("decloner", "borg_syndicate_module", "ai_cam_upgrade", "suppressor", "largecrossbow", "donksofttoyvendor", "donksoft_refill", "advanced_camera" , "arcade_amputation")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	export_price = 5000
 	hidden = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If RnD happens to research illegal technology mediborg's amputation adventure can now be printed at any place any arcade board can.

## Why It's Good For The Game

Allows for extra fun.

## Changelog
:cl:
add: Illegal technology now unlocks Mediborg's Amputation Adventure, the most fun arcade game on the station!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
