### PR TITLE
Yet Another Ovulo Bugfix

### DIFF
--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -277,11 +277,11 @@ BONUS
 	for(var/datum/disease/D in disease)
 		diseases += D
 	if(large_heal)
-		add_initial_reagents(list(/datum/reagent/medicine/bicaridine = 20, /datum/reagent/medicine/tricordrazine = 10))
+		reagents.add_reagent_list(list(/datum/reagent/medicine/bicaridine = 20, /datum/reagent/medicine/tricordrazine = 10))
 		reagents.add_reagent(/datum/reagent/blood, 10, diseases)
 		big_heal = TRUE
 	else
-		add_initial_reagents(list(/datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/tricordrazine = 10))
+		reagents.add_reagent_list(list(/datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/tricordrazine = 10))
 		reagents.add_reagent(/datum/reagent/blood, 15, diseases)
 	if(sneaky)
 		icon_state = "eggsac-sneaky"
@@ -313,10 +313,10 @@ BONUS
 	for(var/datum/disease/D in disease)
 		diseases += D
 	if(large_heal)
-		add_initial_reagents(list(/datum/reagent/medicine/bicaridine = 20, /datum/reagent/medicine/tricordrazine = 10))
+		reagents.add_reagent_list(list(/datum/reagent/medicine/bicaridine = 20, /datum/reagent/medicine/tricordrazine = 10))
 		reagents.add_reagent(/datum/reagent/blood, 10, diseases)
 	else
-		add_initial_reagents(list(/datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/tricordrazine = 10))
+		reagents.add_reagent_list(list(/datum/reagent/medicine/bicaridine = 10, /datum/reagent/medicine/tricordrazine = 10))
 		reagents.add_reagent(/datum/reagent/blood, 15, diseases)
 	if(sneaky)
 		icon_state = "fleshegg-sneaky"

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -221,9 +221,9 @@ BONUS
 	. = ..()
 	if(A.properties["resistance"] >= 10)
 		severity -= 1
-	if(A.properties["transmittability"] >= 12)
+	if(A.properties["transmission"] >= 12)
 		severity += 1
-	if(A.properties["transmittability"] >= 16)
+	if(A.properties["transmission"] >= 16)
 		severity += 1
 	if(A.properties["stealth"] >= 6)
 		severity += 1
@@ -233,9 +233,9 @@ BONUS
 		return
 	if(A.properties["resistance"] >= 10)
 		big_heal = TRUE
-	if(A.properties["transmittability"] >= 12)
+	if(A.properties["transmission"] >= 12)
 		all_disease = TRUE
-	if(A.properties["transmittability"] >= 16)
+	if(A.properties["transmission"] >= 16)
 		eggsplosion = TRUE //Haha get it?
 	if(A.properties["stealth"] >= 6)
 		sneaky = TRUE

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -221,9 +221,9 @@ BONUS
 	. = ..()
 	if(A.properties["resistance"] >= 10)
 		severity -= 1
-	if(A.properties["transmittability"] >= 12)
+	if(A.properties["transmittable"] >= 12)
 		severity += 1
-	if(A.properties["transmittability"] >= 16)
+	if(A.properties["transmittable"] >= 16)
 		severity += 1
 	if(A.properties["stealth"] >= 6)
 		severity += 1
@@ -233,9 +233,9 @@ BONUS
 		return
 	if(A.properties["resistance"] >= 10)
 		big_heal = TRUE
-	if(A.properties["transmittability"] >= 12)
+	if(A.properties["transmittable"] >= 12)
 		all_disease = TRUE
-	if(A.properties["transmittability"] >= 16)
+	if(A.properties["transmittable"] >= 16)
 		eggsplosion = TRUE //Haha get it?
 	if(A.properties["stealth"] >= 6)
 		sneaky = TRUE

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -207,10 +207,10 @@ BONUS
 	base_message_chance = 50
 	symptom_delay_min = 60
 	symptom_delay_max = 105
-	var/big_heal = FALSE
-	var/all_disease = FALSE
-	var/eggsplosion = FALSE
-	var/sneaky = FALSE
+	var/big_heal
+	var/all_disease
+	var/eggsplosion
+	var/sneaky
 	threshold_desc = "<b>Transmission 12:</b> Eggs and Egg Sacs contain all diseases on the host, instead of just the disease containing the symptom.<br>\
 					  <b>Transmission 16:</b> Egg Sacs will 'explode' into eggs after a period of time, covering a larger area with infectious matter.<br>\
 					  <b>Resistance 10:</b> Eggs and Egg Sacs contain more healing chems.<br>\

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -221,9 +221,9 @@ BONUS
 	. = ..()
 	if(A.properties["resistance"] >= 10)
 		severity -= 1
-	if(A.properties["transmission"] >= 12)
+	if(A.properties["transmittability"] >= 12)
 		severity += 1
-	if(A.properties["transmission"] >= 16)
+	if(A.properties["transmittability"] >= 16)
 		severity += 1
 	if(A.properties["stealth"] >= 6)
 		severity += 1
@@ -233,9 +233,9 @@ BONUS
 		return
 	if(A.properties["resistance"] >= 10)
 		big_heal = TRUE
-	if(A.properties["transmission"] >= 12)
+	if(A.properties["transmittability"] >= 12)
 		all_disease = TRUE
-	if(A.properties["transmission"] >= 16)
+	if(A.properties["transmittability"] >= 16)
 		eggsplosion = TRUE //Haha get it?
 	if(A.properties["stealth"] >= 6)
 		sneaky = TRUE

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -260,6 +260,7 @@ BONUS
 					diseases += D
 			new /obj/item/reagent_containers/food/snacks/eggsac(M.loc, diseases, eggsplosion, sneaky, big_heal)
 
