### PR TITLE
Fixes a material dupe exploit

### DIFF
--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -94,7 +94,16 @@
 
 /obj/machinery/mineral/stacking_machine/HasProximity(atom/movable/AM)
 	if(istype(AM, /obj/item/stack/sheet) && AM.loc == get_step(src, input_dir))
-		process_sheet(AM)
+		var/obj/effect/portal/P = locate() in AM.loc
+		if(P)
+			visible_message("<span class='warning'>[src] attempts to stack the portal!</span>")
+			message_admins("Stacking machine exploded via [P.creator ? key_name(P.creator) : "UNKNOWN"]'s portal at [AREACOORD(src)]")
+			log_game("Stacking machine exploded via [P.creator ? key_name(P.creator) : "UNKNOWN"]'s portal at [AREACOORD(src)]")
+			explosion(src.loc, 0, 1, 2, 3)
+			if(!QDELETED(src))
+				qdel(src)
+		else
+			process_sheet(AM)
 
 /obj/machinery/mineral/stacking_machine/multitool_act(mob/living/user, obj/item/multitool/M)
 	if(istype(M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #4381

Is it snowflakey? A bit. Is it hilarious? Very. HasProximity() can't be used because portals don't trigger the proximity checker due to how BYOND handles object creation.

## Why It's Good For The Game

Punish material dupe exploits.

## Changelog
:cl:
fix: Fixed a material dupe exploit with stacking machines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
