### PR TITLE
a lil viro tweak

### DIFF
--- a/code/datums/diseases/advance/symptoms/clockwork.dm
+++ b/code/datums/diseases/advance/symptoms/clockwork.dm
@@ -60,15 +60,15 @@
 			if(O.status == ORGAN_ROBOTIC) //they are either part robotic or we already converted them!
 				continue
 			switch(O.slot) //i hate doing it this way, but the cleaner way runtimes and does not work
-				if(ORGAN_SLOT_BRAIN)
-					var/datum/mind/ownermind = H.mind
+				if(ORGAN_SLOT_BRAIN)				
 					var/obj/item/organ/brain/clockwork/organ = new()
+					var/datum/mind/ownermind = H.mind
 					if(robustbits)
 						organ.robust = TRUE //STOPS THAT GODDAMN CLANGING BECAUSE IT'S WELL OILED OR SOMETHING
 					organ.Insert(H, TRUE, FALSE)
+					ownermind.transfer_to(H)
 					to_chat(H, "<span class='userdanger'>Your head throbs with pain for a moment, and then goes numb.</span>")
 					H.emote("scream")
-					ownermind.transfer_to(H)
 					H.grab_ghost()
 					return TRUE
 				if(ORGAN_SLOT_STOMACH)
@@ -93,7 +93,6 @@
 					if(prob(40))
 						to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your eyeballs!</span>")
 						H.emote("scream")
-						ownermind.transfer_to(H)
 						H.grab_ghost()
 						return TRUE
 				if(ORGAN_SLOT_STOMACH)

--- a/code/datums/diseases/advance/symptoms/clockwork.dm
+++ b/code/datums/diseases/advance/symptoms/clockwork.dm
@@ -8,33 +8,33 @@
 	level = 9
 	severity = 0
 	symptom_delay_min = 10
-	symptom_delay_max = 60
+	symptom_delay_max = 30
 	var/replaceorgans = FALSE
 	var/replacebody = FALSE
 	var/robustbits = FALSE
 	threshold_desc = "<b>Stage Speed 4:</b>The virus will replace the host's organic organs with mundane, biometallic versions. +1 severity.<br>\
-                      <b>Stage Speed 10:</b>The virus will eventually convert the host's entire body to biometallic materials, and maintain its cellular integrity. +1 severity.<br>\
-                      <b>Stage Speed 13:</b>Biometallic mass created by the virus will be superior to typical organic mass. -3 severity."
+                      <b>Resistance 4:</b>The virus will eventually convert the host's entire body to biometallic materials, and maintain its cellular integrity. +1 severity.<br>\
+                      <b>Stage Speed 12:</b>Biometallic mass created by the virus will be superior to typical organic mass. -3 severity."
 
 /datum/symptom/robotic_adaptation/OnAdd(datum/disease/advance/A)
 	A.infectable_biotypes |= MOB_ROBOTIC
 
 /datum/symptom/robotic_adaptation/severityset(datum/disease/advance/A)
 	. = ..()
-	if(A.properties["stage_rate"] >= 5) //at base level, robotic organs are purely a liability
+	if(A.properties["stage_rate"] >= 4) //at base level, robotic organs are purely a liability
 		severity += 1
-	if(A.properties["stage_rate"] >= 10)//at base level, robotic bodyparts have very few bonuses, mostly being a liability in the case of EMPS
+	if(A.properties["resistance"] >= 4)//at base level, robotic bodyparts have very few bonuses, mostly being a liability in the case of EMPS
 		severity += 1 //at this stage, even one EMP will hurt, a lot.
-	if(A.properties["stage_rate"] >= 13)//but at this threshold, it all becomes worthwhile, though getting augged is a better choice
+	if(A.properties["stage_rate"] >= 12)//but at this threshold, it all becomes worthwhile, though getting augged is a better choice
 		severity -= 3//net benefits: 2 damage reduction, flight if you have wings, filter out low amounts of gas, durable ears, flash protection, a liver half as good as an upgraded cyberliver, and flight if you are a winged species
 
 /datum/symptom/robotic_adaptation/Start(datum/disease/advance/A)
 	. = ..()
 	if(A.properties["stage_rate"] >= 4)
 		replaceorgans = TRUE
-	if(A.properties["stage_rate"] >= 10)
+	if(A.properties["resistance"] >= 4)
 		replacebody = TRUE
-	if(A.properties["stage_rate"] >= 14)
+	if(A.properties["stage_rate"] >= 12)
 		robustbits = TRUE //note that having this symptom means most healing symptoms won't work on you
 
 /datum/symptom/robotic_adaptation/Activate(datum/disease/advance/A)
@@ -46,102 +46,128 @@
 			if(replaceorgans)
 				to_chat(H, "<span class='warning'><b>[pick("You feel a grinding pain in your abdomen.", "You exhale a jet of steam.")]</span>")
 		if(5)
-			if(replaceorgans)
+			if(replaceorgans || replacebody)
 				if(Replace(H))
 					return
-				else if(replacebody)
-					H.adjustCloneLoss(-30) //we're fully mechanical, repair integrity. This symptom has a soft synergy with overclocked pituitary, so we want that to be useable. OFI is obviously out
+				if(replacebody)
+					H.adjustCloneLoss(-20) //repair mechanical integrity
 			ADD_TRAIT(H, TRAIT_NANITECOMPATIBLE, DISEASE_TRAIT)
 	return
 
 /datum/symptom/robotic_adaptation/proc/Replace(mob/living/carbon/human/H)
-	for(var/obj/item/organ/O in H.internal_organs)
-		if(O.status == ORGAN_ROBOTIC) //they are either part robotic or we already converted them!
-			continue
-		switch(O.slot) //i hate doing it this way, but the cleaner way runtimes and does not work
-			if(ORGAN_SLOT_BRAIN)
-				var/datum/mind/ownermind = H.mind
-				var/obj/item/organ/brain/clockwork/organ = new()
-				if(robustbits)
-					organ.robust = TRUE //STOPS THAT GODDAMN CLANGING BECAUSE IT'S WELL OILED OR SOMETHING
-				organ.Insert(H, TRUE, FALSE)
-				to_chat(H, "<span class='userdanger'>Your head throbs with pain for a moment, and then goes numb.</span>")
-				H.emote("scream")
-				ownermind.transfer_to(H)
-				H.grab_ghost()
-				return TRUE
-			if(ORGAN_SLOT_STOMACH)
-				var/obj/item/organ/stomach/clockwork/organ = new()
-				organ.Insert(H, TRUE, FALSE)
-				if(prob(40))
-					to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your abdomen!</span>")
+	if(replaceorgans)
+		for(var/obj/item/organ/O in H.internal_organs)
+			if(O.status == ORGAN_ROBOTIC) //they are either part robotic or we already converted them!
+				continue
+			switch(O.slot) //i hate doing it this way, but the cleaner way runtimes and does not work
+				if(ORGAN_SLOT_BRAIN)
+					var/datum/mind/ownermind = H.mind
+					var/obj/item/organ/brain/clockwork/organ = new()
+					if(robustbits)
+						organ.robust = TRUE //STOPS THAT GODDAMN CLANGING BECAUSE IT'S WELL OILED OR SOMETHING
+					organ.Insert(H, TRUE, FALSE)
+					to_chat(H, "<span class='userdanger'>Your head throbs with pain for a moment, and then goes numb.</span>")
 					H.emote("scream")
