### PR TITLE
Hand teleporter nearby turf teleportation fix

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -171,7 +171,7 @@
 			else
 				L["[get_area(com.target)] (Inactive)"] = com.target
 	var/list/turfs = list()
-	for(var/turf/T as() in (RANGE_TURFS(10, src) - get_turf(src)))
+	for(var/turf/T as() in (RANGE_TURFS(10, user) - get_turf(user)))
 		if(T.x>world.maxx-8 || T.x<8)
 			continue	//putting them at the edge is dumb
 		if(T.y>world.maxy-8 || T.y<8)


### PR DESCRIPTION
## About The Pull Request

Makes the "None (Dangerous)" option functional again by changing two instances of `src` to `user`.
Fixes #3806 

## Why It's Good For The Game

Fixes are good.

## Changelog
:cl:
fix: The hand teleporters "None (Dangerous)" option is visible/working again
/:cl: