### PR TITLE
Limits logging after round

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -89,7 +89,7 @@
 	WRITE_LOG(GLOB.world_asset_log, "ASSET: [text]")
 
 /proc/log_access(text)
-	if (CONFIG_GET(flag/log_access) && SSticker.current_state != GAME_STATE_FINISHED)
+	if (CONFIG_GET(flag/log_access))
 		WRITE_LOG(GLOB.world_game_log, "ACCESS: [text]")
 
 /proc/log_law(text)

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -67,19 +67,19 @@
 		WRITE_LOG(GLOB.world_objective_log, "OBJ: [key_name(whom)] was assigned the following objective [admin_involved ? "by [key_name(admin_involved)]" : "automatically"]: [objective]")
 
 /proc/log_mecha(text)
-	if (CONFIG_GET(flag/log_mecha))
+	if (CONFIG_GET(flag/log_mecha) && SSticker.current_state != GAME_STATE_FINISHED)
 		WRITE_LOG(GLOB.world_mecha_log, "MECHA: [text]")
 
 /proc/log_virus(text)
-	if (CONFIG_GET(flag/log_virus))
+	if (CONFIG_GET(flag/log_virus) && SSticker.current_state != GAME_STATE_FINISHED)
 		WRITE_LOG(GLOB.world_virus_log, "VIRUS: [text]")
 
 /proc/log_cloning(text, mob/initiator)
-	if(CONFIG_GET(flag/log_cloning))
+	if(CONFIG_GET(flag/log_cloning) && SSticker.current_state != GAME_STATE_FINISHED)
 		WRITE_LOG(GLOB.world_cloning_log, "CLONING: [text]")
 
 /proc/log_id(text)
-	if(CONFIG_GET(flag/log_id))
+	if(CONFIG_GET(flag/log_id) && SSticker.current_state != GAME_STATE_FINISHED)
 		WRITE_LOG(GLOB.world_id_log, "ID: [text]")
 
 /proc/log_paper(text)
@@ -89,7 +89,7 @@
 	WRITE_LOG(GLOB.world_asset_log, "ASSET: [text]")
 
 /proc/log_access(text)
-	if (CONFIG_GET(flag/log_access))
+	if (CONFIG_GET(flag/log_access) && SSticker.current_state != GAME_STATE_FINISHED)
 		WRITE_LOG(GLOB.world_game_log, "ACCESS: [text]")
 
 /proc/log_law(text)
@@ -97,14 +97,17 @@
 		WRITE_LOG(GLOB.world_game_log, "LAW: [text]")
 
 /proc/log_attack(text)
-	if (CONFIG_GET(flag/log_attack))
+	if (CONFIG_GET(flag/log_attack) && SSticker.current_state != GAME_STATE_FINISHED)
 		WRITE_LOG(GLOB.world_attack_log, "ATTACK: [text]")
 
 /proc/log_manifest(ckey, datum/mind/mind,mob/body, latejoin = FALSE)
-	if (CONFIG_GET(flag/log_manifest))
+	if (CONFIG_GET(flag/log_manifest) && SSticker.current_state != GAME_STATE_FINISHED)
 		WRITE_LOG(GLOB.world_manifest_log, "[ckey] \\ [body.real_name] \\ [mind.assigned_role] \\ [mind.special_role ? mind.special_role : "NONE"] \\ [latejoin ? "LATEJOIN":"ROUNDSTART"]")
 
 /proc/log_bomber(atom/user, details, atom/bomb, additional_details, message_admins = TRUE)
+	if(SSticker.current_state == GAME_STATE_FINISHED)
+		return
+
 	var/bomb_message = "[details][bomb ? " [bomb.name] at [AREACOORD(bomb)]": ""][additional_details ? " [additional_details]" : ""]."
 
 	if(user)
@@ -117,6 +120,7 @@
 
 	if(message_admins)
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")
+
 
 /proc/log_say(text)
 	if (CONFIG_GET(flag/log_say))

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -79,7 +79,7 @@
 		WRITE_LOG(GLOB.world_cloning_log, "CLONING: [text]")
 
 /proc/log_id(text)
-	if(CONFIG_GET(flag/log_id) && SSticker.current_state != GAME_STATE_FINISHED)
+	if(CONFIG_GET(flag/log_id))
 		WRITE_LOG(GLOB.world_id_log, "ID: [text]")
 
 /proc/log_paper(text)
@@ -101,7 +101,7 @@
 		WRITE_LOG(GLOB.world_attack_log, "ATTACK: [text]")
 
 /proc/log_manifest(ckey, datum/mind/mind,mob/body, latejoin = FALSE)
-	if (CONFIG_GET(flag/log_manifest) && SSticker.current_state != GAME_STATE_FINISHED)
+	if (CONFIG_GET(flag/log_manifest))
 		WRITE_LOG(GLOB.world_manifest_log, "[ckey] \\ [body.real_name] \\ [mind.assigned_role] \\ [mind.special_role ? mind.special_role : "NONE"] \\ [latejoin ? "LATEJOIN":"ROUNDSTART"]")
 
 /proc/log_bomber(atom/user, details, atom/bomb, additional_details, message_admins = TRUE)

--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -1,5 +1,5 @@
 /atom/proc/investigate_log(message, subject)
-	if(!message || !subject)
+	if(!message || !subject || SSticker.current_state == GAME_STATE_FINISHED)
 		return
 	var/F = file("[GLOB.log_directory]/[subject].html")
 	WRITE_FILE(F, "[time_stamp()] [REF(src)] ([x],[y],[z]) || [src] [message]<br>")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -534,6 +534,9 @@
 		stack_trace("Empty message")
 		return
 
+	if(SSticker.current_state == GAME_STATE_FINISHED && message_type == LOG_ATTACK)
+		return
+
 	// Cannot use the list as a map if the key is a number, so we stringify it (thank you BYOND)
 	var/smessage_type = num2text(message_type)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Logging stuff such as:
- mech logs
- virus logs
- cloning logs
- access logs
- attacks logs
- bomb logs
- mob specific attack logs (the ones seen in LOGS panel in game)
- investigate logs

won't be logged after the round ends.

Say logs, admin logs and rest are kept and unchanged.

## Why It's Good For The Game

Helps admins investigate stuff and reduces bloat of logs caused by BR.

## Changelog
:cl:
admin: Reduced logging after the round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
