### PR TITLE
Adds a preference to switch walk hotkey toggle.

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -143,12 +143,6 @@
 	M.toggle_move_intent()
 	return TRUE
 
-/datum/keybinding/mob/toggle_move_intent/up(client/user)
-	if(!user.mob) return
-	var/mob/M = user.mob
-	M.toggle_move_intent()
-	return TRUE
-
 /datum/keybinding/mob/target_head_cycle
 	key = "Numpad8"
 	name = "target_head_cycle"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -143,6 +143,13 @@
 	M.toggle_move_intent()
 	return TRUE
 
+/datum/keybinding/mob/toggle_move_intent/up(client/user)
+	if(!user.mob) return
+	if(user.prefs.held_walk == TRUE)
+		var/mob/M = user.mob
+		M.toggle_move_intent()
+		return TRUE
+
 /datum/keybinding/mob/target_head_cycle
 	key = "Numpad8"
 	name = "target_head_cycle"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -145,7 +145,7 @@
 
 /datum/keybinding/mob/toggle_move_intent/up(client/user)
 	if(!user.mob) return
-	if(user.prefs.held_walk == TRUE)
+	if(user.prefs.held_walk)
 		var/mob/M = user.mob
 		M.toggle_move_intent()
 		return TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -62,6 +62,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	// Custom Keybindings
 	var/list/key_bindings = null
 
+	var/held_walk = TRUE
 
 	var/uses_glasses_colour = 0
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -208,6 +208,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	READ_FILE(S["key_bindings"], key_bindings)
 
+	READ_FILE(S["held_walk"], held_walk)
+
 	READ_FILE(S["purchased_gear"], purchased_gear)
 	READ_FILE(S["equipped_gear"], equipped_gear)
 
@@ -312,6 +314,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["show_credits"], show_credits)
 	WRITE_FILE(S["purchased_gear"], purchased_gear)
 	WRITE_FILE(S["equipped_gear"], equipped_gear)
+	WRITE_FILE(S["held_walk"], held_walk)
 
 	if (!key_bindings)
 		key_bindings = deepCopyList(GLOB.keybinding_list_by_key)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -306,8 +306,8 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 
 /client/verb/toggle_inquisition() // warning: unexpected inquisition
 	set name = "Toggle Inquisitiveness"
-	set desc = "Sets whether your ghost examines everything on click by default"
 	set category = "Preferences"
+	set desc = "Sets whether your ghost examines everything on click by default"
 
 	prefs.inquisitive_ghost = !prefs.inquisitive_ghost
 	prefs.save_preferences()
@@ -316,6 +316,16 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	else
 		to_chat(src, "<span class='notice'>You will no longer examine things you click on.</span>")
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Ghost Inquisitiveness", "[prefs.inquisitive_ghost ? "Enabled" : "Disabled"]"))
+
+/client/verb/toggle_walk_intent()
+	set name = "Hold Down/Press Walk Hotkey"
+	set category = "Preferences"
+	set desc = "Switches walk hotkey toggle between holding it down and pressing it once"
+
+	prefs.held_walk = !prefs.held_walk
+	prefs.save_preferences()
+	to_chat(usr, "You will now walk by [(prefs.held_walk) ? "holding" : "pressing"] the walk hotkey.")
+	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Walk Intent", "[prefs.held_walk ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 //Admin Preferences
 /client/proc/toggleadminhelpsound()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the move intent hotkey to be a toggle instead of held down and makes it a preference inside the stats menu's preference tab.

## Why It's Good For The Game
In my opinion it's much easier to just tap alt once to switch between walking and running especially when having to block in combat which results in the player having to constantly hold down alt.

## Changelog
:cl:
add: Preference to switch the walk hotkey between held down and a toggle inside the stats menu's preference tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
