### PR TITLE
Fixes proximity monitor runtime

### DIFF
--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -32,7 +32,8 @@
 	host = null
 	last_host_loc = null
 	hasprox_receiver = null
-	QDEL_LIST(checkers)
+	if(!isnull(checkers))
+		QDEL_LIST(checkers)
 	return ..()
 
 /datum/proximity_monitor/proc/HandleMove()

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -107,7 +107,8 @@
 		return INITIALIZE_HINT_QDEL
 
 /obj/effect/abstract/proximity_checker/Destroy()
-	monitor.checkers -= src
+	if(monitor.checkers)
+		monitor.checkers -= src
 	monitor = null
 	return ..()
 

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -32,8 +32,7 @@
 	host = null
 	last_host_loc = null
 	hasprox_receiver = null
-	if(!isnull(checkers))
-		QDEL_LIST(checkers)
+	QDEL_LIST(checkers)
 	return ..()
 
 /datum/proximity_monitor/proc/HandleMove()
@@ -108,7 +107,7 @@
 		return INITIALIZE_HINT_QDEL
 
 /obj/effect/abstract/proximity_checker/Destroy()
-	LAZYREMOVE(monitor.checkers, src)
+	monitor.checkers -= src
 	monitor = null
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#4275 fixed harddel but lazydeleting from list can null it. This fixes runtime while trying to qdel empty list.

## Why It's Good For The Game

## Changelog
:cl:
fix: Fixed runtime when qdeleting proximity monitor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
