### PR TITLE
Neets ignore hygiene mood effects

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -355,6 +355,8 @@
 			add_event(null, "charge", /datum/mood_event/charged)
 
 /datum/component/mood/proc/HandleHygiene(mob/living/carbon/human/H)
+	if(H.has_quirk(/datum/quirk/neet))
+		return //Neets don't care.
 	switch (H.hygiene)
 		if(HYGIENE_LEVEL_DISGUSTING to HYGIENE_LEVEL_DISGUSTING)//Believe it or not but this is actually the cleaner option.
 			add_event(null, "hygiene", /datum/mood_event/disgusting)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes 

![](https://cdn.discordapp.com/attachments/565330972707651584/838594871371235328/unknown.png)

## Changelog
:cl:
fix: Neets can now properly ignore the hygiene system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
