### PR TITLE
Pacifist traitors do not get murder objectives

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -70,7 +70,7 @@
 			var/datum/mind/agent_mind = M
 			if(ishuman(agent_mind.current))
 				var/mob/living/carbon/human/H = agent_mind.current
-				if(H.stat != DEAD)
+				if(H.stat != DEAD && !HAS_TRAIT(H, TRAIT_PACIFISM)) //pacifists can't be IAA/EAA
 					if(H.client)
 						continue // It all checks out.
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -140,7 +140,7 @@
 
 /datum/antagonist/traitor/proc/forge_single_human_objective() //Returns how many objectives are added
 	.=1
-	if(prob(50) && !HAS_TRAIT(owner, TRAIT_PACIFISM)) //no murder objectives for pacifists
+	if(prob(50) && !HAS_TRAIT(owner.current, TRAIT_PACIFISM)) //no murder objectives for pacifists
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(100/GLOB.joined_player_list.len))
 			var/datum/objective/destroy/destroy_objective = new

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -87,7 +87,7 @@
 	for(var/i = objective_count, i < toa, i++)
 		forge_single_objective()
 
-	if(is_hijacker && objective_count <= toa) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount
+	if(is_hijacker && objective_count <= toa && !HAS_TRAIT(owner, TRAIT_PACIFISM)) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount and don't assign it to pacifists
 		if (!(locate(/datum/objective/hijack) in objectives))
 			var/datum/objective/hijack/hijack_objective = new
 			hijack_objective.owner = owner
@@ -140,7 +140,7 @@
 
 /datum/antagonist/traitor/proc/forge_single_human_objective() //Returns how many objectives are added
 	.=1
-	if(prob(50))
+	if(prob(50) && !HAS_TRAIT(owner, TRAIT_PACIFISM)) //no murder objectives for pacifists
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(100/GLOB.joined_player_list.len))
 			var/datum/objective/destroy/destroy_objective = new

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -87,7 +87,7 @@
 	for(var/i = objective_count, i < toa, i++)
 		forge_single_objective()
 
-	if(is_hijacker && objective_count <= toa && !HAS_TRAIT(owner, TRAIT_PACIFISM)) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount and don't assign it to pacifists
+	if(is_hijacker && objective_count <= toa && !HAS_TRAIT(owner.current, TRAIT_PACIFISM)) //Don't assign hijack if it would exceed the number of objectives set in config.traitor_objectives_amount and don't assign it to pacifists
 		if (!(locate(/datum/objective/hijack) in objectives))
 			var/datum/objective/hijack/hijack_objective = new
 			hijack_objective.owner = owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables all murder objectives for pacifist traitors, and does not allow pacifists to roll IAA or EAA as that entire game mode revolves around murder objectives.

## Why It's Good For The Game

Gives pacifist antags some form of objectives that can be completed, and doesn't leave a lone IAA pacifist as a hunting practice target that has close to zero chance of surviving and absolutely no chance to greentext.

## Changelog
:cl:
tweak: Pacifist antags no longer receive impossible objectives.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
