### PR TITLE
You can now deconstruct ore silo

### DIFF
--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	if(!powered())
 		return ..()
 
-	if (istype(W, /obj/item/stack))
+	if(istype(W, /obj/item/stack))
 		return remote_attackby(src, user, W)
 
 	return ..()

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -66,6 +66,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
 		updateUsrDialog()
 		return
+
 	if(default_deconstruction_crowbar(W))
 		return
 

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -43,6 +43,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 
 /obj/machinery/ore_silo/proc/remote_attackby(obj/machinery/M, mob/user, obj/item/stack/I)
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
+
 	// stolen from /datum/component/material_container/proc/OnAttackBy
 	if(user.a_intent != INTENT_HELP)
 		return
@@ -62,8 +63,18 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	return TRUE
 
 /obj/machinery/ore_silo/attackby(obj/item/W, mob/user, params)
+	if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
+		updateUsrDialog()
+		return
+	if(default_deconstruction_crowbar(W))
+		return
+
+	if(!powered())
+		return ..()
+
 	if (istype(W, /obj/item/stack))
 		return remote_attackby(src, user, W)
+
 	return ..()
 
 /obj/machinery/ore_silo/ui_interact(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ported pr: https://github.com/tgstation/tgstation/pull/52923

## Why It's Good For The Game

Consistency with rest of machines I guess?

I mostly did that to try to replicate infinite rcd materials glitch but it seems it doesn't work for us

## Changelog
:cl:
add: You can deconstruct ore silo now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
