### PR TITLE
Reverts "Ashwalkers can no longer use shuttle consoles"

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -11,10 +11,6 @@
 	var/no_destination_swap = 0
 
 /obj/machinery/computer/shuttle/ui_interact(mob/user)
-	//Ash walkers cannot use the console because they are unga bungas
-	if(user.mind?.has_antag_datum(/datum/antagonist/ashwalker))
-		to_chat(user, "<span class='warning'>This computer has been designed to keep the natives like you from meddling with it, you have no hope of using it.</span>")
-		return
 	. = ..()
 	var/list/options = params2list(possible_destinations)
 	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)


### PR DESCRIPTION
## About The Pull Request

Reverts https://github.com/BeeStation/BeeStation-Hornet/pull/1885

## Why It's Good For The Game

The main reasons for this PR have been addressed via murderbone policy. 

## Changelog
:cl:
tweak: Ash walkers can now use shuttle consoles again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
