### PR TITLE
[PAID]nanite logic

### DIFF
--- a/code/__DEFINES/nanites.dm
+++ b/code/__DEFINES/nanites.dm
@@ -47,3 +47,10 @@
 #define NES_BUTTON_NAME "Button Name"
 #define NES_ICON "Icon"
 #define NES_COLOR "Color"
+#define NES_RULE_LOGIC "Logic"
+
+//Nanite Logic
+#define NL_AND "AND"
+#define NL_OR "OR"
+#define NL_NOR "NOR"
+#define NL_NAND "NAND"

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -54,6 +54,15 @@
 	//Rules that automatically manage if the program's active without requiring separate sensor programs
 	var/list/datum/nanite_rule/rules = list()
 
+	//Logic
+	//a list of logic types a nanite program's rules follow
+	var/list/static/logic = list(
+    	"AND" = NL_AND,
+    	"OR" = NL_OR,
+		"NOR" = NL_NOR,
+		"NAND" = NL_NAND,
+	)
+
 /datum/nanite_program/New()
 	. = ..()
 	register_extra_settings()
@@ -99,6 +108,10 @@
 ///Register extra settings by overriding this.
 ///extra_settings[name] = new typepath() for each extra setting
 /datum/nanite_program/proc/register_extra_settings()
+	var/list/logictypes = list()
+	for(var/name in logic)
+		logictypes += name
+	extra_settings[NES_RULE_LOGIC] = new /datum/nanite_extra_setting/type("AND", logictypes)
 	return
 
 ///You can override this if you need to have special behavior after setting certain settings.
@@ -193,10 +206,28 @@
 //If false, disables active and passive effects, but doesn't consume nanites
 //Can be used to avoid consuming nanites for nothing
 /datum/nanite_program/proc/check_conditions()
-	for(var/R in rules)
-		var/datum/nanite_rule/rule = R
-		if(!rule.check_rule())
-			return FALSE
+	var/datum/nanite_extra_setting/logictype = extra_settings[NES_RULE_LOGIC]
+	switch(logictype.get_value())
+		if(NL_AND)
+			for(var/R in rules)
+				var/datum/nanite_rule/rule = R
+				if(!rule.check_rule())
+					return FALSE
+		if(NL_OR)
+			for(var/R in rules)
+				var/datum/nanite_rule/rule = R
+				if(rule.check_rule())
+					return TRUE
+		if(NL_NOR)
+			for(var/R in rules)
+				var/datum/nanite_rule/rule = R
+				if(rule.check_rule())
+					return FALSE
+		if(NL_NAND)
+			for(var/R in rules)
+				var/datum/nanite_rule/rule = R
+				if(!rule.check_rule())
+					return TRUE
 	return TRUE
 
 //Constantly procs as long as the program is active

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -217,7 +217,8 @@
 			for(var/R in rules)
 				var/datum/nanite_rule/rule = R
 				if(rule.check_rule())
-					break
+					return TRUE
+			return FALSE
 		if(NL_NOR)
 			for(var/R in rules)
 				var/datum/nanite_rule/rule = R
@@ -227,7 +228,8 @@
 			for(var/R in rules)
 				var/datum/nanite_rule/rule = R
 				if(!rule.check_rule())
-					break
+					return TRUE 
+			return FALSE
 	return TRUE
 
 //Constantly procs as long as the program is active

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -217,7 +217,7 @@
 			for(var/R in rules)
 				var/datum/nanite_rule/rule = R
 				if(rule.check_rule())
-					return TRUE
+					break
 		if(NL_NOR)
 			for(var/R in rules)
 				var/datum/nanite_rule/rule = R
@@ -227,7 +227,7 @@
 			for(var/R in rules)
 				var/datum/nanite_rule/rule = R
 				if(!rule.check_rule())
-					return TRUE
+					break
 	return TRUE
 
 //Constantly procs as long as the program is active

--- a/code/modules/research/nanites/nanite_programs.dm
+++ b/code/modules/research/nanites/nanite_programs.dm
@@ -57,10 +57,10 @@
 	//Logic
 	//a list of logic types a nanite program's rules follow
 	var/list/static/logic = list(
-    	"AND" = NL_AND,
-    	"OR" = NL_OR,
-		"NOR" = NL_NOR,
-		"NAND" = NL_NAND,
+    	NL_AND,
+    	NL_OR,
+		NL_NOR,
+		NL_NAND,
 	)
 
 /datum/nanite_program/New()


### PR DESCRIPTION

## About The Pull Request
nanite programs now have a logic field, which can be set to AND, NAND, OR or NOR. This changes the way nanites interpret their rules, in a way proper for each of the logic types. currently, nanites only have AND logic.

## Why It's Good For The Game
allows more complexity for nanite programs

## Changelog
:cl:
add: added OR, NOR, and NAND logic types to nanite programs
/:cl:

