### PR TITLE
Fixes wing thruster exploit

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,8 +1,8 @@
-/mob/living/carbon/movement_delay()	
-	. = ..()	
+/mob/living/carbon/movement_delay()
+	. = ..()
 
-	if(!get_leg_ignore() && legcuffed) //ignore the fact we lack legs	
-		. += legcuffed.slowdown	
+	if(!get_leg_ignore() && legcuffed) //ignore the fact we lack legs
+		. += legcuffed.slowdown
 
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube, paralyze, force_drop)
 	if(movement_type & FLYING)

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -183,6 +183,8 @@
 	var/turf/T = get_turf(owner)
 	if(!T) // No more runtimes from being stuck in nullspace.
 		return 0
+	if(owner.is_flying()) // no super speed from thruster and wings
+		return 0
 
 	// Priority 1: use air from environment.
 	var/datum/gas_mixture/environment = T.return_air()

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -183,9 +183,8 @@
 	var/turf/T = get_turf(owner)
 	if(!T) // No more runtimes from being stuck in nullspace.
 		return 0
-	if(owner.is_flying()) // no super speed from thruster and wings
+	if(owner.is_flying() && owner.has_gravity())
 		return 0
-
 	// Priority 1: use air from environment.
 	var/datum/gas_mixture/environment = T.return_air()
 	if(environment && environment.return_pressure() > 30)


### PR DESCRIPTION

## About The Pull Request

Robos are currently able to implant wings and a thruster implant for quick and easy super speed 

## Why It's Good For The Game

powergame exploit bad

## Changelog
:cl:
fix: Thrusters now check for wings/flight
/:cl:
