### PR TITLE
Recharging flashbulb, Cyborg flash nerf, flash nerf.

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4161,7 +4161,7 @@
 "AC" = (
 /obj/structure/table/reinforced,
 /obj/item/bodypart/head/robot,
-/obj/item/flashbulb/strong{
+/obj/item/flashbulb/recharging/revolution{
 	pixel_x = -5;
 	pixel_y = 8
 	},

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -14,7 +14,7 @@
 	flags_1 = CONDUCT_1
 	throw_speed = 3
 	throw_range = 7
-	var/charges_left = 15
+	var/charges_left = 10
 
 /obj/item/flashbulb/update_icon()
 	if(charges_left <= 0)
@@ -42,13 +42,36 @@
 	name = "weakened flashbulb"
 	charges_left = 4
 
-/obj/item/flashbulb/strong
-	name = "modified flashbulb"
-	charges_left = 120
+/obj/item/flashbulb/recharging
+	charges_left = 3
+	var/max_changes = 3
+	var/charge_time = 10 SECONDS
+	var/recharging = FALSE
 
-/obj/item/flashbulb/cyborg
+/obj/item/flashbulb/recharging/proc/recharge()
+	recharging = FALSE
+	if(charges_left >= max_charges)
+		return
+	charges_left ++
+	icon_state = "flashbulb"
+	if(charges_left < max_charges)
+		addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_UNIQUE)
+		recharging = TRUE
+
+/obj/item/flashbulb/recharging/use_flashbulb()
+	. = ..()
+	if(!recharging)
+		addtimer(CALLBACK(src, .proc/recharge), charge_time, TIMER_UNIQUE)
+		recharging = TRUE
+
+/obj/item/flashbulb/recharging/revolution
+	name = "modified flashbulb"
+	charges_left = 10
+	max_charges = 10
+	charge_time = 15 SECONDS
+
+/obj/item/flashbulb/recharging/cyborg
 	name = "cyborg flashbulb"
-	charges_left = INFINITY
 
 /obj/item/assembly/flash
 	name = "flash"
@@ -73,7 +96,7 @@
 	bulb = /obj/item/flashbulb/weak
 
 /obj/item/assembly/flash/handheld/strong
-	bulb = /obj/item/flashbulb/strong
+	bulb = /obj/item/flashbulb/recharging/revolution
 
 /obj/item/assembly/flash/Initialize()
 	. = ..()
@@ -276,7 +299,7 @@
 
 
 /obj/item/assembly/flash/cyborg
-	bulb = /obj/item/flashbulb/cyborg
+	bulb = /obj/item/flashbulb/recharging/cyborg
 
 /obj/item/assembly/flash/cyborg/attack(mob/living/M, mob/user)
 	..()
@@ -341,7 +364,7 @@
 	flashing_overlay = "flash-hypno"
 	light_color = LIGHT_COLOR_PINK
 	cooldown = 20
-	bulb = /obj/item/flashbulb/cyborg	//Flashbulb with infinite charges
+	bulb = /obj/item/flashbulb/recharging/cyborg	//Flashbulb with infinite charges
 
 /obj/item/assembly/flash/hypnotic/burn_out()
 	return

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -364,7 +364,7 @@
 	flashing_overlay = "flash-hypno"
 	light_color = LIGHT_COLOR_PINK
 	cooldown = 20
-	bulb = /obj/item/flashbulb/recharging/cyborg	//Flashbulb with infinite charges
+	bulb = /obj/item/flashbulb/recharging/revolution
 
 /obj/item/assembly/flash/hypnotic/burn_out()
 	return

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -44,7 +44,7 @@
 
 /obj/item/flashbulb/recharging
 	charges_left = 3
-	var/max_changes = 3
+	var/max_charges = 3
 	var/charge_time = 10 SECONDS
 	var/recharging = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in recharging flashbulbs, which will automatically recharge their charges over time.
Nerfs the cyborg flashbulbs to have 3 charges which auto-recharge every 10 seconds rather than infinite charges.
Revolutionary flashes now have 10 charges and automatically recharge every 15 seconds.
Regular flashbulbs nerfed from 15 to 10 charges.

## Why It's Good For The Game

Cyborgs have an overpowered infinite flash that never runs out.
Revolutionaries are easy to out with their 120 flash (Now they can be outed with a 15 second recharging flash).
Security flash nerfed from 15 to 10, since the 15 charges almost never get depleted.

## Changelog
:cl:
balance: Cyborg flash nerfed to 3 charges and auto-recharge every 10 seconds.
tweak: Revolutionary flash changed to 10 charges and auto-recharged every 15 seconds.
balance: Default flashbulbs nerfed from 15 flashes to 10.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
