### PR TITLE
Fix issue with dynamic draining all threat on latejoin rulesets

### DIFF
--- a/code/game/gamemodes/dynamic/ruleset_picking.dm
+++ b/code/game/gamemodes/dynamic/ruleset_picking.dm
@@ -63,6 +63,7 @@
 	if (!rule.repeatable)
 		latejoin_rules = remove_from_list(latejoin_rules, rule.type)
 	addtimer(CALLBACK(src, .proc/execute_midround_latejoin_rule, rule), rule.delay)
+	return TRUE
 
 /// Mainly here to facilitate delayed rulesets. All midround/latejoin rulesets are executed with a timered callback to this proc.
 /datum/game_mode/dynamic/proc/execute_midround_latejoin_rule(sent_rule)


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/58644

Resolves the issue of dynamic expending all of the threat level on late arrival antagonists, leaving nothing for midrounds

:cl: Mothblocks
fix: Fixes dynamic executing latejoin rulesets more than it should be
/:cl: