### PR TITLE
Changelings cannot last resolt while being absorbed and can hear changeling comms.

### DIFF
--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -64,7 +64,7 @@
 								if (!HAS_TRAIT(L, CHANGELING_HIVEMIND_MUTE) && prob(70))
 									to_chat(M, msg)
 								else
-									to_chat(M, "<span class='changeling'>Wehear a faint chittering from within our mind...</span>")
+									to_chat(M, "<span class='changeling'>We hear a faint chittering from within our mind...</span>")
 		if(LINGHIVE_OUTSIDER)
 			to_chat(user, "<span class='changeling'>Our senses have not evolved enough to be able to communicate this way...</span>")
 	return FALSE

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -64,7 +64,7 @@
 								if (!HAS_TRAIT(L, CHANGELING_HIVEMIND_MUTE) && prob(70))
 									to_chat(M, msg)
 								else
-									to_chat(M, "<span class='changeling'>You hear a faint chittering from within your mind...</span>")
+									to_chat(M, "<span class='changeling'>Wehear a faint chittering from within our mind...</span>")
 		if(LINGHIVE_OUTSIDER)
 			to_chat(user, "<span class='changeling'>Our senses have not evolved enough to be able to communicate this way...</span>")
 	return FALSE

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -37,7 +37,7 @@
 								if (!HAS_TRAIT(L, CHANGELING_HIVEMIND_MUTE) && prob(70))
 									to_chat(M, msg)
 								else
-									to_chat(M, "<span class='changeling'>You hear a faint chittering from within your mind...</span>")
+									to_chat(M, "<span class='changeling'>We hear a faint chittering from within our mind...</span>")
 		if(LINGHIVE_LING)
 			if (HAS_TRAIT(user, CHANGELING_HIVEMIND_MUTE))
 				to_chat(user, "<span class='warning'>The poison in the air hinders our ability to interact with the hivemind.</span>")

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -33,8 +33,11 @@
 							if(LINGHIVE_LINK)
 								to_chat(M, msg)
 							if(LINGHIVE_OUTSIDER)
-								if(prob(40))
-									to_chat(M, "<span class='changeling'>We can faintly sense an outsider trying to communicate through the hivemind...</span>")
+								var/mob/living/L = M
+								if (!HAS_TRAIT(L, CHANGELING_HIVEMIND_MUTE) && prob(70))
+									to_chat(M, msg)
+								else
+									to_chat(M, "<span class='changeling'>You hear a faint chittering from within your mind...</span>")
 		if(LINGHIVE_LING)
 			if (HAS_TRAIT(user, CHANGELING_HIVEMIND_MUTE))
 				to_chat(user, "<span class='warning'>The poison in the air hinders our ability to interact with the hivemind.</span>")
@@ -57,8 +60,11 @@
 								if (!HAS_TRAIT(L, CHANGELING_HIVEMIND_MUTE))
 									to_chat(M, msg)
 							if(LINGHIVE_OUTSIDER)
-								if(prob(40))
-									to_chat(M, "<span class='changeling'>We can faintly sense another of our kind trying to communicate through the hivemind...</span>")
+								var/mob/living/L = M
+								if (!HAS_TRAIT(L, CHANGELING_HIVEMIND_MUTE) && prob(70))
+									to_chat(M, msg)
+								else
+									to_chat(M, "<span class='changeling'>You hear a faint chittering from within your mind...</span>")
 		if(LINGHIVE_OUTSIDER)
 			to_chat(user, "<span class='changeling'>Our senses have not evolved enough to be able to communicate this way...</span>")
 	return FALSE

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/headcrab
 	name = "Last Resort"
-	desc = "We sacrifice our current body in a moment of need, placing us in control of a vessel that can plant our likeness in a new host. Costs 20 chemicals."
-	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us."
+	desc = "We sacrifice our current body in a moment of need, placing us in control of a vessel that can plant our likeness in a new host. Cannot be used while being absorbed by another changeling. Costs 20 chemicals."
+	helptext = "We will be placed in control of a small, fragile creature. We may attack a corpse like this to plant an egg which will slowly mature into a new form for us. Cannot be used while being absorbed by another changeling."
 	button_icon_state = "last_resort"
 	chemical_cost = 20
 	dna_cost = 0
@@ -11,6 +11,14 @@
 
 /datum/action/changeling/headcrab/sting_action(mob/user)
 	set waitfor = FALSE
+	if(isliving(user))
+		var/mob/living/L = user
+		var/mob/living/puller = L.pulledby
+		if(puller)
+			var/datum/antagonist/changeling/other_ling = is_changeling(puller)
+			if(other_ling?.isabsorbing)
+				to_chat(user, "<span class='warning'>Your last resort is being disrupted by another changeling!</span>")
+				return
 	if(alert("Are we sure we wish to kill ourself and create a headslug?",,"Yes", "No") == "No")
 		return
 	..()
@@ -20,7 +28,7 @@
 	for(var/obj/item/organ/I in organs)
 		I.Remove(user, 1)
 
-	for(var/mob/living/A in hearers(2,user))
+	for(var/mob/living/A in view(2,user))
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = A
 			var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)
@@ -32,7 +40,7 @@
 		else if(issilicon(A))
 			var/mob/living/silicon/S = A
 			to_chat(S, "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>")
-			S.Paralyze(60)	
+			S.Paralyze(60)
 	var/turf = get_turf(user)
 	// Headcrab transformation is *very* unique; origin mob death happens *before* resulting mob's creation. Action removal should happen beforehand.
 	for(var/datum/action/cp in user.actions)

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -17,7 +17,7 @@
 		if(puller)
 			var/datum/antagonist/changeling/other_ling = is_changeling(puller)
 			if(other_ling?.isabsorbing)
-				to_chat(user, "<span class='warning'>Your last resort is being disrupted by another changeling!</span>")
+				to_chat(user, "<span class='warning'>Our last resort is being disrupted by another changeling!</span>")
 				return
 	if(alert("Are we sure we wish to kill ourself and create a headslug?",,"Yes", "No") == "No")
 		return

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -337,10 +337,6 @@
 				continue
 		//If you got this far, that means we can process whatever reagent this iteration is for. Handle things normally from here.
 
-		if(!R.metabolizing)
-			R.metabolizing = TRUE
-			R.on_mob_metabolize(C)
-
 		if(C && R)
 			if(C.reagent_check(R) != TRUE)
 				if(liverless && !R.self_consuming) //need to be metabolized

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -337,6 +337,10 @@
 				continue
 		//If you got this far, that means we can process whatever reagent this iteration is for. Handle things normally from here.
 
+		if(!R.metabolizing)
+			R.metabolizing = TRUE
+			R.on_mob_metabolize(C)
+
 		if(C && R)
 			if(C.reagent_check(R) != TRUE)
 				if(liverless && !R.self_consuming) //need to be metabolized


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows changelings a 70% chance to hear messages on changeling comms if they don't have the ability.
Changelings cannot last resort while being absorbed.

## Why It's Good For The Game

Changeling hivemind is a useless ability that you buy only for other people not to hear you. Now at least they can hear you, although others still cannot talk to you.
Additionally absorbing other changelings is more viable now, as they cannot last resort burst if you are absorbing them.

## Changelog
:cl:
tweak: Changelings have a 70% chance to hear hivemind messages even if they do not have the ability.
tweak: Last resort can no longer be used while being absorbed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
