### PR TITLE
Improves security life

### DIFF
--- a/code/datums/components/storage/concrete/egun_slot.dm
+++ b/code/datums/components/storage/concrete/egun_slot.dm
@@ -1,0 +1,19 @@
+/datum/component/storage/concrete/egun_slot/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/living/user)
+	var/atom/P = src.parent
+	var/list/things = contents()
+	var/total_guns = 0
+	var/max_guns = 1 //max guns allowed
+
+	if(istype(W, /obj/item/gun/energy))
+		for(var/i in things)
+			var/obj/item/E = i
+			if(istype(E, /obj/item/gun/energy))
+				total_guns++
+	else
+		. = ..()
+
+	if(total_guns >= max_guns) //No more guns allowed
+		to_chat(user, "<span class='warning'>You cant fit any more guns into [P]!</span>")
+		return
+	else
+		. = ..()

--- a/code/datums/components/storage/concrete/egun_slot.dm
+++ b/code/datums/components/storage/concrete/egun_slot.dm
@@ -1,19 +1,23 @@
-/datum/component/storage/concrete/egun_slot/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/living/user)
-	var/atom/P = src.parent
-	var/list/things = contents()
-	var/total_guns = 0
+/datum/component/storage/concrete/egun_slot
 	var/max_guns = 1 //max guns allowed
+	var/total_guns
+	var/atom/P
+	var/list/things
 
-	if(istype(W, /obj/item/gun/energy))
-		for(var/i in things)
+/datum/component/storage/concrete/egun_slot/handle_item_insertion(obj/item/W, prevent_warning = FALSE, mob/living/user)
+	total_guns = 0
+	P = src.parent
+	things = contents()
+
+	if(istype(W, /obj/item/gun/energy)) //do we try to insert energy gun?
+		for(var/i in things) //look at every item in the storage
 			var/obj/item/E = i
-			if(istype(E, /obj/item/gun/energy))
-				total_guns++
-	else
-		. = ..()
 
-	if(total_guns >= max_guns) //No more guns allowed
-		to_chat(user, "<span class='warning'>You cant fit any more guns into [P]!</span>")
-		return
-	else
-		. = ..()
+			if(istype(E, /obj/item/gun/energy)) //is there any energy guns in the storage already?
+				total_guns++
+
+		if(total_guns >= max_guns) //no space for guns so no more guns allowed
+			to_chat(user, "<span class='warning'>You cant fit any more guns into [P]!</span>")
+			return
+
+	. = ..()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -241,11 +241,12 @@
 	icon_state = "securitybelt"
 	item_state = "security"//Could likely use a better one.
 	content_overlays = TRUE
+	component_type = /datum/component/storage/concrete/egun_slot
 
 /obj/item/storage/belt/security/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 5
+	STR.max_items = 6
 	STR.max_combined_w_class = 18
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
 	STR.can_hold = typecacheof(list(
@@ -267,7 +268,8 @@
 		/obj/item/restraints/legcuffs/bola,
 		/obj/item/holosign_creator/security,
 		/obj/item/club,
-		/obj/item/shield/riot/tele
+		/obj/item/shield/riot/tele,
+		/obj/item/gun/energy
 		))
 
 /obj/item/storage/belt/security/full/PopulateContents()
@@ -295,11 +297,13 @@
 	icon_state = "securitywebbing"
 	item_state = "securitywebbing"
 	content_overlays = FALSE
+	w_class = WEIGHT_CLASS_BULKY
 	custom_premium_price = 800
 
 /obj/item/storage/belt/security/webbing/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_items = 6
 	STR.max_combined_w_class = 21
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since laser guns are bluky items now security is often forced to put the secbelt in the backpack and wear the gun in the beltslot.

Adds one additional slot to sec belt.
Sec belt can now hold up to one normal sized egun. (disablers / hos gun / cap gun)
Sec webbing is a bulky item now. (cant fit it in your backpack anymore)
Sec webbing can hold up to one bulky egun now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Sec dont have to sacrifice their belt for a gunslot now.
More incentive to use security webbing now.
Security life is better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added one additional slot to sec belt
tweak: Sec webbing is a bulky item now
tweak: Sec webbing can hold up to one bulky egun now
tweak: Sec belt can now hold up to one normal sized egun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
