### PR TITLE
modfabs no longer teleport disks when eject disk is pressed

### DIFF
--- a/code/game/machinery/fabricators/modular_fabricator.dm
+++ b/code/game/machinery/fabricators/modular_fabricator.dm
@@ -247,6 +247,7 @@
 				return
 			var/obj/item/disk/design_disk/disk = inserted_disk
 			disk.forceMove(get_turf(src))
+			inserted_disk = null
 			update_viewer_statics()
 
 		if("eject_material")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

## Why It's Good For The Game

bad

## Changelog
:cl:
fix: modfabs no longer teleport disks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
