### PR TITLE
buffs clown honk virus

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -745,9 +745,9 @@ GLOBAL_LIST_EMPTY(PDAs)
 	tnote += "<i><b>&larr; From <a href='byond://?src=[REF(src)];choice=Message;target=[REF(signal.source)]'>[signal.data["name"]]</a> ([signal.data["job"]]):</b></i><br>[signal.format_message()]<br>"
 
 	if (!silent)
-		if(honkamt > 7)//For clown virus.
+		if(honkamt > 9)//For clown virus.
 			var/adminname = pick(strings("admin_nicknames.json", "names", "config"))
-			honkamt -= 7
+			honkamt -= 9
 			playsound(src, 'sound/effects/adminhelp.ogg', 50, 1)
 			audible_message("<font color='red' size='4'><b>-- Administrator private message --</b></font>", null, 3)
 			audible_message("<span class='danger'>Admin PM from-</span><span class='ooc'>[adminname]</span><span class='danger'>: [pick("What do you think you're doing?","Hey, got a minute?", "Care to explain just how you aren't powergaming right now?","We need to talk.","Stop that or I'll ban you.")]</span>", null, 3)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -745,8 +745,16 @@ GLOBAL_LIST_EMPTY(PDAs)
 	tnote += "<i><b>&larr; From <a href='byond://?src=[REF(src)];choice=Message;target=[REF(signal.source)]'>[signal.data["name"]]</a> ([signal.data["job"]]):</b></i><br>[signal.format_message()]<br>"
 
 	if (!silent)
-		playsound(src, 'sound/machines/twobeep_high.ogg', 50, 1)
-		audible_message("[icon2html(src, hearers(src))] *[ttone]*", null, 3)
+		if(honkamt > 7)//For clown virus.
+			var/adminname = pick(strings("admin_nicknames.json", "names", "config"))
+			honkamt -= 7
+			playsound(src, 'sound/effects/adminhelp.ogg', 50, 1)
+			audible_message("<font color='red' size='4'><b>-- Administrator private message --</b></font>", null, 3)
+			audible_message("<span class='danger'>Admin PM from-</span><span class='ooc'>[adminname]</span><span class='danger'>: [pick("What do you think you're doing?","Hey, got a minute?", "Care to explain just how you aren't powergaming right now?","We need to talk.","Stop that or I'll ban you.")]</span>", null, 3)
+			audible_message("<span class='danger'><i>Click on the administrator's name to get pranked.</i></span>", null, 3)
+		else
+			playsound(src, 'sound/machines/twobeep_high.ogg', 50, 1)
+			audible_message("[icon2html(src, hearers(src))] *[ttone]*", null, 3)
 	//Search for holder of the PDA.
 	var/mob/living/L = null
 	if(loc && isliving(loc))

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -22,6 +22,7 @@
 	icon_state = "cart-clown"
 	desc = "A data cartridge for portable microcomputers. It smells vaguely of bananas."
 	access = CART_CLOWN
+	charges = 0
 
 /obj/item/cartridge/virus/clown/send_virus(obj/item/pda/target, mob/living/U)
 	if(charges <= 0)


### PR DESCRIPTION

## About The Pull Request
clown pda virus is buffed. to compensate, it starts with no charges, so the clown MUST slip targets to send virus

## Why It's Good For The Game
:o)
## Changelog
:cl:
balance: greatly buffs clown pda virus.
balance: clown pda virus starts with 0 charge- the clown must slip people to gain charges to use it
/:cl:

