### PR TITLE
Revert "Removes wishgranter from lavaland (#4263)" and does it the right way

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -27,6 +27,14 @@
 	description = "WELCOME TO CLOWN PLANET! HONK HONK HONK etc.!"
 	suffix = "lavaland_biodome_clown_planet.dmm"
 
+/datum/map_template/ruin/lavaland/cube
+	name = "The Wishgranter Cube"
+	id = "wishgranter-cube"
+	description = "Nothing good can come from this. Learn from their mistakes and turn around."
+	suffix = "lavaland_surface_cube.dmm"
+	cost = 10
+	allow_duplicates = FALSE
+
 /datum/map_template/ruin/lavaland/seed_vault
 	name = "Seed Vault"
 	id = "seed-vault"
@@ -214,7 +222,7 @@
 	description = "Mystery to be solved."
 	suffix = "lavaland_surface_puzzle.dmm"
 	cost = 5
-
+  
 /datum/map_template/ruin/lavaland/elite_tumor
 	name = "Pulsating Tumor"
 	id = "tumor"

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -38,3 +38,6 @@
 #_maps/RandomRuins/LavaRuins/lavaland_surface_cultaltar.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_swarmer_crash.dmm
+
+##SELFANTAG
+_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm


### PR DESCRIPTION
## About The Pull Request

Uses config instead of removing code

## Why It's Good For The Game

self antag is bad

## Changelog
:cl:
config: The map blacklist config is used to disable the Wishgranter ruin instead of removing the template
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
