### PR TITLE
Legion core, PDA chem scanner and tribal claw fixes.

### DIFF
--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -4,108 +4,109 @@
 #define TAIL_GRAB_COMBO "DHGG"
 
 /datum/martial_art/tribal_claw
-    name = "Tribal Claw"
-    id = MARTIALART_TRIBALCLAW
-    allow_temp_override = FALSE
-    help_verb = /mob/living/carbon/human/proc/tribal_claw_help
+	name = "Tribal Claw"
+	id = MARTIALART_TRIBALCLAW
+	allow_temp_override = FALSE
+	help_verb = /mob/living/carbon/human/proc/tribal_claw_help
 
 /datum/martial_art/tribal_claw/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    if(findtext(streak,TAIL_SWEEP_COMBO))
-        streak = ""
-        tailSweep(A,D)
-        return TRUE
-    if(findtext(streak,FACE_SCRATCH_COMBO))
-        streak = ""
-        faceScratch(A,D)
-        return TRUE
-    if(findtext(streak,JUGULAR_CUT_COMBO))
-        streak = ""
-        jugularCut(A,D)
-        return TRUE
-    if(findtext(streak,TAIL_GRAB_COMBO))
-        streak = ""
-        tailGrab(A,D)
-        return TRUE
-    return FALSE
+	if(findtext(streak,TAIL_SWEEP_COMBO))
+		streak = ""
+		tailSweep(A,D)
+		return TRUE
+	if(findtext(streak,FACE_SCRATCH_COMBO))
+		streak = ""
+		faceScratch(A,D)
+		return TRUE
+	if(findtext(streak,JUGULAR_CUT_COMBO))
+		streak = ""
+		jugularCut(A,D)
+		return TRUE
+	if(findtext(streak,TAIL_GRAB_COMBO))
+		streak = ""
+		tailGrab(A,D)
+		return TRUE
+	return FALSE
 
 //Tail Sweep, triggers an effect similar to Space Dragon's tail sweep but only affects stuff 1 tile next to you, basically 3x3.
 /datum/martial_art/tribal_claw/proc/tailSweep(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    log_combat(A, D, "tail sweeped(Tribal Claw)")
-    D.visible_message("<span class='warning'>[A] sweeps [D]'s legs with their tail!</span>", \
-                        "<span class='userdanger'>[A] sweeps your legs with their tail!</span>")
-    var/obj/effect/proc_holder/spell/aoe_turf/repulse/spacedragon/R = new
-    R.cast(RANGE_TURFS(1,A))
-    return
+	if(A == current_target)
+		return
+	if(!D.stat)
+		log_combat(A, D, "tail sweeped(Tribal Claw)")
+		D.visible_message("<span class='warning'>[A] sweeps [D]'s legs with their tail!</span>", \
+							"<span class='userdanger'>[A] sweeps your legs with their tail!</span>")
+		var/obj/effect/proc_holder/spell/aoe_turf/repulse/spacedragon/R = new
+		R.cast(RANGE_TURFS(1,A))
+	return basic_hit(A,D)
 
 //Face Scratch, deals 10 brute to head(reduced by armor), blurs the target's vision and gives them the confused effect for a short time.
 /datum/martial_art/tribal_claw/proc/faceScratch(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    var/def_check = D.getarmor(BODY_ZONE_HEAD, "melee")
-    log_combat(A, D, "face scratched (Tribal Claw)")
-    D.visible_message("<span class='warning'>[A] scratches [D]'s face with their claws!</span>", \
-                        "<span class='userdanger'>[A] scratches your face with their claws!</span>")
-    D.apply_damage(10, BRUTE, BODY_ZONE_HEAD, def_check)
-    D.confused += 5
-    D.blur_eyes(5)
-    A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
-    playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
-    return
+	var/def_check = D.getarmor(BODY_ZONE_HEAD, "melee")
+	log_combat(A, D, "face scratched (Tribal Claw)")
+	D.visible_message("<span class='warning'>[A] scratches [D]'s face with their claws!</span>", \
+						"<span class='userdanger'>[A] scratches your face with their claws!</span>")
+	D.apply_damage(10, BRUTE, BODY_ZONE_HEAD, def_check)
+	D.confused += 5
+	D.blur_eyes(5)
+	A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
+	playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
 
 /*
 Jugular Cut, can only be done if the target is in crit, being held in a tier 3 grab by the user or if they are sleeping.
 Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect similar to throat slicing someone with a sharp item.
 */
 /datum/martial_art/tribal_claw/proc/jugularCut(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    var/def_check = D.getarmor(BODY_ZONE_HEAD, "melee")
-    if((D.health <= D.crit_threshold || (A.pulling == D && A.grab_state >= GRAB_NECK) || D.IsSleeping()))
-        log_combat(A, D, "jugular cut (Tribal Claw)")
-        D.visible_message("<span class='warning'>[A] cuts [D]'s jugular vein with their claws!</span>", \
-                            "<span class='userdanger'>[A] cuts your jugular vein!</span>")
-        D.apply_damage(15, BRUTE, BODY_ZONE_HEAD, def_check)
-        D.bleed_rate = CLAMP(D.bleed_rate + 20, 0, 30)
-        D.apply_status_effect(/datum/status_effect/neck_slice)
-        A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
-        playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
-    else
-        return basic_hit(A,D)
+	var/def_check = D.getarmor(BODY_ZONE_HEAD, "melee")
+	if((D.health <= D.crit_threshold || (A.pulling == D && A.grab_state >= GRAB_NECK) || D.IsSleeping()))
+		log_combat(A, D, "jugular cut (Tribal Claw)")
+		D.visible_message("<span class='warning'>[A] cuts [D]'s jugular vein with their claws!</span>", \
+							"<span class='userdanger'>[A] cuts your jugular vein!</span>")
+		D.apply_damage(15, BRUTE, BODY_ZONE_HEAD, def_check)
+		D.bleed_rate = CLAMP(D.bleed_rate + 20, 0, 30)
+		D.apply_status_effect(/datum/status_effect/neck_slice)
+		A.do_attack_animation(D, ATTACK_EFFECT_CLAW)
+		playsound(get_turf(D), 'sound/weapons/slash.ogg', 50, 1, -1)
+	else
+		return basic_hit(A,D)
 
 //Tail Grab, instantly puts your target in a T3 grab and makes them unable to talk for a short time.
 /datum/martial_art/tribal_claw/proc/tailGrab(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    log_combat(A, D, "tail grabbed (Tribal Claw)")
-    D.visible_message("<span class='warning'>[A] grabs [D] with their tail!</span>", \
-                        "<span class='userdanger'>[A] grabs you with their tail!</span>")
-    D.grabbedby(A, 1)
-    D.Knockdown(5) //Without knockdown target still stands up while T3 grabbed.
-    A.setGrabState(GRAB_NECK)
-    if(D.silent <= 10)
-        D.silent = CLAMP(D.silent + 10, 0, 10)
-    return
+	log_combat(A, D, "tail grabbed (Tribal Claw)")
+	D.visible_message("<span class='warning'>[A] grabs [D] with their tail!</span>", \
+						"<span class='userdanger'>[A] grabs you with their tail!</span>")
+	D.grabbedby(A, 1)
+	D.Knockdown(5) //Without knockdown target still stands up while T3 grabbed.
+	A.setGrabState(GRAB_NECK)
+	if(D.silent <= 10)
+		D.silent = CLAMP(D.silent + 10, 0, 10)
 
 /datum/martial_art/tribal_claw/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    add_to_streak("H",D)
-    if(check_streak(A,D))
-        return TRUE
-    return FALSE
+	add_to_streak("H",D)
+	if(check_streak(A,D))
+		return TRUE
+	return FALSE
 
 /datum/martial_art/tribal_claw/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    add_to_streak("D",D)
-    if(check_streak(A,D))
-        return TRUE
-    return FALSE
+	add_to_streak("D",D)
+	if(check_streak(A,D))
+		return TRUE
+	return FALSE
 
 /datum/martial_art/tribal_claw/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-    add_to_streak("G",D)
-    if(check_streak(A,D))
-        return TRUE
-    return FALSE
+	add_to_streak("G",D)
+	if(check_streak(A,D))
+		return TRUE
+	return FALSE
 
 /mob/living/carbon/human/proc/tribal_claw_help()
-    set name = "Recall Teachings"
-    set desc = "Remember the martial techniques of the Tribal Claw"
-    set category = "Tribal Claw"
+	set name = "Recall Teachings"
+	set desc = "Remember the martial techniques of the Tribal Claw"
+	set category = "Tribal Claw"
 
-    to_chat(usr, "<b><i>You retreat inward and recall the teachings of the Tribal Claw...</i></b>")
+	to_chat(usr, "<b><i>You retreat inward and recall the teachings of the Tribal Claw...</i></b>")
 
-    to_chat(usr, "<span class='notice'>Tail Sweep</span>: Disarm Disarm Grab Harm. Pushes everyone around you away and knocks them down.")
-    to_chat(usr, "<span class='notice'>Face Scratch</span>: Harm Disarm. Damages your target's head and confuses them for a short time.")
-    to_chat(usr, "<span class='notice'>Jugular Cut</span>: Harm Harm Grab. Causes your target to rapidly lose blood, works only if you grab your target by their neck, if they are sleeping, or in critical condition.")
-    to_chat(usr, "<span class='notice'>Tail Grab</span>: Disarm Harm Grab Grab. Grabs your target by their neck and makes them unable to talk for a short time.")
+	to_chat(usr, "<span class='notice'>Tail Sweep</span>: Disarm Disarm Grab Harm. Pushes everyone around you away and knocks them down.")
+	to_chat(usr, "<span class='notice'>Face Scratch</span>: Harm Disarm. Damages your target's head and confuses them for a short time.")
+	to_chat(usr, "<span class='notice'>Jugular Cut</span>: Harm Harm Grab. Causes your target to rapidly lose blood, works only if you grab your target by their neck, if they are sleeping, or in critical condition.")
+	to_chat(usr, "<span class='notice'>Tail Grab</span>: Disarm Harm Grab Grab. Grabs your target by their neck and makes them unable to talk for a short time.")

--- a/code/datums/martial/tribal_claw.dm
+++ b/code/datums/martial/tribal_claw.dm
@@ -32,13 +32,11 @@
 /datum/martial_art/tribal_claw/proc/tailSweep(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(A == current_target)
 		return
-	if(!D.stat)
-		log_combat(A, D, "tail sweeped(Tribal Claw)")
-		D.visible_message("<span class='warning'>[A] sweeps [D]'s legs with their tail!</span>", \
-							"<span class='userdanger'>[A] sweeps your legs with their tail!</span>")
-		var/obj/effect/proc_holder/spell/aoe_turf/repulse/spacedragon/R = new
-		R.cast(RANGE_TURFS(1,A))
-	return basic_hit(A,D)
+	log_combat(A, D, "tail sweeped(Tribal Claw)")
+	D.visible_message("<span class='warning'>[A] sweeps [D]'s legs with their tail!</span>", \
+						"<span class='userdanger'>[A] sweeps your legs with their tail!</span>")
+	var/obj/effect/proc_holder/spell/aoe_turf/repulse/spacedragon/R = new
+	R.cast(RANGE_TURFS(1,A))
 
 //Face Scratch, deals 10 brute to head(reduced by armor), blurs the target's vision and gives them the confused effect for a short time.
 /datum/martial_art/tribal_claw/proc/faceScratch(mob/living/carbon/human/A, mob/living/carbon/human/D)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -982,16 +982,19 @@ GLOBAL_LIST_EMPTY(PDAs)
 		return
 	switch(scanmode)
 		if(PDA_SCANNER_REAGENT)
-			if(!isnull(A.reagents))
-				if(A.reagents.reagent_list.len > 0)
-					var/reagents_length = A.reagents.reagent_list.len
-					to_chat(user, "<span class='notice'>[reagents_length] chemical agent[reagents_length > 1 ? "s" : ""] found.</span>")
-					for (var/re in A.reagents.reagent_list)
-						to_chat(user, "<span class='notice'>\t [re]</span>")
+			if(!istype(A, /obj/item/reagent_containers/pill/floorpill))
+				if(!isnull(A.reagents))
+					if(A.reagents.reagent_list.len > 0)
+						var/reagents_length = A.reagents.reagent_list.len
+						to_chat(user, "<span class='notice'>[reagents_length] chemical agent[reagents_length > 1 ? "s" : ""] found.</span>")
+						for (var/re in A.reagents.reagent_list)
+							to_chat(user, "<span class='notice'>\t [re]</span>")
+					else
+						to_chat(user, "<span class='notice'>No active chemical agents found in [A].</span>")
 				else
-					to_chat(user, "<span class='notice'>No active chemical agents found in [A].</span>")
+					to_chat(user, "<span class='notice'>No significant chemical agents found in [A].</span>")
 			else
-				to_chat(user, "<span class='notice'>No significant chemical agents found in [A].</span>")
+				to_chat(user, "<span class='notice'>You can't scan [A].")
 
 		if(PDA_SCANNER_GAS)
 			A.analyzer_act(user, src)

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -12,9 +12,12 @@
 	if(!istype(C, /obj/item/organ/regenerative_core))
 		to_chat(user, "<span class='warning'>The stabilizer only works on certain types of monster organs, generally regenerative in nature.</span>")
 		return ..()
+	if(C.preserved)
+		to_chat(user, "<span class='notice'>[M] is already stabilised.")
+		return
 
 	C.preserved()
-	to_chat(user, "<span class='notice'>You inject the [M] with the stabilizer. It will no longer go inert.</span>")
+	to_chat(user, "<span class='notice'>You inject [M] with the stabilizer. It will no longer go inert.</span>")
 	qdel(src)
 
 /************************Hivelord core*******************/


### PR DESCRIPTION
## About The Pull Request
Tribal claw file ~used spaces~ uses tabs, the tail sweep combo can't be used to perform instant stuns by doing the combo on yourself and removes useless empty returns.
PDA reagent scanner function can't be used to scan floor pills.
Removes useless "the" in regen core chat messages which ends up as "the the" and makes people unable to use stabilisers on already stable regen cores.

## Why It's Good For The Game
Fixes good, instant stuns bad.

## Changelog
:cl:
tweak: Tribal claw tail sweep can't be used on yourself.
fix: Fixes being able to stabilise legion cores multiple times.
fix: Fixes being able to scan floor pill contents using the PDA reagent scanner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
