### PR TITLE
Head revs cannot deplete flashes.

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -269,7 +269,7 @@
 		H.dna.remove_mutation(CLOWNMUT)
 
 	if(give_flash)
-		var/obj/item/assembly/flash/T = new(H)
+		var/obj/item/assembly/flash/handheld/T = new(H)
 		var/list/slots = list (
 			"backpack" = ITEM_SLOT_BACKPACK,
 			"left pocket" = ITEM_SLOT_LPOCKET,

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -269,7 +269,7 @@
 		H.dna.remove_mutation(CLOWNMUT)
 
 	if(give_flash)
-		var/obj/item/assembly/flash/handheld/strong/T = new(H)
+		var/obj/item/assembly/flash/T = new(H)
 		var/list/slots = list (
 			"backpack" = ITEM_SLOT_BACKPACK,
 			"left pocket" = ITEM_SLOT_LPOCKET,

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -184,6 +184,10 @@
 			return FALSE
 		if(FLASH_USE_BURNOUT)
 			burn_out()
+	if(is_head_revolutionary(user) && !burnt_out)
+		//Flash will drain to a minimum of 1 charge when used by a head rev.
+		if(bulb.charges_left < rand(2, initial(bulb.charges_left) - 1))
+			bulb.charges_left ++
 	last_trigger = world.time
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
 	flash_lighting_fx(FLASH_LIGHT_RANGE, light_power, light_color)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes https://github.com/BeeStation/BeeStation-Hornet/pull/4231
Flashes can still be examined to see how many charges they have left.
Head revs spawn with a normal flash.
When a head rev uses a flash it will gain a charge at a random probability inversely proportional to the number of charges left. (When there is only 1 charge or fewer left, an extra charge will always be added, the less charges there are the higher the chance the flash has to recharge)

## Why It's Good For The Game

Prevents metaing head rev flashes, still allows examining to see how many charges are left on a flash.

## Changelog
:cl:
tweak: Head revs now use a normal flash
tweak: When a head rev uses a flash it will gain charges.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
