### PR TITLE
Forensic Scanner can no longer scan heretic tears in reality and runes

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -7,6 +7,7 @@
 	move_resist = INFINITY
 	obj_flags = 0
 	vis_flags = VIS_INHERIT_PLANE
+	var/forensic_protected = FALSE
 
 /obj/effect/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	return

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -5,6 +5,7 @@
 	icon_state = ""
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = SIGIL_LAYER
+	forensic_protected = TRUE
 	///Used mainly for summoning ritual to prevent spamming the rune to create millions of monsters.
 	var/is_in_use = FALSE
 
@@ -144,6 +145,7 @@
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "pierced_illusion"
 	anchored = TRUE
+	forensic_protected = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	alpha = 0
 
@@ -165,7 +167,7 @@
 ///Makes this obj appear out of nothing
 /obj/effect/broken_illusion/proc/show_presence()
 	animate(src,alpha = 255,time = 15 SECONDS)
-	
+
 /obj/effect/broken_illusion/proc/dissipate()
 	animate(src,alpha = 0,time = 2 MINUTES)
 	QDEL_IN(src, 2 MINUTES)
@@ -211,12 +213,13 @@
 	if(istype(human_user) && !IS_HERETIC(human_user) && !IS_HERETIC_MONSTER(human_user))
 		to_chat(human_user,"<span class='warning'>Your mind burns as you stare at the tear!</span>")
 		SEND_SIGNAL(human_user, COMSIG_ADD_MOOD_EVENT, "gates_of_mansus", /datum/mood_event/gates_of_mansus)
-		
+
 /obj/effect/reality_smash
 	name = "reality smash"
 	desc = "A weak spot in the veil of reality. You can pierce reality by harvesting this with your Codex Cicatrix to gain charges."
 	icon = 'icons/effects/eldritch.dmi'
 	anchored = TRUE
+	forensic_protected = TRUE
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	invisibility = INVISIBILITY_OBSERVER
 

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -97,22 +97,31 @@
 
 		else if(!ismob(A))
 
-			fingerprints = A.return_fingerprints()
+			var/obj/effect/targeteffect = A
+			if (targeteffect && istype(targeteffect) && targeteffect.forensic_protected)
+				fingerprints = list()				
+				for(var/i in 1 to 2)
+					LAZYADD(fingerprints,pick("#$^@&#*$H3LP&$(@US^$&#^@#","&$(T@&#C@ME5@##$^@&","^@(#&$ET@US&FR^E#^$&#","#$^@&M*N$US^$(@&#^$&#^@#","&$(@&#^$&#^@##$^@&","^@R(#E$(D@(R&$U&#M^&#","$TH@Y#*$KN@W(@&#^$&#^@#","#$M^DN*S$^@(#&$(@&#^$&#^@##","#","#$^@&#*$^@(#&$(@","#","#$^@&#&#^@","#","@(#&$(@&#^$&#^@"))
+				blood = list("#$^@&LO0K&#@#" = "&$(@AW@Y#$^&")
+				to_chat(user, "<span class='warning'>Your [src] glitched out!</span>")
 
-			// Only get reagents from non-mobs.
-			if(A.reagents && A.reagents.reagent_list.len)
+			else
+				fingerprints = A.return_fingerprints()
 
-				for(var/datum/reagent/R in A.reagents.reagent_list)
-					reagents[R.name] = R.volume
+				// Only get reagents from non-mobs.
+				if(A.reagents && A.reagents.reagent_list.len)
 
-					// Get blood data from the blood reagent.
-					if(istype(R, /datum/reagent/blood))
+					for(var/datum/reagent/R in A.reagents.reagent_list)
+						reagents[R.name] = R.volume
 
-						if(R.data["blood_DNA"] && R.data["blood_type"])
-							var/blood_DNA = R.data["blood_DNA"]
-							var/blood_type = R.data["blood_type"]
-							LAZYINITLIST(blood)
-							blood[blood_DNA] = blood_type
+						// Get blood data from the blood reagent.
+						if(istype(R, /datum/reagent/blood))
+
+							if(R.data["blood_DNA"] && R.data["blood_type"])
+								var/blood_DNA = R.data["blood_DNA"]
+								var/blood_type = R.data["blood_type"]
+								LAZYINITLIST(blood)
+								blood[blood_DNA] = blood_type
 
 		// We gathered everything. Create a fork and slowly display the results to the holder of the scanner.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Forensic scanners 'glitch out' when scanning heretic runes and pierced reality.

## Why It's Good For The Game

A small buff that makes heretics harder to cheese.

## Changelog
:cl:
balance: forensic scanner glitch out when scanning heretic runes and realities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
