### PR TITLE
Reworks reworked softcrit.

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -41,7 +41,7 @@
 
 //Health Defines
 #define HEALTH_THRESHOLD_CRIT 0
-#define HEALTH_THRESHOLD_FULLCRIT -50
+#define HEALTH_THRESHOLD_FULLCRIT -40
 #define HEALTH_THRESHOLD_DEAD -100
 
 #define HEALTH_THRESHOLD_NEARDEATH -90 //Not used mechanically, but to determine if someone is so close to death they hear the other side

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -655,7 +655,7 @@
 	if(health <= crit_threshold)
 		var/severity = 0
 		switch(health)
-			if(-20 to -10)
+			if(-20 to 0)
 				severity = 1
 			if(-30 to -20)
 				severity = 2
@@ -803,38 +803,37 @@
 	med_hud_set_status()
 
 /// Allows mobs to slowly walk in crit for a short time
-/mob/living/carbon/proc/crit_walk(oxy_mult = 1)
+/mob/living/carbon/proc/softcrit_damage()
 	if(stat == SOFT_CRIT)
 		var/duration = 0
 		switch(health)
 			if(HEALTH_THRESHOLD_FULLCRIT to -30)
-				if(prob(50 * crit_weight))
+				if(prob(25 * crit_weight))
 					duration = 60
 
-				if(prob(60))
+				if(prob(30 * crit_weight))
 					INVOKE_ASYNC(src, /mob.proc/emote, "gasp")
 			if(-30 to -20)
-				if(prob(40 * crit_weight))
+				if(prob(20 * crit_weight))
 					duration = 60
 
-				if(prob(50))
+				if(prob(25 * crit_weight))
 					INVOKE_ASYNC(src, /mob.proc/emote, "gasp")
 			if(-20 to -10)
-				if(prob(30 * crit_weight))
+				if(prob(15 * crit_weight))
 					duration = 40
 
-				if(prob(40 * crit_weight))
+				if(prob(20 * crit_weight))
 					INVOKE_ASYNC(src, /mob.proc/emote, "cough")
 			if(-10 to HEALTH_THRESHOLD_CRIT)
-				if(prob(25 * crit_weight))
+				if(prob(15 * crit_weight))
 					duration = 20
 
-				if(prob(30))
+				if(prob(20 * crit_weight))
 					INVOKE_ASYNC(src, /mob.proc/emote, "cough")
 		if(duration)
 			crit_weight = initial(crit_weight) // reset our crit chance multiplier
 			AdjustKnockdown(rand(duration, duration * 2), ignore_canstun = TRUE)
-			adjustOxyLoss(1.5 * oxy_mult)
 		else
 			crit_weight += 0.2
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -100,7 +100,7 @@
 
 //Throwing stuff
 /mob/living/carbon/proc/toggle_throw_mode()
-	if(stat > SOFT_CRIT)
+	if(stat >= SOFT_CRIT)
 		return
 	if(in_throw_mode)
 		throw_mode_off()
@@ -787,6 +787,9 @@
 		else
 			if(health <= crit_threshold && !HAS_TRAIT(src, TRAIT_NOSOFTCRIT))
 				// Slower glide movement handled in update_mobility()
+				//Knockdown at the start of critical status.
+				if(stat != SOFT_CRIT)
+					Knockdown(40, TRUE, TRUE)
 				set_stat(SOFT_CRIT)
 				stuttering = 10
 			else
@@ -806,31 +809,31 @@
 		switch(health)
 			if(HEALTH_THRESHOLD_FULLCRIT to -30)
 				if(prob(50 * crit_weight))
-					duration = 30
+					duration = 60
 
 				if(prob(60))
 					INVOKE_ASYNC(src, /mob.proc/emote, "gasp")
 			if(-30 to -20)
 				if(prob(40 * crit_weight))
-					duration = 20
+					duration = 60
 
 				if(prob(50))
 					INVOKE_ASYNC(src, /mob.proc/emote, "gasp")
 			if(-20 to -10)
 				if(prob(30 * crit_weight))
-					duration = 10
+					duration = 40
 
 				if(prob(40 * crit_weight))
 					INVOKE_ASYNC(src, /mob.proc/emote, "cough")
 			if(-10 to HEALTH_THRESHOLD_CRIT)
 				if(prob(25 * crit_weight))
-					duration = 5
+					duration = 20
 
 				if(prob(30))
 					INVOKE_ASYNC(src, /mob.proc/emote, "cough")
 		if(duration)
 			crit_weight = initial(crit_weight) // reset our crit chance multiplier
-			AdjustUnconscious(rand(duration, duration * 2), ignore_canstun = TRUE)
+			AdjustKnockdown(rand(duration, duration * 2), ignore_canstun = TRUE)
 			adjustOxyLoss(1.5 * oxy_mult)
 		else
 			crit_weight += 0.2

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -16,8 +16,6 @@
 	var/disgust = 0
 
 	var/crit_weight = 1 // Multiplier for soft crit unconscious chance.
-	var/critwalk_oxy_mult = 1 // Multiplier for soft crit oxygen damage, for species this should be handled in on_species_gain()/
-//inventory slots
 	var/obj/item/back = null
 	var/obj/item/clothing/mask/wear_mask = null
 	var/obj/item/clothing/neck/wear_neck = null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -973,7 +973,7 @@
 			admin_ticket_log(src, msg)
 
 /mob/living/carbon/human/MouseDrop_T(mob/living/target, mob/living/user)
-	if(pulling != target || grab_state < GRAB_AGGRESSIVE || stat > SOFT_CRIT || a_intent != INTENT_GRAB)
+	if(pulling != target || grab_state < GRAB_AGGRESSIVE || !is_conscious() || a_intent != INTENT_GRAB)
 		return ..()
 
 	//If they dragged themselves and we're currently aggressively grabbing them try to piggyback

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -76,7 +76,7 @@
 				adjust_hygiene(hygiene_loss)
 
 		if(InCritical())
-			crit_walk(critwalk_oxy_mult)
+			softcrit_damage()
 		dna.species.spec_life(src) // for mutantraces
 
 	//Update our name based on whether our face is obscured/disfigured

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -53,7 +53,6 @@
 	appendix.Remove(C)
 	QDEL_NULL(appendix)
 	ADD_TRAIT(C, TRAIT_XENO_IMMUNE, "xeno immune") //makes the IPC immune to huggers
-	C.critwalk_oxy_mult = 0 // we have our own process for handling oxygen damage
 	if(ishuman(C) && !change_screen)
 		change_screen = new
 		change_screen.Grant(C)

--- a/code/modules/mob/living/carbon/monkey/combat.dm
+++ b/code/modules/mob/living/carbon/monkey/combat.dm
@@ -58,7 +58,7 @@
 		return 1
 	if(IsStun() || IsParalyzed())
 		return 1
-	if(stat > SOFT_CRIT)
+	if(stat >= SOFT_CRIT)
 		return 1
 	return 0
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -416,7 +416,7 @@
 		death()
 
 /mob/living/incapacitated(ignore_restraints = FALSE, ignore_grab = FALSE, check_immobilized = FALSE, ignore_stasis = FALSE)
-	if((stat > SOFT_CRIT) || IsUnconscious() || IsStun() || IsParalyzed() || (check_immobilized && IsImmobilized()) || (!ignore_restraints && restrained(ignore_grab)) || (!ignore_stasis && IsInStasis()))
+	if((stat >= SOFT_CRIT) || IsUnconscious() || IsStun() || IsParalyzed() || (check_immobilized && IsImmobilized()) || (!ignore_restraints && restrained(ignore_grab)) || (!ignore_stasis && IsInStasis()))
 		return TRUE
 
 /mob/living/canUseStorage()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -594,7 +594,7 @@
 //Is the mob aware of their surroundings?
 /// Should be used in place of non-dead stat checks for mobs
 /mob/proc/is_conscious()
