### PR TITLE
Removes bz gas selling, saves atmos. 

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -141,7 +141,6 @@
 	var/obj/machinery/portable_atmospherics/canister/C = O
 	var/worth = 10
 
-	worth += C.air_contents.get_moles(/datum/gas/bz)*4
 	worth += C.air_contents.get_moles(/datum/gas/stimulum)*100
 	worth += C.air_contents.get_moles(/datum/gas/hypernoblium)*1000
 	worth += C.air_contents.get_moles(/datum/gas/miasma)*10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### _**This PR is not about economy balance, so don't refer to gas elasticity unless you're suggesting making BZ so elastic that it's not worthwhile**_

## Why It's Good For The Game

You want a real reason to kill gas mining? It's hell on the CPU. 

It activates so many turfs, ye ole miasma farm isn't terribly much more difficult to pull off and is significantly less impactful. 

![image](https://user-images.githubusercontent.com/40812746/119048169-7c781c00-b984-11eb-9231-2f1dcabd9f53.png)
(For Reference, that number should usually be about 25-50)
![image](https://user-images.githubusercontent.com/40812746/119048161-797d2b80-b984-11eb-9b65-eb48c22b0c7e.png)
![image](https://user-images.githubusercontent.com/40812746/119048169-7c781c00-b984-11eb-9231-2f1dcabd9f53.png)


## Changelog
:cl: Froststahr
del: For performance reasons, bz can no longer be sold. 
/:cl:
