### PR TITLE
[Dependency:#4002] Makes wicker doll and prison cube available via uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2058,6 +2058,20 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list("Curator")
 	limited_stock = 1 //please don't spam deadchat
 
+/datum/uplink_item/role_restricted/voodoo
+	name = "Wicker Doll"
+	desc = "A wicker voodoo doll with a cavity for storing a small item. Once an item has been stored within it, the doll may be used to manipulate the actions of another person that has previously been in contact with the stored item."
+	item = /obj/item/voodoo
+	cost = 12
+	restricted_roles = list("Curator", "Stage Magician")
+
+/datum/uplink_item/role_restricted/prison_cube
+	name = "Prison Cube"
+	desc = "A very strange artifact recovered from a volcanic planet that is useful for keeping people locked away, but not very useful for keeping their disappearance unknown"
+	item = /obj/item/prisoncube
+	cost = 6
+	restricted_roles = list("Curator")
+
 /datum/uplink_item/role_restricted/his_grace
 	name = "His Grace"
 	desc = "An incredibly dangerous weapon recovered from a station overcome by the grey tide. Once activated, He will thirst for blood and must be used to kill to sate that thirst. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the wicker (voodoo) doll to Curator and Stage Magician uplinks for 12 TC.
Adds the Prison Cube to Curator uplinks for 6 TC.

![image](https://user-images.githubusercontent.com/9547572/113152364-ac643800-91fb-11eb-9be2-7d8c5c7048e4.png)

For those who are unfamiliar with the items: They are both currently available to shaft miners as random drops on lavaland, but they rarely see use due to their antagonistic nature and also weak overall power compared to other rewards. They're much better off as quirky antag-only items for use by players who aren't afraid to sacrifice their livelihood for a little chaotic fun. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because these are fun and quirky items that shouldn't be removed entirely from the game per #4002 
Both items are a good match for the Curator's desire to collect oddities, and the Wicker Doll also fits the wizard-lite theme of Stage magician.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Wicker Doll (Voodoo doll) is now available in traitor uplinks for both Curators and Stage Magicians at a cost of 12 TC
add: Prison cube is now available in traitor uplinks for Curators at a cost of 6 TC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
