### PR TITLE
The sigil of vitality looks weak as the color fades from their body

### DIFF
--- a/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
@@ -87,6 +87,6 @@
 			add_servant_of_ratvar(cogger, silent=TRUE)
 			return
 		if(M.client)
-			M.visible_message("<span class='neovgre'>[src] looks weak as the color fades from their body.</span>", "<span class='neovgre'>You feel your soul faltering...</span>")
+			M.visible_message("<span class='neovgre'>[M] looks weak as the color fades from their body.</span>", "<span class='neovgre'>You feel your soul faltering...</span>")
 			GLOB.clockcult_vitality += 30
 		GLOB.clockcult_vitality += 10


### PR DESCRIPTION
fixes some text when a vitality rune siphons someones soul