### PR TITLE
Adds the big sunglasses back to meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19511,6 +19511,7 @@
 /obj/item/folder/red,
 /obj/item/folder/red,
 /obj/item/folder/red,
+/obj/item/clothing/glasses/sunglasses/advanced/big,
 /turf/open/floor/carpet/green,
 /area/lawoffice)
 "aLF" = (


### PR DESCRIPTION
## About The Pull Request
Big sunglasses got stealth removed from metastation in #3963 
This adds them back
Might have been accidental removal idk

## Why It's Good For The Game
Big sunglasses are a signature lawyer item

## Changelog
:cl:
fix: lawyers big sunnies are back on meta
/:cl:
