### PR TITLE
Adds missing mutation toxins and recipes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -628,6 +628,13 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/ipc
 	taste_description = "silicon and copper"
+	
+/datum/reagent/mutationtoxin/ethereal
+	name = "Ethereal Mutation Toxin"
+	description = "A positively electric toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/ethereal
+	taste_description = "shocking"
 
 /datum/reagent/mutationtoxin/squid
 	name = "Squid Mutation Toxin"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -530,6 +530,7 @@
 						/datum/species/lizard,
 						/datum/species/fly,
 						/datum/species/moth,
+						/datum/species/apid,
 						/datum/species/pod,
 						/datum/species/jelly,
 						/datum/species/abductor,
@@ -562,6 +563,13 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/moth
 	taste_description = "clothing"
+	
+/datum/reagent/mutationtoxin/apid
+	name = "Apid Mutation Toxin"
+	description = "A sweet-smelling toxin."
+	color = "#5EFF3B" //RGB: 94, 255, 59
+	race = /datum/species/apid
+	taste_description = "honey"
 
 /datum/reagent/mutationtoxin/pod
 	name = "Podperson Mutation Toxin"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -740,6 +740,12 @@
 	id = /datum/reagent/mutationtoxin/ipc
 	results = list(/datum/reagent/mutationtoxin/ipc = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/teslium = 20)
+	
+/datum/chemical_reaction/mutationtoxin/ethereal
+	name = /datum/reagent/mutationtoxin/ethereal
+	id = /datum/reagent/mutationtoxin/ethereal
+	results = list(/datum/reagent/mutationtoxin/ethereal = 5)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/liquidelectricity = 20)
 
 /datum/chemical_reaction/mutationtoxin/oozeling
 	name = /datum/reagent/mutationtoxin/oozeling

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -705,6 +705,12 @@
 	results = list(/datum/reagent/mutationtoxin/moth = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/toxin/lipolicide = 10) //I know it's the opposite of what moths like, but I am out of ideas for this.
 
+/datum/chemical_reaction/mutationtoxin/apid
+	name = /datum/reagent/mutationtoxin/apid
+	id = /datum/reagent/mutationtoxin/apid
+	results = list(/datum/reagent/mutationtoxin/apid = 5)
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/honey = 20) // beeeeeeeeeeeeeeeeeeeees
+
 /datum/chemical_reaction/mutationtoxin/pod
 	name = /datum/reagent/mutationtoxin/pod
 	id = /datum/reagent/mutationtoxin/pod

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -709,7 +709,7 @@
 	name = /datum/reagent/mutationtoxin/apid
 	id = /datum/reagent/mutationtoxin/apid
 	results = list(/datum/reagent/mutationtoxin/apid = 5)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/honey = 20) // beeeeeeeeeeeeeeeeeeeees
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/honey = 20) // beeeeeeeeeeeeeeeeeeeeees
 
 /datum/chemical_reaction/mutationtoxin/pod
 	name = /datum/reagent/mutationtoxin/pod

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -747,13 +747,13 @@
 	results = list(/datum/reagent/mutationtoxin/oozeling = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/medicine/calomel = 10, /datum/reagent/toxin/bad_food = 30, /datum/reagent/stable_plasma = 5)
 
+//////////////Mutation toxins made out of advanced toxin/////////////
+
 /datum/chemical_reaction/mutationtoxin/skeleton
 	name = /datum/reagent/mutationtoxin/skeleton
 	id = /datum/reagent/mutationtoxin/skeleton
 	results = list(/datum/reagent/mutationtoxin/skeleton = 5)
-	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/milk = 30, /datum/reagent/toxin/acid/fluacid = 30) //Because acid melts flesh off.
-
-//////////////Mutation toxins made out of advanced toxin/////////////
+	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/consumable/milk = 30, /datum/reagent/toxin/acid/fluacid = 30) //Because acid melts flesh off.
 
 ///datum/chemical_reaction/mutationtoxin/zombie //No zombies untill holopara issue is fixed.
 //	name = /datum/reagent/mutationtoxin/zombie

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -741,14 +741,13 @@
 	results = list(/datum/reagent/mutationtoxin/oozeling = 5)
 	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/medicine/calomel = 10, /datum/reagent/toxin/bad_food = 30, /datum/reagent/stable_plasma = 5)
 
-
-//////////////Mutatuion toxins made out of advanced toxin/////////////
-
 /datum/chemical_reaction/mutationtoxin/skeleton
 	name = /datum/reagent/mutationtoxin/skeleton
 	id = /datum/reagent/mutationtoxin/skeleton
 	results = list(/datum/reagent/mutationtoxin/skeleton = 5)
-	required_reagents  = list(/datum/reagent/aslimetoxin = 5, /datum/reagent/consumable/milk = 30, /datum/reagent/toxin/acid/fluacid = 30) //Because acid melts flesh off.
+	required_reagents  = list(/datum/reagent/mutationtoxin/unstable = 5, /datum/reagent/consumable/milk = 30, /datum/reagent/toxin/acid/fluacid = 30) //Because acid melts flesh off.
+
+//////////////Mutation toxins made out of advanced toxin/////////////
 
 ///datum/chemical_reaction/mutationtoxin/zombie //No zombies untill holopara issue is fixed.
 //	name = /datum/reagent/mutationtoxin/zombie


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Apid and Ethereal Mutation Toxin and their recipes to the game.

Apid Mutation Toxin requires 5 units of Unstable Mutation Toxin and 20 units of Honey.
Ethereal Mutation Toxin requires 5 units of Unstable Mutation Toxin and 20 units of Liquid Electricity.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Every other race has its mutation toxin, and now so do apids and ethereals.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: novaremnant
add: Added Apid Mutation Toxin
add: Added recipe for Apid Mutation Toxin
add: Added Ethereal Mutation Toxin
add: Added recipe for Ethereal Mutation Toxin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
