### PR TITLE
Fix load custom outfit

### DIFF
--- a/code/modules/admin/outfits.dm
+++ b/code/modules/admin/outfits.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 	var/outfit_file = input("Pick outfit json file:", "File") as null|file
 	if(!outfit_file)
 		return
-	var/filedata = rustg_file_read(outfit_file)
+	var/filedata = file2text(outfit_file)
 	var/json = json_decode(filedata)
 	if(!json)
 		to_chat(admin,"<span class='warning'>JSON decode error.</span>")

--- a/code/modules/admin/outfits.dm
+++ b/code/modules/admin/outfits.dm
@@ -241,3 +241,4 @@ GLOBAL_LIST_EMPTY(custom_outfits) //Admin created outfits
 
 	GLOB.custom_outfits.Add(O)
 	message_admins("[key_name(usr)] created \"[O.name]\" outfit!")
+	


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

rustg_load_file returned null, thus parsing failed and threw a runtime. Now you can save/load outfits from localy saved files

## Why It's Good For The Game

Aside from making your very own CC OC(dont steal) will also allow people with event idea's to make the outfits before hand and rapidly deploy them onto people without having to make a PR to hard code them in, so fun for all.

## Changelog
:cl:
fix: admin outfit manager can load outfits from json files
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
