### PR TITLE
Allow ghosts to look at the crew monitor UI

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -15,7 +15,7 @@
 /obj/machinery/computer/crew/syndie
 	icon_keyboard = "syndie_key"
 
-/obj/machinery/computer/crew/interact(mob/user)
+/obj/machinery/computer/crew/ui_interact(mob/user)
 	GLOB.crewmonitor.show(user,src)
 
 GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)


### PR DESCRIPTION
## About The Pull Request

Ghosts can now look at the crew sensor console

## Why It's Good For The Game

Not merging this is ghost discrimination

## Changelog
:cl:
fix: Ghosts can now look at the crew monitor console
/:cl: