### PR TITLE
Adds cosmetic versions of sunhuds

### DIFF
--- a/code/datums/components/crafting/tailoring.dm
+++ b/code/datums/components/crafting/tailoring.dm
@@ -114,6 +114,14 @@
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
+/datum/crafting_recipe/beergogglesremoval
+	name = "Beer Goggles removal"
+	result = /obj/item/clothing/glasses/sunglasses/advanced
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/sunglasses/advanced/reagent = 1)
+	category = CAT_CLOTHING
+
 /datum/crafting_recipe/sunhudscience
 	name = "Science Sunglasses"
 	result = /obj/item/clothing/glasses/science/sciencesun
@@ -124,12 +132,84 @@
 				  /obj/item/stack/cable_coil = 5)
 	category = CAT_CLOTHING
 
-/datum/crafting_recipe/beergogglesremoval
-	name = "Beer Goggles removal"
+/datum/crafting_recipe/sunhudscienceremoval
+	name = "Science Sunglasses removal"
 	result = /obj/item/clothing/glasses/sunglasses/advanced
 	time = 20
 	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
-	reqs = list(/obj/item/clothing/glasses/sunglasses/advanced/reagent = 1)
+	reqs = list(/obj/item/clothing/glasses/science/sciencesun = 1)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/deghudsunsec
+	name = "Degraded Security HUDsunglasses"
+	result = /obj/item/clothing/glasses/hud/security/sunglasses/degraded
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/security = 1,
+				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/stack/cable_coil = 5)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/deghudsunsecremoval
+	name = "Degraded Security HUD removal"
+	result = /obj/item/clothing/glasses/sunglasses
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/security/sunglasses/degraded = 1)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/deghudsunmed
+	name = "Degraded Medical HUDsunglasses"
+	result = /obj/item/clothing/glasses/hud/health/sunglasses/degraded
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/health = 1,
+				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/stack/cable_coil = 5)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/deghudsunmedremoval
+	name = "Degraded Medical HUD removal"
+	result = /obj/item/clothing/glasses/sunglasses
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/health/sunglasses/degraded = 1)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/deghudsundiag
+	name = "Degraded Diagnostic HUDsunglasses"
+	result = /obj/item/clothing/glasses/hud/diagnostic/sunglasses/degraded
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/diagnostic = 1,
+				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/stack/cable_coil = 5)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/deghudsundiagremoval
+	name = "Degraded Diagnostic HUD removal"
+	result = /obj/item/clothing/glasses/sunglasses
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/hud/diagnostic/sunglasses/degraded = 1)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/degsunhudscience
+	name = "Degraded Science Sunglasses"
+	result = /obj/item/clothing/glasses/science/sciencesun/degraded
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/science = 1,
+				  /obj/item/clothing/glasses/sunglasses = 1,
+				  /obj/item/stack/cable_coil = 5)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/degsunhudscienceremoval
+	name = "Degraded Science Sunglasses removal"
+	result = /obj/item/clothing/glasses/sunglasses
+	time = 20
+	tools = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
+	reqs = list(/obj/item/clothing/glasses/science/sciencesun/degraded = 1)
 	category = CAT_CLOTHING
 
 /datum/crafting_recipe/ghostsheet

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -111,6 +111,11 @@
 	item_state = "sunhudscience"
 	flash_protect = 1
 
+obj/item/clothing/glasses/science/sciencesun/degraded
+	name = "degraded science sunglasses"
+	desc = "A pair of sunglasses outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion."
+	flash_protect = 0
+
 /obj/item/clothing/glasses/night
 	name = "night vision goggles"
 	desc = "You can totally see in the dark now!"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -111,7 +111,7 @@
 	item_state = "sunhudscience"
 	flash_protect = 1
 
-obj/item/clothing/glasses/science/sciencesun/degraded
+/obj/item/clothing/glasses/science/sciencesun/degraded
 	name = "degraded science sunglasses"
 	desc = "A pair of sunglasses outfitted with apparatus to scan reagents, as well as providing an innate understanding of liquid viscosity while in motion."
 	flash_protect = 0

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -83,6 +83,11 @@
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/blue
 
+/obj/item/clothing/glasses/hud/health/sunglasses/degraded
+	name = "degraded medical HUDSunglasses"
+	desc = "Sunglasses with a medical HUD. They do not provide flash protection."
+	flash_protect = 0
+
 /obj/item/clothing/glasses/hud/diagnostic
 	name = "diagnostic HUD"
 	desc = "A heads-up display capable of analyzing the integrity and status of robotics and exosuits."
@@ -106,6 +111,11 @@
 	item_state = "glasses"
 	flash_protect = 1
 	tint = 1
+
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses/degraded
+	name = "degraded diagnostic sunglasses"
+	desc = "Sunglasses with a diagnostic HUD. They do not provide flash protection."
+	flash_protect = 0
 
 /obj/item/clothing/glasses/hud/security
 	name = "security HUD"
@@ -165,6 +175,11 @@
 	flash_protect = 1
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/darkred
+
+/obj/item/clothing/glasses/hud/security/sunglasses/degraded
+	name = "degraded security HUDSunglasses"
+	desc = "Sunglasses with a security HUD. They do not provide flash protection"
+	flash_protect = 0
 
 /obj/item/clothing/glasses/hud/security/night
 	name = "night vision security HUD"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds cosmetic(degraded) versions of sunhuds which can be crafted from normal sunglasses and dont provide flash protection.
Also adds science sunglasses removal crafting recipe because I forgot to add it earlier.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Apparently an amount of people like sunhuds for the looks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Degraded sunhuds
add: Science sunglasses removal crafting recipe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
