### PR TITLE
Adds lazysynthify proc

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1115,6 +1115,17 @@
 	else
 		to_chat(target, "<span class='warning'>You can't piggyback ride [src] right now!</span>")
 
+/mob/living/carbon/human/proc/lazysynthify(mob/M)
+	var/mob/living/carbon/human/H = M
+	ADD_TRAIT(H, TRAIT_NODISMEMBER, "synth_trait")
+	ADD_TRAIT(H, TRAIT_NOBREATH, "synth_trait")
+	ADD_TRAIT(H, TRAIT_NOLIMBDISABLE, "synth_trait")
+	ADD_TRAIT(H, TRAIT_NOHUNGER, "synth_trait")
+	if(!(MOB_ROBOTIC in H.mob_biotypes))
+		H.mob_biotypes += MOB_ROBOTIC
+		if(MOB_ORGANIC in H.mob_biotypes)
+			H.mob_biotypes -= MOB_ORGANIC
+
 /mob/living/carbon/human/buckle_mob(mob/living/target, force = FALSE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0)
 	if(!force)//humans are only meant to be ridden through piggybacking and special cases
 		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1122,10 +1122,16 @@
 	ADD_TRAIT(H, TRAIT_NOLIMBDISABLE, "synth_trait")
 	ADD_TRAIT(H, TRAIT_NOHUNGER, "synth_trait")
 	H.dna.species.punchdamage = 14
+	H.dna.species.armor = 25
+	H.grant_language(/datum/language/machine)
+	H.grant_language(/datum/language/voltaic)
+	H.grant_language(/datum/language/draconic)
+	H.grant_language(/datum/language/moffic)
 	if(!(MOB_ROBOTIC in H.mob_biotypes))
 		H.mob_biotypes += MOB_ROBOTIC
 		if(MOB_ORGANIC in H.mob_biotypes)
 			H.mob_biotypes -= MOB_ORGANIC
+
 
 /mob/living/carbon/human/buckle_mob(mob/living/target, force = FALSE, check_loc = TRUE, lying_buckle = FALSE, hands_needed = 0, target_hands_needed = 0)
 	if(!force)//humans are only meant to be ridden through piggybacking and special cases

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1121,6 +1121,7 @@
 	ADD_TRAIT(H, TRAIT_NOBREATH, "synth_trait")
 	ADD_TRAIT(H, TRAIT_NOLIMBDISABLE, "synth_trait")
 	ADD_TRAIT(H, TRAIT_NOHUNGER, "synth_trait")
+	H.dna.species.punchdamage = 14
 	if(!(MOB_ROBOTIC in H.mob_biotypes))
 		H.mob_biotypes += MOB_ROBOTIC
 		if(MOB_ORGANIC in H.mob_biotypes)

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -27,7 +27,7 @@
 	id = "military_synth"
 	armor = 25
 	punchdamage = 14
-	disguise_fail_health = 50
+	disguise_fail_health = 50 //This literally does nothing. This doesnt work.
 	changesource_flags = MIRROR_BADMIN | WABBAJACK
 
 /datum/species/synth/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
@@ -47,7 +47,7 @@
 	else
 		return ..()
 
-
+//Mutant body parts dont work. Cat ears and tail fail to apply. Lizard digitigrade legs fail to apply.
 /datum/species/synth/proc/assume_disguise(datum/species/S, mob/living/carbon/human/H)
 	if(S && !istype(S, type))
 		name = S.name
@@ -118,7 +118,7 @@
 
 /datum/species/synth/handle_mutant_bodyparts(mob/living/carbon/human/H, forced_colour)
 	if(fake_species)
-		fake_species.handle_body(H,forced_colour)
+		fake_species.handle_mutant_bodyparts(H,forced_colour)
 	else
 		return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a lazysynthify proc to human.dm to allow for creation of synths that are functionally the same to the current buggy mess of synths, but the mob can retain unique limbs/organs like cat ears and digitigrade legs.

Also, adds code comments to synth.dm
~~(I still need to work out how to increase punch damage using this)~~ done
(This branch was originally for buffing the disabler, thats why its called disablerboof)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Synths are dog ass code, rivaling IPCs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: lazysynthify proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
