### PR TITLE
Corgium 'polymorphs' people into corgis

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -112,6 +112,10 @@
 	if(istype(data))
 		src.data |= data.Copy()
 
+/*
+ * Transformation
+*/
+
 /datum/reagent/transformation
 	name = "Changium"
 	description = "A mysterious reagent that transforms you into a harmless animal."
@@ -128,25 +132,24 @@
 
 /datum/reagent/transformation/overdose_start(mob/living/L)
 	..()
-	polymorph_target(L)
-	metabolization_rate = 10 * REAGENTS_METABOLISM
+	polymorph_target(L,volume/overdose_threshold)
+	volume = 0
 
-/datum/reagent/transformation/proc/polymorph_target(mob/living/L)
+/datum/reagent/magic/polymorphine/proc/polymorph_target(mob/living/L, var/dur)
 	shapeshiftdata = locate() in L
 	if(shapeshiftdata)
 		return
 	var/mob/living/shape = make_mob(get_turf(L))
-	shapeshiftdata = new(shape,null,L)
-	addtimer(CALLBACK(shapeshiftdata, /obj/shapeshift_holder.proc/restore), POLYMORPHIUM_DURATION)
+	shapeshiftdata = new(shape,null,caster,convert_damage = TRUE,convert_damage_type = STAMINA, die_with_shapeshifted_form = FALSE, revert_on_death = TRUE)
+	addtimer(CALLBACK(shapeshiftdata, /obj/shapeshift_holder.proc/restore), 10 SECONDS * dur)
 
 /datum/reagent/transformation/on_mob_end_metabolize(mob/living/L)
 	..()
-	if(!shapeshiftdata)
-		return
-	shapeshiftdata.restore()
+	if(shapeshiftdata)
+		shapeshiftdata.restore()
 
 /datum/reagent/transformation/proc/make_mob(turf/T)
-	return /mob/living/simple_animal/pet/dog/corgi(T)
+	return new /mob/living/simple_animal/chicken(T)
 
 /datum/reagent/transformation/corgium
 	name = "Corgium"
@@ -156,6 +159,10 @@
 
 /datum/reagent/transformation/corgium/make_mob(turf/T)
 	return new /mob/living/simple_animal/pet/dog/corgi(T)
+
+/*
+ *	Water
+ */
 
 /datum/reagent/water
 	name = "Water"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -133,14 +133,14 @@
 /datum/reagent/transformation/overdose_start(mob/living/L)
 	..()
 	polymorph_target(L,volume/overdose_threshold)
-	volume = 0
 
-/datum/reagent/magic/polymorphine/proc/polymorph_target(mob/living/L, var/dur)
+/datum/reagent/transformation/proc/polymorph_target(mob/living/L, var/dur)
+	volume = 0
 	shapeshiftdata = locate() in L
 	if(shapeshiftdata)
 		return
 	var/mob/living/shape = make_mob(get_turf(L))
-	shapeshiftdata = new(shape,null,caster,convert_damage = TRUE,convert_damage_type = STAMINA, die_with_shapeshifted_form = FALSE, revert_on_death = TRUE)
+	shapeshiftdata = new(shape,null,L,convert_damage = TRUE,convert_damage_type = STAMINA, die_with_shapeshifted_form = FALSE, revert_on_death = TRUE)
 	addtimer(CALLBACK(shapeshiftdata, /obj/shapeshift_holder.proc/restore), 10 SECONDS * dur)
 
 /datum/reagent/transformation/on_mob_end_metabolize(mob/living/L)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -141,7 +141,7 @@
 		return
 	var/mob/living/shape = make_mob(get_turf(L))
 	shape.name = L.name
-	shapeshiftdata = new(shape,null,L,convert_damage = TRUE,convert_damage_type = STAMINA, die_with_shapeshifted_form = FALSE, revert_on_death = TRUE)
+	shapeshiftdata = new(shape,null,L,TRUE,STAMINA, FALSE, TRUE)//convert_damage, convert_damage_type, die_with_shapeshifted_form,revert_on_death
 	addtimer(CALLBACK(shapeshiftdata, /obj/shapeshift_holder.proc/restore), 10 SECONDS * dur)
 
 /datum/reagent/transformation/on_mob_end_metabolize(mob/living/L)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -140,6 +140,7 @@
 	if(shapeshiftdata)
 		return
 	var/mob/living/shape = make_mob(get_turf(L))
+	shape.name = L.name
 	shapeshiftdata = new(shape,null,L,convert_damage = TRUE,convert_damage_type = STAMINA, die_with_shapeshifted_form = FALSE, revert_on_death = TRUE)
 	addtimer(CALLBACK(shapeshiftdata, /obj/shapeshift_holder.proc/restore), 10 SECONDS * dur)
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -600,7 +600,7 @@
 /datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, created_volume)
 	if(isliving(holder.my_atom) && !iscorgi(holder.my_atom))
 		var/mob/living/L = holder
-		L.reagents.add_reagent(/datum/reagent/corgium, created_volume)
+		L.reagents.add_reagent(/datum/reagent/transformation/corgium, created_volume)
 	else
 		var/location = get_turf(holder.my_atom)
 		for(var/i in rand(1, created_volume) to created_volume) // More lulz.

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -166,10 +166,8 @@
 	if(death)
 		stored.death()
 	else if(convert_damage)
-		stored.revive(full_heal = TRUE)
-
 		var/damage_percent = (shape.maxHealth - shape.health)/shape.maxHealth;
-		var/damapply = stored.maxHealth * damage_percent
+		var/damapply = stored.maxHealth * damage_percent - stored.health
 
 		stored.apply_damage(damapply, convert_damage_type, forced = TRUE)
 	qdel(shape)

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -104,6 +104,7 @@
 	src.die_with_shapeshifted_form = die_with_shapeshifted_form 
 	src.revert_on_death = revert_on_death
 	shape = loc
+	shape.del_on_death = FALSE
 	if(!istype(shape))
 		CRASH("shapeshift holder created outside mob/living")
 	stored = caster

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -104,7 +104,6 @@
 	src.die_with_shapeshifted_form = die_with_shapeshifted_form 
 	src.revert_on_death = revert_on_death
 	shape = loc
-	shape.del_on_death = FALSE
 	if(!istype(shape))
 		CRASH("shapeshift holder created outside mob/living")
 	stored = caster


### PR DESCRIPTION
## About The Pull Request

Corgium now uses the shapeshift data to store creatures, similarly on how the shapeshifting spells works.

Also the damage transferred to the mob is now stamina damage, so corgium is no longer lethal.

## Why It's Good For The Game

Corgium was never meant to be more than a meme reagent. It shouldn't be a death weapon.

## Changelog
:cl:
tweak: Corgium shapeshifts people into corgis now. The damage taken in corgi form is now carried over as stamina.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
