### PR TITLE
Tail grabbing rising: revengeance (nerfed)

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -300,9 +300,9 @@
 				M.visible_message("<span class ='warning'> [src] grabs [L] by the tail!</span>", null, null, src)
 				to_chat(src, "<span class='notice'>You grab [L] by their tail! Weirdo!</span>")
 			else
-				M.visible_message("<span class='warning'>[src] grabs [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>", \
-								"<span class='warning'>[src] grabs you [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by your hands":"passively"]!</span>", null, null, src)
-				to_chat(src, "<span class='notice'>You grab [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>")
+				M.visible_message("<span class='warning'>[src] grabs [M] [(zone_selected == BODY_ZONE_L_ARM || zone_selected == BODY_ZONE_R_ARM)? "by their hands":"passively"]!</span>", \
+								"<span class='warning'>[src] grabs you [(zone_selected == BODY_ZONE_L_ARM || zone_selected == BODY_ZONE_R_ARM)? "by your hands":"passively"]!</span>", null, null, src)
+				to_chat(src, "<span class='notice'>You grab [M] [(zone_selected == BODY_ZONE_L_ARM|| zone_selected == BODY_ZONE_R_ARM)? "by their hands":"passively"]!</span>")
 		if(!iscarbon(src))
 			M.LAssailant = null
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -295,7 +295,6 @@
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER)))
 			var/mob/living/L = M
 			if (L.getorgan(/obj/item/organ/tail/cat) && zone_selected == BODY_ZONE_PRECISE_GROIN)
-				setGrabState(GRAB_AGGRESSIVE)
 				log_combat(src, M, "grabbed", addition="aggressive grab")
 				M.visible_message("<span class ='warning'> [src] grabs [L] by the tail!</span>", null, null, src)
 				to_chat(src, "<span class='notice'>You grab [L] by their tail! Weirdo!</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -295,7 +295,6 @@
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER)))
 			var/mob/living/L = M
 			if (L.getorgan(/obj/item/organ/tail/cat) && zone_selected == BODY_ZONE_PRECISE_GROIN)
-				log_combat(src, M, "grabbed", addition="aggressive grab")
 				M.visible_message("<span class ='warning'> [src] grabs [L] by the tail!</span>", null, null, src)
 				to_chat(src, "<span class='notice'>You grab [L] by their tail! Weirdo!</span>")
 			else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -293,9 +293,16 @@
 
 		log_combat(src, M, "grabbed", addition="passive grab")
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER)))
-			M.visible_message("<span class='warning'>[src] grabs [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>", \
-							"<span class='warning'>[src] grabs you [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by your hands":"passively"]!</span>", null, null, src)
-			to_chat(src, "<span class='notice'>You grab [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>")
+			var/mob/living/L = M
+			if (L.getorgan(/obj/item/organ/tail/cat) && zone_selected == BODY_ZONE_PRECISE_GROIN)
+				setGrabState(GRAB_AGGRESSIVE)
+				log_combat(src, M, "grabbed", addition="aggressive grab")
+				M.visible_message("<span class ='warning'> [src] grabs [L] by the tail!</span>", null, null, src)
+				to_chat(src, "<span class='notice'>You grab [L] by their tail! Weirdo!</span>")
+			else
+				M.visible_message("<span class='warning'>[src] grabs [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>", \
+								"<span class='warning'>[src] grabs you [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by your hands":"passively"]!</span>", null, null, src)
+				to_chat(src, "<span class='notice'>You grab [M] [(zone_selected == "l_arm" || zone_selected == "r_arm")? "by their hands":"passively"]!</span>")
 		if(!iscarbon(src))
 			M.LAssailant = null
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -769,6 +769,8 @@
 			altered_grab_state++
 		else if(is_species(pulledby, /datum/species/squid) && pulledby.grab_state < GRAB_KILL) // If the puller is a squid, suction cups make it harder to break free
 			altered_grab_state++
+		else if(pulledby.zone_selected == BODY_ZONE_PRECISE_GROIN && src.getorgan(/obj/item/organ/tail/cat))
+			altered_grab_state++
 		var/resist_chance = BASE_GRAB_RESIST_CHANCE // see defines/combat.dm
 		resist_chance = max(resist_chance/altered_grab_state-sqrt((getStaminaLoss()+getBruteLoss()/2)*(3-altered_grab_state)), 0) // https://i.imgur.com/6yAT90T.png for sample output values
 		if(prob(resist_chance))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**PERMISSION: TheFakeElon**

Grabbing the groin region of anyone with a cat tail now has a custom message, and applies the effects of Grab Weakness (If resting, resisting out of a grab is equivalent to 1 grab state higher. wont make the grab state exceed the normal max, however). 

If people want I can apply this to all tails, I just found it extra funny it only applies to cat tails.

If you stop targeting the groin, it will stop applying grab weakness.
**Note: I plan on adding a new felinid ability soon-ish**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Felinid table efficacy increases 200%, and is funny.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: If you have a cat tail and are tail grabbed, you have grab weakness
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
