### PR TITLE
Prevents Midrounds From Spawning After Shuttlecall

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -30,8 +30,9 @@
 	var/triggering	//admin cancellation
 	var/auto_add = TRUE				//Auto add to the event pool, if not you have to do it yourself!
 
-	/// Whether or not dynamic should hijack this event
-	var/dynamic_should_hijack = FALSE
+	
+	var/dynamic_should_hijack = FALSE	// Whether or not dynamic should hijack this event	
+	var/can_spawn_after_shuttlecall = FALSE	// Prevents the event from spawning after the shuttle was called
 
 /datum/round_event_control/New()
 	if(config && !wizardevent) // Magic is unaffected by configs
@@ -57,6 +58,8 @@
 	if(gamemode_whitelist.len && !(gamemode in gamemode_whitelist))
 		return FALSE
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
+		return FALSE
+	if(can_spawn_after_shuttlecall && !EMERGENCY_IDLE_OR_RECALLED)
 		return FALSE
 	if(ispath(typepath, /datum/round_event/ghost_role) && GHOSTROLE_MIDROUND_EVENT)
 		return FALSE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -32,7 +32,7 @@
 
 	
 	var/dynamic_should_hijack = FALSE	// Whether or not dynamic should hijack this event	
-	var/can_spawn_after_shuttlecall = FALSE	// Prevents the event from spawning after the shuttle was called
+	var/cannot_spawn_after_shuttlecall = FALSE	// Prevents the event from spawning after the shuttle was called
 
 /datum/round_event_control/New()
 	if(config && !wizardevent) // Magic is unaffected by configs
@@ -59,7 +59,7 @@
 		return FALSE
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
 		return FALSE
-	if(can_spawn_after_shuttlecall && !EMERGENCY_IDLE_OR_RECALLED)
+	if(cannot_spawn_after_shuttlecall && !EMERGENCY_IDLE_OR_RECALLED)
 		return FALSE
 	if(ispath(typepath, /datum/round_event/ghost_role) && GHOSTROLE_MIDROUND_EVENT)
 		return FALSE

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -7,6 +7,7 @@
 	earliest_start = 8 MINUTES //not particularly dangerous, gives abductors time to do their objective
 	dynamic_should_hijack = TRUE
 	gamemode_blacklist = list("nuclear","wizard","revolution")
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/abductor
 	minimum_required = 2

--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -7,7 +7,7 @@
 	earliest_start = 8 MINUTES //not particularly dangerous, gives abductors time to do their objective
 	dynamic_should_hijack = TRUE
 	gamemode_blacklist = list("nuclear","wizard","revolution")
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/abductor
 	minimum_required = 2

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -6,7 +6,7 @@
 	min_players = 10
 
 	dynamic_should_hijack = TRUE
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event_control/alien_infestation/canSpawnEvent()
 	. = ..()

--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -6,6 +6,7 @@
 	min_players = 10
 
 	dynamic_should_hijack = TRUE
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event_control/alien_infestation/canSpawnEvent()
 	. = ..()

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -7,6 +7,7 @@
 	min_players = 20
 
 	dynamic_should_hijack = TRUE
+	can_spawn_after_shuttlecall = TRUE
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -7,7 +7,6 @@
 	min_players = 20
 
 	dynamic_should_hijack = TRUE
-	can_spawn_after_shuttlecall = TRUE
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/obsessed
 	max_occurrences = 1
 	min_players = 20
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/obsessed
 	fakeable = FALSE

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/obsessed
 	max_occurrences = 1
 	min_players = 20
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/obsessed
 	fakeable = FALSE

--- a/code/modules/events/fugitive_spawning.dm
+++ b/code/modules/events/fugitive_spawning.dm
@@ -5,6 +5,7 @@
 	min_players = 20
 	earliest_start = 30 MINUTES //deadchat sink, lets not even consider it early on.
 	gamemode_blacklist = list("nuclear")
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/fugitives
 	minimum_required = 1

--- a/code/modules/events/fugitive_spawning.dm
+++ b/code/modules/events/fugitive_spawning.dm
@@ -5,7 +5,7 @@
 	min_players = 20
 	earliest_start = 30 MINUTES //deadchat sink, lets not even consider it early on.
 	gamemode_blacklist = list("nuclear")
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/fugitives
 	minimum_required = 1

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -4,7 +4,7 @@
 	max_occurrences = 1
 	min_players = 20
 	dynamic_should_hijack = TRUE
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/nightmare
 	minimum_required = 1

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -4,6 +4,7 @@
 	max_occurrences = 1
 	min_players = 20
 	dynamic_should_hijack = TRUE
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/nightmare
 	minimum_required = 1

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -4,6 +4,7 @@
 	weight = 0 //Admin only
 	max_occurrences = 1
 	dynamic_should_hijack = TRUE
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -4,7 +4,7 @@
 	weight = 0 //Admin only
 	max_occurrences = 1
 	dynamic_should_hijack = TRUE
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -7,7 +7,7 @@
 	earliest_start = 30 MINUTES
 	dynamic_should_hijack = TRUE
 	gamemode_blacklist = list("nuclear")
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event_control/pirates/preRunEvent()
 	if (!SSmapping.empty_space)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -7,6 +7,7 @@
 	earliest_start = 30 MINUTES
 	dynamic_should_hijack = TRUE
 	gamemode_blacklist = list("nuclear")
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event_control/pirates/preRunEvent()
 	if (!SSmapping.empty_space)

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -6,7 +6,7 @@
 	earliest_start = 50 MINUTES
 	min_players = 20
 	dynamic_should_hijack = TRUE
-	can_spawn_after_shuttlecall = TRUE
+	cannot_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/space_dragon
 	minimum_required = 1

--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -6,6 +6,7 @@
 	earliest_start = 50 MINUTES
 	min_players = 20
 	dynamic_should_hijack = TRUE
+	can_spawn_after_shuttlecall = TRUE
 
 /datum/round_event/ghost_role/space_dragon
 	minimum_required = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents certain events from spawning after shuttle has been called.

## Why It's Good For The Game

It's not fun when you're midround alien/abductor/pirate and you have less than 10 minutes to do your thing.

## Changelog
:cl:
tweak: Prevents midround antags from spawning after shuttle has been called.
/:cl:
