### PR TITLE
Makes botany able to turn people into skeletons again.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -533,7 +533,8 @@
 						/datum/species/pod,
 						/datum/species/jelly,
 						/datum/species/abductor,
-						/datum/species/squid)
+						/datum/species/squid,
+						/datum/species/skeleton)
 	can_synth = TRUE
 
 /datum/reagent/mutationtoxin/felinid


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since #4078 botany has been unable to turn anyone into a skeleton, this other PR: #4177 tries alleviating the issue by altering the recipe for skeleton mutation toxin, this PR instead tries alleviating the issue by adding skeletons to the large list of random species that the unstable mutation toxin can turn you into.

## Why It's Good For The Game

### _Ack._

## Changelog
:cl:
tweak: Unstable mutation toxin can now also turn you into a skeleton.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
