### PR TITLE
biometallic replication now allows nanites on inorganics properly

### DIFF
--- a/code/datums/diseases/advance/symptoms/clockwork.dm
+++ b/code/datums/diseases/advance/symptoms/clockwork.dm
@@ -51,7 +51,7 @@
 					return
 				else if(replacebody)
 					H.adjustCloneLoss(-30) //we're fully mechanical, repair integrity. This symptom has a soft synergy with overclocked pituitary, so we want that to be useable. OFI is obviously out
-					ADD_TRAIT(H, TRAIT_NANITECOMPATIBLE, DISEASE_TRAIT)
+			ADD_TRAIT(H, TRAIT_NANITECOMPATIBLE, DISEASE_TRAIT)
 	return
 
 /datum/symptom/robotic_adaptation/proc/Replace(mob/living/carbon/human/H)

--- a/code/modules/research/nanites/nanite_chamber_computer.dm
+++ b/code/modules/research/nanites/nanite_chamber_computer.dm
@@ -48,7 +48,7 @@
 
 	var/mob/living/L = chamber.occupant
 
-	if(!(MOB_ORGANIC in L.mob_biotypes) && !(MOB_UNDEAD in L.mob_biotypes))
+	if(!(MOB_ORGANIC in L.mob_biotypes) && !(MOB_UNDEAD in L.mob_biotypes) && !HAS_TRAIT(L, TRAIT_NANITECOMPATIBLE))
 		data["status_msg"] = "Occupant not compatible with nanites."
 		return data
 

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -241,7 +241,7 @@
 	for(var/mob/living/L in ohearers(5, host_mob))
 		if(!prob(25))
 			continue
-		if(!(MOB_ORGANIC in L.mob_biotypes) && !(MOB_UNDEAD in L.mob_biotypes))
+		if(!(MOB_ORGANIC in L.mob_biotypes) && !(MOB_UNDEAD in L.mob_biotypes) && !HAS_TRAIT(host_mob, TRAIT_NANITECOMPATIBLE))
 			continue
 		target_hosts += L
 	if(!target_hosts.len)
@@ -264,7 +264,7 @@
 /datum/nanite_program/nanite_sting/on_trigger(comm_message)
 	var/list/mob/living/target_hosts = list()
 	for(var/mob/living/L in oview(1, host_mob))
-		if(!(MOB_ORGANIC in L.mob_biotypes) && !(MOB_UNDEAD in L.mob_biotypes))
+		if(!(MOB_ORGANIC in L.mob_biotypes) && !(MOB_UNDEAD in L.mob_biotypes) && !HAS_TRAIT(host_mob, TRAIT_NANITECOMPATIBLE))
 			continue
 		if(SEND_SIGNAL(L, COMSIG_HAS_NANITES) || !L.Adjacent(host_mob))
 			continue

--- a/code/modules/research/nanites/public_chamber.dm
+++ b/code/modules/research/nanites/public_chamber.dm
@@ -166,7 +166,7 @@
 			if(nanites && nanites.cloud_id != cloud_id)
 				change_cloud(attacker)
 			return
-		if((MOB_ORGANIC in L.mob_biotypes) || (MOB_UNDEAD in L.mob_biotypes))
+		if((MOB_ORGANIC in L.mob_biotypes) || (MOB_UNDEAD in L.mob_biotypes) || HAS_TRAIT(L, TRAIT_NANITECOMPATIBLE))
 			inject_nanites(attacker)
 
 /obj/machinery/public_nanite_chamber/open_machine()


### PR DESCRIPTION
## About The Pull Request
yadda yadda, symptom says on the tin it allows nanites on non nanite races, doesnt do this unless a threshold is met currently due to bad indentation, now it does what its sposed to do, bam

## Why It's Good For The Game

i use vscode instead of a wiki because im a fucking nerd, there was a little error here i couldnt not fix

hey ike i did a code

## Changelog
:cl:
fix: biometallic replication now allows nanites on inorganics properly
/:cl:
