### PR TITLE
Removes don't Improves X-ray mutation

### DIFF
--- a/code/datums/mutations/_combined.dm
+++ b/code/datums/mutations/_combined.dm
@@ -17,10 +17,6 @@
 	required = "/datum/mutation/human/strong; /datum/mutation/human/radioactive"
 	result = HULK
 
-/datum/generecipe/x_ray
-	required = "/datum/mutation/human/thermal; /datum/mutation/human/radioactive"
-	result = /datum/mutation/human/thermal/x_ray
-
 /datum/generecipe/mindread
 	required = "/datum/mutation/human/antenna; /datum/mutation/human/paranoia"
 	result = MINDREAD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the ability to combine mutations to make x-ray

## Why It's Good For The Game

It's something that comes up often, was bored, thought i may as well do it real quick

and imo, is probably the strongest mutation. Especially if distributed and absolutely massacres a lot of antags, especially ones who play remotely stealthy (not talking just passive bois either)

**There are other ways to get x-ray too**, it's just that they require actually getting someone to surgically implant something. So a lot higher effort if you want this same power, more fitting for how powerful the reward is. 

## Changelog
:cl:Froststahr
del: X-ray is no longer a possible reward from genetics. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
