### PR TITLE
Fixes mat duping using the autolathe

### DIFF
--- a/code/game/machinery/fabricators/modular_fabricator.dm
+++ b/code/game/machinery/fabricators/modular_fabricator.dm
@@ -15,7 +15,8 @@
 	var/disabled = 0
 
 	var/busy = FALSE
-	var/prod_coeff = 1
+	///the multiplier for how much materials the created object takes from this machines stored materials
+	var/creation_efficiency = 1.6
 
 	var/can_sync = FALSE
 	var/can_be_hacked_or_unlocked = FALSE
@@ -82,26 +83,27 @@
 	return container
 
 /obj/machinery/modular_fabricator/RefreshParts()
-	var/T = 0
-	for(var/obj/item/stock_parts/matter_bin/MB in component_parts)
-		T += MB.rating*75000
+	var/mat_capacity = 0
+	for(var/obj/item/stock_parts/matter_bin/new_matter_bin in component_parts)
+		mat_capacity += new_matter_bin.rating*75000
 	//Material container
 	var/datum/component/remote_materials/materials = GetComponent(/datum/component/remote_materials)
 	if(materials)
-		materials.set_local_size(T)
+		materials.set_local_size(mat_capacity)
 	else
 		var/datum/component/material_container/container = GetComponent(/datum/component/material_container)
-		container.max_amount = T
-	T=1.2
-	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		T -= M.rating*0.2
-	prod_coeff = min(1,max(0,T)) // Coeff going 1 -> 0,8 -> 0,6 -> 0,4
+		container.max_amount = mat_capacity
+
+	var/efficiency = 1.8
+	for(var/obj/item/stock_parts/manipulator/new_manipulator in component_parts)
+		efficiency -= new_manipulator.rating*0.2
+	creation_efficiency = max(1,efficiency) // creation_efficiency goes 1.6 -> 1.4 -> 1.2 -> 1 per level of manipulator efficiency
 
 /obj/machinery/modular_fabricator/examine(mob/user)
 	. += ..()
 	var/datum/component/material_container/materials = get_material_container()
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Storing up to <b>[materials.max_amount]</b> material units.<br>Material consumption at <b>[prod_coeff*100]%</b>.</span>"
+		. += "<span class='notice'>The status display reads: Storing up to <b>[materials.max_amount]</b> material units.<br>Material consumption at <b>[creation_efficiency*100]%</b>.</span>"
 
 /obj/machinery/modular_fabricator/ui_state()
 	return GLOB.default_state
@@ -386,7 +388,7 @@
 
 	/////////////////
 
-	var/coeff = (is_stack ? 1 : prod_coeff) //stacks are unaffected by production coefficient
+	var/coeff = (is_stack ? 1 : creation_efficiency) //stacks are unaffected by production coefficient
 	var/total_amount = 0
 
 	for(var/MAT in being_built.materials)


### PR DESCRIPTION
## About The Pull Request
Ports tgstation/tgstation#56630
Fully upgraded autolathes had a material cost multiplier of less than 1 which caused them to be able to create some items with less mats than what you recycle them for. This changes the upgrade multipliers to go 1.6 -> 1.4 -> 1.2 -> 1 instead of 1 -> 0,8 -> 0,6 -> 0,4

## Why It's Good For The Game
Duping mats bad

## Changelog
:cl:Kylerace, r1ks-iwnl
fix: Autolathes can't create items for cheaper than what they recycle for.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
