### PR TITLE
Status message small tweaks

### DIFF
--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -18,6 +18,3 @@
 
 	update_icon(preferred_form)
 	updateghostimages()
-
-	if(mind?.current)
-		client.tgui_panel?.give_dead_popup()

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -2,7 +2,7 @@
 	update_z(null)
 	if (client)
 		client.images -= (GLOB.ghost_images_default+GLOB.ghost_images_simple)
-		client.tgui_panel?.clear_dead_poup()
+		client.tgui_panel?.clear_dead_popup()
 
 	if(observetarget)
 		if(ismob(observetarget))

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -99,6 +99,9 @@
 		var/datum/soullink/S = s
 		S.sharerDies(gibbed)
 
+	if(mind?.current)
+		client.tgui_panel?.give_dead_popup()
+
 	return TRUE
 
 /mob/living/carbon/death(gibbed)

--- a/code/modules/tgui_panel/stat.dm
+++ b/code/modules/tgui_panel/stat.dm
@@ -97,7 +97,7 @@
  *
  * Clears the death message
  */
-/datum/tgui_panel/proc/clear_dead_poup()
+/datum/tgui_panel/proc/clear_dead_popup()
 	if(!is_ready())
 		return
 	window.send_message("stat/clearDeadPopup", list())

--- a/code/modules/tgui_panel/stat.dm
+++ b/code/modules/tgui_panel/stat.dm
@@ -69,6 +69,17 @@
 	payload["title"] = title
 	payload["text"] = text
 	window.send_message("stat/antagPopup", payload)
+	addtimer(CALLBACK(src, .proc/clear_antagonist_popup), 3 MINUTES)
+
+/**
+ * public
+ *
+ * Clears the antagonist popup.
+ */
+/datum/tgui_panel/proc/clear_antagonist_popup()
+	if(!is_ready())
+		return
+	window.send_message("stat/clearAntagPopup", list())
 
 /**
  * public
@@ -79,6 +90,7 @@
 	if(!is_ready())
 		return
 	window.send_message("stat/deadPopup", list())
+	addtimer(CALLBACK(src, .proc/clear_dead_poup), 3 MINUTES)
 
 /**
  * public

--- a/code/modules/tgui_panel/stat.dm
+++ b/code/modules/tgui_panel/stat.dm
@@ -69,7 +69,6 @@
 	payload["title"] = title
 	payload["text"] = text
 	window.send_message("stat/antagPopup", payload)
-	addtimer(CALLBACK(src, .proc/clear_antagonist_popup), 3 MINUTES)
 
 /**
  * public

--- a/code/modules/tgui_panel/stat.dm
+++ b/code/modules/tgui_panel/stat.dm
@@ -90,7 +90,7 @@
 	if(!is_ready())
 		return
 	window.send_message("stat/deadPopup", list())
-	addtimer(CALLBACK(src, .proc/clear_dead_poup), 3 MINUTES)
+	addtimer(CALLBACK(src, .proc/clear_dead_popup), 3 MINUTES)
 
 /**
  * public

--- a/code/modules/tgui_panel/stat.dm
+++ b/code/modules/tgui_panel/stat.dm
@@ -90,7 +90,6 @@
 	if(!is_ready())
 		return
 	window.send_message("stat/deadPopup", list())
-	addtimer(CALLBACK(src, .proc/clear_dead_popup), 3 MINUTES)
 
 /**
  * public


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Death message will appear when your mob dies (no longer appears when you simply ghost).

## Why It's Good For The Game



## Changelog
:cl:
tweak: Death pop up will only appear when your mob dies, not on ghosting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
