### PR TITLE
Adds biting

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1372,7 +1372,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				target.apply_damage(damage*1.5, attack_type, affecting, armor_block)
 				log_combat(user, target, "kicked")
 			if(ATTACK_EFFECT_BITE)
-				damage += 5 // Does more damage, but has effects
+				damage += 3 // Does more damage, but has effects
 				damage = target.dna.species.bite_effect(user, damage, target)
 				target.apply_damage(damage, attack_type, affecting, armor_block)
 				for(var/datum/disease/D in user.diseases) // spread any transmittable diseases

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -177,3 +177,8 @@
 	H.dna.features["ipc_screen"] = saved_screen
 	H.update_body()
 	return
+
+/datum/species/ipc/bite_effect(mob/living/carbon/human/H, damage)
+	H.visible_message("<span class='danger'>[H]'s teeth shatter!</span>", "<span class='userdanger'>Your teeth shatter!</span>")
+	H.apply_damage(5, BRUTE, BODY_ZONE_HEAD)
+	return 0 // No damage done to the metal

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -147,3 +147,9 @@
 
 /datum/species/ethereal/proc/set_charge(var/change)
 	ethereal_charge = CLAMP(change, ETHEREAL_CHARGE_NONE, ETHEREAL_CHARGE_FULL)
+
+/datum/species/ethereal/bite_effect(mob/living/carbon/human/H, damage, mob/living/carbon/human/target)
+	. = ..()
+	target.stop_pulling()
+	H.electrocute_act(15, src, 1, FALSE, FALSE, FALSE, FALSE, TRUE)
+

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -44,6 +44,11 @@
 	var/golem_name = "[prefix] [golem_surname]"
 	return golem_name
 
+/datum/species/golem/bite_effect(mob/living/carbon/human/H, damage)
+	H.visible_message("<span class='danger'>[H]'s teeth shatter!</span>", "<span class='userdanger'>Your teeth shatter!</span>")
+	H.apply_damage(5, BRUTE, BODY_ZONE_HEAD)
+	return 0 // No damage done to the golem
+
 /datum/species/golem/random
 	name = "Random golem"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -107,7 +107,7 @@
 /datum/species/jelly/bite_effect(mob/living/carbon/human/H, damage)
 	H.apply_damage(5, TOX) // Slime does not taste good
 	to_chat(H, "<span class='danger'>You get some slime in your mouth! That's probably bad...</span>")
-	return (damage - 1) // slime is squishy
+	return (damage - 4) // slime is squishy
 
 ////////////////////////////////////////////////////////SLIMEPEOPLE///////////////////////////////////////////////////////////////////
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -104,6 +104,11 @@
 		return
 	to_chat(H, "<span class='warning'>...but there is not enough of you to go around! You must attain more mass to heal!</span>")
 
+/datum/species/jelly/bite_effect(mob/living/carbon/human/H, damage)
+	H.apply_damage(5, TOX) // Slime does not taste good
+	to_chat(H, "<span class='danger'>You get some slime in your mouth! That's probably bad...</span>")
+	return (damage - 1) // slime is squishy
+
 ////////////////////////////////////////////////////////SLIMEPEOPLE///////////////////////////////////////////////////////////////////
 
 //Slime people are able to split like slimes, retaining a single mind that can swap between bodies at will, even after death.

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -78,3 +78,7 @@
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
 	inherent_traits = list(TRAIT_NOGUNS,TRAIT_NOBREATH)
 	species_language_holder = /datum/language_holder/lizard/ash
+
+/datum/species/lizard/bite_effect(mob/living/carbon/human/H, damage)
+	to_chat(src, "<span class='danger'>Your scales soften the bite!</span>")
+	return (damage - 3)

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -81,4 +81,4 @@
 
 /datum/species/lizard/bite_effect(mob/living/carbon/human/H, damage)
 	to_chat(src, "<span class='danger'>Your scales soften the bite!</span>")
-	return (damage - 3)
+	return (damage - 7)

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -159,3 +159,9 @@
 		H.blood_volume -= 25
 		H.reagents.remove_reagent(chem.type, chem.metabolization_rate)
 		return TRUE
+
+/datum/species/oozeling/bite_effect(mob/living/carbon/human/H, damage)
+	H.apply_damage(5, TOX) // Slime does not taste good
+	to_chat(H, "<span class='danger'>You get some slime in your mouth! That's probably bad...</span>")
+	return (damage - 1) // slime is squishy
+

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -163,5 +163,5 @@
 /datum/species/oozeling/bite_effect(mob/living/carbon/human/H, damage)
 	H.apply_damage(5, TOX) // Slime does not taste good
 	to_chat(H, "<span class='danger'>You get some slime in your mouth! That's probably bad...</span>")
-	return (damage - 1) // slime is squishy
+	return (damage - 4) // slime is squishy
 

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -80,7 +80,7 @@
 
 		if("Stage Magician")
 			O = new /datum/outfit/plasmaman/magic
-		
+
 		if("VIP")
 			O = new /datum/outfit/plasmaman/vip
 
@@ -219,3 +219,8 @@
 					H.emote("sigh")
 		H.reagents.remove_reagent(chem.type, chem.metabolization_rate)
 		return TRUE
+
+/datum/species/plasmaman/bite_effect(mob/living/carbon/human/H, damage, mob/living/carbon/human/target)
+	. = ..()
+	H.apply_damage(5, BURN)
+	to_chat(H, "<span class='danger'>You burn your mouth on [target]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When aggressive grabbed, if your mouth is free and you target arms, you will bite your grabber. This has different effects based on the species you bite, such as ethereals shocking you, IPCs/golems shattering your teeth, and oozelings/slimepeople giving you toxin damage. You will also transfer all diseases (that are able to be transferred) to whoever you bite.
This bite does 3 more damage than a normal attack, but this damage can be changed depending on what you are biting.
Alternative to #4159
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I believe the idea of a rabid assistant biting sec while being arrested is extremely funny, and all races can get funny effects for being bitten if people want more. It shouldn't be OP, as you can just not target arms to not incur the bite effects.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added biting! While grabbed, target arms to bite your attacker. Could have side effects, based on what you bite...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
