### PR TITLE
Flashes (and flash bulbs) will no longer say their number of uses

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -80,6 +80,7 @@
 
 /obj/item/assembly/flash/examine(mob/user)
 	. = ..()
+	. += "[bulb ? "It looks like you can cut out the flashbulb with a pair of wirecutters." : "The device has no bulb installed."]"
 
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(!bulb)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -24,7 +24,6 @@
 
 /obj/item/flashbulb/examine(mob/user)
 	. = ..()
-	. += "This one can probably just about handle [charges_left] more uses."
 
 /obj/item/flashbulb/proc/check_working()
 	return charges_left > 0
@@ -81,7 +80,6 @@
 
 /obj/item/assembly/flash/examine(mob/user)
 	. = ..()
-	. += "[bulb ? "The bulb looks like it can handle just about [bulb.charges_left] more uses.\nIt looks like you can cut out the flashbulb with a pair of wirecutters." : "The device has no bulb installed."]"
 
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(!bulb)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

No more metagaming revheads by looking at uses in their flash

## Changelog
:cl:
tweak: Flashes will no longer say their number of uses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
