### PR TITLE
Shields no longer block projectiles.

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/shields.dmi'
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = BLOCKING_PROJECTILE
 	block_power = 50
 	max_integrity =  75
 	var/transparent = FALSE	// makes beam projectiles pass through the shield
@@ -255,6 +254,7 @@
 	throw_speed = 3
 	max_integrity = 50
 	block_sound = 'sound/weapons/egloves.ogg'
+	block_flags = BLOCKING_PROJECTILE
 	var/base_icon_state = "eshield" // [base_icon_state]1 for expanded, [base_icon_state]0 for contracted
 	var/on_force = 10
 	var/on_throwforce = 8

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -885,6 +885,7 @@
 	throw_range = 4
 	max_integrity = 50
 	w_class = WEIGHT_CLASS_BULKY
+	block_flags = BLOCKING_PROJECTILE
 	attack_verb = list("bumped", "prodded")
 	hitsound = 'sound/weapons/smash.ogg'
 	var/illusions = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shields no longer block projectiles.
Energy shields and cult mirror shields still block projectiles.

## Why It's Good For The Game

Shields should not be able to block projectiles entirely, especially the security ones which end with security fighting using projectiles while blocking projectiles themselves.
Energy shields and cult shields will still block projectiles.
Shields were weak to projectiles before and broke easily, but getting 1 or 2 bullets of full invulnerability from bullets is a bit cheesy and removing this, for now, is way easier than reworking the entire bodge of a blocking system we have.

## Changelog
:cl:
tweak: Riot shields, Roman shields, Goliath shields no longer block bullets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
