### PR TITLE
Station traits are less common, can't be rolled twice and tweaks some weights

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -34,9 +34,9 @@ PROCESSING_SUBSYSTEM_DEF(station)
 			continue //Dont add abstract ones to it
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
 
-	var/positive_trait_count = pick(12;0, 5;1, 1;2)
-	var/neutral_trait_count = pick(5;0, 10;1, 3;2)
-	var/negative_trait_count = pick(12;0, 5;1, 1;2)
+	var/positive_trait_count = pick(20;0, 5;1, 1;2)
+	var/neutral_trait_count = pick(10;0, 10;1, 3;2)
+	var/negative_trait_count = pick(20;0, 5;1, 1;2)
 
 	pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
 	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
@@ -48,8 +48,11 @@ PROCESSING_SUBSYSTEM_DEF(station)
 		return
 	for(var/iterator in 1 to amount)
 		var/datum/station_trait/picked_trait = pickweight(selectable_traits_by_types[trait_type]) //Rolls from the table for the specific trait type
+		if(!picked_trait)
+			return
 		picked_trait = new picked_trait()
 		station_traits += picked_trait
+		selectable_traits_by_types[picked_trait.trait_type] -= picked_trait.type		//We don't want it to roll trait twice
 		if(!picked_trait.blacklist)
 			continue
 		for(var/i in picked_trait.blacklist)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -8,7 +8,7 @@
 /datum/station_trait/unnatural_atmosphere
 	name = "Unnatural atmospherical properties"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 5
+	weight = 3
 	show_in_report = TRUE
 	report_message = "System's local planet has irregular atmospherical properties"
 	trait_to_give = STATION_TRAIT_UNNATURAL_ATMOSPHERE
@@ -47,7 +47,7 @@
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 5
+	weight = 1
 	show_in_report = TRUE
 	report_message = "Please be nice to him."
 	blacklist = list(/datum/station_trait/announcement_medbot)
@@ -59,7 +59,7 @@
 /datum/station_trait/announcement_medbot
 	name = "Announcement \"System\""
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 1
+	weight = 5
 	show_in_report = TRUE
 	report_message = "Our announcement system is under scheduled maintanance at the moment. Thankfully, we have a backup."
 	blacklist = list(/datum/station_trait/announcement_intern)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -47,7 +47,7 @@
 /datum/station_trait/announcement_intern
 	name = "Announcement Intern"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 1
+	weight = 3
 	show_in_report = TRUE
 	report_message = "Please be nice to him."
 	blacklist = list(/datum/station_trait/announcement_medbot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Traits cannot be rolled twice.
Traits are less common overall.
Atmos trait is less common.
Intern is less common.
Medbot is more common now.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Same station trait cannot appear twice (shouldn't affect anything in game).
tweak: Station traits will appear less often.
tweak: Intern and unnatural atmosphere are less common, medbot announcer is more common now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
