### PR TITLE
Box item spawning rework (and illegal tech introspection)

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -409,7 +409,7 @@
 
 /obj/item/storage/box/syndie_kit/emp
 	name = "EMP kit"
-	items_inside = (
+	items_inside = list(
 		/obj/item/grenade/empgrenade = 5,
 		/obj/item/implanter/emp = 1
 	)
@@ -560,10 +560,9 @@
 /obj/item/storage/box/syndie_kit/bee_grenades
 	name = "buzzkill grenade box"
 	desc = "A sleek, sturdy box with a buzzing noise coming from the inside. Uh oh."
-
-/obj/item/storage/box/syndie_kit/bee_grenades/PopulateContents()
-	for(var/i in 1 to 3)
-		new /obj/item/grenade/spawnergrenade/buzzkill(src)
+	items_inside = list(
+		/obj/item/grenade/spawnergrenade/buzzkill = 3
+	)
 
 /obj/item/storage/box/syndie_kit/cultconstructkit
 	name = "cult construct kit"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -312,7 +312,7 @@
 	desc = "A sleek, sturdy box."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
-	var/static/items_inside = list() //used for illegal tech to look inside of boxes and storage from only the typepath
+	var/static/list/items_inside //used for illegal tech to look inside of boxes and storage from only the typepath
 
 /obj/item/storage/box/syndie_kit/PopulateContents()
 	if(items_inside?.len)
@@ -330,7 +330,7 @@
 	redpaper.color = "#FF0000" //Red paper, for an extra special calling card flair
 
 /obj/item/storage/box/syndie_kit/imp_freedom
-	var/static/items_inside = list(
+	items_inside = list(
 		/obj/item/implanter/freedom = 1
 	)
 	name = "freedom implant box"
@@ -342,9 +342,9 @@
 
 /obj/item/storage/box/syndie_kit/imp_microbomb
 	name = "microbomb implant box"
-
-/obj/item/storage/box/syndie_kit/imp_microbomb/PopulateContents()
-	new /obj/item/implanter/explosive(src)
+	items_inside = list(
+		/obj/item/implanter/explosive = 1
+	)
 
 /obj/item/storage/box/syndie_kit/imp_macrobomb
 	name = "macrobomb implant box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -409,11 +409,10 @@
 
 /obj/item/storage/box/syndie_kit/emp
 	name = "EMP kit"
-
-/obj/item/storage/box/syndie_kit/emp/PopulateContents()
-	for(var/i in 1 to 5)
-		new /obj/item/grenade/empgrenade(src)
-	new /obj/item/implanter/emp(src)
+	items_inside = (
+		/obj/item/grenade/empgrenade = 5,
+		/obj/item/implanter/emp = 1
+	)
 
 /obj/item/storage/box/syndie_kit/chemical
 	name = "chemical kit"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -312,6 +312,11 @@
 	desc = "A sleek, sturdy box."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
+	var/static/items_inside = list() //used for illegal tech to look inside of boxes and storage from only the typepath
+
+/obj/item/storage/box/syndie_kit/PopulateContents()
+	if(items_inside?.len)
+		generate_items_inside(items_inside,src)
 
 /obj/item/storage/box/syndie_kit/origami_bundle
 	name = "origami kit"
@@ -325,14 +330,15 @@
 	redpaper.color = "#FF0000" //Red paper, for an extra special calling card flair
 
 /obj/item/storage/box/syndie_kit/imp_freedom
-	var/static/list/init_contents = list(
-		/obj/item/implanter/freedom
+	var/static/items_inside = list(
+		/obj/item/implanter/freedom = 1
 	)
 	name = "freedom implant box"
 
-/obj/item/storage/box/syndie_kit/imp_freedom/PopulateContents()
-	for (/obj/item/init_item in init_contents)
-		new init_item(src)
+///obj/item/storage/box/syndie_kit/imp_freedom/PopulateContents()
+//	//pretend this is /obj/item/storage/box/syndie_kit/PopulateContents()
+//	for (var/item in init_contents)
+//		new item(src)
 
 /obj/item/storage/box/syndie_kit/imp_microbomb
 	name = "microbomb implant box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -325,14 +325,14 @@
 	redpaper.color = "#FF0000" //Red paper, for an extra special calling card flair
 
 /obj/item/storage/box/syndie_kit/imp_freedom
-	init_contents = list(
+	var/static/list/init_contents = list(
 		/obj/item/implanter/freedom
 	)
 	name = "freedom implant box"
 
 /obj/item/storage/box/syndie_kit/imp_freedom/PopulateContents()
-	for (item in init_contents)
-		new item(src)
+	for (/obj/item/init_item in init_contents)
+		new init_item(src)
 
 /obj/item/storage/box/syndie_kit/imp_microbomb
 	name = "microbomb implant box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -325,10 +325,14 @@
 	redpaper.color = "#FF0000" //Red paper, for an extra special calling card flair
 
 /obj/item/storage/box/syndie_kit/imp_freedom
+	init_contents = list(
+		/obj/item/implanter/freedom
+	)
 	name = "freedom implant box"
 
 /obj/item/storage/box/syndie_kit/imp_freedom/PopulateContents()
-	new /obj/item/implanter/freedom(src)
+	for (item in init_contents)
+		new item(src)
 
 /obj/item/storage/box/syndie_kit/imp_microbomb
 	name = "microbomb implant box"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -312,7 +312,7 @@
 	desc = "A sleek, sturdy box."
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
-	var/static/list/items_inside //used for illegal tech to look inside of boxes and storage from only the typepath
+	var/list/items_inside = null//used for illegal tech to look inside of boxes and storage from only the typepath
 
 /obj/item/storage/box/syndie_kit/PopulateContents()
 	if(items_inside?.len)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1141,8 +1141,9 @@
 		var/datum/uplink_item/UI = new path
 		if(!UI.item || !UI.illegal_tech)
 			continue
-		if(ispath(UI.item, /obj/item/storage/box/syndie_kit) && UI.item?.items_inside)
-			for(var/each_item in items_inside)
+		if(ispath(UI.item, /obj/item/storage/box/syndie_kit))
+			var/obj/item/storage/box/syndie_kit/my_kit = UI.item
+			for(var/each_item in my_kit.items_inside)
 				boost_item_paths |= each_item
 		boost_item_paths |= UI.item	//allows deconning to unlock.
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1141,6 +1141,9 @@
 		var/datum/uplink_item/UI = new path
 		if(!UI.item || !UI.illegal_tech)
 			continue
+		if(ispath(UI.item, /obj/item/storage/box/syndie_kit) && UI.item?.items_inside)
+			for(var/each_item in items_inside)
+				boost_item_paths |= each_item
 		boost_item_paths |= UI.item	//allows deconning to unlock.
 
 //Helpers for debugging/balancing the techweb in its entirety!

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1138,12 +1138,15 @@
 	. = ..()
 	boost_item_paths = list()
 	for(var/path in GLOB.uplink_items)
-		var/datum/uplink_item/UI = new path
-		if(!UI.item || !UI.illegal_tech)
+		var/datum/uplink_item/UI = new path //instantiate the Uplink Item
+		if(!UI.item || !UI.illegal_tech) //fall through logic
 			continue
-		if(ispath(UI.item, /obj/item/storage/box/syndie_kit))
-			var/obj/item/storage/box/syndie_kit/my_kit = UI.item
+		if(ispath(UI.item, /obj/item/storage/box/syndie_kit)) //if the item awards a syndie kit PATH
+			var/obj/item/storage/box/syndie_kit/my_kit = new UI.item //init that item so I can get the variables from it
 			for(var/each_item in my_kit.items_inside)
+				//TODO: Default off bitflag for items, ILLEGAL_TECH, that is checked here so that when an item is searched this proc can check it for illegal technology
+				//we don't want to give illegal tech for items like paper, since those also spawn in syndicate things
+				//or I change the box definition to major/minor items, but eh
 				boost_item_paths |= each_item
 		boost_item_paths |= UI.item	//allows deconning to unlock.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Boxes spawn their contents with PopulateContents() when the box is created. This is fine, except no procs can _see_ into those boxes.

In order for RnD's illegal technology to see _into_ boxes in order to determine what should be illegal or not, it needs to have runtime access to box/storage contents.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
![image](https://user-images.githubusercontent.com/3241376/113025352-78cad480-914d-11eb-8ff6-d4f56593f7ef.png)

Goal is to make this give illegal technology :)

![image](https://user-images.githubusercontent.com/3241376/113026539-cc89ed80-914e-11eb-8033-e99495b91f28.png)


## Changelog
:cl:
code: changed some code
refactor: refactored some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
