### PR TITLE
Makes brains indestructible

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -32,7 +32,7 @@
 			new recipe.output(drop_location())
 	if (ismob(what))
 		var/mob/themob = what
-		themob.gib(TRUE,TRUE,TRUE)
+		themob.gib(FALSE,TRUE,TRUE)
 	else
 		qdel(what)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -262,9 +262,11 @@
 	I.dropped(src)
 	return FALSE
 
-/mob/proc/drop_all_held_items()
+/mob/proc/drop_all_held_items(only_indestructible = FALSE)
 	. = FALSE
 	for(var/obj/item/I in held_items)
+		if(only_indestructible && !(I.resistance_flags & INDESTRUCTIBLE))
+			continue
 		. |= dropItemToGround(I)
 
 //Here lie drop_from_inventory and before_item_take, already forgotten and not missed.
@@ -377,12 +379,18 @@
 			items += s_store
 	return items
 
-/mob/living/proc/unequip_everything()
+/mob/living/proc/unequip_everything(only_indestructible = FALSE)
 	var/list/items = list()
 	items |= get_equipped_items(TRUE)
 	for(var/I in items)
+		if(!I)
+			continue
+		if(isobj(I))
+			var/obj/O = I
+			if(only_indestructible && !(O.resistance_flags & INDESTRUCTIBLE))
+				continue
 		dropItemToGround(I)
-	drop_all_held_items()
+	drop_all_held_items(only_indestructible)
 
 
 /mob/living/carbon/proc/check_obscured_slots(transparent_protection)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -10,6 +10,8 @@
 	organ_flags = ORGAN_VITAL
 	attack_verb = list("attacked", "slapped", "whacked")
 
+	resistance_flags = INDESTRUCTIBLE
+
 	///The brain's organ variables are significantly more different than the other organs, with half the decay rate for balance reasons, and twice the maxHealth
 	decay_factor = STANDARD_ORGAN_DECAY	/ 2		//30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -8,6 +8,12 @@
 	GLOB.carbon_list += src
 
 /mob/living/carbon/Destroy()
+	//Drop brain
+	var/obj/item/organ/brain/brain = locate() in internal_organs
+	if(brain)
+		brain.forceMove(get_turf(src))
+		internal_organs -= brain
+
 	//This must be done first, so the mob ghosts correctly before DNA etc is nulled
 	. =  ..()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -10,7 +10,7 @@
 /mob/living/carbon/Destroy()
 	//Drop brain
 	var/obj/item/organ/brain/brain = locate() in internal_organs
-	if(brain)
+	if(brain?.brainmob?.get_ghost(FALSE, TRUE))
 		brain.forceMove(get_turf(src))
 		internal_organs -= brain
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,4 +1,6 @@
 /mob/living/gib(no_brain, no_organs, no_bodyparts)
+	unequip_everything(TRUE)
+
 	var/prev_lying = lying
 	if(stat != DEAD)
 		death(TRUE)
@@ -29,8 +31,7 @@
 /mob/living/dust(just_ash, drop_items, force)
 	death(TRUE)
 
-	if(drop_items)
-		unequip_everything()
+	unequip_everything(!drop_items)
 
 	if(buckled)
 		buckled.unbuckle_mob(src, force = TRUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -22,7 +22,10 @@
 	med_hud_set_health()
 	med_hud_set_status()
 
-/mob/living/Destroy()
+/mob/living/Destroy(force = FALSE)
+	//Remove indestructible things from the person
+	if(!force)
+		unequip_everything(TRUE)
 	if(LAZYLEN(status_effects))
 		for(var/s in status_effects)
 			var/datum/status_effect/S = s


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes brains an indestructible item.
When a mob is destroyed the brain will be dropped (if it has a person in it) along with any other indestructible items on them.

## Why It's Good For The Game

Being permanently removed from the round is very dull, especially in cases where it was an accident/grief, gives people always a chance to remain in the game alive (the fun part of the game).
Since the brain is dropped changelings will not be able to just infinitely revive and be immortal due to this.

## Changelog
:cl:
tweak: Brains cannot be destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
