### PR TITLE
Fix Mining Borg Cutter Upgrade Not Being Appliable

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -206,7 +206,7 @@
 	desc = "An upgrade to the mining module granting a self-recharging plasma cutter."
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type = /obj/item/robot_module/miner
+	module_type = list(/obj/item/robot_module/miner)
 
 /obj/item/borg/upgrade/cutter/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Title

## Why It's Good For The Game
Title

## Changelog
:cl:
fix: mining borg cutter upgrade can be applied again
/:cl:
