### PR TITLE
Adds cat tongue

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -3,7 +3,6 @@
 	name = "Felinid"
 	id = "felinid"
 	limbs_id = "human"
-	say_mod = "meows"
 
 	disliked_food = VEGETABLES | SUGAR
 	liked_food = DAIRY | MEAT
@@ -14,6 +13,8 @@
 
 	mutantears = /obj/item/organ/ears/cat
 	mutanttail = /obj/item/organ/tail/cat
+	mutanttongue = /obj/item/organ/tongue/cat
+
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
 	swimming_component = /datum/component/swimming/felinid

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -52,7 +52,7 @@
 			if(C.stat && (!HAS_TRAIT(C, TRAIT_NOMETABOLISM) || !istype(C.dna.species, /datum/species/ipc)))//unless they need healing
 				return ..()
 			else
-				return FALSE 
+				return FALSE
 	return ..()
 
 /mob/living/simple_animal/hostile/cat_butcherer/AttackingTarget()
@@ -80,7 +80,18 @@
 				var/obj/item/organ/tail/cat/newtail = new
 				newtail.Insert(L, drop_if_replaced = FALSE)
 				return
-		else if(!L.has_trauma_type(/datum/brain_trauma/severe/pacifism) && L.getorgan(/obj/item/organ/ears/cat) && L.getorgan(/obj/item/organ/tail/cat)) //still does damage. This also lacks a Stat check- felinids beware.
+		else if(!L.getorgan(/obj/item/organ/tongue/cat) && L.stat))
+			if(L.getorgan(/obj/item/organ/tongue))
+				var/obj/item/organ/tongue/tongue = L.getorgan(/obj/item/organ/tongue)
+				visible_message("[src] slices off [L]'s tongue!", "<span class='notice'>You slice [L]'s tongue off.</span>")
+				tongue.Remove(L)
+				tongue.forceMove(get_turf(L))
+			else
+				visible_message("[src] implants a cat tongue into [L]!", "<span class='notice'>You implant a cat tongue into [L].</span>")
+				var/obj/item/organ/ears/cat/newtongue = new
+				newtongue.Insert(L, drop_if_replaced = FALSE)
+				return
+		else if(!L.has_trauma_type(/datum/brain_trauma/severe/pacifism) && L.getorgan(/obj/item/organ/ears/cat) && L.getorgan(/obj/item/organ/tail/cat) && L.getorgan(/obj/item/organ/tongue/cat)) //still does damage. This also lacks a Stat check- felinids beware.
 			visible_message("[src] drills a hole in [L]'s skull!", "<span class='notice'>You pacify [L]. Another successful creation.</span>")
 			if(!L.stat)
 				L.emote("scream")
@@ -89,7 +100,7 @@
 			if(L.mind && maxHealth <= 300) //if he robusts a tider, he becomes stronger
 				maxHealth += 20
 			adjustHealth(-(maxHealth)) //he heals whenever he finishes
-		else if(L.stat) //quickly heal them up and move on to our next target! 
+		else if(L.stat) //quickly heal them up and move on to our next target!
 			visible_message("[src] injects [L] with an unknown medicine!", "<span class='notice'>You inject [L] with medicine.</span>")
 			L.SetSleeping(0, FALSE)
 			L.SetUnconscious(0, FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -80,7 +80,7 @@
 				var/obj/item/organ/tail/cat/newtail = new
 				newtail.Insert(L, drop_if_replaced = FALSE)
 				return
-		else if(!L.getorgan(/obj/item/organ/tongue/cat) && L.stat))
+		else if(!L.getorgan(/obj/item/organ/tongue/cat) && L.stat)
 			if(L.getorgan(/obj/item/organ/tongue))
 				var/obj/item/organ/tongue/tongue = L.getorgan(/obj/item/organ/tongue)
 				visible_message("[src] slices off [L]'s tongue!", "<span class='notice'>You slice [L]'s tongue off.</span>")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -280,9 +280,9 @@
 
 /obj/item/organ/tongue/cat/handle_speech(datum/source, list/speech_args)
 	var/static/regex/cat_w = new("l|r", "g")
-	var/static/regex/cat_ww = new("ll", "g")
+	var/static/regex/cat_W = new("L|R", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*" && prob(1)) // 1% chance to speak stupid
 		message = cat_w.Replace(message, "w")
-		message = cat_ww.Replace(message, "ww")
+		message = cat_ww.Replace(message, "W")
 	speech_args[SPEECH_MESSAGE] = message

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -284,5 +284,5 @@
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*" && prob(1)) // 1% chance to speak stupid
 		message = cat_w.Replace(message, "w")
-		message = cat_ww.Replace(message, "W")
+		message = cat_W.Replace(message, "W")
 	speech_args[SPEECH_MESSAGE] = message

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -270,3 +270,19 @@
 /obj/item/organ/tongue/ethereal/Initialize(mapload)
 	. = ..()
 	languages_possible = languages_possible_base += typecacheof(/datum/language/voltaic)
+
+/obj/item/organ/tongue/cat
+	name = "cat tongue"
+	desc = "A cat's tongue covered in tiny barbs."
+	say_mod = "meows"
+	taste_sensitivity = 12
+	modifies_speech = TRUE
+
+/obj/item/organ/tongue/cat/handle_speech(datum/source, list/speech_args)
+	var/static/regex/cat_w = new("l|r", "g")
+	var/static/regex/cat_ww = new("ll", "g")
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message[1] != "*" && prob(1)) // 1% chance to speak stupid
+		message = cat_w.Replace(message, "w")
+		message = cat_ww.Replace(message, "ww")
+	speech_args[SPEECH_MESSAGE] = message


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #3930 

Correctly places the say_mod of felinids under their tongue, as would be expected.

## Why It's Good For The Game

This just makes more sense, and now you have another reason to surgically replace tongues.

## Changelog
:cl:
add: added cat tongues to felinids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
