### PR TITLE
Fixes incursion uplink sometimes not spawning

### DIFF
--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -96,9 +96,10 @@
 	if(ishuman(owner.current))		//if he's not a human, uplink will spawn under his feet
 		var/mob/living/carbon/human/H = owner.current
 		var/list/slots = list(
+			"in your backpack" = ITEM_SLOT_BACKPACK,
 			"in your left pocket" = ITEM_SLOT_LPOCKET,
 			"in your right pocket" = ITEM_SLOT_RPOCKET,
-			"in your backpack" = ITEM_SLOT_BACKPACK
+			"in your hands" = ITEM_SLOT_HANDS
 		)
 		where = H.equip_in_one_of_slots(uplink, slots, FALSE)
 	to_chat(owner.current, "<span class='notice'><b>You have been equipped with a syndicate uplink located [where ? where : "at your feet"]. Activate the transponder in hand to access the market.</b></span>")

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -91,9 +91,17 @@
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(new_owner.current)] into incursion traitor team.")
 
 /datum/antagonist/incursion/proc/equip(var/silent = FALSE)
-	var/obj/item/uplink/incursion/uplink = new(owner, owner.key, 15)
-	owner.current.equip_to_slot(uplink, ITEM_SLOT_BACKPACK)
-	to_chat(owner.current, "<span class='notice'><b>You have been equipped with a syndicate uplink located in your backpack. Activate the transponder in hand to access the market.</b></span>")
+	var/obj/item/uplink/incursion/uplink = new(owner.current.loc, owner.key, 15)
+	var/where
+	if(ishuman(owner.current))		//if he's not a human, uplink will spawn under his feet
+		var/mob/living/carbon/human/H = owner.current
+		var/list/slots = list(
+			"in your left pocket" = ITEM_SLOT_LPOCKET,
+			"in your right pocket" = ITEM_SLOT_RPOCKET,
+			"in your backpack" = ITEM_SLOT_BACKPACK
+		)
+		where = H.equip_in_one_of_slots(uplink, slots, FALSE)
+	to_chat(owner.current, "<span class='notice'><b>You have been equipped with a syndicate uplink located [where ? where : "at your feet"]. Activate the transponder in hand to access the market.</b></span>")
 	var/obj/item/implant/radio/syndicate/selfdestruct/syndio = new
 	syndio.implant(owner.current)
 

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -95,7 +95,7 @@
 	var/where
 	if(ishuman(owner.current))		//if he's not a human, uplink will spawn under his feet
 		var/mob/living/carbon/human/H = owner.current
-		var/list/slots = list(
+		var/static/list/slots = list(
 			"in your backpack" = ITEM_SLOT_BACKPACK,
 			"in your left pocket" = ITEM_SLOT_LPOCKET,
 			"in your right pocket" = ITEM_SLOT_RPOCKET,
@@ -219,5 +219,4 @@
 
 /datum/team/incursion/antag_listing_name()
 	return "[name]"
-
 

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -91,7 +91,7 @@
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(new_owner.current)] into incursion traitor team.")
 
 /datum/antagonist/incursion/proc/equip(var/silent = FALSE)
-	var/obj/item/uplink/incursion/uplink = new(owner.current.loc, owner.key, 15)
+	var/obj/item/uplink/incursion/uplink = new(get_turf(owner.current), owner.key, 15)
 	var/where
 	if(ishuman(owner.current))		//if he's not a human, uplink will spawn under his feet
 		var/mob/living/carbon/human/H = owner.current

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -14,9 +14,9 @@
 			return legcuffed
 	return null
 
-/mob/living/carbon/proc/equip_in_one_of_slots(obj/item/I, list/slots, qdel_on_fail = 1)
+/mob/living/carbon/proc/equip_in_one_of_slots(obj/item/I, list/slots, qdel_on_fail = TRUE)
 	for(var/slot in slots)
-		if(equip_to_slot_if_possible(I, slots[slot], qdel_on_fail = 0, disable_warning = TRUE))
+		if(equip_to_slot_if_possible(I, slots[slot], qdel_on_fail = FALSE, disable_warning = TRUE))
 			return slot
 	if(qdel_on_fail)
 		qdel(I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Incursion uplink will now try to spawn in backpack, then pockets, then hands and if it fail (or spawned mob is not human) it will appear under the feet

## Why It's Good For The Game


## Changelog
:cl:
fix: Fixed rare case of incursion uplink not spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
