### PR TITLE
Autolathe economy overhaul v2

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -5,6 +5,7 @@
 
 #define WIRE_DUD_PREFIX "__dud"
 #define WIRE_ACTIVATE "Activate"
+#define WIRE_ACCOUNT "Account"
 #define WIRE_AI "AI Connection"
 #define WIRE_ALARM "Alarm"
 #define WIRE_AVOIDANCE "Avoidance"

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -5,9 +5,10 @@
 /datum/wires/autolathe/New(atom/holder)
 	wires = list(
 		WIRE_HACK, WIRE_DISABLE,
-		WIRE_SHOCK, WIRE_ZAP, WIRE_ACTIVATE
+		WIRE_SHOCK, WIRE_ZAP, 
+		WIRE_ACTIVATE, WIRE_ACCOUNT
 	)
-	add_duds(5)
+	add_duds(4)
 	..()
 
 /datum/wires/autolathe/interactable(mob/user)
@@ -20,6 +21,7 @@
 	var/list/status = list()
 	status += "The red light is [A.disabled ? "on" : "off"]."
 	status += "The blue light is [A.hacked ? "on" : "off"]."
+	status += "The yellow light is [A.recieving_account ? "blinking" : "off"]."
 	return status
 
 /datum/wires/autolathe/on_pulse(wire)
@@ -36,6 +38,8 @@
 			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_ACTIVATE)
 			A.begin_process()
+		if(WIRE_ACCOUNT)
+			A.recieving_account = null
 
 /datum/wires/autolathe/on_cut(wire, mend)
 	var/obj/machinery/autolathe/A = holder

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -18,6 +18,7 @@
 	var/hack_wire
 	var/disable_wire
 	var/shock_wire
+	var/price_factor = 50
 
 	//Security modes
 	var/security_interface_locked = TRUE
@@ -120,12 +121,12 @@
 			
 			for(var/material_id in D.materials)
 				if(material_id != "rigid material")
-					price += ore_values["[material_id]"] * D.materials[material_id] / 50 // also multiplied by 2000, since there are 2000 mat units in a sheet
+					price += ore_values["[material_id]"] * D.materials[material_id] / price_factor // also multiplied by 2000, since there are 2000 mat units in a sheet
 					material_cost += list(list(
 						"name" = material_id,
 						"amount" = D.materials[material_id] / MINERAL_MATERIAL_AMOUNT,))
 				else
-					price += D.materials[material_id] / 50
+					price += D.materials[material_id] / price_factor
 
 			if(price < 10) //To ensure the price isnt too low.
 				price += 10
@@ -452,7 +453,7 @@
 
 	var/price = 0 
 	for(var/MAT in being_built.materials)
-		price += ore_values["[MAT]"] * being_built.materials[MAT] / 50
+		price += ore_values["[MAT]"] * being_built.materials[MAT] / price_factor
 		var/datum/material/used_material = MAT
 		var/amount_needed = being_built.materials[MAT] * coeff * multiplier
 		if(istext(used_material)) //This means its a category

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -1,5 +1,5 @@
 #define AUTOLATHE_MAX_POWER_USE 2000
-#define MINIMUM_PRICE 10
+#define MINIMUM_PRICE 5
 
 /obj/machinery/autolathe
 	name = "autolathe"
@@ -19,7 +19,7 @@
 	var/hack_wire
 	var/disable_wire
 	var/shock_wire
-	var/price_factor = 50
+	var/price_factor = 20
 
 	//Security modes
 	var/security_interface_locked = TRUE
@@ -107,7 +107,7 @@
 	var/list/data = list()	
 	data["acceptsDisk"] = TRUE
 
-	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
+	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 3, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
 
 	//Items
 	data["items"] = list()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -80,11 +80,6 @@
 
 	wires = new /datum/wires/autolathe(src)
 	stored_research = new /datum/techweb/specialized/autounlocking/autolathe
-	
-	if(recieving_account)
-		message_admins("[recieving_account.name]")	
-	else
-		message_admins("Null account")
 
 /obj/machinery/autolathe/Destroy()
 	QDEL_NULL(wires)
@@ -518,20 +513,15 @@
 		
 	if(materials.has_materials(materials_used))
 		if(price != 0)
-			message_admins("Printing...")
 			var/datum/bank_account/Civ = SSeconomy.get_dep_account(ACCOUNT_CIV)
 			if(recieving_account) // 20% NanoTrasen/Syndi, 70% linked ID, 10% Civ budget
-				message_admins("Charging, custom...")
 				var/datum/bank_account/Reci = recieving_account.registered_account
 				B._adjust_money(-price*0.2)
 				Reci.transfer_money(B, price*0.7)
 				Civ.transfer_money(B, price*0.1) 
-				message_admins("Done...")
 			else // 30% NanoTrasen/Syndi, 70% Civ budget
-				message_admins("Charging...")
 				B._adjust_money(-price*0.3)
 				Civ.transfer_money(B, price*0.7)
-				message_admins("Done...")
 		busy = TRUE
 		use_power(power)
 		icon_state = "autolathe_n"

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -112,8 +112,7 @@
 
 	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 3, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
 
-	var/turf/here = get_turf(src)
-	if(!is_station_level(here.z))
+	if(!is_station_level(z))
 		free_mode = TRUE
 
 	//Items

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -101,7 +101,7 @@
 	var/list/data = list()	
 	data["acceptsDisk"] = TRUE
 
-	var/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
+	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
 
 	//Items
 	data["items"] = list()
@@ -121,12 +121,12 @@
 			
 			for(var/material_id in D.materials)
 				if(material_id != "rigid material")
-					price += ore_values["[material_id]"] * D.materials[material_id] / price_factor // also multiplied by 2000, since there are 2000 mat units in a sheet
+					price += round(ore_values["[material_id]"] * D.materials[material_id] / price_factor) // also multiplied by 2000, since there are 2000 mat units in a sheet
 					material_cost += list(list(
 						"name" = material_id,
 						"amount" = D.materials[material_id] / MINERAL_MATERIAL_AMOUNT,))
 				else
-					price += D.materials[material_id] / price_factor
+					price += round(D.materials[material_id] / price_factor)
 
 			if(price < 10) //To ensure the price isnt too low.
 				price += 10
@@ -449,11 +449,11 @@
 	var/list/materials_used = list()
 	var/list/custom_materials = list() //These will apply their material effect, This should usually only be one.
 
-	var/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
+	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 5, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
 
 	var/price = 0 
 	for(var/MAT in being_built.materials)
-		price += ore_values["[MAT]"] * being_built.materials[MAT] / price_factor
+		price += round(ore_values["[MAT]"] * being_built.materials[MAT] / price_factor)
 		var/datum/material/used_material = MAT
 		var/amount_needed = being_built.materials[MAT] * coeff * multiplier
 		if(istext(used_material)) //This means its a category
@@ -520,13 +520,14 @@
 		autolathe_failure(1)
 
 /obj/machinery/autolathe/proc/autolathe_failure(failure) 
-	if(failure == 1)
-		failure = "bank credentials"
-	else if (failure == 2)
-		failure = "materials"
-		wants_operate = TRUE
-	else if (failure == 3)
-		failure = "credits"
+	switch(failure)
+		if(1)
+			failure = "bank credentials"
+		if(2)
+			failure = "materials"
+			wants_operate = TRUE
+		if(3)
+			failure = "credits"
 	say("Insufficient [failure], operation will proceed when sufficient [failure] are made available.")
 	operating = FALSE
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -112,6 +112,10 @@
 
 	var/static/list/ore_values = list(iron = 1, glass = 1, copper = 3, plasma = 15, silver = 16, gold = 18, titanium = 30, uranium = 30, diamond = 50, bluespace = 50, bananium = 60)
 
+	var/turf/here = get_turf(src)
+	if(!is_station_level(here.z))
+		free_mode = TRUE
+
 	//Items
 	data["items"] = list()
 	var/list/categories_associative = list()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -71,7 +71,8 @@
 	AddComponent(/datum/component/material_container, list(/datum/material/iron, /datum/material/glass, /datum/material/copper, /datum/material/gold, /datum/material/gold, /datum/material/silver, /datum/material/diamond, /datum/material/uranium, /datum/material/plasma, /datum/material/bluespace, /datum/material/bananium, /datum/material/titanium), 0, TRUE, null, null, CALLBACK(src, .proc/AfterMaterialInsert))
 	. = ..()
 
-	if(is_station_level(obj/machinery/autolathe))
+	var/turf/here = get_turf(src)
+	if(!is_station_level(here.z))
 		free_mode = TRUE
 
 	wires = new /datum/wires/autolathe(src)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -6,7 +6,7 @@
 	name = "Bucket"
 	id = "bucket"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 200)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/reagent_containers/glass/bucket
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -15,7 +15,7 @@
 	name = "Mop"
 	id = "mop"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 1000)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/mop
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -24,7 +24,7 @@
 	name="Push Broom"
 	id="pushbroom"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 2000)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/twohanded/pushbroom
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -33,7 +33,7 @@
 	name = "Pocket Crowbar"
 	id = "crowbar"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/crowbar
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
@@ -42,7 +42,7 @@
 	name = "Flashlight"
 	id = "flashlight"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200, /datum/material/copper = 100)
 	build_path = /obj/item/flashlight
 	category = list("initial","Tools")
 
@@ -50,7 +50,7 @@
 	name = "Fire Extinguisher"
 	id = "extinguisher"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 90)
+	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/extinguisher
 	category = list("initial","Tools")
 
@@ -58,7 +58,7 @@
 	name = "Pocket Fire Extinguisher"
 	id = "pocketfireextinguisher"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 40)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
 	build_path = /obj/item/extinguisher/mini
 	category = list("initial","Tools")
 
@@ -66,7 +66,7 @@
 	name = "Multitool"
 	id = "multitool"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200, /datum/material/copper = 50)
 	build_path = /obj/item/multitool
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
@@ -75,7 +75,7 @@
 	name = "Analyzer"
 	id = "analyzer"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30, /datum/material/glass = 20)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/glass = 100)
 	build_path = /obj/item/analyzer
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -84,7 +84,7 @@
 	name = "T-Ray Scanner"
 	id = "tscanner"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 150)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/glass = 100)
 	build_path = /obj/item/t_scanner
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -93,7 +93,7 @@
 	name = "Welding Tool"
 	id = "welding_tool"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 70, /datum/material/glass = 20)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 250)
 	build_path = /obj/item/weldingtool
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
@@ -102,7 +102,7 @@
 	name = "Emergency Welding Tool"
 	id = "mini_welding_tool"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30, /datum/material/glass = 10)
+	materials = list(/datum/material/iron = 750, /datum/material/glass = 100)
 	build_path = /obj/item/weldingtool/mini
 	category = list("initial","Tools")
 
@@ -110,7 +110,7 @@
 	name = "Screwdriver"
 	id = "screwdriver"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 75)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/screwdriver
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
@@ -119,7 +119,7 @@
 	name = "Wirecutters"
 	id = "wirecutters"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 80)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/wirecutters
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
@@ -128,7 +128,7 @@
 	name = "Wrench"
 	id = "wrench"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 150)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/wrench
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
@@ -137,7 +137,7 @@
 	name = "Plunger"
 	id = "plunger"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 150)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/plunger
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_MEDICAL
@@ -146,7 +146,7 @@
 	name = "Welding Helmet"
 	id = "welding_helmet"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 1750, /datum/material/glass = 400)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 500)
 	build_path = /obj/item/clothing/head/welding
 	category = list("initial","Tools")
 
@@ -154,7 +154,7 @@
 	name = "Cable Coil"
 	id = "cable_coil"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 10, /datum/material/glass = 5)
+	materials = list(/datum/material/copper = 1, /datum/material/glass = 5)
 	build_path = /obj/item/stack/cable_coil
 	category = list("initial","Tools","Tool Designs")
 	maxstack = 30
@@ -164,7 +164,7 @@
 	name = "Toolbox"
 	id = "tool_box"
 	build_type = AUTOLATHE
-	materials = list(MAT_CATEGORY_RIGID = 500)
+	materials = list(MAT_CATEGORY_RIGID = 2000)
 	build_path = /obj/item/storage/toolbox
 	category = list("initial","Tools")
 
@@ -172,7 +172,7 @@
 	name = "APC Module"
 	id = "power control"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 100, /datum/material/glass = 100)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 200)
 	build_path = /obj/item/electronics/apc
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -181,7 +181,7 @@
 	name = "Airlock Electronics"
 	id = "airlock_board"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 200)
 	build_path = /obj/item/electronics/airlock
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -190,7 +190,7 @@
 	name = "Firelock Circuitry"
 	id = "firelock_board"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 100)
 	build_path = /obj/item/electronics/firelock
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -199,7 +199,7 @@
 	name = "Air Alarm Electronics"
 	id = "airalarm_electronics"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 200)
 	build_path = /obj/item/electronics/airalarm
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -208,7 +208,7 @@
 	name = "Airlock Controller Electronics"
 	id = "aac_electronics"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 200)
 	build_path = /obj/item/electronics/advanced_airlock_controller
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -217,7 +217,7 @@
 	name = "Fire Alarm Electronics"
 	id = "firealarm_electronics"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 200)
 	build_path = /obj/item/electronics/firealarm
 	category = list("initial", "Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -226,7 +226,7 @@
 	name = "Camera"
 	id = "camera"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 100)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 100, /datum/material/copper = 100)
 	build_path = /obj/item/camera
 	category = list("initial", "Misc")
 
@@ -234,7 +234,7 @@
 	name = "Camera Film Cartridge"
 	id = "camera_film"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 10, /datum/material/glass = 10)
+	materials = list(/datum/material/iron = 100, /datum/material/glass = 50)
 	build_path = /obj/item/camera_film
 	category = list("initial", "Misc")
 
