### PR TITLE
Adds Emote CD

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -24,6 +24,7 @@
 	var/sound //Sound to play when emote is called
 	var/vary = FALSE	//used for the honk borg emote
 	var/only_forced_audio = FALSE //can only code call this event instead of the player.
+	var/cooldown = 0.2 SECONDS
 
 /datum/emote/New()
 	if (ispath(mob_type_allowed_typecache))
@@ -80,6 +81,17 @@
 		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE)
 	else
 		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE)
+
+/// For handling emote cooldown, return true to allow the emote to happen
+/datum/emote/proc/check_cooldown(mob/user, intentional)
+	if(!intentional)
+		return TRUE
+	if(user.emotes_used && user.emotes_used[src] + cooldown > world.time)
+		return FALSE
+	if(!user.emotes_used)
+		user.emotes_used = list()
+	user.emotes_used[src] = world.time
+	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)
 	return sound //by default just return this var.

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -3,12 +3,12 @@
 
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
+	if(emotecd > world.time)
+		return
+	emotecd = (world.time + 5)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findchar(act, " ")
-	if(emotecd > world.time)
-		return
-
 	if(custom_param)
 		param = copytext(act, custom_param + length(act[custom_param]))
 		act = copytext(act, 1, custom_param)
@@ -23,7 +23,6 @@
 	for(var/datum/emote/P in key_emotes)
 		if(P.run_emote(src, param, m_type, intentional))
 			SEND_SIGNAL(src, COMSIG_MOB_EMOTE, P, act, m_type, message, intentional)
-			emotecd = world.time
 			return
 	if(intentional)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,8 +1,14 @@
+/mob
+	var/emotecd
+
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findchar(act, " ")
+	if(emotecd > world.time)
+		return
+
 	if(custom_param)
 		param = copytext(act, custom_param + length(act[custom_param]))
 		act = copytext(act, 1, custom_param)
@@ -17,6 +23,7 @@
 	for(var/datum/emote/P in key_emotes)
 		if(P.run_emote(src, param, m_type, intentional))
 			SEND_SIGNAL(src, COMSIG_MOB_EMOTE, P, act, m_type, message, intentional)
+			emotecd = world.time
 			return
 	if(intentional)
 		to_chat(src, "<span class='notice'>Unusable emote '[act]'. Say *help for a list.</span>")

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -3,7 +3,7 @@
 
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
-	if(emotecd > world.time)
+	if(emotecd > world.time && intentional)
 		return
 	emotecd = (world.time + 5)
 	act = lowertext(act)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -1,11 +1,8 @@
-/mob
-	var/emotecd
-
 //The code execution of the emote datum is located at code/datums/emotes.dm
 /mob/proc/emote(act, m_type = null, message = null, intentional = FALSE)
-	if(emotecd > world.time && intentional)
+	if(emote_used > world.time && intentional)
 		return
-	emotecd = (world.time + 5)
+	emote_used = (world.time + emote_cooldown)
 	act = lowertext(act)
 	var/param = message
 	var/custom_param = findchar(act, " ")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -51,6 +51,7 @@
 	message = "screams"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
+	cooldown = 0.6 SECONDS
 
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)
 	if(!ishuman(user))
@@ -163,6 +164,7 @@
 	message = "farts"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
+	cooldown = 0.6 SECONDS
 
 /datum/emote/living/carbon/human/fart/get_sound(mob/living/user)
 	if(!ishuman(user))
@@ -172,6 +174,9 @@
 //Ayy lmao
 
 // Robotic Tongue emotes. Beep!
+
+/datum/emote/living/carbon/human/robot_tongue
+	cooldown = 0.6 SECONDS
 
 /datum/emote/living/carbon/human/robot_tongue/can_run_emote(mob/user, status_check = TRUE , intentional)
 	if(!..())

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -3,6 +3,7 @@
 /datum/emote/living
 	mob_type_allowed_typecache = /mob/living
 	mob_type_blacklist_typecache = list(/mob/living/simple_animal/slime, /mob/living/brain)
+	cooldown = 0.4 SECONDS
 
 /datum/emote/living/blush
 	key = "blush"

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -214,6 +214,7 @@
 	/// A mock client, provided by tests and friends
 	var/datum/client_interface/mock_client
 
-	/// two vars for determining emote cooldown
-	var/emote_used = 0
-	var/emote_cooldown = 0.5 SECONDS
+	/// Used for tracking last uses of emotes for cooldown purposes
+	var/list/emotes_used
+	var/static/emote_antispam = 0.1 SECONDS
+	var/emote_timer

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -213,3 +213,7 @@
 
 	/// A mock client, provided by tests and friends
 	var/datum/client_interface/mock_client
+
+	/// two vars for determining emote cooldown
+	var/emote_used = 0
+	var/emote_cooldown = 0.5 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a 1 tick global cooldown on emotes, also partly ports tgstation/tgstation#47868 (only the emote cooldown system)

## Why It's Good For The Game

You can't crash the server with emotes now.

## Changelog
:cl:
server: you can't fart the server to death now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
