### PR TITLE
Adds Paci-Fist Martial Art!

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -545,6 +545,7 @@
 #include "code\datums\martial\sleeping_carp.dm"
 #include "code\datums\martial\tribal_claw.dm"
 #include "code\datums\martial\wrestling.dm"
+#include "code\datums\martial\pacifist.dm"
 #include "code\datums\materials\_material.dm"
 #include "code\datums\materials\basemats.dm"
 #include "code\datums\mocking\client.dm"

--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -10,3 +10,4 @@
 #define MARTIALART_PLASMAFIST "plasma fist"
 #define MARTIALART_KARATE "karate"
 #define MARTIALART_TRIBALCLAW "tribal claw"
+#define MARTIALART_PACIFIST "pacifist"

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -174,10 +174,9 @@
 			if(I.restricted_species && !I.discounted && ishuman(user))
 				var/is_inaccessible = TRUE
 				var/mob/living/carbon/human/H = user
-				for(var/F in I.restricted_species)
-					if(F == H.dna.species.id || debug)
-						is_inaccessible = FALSE
-						break
+				if(locate(H.dna.species.id) in I.restricted_species)
+					is_inaccessible = FALSE
+					break
 				if(is_inaccessible)
 					continue
 			if(I.restricted_roundstart_traits && !I.discounted && ishuman(user))

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -164,17 +164,18 @@
 			var/datum/uplink_item/I = uplink_items[category][item]
 			if(I.limited_stock == 0)
 				continue
-			if(I.restricted_roles.len && !I.discounted)
+			if(I.restricted_roles.len && !I.discounted && ishuman(user))
 				var/is_inaccessible = TRUE
-				for(var/R in I.restricted_roles)
-					if(R == user.mind.assigned_role || debug)
-						is_inaccessible = FALSE
+				var/mob/living/carbon/human/H = user
+				if(locate(H.mind.assigned_role) in I.restricted_roles || debug)
+					is_inaccessible = FALSE
+					break
 				if(is_inaccessible)
 					continue
 			if(I.restricted_species && !I.discounted && ishuman(user))
 				var/is_inaccessible = TRUE
 				var/mob/living/carbon/human/H = user
-				if(locate(H.dna.species.id) in I.restricted_species)
+				if(locate(H.dna.species.id) in I.restricted_species || debug)
 					is_inaccessible = FALSE
 					break
 				if(is_inaccessible)
@@ -182,12 +183,11 @@
 			if(I.restricted_roundstart_traits && !I.discounted && ishuman(user))
 				var/is_inaccessible = TRUE
 				var/mob/living/carbon/human/H = user