@@ -242,7 +242,7 @@
 	name = "Earmuffs"
 	id = "earmuffs"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 1000)
 	build_path = /obj/item/clothing/ears/earmuffs
 	category = list("initial", "Misc")
 
@@ -250,7 +250,7 @@
 	name = "Pipe Painter"
 	id = "pipe_painter"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2000)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000)
 	build_path = /obj/item/pipe_painter
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -259,7 +259,7 @@
 	name = "Airlock Painter"
 	id = "airlock_painter"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 1000)
 	build_path = /obj/item/airlock_painter
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
@@ -268,7 +268,7 @@
 	name = "Emergency Oxygen Tank"
 	id = "emergency_oxygen"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 500)
+	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/tank/internals/emergency_oxygen/empty
 	category = list("initial","Misc","Equipment")
 
@@ -276,7 +276,7 @@
 	name = "Extended-Capacity Emergency Oxygen Tank"
 	id = "emergency_oxygen_engi"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 750)
+	materials = list(/datum/material/iron = 2500)
 	build_path = /obj/item/tank/internals/emergency_oxygen/engi/empty
 	category = list("hacked","Misc","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
@@ -285,7 +285,7 @@
 	name = "Extended-Capacity Plasmaman Tank"
 	id = "plasmaman_tank"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 3200)
+	materials = list(/datum/material/iron = 3000)
 	build_path = /obj/item/tank/internals/plasmaman/empty
 	category = list("hacked","Misc","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
@@ -294,7 +294,7 @@
 	name = "Plasmaman Belt Tank"
 	id = "plasmaman_tank_belt"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 800)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/tank/internals/plasmaman/belt/empty
 	category = list("hacked","Misc","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
@@ -339,7 +339,7 @@
 	name = "Compressed Matter Cartridge"
 	id = "rcd_ammo"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 12000, /datum/material/glass = 8000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	build_path = /obj/item/rcd_ammo
 	category = list("initial","Construction")
 
@@ -347,7 +347,7 @@
 	name = "Kitchen Knife"
 	id = "kitchen_knife"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 12000)
+	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/kitchen/knife
 	category = list("initial","Dinnerware")
 
@@ -355,7 +355,7 @@
 	name = "Fork"
 	id = "fork"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 80)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/kitchen/fork
 	category = list("initial","Dinnerware")
 
@@ -395,7 +395,7 @@
 	name = "Shaker"
 	id = "shaker"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 1500)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/reagent_containers/food/drinks/shaker
 	category = list("initial","Dinnerware")
 
@@ -403,7 +403,7 @@
 	name = "Cultivator"
 	id = "cultivator"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron=50)
+	materials = list(/datum/material/iron=1000)
 	build_path = /obj/item/cultivator
 	category = list("initial","Misc", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -412,7 +412,7 @@
 	name = "Plant Analyzer"
 	id = "plant_analyzer"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 30, /datum/material/glass = 20)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200, /datum/material/copper = 200)
 	build_path = /obj/item/plant_analyzer
 	category = list("initial","Misc", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -421,7 +421,7 @@
 	name = "Shovel"
 	id = "shovel"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/shovel
 	category = list("initial","Misc", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -430,7 +430,7 @@
 	name = "Spade"
 	id = "spade"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 50)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/shovel/spade
 	category = list("initial","Misc", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -439,7 +439,7 @@
 	name = "Hatchet"
 	id = "hatchet"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 15000)
+	materials = list(/datum/material/iron = 6000)
 	build_path = /obj/item/hatchet
 	category = list("initial","Misc", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
@@ -448,7 +448,7 @@
 	name = "Tinfoil Hat"
 	id = "tinfoil_hat"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 5500)
+	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/clothing/head/foilhat
 	category = list("hacked", "Misc")
 
@@ -456,7 +456,7 @@
 	name = "Blood Filter"
 	id = "blood_filter"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1500, /datum/material/silver = 500)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1500, /datum/material/silver = 500)
 	build_path = /obj/item/blood_filter
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
@@ -465,7 +465,7 @@
 	name = "Scalpel"
 	id = "scalpel"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	build_path = /obj/item/scalpel
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
@@ -474,7 +474,7 @@
 	name = "Circular Saw"
 	id = "circular_saw"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 6000)
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000)
 	build_path = /obj/item/circular_saw
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
@@ -483,7 +483,7 @@
 	name = "Surgical Drill"
 	id = "surgicaldrill"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 6000)
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000)
 	build_path = /obj/item/surgicaldrill
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
@@ -492,7 +492,7 @@
 	name = "Retractor"
 	id = "retractor"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 6000, /datum/material/glass = 3000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	build_path = /obj/item/retractor
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
@@ -501,7 +501,7 @@
 	name = "Cautery"
 	id = "cautery"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 2500, /datum/material/glass = 750)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	build_path = /obj/item/cautery
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
@@ -510,7 +510,7 @@
 	name = "Hemostat"
 	id = "hemostat"
 	build_type = PROTOLATHE
-	materials = list(/datum/material/iron = 5000, /datum/material/glass = 2500)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
 	build_path = /obj/item/hemostat
 	category = list("initial", "Medical", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
@@ -519,7 +519,7 @@
 	name = "Beaker"
 	id = "beaker"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/glass = 500)
+	materials = list(/datum/material/glass = 2000)
 	build_path = /obj/item/reagent_containers/glass/beaker
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SERVICE
@@ -528,7 +528,7 @@
 	name = "Large Beaker"
 	id = "large_beaker"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/glass = 2500)
+	materials = list(/datum/material/glass = 4000)
 	build_path = /obj/item/reagent_containers/glass/beaker/large
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SERVICE
@@ -537,7 +537,7 @@
 	name = "Health Analyzer"
 	id = "healthanalyzer"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200, /datum/material/copper = 200)
 	build_path = /obj/item/healthanalyzer
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -546,7 +546,7 @@
 	name = "Pill Bottle"
 	id = "pillbottle"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 20, /datum/material/glass = 100)
+	materials = list(/datum/material/iron = 250, /datum/material/glass = 500)
 	build_path = /obj/item/storage/pill_bottle
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -555,7 +555,7 @@
 	name = "Beanbag Slug"
 	id = "beanbag_slug"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 2000)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 250)
 	build_path = /obj/item/ammo_casing/shotgun/beanbag
 	category = list("initial", "Security")
 
@@ -563,7 +563,7 @@
 	name = "Rubber Shot"
 	id = "rubber_shot"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 250)
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
 	category = list("initial", "Security")
 
@@ -571,7 +571,7 @@
 	name = "Speed Loader (.38)"
 	id = "c38"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 20000)
+	materials = list(/datum/material/iron = 2000, /datum/material/copper = 500)
 	build_path = /obj/item/ammo_box/c38
 	category = list("initial", "Security")
 
@@ -579,7 +579,7 @@
 	name = "Universal Recorder"
 	id = "recorder"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 60, /datum/material/glass = 30)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200, /datum/material/copper = 200)
 	build_path = /obj/item/taperecorder/empty
 	category = list("initial", "Misc")
 
@@ -587,7 +587,7 @@
 	name = "Tape"
 	id = "tape"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 20, /datum/material/glass = 5)
+	materials = list(/datum/material/iron = 250, /datum/material/glass = 250)
 	build_path = /obj/item/tape/random
 	category = list("initial", "Misc")
 
@@ -595,7 +595,7 @@
 	name = "Igniter"
 	id = "igniter"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/copper = 100)
 	build_path = /obj/item/assembly/igniter
 	category = list("initial", "Misc")
 
@@ -603,7 +603,7 @@
 	name = "Remote Signaling Device"
 	id = "signaler"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 400, /datum/material/glass = 120)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 200, /datum/material/copper = 200)
 	build_path = /obj/item/assembly/signaler
 	category = list("initial", "T-Comm")
 
@@ -611,7 +611,7 @@
 	name = "Radio Headset"
 	id = "radio_headset"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 75)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 250)
 	build_path = /obj/item/radio/headset
 	category = list("initial", "T-Comm")
 
@@ -619,7 +619,7 @@
 	name = "Station Bounced Radio"
 	id = "bounced_radio"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 75, /datum/material/glass = 25)
+	materials = list(/datum/material/iron = 1500, /datum/material/glass = 500)
 	build_path = /obj/item/radio/off
 	category = list("initial", "T-Comm")
 
@@ -627,7 +627,7 @@
 	name = "Intercom Frame"
 	id = "intercom_frame"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 75, /datum/material/glass = 25)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 500)
 	build_path = /obj/item/wallframe/intercom
 	category = list("initial", "T-Comm")
 
@@ -635,7 +635,7 @@
 	name = "Infrared Emitter"
 	id = "infrared_emitter"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500, /datum/material/copper = 100)
 	build_path = /obj/item/assembly/infra
 	category = list("initial", "Misc")
 
@@ -643,7 +643,7 @@
 	name = "Health Sensor"
 	id = "health_sensor"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 800, /datum/material/glass = 200)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 100)
 	build_path = /obj/item/assembly/health
 	category = list("initial", "Medical")
 
@@ -651,7 +651,7 @@
 	name = "Timer"
 	id = "timer"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 100)
 	build_path = /obj/item/assembly/timer
 	category = list("initial", "Misc")
 
@@ -659,7 +659,7 @@
 	name = "Voice Analyser"
 	id = "voice_analyser"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 100)
 	build_path = /obj/item/assembly/voice
 	category = list("initial", "Misc")
 
