### PR TITLE
Various trait-related bugfixes

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -210,7 +210,7 @@
 		scarcounter++
 
 	if(M.getToxLoss() && M.getToxLoss() <= threshhold)
-		M.adjustToxLoss(-power, null, TRUE)
+		M.adjustToxLoss(-power, FALSE, TRUE)
 
 	if(healed)
 		if(prob(10))

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -210,7 +210,7 @@
 		scarcounter++
 
 	if(M.getToxLoss() && M.getToxLoss() <= threshhold)
-		M.adjustToxLoss(-power, NULL, TRUE)
+		M.adjustToxLoss(-power, null, TRUE)
 
 	if(healed)
 		if(prob(10))

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -210,7 +210,7 @@
 		scarcounter++
 
 	if(M.getToxLoss() && M.getToxLoss() <= threshhold)
-		M.adjustToxLoss(-power, forced=TRUE)
+		M.adjustToxLoss(-power, NULL, TRUE)
 
 	if(healed)
 		if(prob(10))

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -210,7 +210,7 @@
 		scarcounter++
 
 	if(M.getToxLoss() && M.getToxLoss() <= threshhold)
-		M.adjustToxLoss(-power)
+		M.adjustToxLoss(-power, forced=TRUE)
 
 	if(healed)
 		if(prob(10))

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -433,7 +433,7 @@
 			if(iscarbon(L))
 				L.adjustBruteLoss(-3.5)
 				L.adjustFireLoss(-3.5)
-				L.adjustToxLoss(-3.5, null, TRUE) //Because Slime People are people too
+				L.adjustToxLoss(-3.5, FALSE, TRUE) //Because Slime People are people too
 				L.adjustOxyLoss(-3.5)
 				L.adjustStaminaLoss(-3.5)
 				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3.5)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -433,7 +433,7 @@
 			if(iscarbon(L))
 				L.adjustBruteLoss(-3.5)
 				L.adjustFireLoss(-3.5)
-				L.adjustToxLoss(-3.5, NULL, TRUE) //Because Slime People are people too
+				L.adjustToxLoss(-3.5, null, TRUE) //Because Slime People are people too
 				L.adjustOxyLoss(-3.5)
 				L.adjustStaminaLoss(-3.5)
 				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3.5)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -433,7 +433,7 @@
 			if(iscarbon(L))
 				L.adjustBruteLoss(-3.5)
 				L.adjustFireLoss(-3.5)
-				L.adjustToxLoss(-3.5, forced = TRUE) //Because Slime People are people too
+				L.adjustToxLoss(-3.5, NULL, TRUE) //Because Slime People are people too
 				L.adjustOxyLoss(-3.5)
 				L.adjustStaminaLoss(-3.5)
 				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3.5)

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -119,7 +119,7 @@
 			spell.update_icon()
 		rewarded.adjustBruteLoss(-25)
 		rewarded.adjustFireLoss(-25)
-		rewarded.adjustToxLoss(-25, null, TRUE)
+		rewarded.adjustToxLoss(-25, FALSE, TRUE)
 		rewarded.adjustOxyLoss(-25)
 		rewarded.adjustCloneLoss(-25)
 

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -119,7 +119,7 @@
 			spell.update_icon()
 		rewarded.adjustBruteLoss(-25)
 		rewarded.adjustFireLoss(-25)
-		rewarded.adjustToxLoss(-25, forced=TRUE)
+		rewarded.adjustToxLoss(-25, NULL, TRUE)
 		rewarded.adjustOxyLoss(-25)
 		rewarded.adjustCloneLoss(-25)
 

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -119,7 +119,7 @@
 			spell.update_icon()
 		rewarded.adjustBruteLoss(-25)
 		rewarded.adjustFireLoss(-25)
-		rewarded.adjustToxLoss(-25)
+		rewarded.adjustToxLoss(-25, forced=TRUE)
 		rewarded.adjustOxyLoss(-25)
 		rewarded.adjustCloneLoss(-25)
 

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -119,7 +119,7 @@
 			spell.update_icon()
 		rewarded.adjustBruteLoss(-25)
 		rewarded.adjustFireLoss(-25)
-		rewarded.adjustToxLoss(-25, NULL, TRUE)
+		rewarded.adjustToxLoss(-25, null, TRUE)
 		rewarded.adjustOxyLoss(-25)
 		rewarded.adjustCloneLoss(-25)
 

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -120,7 +120,7 @@
 	category = CAT_MISC
 
 /obj/item/banner/medical/special_inspiration(mob/living/carbon/human/H)
-	H.adjustToxLoss(-15, null, TRUE)
+	H.adjustToxLoss(-15, FALSE, TRUE)
 	H.setOxyLoss(0)
 	H.reagents.add_reagent(/datum/reagent/medicine/inaprovaline, 5)
 

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -120,7 +120,7 @@
 	category = CAT_MISC
 
 /obj/item/banner/medical/special_inspiration(mob/living/carbon/human/H)
-	H.adjustToxLoss(-15, NULL, TRUE)
+	H.adjustToxLoss(-15, null, TRUE)
 	H.setOxyLoss(0)
 	H.reagents.add_reagent(/datum/reagent/medicine/inaprovaline, 5)
 

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -120,7 +120,7 @@
 	category = CAT_MISC
 
 /obj/item/banner/medical/special_inspiration(mob/living/carbon/human/H)
-	H.adjustToxLoss(-15)
+	H.adjustToxLoss(-15, forced=TRUE)
 	H.setOxyLoss(0)
 	H.reagents.add_reagent(/datum/reagent/medicine/inaprovaline, 5)
 

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -120,7 +120,7 @@
 	category = CAT_MISC
 
 /obj/item/banner/medical/special_inspiration(mob/living/carbon/human/H)
-	H.adjustToxLoss(-15, forced=TRUE)
+	H.adjustToxLoss(-15, NULL, TRUE)
 	H.setOxyLoss(0)
 	H.reagents.add_reagent(/datum/reagent/medicine/inaprovaline, 5)
 

--- a/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
@@ -72,7 +72,7 @@
 		if(!L.toxloss && !L.staminaloss && !L.bruteloss && !L.fireloss)
 			continue
 		if(use_power(2))
-			L.adjustToxLoss(-10)
+			L.adjustToxLoss(-10, forced=TRUE)
 			L.adjustStaminaLoss(-10)
 			L.adjustBruteLoss(-2)
 			L.adjustFireLoss(-2)

--- a/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
@@ -72,7 +72,7 @@
 		if(!L.toxloss && !L.staminaloss && !L.bruteloss && !L.fireloss)
 			continue
 		if(use_power(2))
-			L.adjustToxLoss(-10, null, TRUE)
+			L.adjustToxLoss(-10, FALSE, TRUE)
 			L.adjustStaminaLoss(-10)
 			L.adjustBruteLoss(-2)
 			L.adjustFireLoss(-2)

--- a/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/prosperity_prism.dm
@@ -72,7 +72,7 @@
 		if(!L.toxloss && !L.staminaloss && !L.bruteloss && !L.fireloss)
 			continue
 		if(use_power(2))
-			L.adjustToxLoss(-10, forced=TRUE)
+			L.adjustToxLoss(-10, null, TRUE)
 			L.adjustStaminaLoss(-10)
 			L.adjustBruteLoss(-2)
 			L.adjustFireLoss(-2)

--- a/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
@@ -68,7 +68,7 @@
 			M.adjustBruteLoss(-5, FALSE)
 			M.adjustFireLoss(-5, FALSE)
 			M.adjustOxyLoss(-5, FALSE)
-			M.adjustToxLoss(-5, FALSE)
+			M.adjustToxLoss(-5, FALSE, TRUE)
 			M.adjustCloneLoss(-5)
 		else
 			visible_message("<span class='neovgre'>\The [src] fails to heal [M]!</span>", "<span class='neovgre'>There is insufficient vitality to heal your wounds!</span>")

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -497,7 +497,7 @@
 		human_user.adjustBruteLoss(-10, FALSE)
 		human_user.adjustFireLoss(-10, FALSE)
 		human_user.adjustStaminaLoss(-10, FALSE)
-		human_user.adjustToxLoss(-10, FALSE)
+		human_user.adjustToxLoss(-10, FALSE, TRUE)
 		human_user.adjustOxyLoss(-10)
 
 /obj/effect/proc_holder/spell/targeted/shed_human_form

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -130,7 +130,7 @@
 	var/mob/living/carbon/human/human_user = user
 	human_user.adjustBruteLoss(-4, FALSE)
 	human_user.adjustFireLoss(-4, FALSE)
-	human_user.adjustToxLoss(-4, FALSE)
+	human_user.adjustToxLoss(-4, FALSE, TRUE)
 	human_user.adjustOxyLoss(-2, FALSE)
 	human_user.adjustStaminaLoss(-20)
 	human_user.AdjustAllImmobility(-10)

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -16,8 +16,6 @@
 
 
 /mob/living/carbon/human/bee_friendly()
-	if(dna?.species?.id == "pod") //bees pollinate plants, duh.
-		return 1
 	if (wear_suit && head && isclothing(wear_suit) && isclothing(head))
 		var/obj/item/clothing/CS = wear_suit
 		var/obj/item/clothing/CH = head

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -495,7 +495,7 @@
 				if(2)
 					L.receive_damage(0,5)
 					Paralyze(100)
-			if((TRAIT_EASYDISMEMBER in L.owner.dna.species.species_traits) && L.body_zone != "chest")
+			if(HAS_TRAIT(L, TRAIT_EASYDISMEMBER) && L.body_zone != "chest")
 				if(prob(20))
 					L.dismember(BRUTE)
 

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -3,8 +3,8 @@
 	id = "ipc"
 	say_mod = "states" //inherited from a user's real species
 	sexes = 0
-	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,TRAIT_EASYDISMEMBER,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH) //all of these + whatever we inherit from the real species
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE)
+	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOBLOOD,ROBOTIC_LIMBS,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH) //all of these + whatever we inherit from the real species
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE,TRAIT_EASYDISMEMBER)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutant_brain = /obj/item/organ/brain/positron
 	mutanteyes = /obj/item/organ/eyes/robotic

--- a/code/modules/mob/living/carbon/human/species_types/apid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/apid.dm
@@ -4,8 +4,9 @@
 	id = "apid"
 	say_mod = "buzzes"
 	default_color = "FFE800"
-	species_traits = list(LIPS, NOEYESPRITES, TRAIT_BEEFRIEND)
-	inherent_biotypes = list(MOB_ORGANIC, MOB_HUMANOID, MOB_BUG)
+	species_traits = list(LIPS,NOEYESPRITES)
+	inherent_traits = list(TRAIT_BEEFRIEND)
+	inherent_biotypes = list(MOB_ORGANIC,MOB_HUMANOID,MOB_BUG)
 	mutanttongue = /obj/item/organ/tongue/bee
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slash.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozelings.dm
@@ -3,8 +3,8 @@
 	id = "oozeling"
 	default_color = "00FF90"
 	say_mod = "blorbles"
-	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,TRAIT_EASYDISMEMBER)
-	inherent_traits = list(TRAIT_TOXINLOVER,TRAIT_NOFIRE,TRAIT_ALWAYS_CLEAN)
+	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR)
+	inherent_traits = list(TRAIT_TOXINLOVER,TRAIT_NOFIRE,TRAIT_ALWAYS_CLEAN,TRAIT_EASYDISMEMBER)
 	hair_color = "mutcolor"
 	hair_alpha = 150
 	mutantlungs = /obj/item/organ/lungs/oozeling

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -4,7 +4,7 @@
 	id = "pod"
 	default_color = "59CE00"
 	species_traits = list(MUTCOLORS,EYECOLOR)
-	inherent_traits = list(TRAIT_ALWAYS_CLEAN)
+	inherent_traits = list(TRAIT_ALWAYS_CLEAN,TRAIT_BEEFRIEND)
 	inherent_factions = list("plants", "vines")
 	attack_verb = "slash"
 	attack_sound = 'sound/weapons/slice.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -2,8 +2,8 @@
 	name = "Squidperson"
 	id = "squid"
 	default_color = "b8dfda"
-	species_traits = list(MUTCOLORS,EYECOLOR,TRAIT_EASYDISMEMBER)
-	inherent_traits = list(TRAIT_NOSLIPALL)
+	species_traits = list(MUTCOLORS,EYECOLOR)
+	inherent_traits = list(TRAIT_NOSLIPALL,TRAIT_EASYDISMEMBER)
 	default_features = list("mcolor" = "FFF") // bald
 	speedmod = 0.5
 	burnmod = 1.5

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -421,10 +421,10 @@ GLOBAL_VAR(medibot_unique_id_gen)
 				if((get_dist(src, patient) <= 1) && (on) && assess_patient(patient))
 					var/healies = heal_amount
 					var/obj/item/storage/firstaid/FA = firstaid
-					if(treatment_method == TOX && isoozeling(patient))
-						healies *= -1.5
 					if(treatment_method == initial(FA.damagetype_healed)) //using the damage specific medkits give bonuses when healing this type of damage.
 						healies *= 1.5
+					if(treatment_method == TOX && HAS_TRAIT(patient, TRAIT_TOXINLOVER))
+						healies *= -1.5
 					if(emagged == 2)
 						patient.reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 5)
 						patient.apply_damage_type((healies*1),treatment_method)

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -32,7 +32,7 @@
 		C.adjustBruteLoss(-5)
 		C.adjustFireLoss(-5)
 		C.adjustOxyLoss(-5)
-		C.adjustToxLoss(-5, NULL, TRUE)
+		C.adjustToxLoss(-5, null, TRUE)
 		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(C))
 		if(guardiancolor)
 			H.color = guardiancolor

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -32,7 +32,7 @@
 		C.adjustBruteLoss(-5)
 		C.adjustFireLoss(-5)
 		C.adjustOxyLoss(-5)
-		C.adjustToxLoss(-5)
+		C.adjustToxLoss(-5, forced=TRUE)
 		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(C))
 		if(guardiancolor)
 			H.color = guardiancolor

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -32,7 +32,7 @@
 		C.adjustBruteLoss(-5)
 		C.adjustFireLoss(-5)
 		C.adjustOxyLoss(-5)
-		C.adjustToxLoss(-5, null, TRUE)
+		C.adjustToxLoss(-5, FALSE, TRUE)
 		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(C))
 		if(guardiancolor)
 			H.color = guardiancolor

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -32,7 +32,7 @@
 		C.adjustBruteLoss(-5)
 		C.adjustFireLoss(-5)
 		C.adjustOxyLoss(-5)
-		C.adjustToxLoss(-5, forced=TRUE)
+		C.adjustToxLoss(-5, NULL, TRUE)
 		var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(C))
 		if(guardiancolor)
 			H.color = guardiancolor

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -116,7 +116,7 @@
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
-	target.adjustToxLoss(-1)
+	target.adjustToxLoss(-1, forced=TRUE)
 	target.adjustOxyLoss(-1)
 	return
 

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -116,7 +116,7 @@
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
-	target.adjustToxLoss(-1, NULL, TRUE)
+	target.adjustToxLoss(-1, null, TRUE)
 	target.adjustOxyLoss(-1)
 	return
 

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -116,7 +116,7 @@
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
-	target.adjustToxLoss(-1, null, TRUE)
+	target.adjustToxLoss(-1, FALSE, TRUE)
 	target.adjustOxyLoss(-1)
 	return
 

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -116,7 +116,7 @@
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
-	target.adjustToxLoss(-1, forced=TRUE)
+	target.adjustToxLoss(-1, NULL, TRUE)
 	target.adjustOxyLoss(-1)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some generic sources of healing to not cause toxin damage to for example oozelings.
Moves a couple of misplaced traits from species_traits to inherent_traits, making them actually functionable for once.


## Why It's Good For The Game

Bugfixes/Oversights.
Closes #4163 - it was never about any species changes, the trait was always there, simply just not working.

## Changelog
:cl:
fix: made some generic healing sources handle toxinlovers properly
fix: made the easy dismemberment trait on several species actually function
fix: made the beelover trait actually function
code: some related code cleanup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
