### PR TITLE
Lavaland loot overhaul

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -460,3 +460,18 @@
 		/obj/effect/trap/nexus/trickyspawner/clownmutant = 2,
 		/obj/effect/trap/nexus/trickyspawner/honkling = 3,
 		/obj/effect/trap/nexus/cluwnecurse = 1)
+		
+/obj/effect/spawner/lootdrop/megafaunaore
+	name = "megafauna ore drop"
+	lootcount = 100
+	lootdoubles = TRUE
+	loot = list(
+		/obj/item/stack/ore/iron = 5,
+		/obj/item/stack/ore/glass/basalt = 5,
+		/obj/item/stack/ore/plasma = 3,
+		/obj/item/stack/ore/silver = 3,
+		/obj/item/stack/ore/gold = 3, 
+		/obj/item/stack/ore/copper = 3,
+		/obj/item/stack/ore/titanium = 2,
+		/obj/item/stack/ore/uranium = 2,
+		/obj/item/stack/ore/diamond = 2)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -421,7 +421,7 @@
 	armour_penetration = 100
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
-	paralyze = 30
+	knockdown = 30
 	var/chain
 
 /obj/item/projectile/hook/fire(setAngle)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1,6 +1,6 @@
 //The chests dropped by mob spawner tendrils. Also contains associated loot.
 
-#define HIEROPHANT_CLUB_CARDINAL_DAMAGE 30
+#define HIEROPHANT_CLUB_CARDINAL_DAMAGE 15
 
 
 /obj/structure/closet/crate/necropolis
@@ -14,48 +14,34 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,30)
+	var/loot = rand(1,25)
 	switch(loot)
-		if(1)
-			new /obj/item/shared_storage/red(src)
-		if(2)
-			new /obj/item/clothing/suit/space/hardsuit/cult(src)
-		if(3)
-			new /obj/item/soulstone/anybody(src)
-		if(4)
-			new /obj/item/katana/cursed(src)
-		if(5)
-			new /obj/item/clothing/glasses/godeye(src)
-		if(6)
-			new /obj/item/reagent_containers/glass/bottle/potion/flight(src)
-		if(7)
-			new /obj/item/pickaxe/diamond(src)
-		if(8)
-			if(prob(50))
-				new /obj/item/disk/design_disk/modkit_disc/resonator_blast(src)
-			else
-				new /obj/item/disk/design_disk/modkit_disc/rapid_repeater(src)
+		if(1 to 2)
+			new /obj/item/disk/design_disk/modkit_disc/resonator_blast(src)  //Doubled chance to receive upgrade disk that is directly relevant to mining
+		if(3 to 4)
+			new /obj/item/disk/design_disk/modkit_disc/rapid_repeater(src)
+		if(5 to 6)	
+			new /obj/item/disk/design_disk/modkit_disc/mob_and_turf_aoe(src)
+		if(7 to 8)
+			new /obj/item/disk/design_disk/modkit_disc/bounty(src)
 		if(9)
-			new /obj/item/rod_of_asclepius(src)
+			new /obj/item/borg/upgrade/modkit/lifesteal(src)
 		if(10)
-			new /obj/item/organ/heart/cursed/wizard(src)
+			new /obj/item/shared_storage/red(src)
 		if(11)
-			new /obj/item/ship_in_a_bottle(src)
+			new /obj/item/clothing/glasses/godeye(src)
 		if(12)
-			new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/lavaland/beserker(src)
+			new /obj/item/reagent_containers/glass/bottle/potion/flight(src)
 		if(13)
-			new /obj/item/jacobs_ladder(src)
+			new /obj/item/pickaxe/diamond(src) //Ashwalkers exist. This is actually a great drop for them
 		if(14)
-			new /obj/item/nullrod/scythe/talking(src)
+			new /obj/item/rod_of_asclepius(src)
 		if(15)
-			new /obj/item/nullrod/armblade(src)
+			new /obj/item/organ/heart/cursed/wizard(src)
 		if(16)
