### PR TITLE
Adds Old insuls and Old gas mask among assistant heirlooms

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -134,7 +134,7 @@
 			if("Chaplain")
 				heirloom_type = pick(/obj/item/toy/windupToolbox, /obj/item/reagent_containers/food/drinks/bottle/holywater)
 			if("Assistant")
-				heirloom_type = /obj/item/storage/toolbox/mechanical/old/heirloom
+				heirloom_type = pick(/obj/item/storage/toolbox/mechanical/old/heirloom,/obj/item/clothing/mask/gas/old,/obj/item/clothing/gloves/color/fyellow/old)
 			if("Barber")
 				heirloom_type = /obj/item/handmirror
 			if("Stage Magician")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -134,7 +134,7 @@
 			if("Chaplain")
 				heirloom_type = pick(/obj/item/toy/windupToolbox, /obj/item/reagent_containers/food/drinks/bottle/holywater)
 			if("Assistant")
-				heirloom_type = pick(/obj/item/storage/toolbox/mechanical/old/heirloom,/obj/item/clothing/mask/gas/old,/obj/item/clothing/gloves/color/fyellow/old)
+				heirloom_type = pick(/obj/item/storage/toolbox/mechanical/old/heirloom, /obj/item/clothing/mask/gas/old, /obj/item/clothing/gloves/color/fyellow/old)
 			if("Barber")
 				heirloom_type = /obj/item/handmirror
 			if("Stage Magician")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -134,7 +134,7 @@
 			if("Chaplain")
 				heirloom_type = pick(/obj/item/toy/windupToolbox, /obj/item/reagent_containers/food/drinks/bottle/holywater)
 			if("Assistant")
-				heirloom_type = pick(/obj/item/storage/toolbox/mechanical/old/heirloom, /obj/item/clothing/mask/gas/old, /obj/item/clothing/gloves/color/fyellow/old)
+				heirloom_type = pick(/obj/item/storage/toolbox/mechanical/old/heirloom, /obj/item/clothing/mask/gas/old)
 			if("Barber")
 				heirloom_type = /obj/item/handmirror
 			if("Stage Magician")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds ~~worn down insuls~~ and old gas mask among assistant heirlooms.

## Why It's Good For The Game

Gotta nail that classic assistant look!

## Changelog
:cl:
add: Old gas mask among assistant heirlooms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
