### PR TITLE
Syndicate Tome Unlocks Extra Rites At The Altar

### DIFF
--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -83,22 +83,21 @@
 			return
 		var/synditome_check = istype(the_item, /obj/item/storage/book/bible/syndicate)
 		var/catalyst_check = synditome_check || (istype(the_item, catalyst_type))
-		if(!catalyst_check)			
+		if(!catalyst_check)
 			return
 		. = force_catalyst_afterattack ? null : COMPONENT_NO_AFTERATTACK
 		var/list/rite_list
-		for(var/datum/religion_rites/trite in easy_access_sect.rites_list)
-			LAZYADD(rite_list,trite)
-		if (synditome_check)
-			for(var/datum/religion_rites/crite in easy_access_sect.corrupted_rites)
-				LAZYADD(rite_list,crite)
+		for(var/trite in easy_access_sect.rites_list)
+			to_chat(user,"[trite];[trite[1]]")
+			if (trite[1] != "!" || synditome_check)
+				LAZYADD(rite_list,trite)
 		if(LAZYLEN(rite_list)==0)
 			to_chat(user, "<span class='notice'>Your sect doesn't have any rites to perform!")
 			return
 		var/rite_select = input(user,"Select a rite to perform!","Select a rite",null) in rite_list
 		if(!rite_select || !user.canUseTopic(parent, BE_CLOSE, FALSE, NO_TK))
 			to_chat(user,"<span class ='warning'>You cannot perform the rite at this time.</span>")
-			return			
+			return
 		var/selection2type = easy_access_sect.rites_list[rite_select]
 		performing_rite = new selection2type(parent)
 		if(!performing_rite.perform_rite(user, parent))

--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -78,26 +78,25 @@
 		return
 	else if((operation_flags & RELIGION_TOOL_INVOKE))
 		/**********Rite Invocation**********/
+		. = force_catalyst_afterattack ? null : COMPONENT_NO_AFTERATTACK
 		if(performing_rite)
 			to_chat(user, "<span class='notice'>There is a rite currently being performed here already!")
-			return
+			return .
 		var/synditome_check = istype(the_item, /obj/item/storage/book/bible/syndicate)
 		var/catalyst_check = synditome_check || (istype(the_item, catalyst_type))
 		if(!catalyst_check)
-			return
-		. = force_catalyst_afterattack ? null : COMPONENT_NO_AFTERATTACK
+			return .
 		var/list/rite_list
 		for(var/trite in easy_access_sect.rites_list)
-			to_chat(user,"[trite];[trite[1]]")
 			if (trite[1] != "!" || synditome_check)
 				LAZYADD(rite_list,trite)
 		if(LAZYLEN(rite_list)==0)
 			to_chat(user, "<span class='notice'>Your sect doesn't have any rites to perform!")
-			return
+			return .
 		var/rite_select = input(user,"Select a rite to perform!","Select a rite",null) in rite_list
 		if(!rite_select || !user.canUseTopic(parent, BE_CLOSE, FALSE, NO_TK))
 			to_chat(user,"<span class ='warning'>You cannot perform the rite at this time.</span>")
-			return
+			return .
 		var/selection2type = easy_access_sect.rites_list[rite_select]
 		performing_rite = new selection2type(parent)
 		if(!performing_rite.perform_rite(user, parent))
@@ -106,7 +105,7 @@
 			performing_rite.invoke_effect(user, parent)
 			easy_access_sect.adjust_favor(-performing_rite.favor_cost)
 			QDEL_NULL(performing_rite)
-		return
+		return .
 	/**********Sacrificing**********/
 	else if(operation_flags & RELIGION_TOOL_SACRIFICE)
 		if(!easy_access_sect?.can_sacrifice(the_item,user))
@@ -154,4 +153,6 @@
 		return //if we dont have rites it doesnt do us much good if the object can be used to invoke them!
 	if(operation_flags & RELIGION_TOOL_INVOKE)
 		examine_list += "List of available Rites:"
-		examine_list += easy_access_sect.rites_list
+		for(var/trite in easy_access_sect.rites_list)
+			if (trite[1] != "!")
+				examine_list += trite

--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -76,7 +76,7 @@
 		easy_access_sect = GLOB.religious_sect
 		after_sect_select_cb?.Invoke()
 		return
-	if((operation_flags & RELIGION_TOOL_INVOKE))
+	if(operation_flags & RELIGION_TOOL_INVOKE)
 		/**********Rite Invocation**********/
 		if(performing_rite)
 			to_chat(user, "<span class='notice'>There is a rite currently being performed here already!")

--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -14,7 +14,7 @@
 	///Sets the type for catalyst
 	var/catalyst_type = /obj/item/storage/book/bible
 	///Enables overide of COMPONENT_NO_AFTERATTACK, not recommended as it means you can potentially cause damage to the item using the catalyst.
-	var/force_catalyst_afterattack = FALSE
+	var/force_catalyst_afterattack = TRUE
 	var/datum/callback/after_sect_select_cb
 
 /datum/component/religious_tool/Initialize(_flags = ALL, _force_catalyst_afterattack = FALSE, _after_sect_select_cb, override_catalyst_type)
@@ -76,9 +76,9 @@
 		easy_access_sect = GLOB.religious_sect
 		after_sect_select_cb?.Invoke()
 		return
-	else 
+	else
 		/**********Rite Invocation**********/
-		var/synditome_check = istype(the_item, /obj/item/storage/book/bible/syndicate)	
+		var/synditome_check = istype(the_item, /obj/item/storage/book/bible/syndicate)
 		var/catalyst_check = synditome_check || (istype(the_item, catalyst_type))
 		if(catalyst_check)
 			if(!(operation_flags & RELIGION_TOOL_INVOKE))
@@ -87,9 +87,10 @@
 			if(performing_rite)
 				to_chat(user, "<span class='notice'>There is a rite currently being performed here already!")
 				return
-			var/list/rite_list = easy_access_sect.rites_list
-			if (synditome_check)
-				rite_list = easy_access_sect.on_gods_offended
+			var/list/rite_list = list()
+			for(var/datum/religion_rites/trite in easy_access_sect.rites_list)
+				if (synditome_check || !trite.requires_corruption)
+					LAZYADD(rite_list,trite)
 			if(!rite_list)
 				to_chat(user, "<span class='notice'>Your sect doesn't have any rites to perform!")
 				return
@@ -97,11 +98,14 @@
 			if(!rite_select || !user.canUseTopic(parent, BE_CLOSE, FALSE, NO_TK))
 				to_chat(user,"<span class ='warning'>You cannot perform the rite at this time.</span>")
 				return
-			var/selection2type = easy_access_sect.rites_list[rite_select]
+			to_chat(user,"[rite_select]")
+			var/selection2type = rite_list[rite_select]
+			to_chat(user,"[selection2type]")
 			performing_rite = new selection2type(parent)
 			if(!performing_rite.perform_rite(user, parent))
 				QDEL_NULL(performing_rite)
 			else
+				to_chat(user,"[performing_rite]")
 				performing_rite.invoke_effect(user, parent)
 				easy_access_sect.adjust_favor(-performing_rite.favor_cost)
 				QDEL_NULL(performing_rite)

--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -82,9 +82,8 @@
 			to_chat(user, "<span class='notice'>There is a rite currently being performed here already!")
 			return COMPONENT_NO_AFTERATTACK
 		var/synditome_check = istype(the_item, /obj/item/storage/book/bible/syndicate)
-		var/catalyst_check = synditome_check || (istype(the_item, catalyst_type))
-		if(catalyst_check)
-			var/list/rite_list
+		if(synditome_check || (istype(the_item, catalyst_type)))
+			var/list/rite_list = list()
 			for(var/trite in easy_access_sect.rites_list)
 				if (trite[1] != "!" || synditome_check)
 					LAZYADD(rite_list,trite)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -248,7 +248,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 
 /obj/item/storage/book/bible/syndicate/attack_self(mob/living/carbon/human/H)
 	if (uses)
-		H.mind.holy_role = HOLY_ROLE_PRIEST
+		H.mind.holy_role = max(H.mind.holy_role,HOLY_ROLE_PRIEST)
 		uses -= 1
 		to_chat(H, "<span class='userdanger'>You try to open the book AND IT BITES YOU!</span>")
 		playsound(src.loc, 'sound/effects/snap.ogg', 50, 1)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -41,7 +41,6 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/deity_name = "Christ"
 	force_string = "holy"
 	block_upgrade_walk = 1
-	var/corrupted = FALSE
 
 /obj/item/storage/book/bible/Initialize()
 	. = ..()
@@ -256,7 +255,6 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		H.apply_damage(5, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 		to_chat(H, "<span class='notice'>Your name appears on the inside cover, in blood.</span>")
 		var/ownername = H.real_name
-		corrupted = TRUE
 		desc += "<span class='warning'>The name [ownername] is written in blood inside the cover.</span>"
 
 /obj/item/storage/book/bible/syndicate/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/deity_name = "Christ"
 	force_string = "holy"
 	block_upgrade_walk = 1
+	var/corrupted = FALSE
 
 /obj/item/storage/book/bible/Initialize()
 	. = ..()
@@ -255,6 +256,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		H.apply_damage(5, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 		to_chat(H, "<span class='notice'>Your name appears on the inside cover, in blood.</span>")
 		var/ownername = H.real_name
+		corrupted = TRUE
 		desc += "<span class='warning'>The name [ownername] is written in blood inside the cover.</span>"
 
 /obj/item/storage/book/bible/syndicate/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -205,7 +205,8 @@
 	foodtype = NONE
 
 /obj/item/reagent_containers/food/drinks/bottle/holywater/hell
-	desc = "A flask of holy water...it's been sitting in the Necropolis a while though."
+	name = "bottle of cleansing fire"
+	desc = "A bottle of hellwater used for religious rites. Said to purge all evil from your system."
 	list_reagents = list(/datum/reagent/hellwater = 100)
 
 /obj/item/reagent_containers/food/drinks/bottle/vermouth

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -36,8 +36,6 @@
 	var/altar_icon_state
 /// Currently Active (non-deleted) rites
 	var/list/active_rites
-/// Rites availalble when the altar is struck with a corrupt syndicate tome
-	var/list/on_gods_offended
 
 /datum/religion_sect/New()
 	. = ..()
@@ -131,8 +129,7 @@
 	convert_opener = "May you find peace in a metal shell, acolyte.<br>Bibles now recharge cyborgs and heal robotic limbs if targeted, but they do not heal organic limbs. You can now sacrifice cells, with favor depending on their charge."
 	alignment = ALIGNMENT_NEUT
 	desired_items = list(/obj/item/stock_parts/cell)
-	rites_list = list(/datum/religion_rites/synthconversion)
-	on_gods_offended = list(/datum/religion_rites/black_out)
+	rites_list = list(/datum/religion_rites/synthconversion,/datum/religion_rites/black_out)
 	altar_icon_state = "convertaltar-blue"
 
 /datum/religion_sect/technophile/sect_bless(mob/living/L, mob/living/user)
@@ -201,8 +198,7 @@
 	alignment = ALIGNMENT_NEUT
 	max_favor = 10000
 	desired_items = list(/obj/item/candle)
-	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle)
-	on_gods_offended = list(/datum/religion_rites/pyromania)
+	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle, /datum/religion_rites/hellwater)
 	altar_icon_state = "convertaltar-red"
 
 //candle sect bibles don't heal or do anything special apart from the standard holy water blessings

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -36,6 +36,8 @@
 	var/altar_icon_state
 /// Currently Active (non-deleted) rites
 	var/list/active_rites
+/// Rites availalble when the altar is struck with a corrupt syndicate tome
+	var/list/corrupted_rites
 
 /datum/religion_sect/New()
 	. = ..()
