### PR TITLE
Fix servant golems created by clockwork cultists not receiving the antag status

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -329,7 +329,7 @@
 		SSticker.mode.add_cultist(src)
 
 	else if(is_servant_of_ratvar(creator))
-		add_servant_of_ratvar(src)
+		add_servant_of_ratvar(current)
 
 	else if(is_revolutionary(creator))
 		var/datum/antagonist/rev/converter = creator.mind.has_antag_datum(/datum/antagonist/rev,TRUE)


### PR DESCRIPTION
:cl:
fix: Golems created by servants of ratvar will automatically get the clockwork cult antag status
/:cl: