### PR TITLE
Fixes rotation on TEG circulators and drinks dispensers

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -324,6 +324,7 @@
 	//PLACEHOLDER COMMENT FOR ME TO READD THE 1 (?) DS DELAY THAT WAS IMPLEMENTED WITH A... TIMER?
 
 /obj/machinery/atmospherics/AltClick(mob/living/L)
+	. = ..()
 	if(istype(L) && is_type_in_list(src, GLOB.ventcrawl_machinery))
 		L.handle_ventcrawl(src)
 		return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -410,6 +410,7 @@
 	return ..()
 
 /obj/machinery/chem_dispenser/AltClick(mob/living/user)
+	. = ..()
 	if(istype(user) && user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		replace_beaker(user)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Overrides of AltClick on TEG circulators and drinks dispensers caused the alt click signal to never be sent. Therefore the rotation component never received the signal to rotate because it was never sent. This fixes it by calling the parent proc.
Edit: I checked all instances of the rotation component that I saw and these were the only two with an AltClick override.

## Why It's Good For The Game
Fixes a broken feature

## Changelog
:cl:
fix: fixed alt-click rotation on TEG circulators and drink/booze dispensers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
