### PR TITLE
Fixes multi-z disposal mailing issues and recyclers and SSU's deleting items.

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -23,6 +23,10 @@
 	AddComponent(/datum/component/material_container, list(/datum/material/iron, /datum/material/glass, /datum/material/copper, /datum/material/silver, /datum/material/plasma, /datum/material/gold, /datum/material/diamond, /datum/material/plastic, /datum/material/uranium, /datum/material/bananium, /datum/material/titanium, /datum/material/bluespace), INFINITY, FALSE, null, null, null, TRUE)
 	AddComponent(/datum/component/butchering, 1, amount_produced,amount_produced/5)
 	. = ..()
+	if(I.resistance_flags & INDESTRUCTIBLE) //NSV13 start - indestructible item check
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		I.forceMove(loc)
+		return //NSV13 end
 	update_icon()
 	req_one_access = get_all_accesses() + get_all_centcom_access()
 
@@ -129,7 +133,10 @@
 		playsound(src, item_recycle_sound, 50, 1)
 
 /obj/machinery/recycler/proc/recycle_item(obj/item/I)
-
+	if(I.resistance_flags & INDESTRUCTIBLE) //indestructible item check
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		I.forceMove(loc)
+		return
 	I.forceMove(loc)
 	var/obj/item/grown/log/L = I
 	if(istype(L))

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -23,10 +23,6 @@
 	AddComponent(/datum/component/material_container, list(/datum/material/iron, /datum/material/glass, /datum/material/copper, /datum/material/silver, /datum/material/plasma, /datum/material/gold, /datum/material/diamond, /datum/material/plastic, /datum/material/uranium, /datum/material/bananium, /datum/material/titanium, /datum/material/bluespace), INFINITY, FALSE, null, null, null, TRUE)
 	AddComponent(/datum/component/butchering, 1, amount_produced,amount_produced/5)
 	. = ..()
-	if(I.resistance_flags & INDESTRUCTIBLE) //NSV13 start - indestructible item check
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
-		I.forceMove(loc)
-		return //NSV13 end
 	update_icon()
 	req_one_access = get_all_accesses() + get_all_centcom_access()
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -40,9 +40,11 @@
 	* If the hack wire is cut/pulsed.
 	* Modifies effects of cook()
 	* * If FALSE, decontamination sequence will clear radiation for all atoms (and their contents) contained inside the unit, and burn any mobs inside.
-	* * If TRUE, decontamination sequence will delete all items contained within, and if occupied by a mob, intensifies burn damage delt. All wires will be cut at the end.
+	* * If TRUE, decontamination sequence will burn and decontaminate all items contained within, and if occupied by a mob, intensifies burn damage delt. All wires will be cut at the end.
 	*/
 	var/uv_super = FALSE
+	/// For managing the messages sent back when the machine was hacked
+	var/toasted = FALSE
 	/// How many cycles remain for the decontamination sequence.
 	var/uv_cycles = 6
 	/// Cooldown for occupant breakout messages via relaymove()
@@ -150,17 +152,14 @@
 	update_icon()
 
 /obj/machinery/suit_storage_unit/Destroy()
-	QDEL_NULL(suit)
-	QDEL_NULL(helmet)
-	QDEL_NULL(mask)
-	QDEL_NULL(storage)
+	dump_contents()
 	return ..()
 
 /obj/machinery/suit_storage_unit/update_icon()
 	cut_overlays()
 
 	if(uv)
-		if(uv_super)
+		if(uv_super | (obj_flags & EMAGGED))
 			add_overlay("super")
 		else if(occupant)
 			add_overlay("uvhuman")
@@ -195,6 +194,16 @@
 	storage = null
 	occupant = null
 
+/obj/machinery/suit_storage_unit/emp_act()
+	. = ..()
+	uv_super = TRUE
+
+/obj/machinery/suit_storage_unit/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	to_chat(user, "<span class='warning'>You reprogram [src]'s decontamination subroutines.</span>")
+
 /obj/machinery/suit_storage_unit/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		open_machine()
@@ -219,7 +228,6 @@
 	if(occupant || helmet || suit || storage)
 		to_chat(user, "<span class='warning'>It's too cluttered inside to fit in!</span>")
 		return
-
 	if(target == user)
 		user.visible_message("<span class='warning'>[user] starts squeezing into [src]!</span>", "<span class='notice'>You start working your way into [src]...</span>")
 	else
@@ -251,7 +259,7 @@
 		locked = TRUE
 		update_icon()
 		if(occupant)
-			if(uv_super)
+			if(uv_super | (obj_flags & EMAGGED))
 				mob_occupant.adjustFireLoss(rand(20, 36))
 			else
 				mob_occupant.adjustFireLoss(rand(10, 16))
@@ -261,47 +269,52 @@
 		uv_cycles = initial(uv_cycles)
 		uv = FALSE
 		locked = FALSE
-		if(uv_super)
-			visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A cloud of foul black smoke escapes from its chamber.</span>")
+		if(uv_super | (obj_flags & EMAGGED))
+			toasted = TRUE
+			if(occupant)
+				visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A foul stench and a cloud of smoke exit the chamber.</span>")
+			else
+				visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A cloud of foul black smoke escapes from its chamber.</span>")
 			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 50, TRUE)
-			helmet = null
-			qdel(helmet)
-			suit = null
-			qdel(suit) // Delete everything but the occupant.
-			mask = null
-			qdel(mask)
-			storage = null
-			qdel(storage)
+			if(helmet)
+				helmet.take_damage(100,BURN,"fire")
+			if(suit)
+				suit.take_damage(100,BURN,"fire")
+			if(mask)
+				mask.take_damage(100,BURN,"fire")
+			if(storage)
+				storage.take_damage(100,BURN,"fire")
 			// The wires get damaged too.
 			wires.cut_all()
