### PR TITLE
Refactor drone shells to use mob spawners

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1666,7 +1666,7 @@
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "fw" = (
-/obj/item/drone_shell/dusty,
+/obj/effect/mob_spawn/drone/dusty,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/bridge/access)
 "fx" = (
@@ -2252,9 +2252,9 @@
 "hF" = (
 /obj/structure/table,
 /obj/machinery/computer/pod/old{
+	id = "derelict_gun";
 	name = "ProComp IIe";
-	pixel_y = 7;
-	id = "derelict_gun"
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/chapel,
 /area/ruin/space/derelict/medical/chapel)
@@ -2440,7 +2440,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "in" = (
-/obj/item/drone_shell/dusty,
+/obj/effect/mob_spawn/drone/dusty,
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/singularity_engine)
 "io" = (
@@ -4122,10 +4122,10 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/item/drone_shell/dusty,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/mob_spawn/drone/dusty,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/derelict/se_solar)
 "nV" = (

--- a/_maps/map_files/generic/CityOfCogs.dmm
+++ b/_maps/map_files/generic/CityOfCogs.dmm
@@ -80,7 +80,7 @@
 /area/reebe/city_of_cogs)
 "v" = (
 /obj/structure/table/brass,
-/obj/item/drone_shell/cogscarab,
+/obj/effect/mob_spawn/drone/cogscarab,
 /turf/open/floor/clockwork/reebe,
 /area/reebe/city_of_cogs)
 "w" = (

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -30,7 +30,7 @@
 	var/cooldownTime = 1800 //3 minutes
 	var/production_time = 30
 	//The item the dispenser will create
-	var/dispense_type = /obj/effect/mob_spawn/drone/
+	var/dispense_type = /obj/effect/mob_spawn/drone
 
 	// The maximum number of "idle" drone shells it will make before
 	// ceasing production. Set to 0 for infinite.

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -30,7 +30,7 @@
 	var/cooldownTime = 1800 //3 minutes
 	var/production_time = 30
 	//The item the dispenser will create
-	var/dispense_type = /obj/item/drone_shell
+	var/dispense_type = /obj/effect/mob_spawn/drone/
 
 	// The maximum number of "idle" drone shells it will make before
 	// ceasing production. Set to 0 for infinite.
@@ -61,7 +61,7 @@
 /obj/machinery/droneDispenser/syndrone //Please forgive me
 	name = "syndrone shell dispenser"
 	desc = "A suspicious machine that will create Syndicate exterminator drones when supplied with iron and glass. Disgusting."
-	dispense_type = /obj/item/drone_shell/syndrone
+	dispense_type = /obj/effect/mob_spawn/drone/syndrone
 	//If we're gonna be a jackass, go the full mile - 10 second recharge timer
 	cooldownTime = 100
 	end_create_message = "dispenses a suspicious drone shell."
@@ -70,14 +70,14 @@
 /obj/machinery/droneDispenser/syndrone/badass //Please forgive me
 	name = "badass syndrone shell dispenser"
 	desc = "A suspicious machine that will create Syndicate exterminator drones when supplied with iron and glass. Disgusting. This one seems ominous."
-	dispense_type = /obj/item/drone_shell/syndrone/badass
+	dispense_type = /obj/effect/mob_spawn/drone/syndrone/badass
 	end_create_message = "dispenses an ominous suspicious drone shell."
 
 // I don't need your forgiveness, this is awesome.
 /obj/machinery/droneDispenser/snowflake
 	name = "snowflake drone shell dispenser"
 	desc = "A hefty machine that, when supplied with iron and glass, will periodically create a snowflake drone shell. Does not need to be manually operated."
-	dispense_type = /obj/item/drone_shell/snowflake
+	dispense_type = /obj/effect/mob_spawn/drone/snowflake
 	end_create_message = "dispenses a snowflake drone shell."
 	// Those holoprojectors aren't cheap
 	iron_cost = 2000

--- a/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
@@ -47,13 +47,18 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 
 //====Shell====
 
-/obj/item/drone_shell/cogscarab
+/obj/effect/mob_spawn/drone/cogscarab
 	name = "cogscarab construct"
 	desc = "The shell of an ancient construction drone, loyal to Ratvar."
 	icon_state = "drone_clock_hat"
-	drone_type = /mob/living/simple_animal/drone/cogscarab
+	mob_name = "cogscarab"
+	mob_type = /mob/living/simple_animal/drone/cogscarab
+	short_desc = "You are a cogscarab!"
+	flavour_text = {"You are a cogscarab, a tiny building construct of Ratvar. While you're weak and can't leave Reebe, \
+	you have a set of quick tools, as well as a replica fabricator that can create brass for construction. Work with the servants of Ratvar \
+	to construct and maintain defenses at the City of Cogs."}
 
-/obj/item/drone_shell/cogscarab/attack_ghost(mob/user)
+/obj/effect/mob_spawn/drone/cogscarab/attack_ghost(mob/user)
 	if(is_banned_from(user.ckey, ROLE_SERVANT_OF_RATVAR) || QDELETED(src) || QDELETED(user))
 		return
 	if(CONFIG_GET(flag/use_age_restriction_for_jobs))
@@ -67,11 +72,7 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 	var/be_drone = alert("Become a cogscarab? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(be_drone == "No" || QDELETED(src) || !isobserver(user))
 		return
-	var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
-	if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
-		var/hat_type = pick(possible_seasonal_hats)
-		var/obj/item/new_hat = new hat_type(D)
-		D.equip_to_slot_or_del(new_hat, ITEM_SLOT_HEAD)
+	var/mob/living/simple_animal/drone/D = new mob_type(get_turf(loc))
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	D.key = user.key
 	add_servant_of_ratvar(D, silent=TRUE)

--- a/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
@@ -73,6 +73,10 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 	if(be_drone == "No" || QDELETED(src) || !isobserver(user))
 		return
 	var/mob/living/simple_animal/drone/D = new mob_type(get_turf(loc))
+	if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
+		var/hat_type = pick(possible_seasonal_hats)
+		var/obj/item/new_hat = new hat_type(D)
+		D.equip_to_slot_or_del(new_hat, ITEM_SLOT_HEAD)
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	D.key = user.key
 	add_servant_of_ratvar(D, silent=TRUE)

--- a/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
@@ -54,9 +54,9 @@ GLOBAL_LIST_INIT(cogscarabs, list())
 	mob_name = "cogscarab"
 	mob_type = /mob/living/simple_animal/drone/cogscarab
 	short_desc = "You are a cogscarab!"
-	flavour_text = {"You are a cogscarab, a tiny building construct of Ratvar. While you're weak and can't leave Reebe, \
+	flavour_text = "You are a cogscarab, a tiny building construct of Ratvar. While you're weak and can't leave Reebe, \
 	you have a set of quick tools, as well as a replica fabricator that can create brass for construction. Work with the servants of Ratvar \
-	to construct and maintain defenses at the City of Cogs."}
+	to construct and maintain defenses at the City of Cogs."
 
 /obj/effect/mob_spawn/drone/cogscarab/attack_ghost(mob/user)
 	if(is_banned_from(user.ckey, ROLE_SERVANT_OF_RATVAR) || QDELETED(src) || QDELETED(user))

--- a/code/modules/antagonists/clock_cult/scriptures/summon_cogscarab.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/summon_cogscarab.dm
@@ -28,4 +28,4 @@
 	. = ..()
 
 /datum/clockcult/scripture/cogscarab/invoke_success()
-	new /obj/item/drone_shell/cogscarab(get_turf(invoker))
+	new /obj/effect/mob_spawn/drone/cogscarab(get_turf(invoker))

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -32,7 +32,7 @@
 	if(isnull(possible_seasonal_hats))
 		build_seasonal_hats()
 
-/obj/item/drone_shell/proc/build_seasonal_hats()
+/obj/effect/mob_spawn/drone/proc/build_seasonal_hats()
 	possible_seasonal_hats = list()
 	if(!length(SSevents.holidays))
 		return //no holidays, no hats; we'll keep the empty list so we never call this proc again

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -6,7 +6,7 @@
 //Drone shells
 
 //DRONE SHELL
-/obj/effect/mob_spawn/drone/
+/obj/effect/mob_spawn/drone
 	name = "drone shell"
 	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs."
 	icon = 'icons/mob/drone.dmi'

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -6,41 +6,34 @@
 //Drone shells
 
 //DRONE SHELL
-/obj/item/drone_shell
+/obj/effect/mob_spawn/drone/
 	name = "drone shell"
 	desc = "A shell of a maintenance drone, an expendable robot built to perform station repairs."
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_hat"//yes reuse the _hat state.
 	layer = BELOW_MOB_LAYER
+	density = FALSE
+	death = FALSE
+	roundstart = FALSE
+	short_desc = "You are a drone."
+	flavour_text = {"
+	You are a drone, a tiny insect-like creature. Follow your assigned laws to the best of your ability.
+	"}
+	mob_type = /mob/living/simple_animal/drone
 
-	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
-	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
-	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!
-
-/obj/item/drone_shell/Initialize()
+/obj/effect/mob_spawn/drone/Initialize()
 	. = ..()
 	var/area/A = get_area(src)
 	if(A)
 		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_DRONE, notify_suiciders = FALSE)
 	GLOB.poi_list |= src
-	if(isnull(possible_seasonal_hats))
-		build_seasonal_hats()
-
-/obj/item/drone_shell/proc/build_seasonal_hats()
-	possible_seasonal_hats = list()
-	if(!length(SSevents.holidays))
-		return //no holidays, no hats; we'll keep the empty list so we never call this proc again
-	for(var/V in SSevents.holidays)
-		var/datum/holiday/holiday = SSevents.holidays[V]
-		if(holiday.drone_hat)
-			possible_seasonal_hats += holiday.drone_hat
 
 /obj/item/drone_shell/Destroy()
 	GLOB.poi_list -= src
 	. = ..()
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/item/drone_shell/attack_ghost(mob/user)
+/obj/effect/mob_spawn/drone/attack_ghost(mob/user)
 	if(is_banned_from(user.ckey, ROLE_DRONE) || QDELETED(src) || QDELETED(user))
 		return
 	if(CONFIG_GET(flag/use_age_restriction_for_jobs))
@@ -55,11 +48,7 @@
 	var/be_drone = alert("Become a drone? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(be_drone == "No" || QDELETED(src) || !isobserver(user))
 		return
-	var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
-	if(!D.default_hatmask && seasonal_hats && possible_seasonal_hats.len)
-		var/hat_type = pick(possible_seasonal_hats)
-		var/obj/item/new_hat = new hat_type(D)
-		D.equip_to_slot_or_del(new_hat, ITEM_SLOT_HEAD)
+	var/mob/living/simple_animal/drone/D = new mob_type(get_turf(loc))
 	D.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 	D.key = user.key
 	message_admins("[ADMIN_LOOKUPFLW(user)] has taken possession of \a [src] in [AREACOORD(src)].")

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -16,9 +16,7 @@
 	death = FALSE
 	roundstart = FALSE
 	short_desc = "You are a drone."
-	flavour_text = {"
-	You are a drone, a tiny insect-like creature. Follow your assigned laws to the best of your ability.
-	"}
+	flavour_text = "You are a drone, a tiny insect-like creature. Follow your assigned laws to the best of your ability."
 	mob_type = /mob/living/simple_animal/drone
 	var/seasonal_hats = TRUE //If TRUE, and there are no default hats, different holidays will grant different hats
 	var/static/list/possible_seasonal_hats //This is built automatically in build_seasonal_hats() but can also be edited by admins!

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -59,20 +59,23 @@
 	. = ..()
 	desc += " This drone appears to have a complex holoprojector built on its 'head'."
 
-/obj/item/drone_shell/syndrone
+/obj/effect/mob_spawn/drone/syndrone
 	name = "syndrone shell"
 	desc = "A shell of a syndrone, a modified maintenance drone designed to infiltrate and annihilate."
 	icon_state = "syndrone_item"
-	drone_type = /mob/living/simple_animal/drone/syndrone
+	mob_name = "syndrone"
+	mob_type = /mob/living/simple_animal/drone/syndrone
 
-/obj/item/drone_shell/syndrone/badass
+/obj/effect/mob_spawn/drone/syndrone/badass
 	name = "badass syndrone shell"
-	drone_type = /mob/living/simple_animal/drone/syndrone/badass
+	mob_name = "badass syndrone"
+	mob_type = /mob/living/simple_animal/drone/syndrone/badass
 
-/obj/item/drone_shell/snowflake
+/obj/effect/mob_spawn/drone/snowflake
 	name = "snowflake drone shell"
 	desc = "A shell of a snowflake drone, a maintenance drone with a built in holographic projector to display hats and masks."
-	drone_type = /mob/living/simple_animal/drone/snowflake
+	mob_name = "snowflake drone"
+	mob_type = /mob/living/simple_animal/drone/snowflake
 
 /mob/living/simple_animal/drone/polymorphed
 	default_storage = null
@@ -93,10 +96,17 @@
 	icon_living = icon_state
 	icon_dead = "[visualAppearence]_dead"
 
-/obj/item/drone_shell/dusty
+/obj/effect/mob_spawn/drone/dusty
 	name = "derelict drone shell"
 	desc = "A long-forgotten drone shell. It seems kind of... Space Russian."
-	drone_type = /mob/living/simple_animal/drone/derelict
+	icon = 'icons/mob/drone.dmi'
+	icon_state = "drone_maint_hat"
+	mob_name = "derelict drone"
+	mob_type = /mob/living/simple_animal/drone/derelict
+	short_desc = "You are a long forgotten drone!"
+	flavour_text = {"
+	You are a drone on Kosmicheskaya Stantsiya 13. Something has brought you out of hibernation, and the station is in gross disrepair. Build, repair, maintain and improve the station that housed you on activation.
+	"}
 
 /mob/living/simple_animal/drone/derelict
 	name = "derelict drone"

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -104,9 +104,8 @@
 	mob_name = "derelict drone"
 	mob_type = /mob/living/simple_animal/drone/derelict
 	short_desc = "You are a long forgotten drone!"
-	flavour_text = {"
-	You are a drone on Kosmicheskaya Stantsiya 13. Something has brought you out of hibernation, and the station is in gross disrepair. Build, repair, maintain and improve the station that housed you on activation.
-	"}
+	flavour_text = "You are a drone on Kosmicheskaya Stantsiya 13. Something has brought you out of hibernation, and the station is in gross disrepair. \
+	Build, repair, maintain and improve the station that housed you on activation."
 
 /mob/living/simple_animal/drone/derelict
 	name = "derelict drone"


### PR DESCRIPTION
## About The Pull Request

Drone shells now use mob spawners instead of items, so they will show up in the spawners list.

## Why It's Good For The Game

Maybe ghosts will use the derelict/cogscarab drone spawns now.

## Changelog
:cl:
tweak: Drone shells now appear in the ghost spawners list
/:cl: