### PR TITLE
Ethereal Blood Creation

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -711,8 +711,8 @@
 		var/mob/living/carbon/human/H = M
 		var/datum/species/ethereal/E = H.dna?.species
 		E.adjust_charge(5*REM)
-	else if(prob(25)) //scp13 optimization
-		M.electrocute_act(rand(10,15), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
+	else if(prob(3)) //scp13 optimization
+		M.electrocute_act(rand(3,5), "Liquid Electricity in their body", 1) //lmao at the newbs who eat energy bars
 		playsound(M, "sparks", 50, 1)
 	return ..()
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -311,3 +311,11 @@
 	results = list(/datum/reagent/medicine/hepanephrodaxon = 5)
 	required_reagents = list(/datum/reagent/medicine/carthatoline = 2, /datum/reagent/carbon = 2, /datum/reagent/lithium = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
+
+/datum/chemical_reaction/liquidelectricity
+	name = "Liquid Electricity"
+	id = /datum/reagent/consumable/liquidelectricity
+	results = list(/datum/reagent/consumable/liquidelectricity = 5)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/silver = 1)
+	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
+	mix_message = "The mixture sparks and then subsides."

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -315,7 +315,6 @@
 /datum/chemical_reaction/liquidelectricity
 	name = "Liquid Electricity"
 	id = /datum/reagent/consumable/liquidelectricity
-	results = list(/datum/reagent/consumable/liquidelectricity = 5)
-	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/silver = 1)
-	required_catalysts = list(/datum/reagent/toxin/plasma = 1)
+	results = list(/datum/reagent/consumable/liquidelectricity = 3)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 3, /datum/reagent/consumable/liquidelectricity = 1, /datum/reagent/toxin/plasma = 1)
 	mix_message = "The mixture sparks and then subsides."


### PR DESCRIPTION
## About The Pull Request

Added a chemical recipe for Liquid Electricity: 1 Ground Plasma, 1 Liquid Electricity, 3 Ethanol (creates 3 units)
Lowered Liquid Electricity shock probability and damage to prevent it from being used effectively as a weapon.
This is a clone of a downstream PR I created https://github.com/BeeStation/NSV13/pull/1361.

## Why It's Good For The Game

Ethereals can now be refilled on their blood analogue without 20 minutes of work by them and medical department personnel.

## Changelog
:cl:
add: Recipe for Liquid Electricity.
tweak: Lowered Liquid electricity shock damage and probability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