@@ -129,7 +131,8 @@
 	convert_opener = "May you find peace in a metal shell, acolyte.<br>Bibles now recharge cyborgs and heal robotic limbs if targeted, but they do not heal organic limbs. You can now sacrifice cells, with favor depending on their charge."
 	alignment = ALIGNMENT_NEUT
 	desired_items = list(/obj/item/stock_parts/cell)
-	rites_list = list(/datum/religion_rites/synthconversion,/datum/religion_rites/black_out)
+	rites_list = list(/datum/religion_rites/synthconversion)
+	corrupted_rites = list(/datum/religion_rites/black_out)
 	altar_icon_state = "convertaltar-blue"
 
 /datum/religion_sect/technophile/sect_bless(mob/living/L, mob/living/user)
@@ -198,7 +201,8 @@
 	alignment = ALIGNMENT_NEUT
 	max_favor = 10000
 	desired_items = list(/obj/item/candle)
-	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle, /datum/religion_rites/hellwater)
+	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle)
+	corrupted_rites = list(/datum/religion_rites/hellwater)
 	altar_icon_state = "convertaltar-red"
 
 //candle sect bibles don't heal or do anything special apart from the standard holy water blessings

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -36,15 +36,14 @@
 	var/altar_icon_state
 /// Currently Active (non-deleted) rites
 	var/list/active_rites
-/// Rites availalble when the altar is struck with a corrupt syndicate tome
-	var/list/corrupted_rites
 
 /datum/religion_sect/New()
 	. = ..()
 	if(desired_items)
 		desired_items_typecache = typecacheof(desired_items)
 	if(rites_list)
-		rites_list = generate_rites_list()
+		var/listylist = generate_rites_list()
+		rites_list = listylist
 	on_select()
 
 ///Generates a list of rites with 'name' = 'type'
@@ -55,8 +54,8 @@
 			continue
 		var/datum/religion_rites/RI = i
 		var/name_entry = "[initial(RI.name)]"
-		if(initial(RI.desc))
-			name_entry += " - [initial(RI.desc)]"
+		if (initial(RI.requires_corruption))
+			name_entry = "![name_entry]"
 		if(initial(RI.favor_cost))
 			name_entry += " ([initial(RI.favor_cost)] favor)"
 
@@ -131,8 +130,7 @@
 	convert_opener = "May you find peace in a metal shell, acolyte.<br>Bibles now recharge cyborgs and heal robotic limbs if targeted, but they do not heal organic limbs. You can now sacrifice cells, with favor depending on their charge."
 	alignment = ALIGNMENT_NEUT
 	desired_items = list(/obj/item/stock_parts/cell)
-	rites_list = list(/datum/religion_rites/synthconversion)
-	corrupted_rites = list(/datum/religion_rites/black_out)
+	rites_list = list(/datum/religion_rites/synthconversion,/datum/religion_rites/black_out)
 	altar_icon_state = "convertaltar-blue"
 
 /datum/religion_sect/technophile/sect_bless(mob/living/L, mob/living/user)
@@ -201,8 +199,7 @@
 	alignment = ALIGNMENT_NEUT
 	max_favor = 10000
 	desired_items = list(/obj/item/candle)
-	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle)
-	corrupted_rites = list(/datum/religion_rites/hellwater)
+	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle,/datum/religion_rites/hellwater)
 	altar_icon_state = "convertaltar-red"
 
 //candle sect bibles don't heal or do anything special apart from the standard holy water blessings

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -36,14 +36,15 @@
 	var/altar_icon_state
 /// Currently Active (non-deleted) rites
 	var/list/active_rites
+/// Rites availalble when the altar is struck with a corrupt syndicate tome
+	var/list/on_gods_offended
 
 /datum/religion_sect/New()
 	. = ..()
 	if(desired_items)
 		desired_items_typecache = typecacheof(desired_items)
 	if(rites_list)
-		var/listylist = generate_rites_list()
-		rites_list = listylist
+		rites_list = generate_rites_list()
 	on_select()
 
 ///Generates a list of rites with 'name' = 'type'
