### PR TITLE
[BOUNTY] Electroadaptive pseudocircuit functions as airlock electronics

### DIFF
--- a/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
+++ b/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
@@ -7,13 +7,16 @@
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 300)
 	var/recharging = FALSE
+	var/obj/item/electronics/airlock/electronics = null
 	var/circuits = 5 //How many circuits the pseudocircuit has left
 	var/static/recycleable_circuits = typecacheof(list(/obj/item/electronics/firelock, /obj/item/electronics/airalarm, /obj/item/electronics/firealarm, \
-	/obj/item/electronics/apc, /obj/item/electronics/advanced_airlock_controller))//A typecache of circuits consumable for material
+	/obj/item/electronics/apc, /obj/item/electronics/advanced_airlock_controller, /obj/item/electronics/airlock))//A typecache of circuits consumable for material
 
 /obj/item/electroadaptive_pseudocircuit/Initialize()
 	. = ..()
 	maptext = MAPTEXT("[circuits]")
+	electronics = new/obj/item/electronics/airlock(src)
+	electronics.holder = src
 
 /obj/item/electroadaptive_pseudocircuit/examine(mob/user)
 	. = ..()
@@ -63,3 +66,12 @@
 	playsound(src, 'sound/machines/chime.ogg', 25, TRUE)
 	recharging = FALSE
 	icon_state = initial(icon_state)
+
+/obj/item/electroadaptive_pseudocircuit/attack_self(mob/user)
+	. = ..()
+	electronics.ui_interact(user)
+
+/obj/item/electroadaptive_pseudocircuit/Destroy()
+	QDEL_NULL(electronics)
+	. = ..()
+	

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -160,6 +160,27 @@
 			state = AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER
 			name = "near finished airlock assembly"
 			electronics = W
+			
+	else if(istype(W, /obj/item/electroadaptive_pseudocircuit) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
+		var/obj/item/electroadaptive_pseudocircuit/EP = W
+		if(EP.adapt_circuit(user, 25))
+			var/obj/item/electronics/airlock/AE = new
+			AE.accesses = EP.electronics.accesses
+			AE.one_access = EP.electronics.one_access
+			AE.unres_sides = EP.electronics.unres_sides
+			AE.play_tool_sound(src, 100)
+			user.visible_message("[user] installs the electronics into the airlock assembly.", \
+								"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
+			if(do_after(user, 40, target = src))
+				if( state != AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
+					return
+				if(!user.transferItemToLoc(AE, src))
+					return
+
+				to_chat(user, "<span class='notice'>You install the electroadaptive pseudocircuit.</span>")
+				state = AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER
+				name = "near finished airlock assembly"
+				electronics = AE
 
 
 	else if((W.tool_behaviour == TOOL_CROWBAR) && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER )

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -160,11 +160,11 @@
 			state = AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER
 			name = "near finished airlock assembly"
 			electronics = W
-			
+
 	else if(istype(W, /obj/item/electroadaptive_pseudocircuit) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
 		var/obj/item/electroadaptive_pseudocircuit/EP = W
 		if(EP.adapt_circuit(user, 25))
-			var/obj/item/electronics/airlock/AE = new
+			var/obj/item/electronics/airlock/AE = new(src)
 			AE.accesses = EP.electronics.accesses
 			AE.one_access = EP.electronics.one_access
 			AE.unres_sides = EP.electronics.unres_sides
@@ -173,14 +173,18 @@
 								"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
 			if(do_after(user, 40, target = src))
 				if( state != AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
+					qdel(AE)
 					return
 				if(!user.transferItemToLoc(AE, src))
+					qdel(AE)
 					return
 
 				to_chat(user, "<span class='notice'>You install the electroadaptive pseudocircuit.</span>")
 				state = AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER
 				name = "near finished airlock assembly"
 				electronics = AE
+			else 
+				qdel(AE)
 
 
 	else if((W.tool_behaviour == TOOL_CROWBAR) && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER )

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -218,6 +218,30 @@
 				else
 					W.forceMove(drop_location())
 
+			//Adding an electroadaptive pseudocircuit for access. Step 6 complete.		
+			else if(istype(W, /obj/item/electroadaptive_pseudocircuit))
+				var/obj/item/electroadaptive_pseudocircuit/EP = W
+				if(EP.adapt_circuit(user, 25))
+					var/obj/item/electronics/airlock/AE = new
+					AE.accesses = EP.electronics.accesses
+					AE.one_access = EP.electronics.one_access
+					AE.unres_sides = EP.electronics.unres_sides
+					if(!user.transferItemToLoc(AE, src))
+						return
+					AE.play_tool_sound(src, 100)
+					user.visible_message("[user] installs the electronics into the airlock assembly.",
+						"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
+
+					if(do_after(user, 40, target = src))
+						if(!src || electronics)
+							AE.forceMove(drop_location())
+							return
+						to_chat(user, "<span class='notice'>You install the electroadaptive pseudocircuit.</span>")
+						name = "near finished windoor assembly"
+						electronics = AE
+					else
+						AE.forceMove(drop_location())
+
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(W.tool_behaviour == TOOL_SCREWDRIVER)
 				if(!electronics)
@@ -242,8 +266,6 @@
 					return
 				created_name = t
 				return
-
-
 
 			//Crowbar to complete the assembly, Step 7 complete.
 			else if(W.tool_behaviour == TOOL_CROWBAR)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -222,11 +222,12 @@
 			else if(istype(W, /obj/item/electroadaptive_pseudocircuit))
 				var/obj/item/electroadaptive_pseudocircuit/EP = W
 				if(EP.adapt_circuit(user, 25))
-					var/obj/item/electronics/airlock/AE = new
+					var/obj/item/electronics/airlock/AE = new(src)
 					AE.accesses = EP.electronics.accesses
 					AE.one_access = EP.electronics.one_access
 					AE.unres_sides = EP.electronics.unres_sides
 					if(!user.transferItemToLoc(AE, src))
+						qdel(AE)
 						return
 					AE.play_tool_sound(src, 100)
 					user.visible_message("[user] installs the electronics into the airlock assembly.",
@@ -234,13 +235,13 @@
 
 					if(do_after(user, 40, target = src))
 						if(!src || electronics)
-							AE.forceMove(drop_location())
+							qdel(AE)
 							return
 						to_chat(user, "<span class='notice'>You install the electroadaptive pseudocircuit.</span>")
 						name = "near finished windoor assembly"
 						electronics = AE
 					else
-						AE.forceMove(drop_location())
+						qdel(AE)
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(W.tool_behaviour == TOOL_SCREWDRIVER)


### PR DESCRIPTION
## About The Pull Request
-Using an electroadaptive pseudocircuit in hand brings up an airlock electronics interface
-it may be used in place of airlock electronics in windoor or airlock construction, and carries its access settings
-closes https://github.com/BeeStation/BeeStation-Hornet/issues/4003

## Why It's Good For The Game

borgs can now repair windoors

## Changelog
:cl:
add: electroadaptive pseudocircuit now functions as airlock electronics
/:cl:
