### PR TITLE
RPG Loot Bug on various storages

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -290,10 +290,10 @@
 	for(var/obj/item/I in real_location.contents)
 		if(QDELETED(I))
 			continue
-		if(!.["[I.type]-[I.name]"])
-			.["[I.type]-[I.name]"] = new /datum/numbered_display(I, 1)
+		if(!.["[I.type]"])
+			.["[I.type]"] = new /datum/numbered_display(I, 1)
 		else
-			var/datum/numbered_display/ND = .["[I.type]-[I.name]"]
+			var/datum/numbered_display/ND = .["[I.type]"]
 			ND.number++
 
 //This proc determines the size of the inventory to be displayed. Please touch it only if you know what you're doing.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #3882 

Basically when a RPGLoot event is triggered. All the items in the game get renamed (as they should) with ridicoulous prefixes and suffixes. 
The thing is that some storages have stackable items, and right now, Each and every one of those stacked items get renamed individually, so they don't stack 😮 (check the screenshots).

**TL;DR**
When an RPGLoot happens certain storages get filled with lot's of the same items.

### Bug Showcase 

The following screenshot has the player with an RPED with some stock parts in it.

![part_replacer_items_before_rpgloot_as_it_is_now](https://user-images.githubusercontent.com/34402401/112712119-1606de00-8eac-11eb-826c-1de4325baf11.png)

The following is the state of the RPED after an RPGLoot event! (those are a lot of repeated items with slighty different names)
 
![part_replacer_items_after_rpgLoot_as_it_is_now](https://user-images.githubusercontent.com/34402401/112712168-74cc5780-8eac-11eb-83f5-d8ca776e64a2.png)

### Behavior After Fix

Player with RPED with some stock parts in it.

![part_replacer_items_before_rpgLoot_fixed](https://user-images.githubusercontent.com/34402401/112712257-f7551700-8eac-11eb-80fe-3ae60bd919da.png)

Now after the RPGLoot event, the items (even though they have different names) stack onto each other without problem.

![part_replacer_items_after_rpgloot_fixed](https://user-images.githubusercontent.com/34402401/112712268-2075a780-8ead-11eb-8feb-6355d046fa38.png) 


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Because it solves a bug that could be annoying when an RPGLoot happens.

## Changelog
:cl:
fix: Stops RPGLoot from unstacking stackable items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
