### PR TITLE
Reverts making space sharks sentient

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -33,8 +33,6 @@
 			fish = new (C.loc)
 		else
 			fish = new /mob/living/simple_animal/hostile/carp/megacarp(C.loc)
-			fish.flavor_text = FLAVOR_TEXT_EVIL
-			fish.set_playable()
 
 			fishannounce(fish) //Prefer to announce the megacarps over the regular fishies
 	fishannounce(fish)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Very bad idea that was right.

## Why It's Good For The Game
Carp migration is a very common event
One of the mobs was given auto-sentience

Said mob isn't strong enough to actually engage the crew like the space dragon and thus literally only exists to break windows and space the station. 

This hasn't been fun for people. 

## Changelog
:cl:Froststahr
del: Sapient space sharks have been hunted to extinction, leaving only non-sapient ones in the wild. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
