### PR TITLE
makes meta bridge actually secure

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33984,35 +33984,8 @@
 /area/maintenance/central)
 "bmt" = (
 /obj/item/radio/off,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bmu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Bridge"
-	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/maintenance/central)
-"bmv" = (
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Bridge Deliveries";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/bridge)
 "bmw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -112247,7 +112220,7 @@ bfq
 bdG
 bdG
 bcg
-bmu
+bcg
 bkz
 bqG
 dbe
@@ -112504,7 +112477,7 @@ aaf
 aaf
 bfv
 bfv
-bmv
+bfv
 bfv
 bqH
 bqH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes the single windoor from MetaStation, replaces it with a reinforced wall
![image](https://user-images.githubusercontent.com/3241376/113814833-dbb50080-9737-11eb-970c-30b8ffa5a475.png)

![image](https://user-images.githubusercontent.com/3241376/113815231-70b7f980-9738-11eb-8139-b95325a8d1ca.png)


## Why It's Good For The Game
Now you need more than an oxygen tank to steal the fireaxe and fuck the station up

- shakes up the fireaxe meta

## Changelog
:cl:
tweak: The bridge on MetaStation is now slightly more secure from the previous state of laughably insecure
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