-			new /obj/item/guardiancreator/hive(src)
+			new /obj/item/ship_in_a_bottle(src)
 		if(17)
-			if(prob(50))
-				new /obj/item/disk/design_disk/modkit_disc/mob_and_turf_aoe(src)
-			else
-				new /obj/item/disk/design_disk/modkit_disc/bounty(src)
+			new /obj/item/jacobs_ladder(src)
 		if(18)
 			new /obj/item/warp_cube/red(src)
 		if(19)
@@ -65,24 +51,12 @@
 		if(21)
 			new /obj/item/gun/magic/hook(src)
 		if(22)
-			new /obj/item/voodoo(src)
-		if(23)
-			new /obj/item/grenade/clusterbuster/inferno(src)
-		if(24)
-			new /obj/item/reagent_containers/food/drinks/bottle/holywater/hell(src)
-			new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/lavaland/inquisitor(src)
-		if(25)
-			new /obj/item/book/granter/spell/summonitem(src)
-		if(26)
 			new /obj/item/book_of_babel(src)
-		if(27)
-			new /obj/item/borg/upgrade/modkit/lifesteal(src)
-			new /obj/item/bedsheet/cult(src)
-		if(28)
+		if(23)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
-		if(29)
+		if(24)
 			new /obj/item/reagent_containers/glass/waterbottle/relic(src)
-		if(30)
+		if(25)
 			new /obj/item/reagent_containers/glass/bottle/necropolis_seed(src)
 
 //KA modkit design discs
@@ -427,8 +401,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	fire_sound = 'sound/weapons/batonextend.ogg'
 	max_charges = 1
-	item_flags = NEEDS_PERMIT | NOBLUDGEON
-	force = 18
+	item_flags = NEEDS_PERMIT
+	force = 15
 	attack_weight = 2
 
 /obj/item/ammo_casing/magic/hook
@@ -443,7 +417,7 @@
 	icon_state = "hook"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	pass_flags = PASSTABLE
-	damage = 25
+	damage = 10
 	armour_penetration = 100
 	damage_type = BRUTE
 	hitsound = 'sound/effects/splat.ogg'
@@ -698,13 +672,31 @@
 
 ///Bosses
 
+//Legion
+
+/obj/structure/closet/crate/necropolis/legion
+	name = "legion chest"
+	
+/obj/structure/closet/crate/necropolis/legion/PopulateContents()
+	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
+	var/random_crystal = pick(choices)
+	new random_crystal(src)
+	new /obj/effect/spawner/lootdrop/megafaunaore(src)
+
 //Miniboss Miner
+
+/obj/structure/closet/crate/necropolis/bdm
+	name = "blood-drunk miner chest"
+	
+/obj/structure/closet/crate/necropolis/bdm/PopulateContents()
+	new /obj/item/melee/transforming/cleaving_saw(src)
+	new /obj/effect/spawner/lootdrop/megafaunaore(src)
 
 /obj/item/melee/transforming/cleaving_saw
 	name = "cleaving saw"
 	desc = "This saw, effective at drawing the blood of beasts, transforms into a long cleaver that makes use of centrifugal force."
-	force = 12
-	force_on = 20 //force when active
+	force = 8
+	force_on = 15 //force when active
 	throwforce = 20
 	throwforce_on = 20
 	icon = 'icons/obj/lavaland/artefacts.dmi'
@@ -722,7 +714,7 @@
 	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = IS_SHARP
-	faction_bonus_force = 30
+	faction_bonus_force = 45
 	nemesis_factions = list("mining", "boss")
 	var/transform_cooldown
 	var/swiping = FALSE
@@ -798,24 +790,10 @@
 	name = "dragon chest"
 
 /obj/structure/closet/crate/necropolis/dragon/PopulateContents()
-	var/loot = rand(1,4)
-	switch(loot)
-		if(1)
-			new /obj/item/melee/ghost_sword(src)
-		if(2)
-			new /obj/item/lava_staff(src)
-		if(3)
-			new /obj/item/book/granter/spell/sacredflame(src)
-			new /obj/item/gun/magic/wand/fireball(src)
-		if(4)
-			new /obj/item/dragons_blood(src)
+	new /obj/effect/spawner/lootdrop/megafaunaore(src)
+	new /obj/item/dragons_blood(src)
 
-/obj/structure/closet/crate/necropolis/dragon/crusher
-	name = "firey dragon chest"
-
-/obj/structure/closet/crate/necropolis/dragon/crusher/PopulateContents()
-	..()
-	new /obj/item/crusher_trophy/tail_spike(src)
+// Ghost Sword - left in for other references and admin shenanigans
 
 /obj/item/melee/ghost_sword
 	name = "\improper spectral blade"
@@ -925,7 +903,7 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/random = rand(1,4)
+	var/random = rand(1,3)
 
 	switch(random)
 		if(1)
@@ -937,11 +915,6 @@
 			to_chat(user, "<span class='danger'>Your flesh begins to melt! Miraculously, you seem fine otherwise.</span>")
 			H.set_species(/datum/species/skeleton)
 		if(3)
-			to_chat(user, "<span class='danger'>Power courses through you! You can now shift your form at will.</span>")
-			if(user.mind)
-				var/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/D = new
-				user.mind.AddSpell(D)
-		if(4)
 			to_chat(user, "<span class='danger'>You feel like you could walk straight through lava now.</span>")
 			H.weather_immunities |= "lava"
 
@@ -1039,21 +1012,7 @@
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
-	var/loot = rand(1,3)
-	switch(loot)
-		if(1)
-			new /obj/item/mayhem(src)
-		if(2)
-			new /obj/item/blood_contract(src)
-		if(3)
-			new /obj/item/gun/magic/staff/spellblade(src)
-
-/obj/structure/closet/crate/necropolis/bubblegum/crusher
-	name = "bloody bubblegum chest"
-
-/obj/structure/closet/crate/necropolis/bubblegum/crusher/PopulateContents()
-	..()
-	new /obj/item/crusher_trophy/demon_claws(src)
+	new /obj/effect/spawner/lootdrop/megafaunaore(src)
 
 /obj/item/mayhem
 	name = "mayhem in a bottle"
@@ -1125,19 +1084,19 @@
 	return ..()
 
 /obj/structure/closet/crate/necropolis/colossus/PopulateContents()
-	var/list/choices = subtypesof(/obj/machinery/anomalous_crystal)
-	var/random_crystal = pick(choices)
-	new random_crystal(src)
 	new /obj/item/organ/vocal_cords/colossus(src)
+	new /obj/effect/spawner/lootdrop/megafaunaore(src)
 
-/obj/structure/closet/crate/necropolis/colossus/crusher
-	name = "angelic colossus chest"
-
-/obj/structure/closet/crate/necropolis/colossus/crusher/PopulateContents()
-	..()
-	new /obj/item/crusher_trophy/blaster_tubes(src)
 
 //Hierophant
+
+/obj/structure/closet/crate/necropolis/hierophant
+	name = "hierophant chest"
+	
+/obj/structure/closet/crate/necropolis/hierophant/PopulateContents()
+	new /obj/item/hierophant_club(src)
+	new /obj/effect/spawner/lootdrop/megafaunaore(src)
+	
 /obj/item/hierophant_club
 	name = "hierophant club"
 	desc = "The strange technology of this large club allows various nigh-magical feats. It used to beat you, but now you can set the beat."
@@ -1150,7 +1109,7 @@
 	inhand_y_dimension = 64
 	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	force = 15
+	force = 5 //Melee attacks also invoke a 15 burn damage AoE, for a total of 20 damage
 	attack_verb = list("clubbed", "beat", "pummeled")
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	actions_types = list(/datum/action/item_action/vortex_recall, /datum/action/item_action/toggle_unfriendly_fire)
@@ -1202,7 +1161,7 @@
 			if(isliving(target) && chaser_timer <= world.time) //living and chasers off cooldown? fire one!
 				chaser_timer = world.time + chaser_cooldown
 				var/obj/effect/temp_visual/hierophant/chaser/C = new(get_turf(user), user, target, chaser_speed, friendly_fire_check)
-				C.damage = 30
+				C.damage = 15
 				C.monster_damage_boost = FALSE
 				log_combat(user, target, "fired a chaser at", src)
 			else
@@ -1405,17 +1364,20 @@
 		var/obj/effect/temp_visual/hierophant/blast/B = new(t, user, friendly_fire_check)
 		B.damage = 15 //keeps monster damage boost due to lower damage
 
-
 //Just some minor stuff
 /obj/structure/closet/crate/necropolis/puzzle
 	name = "puzzling chest"
 
 /obj/structure/closet/crate/necropolis/puzzle/PopulateContents()
-	var/loot = rand(1,3)
+	var/loot = rand(1,5)
 	switch(loot)
 		if(1)
-			new /obj/item/soulstone/anybody(src)
+			new /obj/item/disk/design_disk/modkit_disc/resonator_blast(src)
 		if(2)
-			new /obj/item/wisp_lantern(src)
+			new /obj/item/disk/design_disk/modkit_disc/rapid_repeater(src)
 		if(3)
-			new /obj/item/prisoncube(src)
+			new /obj/item/disk/design_disk/modkit_disc/mob_and_turf_aoe(src)
+		if(4)
+			new /obj/item/disk/design_disk/modkit_disc/bounty(src)
+		if(5)
+			new /obj/item/borg/upgrade/modkit/lifesteal(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -39,8 +39,8 @@ Difficulty: Medium
 	ranged = TRUE
 	ranged_cooldown_time = 16
 	pixel_x = -16
-	crusher_loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator, /obj/item/crusher_trophy/miner_eye)
-	loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/bdm, /obj/item/crusher_trophy/miner_eye)
+	loot = list(/obj/structure/closet/crate/necropolis/bdm)
 	wander = FALSE
 	del_on_death = TRUE
 	blood_volume = BLOOD_VOLUME_NORMAL

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -18,10 +18,7 @@ It may summon clones charging from all sides, one of these charges being bubbleg
 It can charge at its target, and also heavily damaging anything directly hit in the charge.
 If at half health it will start to charge from all sides with clones.
 
-When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a chest that can contain three things:
- 1. A bottle that, when activated, drives everyone nearby into a frenzy
- 2. A contract that marks for death the chosen target
- 3. A spellblade that can slice off limbs at range
+When Bubblegum dies, it leaves behind a H.E.C.K. mining suit.
 
 Difficulty: Hard
 
@@ -51,7 +48,7 @@ Difficulty: Hard
 	ranged = TRUE
 	pixel_x = -32
 	del_on_death = TRUE
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/crusher)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum, /obj/item/crusher_trophy/demon_claws)
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
 	blood_volume = BLOOD_VOLUME_MAXIMUM //BLEED FOR ME
 	var/charging = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -44,7 +44,7 @@ Difficulty: Very Hard
 	gps_name = "Angelic Signal"
 	medal_type = BOSS_MEDAL_COLOSSUS
 	score_type = COLOSSUS_SCORE
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/colossus/crusher)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/colossus, /obj/item/crusher_trophy/blaster_tubes)
 	loot = list(/obj/structure/closet/crate/necropolis/colossus)
 	deathmessage = "disintegrates, leaving a glowing core in its wake."
 	deathsound = 'sound/magic/demon_dies.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -18,11 +18,7 @@ The drake also utilizes its wings to fly into the sky, flying after its target a
  - Sometimes it will chain these swooping attacks over and over, making swiftness a necessity.
  - Sometimes, it will encase its target in an arena of lava
 
