### PR TITLE
Plasmaman now have there own catagory in equip outfit menu

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -521,7 +521,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [ADMIN_LOOKUPFLW(H)] to [dresscode].</span>")
 
 /client/proc/robust_dress_shop()
-	var/list/outfits = list("Naked","Custom","As Plasmaman job...","As Job...")
+	var/list/outfits = list("Naked","Custom","As Plasmaman...","As Job...")
 	var/list/paths = subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman)
 	for(var/path in paths)
 		var/datum/outfit/O = path //not much to initalize here but whatever
@@ -536,14 +536,14 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		dresscode = outfits[dresscode]
 
 	if(dresscode == "As Plasmaman job...")
-		var/list/job_paths = subtypesof(/datum/plasmaman/job)
+		var/list/job_paths = subtypesof(/datum/plasmaman)
 		var/list/job_outfits = list()
 		for(var/path in job_paths)
 			var/datum/outfit/O = path
 			if(initial(O.can_be_admin_equipped))
 				job_outfits[initial(O.name)] = path
 
-		dresscode = input("Select plasmaman job equipment", "Robust quick dress shop") as null|anything in sortList(job_outfits)
+		dresscode = input("Select plasmaman equipment", "Robust quick dress shop") as null|anything in sortList(job_outfits)
 		dresscode = job_outfits[dresscode]
 		if(isnull(dresscode))
 			return

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -521,8 +521,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [ADMIN_LOOKUPFLW(H)] to [dresscode].</span>")
 
 /client/proc/robust_dress_shop()
-	var/list/outfits = list("Naked","Custom","As Job...")
-	var/list/paths = subtypesof(/datum/outfit) - typesof(/datum/outfit/job)
+	var/list/outfits = list("Naked","Custom","As Plasmaman job...","As Job...")
+	var/list/paths = subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman)
 	for(var/path in paths)
 		var/datum/outfit/O = path //not much to initalize here but whatever
 		if(initial(O.can_be_admin_equipped))
@@ -534,6 +534,19 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 	if (outfits[dresscode])
 		dresscode = outfits[dresscode]
+
+	if(dresscode == "As Plasmaman job...")
+		var/list/job_paths = subtypesof(/datum/plasmaman/job)
+		var/list/job_outfits = list()
+		for(var/path in job_paths)
+			var/datum/outfit/O = path
+			if(initial(O.can_be_admin_equipped))
+				job_outfits[initial(O.name)] = path
+
+		dresscode = input("Select plasmaman job equipment", "Robust quick dress shop") as null|anything in sortList(job_outfits)
+		dresscode = job_outfits[dresscode]
+		if(isnull(dresscode))
+			return
 
 	if (dresscode == "As Job...")
 		var/list/job_paths = subtypesof(/datum/outfit/job)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -521,8 +521,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [ADMIN_LOOKUPFLW(H)] to [dresscode].</span>")
 
 /client/proc/robust_dress_shop()
-	var/list/outfits = list("Naked","Custom","As Plasmaman...","As Job...")
-	var/list/paths = subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman)
+	var/list/outfits = list("Naked","Custom","As Job...","As Job(Plasmaman)...", "Debug")
+	var/list/paths = subtypesof(/datum/outfit) - typesof(/datum/outfit/job) - typesof(/datum/outfit/plasmaman) - typesof(/datum/outfit/debug)
 	for(var/path in paths)
 		var/datum/outfit/O = path //not much to initalize here but whatever
 		if(initial(O.can_be_admin_equipped))
@@ -535,7 +535,22 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if (outfits[dresscode])
 		dresscode = outfits[dresscode]
 
-	if(dresscode == "As Plasmaman...")
+
+
+	if (dresscode == "As Job...")
+		var/list/job_paths = subtypesof(/datum/outfit/job)
+		var/list/job_outfits = list()
+		for(var/path in job_paths)
+			var/datum/outfit/O = path
+			if(initial(O.can_be_admin_equipped))
+				job_outfits[initial(O.name)] = path
+
+		dresscode = input("Select job equipment", "Robust quick dress shop") as null|anything in sortList(job_outfits)
+		dresscode = job_outfits[dresscode]
+		if(isnull(dresscode))
+			return
+
+	if(dresscode == "As Job(Plasmaman)...")
 		var/list/job_paths = subtypesof(/datum/outfit/plasmaman)
 		var/list/job_outfits = list()
 		for(var/path in job_paths)
@@ -548,16 +563,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		if(isnull(dresscode))
 			return
 