-				for(var/T in I.restricted_roundstart_traits)
-					if(HAS_TRAIT_FROM_ONLY(H, T, ROUNDSTART_TRAIT) || debug)
-						is_inaccessible = FALSE
-						break
-					if(is_inaccessible)
-						continue
+				if(locate(H.roundstart_quirks) in I.restricted_roundstart_traits || debug)
+					is_inaccessible = FALSE
+					break
+				if(is_inaccessible)
+					continue
 			cat["items"] += list(list(
 				"name" = I.name,
 				"cost" = I.cost,

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -181,6 +181,16 @@
 							break
 					if(is_inaccessible)
 						continue
+			if(I.restricted_traits && I.discounted == FALSE)
+				if(ishuman(user))
+					var/is_inaccessible = TRUE
+					var/mob/living/carbon/human/H = user
+					for(var/T in I.restricted_traits)
+						if(HAS_TRAIT(H, T) || debug)
+							is_inaccessible = FALSE
+							break
+					if(is_inaccessible)
+						continue
 			cat["items"] += list(list(
 				"name" = I.name,
 				"cost" = I.cost,

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -181,7 +181,7 @@
 							break
 					if(is_inaccessible)
 						continue
-			if(I.restricted_traits && I.discounted == FALSE)
+			if(I.restricted_traits && !I.discounted)
 				if(ishuman(user))
 					var/is_inaccessible = TRUE
 					var/mob/living/carbon/human/H = user

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -180,15 +180,6 @@
 						break
 				if(is_inaccessible)
 					continue
-			if(I.restricted_traits && !I.discounted && ishuman(user))
-				var/is_inaccessible = TRUE
-				var/mob/living/carbon/human/H = user
-				for(var/T in I.restricted_traits)
-					if(HAS_TRAIT(H, T) || debug)
-						is_inaccessible = FALSE
-						break
-					if(is_inaccessible)
-						continue
 			cat["items"] += list(list(
 				"name" = I.name,
 				"cost" = I.cost,

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -164,31 +164,29 @@
 			var/datum/uplink_item/I = uplink_items[category][item]
 			if(I.limited_stock == 0)
 				continue
-			if(I.restricted_roles.len && I.discounted == FALSE)
+			if(I.restricted_roles.len && !I.discounted)
 				var/is_inaccessible = TRUE
 				for(var/R in I.restricted_roles)
 					if(R == user.mind.assigned_role || debug)
 						is_inaccessible = FALSE
 				if(is_inaccessible)
 					continue
-			if(I.restricted_species && I.discounted == FALSE)
-				if(ishuman(user))
-					var/is_inaccessible = TRUE
-					var/mob/living/carbon/human/H = user
-					for(var/F in I.restricted_species)
-						if(F == H.dna.species.id || debug)
-							is_inaccessible = FALSE
-							break
-					if(is_inaccessible)
-						continue
-			if(I.restricted_traits && !I.discounted)
-				if(ishuman(user))
-					var/is_inaccessible = TRUE
-					var/mob/living/carbon/human/H = user
-					for(var/T in I.restricted_traits)
-						if(HAS_TRAIT(H, T) || debug)
-							is_inaccessible = FALSE
-							break
+			if(I.restricted_species && !I.discounted && ishuman(user))
+				var/is_inaccessible = TRUE
+				var/mob/living/carbon/human/H = user
+				for(var/F in I.restricted_species)
+					if(F == H.dna.species.id || debug)
+						is_inaccessible = FALSE
+						break
+				if(is_inaccessible)
+					continue
+			if(I.restricted_traits && !I.discounted && ishuman(user))
+				var/is_inaccessible = TRUE
+				var/mob/living/carbon/human/H = user
+				for(var/T in I.restricted_traits)
+					if(HAS_TRAIT(H, T) || debug)
+						is_inaccessible = FALSE
+						break
 					if(is_inaccessible)
 						continue
 			cat["items"] += list(list(

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -180,6 +180,15 @@
 						break
 				if(is_inaccessible)
 					continue
+			if(I.restricted_roundstart_traits && !I.discounted && ishuman(user))
+				var/is_inaccessible = TRUE
+				var/mob/living/carbon/human/H = user
+				for(var/T in I.restricted_roundstart_traits)
+					if(HAS_TRAIT_FROM_ONLY(H, T, ROUNDSTART_TRAIT) || debug)
+						is_inaccessible = FALSE
+						break
+					if(is_inaccessible)
+						continue
 			cat["items"] += list(list(
 				"name" = I.name,
 				"cost" = I.cost,

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -105,4 +105,4 @@
 	to_chat(usr, "<span class='notice'>Grabs</span>: Your grabs instantly grab your opponents firmly.")
 	to_chat(usr, "<span class='notice'>Disarm Combo</span>: Grab Disarm. You will grab opponents item out of their hand.")
 	to_chat(usr, "<span class='notice'>Nerve Pinch Combo</span>: Grab Grab. You will reach for your opponents neck and after some time pacify them.")
-	to_chat(usr, "<b><i>In addition, by having your throw mode on when being attacked, you enter an active defense mode where you have a chance to block and sometimes even counter attacks done to you.</i></b>")
+	to_chat(usr, "<b><i>In addition, by having your throw mode on when being attacked, you enter an active defense mode where you have a chance to block attacks done to you.</i></b>")

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -60,7 +60,7 @@
 	var/obj/item/I = null
 	if(!can_use(A))
 		return FALSE
-	if(!D.stat || !D.IsParalyzed() || !restraining)
+	if(!D.stat || !D.IsParalyzed())
 		I = D.get_active_held_item()
 		if(I && D.temporarilyRemoveItemFromInventory(I))
 			A.put_in_hands(I)
@@ -74,9 +74,9 @@
 /datum/martial_art/pacifist/proc/Vulcan(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE
-	if(restraining && A.pulling == D)
+	if(A.pulling == D)
 		while(do_after(A, 20, target = D))
-			if(!A.CanReach(D) || !restraining || A.pulling == D)
+			if(!A.CanReach(D) || A.pulling == D)
 				break
 			else
 				log_combat(A, D, "knocked out (Vulcan Nerve Pinch)(Paci-Fist)")

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -58,7 +58,6 @@
 	return FALSE
 
 /datum/martial_art/pacifist/proc/Disarm(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	var/obj/item/I = null
 	if(!can_use(A))
 		return FALSE
 	if(!D.stat)

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -90,4 +90,5 @@
 				D.SetSleeping(400)
 				if(A.grab_state < GRAB_NECK)
 					A.setGrabState(GRAB_NECK)
+				break
 	return TRUE

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -61,7 +61,7 @@
 	if(!can_use(A))
 		return FALSE
 	if(!D.stat)
-		I = D.get_active_held_item()
+			var/obj/item/I = D.get_active_held_item()
 		if(I && D.temporarilyRemoveItemFromInventory(I))
 			playsound(get_turf(D), 'sound/weapons/punchmiss.ogg', 50, 1, -1)
 			D.Stun(10)

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -60,7 +60,7 @@
 	var/obj/item/I = null
 	if(!can_use(A))
 		return FALSE
-	if(!D.stat || !D.IsParalyzed())
+	if(!D.stat)
 		I = D.get_active_held_item()
 		if(I && D.temporarilyRemoveItemFromInventory(I))
 			A.put_in_hands(I)
@@ -69,21 +69,25 @@
 							"<span class='userdanger'>[A] swiftly grabs your [I] out of your hand!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(get_turf(D), 'sound/weapons/punchmiss.ogg', 50, 1, -1)
 			D.Jitter(2)
+			return TRUE
 	return TRUE
 
 /datum/martial_art/pacifist/proc/Vulcan(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE
-	if(A.pulling == D)
+	if(A.pulling == D && !D.IsSleeping())
 		while(do_after(A, 20, target = D))
-			if(!A.CanReach(D) || A.pulling == D)
+			D.visible_message("<span class='danger'>[A] reaches for [D]'s neck!</span>", \
+							"<span class='userdanger'>[A] reaches for your neck!</span>")
+			if(!A.CanReach(D) || !A.pulling == D || D.IsSleeping())
+				A.visible_message("<span class='notice'>[A] fails to reach [D]'s neck...</span>", \
+							"<span class='notice'>[A] fails to reach your neck...</span>")
 				break
 			else
 				log_combat(A, D, "knocked out (Vulcan Nerve Pinch)(Paci-Fist)")
 				D.visible_message("<span class='danger'>[A] pinches a nerve in [D]'s neck!</span>", \
 								"<span class='userdanger'>[A] pinches a nerve in your neck!</span>")
 				D.SetSleeping(400)
-				restraining = FALSE
 				if(A.grab_state < GRAB_NECK)
 					A.setGrabState(GRAB_NECK)
 	return TRUE

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -19,9 +19,9 @@
 		D.grabbedby(A, 1)
 		if(A.grab_state == GRAB_PASSIVE)
 			A.setGrabState(GRAB_AGGRESSIVE) //Instant "firm" grab if on grab intent
-			log_combat(A, D, "grabbed", addition="firmly")
-			D.visible_message("<span class='warning'>[A] firmly grabs [D]!</span>", \
-							"<span class='userdanger'>[A] firmly grabs you!</span>")
+			log_combat(A, D, "grabbed", addition="aggressive grab (paci-fist)")
+			D.visible_message("<span class='danger'>[A] firmly grips [D]!</span>",
+							"<span class='danger'>[A] firmly grips you!</span>")
 	else
 		D.grabbedby(A, 1)
 	return TRUE
@@ -36,7 +36,7 @@
 		D.visible_message("<span class='warning'>[A] feints [D]!</span>", \
 						"<span class='userdanger'>[A] feints you!</span>")
 		D.dropItemToGround(D.get_active_held_item())
-		D.Stun(60)
+		D.Stun(30)
 	return ..()
 
 /datum/martial_art/pacifist/can_use(mob/living/carbon/human/H)
@@ -64,12 +64,13 @@
 	if(!D.stat)
 		I = D.get_active_held_item()
 		if(I && D.temporarilyRemoveItemFromInventory(I))
-			A.put_in_hands(I)
+			playsound(get_turf(D), 'sound/weapons/punchmiss.ogg', 50, 1, -1)
+			D.Stun(10)
+			D.Jitter(2)
 			log_combat(A, D, "took [I] from (Disarm)(Paci-Fist)")
 			D.visible_message("<span class='warning'>[A] swiftly grabs [D]'s [I] out of their their hand!</span>", \
 							"<span class='userdanger'>[A] swiftly grabs your [I] out of your hand!</span>", null, COMBAT_MESSAGE_RANGE)
-			playsound(get_turf(D), 'sound/weapons/punchmiss.ogg', 50, 1, -1)
-			D.Jitter(2)
+			A.put_in_hands(I)
 			return TRUE
 	return TRUE
 

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -77,7 +77,7 @@
 	if(!can_use(A))
 		return FALSE
 	if(A.pulling == D && !D.IsSleeping())
-		while(do_after(A, 20, target = D))
+		while(do_after(A, 30, target = D))
 			D.visible_message("<span class='danger'>[A] reaches for [D]'s neck!</span>", \
 							"<span class='userdanger'>[A] reaches for your neck!</span>")
 			if(!A.CanReach(D) || !A.pulling == D || D.IsSleeping())

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -4,6 +4,7 @@
 /datum/martial_art/pacifist
 	name = "The Paci-Fist"
 	id = MARTIALART_PACIFIST
+	help_verb = /mob/living/carbon/human/proc/pacifist_help
 	block_chance = 75
 
 /datum/martial_art/pacifist/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -92,3 +93,15 @@
 					A.setGrabState(GRAB_NECK)
 				break
 	return TRUE
+
+/mob/living/carbon/human/proc/pacifist_help()
+	set name = "Remember The Basics"
+	set desc = "You try to remember some of the basics of Paci-Fist."
+	set category = "Paci-Fist"
+	to_chat(usr, "<b><i>You try to remember some of the basics of Paci-Fist.</i></b>")
+
+	to_chat(usr, "<span class='notice'>Disarms</span>: Your disarms have a higher chance to disarm.")
+	to_chat(usr, "<span class='notice'>Grabs</span>: Your grabs instantly grab your opponents firmly.")
+	to_chat(usr, "<span class='notice'>Disarm Combo</span>: Grab Disarm. You will grab opponents item out of their hand.")
+	to_chat(usr, "<span class='notice'>Nerve Pinch Combo</span>: Grab Grab. You will reach for your opponents neck and after some time pacify them.")
+	to_chat(usr, "<b><i>In addition, by having your throw mode on when being attacked, you enter an active defense mode where you have a chance to block and sometimes even counter attacks done to you.</i></b>")

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -19,7 +19,7 @@
 		D.grabbedby(A, 1)
 		if(A.grab_state == GRAB_PASSIVE)
 			A.setGrabState(GRAB_AGGRESSIVE) //Instant "firm" grab if on grab intent
-			log_combat(A, D, "grabbed", addition="aggressive grab (paci-fist)")
+			log_combat(A, D, "grabbed", addition="aggressively (Paci-Fist)")
 			D.visible_message("<span class='danger'>[A] firmly grips [D]!</span>",
 							"<span class='danger'>[A] firmly grips you!</span>")
 	else
@@ -33,6 +33,7 @@
 	if(check_streak(A,D))
 		return TRUE
 	if(prob(25))
+		log_combat(A, D, "feinted (Paci-Fist)")
 		D.visible_message("<span class='warning'>[A] feints [D]!</span>", \
 						"<span class='userdanger'>[A] feints you!</span>")
 		D.drop_all_held_items()
@@ -66,7 +67,7 @@
 			playsound(get_turf(D), 'sound/weapons/punchmiss.ogg', 50, 1, -1)
 			D.Stun(10)
 			D.Jitter(2)
-			log_combat(A, D, "took [I] from (Disarm)(Paci-Fist)")
+			log_combat(A, D, "took [I] from (Disarm) (Paci-Fist)")
 			D.visible_message("<span class='warning'>[A] swiftly grabs [D]'s [I] out of their their hand!</span>", \
 							"<span class='userdanger'>[A] swiftly grabs your [I] out of your hand!</span>", null, COMBAT_MESSAGE_RANGE)
 			A.put_in_hands(I)
@@ -85,7 +86,7 @@
 							"<span class='notice'>[A] fails to reach your neck...</span>")
 				break
 			else
-				log_combat(A, D, "knocked out (Vulcan Nerve Pinch)(Paci-Fist)")
+				log_combat(A, D, "knocked out (Vulcan Nerve Pinch) (Paci-Fist)")
 				D.visible_message("<span class='danger'>[A] pinches a nerve in [D]'s neck!</span>", \
 								"<span class='userdanger'>[A] pinches a nerve in your neck!</span>")
 				D.SetSleeping(400)

--- a/code/datums/martial/pacifist.dm
+++ b/code/datums/martial/pacifist.dm
@@ -35,7 +35,7 @@
 	if(prob(25))
 		D.visible_message("<span class='warning'>[A] feints [D]!</span>", \
 						"<span class='userdanger'>[A] feints you!</span>")
-		D.dropItemToGround(D.get_active_held_item())
+		D.drop_all_held_items()
 		D.Stun(30)
 	return ..()
 
@@ -61,7 +61,7 @@
 	if(!can_use(A))
 		return FALSE
 	if(!D.stat)
-			var/obj/item/I = D.get_active_held_item()
+		var/obj/item/I = D.get_active_held_item()
 		if(I && D.temporarilyRemoveItemFromInventory(I))
 			playsound(get_turf(D), 'sound/weapons/punchmiss.ogg', 50, 1, -1)
 			D.Stun(10)

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -451,7 +451,7 @@
 	remarks = list("I must prove myself worthy to the masters of the paci-fist...", "Stance means everything...", "Focus... And you'll be able to pacify any foe in seconds...", "I must avoid conflict for maximum efficiency...", "I don't think this would combine with other martial arts...", "Grab them first and pacify them...", "I must prove myself worthy of this power...")
 
 /obj/item/book/granter/martial/pacifist/already_known(mob/user)
-	.=..()
+	. = ..()
 	if(!.)
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			return FALSE

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -459,8 +459,7 @@
 			var/confirm = alert(user, "Reading this scroll will make you devote yourself to a lifestyle of pacifism, you will be unable to cause any harm to any living thing after reading it.", "Read the scroll?", "Abort", "Proceed")
 			if(confirm != "Proceed")
 				return TRUE
-			else
-				return FALSE
+			return FALSE
 
 /obj/item/book/granter/martial/pacifist/onlearned(mob/living/carbon/user)
 	..()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -445,7 +445,7 @@
 	martialname = "paci-fist"
 	desc = "A strange scroll filled with martial lessons. It seems to be drawings of some sort of pacifist martial art."
 	greet = "<span class='sciradio'>You have learned the ancient martial art of the Paci-Fist! Your non-harmful abilities of disarming and grabbing have become much more effective, and you are now able to block most attacks \
-	directed toward you. You are also able to nerve pinch an opponent to sleep. You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
+	directed toward you. You are also able to nerve pinch an opponent to sleep. You can learn more about your newfound art by using the Recall Teachings verb in the Paci-Fist tab.</span>"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
 	remarks = list("I must prove myself worthy to the masters of the paci-fist...", "Stance means everything...", "Focus... And you'll be able to pacify any foe in seconds...", "I must avoid conflict for maximum efficiency...", "I don't think this would combine with other martial arts...", "Grab them first and pacify them...", "I must prove myself worthy of this power...")

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -464,7 +464,7 @@
 
 /obj/item/book/granter/martial/pacifist/onlearned(mob/living/carbon/user)
 	..()
-	ADD_TRAIT(user, TRAIT_PACIFISM)
+	ADD_TRAIT(user, TRAIT_PACIFISM, "paci-fist")
 	if(oneuse)
 		desc = "It's completely blank."
 		name = "empty scroll"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -444,7 +444,7 @@
 	name = "strange scroll"
 	martialname = "paci-fist"
 	desc = "A strange scroll filled with martial lessons. It seems to be drawings of some sort of pacifist martial art."
-	greet = "<span class='sciradio'>You have learned the ancient martial art of the Paci-Fist! Your non-harmful abilities has become much more effective, and you are now able to block most attacks \
+	greet = "<span class='sciradio'>You have learned the ancient martial art of the Paci-Fist! Your non-harmful abilities of disarming and grabbing have become much more effective, and you are now able to block most attacks \
 	directed toward you. You are also able to nerve pinch an opponent to sleep. You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -451,11 +451,13 @@
 	remarks = list("I must prove myself worthy to the masters of the paci-fist...", "Stance means everything...", "Focus... And you'll be able to pacify any foe in seconds...", "I must avoid conflict for maximum efficiency...", "I don't think this would combine with other martial arts...", "Grab them first and pacify them...", "I must prove myself worthy of this power...")
 
 /obj/item/book/granter/martial/pacifist/already_known(mob/user)
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
-		return FALSE
-	else
-		to_chat(user, "<span class='warning'>You try to read the scroll but only a real pacifist would probably understand it.</span>")
-		return TRUE
+	.=..()
+	if(!.)
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			return FALSE
+		else
+			to_chat(user, "<span class='warning'>You try to read the scroll but only a real pacifist would probably understand it.</span>")
+			return TRUE
 
 /obj/item/book/granter/martial/pacifist/onlearned(mob/living/carbon/user)
 	..()

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -448,7 +448,7 @@
 	directed toward you. You are also able to nerve pinch an opponent to sleep. You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll2"
-	remarks = list("I must prove myself worthy to the masters of the paci-fist...", "Stance means everything...", "Focus... And you'll be able to incapacitate any foe in seconds...", "I must avoid conflict for maximum efficiency...", "I don't think this would combine with other martial arts...", "Grab them first and pacify them...", "I must prove myself worthy of this power...")
+	remarks = list("I must prove myself worthy to the masters of the paci-fist...", "Stance means everything...", "Focus... And you'll be able to pacify any foe in seconds...", "I must avoid conflict for maximum efficiency...", "I don't think this would combine with other martial arts...", "Grab them first and pacify them...", "I must prove myself worthy of this power...")
 
 /obj/item/book/granter/martial/pacifist/already_known(mob/user)
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -456,11 +456,15 @@
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			return FALSE
 		else
-			to_chat(user, "<span class='warning'>You try to read the scroll but only a real pacifist would probably understand it.</span>")
-			return TRUE
+			var/confirm = alert(user, "Reading this scroll will make you devote yourself to a lifestyle of pacifism, you will be unable to cause any harm to any living thing after reading it.", "Read the scroll?", "Abort", "Proceed")
+			if(confirm != "Proceed")
+				return TRUE
+			else
+				return FALSE
 
 /obj/item/book/granter/martial/pacifist/onlearned(mob/living/carbon/user)
 	..()
+	ADD_TRAIT(user, TRAIT_PACIFISM)
 	if(oneuse)
 		desc = "It's completely blank."
 		name = "empty scroll"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -439,6 +439,31 @@
 		name = "empty scroll"
 		icon_state = "blankscroll"
 
+/obj/item/book/granter/martial/pacifist
+	martial = /datum/martial_art/pacifist
+	name = "strange scroll"
+	martialname = "paci-fist"
+	desc = "A strange scroll filled with martial lessons. It seems to be drawings of some sort of pacifist martial art."
+	greet = "<span class='sciradio'>You have learned the ancient martial art of the Paci-Fist! Your non-harmful abilities has become much more effective, and you are now able to block most attacks \
+	directed toward you. You are also able to nerve pinch an opponent to sleep. You can learn more about your newfound art by using the Recall Teachings verb in the Sleeping Carp tab.</span>"
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "scroll2"
+	remarks = list("I must prove myself worthy to the masters of the paci-fist...", "Stance means everything...", "Focus... And you'll be able to incapacitate any foe in seconds...", "I must avoid conflict for maximum efficiency...", "I don't think this would combine with other martial arts...", "Grab them first and pacify them...", "I must prove myself worthy of this power...")
+
+/obj/item/book/granter/martial/pacifist/already_known(mob/user)
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return FALSE
+	else
+		to_chat(user, "<span class='warning'>You try to read the scroll but only a real pacifist would probably understand it.</span>")
+		return TRUE
+
+/obj/item/book/granter/martial/pacifist/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse == TRUE)
+		desc = "It's completely blank."
+		name = "empty scroll"
+		icon_state = "blankscroll"
+
 // I did not include mushpunch's grant, it is not a book and the item does it just fine.
 
 //Crafting Recipe books

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -459,7 +459,7 @@
 
 /obj/item/book/granter/martial/pacifist/onlearned(mob/living/carbon/user)
 	..()
-	if(oneuse == TRUE)
+	if(oneuse)
 		desc = "It's completely blank."
 		name = "empty scroll"
 		icon_state = "blankscroll"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -768,7 +768,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			various ways to disarm and pacify your foes. Normally costs 16TC, discounted especially for you."
 	cost = 10
 	surplus = 0
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	restricted_roundstart_traits = list(TRAIT_PACIFISM) // Discounted for roundstart trait pacifists, since they already have irrevertible pacifism.
 	restricted = TRUE
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -763,12 +763,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //nukies lose their pacifism trait at roundstart, it would be counterintuitive and cheesy to add this in
 
 /datum/uplink_item/stealthy_weapons/pacifist/restricted
-	category = "Discounts"
+	category = "Discounted Gear"
 	desc = "This scroll contains the secrets of the ancient martial arts technique of the Paci-Fist. You will learn \
 			various ways to disarm and pacify your foes. Normally costs 16TC, discounted especially for you."
 	cost = 10
 	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	restricted_roundstart_traits = list(TRAIT_PACIFISM) // Discounted for roundstart trait pacifists, since they already have irrevertible pacifism.
+	restricted = TRUE
 
 /datum/uplink_item/stealthy_weapons/radbow
 	name = "Gamma-Bow"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -120,7 +120,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/list/include_modes = list() // Game modes to allow this item in.
 	var/list/exclude_modes = list() // Game modes to disallow this item from.
 	var/list/restricted_roles = list() //If this uplink item is only available to certain roles. Roles are dependent on the frequency chip or stored ID.
-	var/list/restricted_traits = list() //If this uplink item is only available to certain traits.
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
 	var/purchase_log_vis = TRUE // Visible in the purchase log?
 	var/restricted = FALSE // Adds restrictions for VR/Events
@@ -752,6 +751,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	player_minimum = 20
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/incursion)
+
+/datum/uplink_item/stealthy_weapons/pacifist
+	name = "Paci-Fist Martial Arts Scroll"
+	desc = "This scroll contains the secrets of the ancient martial arts technique of the Paci-Fist. You will learn \
+			various ways to disarm and pacify your foes."
+	item = /obj/item/book/granter/martial/pacifist
+	cost = 10
+	surplus = 10
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //nukies lose their pacifism trait at roundstart, it would be counterintuitive and cheesy to add this in
 
 /datum/uplink_item/stealthy_weapons/radbow
 	name = "Gamma-Bow"
@@ -2257,16 +2265,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 12
 	item = /obj/item/autosurgeon/syndicate/laser_arm
 	restricted_roles = list("Roboticist", "Research Director")
-
-/datum/uplink_item/role_restricted/pacifist
-	name = "Paci-Fist Martial Arts Scroll"
-	desc = "This scroll contains the secrets of the ancient martial arts technique of the Paci-Fist. You will learn \
-			various ways to disarm and pacify your foes."
-	item = /obj/item/book/granter/martial/pacifist
-	cost = 10
-	surplus = 5 // for the lucky few, but you can still only read it if you have the pacifist trait
-	restricted_traits = list(TRAIT_PACIFISM)
-
 
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -768,7 +768,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			various ways to disarm and pacify your foes. Normally costs 16TC, discounted especially for you."
 	cost = 10
 	surplus = 0
-	restricted_traits = list(TRAIT_PACIFISM) // Discounted for roundstart trait pacifists, since they already have irrevertible pacifism.
+	restricted_roundstart_traits = list(TRAIT_PACIFISM) // Discounted for roundstart trait pacifists, since they already have irrevertible pacifism.
 
 /datum/uplink_item/stealthy_weapons/radbow
 	name = "Gamma-Bow"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -120,6 +120,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/list/include_modes = list() // Game modes to allow this item in.
 	var/list/exclude_modes = list() // Game modes to disallow this item from.
 	var/list/restricted_roles = list() //If this uplink item is only available to certain roles. Roles are dependent on the frequency chip or stored ID.
+	var/list/restricted_traits = list() //If this uplink item is only available to certain traits.
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
 	var/purchase_log_vis = TRUE // Visible in the purchase log?
 	var/restricted = FALSE // Adds restrictions for VR/Events
@@ -751,14 +752,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	player_minimum = 20
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/incursion)
-
-/datum/uplink_item/stealthy_weapons/pacifist
-	name = "Paci-Fist Martial Arts Scroll"
-	desc = "This scroll contains the secrets of the ancient martial arts technique of The Paci-Fist. You will learn \
-			various ways to incapacitate and pacify your foes."
-	item = /obj/item/book/granter/martial/pacifist
-	cost = 6
-	surplus = 10
 
 /datum/uplink_item/stealthy_weapons/radbow
 	name = "Gamma-Bow"
@@ -2264,6 +2257,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 12
 	item = /obj/item/autosurgeon/syndicate/laser_arm
 	restricted_roles = list("Roboticist", "Research Director")
+
+/datum/uplink_item/role_restricted/pacifist
+	name = "Paci-Fist Martial Arts Scroll"
+	desc = "This scroll contains the secrets of the ancient martial arts technique of The Paci-Fist. You will learn \
+			various ways to incapacitate and pacify your foes."
+	item = /obj/item/book/granter/martial/pacifist
+	cost = 6
+	surplus = 10
+	restricted_traits = list(TRAIT_PACIFISM)
 
 
 // Pointless

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -120,6 +120,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/list/include_modes = list() // Game modes to allow this item in.
 	var/list/exclude_modes = list() // Game modes to disallow this item from.
 	var/list/restricted_roles = list() //If this uplink item is only available to certain roles. Roles are dependent on the frequency chip or stored ID.
+	var/list/restricted_roundstart_traits = list() //If this uplink item is only available to certain roundstart traits.
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
 	var/purchase_log_vis = TRUE // Visible in the purchase log?
 	var/restricted = FALSE // Adds restrictions for VR/Events
@@ -755,11 +756,19 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/stealthy_weapons/pacifist
 	name = "Paci-Fist Martial Arts Scroll"
 	desc = "This scroll contains the secrets of the ancient martial arts technique of the Paci-Fist. You will learn \
-			various ways to disarm and pacify your foes."
+			various ways to disarm and pacify your foes. Might alter an individuals outlook on life."
 	item = /obj/item/book/granter/martial/pacifist
-	cost = 10
+	cost = 16
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops) //nukies lose their pacifism trait at roundstart, it would be counterintuitive and cheesy to add this in
+
+/datum/uplink_item/stealthy_weapons/pacifist/restricted
+	category = "Discounts"
+	desc = "This scroll contains the secrets of the ancient martial arts technique of the Paci-Fist. You will learn \
+			various ways to disarm and pacify your foes. Normally costs 16TC, discounted especially for you."
+	cost = 10
+	surplus = 0
+	restricted_traits = list(TRAIT_PACIFISM) // Discounted for roundstart trait pacifists, since they already have irrevertible pacifism.
 
 /datum/uplink_item/stealthy_weapons/radbow
 	name = "Gamma-Bow"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2261,7 +2261,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/pacifist
 	name = "Paci-Fist Martial Arts Scroll"
 	desc = "This scroll contains the secrets of the ancient martial arts technique of The Paci-Fist. You will learn \
-			various ways to incapacitate and pacify your foes."
+			various ways to disarm and pacify your foes."
 	item = /obj/item/book/granter/martial/pacifist
 	cost = 6
 	surplus = 10

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2260,11 +2260,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/role_restricted/pacifist
 	name = "Paci-Fist Martial Arts Scroll"
-	desc = "This scroll contains the secrets of the ancient martial arts technique of The Paci-Fist. You will learn \
+	desc = "This scroll contains the secrets of the ancient martial arts technique of the Paci-Fist. You will learn \
 			various ways to disarm and pacify your foes."
 	item = /obj/item/book/granter/martial/pacifist
-	cost = 6
-	surplus = 10
+	cost = 10
+	surplus = 5 // for the lucky few, but you can still only read it if you have the pacifist trait
 	restricted_traits = list(TRAIT_PACIFISM)
 
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -752,6 +752,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/incursion)
 
+/datum/uplink_item/stealthy_weapons/pacifist
+	name = "Paci-Fist Martial Arts Scroll"
+	desc = "This scroll contains the secrets of the ancient martial arts technique of The Paci-Fist. You will learn \
+			various ways to incapacitate and pacify your foes."
+	item = /obj/item/book/granter/martial/pacifist
+	cost = 6
+	surplus = 10
+
 /datum/uplink_item/stealthy_weapons/radbow
 	name = "Gamma-Bow"
 	desc = "The energy crossbow's newly developed lethal cousin. Has considerably increased lethality \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a pacifist exclusive martial art called Paci-Fist, this martial art gives you 75% blocking power when on throw mode, one-click "firm" grabs, a 25% chance on each disarm intent to actually disarm your opponent, and two combos, one which nabs the held item from your opponent, and a second combo which puts your opponent to sleep after a 3 second cast timer.

## Why It's Good For The Game

Gives pacifists with an uplink something actually interesting to use.

## Changelog
:cl:
add: Added The Paci-Fist Martial Art, available as a pacifist exclusive non-lethal martial arts for 16TC in uplinks. Discounted to 10TC if you're already a roundstart pacifist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