@@ -131,6 +132,7 @@
 	alignment = ALIGNMENT_NEUT
 	desired_items = list(/obj/item/stock_parts/cell)
 	rites_list = list(/datum/religion_rites/synthconversion)
+	on_gods_offended = list(/datum/religion_rites/black_out)
 	altar_icon_state = "convertaltar-blue"
 
 /datum/religion_sect/technophile/sect_bless(mob/living/L, mob/living/user)
@@ -200,6 +202,7 @@
 	max_favor = 10000
 	desired_items = list(/obj/item/candle)
 	rites_list = list(/datum/religion_rites/fireproof, /datum/religion_rites/burning_sacrifice, /datum/religion_rites/infinite_candle)
+	on_gods_offended = list(/datum/religion_rites/pyromania)
 	altar_icon_state = "convertaltar-red"
 
 //candle sect bibles don't heal or do anything special apart from the standard holy water blessings

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -42,8 +42,7 @@
 	if(desired_items)
 		desired_items_typecache = typecacheof(desired_items)
 	if(rites_list)
-		var/listylist = generate_rites_list()
-		rites_list = listylist
+		rites_list = generate_rites_list()
 	on_select()
 
 ///Generates a list of rites with 'name' = 'type'
@@ -58,6 +57,8 @@
 			name_entry = "![name_entry]"
 		if(initial(RI.favor_cost))
 			name_entry += " ([initial(RI.favor_cost)] favor)"
+		if(initial(RI.desc))
+			name_entry += " - [initial(RI.desc)]"
 
 		. += list("[name_entry]" = i)
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -10,6 +10,7 @@
 /// message when you invoke
 	var/invoke_msg
 	var/favor_cost = 0
+	var/requires_corruption = FALSE
 
 /datum/religion_rites/New()
 	. = ..()
@@ -104,6 +105,7 @@
 	ritual_length = 30 SECONDS
 	invoke_msg = "these blind fools are not worthy of the light. Let them live in darkness!"
 	favor_cost = 1000
+	requires_corruption = TRUE
 
 /datum/religion_rites/black_out/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/datum/round_event_control/electrical_storm/curse = new()
@@ -237,6 +239,7 @@
 	ritual_length = 10 SECONDS
 	invoke_msg = "from ashes we come, to ashes we go. No pain, only memories..."
 	favor_cost = 2000
+	requires_corruption = TRUE
 
 /datum/religion_rites/hellwater/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/altar_turf = get_turf(religious_tool)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -98,6 +98,19 @@
 	human2borg.visible_message("<span class='notice'>[human2borg] has been converted by the rite of [name]!</span>")
 	return ..()
 
+/datum/religion_rites/black_out
+	name = "Blackout"
+	desc = "Send the station in complete blackout for a limited duration."
+	ritual_length = 30 SECONDS
+	invoke_msg = "these blind fools are not worthy of the light. Let them live in darkness!"
+	favor_cost = 1000
+
+/datum/religion_rites/black_out/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	var/datum/round_event_control/electrical_storm/curse = new()
+	curse.runEvent()
+	return ..()
+
+
 /*********Ever-Burning Candle**********/
 
 ///apply a bunch of fire immunity effect to clothing
@@ -144,7 +157,6 @@
 	chosen_clothing = null
 	to_chat(user, "<span class='warning'>The clothing that was chosen for the rite is no longer on the altar!</span>")
 	return FALSE
-
 
 /datum/religion_rites/burning_sacrifice
 	name = "Candle Fuel"
@@ -217,4 +229,18 @@
 	for(var/i in 1 to 5)
 		new /obj/item/candle/infinite(altar_turf)
 	playsound(altar_turf, 'sound/magic/fireball.ogg', 50, TRUE)
+	return ..()
+
+/datum/religion_rites/pyromania
+	name = "Pyromania"
+	desc = "Manifest Pyromania, a fireball shooting wand."
+	ritual_length = 10 SECONDS
+	invoke_msg = "from ashes we come, to ashes we go. No pain, only memories..."
+	favor_cost = 2000
+
+/datum/religion_rites/pyromania/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	var/altar_turf = get_turf(religious_tool)
+	var/obj/item/gun/magic/wand/fireball/inert/mwand = new /obj/item/gun/magic/wand/fireball/inert(altar_turf)
+	mwand.name = "Pyromania"
+	playsound(altar_turf, 'sound/magic/demon_attack1.ogg', 50, TRUE)
 	return ..()

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -10,6 +10,7 @@
 /// message when you invoke
 	var/invoke_msg
 	var/favor_cost = 0
+	var/requires_corruption = FALSE
 
 /datum/religion_rites/New()
 	. = ..()
@@ -104,6 +105,7 @@
 	ritual_length = 30 SECONDS
 	invoke_msg = "these blind fools are not worthy of the light. Let them live in darkness!"
 	favor_cost = 1000
+	requires_corruption = TRUE
 
 /datum/religion_rites/black_out/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/datum/round_event_control/electrical_storm/curse = new()
@@ -231,16 +233,16 @@
 	playsound(altar_turf, 'sound/magic/fireball.ogg', 50, TRUE)
 	return ..()
 
-/datum/religion_rites/pyromania
-	name = "Pyromania"
-	desc = "Manifest Pyromania, a fireball shooting wand."
+/datum/religion_rites/hellwater
+	name = "Bottle Of Cleansing Fire"
+	desc = "Manifest a bottle dangerous hellwater, to purge the world of impure thought."
 	ritual_length = 10 SECONDS
 	invoke_msg = "from ashes we come, to ashes we go. No pain, only memories..."
 	favor_cost = 2000
+	requires_corruption = TRUE
 
-/datum/religion_rites/pyromania/invoke_effect(mob/living/user, atom/movable/religious_tool)
+/datum/religion_rites/hellwater/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/altar_turf = get_turf(religious_tool)
-	var/obj/item/gun/magic/wand/fireball/inert/mwand = new /obj/item/gun/magic/wand/fireball/inert(altar_turf)
-	mwand.name = "Pyromania"
+	new /obj/item/reagent_containers/food/drinks/bottle/holywater/hell(altar_turf)
 	playsound(altar_turf, 'sound/magic/demon_attack1.ogg', 50, TRUE)
 	return ..()

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -10,7 +10,6 @@
 /// message when you invoke
 	var/invoke_msg
 	var/favor_cost = 0
-	var/requires_corruption = FALSE
 
 /datum/religion_rites/New()
 	. = ..()
@@ -105,7 +104,6 @@
 	ritual_length = 30 SECONDS
 	invoke_msg = "these blind fools are not worthy of the light. Let them live in darkness!"
 	favor_cost = 1000
-	requires_corruption = TRUE
 
 /datum/religion_rites/black_out/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/datum/round_event_control/electrical_storm/curse = new()
@@ -239,7 +237,6 @@
 	ritual_length = 10 SECONDS
 	invoke_msg = "from ashes we come, to ashes we go. No pain, only memories..."
 	favor_cost = 2000
-	requires_corruption = TRUE
 
 /datum/religion_rites/hellwater/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/altar_turf = get_turf(religious_tool)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows the syndicate tome to unlock certain, malicious rites when used on Altars Of God. These rites are not free, and still cost mana (ie, altar points) to use. They are quite powerful, however. The rites are as follow:
* Candle: Allows you to manifest a hellwater potion
* Technophile: Allows you to launch a station wide blackout event for 2000 points.

## Why It's Good For The Game

Syndicate tome is already an underwhelming item. Maybe this will grant it additional usability and more way to see it used in game. It's powerful, but not overpowered, and requires a bit of work to obtain.

## Changelog
:cl:
add: Technophile: Syndie tome allows a new rite: Blackout - creates a station wide electrical storm on command
add: Ever-Burning Candle: Syndie tome allows a new rite: Bottle Of Cleansing Fire - allows you to create bottles of hellwater out of thin air
bug: Syndie Tome no longer demotes the chaplain, making him unable to use the Altar of Gods properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
