### PR TITLE
Prevents shooting yourself while pacified to create 1 hit kill projectiles.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -534,6 +534,9 @@
 	if(!ishuman(user) || !ishuman(target))
 		return
 
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
+
 	if(semicd)
 		return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -534,7 +534,7 @@
 	if(!ishuman(user) || !ishuman(target))
 		return
 
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(HAS_TRAIT(user, TRAIT_PACIFISM)) //This prevents multiplying projectile damage without shooting yourself.
 		return
 
 	if(semicd)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Credits to teamfortress41#4207 on discord for reporting this.
So shooting yourself in the mouth with a gun multiplies the damage of the projectile you are shooting with by 5, drinking pax or being pacified in any other way prevents you shooting yourself but still multiplies the damage of the projectile so if you attempt to shoot yourself enough you can turn any projectile into a 1 hit kill.

## Why It's Good For The Game
Glitch bad, very bad.

## Changelog
:cl:
fix: fixed shooting yourself in the mouth with a gun while pacified to create 1 hit kill projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