-	if (dresscode == "As Job...")
-		var/list/job_paths = subtypesof(/datum/outfit/job)
-		var/list/job_outfits = list()
-		for(var/path in job_paths)
-			var/datum/outfit/O = path
-			if(initial(O.can_be_admin_equipped))
-				job_outfits[initial(O.name)] = path
-
-		dresscode = input("Select job equipment", "Robust quick dress shop") as null|anything in sortList(job_outfits)
-		dresscode = job_outfits[dresscode]
+	if(dresscode == "Debug")
+		dresscode = /datum/outfit/debug
 		if(isnull(dresscode))
 			return
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -536,7 +536,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		dresscode = outfits[dresscode]
 
 	if(dresscode == "As Plasmaman job...")
-		var/list/job_paths = subtypesof(/datum/plasmaman)
+		var/list/job_paths = subtypesof(/datum/outfit/plasmaman)
 		var/list/job_outfits = list()
 		for(var/path in job_paths)
 			var/datum/outfit/O = path

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -535,7 +535,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	if (outfits[dresscode])
 		dresscode = outfits[dresscode]
 
-	if(dresscode == "As Plasmaman job...")
+	if(dresscode == "As Plasmaman...")
 		var/list/job_paths = subtypesof(/datum/outfit/plasmaman)
 		var/list/job_outfits = list()
 		for(var/path in job_paths)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -1,3 +1,26 @@
+/datum/outfit/debug //Debug objs plus hardsuit
+	name = "Debug outfit"
+	uniform = /obj/item/clothing/under/misc/patriotsuit
+	suit = /obj/item/clothing/suit/space/hardsuit/syndi/elite
+	mask = /obj/item/clothing/mask/gas/welding/up
+	gloves = /obj/item/clothing/gloves/combat
+	belt = /obj/item/storage/belt/utility/chief/full
+	shoes = /obj/item/clothing/shoes/magboots/advance
+	id = /obj/item/card/id/ert
+	suit_store = /obj/item/tank/internals/oxygen
+	internals_slot = ITEM_SLOT_SUITSTORE
+	glasses = /obj/item/clothing/glasses/meson/night
+	ears = /obj/item/radio/headset/headset_cent/commander
+	box = /obj/item/storage/box/debugtools
+	back = /obj/item/storage/backpack/holding
+	backpack_contents = list(/obj/item/flashlight/emp/debug=1,\
+		/obj/item/gun/magic/wand/resurrection/debug=1,\
+		/obj/item/melee/transforming/energy/axe=1,\
+		/obj/item/storage/part_replacer/bluespace/tier4=1,\
+		/obj/item/debug/human_spawner=1,\
+		/obj/item/debug/omnitool=1
+		)
+
 /datum/outfit/space
 	name = "Standard Space Gear"
 
@@ -455,25 +478,4 @@
 	id = /obj/item/card/id/job/clown
 	ears = /obj/item/radio/headset/headset_srv
 
-/datum/outfit/debug //Debug objs plus hardsuit
-	name = "Debug outfit"
-	uniform = /obj/item/clothing/under/misc/patriotsuit
-	suit = /obj/item/clothing/suit/space/hardsuit/syndi/elite
-	mask = /obj/item/clothing/mask/gas/welding/up
-	gloves = /obj/item/clothing/gloves/combat
-	belt = /obj/item/storage/belt/utility/chief/full
-	shoes = /obj/item/clothing/shoes/magboots/advance
-	id = /obj/item/card/id/ert
-	suit_store = /obj/item/tank/internals/oxygen
-	internals_slot = ITEM_SLOT_SUITSTORE
-	glasses = /obj/item/clothing/glasses/meson/night
-	ears = /obj/item/radio/headset/headset_cent/commander
-	box = /obj/item/storage/box/debugtools
-	back = /obj/item/storage/backpack/holding
-	backpack_contents = list(/obj/item/flashlight/emp/debug=1,\
-		/obj/item/gun/magic/wand/resurrection/debug=1,\
-		/obj/item/melee/transforming/energy/axe=1,\
-		/obj/item/storage/part_replacer/bluespace/tier4=1,\
-		/obj/item/debug/human_spawner=1,\
-		/obj/item/debug/omnitool=1
-		)
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In the same way you have catagory for job outfits you have for plasmaman outfits

![jobmenu](https://user-images.githubusercontent.com/36102060/117946894-fcacda80-b30f-11eb-9f2f-2299f2f544bc.gif)


Also makes debug show up higher in the list, press d once to jump to it

## Why It's Good For The Game

QoL for admins to more easily find outfits between all the plasmaman ones

Also arch really wanted the debug thingy

## Changelog
:cl:
tweak: Admin equip outfit now has plasmaman clothing as sub catagory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