+#define EGGSPLODE_DELAY 100 SECONDS
 /obj/item/reagent_containers/food/snacks/eggsac
 	name = "Fleshy Egg Sac"
 	desc = "A small Egg Sac which appears to be made out of someone's flesh!"
@@ -267,7 +268,6 @@ BONUS
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "eggsac"
 	bitesize = 4
-	var/eggsplode_delay = 100 SECONDS
 	var/list/diseases = list()
 	var/sneaky_egg
 	var/big_heal
@@ -288,10 +288,11 @@ BONUS
 		icon_state = "eggsac-sneaky"
 		sneaky_egg = sneaky
 	if(eggsplodes)
-		addtimer(CALLBACK(src, .proc/eggsplode), eggsplode_delay)
+		addtimer(CALLBACK(src, .proc/eggsplode), EGGSPLODE_DELAY)
 	if(LAZYLEN(diseases))
 		AddComponent(/datum/component/infective, diseases)
 
+#undef EGGSPLODE_DELAY
 
 /obj/item/reagent_containers/food/snacks/eggsac/proc/eggsplode()
 	for(var/i = 1, i <= rand(4,8), i++)

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -287,7 +287,7 @@ BONUS
 		icon_state = "eggsac-sneaky"
 		sneaky_egg = sneaky
 	if(eggsplodes)
-		addtimer(CALLBACK(src, .proc/eggsplode), 100 SECONDS)
+		addtimer(CALLBACK(src, /obj/item/reagent_containers/food/snacks/eggsac/proc/eggsplode), 100 SECONDS)
 	if(LAZYLEN(diseases))
 		AddComponent(/datum/component/infective, diseases)
 

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -273,6 +273,7 @@ BONUS
 
 //Constructor
 /obj/item/reagent_containers/food/snacks/eggsac/New(loc, var/list/disease, var/eggsplodes, var/sneaky, var/large_heal)
+	..()
 	for(var/datum/disease/D in disease)
 		diseases += D
 	if(large_heal)
@@ -308,6 +309,7 @@ BONUS
 	var/list/diseases = list()
 
 /obj/item/reagent_containers/food/snacks/fleshegg/New(loc, var/list/disease, var/sneaky, var/large_heal)
+	..()
 	for(var/datum/disease/D in disease)
 		diseases += D
 	if(large_heal)

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -207,10 +207,10 @@ BONUS
 	base_message_chance = 50
 	symptom_delay_min = 60
 	symptom_delay_max = 105
-	var/big_heal
-	var/all_disease
-	var/eggsplosion
-	var/sneaky
+	var/big_heal = FALSE
+	var/all_disease = FALSE
+	var/eggsplosion = FALSE
+	var/sneaky = FALSE
 	threshold_desc = "<b>Transmission 12:</b> Eggs and Egg Sacs contain all diseases on the host, instead of just the disease containing the symptom.<br>\
 					  <b>Transmission 16:</b> Egg Sacs will 'explode' into eggs after a period of time, covering a larger area with infectious matter.<br>\
 					  <b>Resistance 10:</b> Eggs and Egg Sacs contain more healing chems.<br>\

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -287,7 +287,8 @@ BONUS
 		icon_state = "eggsac-sneaky"
 		sneaky_egg = sneaky
 	if(eggsplodes)
-		addtimer(CALLBACK(src, /obj/item/reagent_containers/food/snacks/eggsac/proc/eggsplode), 100 SECONDS)
+		var/obj/item/reagent_containers/food/snacks/eggsac/sac = src
+		addtimer(CALLBACK(sac, .proc/eggsplode), 100 SECONDS)
 	if(LAZYLEN(diseases))
 		AddComponent(/datum/component/infective, diseases)
 

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -273,7 +273,6 @@ BONUS
 
 //Constructor
 /obj/item/reagent_containers/food/snacks/eggsac/New(loc, var/list/disease, var/eggsplodes, var/sneaky, var/large_heal)
-	..()
 	for(var/datum/disease/D in disease)
 		diseases += D
 	if(large_heal)
@@ -309,7 +308,6 @@ BONUS
 	var/list/diseases = list()
 
 /obj/item/reagent_containers/food/snacks/fleshegg/New(loc, var/list/disease, var/sneaky, var/large_heal)
-	..()
 	for(var/datum/disease/D in disease)
 		diseases += D
 	if(large_heal)

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -267,6 +267,7 @@ BONUS
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "eggsac"
 	bitesize = 4
+	var/eggsplode_delay = 100 SECONDS
 	var/list/diseases = list()
 	var/sneaky_egg
 	var/big_heal
@@ -287,8 +288,7 @@ BONUS
 		icon_state = "eggsac-sneaky"
 		sneaky_egg = sneaky
 	if(eggsplodes)
-		var/obj/item/reagent_containers/food/snacks/eggsac/sac = src
-		addtimer(CALLBACK(sac, .proc/eggsplode), 100 SECONDS)
+		addtimer(CALLBACK(src, .proc/eggsplode), eggsplode_delay)
 	if(LAZYLEN(diseases))
 		AddComponent(/datum/component/infective, diseases)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have learned a great many things. Including not coding while at work on a Mac, in the middle of a semester.

Add initial reagents just doesn't work. So that's cool. Ovulogenesis doesn't use that anymore. Now they have the reagents.

Eggsplosion didn't work because for some fucking reason the disease stat for transmission is named "transmittable" in code, while the symptom and screen reference to it is transmission. Due to this the threshold was checking a stat that didn't "exist".
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
FIX BUG
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
fix: Ovulogenesis uses a new method for adding its reagents now they all get added
fix: Eggsacs actually have their transmission thresholds work
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