-		else
-			if(!occupant)
-				visible_message("<span class='notice'>[src]'s door slides open. The glowing yellow lights dim to a gentle green.</span>")
-			else
+		if(!toasted) //Special toast check to prevent a double finishing message.
+			if(occupant)
 				visible_message("<span class='warning'>[src]'s door slides open, barraging you with the nauseating smell of charred flesh.</span>")
 				mob_occupant.radiation = 0
-			playsound(src, 'sound/machines/airlockclose.ogg', 25, TRUE)
-			var/list/things_to_clear = list() //Done this way since using GetAllContents on the SSU itself would include circuitry and such.
-			if(suit)
-				things_to_clear += suit
-				things_to_clear += suit.GetAllContents()
-			if(helmet)
-				things_to_clear += helmet
-				things_to_clear += helmet.GetAllContents()
-			if(mask)
-				things_to_clear += mask
-				things_to_clear += mask.GetAllContents()
-			if(storage)
-				things_to_clear += storage
-				things_to_clear += storage.GetAllContents()
-			if(occupant)
-				things_to_clear += occupant
-				things_to_clear += occupant.GetAllContents()
-			for(var/atom/movable/AM in things_to_clear) //Scorches away blood and forensic evidence, although the SSU itself is unaffected
-				SEND_SIGNAL(AM, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRONG)
-				var/datum/component/radioactive/contamination = AM.GetComponent(/datum/component/radioactive)
-				if(contamination)
-					qdel(contamination)
+			else
+				visible_message("<span class='notice'>[src]'s door slides open. The glowing yellow lights dim to a gentle green.</span>")
+		toasted = FALSE
+		playsound(src, 'sound/machines/airlockclose.ogg', 25, TRUE)
+		var/list/things_to_clear = list() //Done this way since using GetAllContents on the SSU itself would include circuitry and such.
+		if(suit)
+			things_to_clear += suit
+			things_to_clear += suit.GetAllContents()
+		if(helmet)
+			things_to_clear += helmet
+			things_to_clear += helmet.GetAllContents()
+		if(mask)
+			things_to_clear += mask
+			things_to_clear += mask.GetAllContents()
+		if(storage)
+			things_to_clear += storage
+			things_to_clear += storage.GetAllContents()
+		if(occupant)
+			things_to_clear += occupant
+			things_to_clear += occupant.GetAllContents()
+		for(var/atom/movable/AM in things_to_clear) //Scorches away blood and forensic evidence, although the SSU itself is unaffected
+			SEND_SIGNAL(AM, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_STRONG)
+			var/datum/component/radioactive/contamination = AM.GetComponent(/datum/component/radioactive)
+			if(contamination)
+				qdel(contamination)
 		open_machine(FALSE)
 		if(occupant)
 			dump_contents()

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -196,7 +196,7 @@
 
 /obj/machinery/suit_storage_unit/emp_act()
 	. = ..()
-	uv_super ^= TRUE
+	uv_super = !uv_super
 
 /obj/machinery/suit_storage_unit/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -196,7 +196,7 @@
 
 /obj/machinery/suit_storage_unit/emp_act()
 	. = ..()
-	uv_super = TRUE
+	uv_super ^= TRUE
 
 /obj/machinery/suit_storage_unit/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -159,7 +159,7 @@
 	cut_overlays()
 
 	if(uv)
-		if(uv_super | (obj_flags & EMAGGED))
+		if(uv_super || (obj_flags & EMAGGED))
 			add_overlay("super")
 		else if(occupant)
 			add_overlay("uvhuman")
@@ -259,7 +259,7 @@
 		locked = TRUE
 		update_icon()
 		if(occupant)
-			if(uv_super | (obj_flags & EMAGGED))
+			if(uv_super || (obj_flags & EMAGGED))
 				mob_occupant.adjustFireLoss(rand(20, 36))
 			else
 				mob_occupant.adjustFireLoss(rand(10, 16))
@@ -269,7 +269,7 @@
 		uv_cycles = initial(uv_cycles)
 		uv = FALSE
 		locked = FALSE
-		if(uv_super | (obj_flags & EMAGGED))
+		if(uv_super || (obj_flags & EMAGGED))
 			toasted = TRUE
 			if(occupant)
 				visible_message("<span class='warning'>[src]'s door creaks open with a loud whining noise. A foul stench and a cloud of smoke exit the chamber.</span>")

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -103,6 +103,7 @@
 // merge two holder objects
 // used when a holder meets a stuck holder
 /obj/structure/disposalholder/proc/merge(obj/structure/disposalholder/other)
+	destinationTag = other.destinationTag //copies typetag from other holder
 	for(var/A in other)
 		var/atom/movable/AM = A
 		AM.forceMove(src)		// move everything in other holder to this one


### PR DESCRIPTION
## About The Pull Request

Allows disposal holders to transfer typetags when going up/down z-levels.
Makes it so recyclers can no longer qdel indestructible items (traitor objectives among others).
Reworked how suit storage units operate, making it impossible for them to delete indestructible items (CE magboots, Captain's Jetpack) when hacked or destroyed and adds a funny EMP/Emag interaction! :)

## Why It's Good For The Game

Deleting things that really shouldn't get deleted is bad.

## Changelog
:cl:
add: Allows you to hack suit storage units with an EMP or Emag.
fix: Fixed recyclers and suit storage units deleting important items.
fix: Fixed disposals mailing not working across z-levels.
/:cl:

