### PR TITLE
Slime fix

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -203,6 +203,9 @@
 #define ETHEREAL_CHARGE_ALMOSTFULL 75
 #define ETHEREAL_CHARGE_FULL 100
 
+//Base nutrition value used for newly initialized slimes
+#define SLIME_DEFAULT_NUTRITION 700
+
 //Slime evolution threshold. Controls how fast slimes can split/grow
 #define SLIME_EVOLUTION_THRESHOLD 10
 

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -179,7 +179,7 @@
 				to_chat(src, "<i>There are too many of us...</i>")
 				return
 			var/list/babies = list()
-			var/new_nutrition = 700
+			var/new_nutrition = SLIME_DEFAULT_NUTRITION
 			var/new_powerlevel = round(powerlevel / 4)
 			var/datum/component/nanites/original_nanites = GetComponent(/datum/component/nanites)
 			var/turf/drop_loc = drop_location()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -179,7 +179,7 @@
 				to_chat(src, "<i>There are too many of us...</i>")
 				return
 			var/list/babies = list()
-			var/new_nutrition = round(nutrition * 0.25)
+			var/new_nutrition = round(nutrition * 0.6)
 			var/new_powerlevel = round(powerlevel / 4)
 			var/datum/component/nanites/original_nanites = GetComponent(/datum/component/nanites)
 			var/turf/drop_loc = drop_location()
@@ -238,8 +238,7 @@
 			child_colour = colour
 	var/mob/living/simple_animal/slime/M = new(drop_loc, child_colour, new_adult)
 	M.transformeffects = transformeffects
-	if(ckey || transformeffects & SLIME_EFFECT_CERULEAN)
-		M.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
+	M.set_nutrition(new_nutrition)
 	M.powerlevel = new_powerlevel
 	if(transformeffects & SLIME_EFFECT_METAL)
 		M.maxHealth = round(M.maxHealth * 1.3)

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -179,7 +179,7 @@
 				to_chat(src, "<i>There are too many of us...</i>")
 				return
 			var/list/babies = list()
-			var/new_nutrition = round(nutrition * 0.6)
+			var/new_nutrition = 700
 			var/new_powerlevel = round(powerlevel / 4)
 			var/datum/component/nanites/original_nanites = GetComponent(/datum/component/nanites)
 			var/turf/drop_loc = drop_location()

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -179,7 +179,7 @@
 				to_chat(src, "<i>There are too many of us...</i>")
 				return
 			var/list/babies = list()
-			var/new_nutrition = round(nutrition * 0.9)
+			var/new_nutrition = round(nutrition * 0.25)
 			var/new_powerlevel = round(powerlevel / 4)
 			var/datum/component/nanites/original_nanites = GetComponent(/datum/component/nanites)
 			var/turf/drop_loc = drop_location()
@@ -233,7 +233,7 @@
 		else if(prob(mutation_chance))
 			if(transformeffects & SLIME_EFFECT_PYRITE)
 				slime_mutation = mutation_table(pick(slime_colours - list("rainbow")))
-			child_colour = slime_mutation[rand(1,4)]				
+			child_colour = slime_mutation[rand(1,4)]
 		else
 			child_colour = colour
 	var/mob/living/simple_animal/slime/M = new(drop_loc, child_colour, new_adult)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -108,7 +108,7 @@
 	create_reagents(100)
 	set_colour(new_colour)
 	. = ..()
-	set_nutrition(700)	
+	set_nutrition(700)
 	if(transformeffects & SLIME_EFFECT_LIGHT_PINK)
 		set_playable()
 
@@ -295,7 +295,7 @@
 		attacked += 5
 		if(nutrition >= 100) //steal some nutrition. negval handled in life()
 			adjust_nutrition(-(50 + (40 * M.is_adult)))
-			M.add_nutrition(50 + (40 * M.is_adult))
+			M.add_nutrition(25 + (20 * M.is_adult))
 		if(health > 0)
 			M.adjustBruteLoss(-10 + (-10 * M.is_adult))
 			M.updatehealth()

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -108,7 +108,7 @@
 	create_reagents(100)
 	set_colour(new_colour)
 	. = ..()
-	set_nutrition(700)
+	set_nutrition(SLIME_DEFAULT_NUTRITION)
 	if(transformeffects & SLIME_EFFECT_LIGHT_PINK)
 		set_playable()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an oversight which allows sentient slimes to reproduce infinitely via cannibalism after being well fed enough to reproduce once. Slimes should probably not be able to generate energy/matter from nothing. 

Additionally, removes the "feature" that player controlled slimes get substantially more nutrition after splitting than non-sentient slimes. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

To be honest, it might not be - It's definitely an oversight to be able to do this, but I'm not wholly convinced that it's bad for the game.
It takes a bit time to do and non-sentient slimes are relatively weak and slow mobs, even in very large numbers. If this is deemed to be a feature rather than an exploit worth patching, I personally look forward to terrorizing the station as a pyro slime by abusing it to fill every side room I can vent crawl into with free baby slimes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Slimes gain less nutrition by feeding on other slimes due to an infinite breeding exploit
tweak: Sentient slimes no longer get bonus nutrition when breeding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