-				return TRUE
-			if(ORGAN_SLOT_EARS)
-				var/obj/item/organ/ears/robot/clockwork/organ = new()
-				if(robustbits)
-					organ.damage_multiplier = 0.5
-				organ.Insert(H, TRUE, FALSE)
-				to_chat(H, "<span class='warning'>Your ears pop.</span>")
-				return TRUE
-			if(ORGAN_SLOT_EYES)
-				var/obj/item/organ/eyes/robotic/clockwork/organ = new()
-				if(robustbits)
-					organ.flash_protect = 1
-				organ.Insert(H, TRUE, FALSE)
-				if(prob(40))
-					to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your eyeballs!</span>")
-					H.emote("scream")
-				return TRUE
-			if(ORGAN_SLOT_LUNGS)
-				var/obj/item/organ/lungs/clockwork/organ = new()
-				if(robustbits)
-					organ.safe_toxins_max = 15
-					organ.safe_co2_max = 15
-					organ.SA_para_min = 15
-					organ.SA_sleep_min = 15
-					organ.BZ_trip_balls_min = 15
-					organ.gas_stimulation_min = 15
-				organ.Insert(H, TRUE, FALSE)
-				if(prob(40))
+					ownermind.transfer_to(H)
+					H.grab_ghost()
+					return TRUE
+				if(ORGAN_SLOT_STOMACH)
+					var/obj/item/organ/stomach/clockwork/organ = new()
+					organ.Insert(H, TRUE, FALSE)
+					if(prob(40))
+						to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your abdomen!</span>")
+						H.emote("scream")
+					return TRUE
+				if(ORGAN_SLOT_EARS)
+					var/obj/item/organ/ears/robot/clockwork/organ = new()
+					if(robustbits)
+						organ.damage_multiplier = 0.5
+					organ.Insert(H, TRUE, FALSE)
+					to_chat(H, "<span class='warning'>Your ears pop.</span>")
+					return TRUE
+				if(ORGAN_SLOT_EYES)
+					var/obj/item/organ/eyes/robotic/clockwork/organ = new()
+					if(robustbits)
+						organ.flash_protect = 1
+					organ.Insert(H, TRUE, FALSE)
+					if(prob(40))
+						to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your eyeballs!</span>")
+						H.emote("scream")
+						ownermind.transfer_to(H)
+						H.grab_ghost()
+						return TRUE
+				if(ORGAN_SLOT_STOMACH)
+					var/obj/item/organ/stomach/clockwork/organ = new()
+					organ.Insert(H, TRUE, FALSE)
+					if(prob(40))
+						to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your abdomen!</span>")
+						H.emote("scream")
+					return TRUE
+				if(ORGAN_SLOT_EARS)
+					var/obj/item/organ/ears/robot/clockwork/organ = new()
+					if(robustbits)
+						organ.damage_multiplier = 0.5
+					organ.Insert(H, TRUE, FALSE)
+					to_chat(H, "<span class='warning'>Your ears pop.</span>")
+					return TRUE
+				if(ORGAN_SLOT_EYES)
+					var/obj/item/organ/eyes/robotic/clockwork/organ = new()
+					if(robustbits)
+						organ.flash_protect = 1
+					organ.Insert(H, TRUE, FALSE)
+					if(prob(40))
+						to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your eyeballs!</span>")
+						H.emote("scream")
+					return TRUE
+				if(ORGAN_SLOT_LUNGS)
+					var/obj/item/organ/lungs/clockwork/organ = new()
+					if(robustbits)
+						organ.safe_toxins_max = 15
+						organ.safe_co2_max = 15
+						organ.SA_para_min = 15
+						organ.SA_sleep_min = 15
+						organ.BZ_trip_balls_min = 15
+						organ.gas_stimulation_min = 15
+					organ.Insert(H, TRUE, FALSE)
+					if(prob(40))
+						to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your chest!</span>")
+						H.emote("scream")
+					return TRUE
+				if(ORGAN_SLOT_HEART)
+					var/obj/item/organ/heart/clockwork/organ = new()
+					organ.Insert(H, TRUE, FALSE)
 					to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your chest!</span>")
 					H.emote("scream")
-				return TRUE
-			if(ORGAN_SLOT_HEART)
-				var/obj/item/organ/heart/clockwork/organ = new()
-				organ.Insert(H, TRUE, FALSE)
-				to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your chest!</span>")
-				H.emote("scream")
-				return TRUE
-			if(ORGAN_SLOT_LIVER)
-				var/obj/item/organ/liver/clockwork/organ = new()
-				if(robustbits)
-					organ.toxTolerance = 7
-				organ.Insert(H, TRUE, FALSE)
-				if(prob(40))
-					to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your abdomen!</span>")
-					H.emote("scream")
-				return TRUE
-			if(ORGAN_SLOT_TONGUE)
-				if(robustbits)
-					var/obj/item/organ/tongue/robot/clockwork/better/organ = new()
+					return TRUE
+				if(ORGAN_SLOT_LIVER)
+					var/obj/item/organ/liver/clockwork/organ = new()
+					if(robustbits)
+						organ.toxTolerance = 7
+					organ.Insert(H, TRUE, FALSE)
+					if(prob(40))
+						to_chat(H, "<span class='userdanger'>You feel a stabbing pain in your abdomen!</span>")
+						H.emote("scream")
+					return TRUE
+				if(ORGAN_SLOT_TONGUE)
+					if(robustbits)
+						var/obj/item/organ/tongue/robot/clockwork/better/organ = new()
+						organ.Insert(H, TRUE, FALSE)
+						return TRUE
+					else
+						var/obj/item/organ/tongue/robot/clockwork/organ = new()
+						organ.Insert(H, TRUE, FALSE)
+						return TRUE
+				if(ORGAN_SLOT_TAIL)
+					var/obj/item/organ/tail/clockwork/organ = new()
 					organ.Insert(H, TRUE, FALSE)
 					return TRUE
-				else
-					var/obj/item/organ/tongue/robot/clockwork/organ = new()
+				if(ORGAN_SLOT_WINGS)
+					var/obj/item/organ/wings/cybernetic/clockwork/organ = new()
+					if(robustbits)
+						organ.flight_level = WINGS_FLYING
 					organ.Insert(H, TRUE, FALSE)
+					to_chat(H, "<span class='warning'>Your wings feel stiff.</span>")
 					return TRUE
-			if(ORGAN_SLOT_TAIL)
-				var/obj/item/organ/tail/clockwork/organ = new()
-				organ.Insert(H, TRUE, FALSE)
-				return TRUE
-			if(ORGAN_SLOT_WINGS)
-				var/obj/item/organ/wings/cybernetic/clockwork/organ = new()
-				if(robustbits)
-					organ.flight_level = WINGS_FLYING
-				organ.Insert(H, TRUE, FALSE)
-				to_chat(H, "<span class='warning'>Your wings feel stiff.</span>")
-				return TRUE
 	if(replacebody)
 		for(var/obj/item/bodypart/O in H.bodyparts)
 			if(O.status == BODYPART_ROBOTIC)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -426,7 +426,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	switch(A.stage)
 		if(4, 5)
 			if(burnheal)
-				M.heal_overall_damage(0, 1) //no required_status checks here, this does all bodyparts equally
+				M.heal_overall_damage(0, 1.5) //no required_status checks here, this does all bodyparts equally
 			if(prob(5) && (M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT || M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT))
 				location_return = get_turf(M)	//sets up return point
 				if(prob(50))
@@ -494,16 +494,22 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 		if(4, 5)
 			if(prob(5) && bruteheal)
 				to_chat(M, "<span class='userdanger'>You retch, and a splatter of gore escapes your gullet!</span>")
-				M.Knockdown(10)
+				M.Immobilize(5)
 				new /obj/effect/decal/cleanable/blood/(M.loc)
 				playsound(get_turf(M), 'sound/effects/splat.ogg', 50, 1)
 				if(prob(60))
+					if(tetsuo && prob(15))
+						if(A.affected_mob.job == "Clown")
+							new /obj/effect/spawner/lootdrop/teratoma/major/clown(M.loc)
+						if(MOB_ROBOTIC in A.infectable_biotypes)
+							new /obj/effect/decal/cleanable/robot_debris(M.loc)
+							new /obj/effect/spawner/lootdrop/teratoma/robot(M.loc)
 					new /obj/effect/spawner/lootdrop/teratoma/minor(M.loc)
 				if(tetsuo)
 					var/list/organcantidates = list()
 					var/list/missing = M.get_missing_limbs()
 					if(prob(35))
-						new /obj/effect/gibspawner/human/bodypartless(M.loc) //yes. this is very messy. very, very messy.
+						new /obj/effect/decal/cleanable/blood/gibs(M.loc) //yes. this is very messy. very, very messy.
 						new /obj/effect/spawner/lootdrop/teratoma/major(M.loc)
 						for(var/obj/item/organ/O in M.loc)
 							if(O.organ_flags & ORGAN_FAILING || O.organ_flags & ORGAN_VITAL) //dont use shitty organs or brains
@@ -547,8 +553,6 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 									ownermind.transfer_to(M)
 									M.grab_ghost()
 								break
-				if(tetsuo && prob(10) && A.affected_mob.job == "Clown")
-					new /obj/effect/spawner/lootdrop/teratoma/major/clown(M.loc)
 			if(bruteheal)
 				M.heal_overall_damage(2 * power, required_status = BODYPART_ORGANIC)
 				if(prob(11 * power))

--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -77,7 +77,7 @@
 			LAZYCLEARLIST(cached_tentacle_turfs)
 			last_location = loc
 			tentacle_recheck_cooldown = world.time + initial(tentacle_recheck_cooldown)
-			for(var/turf/open/T in (RANGE_TURFS(2, loc)-loc))
+			for(var/turf/open/T in (RANGE_TURFS(1, loc)-loc))
 				LAZYADD(cached_tentacle_turfs, T)
 		for(var/t in cached_tentacle_turfs)
 			if(isopenturf(t))

--- a/code/datums/diseases/advance/symptoms/oxygen.dm
+++ b/code/datums/diseases/advance/symptoms/oxygen.dm
@@ -50,7 +50,7 @@ Bonus
 			M.adjustOxyLoss(-7, 0)
 			M.losebreath = max(0, M.losebreath - 4)
 			if(regenerate_blood && M.blood_volume < BLOOD_VOLUME_NORMAL)
-				M.blood_volume += 1
+				M.blood_volume += 8 //it takes 4 seconds to lose one point of bleed_rate. this is exactly sufficient to counter autophageocytosis' Heparin production. Theoretically.
 			if(prob(1) && prob(50))
 				var/turf/open/T = get_turf(M)
 				if(!istype(T))

--- a/code/datums/diseases/advance/symptoms/wizarditis.dm
+++ b/code/datums/diseases/advance/symptoms/wizarditis.dm
@@ -16,17 +16,17 @@
 
 /datum/symptom/wizarditis/severityset(datum/disease/advance/A)
 	. = ..()
-	if(A.properties["transmittable"] >= 12)
+	if(A.properties["transmittable"] >= 8)
 		severity += 1
-	if(A.properties["speed"] >= 7)
+	if(A.properties["stage_rate"] >= 7)
 		severity += 1
 
 /datum/symptom/wizarditis/Start(datum/disease/advance/A)
 	if(!..())
 		return
-	if(A.properties["transmission"] >= 14)
+	if(A.properties["transmittable"] >= 8)
 		teleport = TRUE
-	if(A.properties["speed"] >= 7)
+	if(A.properties["stage_rate"] >= 7)
 		robes = TRUE
 
 /datum/symptom/wizarditis/Activate(datum/disease/advance/A)

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -216,9 +216,37 @@
 		/obj/item/organ/vocal_cords/adamantine = 1,
 		/obj/effect/gibspawner/xeno = 1,
 		/obj/effect/mob_spawn/human/corpse/assistant = 1,
-		/obj/effect/mob_spawn/teratomamonkey = 5,
+		/obj/effect/mob_spawn/teratomamonkey = 1,
 		/obj/item/organ/wings/moth/robust = 1,
 		/obj/item/organ/wings/dragon = 1)
+
+/obj/effect/spawner/lootdrop/teratoma/robot
+	name = "robotic teratoma spawner"
+	loot = list(
+		/obj/item/organ/ears/robot = 5,
+		/obj/item/organ/eyes/robotic = 5,
+		/obj/item/organ/eyes/robotic/flashlight = 1,
+		/obj/item/organ/eyes/night_vision = 1,
+		/obj/item/organ/liver/cybernetic = 4,
+		/obj/item/organ/liver/cybernetic/upgraded/ipc = 3,
+		/obj/item/organ/lungs/cybernetic = 4,
+		/obj/item/organ/lungs/cybernetic/upgraded= 2,
+		/obj/item/organ/stomach/cell = 4,
+		/obj/item/organ/heart/clockwork = 6,
+		/obj/item/organ/stomach/clockwork = 6,
+		/obj/item/organ/liver/clockwork = 6,
+		/obj/item/organ/lungs/clockwork = 6,
+		/obj/item/organ/tail/clockwork = 6,
+		/obj/item/organ/adamantine_resonator = 1,
+		/obj/item/organ/eyes/robotic/thermals = 2,
+		/obj/item/organ/heart/gland/viral = 1,
+		/obj/item/organ/eyes/robotic/shield = 2,
+		/obj/item/organ/eyes/robotic/glow = 2,
+		/obj/item/organ/heart/cybernetic = 2,
+		/obj/item/organ/wings/cybernetic = 2,
+		/obj/item/organ/tongue/robot/clockwork/better = 2,
+		/obj/effect/gibspawner/robot = 4,
+		/obj/item/drone_shell = 1)
 
 /obj/effect/spawner/lootdrop/teratoma/major/clown
 	name = "funny teratoma spawner"


### PR DESCRIPTION
## About The Pull Request
Biometallic replication
-now has consistent threshold descriptions and severity
-now activates faster, but has reduced cell healing
-now has limb replacement at a low resistance threshold, allowing it to be separated from organ replacement.
-slightly tweaked threshold numbers

Pituitary disruption
-less messy
-now immobilizes for a half second instead of knocking down for a second
-teratomas are now FAR rarer
-has robot tumors for robot compatible diseases 

Self-Respiration
-Blood healing buffed, such that it can counteract autophageocytosis' heparin production (leaving alkali perspiration as the only level 9 death symptom that cannot be fully counteracted in a trifecta, which will be fixed in a future PR with a new symptom)

Necroseed
-Tendril range halved

## Why It's Good For The Game
uhh some viruses now work as intended and are less annoying overall

## Changelog
:cl:
tweak: necroseed tendril range halved. if an admin bwoinks you for this they should be ridiculed and kicked in a corner
tweak: self respiration can now counteract autophageocytosis bleeding
tweak: pituitary disruption is less disruptive to a round overall
tweak: biometallic replication numbers and thresholds have been tweaked
tweak: wizarditis transmission threshold is significantly easier
fix: wizarditis now works
/:cl:

