### PR TITLE
Optimises client MouseMove

### DIFF
--- a/code/__HELPERS/mouse_control.dm
+++ b/code/__HELPERS/mouse_control.dm
@@ -1,5 +1,5 @@
-/proc/mouse_angle_from_client(client/client)
-	var/list/mouse_control = params2list(client.mouseParams)
+/proc/mouse_angle_from_client(client/client, mouseParams)
+	var/list/mouse_control = params2list(mouseParams)
 	if(mouse_control["screen-loc"] && client)
 		var/list/screen_loc_params = splittext(mouse_control["screen-loc"], ",")
 		var/list/screen_loc_X = splittext(screen_loc_params[1],":")
@@ -15,10 +15,10 @@
 		return angle
 
 //Wow, specific name!
-/proc/mouse_absolute_datum_map_position_from_client(client/client)
+/proc/mouse_absolute_datum_map_position_from_client(client/client, params)
 	if(!isloc(client.mob.loc))
 		return
-	var/list/mouse_control = params2list(client.mouseParams)
+	var/list/mouse_control = params2list(params)
 	var/atom/A = client.eye
 	var/turf/T = get_turf(A)
 	var/cx = T.x

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -27,10 +27,6 @@
 /client
 	var/list/atom/selected_target[2]
 	var/obj/item/active_mousedown_item = null
-	var/mouseParams = ""
-	var/mouseLocation = null
-	var/mouseObject = null
-	var/mouseControlObject = null
 	var/middragtime = 0
 	var/atom/middragatom
 
@@ -97,10 +93,6 @@
 
 //Please don't roast me too hard
 /client/MouseMove(object,location,control,params)
-	mouseParams = params
-	mouseLocation = location
-	mouseObject = object
-	mouseControlObject = control
 	if(mob && LAZYLEN(mob.mousemove_intercept_objects))
 		for(var/datum/D in mob.mousemove_intercept_objects)
 			D.onMouseMove(object, location, control, params)
@@ -118,10 +110,6 @@
 		else
 			middragtime = 0
 			middragatom = null
-	mouseParams = params
-	mouseLocation = over_location
-	mouseObject = over_object
-	mouseControlObject = over_control
 	if(selected_target[1] && over_object && over_object.IsAutoclickable())
 		selected_target[1] = over_object
 		selected_target[2] = params

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -25,7 +25,6 @@
 
 
 /client
-	var/list/atom/selected_target[2]
 	var/obj/item/active_mousedown_item = null
 	var/middragtime = 0
 	var/atom/middragatom
@@ -40,7 +39,6 @@
 /client/MouseUp(object, location, control, params)
 	if (mouse_up_icon)
 		mouse_pointer_icon = mouse_up_icon
-	selected_target[1] = null
 	if(active_mousedown_item)
 		active_mousedown_item.onMouseUp(object, location, params, mob)
 		active_mousedown_item = null
@@ -110,9 +108,6 @@
 		else
 			middragtime = 0
 			middragatom = null
-	if(selected_target[1] && over_object && over_object.IsAutoclickable())
-		selected_target[1] = over_object
-		selected_target[2] = params
 	if(active_mousedown_item)
 		active_mousedown_item.onMouseDrag(src_object, over_object, src_location, over_location, params, mob)
 

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -23,7 +23,6 @@
 	SEND_SIGNAL(src, COMSIG_MOUSEDROPPED_ONTO, dropping, user)
 	return
 
-
 /client
 	var/obj/item/active_mousedown_item = null
 	var/middragtime = 0
@@ -110,7 +109,6 @@
 			middragatom = null
 	if(active_mousedown_item)
 		active_mousedown_item.onMouseDrag(src_object, over_object, src_location, over_location, params, mob)
-
 
 /obj/item/proc/onMouseDrag(src_object, over_object, src_location, over_location, params, mob)
 	return

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -94,7 +94,7 @@
 //Please don't roast me too hard
 /client/MouseMove(object,location,control,params)
 	if(mob && LAZYLEN(mob.mousemove_intercept_objects))
-		for(var/datum/D in mob.mousemove_intercept_objects)
+		for(var/datum/D as() in mob.mousemove_intercept_objects)
 			D.onMouseMove(object, location, control, params)
 	..()
 

--- a/code/datums/components/lockon_aiming.dm
+++ b/code/datums/components/lockon_aiming.dm
@@ -18,6 +18,7 @@
 	var/list/last_location
 	var/datum/callback/on_lock
 	var/datum/callback/can_target_callback
+	var/aiming_params
 
 /datum/component/lockon_aiming/Initialize(range, list/typecache, amount, list/immune, datum/callback/when_locked, icon, icon_state, datum/callback/target_callback)
 	if(!ismob(parent))
@@ -123,7 +124,8 @@
 	var/mob/M = parent
 	if(!istype(M) || !M.client)
 		return
-	var/datum/position/P = mouse_absolute_datum_map_position_from_client(M.client)
+	aiming_params = params
+	var/datum/position/P = mouse_absolute_datum_map_position_from_client(M.client, aiming_params)
 	if(!P)
 		return
 	var/turf/T = P.return_turf()
@@ -163,7 +165,7 @@
 	var/mob/M = parent
 	if(!M.client)
 		return FALSE
-	var/datum/position/current = mouse_absolute_datum_map_position_from_client(M.client)
+	var/datum/position/current = mouse_absolute_datum_map_position_from_client(M.client, aiming_params)
 	var/turf/target = current.return_turf()
 	var/list/atom/targets = get_nearest(target, target_typecache, lock_amount, lock_cursor_range)
 	if(targets == LOCKON_IGNORE_RESULT)

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -66,7 +66,7 @@
 	anchored = TRUE
 	if(M.client)
 		M.client.view_size.setTo(view_range)
-	LAZYADD(M.mousemove_intercept_objects, src)
+	LAZYOR(M.mousemove_intercept_objects, src)
 
 /obj/machinery/manned_turret/onMouseMove(object, location, control, params)
 	. = ..()

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -41,7 +41,7 @@
 			buckled_mob.client.view_size.resetToDefault()
 	anchored = FALSE
 	. = ..()
-	STOP_PROCESSING(SSfastprocess, src)
+	LAZYREMOVE(buckled_mob, src)
 
 /obj/machinery/manned_turret/user_buckle_mob(mob/living/M, mob/living/carbon/user)
 	if(user.incapacitated() || !istype(user))
@@ -66,13 +66,13 @@
 	anchored = TRUE
 	if(M.client)
 		M.client.view_size.setTo(view_range)
-	START_PROCESSING(SSfastprocess, src)
+	LAZYADD(M.mousemove_intercept_objects, src)
 
-/obj/machinery/manned_turret/process()
-	if (!update_positioning())
-		return PROCESS_KILL
+/obj/machinery/manned_turret/onMouseMove(object, location, control, params)
+	. = ..()
+	update_positioning(object, params)
 
-/obj/machinery/manned_turret/proc/update_positioning()
+/obj/machinery/manned_turret/proc/update_positioning(mouseObject, params)
 	if (!LAZYLEN(buckled_mobs))
 		return FALSE
 	var/mob/living/controller = buckled_mobs[1]
@@ -80,11 +80,11 @@
 		return FALSE
 	var/client/C = controller.client
 	if(C)
-		var/atom/A = C.mouseObject
+		var/atom/A = mouseObject
 		var/turf/T = get_turf(A)
 		if(istype(T))	//They're hovering over something in the map.
 			direction_track(controller, T)
-			calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(controller, C.mouseParams)
+			calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(controller, params)
 
 /obj/machinery/manned_turret/proc/direction_track(mob/user, atom/targeted)
 	if(user.incapacitated())
@@ -147,7 +147,6 @@
 /obj/machinery/manned_turret/proc/fire_helper(mob/user)
 	if(user.incapacitated() || !(user in buckled_mobs))
 		return
-	update_positioning()						//REFRESH MOUSE TRACKING!!
 	var/turf/targets_from = get_turf(src)
 	if(QDELETED(target))
 		target = target_turf

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -780,14 +780,13 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CULT_TRAIT)
 
-
 /obj/item/blood_beam/afterattack(atom/A, mob/living/user, flag, params)
 	. = ..()
 	if(firing || charging)
 		return
 	var/C = user.client
 	if(ishuman(user) && C)
-		angle = mouse_angle_from_client(C)
+		angle = Get_Angle(get_turf(src), get_turf(A))
 	else
 		qdel(src)
 		return

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -76,6 +76,9 @@
 	var/datum/action/item_action/zoom_lock_action/zoom_lock_action
 	var/mob/listeningTo
 
+	var/obj/aiming_target
+	var/aiming_params
+
 /obj/item/gun/energy/beam_rifle/debug
 	delay = 0
 	cell_type = /obj/item/stock_parts/cell/infinite
@@ -197,12 +200,12 @@
 	else
 		P.color = rgb(0, 255, 0)
 	var/turf/curloc = get_turf(src)
-	var/turf/targloc = get_turf(current_user.client.mouseObject)
+	var/turf/targloc = get_turf(aiming_target)
 	if(!istype(targloc))
 		if(!istype(curloc))
 			return
 		targloc = get_turf_in_angle(lastangle, curloc, 10)
-	P.preparePixelProjectile(targloc, current_user, current_user.client.mouseParams, 0)
+	P.preparePixelProjectile(targloc, current_user, aiming_params, 0)
 	P.fire(lastangle)
 
 /obj/item/gun/energy/beam_rifle/process()
@@ -224,8 +227,8 @@
 	return TRUE
 
 /obj/item/gun/energy/beam_rifle/proc/process_aim()
-	if(istype(current_user) && current_user.client && current_user.client.mouseParams)
-		var/angle = mouse_angle_from_client(current_user.client)
+	if(istype(current_user) && current_user.client)
+		var/angle = mouse_angle_from_client(current_user.client, aiming_params)
 		current_user.setDir(angle2dir_cardinal(angle))
 		var/difference = abs(closer_angle_difference(lastangle, angle))
 		delay_penalty(difference * aiming_time_increase_angle_multiplier)
@@ -270,6 +273,8 @@
 		listeningTo = user
 
 /obj/item/gun/energy/beam_rifle/onMouseDrag(src_object, over_object, src_location, over_location, params, mob)
+	aiming_target = over_object
+	aiming_params = params
 	if(aiming)
 		process_aim()
 		aiming_beam()
@@ -294,7 +299,7 @@
 	process_aim()
 	if(aiming_time_left <= aiming_time_fire_threshold && check_user())
 		sync_ammo()
-		afterattack(M.client.mouseObject, M, FALSE, M.client.mouseParams, passthrough = TRUE)
+		afterattack(object, M, FALSE, params, passthrough = TRUE)
 	stop_aiming()
 	QDEL_LIST(current_tracers)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stops constantly updating the clients mouse params variables, instead uses onMouseMove for things that use those vars.

## Why It's Good For The Game

I don't think this will make a huge difference, but this proc gets called a shit ton (like >10000 times in a few seconds).
![image](https://user-images.githubusercontent.com/26465327/116814283-097f4080-ab50-11eb-88f1-04e14e119aa3.png)
Calls across a couple of minutes. !!!

## Changelog
:cl:
code: Microoptimises MouseMove
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