@@ -667,7 +667,7 @@
 	name = "Light Tube"
 	id = "light_tube"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/glass = 100)
+	materials = list(/datum/material/glass = 400, /datum/material/copper = 100)
 	build_path = /obj/item/light/tube
 	category = list("initial", "Construction")
 
@@ -675,7 +675,7 @@
 	name = "Light Bulb"
 	id = "light_bulb"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/glass = 100)
+	materials = list(/datum/material/glass = 250, /datum/material/copper = 50)
 	build_path = /obj/item/light/bulb
 	category = list("initial", "Construction")
 
@@ -683,7 +683,7 @@
 	name = "Camera Assembly"
 	id = "camera_assembly"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 400, /datum/material/glass = 250)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 250, /datum/material/copper = 100)
 	build_path = /obj/item/wallframe/camera
 	category = list("initial", "Construction")
 
@@ -691,7 +691,7 @@
 	name = "Newscaster Frame"
 	id = "newscaster_frame"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 14000, /datum/material/glass = 8000)
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/copper = 250)
 	build_path = /obj/item/wallframe/newscaster
 	category = list("initial", "Construction")
 
@@ -699,7 +699,7 @@
 	name = "Syringe"
 	id = "syringe"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 10, /datum/material/glass = 20)
+	materials = list(/datum/material/iron = 100, /datum/material/glass = 500)
 	build_path = /obj/item/reagent_containers/syringe
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -708,7 +708,7 @@
 	name = "Dropper"
 	id = "dropper"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 10, /datum/material/glass = 30)
+	materials = list(/datum/material/glass = 300)
 	build_path = /obj/item/reagent_containers/dropper
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
@@ -717,7 +717,7 @@
 	name = "Proximity Sensor"
 	id = "prox_sensor"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 800, /datum/material/glass = 200)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 100, /datum/material/copper = 100)
 	build_path = /obj/item/assembly/prox_sensor
 	category = list("initial", "Misc")
 
@@ -725,7 +725,7 @@
 	name = "Box of Foam Darts"
 	id = "foam_dart"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_box/foambox
 	category = list("initial", "Misc")
 
@@ -734,7 +734,7 @@
 	name = "Flamethrower"
 	id = "flamethrower"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500)
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 500)
 	build_path = /obj/item/flamethrower/full
 	category = list("hacked", "Security")
 
@@ -742,7 +742,7 @@
 	name = "Electropack"
 	id = "electropack"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 2500)
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 1000)
 	build_path = /obj/item/electropack
 	category = list("hacked", "Tools")
 
@@ -750,7 +750,7 @@
 	name = "Industrial Welding Tool"
 	id = "large_welding_tool"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 70, /datum/material/glass = 60)
+	materials = list(/datum/material/iron = 1250, /datum/material/glass = 250, /datum/material/copper = 250)
 	build_path = /obj/item/weldingtool/largetank
 	category = list("hacked", "Tools")
 
@@ -758,7 +758,7 @@
 	name = "Handcuffs"
 	id = "handcuffs"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/restraints/handcuffs
 	category = list("hacked", "Security")
 
@@ -766,7 +766,7 @@
 	name = "Modular Receiver"
 	id = "receiver"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 15000)
+	materials = list(/datum/material/iron = 8000, /datum/material/copper = 1000)
 	build_path = /obj/item/weaponcrafting/receiver
 	category = list("hacked", "Security")
 
@@ -774,7 +774,7 @@
 	name = "Shotgun Slug"
 	id = "shotgun_slug"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/shotgun
 	category = list("hacked", "Security")
 
@@ -782,7 +782,7 @@
 	name = "Buckshot Shell"
 	id = "buckshot_shell"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
 	category = list("hacked", "Security")
 
@@ -790,7 +790,7 @@
 	name = "Shotgun Dart"
 	id = "shotgun_dart"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/shotgun/dart
 	category = list("hacked", "Security")
 
@@ -798,7 +798,7 @@
 	name = "Incendiary Slug"
 	id = "incendiary_slug"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/shotgun/incendiary
 	category = list("hacked", "Security")
 
@@ -806,7 +806,7 @@
 	name = "Foam Riot Dart"
 	id = "riot_dart"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 1000) //Discount for making individually - no box = less metal!
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
 	category = list("hacked", "Security")
 
@@ -814,7 +814,7 @@
 	name = "Foam Riot Dart Box"
 	id = "riot_darts"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 50000) //Comes with 40 darts
+	materials = list(/datum/material/iron = 3000, /datum/material/glass = 250, /datum/material/copper = 200) //Comes with 40 darts
 	build_path = /obj/item/ammo_box/foambox/riot
 	category = list("hacked", "Security")
 
@@ -822,7 +822,7 @@
 	name = ".357 Casing"
 	id = "a357"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = 750, /datum/material/copper = 200)
 	build_path = /obj/item/ammo_casing/a357
 	category = list("hacked", "Security")
 
@@ -830,7 +830,7 @@
 	name = "Ammo Box (10mm)"
 	id = "c10mm"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30000)
+	materials = list(/datum/material/iron = 4000, /datum/material/copper = 500)
 	build_path = /obj/item/ammo_box/c10mm
 	category = list("hacked", "Security")
 
@@ -838,7 +838,7 @@
 	name = "Ammo Box (.45)"
 	id = "c45"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30000)
+	materials = list(/datum/material/iron = 5000, /datum/material/copper = 500)
 	build_path = /obj/item/ammo_box/c45
 	category = list("hacked", "Security")
 
@@ -846,7 +846,7 @@
 	name = "Ammo Box (9mm)"
 	id = "c9mm"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 30000)
+	materials = list(/datum/material/iron = 4000, /datum/material/copper = 500)
 	build_path = /obj/item/ammo_box/c9mm
 	category = list("hacked", "Security")
 
@@ -854,7 +854,7 @@
 	name = "Butcher's Cleaver"
 	id = "cleaver"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 18000)
+	materials = list(/datum/material/iron = 6000)
 	build_path = /obj/item/kitchen/knife/butcher
 	category = list("hacked", "Dinnerware")
 
@@ -862,7 +862,7 @@
 	name = "Spraycan"
 	id = "spraycan"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 100, /datum/material/glass = 100)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 250)
 	build_path = /obj/item/toy/crayon/spraycan
 	category = list("initial", "Tools")
 
@@ -870,7 +870,7 @@
 	name = "Destination Tagger"
 	id = "desttagger"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 250, /datum/material/glass = 125)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 250)
 	build_path = /obj/item/destTagger
 	category = list("initial", "Electronics")
 
@@ -878,7 +878,7 @@
 	name = "Hand Labeler"
 	id = "handlabel"
 	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 150, /datum/material/glass = 125)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 250)
 	build_path = /obj/item/hand_labeler
 	category = list("initial", "Electronics")
 
@@ -886,7 +886,7 @@
 	name = "Geiger Counter"
 	id = "geigercounter"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 150, /datum/material/glass = 150)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200, /datum/material/copper = 200)
 	build_path = /obj/item/geiger_counter
 	category = list("initial", "Tools")
 
@@ -894,7 +894,7 @@
 	name = "Turret Control Frame"
 	id = "turret_control"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 12000)
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 1000, /datum/material/copper = 1000)
 	build_path = /obj/item/wallframe/turret_control
 	category = list("initial", "Construction")
 
@@ -902,7 +902,7 @@
 	name = "Conveyor Belt"
 	id = "conveyor_belt"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 3000)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/stack/conveyor
 	category = list("initial", "Construction")
 	maxstack = 30
@@ -911,7 +911,7 @@
 	name = "Conveyor Belt Switch"
 	id = "conveyor_switch"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 450, /datum/material/glass = 190)
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 200)
 	build_path = /obj/item/conveyor_switch_construct
 	category = list("initial", "Construction")
 
@@ -919,7 +919,7 @@
 	name = "Laptop Frame"
 	id = "laptop"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 10000, /datum/material/glass = 1000)
+	materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000, /datum/material/copper = 500)
 	build_path = /obj/item/modular_computer/laptop/buildable
 	category = list("initial","Misc")
 
@@ -927,7 +927,7 @@
 	name = "Tablet Frame"
 	id = "tablet"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000)
+	materials = list(/datum/material/iron = 3000, /datum/material/glass = 2000, /datum/material/copper = 250)
 	build_path = /obj/item/modular_computer/tablet
 	category = list("initial","Misc")
 
@@ -935,7 +935,7 @@
 	name = "Slime Scanner"
 	id = "slime_scanner"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 300, /datum/material/glass = 200)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200, /datum/material/copper = 200)
 	build_path = /obj/item/slime_scanner
 	category = list("initial", "Misc")
 
@@ -943,7 +943,7 @@
 	name = "Pet Carrier"
 	id = "pet_carrier"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 7500, /datum/material/glass = 100)
+	materials = list(/datum/material/iron = 3000, /datum/material/glass = 2000)
 	build_path = /obj/item/pet_carrier
 	category = list("initial", "Misc")
 
@@ -951,7 +951,7 @@
 	name = "Light Fixture Battery"
 	id = "miniature_power_cell"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/glass = 20)
+	materials = list(/datum/material/iron = 100, /datum/material/copper = 50)
 	build_path = /obj/item/stock_parts/cell/emergency_light
 	category = list("initial", "Electronics")
 
@@ -968,7 +968,7 @@
 	name = "Holodisk"
 	id = "holodisk"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 100, /datum/material/glass = 100)
+	materials = list(/datum/material/iron = 200, /datum/material/glass = 200, /datum/material/copper = 100)
 	build_path = /obj/item/disk/holodisk
 	category = list("initial", "Misc")
 
@@ -976,7 +976,7 @@
 	name = "Blue Circuit Tile"
 	id = "circuit"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/stack/tile/circuit
 	category = list("initial", "Misc")
 	maxstack = 50
@@ -985,7 +985,7 @@
 	name = "Green Circuit Tile"
 	id = "circuitgreen"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/stack/tile/circuit/green
 	category = list("initial", "Misc")
 	maxstack = 50
@@ -994,7 +994,7 @@
 	name = "Red Circuit Tile"
 	id = "circuitred"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500)
+	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/stack/tile/circuit/red
 	category = list("initial", "Misc")
 	maxstack = 50
@@ -1003,7 +1003,7 @@
 	name = "Price Tagger"
 	id = "price_tagger"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 1500, /datum/material/glass = 500)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
 	build_path = /obj/item/price_tagger
 	category = list("initial", "Misc")
 
@@ -1019,7 +1019,7 @@
 	name = "Cap Gun"
 	id = "toygun"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 100, /datum/material/glass = 50)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
 	build_path = /obj/item/toy/gun
 	category = list("hacked", "Misc")
 
@@ -1027,7 +1027,7 @@
 	name = "Box of Cap Gun Shots"
 	id = "capbox"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 20, /datum/material/glass = 5)
+	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/toy/ammo/gun
 	category = list("hacked", "Misc")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I am back after a short break... I have this amazing PR for you. I have massively changed this since it's last iteration. What has been added?

- Printing items from the autolathe costs money depending on the amount and type of mats it uses to print
- An ID or department budget can be linked to the autolathe. 70% of the fee will go to the linked account, 10% to the civilian budget and 20% disappears to NT, the syndicate or maybe somewhere else? Your guess is as good as mine. 
- The linked account can be cleared by pulsing a new wire.
- The autolathe can be set to "free mode" where everything is free, if the autolathe spawns/is built offstation, it will be set automatically to this.
- The autolathe can be emagged to be set to free mode.
- All autolathe item's material value have been changed to properly balance the costs.

Mat costs/prices have been set to reflect their individual value rather than realistic mineral cost. Generally if an item can already be bought at a vendor, it is cheaper at that vendor by a factor of 2.5. Basic tools like crowbars and screwdrivers have been set to 50c, multitool is 67c, welding tools are around that price too. I haven't changed part mat requirements and as such they are cheaper, ranging around 20c for basic parts. Weapons and ammo are more expensive, shotgun shells range at 50c. All of these prices are negotiable and I don't expect them to be perfect, even so, insignificant pricing is better than no pricing.

## Why It's Good For The Game

This adds another avenue of balancing items rather than is there enough mats yes/no? I saw some people wanted to change prices in vendors and this supports that ability by not having a free source of items that is objectively better than those vendors.
Money has long been near useless and I aim to change that.  Fining people as a means of punishment has more weight now.

What about assistants, they have no money? They wont be able to buy anything! Good. Those lazy parasites should do something productive instead of getting free handouts and committing crimes with those handouts. Next, if this is merged I will add pricing to items from protolathes, that too is a case of is it researched Y/N? Is there enough mats Y/N? I can also tie in the ability for the HOP being able to change the percentage of tax to the civ budget and for the price to inflate because of that, hooray.

Let's talk stats. I counted 45 possible sets of tools roundstart on boxstation.
- 10 sets were in public areas.
- 10 sets purchasable from youtools.
- 20 sets were in restricted areas, these can be negotiated for.
- 5 misc sets of tools spread around both.
- any I missed

There is an abundance of tools roundstart and if all else fails money can be gained by:
- 24 bounties + 5 extra bounties for enterprising assistants. Any of which can buy several sets of tools from an autolathe several times over.
- Every crew member can be convinced through a loan, an odd job, or something else creative.
- 7 department budgets with an abundance of money, talk to the heads
- Assistants can pitch in together and share a set of tools

Later on into the round the autolathe would be upgraded and tools printed from there will be cheaper than purchasing them from youtools, youtools can also be restocked. Simply put assistants getting tools wont be an issue if they make an effort. Why should assistants get handouts if they disproportionately commit more crime?

## Changelog
add: Autolathe items cost money
add: Accounts can be linked to autolathes
add: New wire for the autolathe
add: Autolathe freemode for communists and ghost roles
add: Emagged autolathes enter freemode
balance: rebalanced mat costs for autolathe items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
