### PR TITLE
Readds the wishgranter spawn datum.

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -35,6 +35,14 @@
 	cost = 10
 	allow_duplicates = FALSE
 
+/datum/map_template/ruin/lavaland/cube
+	name = "The Wishgranter Cube"
+	id = "wishgranter-cube"
+	description = "Nothing good can come from this. Learn from their mistakes and turn around."
+	suffix = "lavaland_surface_cube.dmm"
+	cost = 10
+	allow_duplicates = FALSE
+
 /datum/map_template/ruin/lavaland/seed_vault
 	name = "Seed Vault"
 	id = "seed-vault"
@@ -222,7 +230,7 @@
 	description = "Mystery to be solved."
 	suffix = "lavaland_surface_puzzle.dmm"
 	cost = 5
-  
+
 /datum/map_template/ruin/lavaland/elite_tumor
 	name = "Pulsating Tumor"
 	id = "tumor"


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#4263

**!!NOTE: WISHGRANTER WAS ALREADY IN THE RUIN BLACKLIST!!**

Removing a ruin should either be:
 - Full removal from files including map
 - Added to the ruins blacklist.

Removing the datum is a poor solution, since it doesn't remove the large map file and is less helpful for downstream that might want to have it enabled in config.

🆑
code: Readds the wishgranter map file datum since it was blacklisted anyway.
/🆑