-	return stat <= SOFT_CRIT
+	return stat == CONSCIOUS
 
 // https://github.com/tgstation/tgstation/pull/44056
 // Used to make sure that a player has a valid job preference setup, used to knock players out of eligibility for anything if their prefs don't make sense.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes some softcrit things.

 - You can no longer perform normal actions such as healing, attacking or using items while in critical condition.
 - Softcrit will call knockdown instead of sleep so that if you are typing a message like 'help me' it doesn't get sent to the void by the inability to speak during the random sleeps.
 - Players are knocked down at the start of soft crit period for better communication of damages.
 - Moved the oxygen damage out of the random durations but decreases the amount dealt so that its a constant drain.
 - Removed random oxy damage during softcrit and lowered hardcrit health threadhold back to -40. Oxygen loss is handled by the lungs, rather than life.

## Why It's Good For The Game

The ability to use items, heal and attack during softcrit essentially resulted in increasing the health of the player with nothing really different. Being able to attack and use items in crit leads to a few problems.
 - You can heal yourself out of crit: There are many healing items in the game which provide an extremely robust heal to the player if they are in crit. These are for doctors to quickly get someone out of critical condition, however there is no need for a doctor or someone to come by and help you out now as you can simply heal yourself as long as you keep a few chemicals in your bag.
 - Combat will very commonly result in 1 person going into crit, and being able to crit their attacker during the long time they get while in crit and although both parties can just inject themselves with an epipen and just spam click until one of them dies.
 - This heavily advantages those who powergame and spend the game preparing before hand. Anybody who prepares can make it so their attacker can **never** win a fight. (Sure you won't always win if you are prepared, but you can make it so your attacker can't win either). Cheesy tactics such as suicide bombing your attacker are a lot less costly now when you can activate them after you have already lost rather than beforehand. Additionally, with the power of some healing meds to heal when below the crit threshold, you can become incredibly strong while in softcrit.

The system is very frustrating to use if you are trying to talk in critical condition.
The unconsciousness that happens as a result of moving while in critical condition can be very frustrating when you are trying to talk. The current system makes it very difficult to see if someone is in soft-crit or not as you can only really tell with a med-hud or by watching them fall over which isn't too obvious (It can be attributed to things other than soft crit). One of the only ways is to walk up to someone and ask them for help, however the sleeping can cause your pre-typed messages to be lost if you get unlucky. As a result, the sleep has been changed to knockdown with a longer time. You can still move and talk while knocked down however it lasts longer than the unconsciousness.
Addendum:
The unconsciousness isn't random as a result of moving, its just random whether you move or not (Misread the code). Point remains the same though.

Falling into softcrit is very poorly communicated.
The only indication that you have suddenly passed the line of soft-crit and full consciousness is the health icon on the right of the screen, however it is very unlikely that you will actually be looking at it while being beaten into softcrit. Additionally, it is very hard to tell when you have hit someone into softcrit as nothing changes, they just stand there and continue to fight back which leads to the perception of players having very high amounts of health. To change this, I have added a 4 second knockdown at the start of softcrit. This is a clear indication that you have fallen into softcrit, or beaten someone into softcrit yourself.

Random oxyloss from softcrit has been removed. Critical condition oxyloss is handled by the lungs. Health threshold full crit has been set back to -40 instead of -50 as a result of lowing health more slowly.

Reduced the change for the knockdown and gasping events. I assume the proc critwalk was meant to be called when the player moves in crit, however it is just called in life() for whatever reason. Renamed the proc and reduced the probabilities to account for it happening in life and not on move.

## Changelog
:cl:
refactor: Entering softcrit knocks the player down for 4 seconds.
refactor: Items cannot be used during softcrit. (Attacking, healing, suicide bombing can no longer be performed)
refactor: Hardcrit threshold changed from -50 to -40.
refactor: Random oxy damage during softcrit removed. (Oxygen damage is already handled by the lungs)
refactor: Random sleeping during softcrit replaced with knockdown.
refactor: Reduced the probability of being knocked down / gasping / coughing during softcrit.
refactor: Damage effect overlay now kicks in at -0 health rather than -10 health.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
