### PR TITLE
Changeling item deletes on drop.

### DIFF
--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -89,6 +89,7 @@
 	name = "flesh"
 	slot_flags = ALL
 	allowed = list(/obj/item/changeling)
+	item_flags = DROPDEL
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/changeling/attack_hand(mob/user)

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -93,8 +93,11 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/changeling/attack_hand(mob/user)
-	if(loc == user && user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling))
-		to_chat(user, "<span class='notice'>You reabsorb [src] into your body.</span>")
+	if(loc == user)
+		if(user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling))
+			to_chat(user, "<span class='notice'>You reabsorb [src] into your body.</span>")
+		else
+			to_chat(user, "<span class='notice'>[src] vanishes, it was just an illusion!</span>")
 		qdel(src)
 		return
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When dropped due to gibbing the changing item gets put on the ground where it can no longer be picked up. This causes them to get deleted on drop to prevent this from happening.
Also allows non changeling to delete the changeling item in the case that they somehow get it in their hand.

## Why It's Good For The Game

Fixes items being on the ground which cannot be picked up.

## Changelog
:cl:
fix: Changeling item will not delete on drop.
tweak: Changeling items can be deleted by non changelings by clicking on it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