-When an ash drake dies, it leaves behind a chest that can contain four things:
- 1. A spectral blade that allows its wielder to call ghosts to it, enhancing its power
- 2. A lava staff that allows its wielder to create lava
- 3. A spellbook and wand of fireballs
- 4. A bottle of dragon's blood with several effects, including turning its imbiber into a drake themselves.
+When an ash drake dies, it leaves behind a chest that contains a bottle of dragon's blood with several effects, ranging from turning the imbiber into a lizard, skeleton or just making them lavaproof.
 
 When butchered, they leave behind diamonds, sinew, bone, and ash drake hide. Ash drake hide can be used to create a hooded cloak that protects its wearer from ash storms.
 
@@ -49,7 +45,7 @@ Difficulty: Medium
 	move_to_delay = 5
 	ranged = TRUE
 	pixel_x = -16
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/dragon/crusher)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/dragon, /obj/item/crusher_trophy/tail_spike)
 	loot = list(/obj/structure/closet/crate/necropolis/dragon)
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
 	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/ashdrake = 10)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -54,8 +54,8 @@ Difficulty: Hard
 	ranged = TRUE
 	ranged_cooldown_time = 40
 	aggro_vision_range = 21 //so it can see to one side of the arena to the other
-	loot = list(/obj/item/hierophant_club)
-	crusher_loot = list(/obj/item/hierophant_club, /obj/item/crusher_trophy/vortex_talisman)
+	loot = list(/obj/structure/closet/crate/necropolis/hierophant)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/hierophant, /obj/item/crusher_trophy/vortex_talisman)
 	wander = FALSE
 	gps_name = "Zealous Signal"
 	medal_type = BOSS_MEDAL_HIEROPHANT

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -153,7 +153,7 @@ Difficulty: Medium
 				last_legion = FALSE
 				break
 		if(last_legion)
-			loot = list(/obj/item/staff/storm)
+			loot = list(/obj/structure/closet/crate/necropolis/legion)
 			elimination = FALSE
 		else if(prob(5))
 			loot = list(/obj/structure/closet/crate/necropolis/tendril)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### This PR aims to reduce the maximum power ceiling for Shaft Miners and also increase the consistency of specific drops from bosses and tendrils.

***

Every boss now has a single unique item drop which they will always drop upon defeat, as well as a randomized cache of 100 ores (about 1200-1800 mining points worth, does not include bluespace crystals but does include diamond)
* Ash Drake always drops vial of dragon blood
* Colossus always drops the vocal chords
* Bubblegum always drops H.E.C.K. Suit
* Legion always drops an anomalous crystal (used to be part of Colossus drops)
* Hierophant always drops its staff (No change beyond now also dropping ore)
* Blood Drunk Miner always drops cleaving saw (Removed pka from its drop)

***

Most items useful only for pvp or grief have been removed from boss and necropolis chest drops both, and a few items widely considered to be "worthless" drops have been removed as well to compensate the overall quality of loot somewhat. Several of this items are equivalent to high-cost traitor items, or even so powerful there is no equivalent outside of Space Wizards.

Removed from Necro Chests:
* All three ERT-level Hardsuits
* Both Chaplain weapons
* Katana
* Infinite soulstone
* Mysterious Core
* Inferno Grenade
* Voodoo Doll
* Instant Summons Spellbook
* Puzzle Cube

Removed from Boss drop tables:
* **Spectral Blade** - Extremely annoying for ghosts due to being a permanent tether, and frequently a worthless drop beyond annoying them. When it wasn't worthless it's because the weapon had no upper damage cap
* **Lava staff** - Useful almost exclusively for grief considering the availability of RCDs. Even antagonists will have a somewhat hard time making use of the lava ability. 
* **Spellbook of Sacred Flame** - Again, almost exclusively useful for grief and nothing else.
* **Staff of Storms** - Ditto the above two items. 
* **Wand of Fireball** - Useless outside of PvP, and in PvP against anyone that isn't magic proof it's a one-hit ranged AoE stun and a 2-hit crit. 
* **Mayhem in a Bottle** - Useful for grief/murderbone and pretty much nothing else. If I tried to pass this as an uplink item, it would fail; so why is it available to non-antags just because they can kill a boss?
* **Blood Contract** - Who even thought this was a good idea? Same as above - this wouldn't even pass for a traitor uplink item and it's dedicated to the remote killing of someone. 
* **Spellblade** - While this one is substantially better balanced on damage, it's still exclusively useful for pvp and extraordinarily powerful for it due to the high dismember chance and duo of being powerful at both short and long range. 

***

Three of the remaining weapons have been rebalanced:
* **Hierophant Staff** has had its absurdly high 30 burn damage reduced to 15 across the board, and melee attacks now do 5 brute damage + 15 burn on AoE for a total of 20 damage. The staff remains one of the most powerful utility tools available due to its teleportation and ability to rapidly clear rocks as a mining tool, but it is no longer *also* an absurdly powerful weapon. 
* **Cleaving Saw** has had its damage against players reduced by 25% when unfolded and 33% when folded. It's bonus damage to fauna has been increased to compensate when using the unfolded form, but the bleeding effect while it is folded is so powerful that no tweaking was necessary to achieve the same number of hits until death. This is still an extremely powerful pvp weapon, and also still the highest DPS weapon for killing fauna as well, it's just been dialed back a little bit against players. 
* **Meat Hook** is now usable as a melee weapon when using harm intent... however its ranged damage has been decreased from 25 to 10. Melee swings deal 15 damage and follow normal armor calculations unlike the ranged attack. While this is a weapon that is useful almost exclusively for pvp, it's not *just* a weapon, and has its own unique gimmick while not being off the scales when it comes to power.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Members of security and antagonists should generally be the most powerfully equipped forces on the station when it comes to dealing with other players and rewards for mining should be heavily weighted toward rewards that are either directly related to mining or gimmicky fun - not items dedicated to grief and pvp.

Additionally many players wish to be miners just to learn how to fight the bosses and get better at fighting them - this allows players who find normal mining boring to still acquire ores that help the station as a whole as a reward for completing boss fights. No longer will miners rushing fauna be an issue to both the station and other miners who feel it isn't fair that they lose out because they decided to contribute to the station first. *If they choose to completely ignore the ore drops, it still won't help the station, but the players that do this can eat my shoe* 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Meat Hook Grab now does 10 Armor-piercing damage instead of 25. Can now be used for normal melee attacks as well.
balance: Hierophant club now does 20 damage on melee attack w/ AoE (down from 30), and 15 on homing projectile (down from 30)
balance: Open cleaving saw now does 15 (down from 20) damage to players and 60 (up from 50) damage to fauna
balance: Closed cleaving saw now does 8 (down from 12) damage, bonus bleed effect on fauna is unchanged, and this still kills all non-boss fauna in the same number of hits as before
del: Eleven items have been removed from Necropolis chest drop table: All three hardsuits, Chaplain weapons, Infinite Soulstone, Katana,  Mysterious Core, Inferno Grenade, Voodoo Doll, and the Instant Summons spellbook. 
del: Spectral Blade, Lava staff, Spellbook of Sacred Flame, Wand of Fireball, Mayhem in a Bottle, Blood Contract, Spellblade, and Staff of Storms have all been removed from megafauna drop tables. 
tweak: PKA-related rewards have increased drop chances for necropolis chests.
tweak: Lavaland puzzle chest now always awards PKA-related rewards
tweak: All megafauna now drop a moderately large caches of ores, roughly 1500 points worth. 
tweak: All megafauna will now always drop the same equipment reward every time they are killed, 
tweak: Anomalous crystals are now dropped by the greater Legion instead of Colossus.
tweak: Bottle of dragon's blood no longer has a chance to grant an Ash Drake transformation, but retained its other three effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
