### PR TITLE
Blacklist corgium from strange seeds

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -117,6 +117,7 @@
 	description = "A happy looking liquid that you feel compelled to consume if you want a better life."
 	color = "#ecca7f"
 	taste_description = "dog treats"
+	can_synth = FALSE
 	var/mob/living/simple_animal/pet/dog/corgi/new_corgi
 
 /datum/reagent/corgium/on_mob_metabolize(mob/living/L)


### PR DESCRIPTION
## About The Pull Request

Simply adds can_synth = FALSE to corgium

## Why It's Good For The Game

Since Corgium was changed it has primarily been used as a murder chemical because instantly transforming someone to a corgi is a very effective way of killing them.
Being able to mass produce crazy amounts of it in botany is one of the largest and most urgent detrimental problem with botany.

## Changelog
:cl:
del: Strange seeds can no longer contain corgium.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
