### PR TITLE
fixes LAZYLEN

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -18,7 +18,7 @@
 #define LAZYFIND(L, V) L ? L.Find(V) : 0
 #define LAZYACCESS(L, I) (L ? (isnum_safe(I) ? (I > 0 && I <= length(L) ? L[I] : null) : L[I]) : null)
 #define LAZYSET(L, K, V) if(!L) { L = list(); } L[K] = V;
-#define LAZYLEN(L) length(L)
+#define LAZYLEN(L) length(L) // should only be used for lazy lists. Using this with non-lazy lists is bad
 #define LAZYCLEARLIST(L) if(L) L.Cut()
 #define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 #define reverseList(L) reverseRange(L.Copy())


### PR DESCRIPTION
## About The Pull Request

LAZYLEN is only for lazy lists. This documents that.

## Why It's Good For The Game

> iirc the reason this exists is so people are aware that the list youre touching is a lazy list, that way its easier to keep track. Yes the define is mostly redundant, but if someone sees `LAZYLEN`, they instantly know that what they are touching is a lazy list, and should use the other `LAZY` operators.

https://github.com/BeeStation/BeeStation-Hornet/pull/4373#discussion_r637512300

## Changelog
:cl:
code: Justifies LAZYLEN()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
