### PR TITLE
Glowshrooms (and shadowshrooms) no longer spread

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -31,6 +31,8 @@
 	myseed = /obj/item/seeds/glowshroom/shadowshroom
 
 
+/obj/structure/glowshroom/single/
+
 /obj/structure/glowshroom/examine(mob/user)
 	. = ..()
 	. += "This is a [generation]\th generation [name]!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Glowshrooms and variants no longer spread 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Glowshrooms are fugly, this makes it harder to fuglify the entire station with a few clicks and some time. It's now roughly as difficult to fuglify the station as it is to scrape the mushrooms back off the walls and floors. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Glowshrooms, Shadowshrooms and Glowcaps no longer spread on their own
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
