### PR TITLE
Removes C*der

### DIFF
--- a/config/Sage/admin_ranks.txt
+++ b/config/Sage/admin_ranks.txt
@@ -89,7 +89,7 @@ Include = EVERYTHING
 Exclude =
 Edit = EVERYTHING
 
-Name = Coder
+Name = Code Maintainer
 Include = DEBUG VAREDIT SERVER SPAWN POLL
 Exclude = AUTOADMIN
 Edit =

--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -89,7 +89,7 @@ Include = EVERYTHING
 Exclude =
 Edit = EVERYTHING
 
-Name = Coder
+Name = Code Maintainer
 Include = DEBUG VAREDIT SERVER SPAWN POLL
 Exclude = AUTOADMIN
 Edit =


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The in game rank for maintainers refers to them as mere c\*ders, changes it to "C*de Maintainer"

(because according to our marketing team, "High Overseer" was too condescending)

## Why It's Good For The Game

More diplomatic power for me, more review rations for thee

## Changelog
:cl:
config: renames "coder" rank to "code maintainer"
/:cl:
