### PR TITLE
Removes slowdown from the clockwork armour

### DIFF
--- a/code/modules/antagonists/clock_cult/items/brass_clothing.dm
+++ b/code/modules/antagonists/clock_cult/items/brass_clothing.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/clothing/clockwork_garb.dmi'
 	icon_state = "clockwork_cuirass"
 	armor = list("melee" = 50, "bullet" = 60, "laser" = 30, "energy" = 80, "bomb" = 80, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "stamina" = 60)
-	slowdown = 0.6
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	w_class = WEIGHT_CLASS_BULKY
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS


### PR DESCRIPTION
Removes the slowdown modifier from basic clockwork armour, so it is more useful on the station. The big slowdown modifier makes you an easy, very obvious target when you're wearing the armour balatantly.

:cl:
balance: You can now run at full speed while wearing clockwork armour
/:cl: