### PR TITLE
changes flashbulb examination message

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -24,7 +24,6 @@
 
 /obj/item/flashbulb/examine(mob/user)
 	. = ..()
-	. += "This one can probably just about handle [charges_left] more uses."
 
 /obj/item/flashbulb/proc/check_working()
 	return charges_left > 0
@@ -81,7 +80,7 @@
 
 /obj/item/assembly/flash/examine(mob/user)
 	. = ..()
-	. += "[bulb ? "The bulb looks like it can handle just about [bulb.charges_left] more uses.\nIt looks like you can cut out the flashbulb with a pair of wirecutters." : "The device has no bulb installed."]"
+	. += "[bulb ? "It looks like you can cut out the flashbulb with a pair of wirecutters." : "The device has no bulb installed."]"
 
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(!bulb)


### PR DESCRIPTION


## About The Pull Request

changes flashbulb examination message

## Why It's Good For The Game

It is a common strategy to examine the flash that a player has on them in order to see if that player is a Head Revolutionary or not. If it is a strong flash, then Security/Validhunters can immediately confirm that a Revolution is happening.

For an item that is otherwise physically identical, this makes very little sense, and encourages metagame.

## Changelog
:cl:
del: Removes flash/flashbulb examination message to discourage metagaming
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
