### PR TITLE
Transformation sting wears off after time

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -116,7 +116,7 @@
 		C.updateappearance(mutcolor_update=1)
 		addtimer(CALLBACK(src, .proc/remove_transform, target, OldDNA), 1200)
 
-/datum/action/changeling/sting/transformation/proc/remove_transform(mob/target, var/datum/dna/oldself)
+/datum/action/changeling/sting/transformation/proc/remove_transform(mob/target, var/datum/dna/old_self)
 	if(target)
 		var/mob/living/carbon/C = target
 		if(istype(C))

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -108,20 +108,20 @@
 	. = TRUE
 	if(istype(C))
 		var/datum/dna/old_dna = new /datum/dna
-		C.dna.copy_dna(OldDNA)
-		NewDNA.transfer_identity(C)
-		C.real_name = NewDNA.real_name
+		C.dna.copy_dna(old_dna)
+		new_dna.transfer_identity(C)
+		C.real_name = new_dna.real_name
 		if(ismonkey(C))
 			C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG)
 		C.updateappearance(mutcolor_update=1)
-		addtimer(CALLBACK(src, .proc/remove_transform, target, OldDNA), 1200)
+		addtimer(CALLBACK(src, .proc/remove_transform, target, old_dna), 6000)
 
 /datum/action/changeling/sting/transformation/proc/remove_transform(mob/target, var/datum/dna/old_self)
 	if(target)
 		var/mob/living/carbon/C = target
 		if(istype(C))
-			oldself.transfer_identity(C)
-			C.real_name = oldself.real_name
+			old_self.transfer_identity(C)
+			C.real_name = old_self.real_name
 			if(ismonkey(C))
 				C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG)
 			C.updateappearance(mutcolor_update=1)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -107,7 +107,7 @@
 	var/mob/living/carbon/C = target
 	. = TRUE
 	if(istype(C))
-		var/datum/dna/OldDNA = new /datum/dna
+		var/datum/dna/old_dna = new /datum/dna
 		C.dna.copy_dna(OldDNA)
 		NewDNA.transfer_identity(C)
 		C.real_name = NewDNA.real_name

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -99,17 +99,32 @@
 /datum/action/changeling/sting/transformation/sting_action(mob/user, mob/target)
 	log_combat(user, target, "stung", "transformation sting", " new identity is '[selected_dna.dna.real_name]'")
 	var/datum/dna/NewDNA = selected_dna.dna
+
+
 	if(ismonkey(target))
 		to_chat(user, "<span class='notice'>Our genes cry out as we sting [target.name]!</span>")
 
 	var/mob/living/carbon/C = target
 	. = TRUE
 	if(istype(C))
-		C.real_name = NewDNA.real_name
+		var/datum/dna/OldDNA = new /datum/dna
+		C.dna.copy_dna(OldDNA)
 		NewDNA.transfer_identity(C)
+		C.real_name = NewDNA.real_name
 		if(ismonkey(C))
 			C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG)
 		C.updateappearance(mutcolor_update=1)
+		addtimer(CALLBACK(src, .proc/remove_transform, target, OldDNA), 1200)
+
+/datum/action/changeling/sting/transformation/proc/remove_transform(mob/target, var/datum/dna/oldself)
+	if(target)
+		var/mob/living/carbon/C = target
+		if(istype(C))
+			oldself.transfer_identity(C)
+			C.real_name = oldself.real_name
+			if(ismonkey(C))
+				C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG)
+			C.updateappearance(mutcolor_update=1)
 
 
 /datum/action/changeling/sting/false_armblade

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -98,7 +98,7 @@
 
 /datum/action/changeling/sting/transformation/sting_action(mob/user, mob/target)
 	log_combat(user, target, "stung", "transformation sting", " new identity is '[selected_dna.dna.real_name]'")
-	var/datum/dna/NewDNA = selected_dna.dna
+	var/datum/dna/new_dna = selected_dna.dna
 
 
 	if(ismonkey(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Transformation sting will now dissapear after X amount of time(6000 currently)
## Why It's Good For The Game

ided

Its pretty annoying to get transform stung into glass golem/felind/IPC round start with no realistic way to revert it and no real way to defend against it in the first place. Atleast being able to turn back makes it not used only to cheese and meme

## Changelog
:cl:
balance: Transformation sting will undo itself after certain amount of time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
