### PR TITLE
Adds a URL config entry for the Discord webhook

### DIFF
--- a/code/modules/discord/discord.dm
+++ b/code/modules/discord/discord.dm
@@ -1,5 +1,7 @@
 // discord config option
 /datum/config_entry/flag/using_discord
+/datum/config_entry/string/discord_webhook
+    config_entry_value = "http://127.0.0.1:5000/api/"
 
 /proc/msg2url(var/msg as text)
     var/list/conversions = list(
@@ -24,5 +26,5 @@
         return
     msg = msg2url(msg)
     var/datum/http_request/request = new()
-    request.prepare(RUSTG_HTTP_METHOD_GET, "http://127.0.0.1:5000/api/[channel]/[msg]")
+    request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/discord_webhook)][channel]/[msg]")
     request.begin_async()

--- a/config/config.txt
+++ b/config/config.txt
@@ -32,7 +32,9 @@ LOBBY_COUNTDOWN 180
 ## Round End Time: This is the amount of time after the round ends that players have to murder death kill each other.
 ROUND_END_COUNTDOWN 90
 
+## Uncomment this if you want to use the Discord webhook handler
 #USING_DISCORD
+#DISCORD_WEBHOOK http://127.0.0.1:5000/api/
 
 ## Comment this out if you want to use the SQL based admin system, the legacy system uses admins.txt.
 ## You need to set up your database to use the SQL based system.


### PR DESCRIPTION
This thing is terrible and needs to be replaced but I don't have the time.

## Changelog
:cl:
server: The discord webhook handler's URL can be configured now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
