### PR TITLE
Filthy Station Trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -300,3 +300,4 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
 #define STATION_TRAIT_DISTANT_SUPPLY_LINES "distant_supply_lines"
 #define STATION_TRAIT_STRONG_SUPPLY_LINES "strong_supply_lines"
+#define STATION_TRAIT_FILTHY "janitor_get_to_work"

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -14,6 +14,8 @@ SUBSYSTEM_DEF(minor_mapping)
 	var/mob/living/simple_animal/mouse/M
 	var/turf/proposed_turf
 
+	if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
+		num_mice+=3
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
 		if(!M)

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -15,7 +15,7 @@ SUBSYSTEM_DEF(minor_mapping)
 	var/turf/proposed_turf
 
 	if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
-		num_mice+=3
+		num_mice += 3
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
 		if(!M)

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -136,7 +136,7 @@
 /datum/station_trait/filthy
 	name = "Filthy Station"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 999999
+	weight = 3
 	show_in_report = TRUE
 	report_message = "The previous inhabitants left in a hurry, and the station is a mess."
 	trait_to_give = STATION_TRAIT_FILTHY

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -132,3 +132,11 @@
 		/// The bot's language holder - so we can randomize and change their language
 		var/datum/language_holder/bot_languages = found_bot.get_language_holder()
 		bot_languages.selected_language = bot_languages.get_random_spoken_language()
+
+/datum/station_trait/filthy
+	name = "Filthy Station"
+	trait_type = STATION_TRAIT_NEGATIVE
+	weight = 999999
+	show_in_report = TRUE
+	report_message = "The previous inhabitants left in a hurry, and the station is a mess."
+	trait_to_give = STATION_TRAIT_FILTHY

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -136,7 +136,7 @@
 /datum/station_trait/filthy
 	name = "Filthy Station"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 3
+	weight = 100
 	show_in_report = TRUE
 	report_message = "The previous inhabitants left in a hurry, and the station is a mess."
 	trait_to_give = STATION_TRAIT_FILTHY

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -136,7 +136,7 @@
 /datum/station_trait/filthy
 	name = "Filthy Station"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 100
+	weight = 3
 	show_in_report = TRUE
 	report_message = "The previous inhabitants left in a hurry, and the station is a mess."
 	trait_to_give = STATION_TRAIT_FILTHY

--- a/code/game/turfs/open/dirtystation.dm
+++ b/code/game/turfs/open/dirtystation.dm
@@ -127,4 +127,24 @@
 			new /obj/effect/decal/cleanable/greenglow/filled(src)	//this cleans itself up but it might startle you when you see it.
 		return
 
+	if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
+		if (prob(30))
+			new /obj/effect/decal/cleanable/dirt(src)
+		else if (prob(10))
+			new /obj/effect/decal/cleanable/vomit/old(src)
+		else if (prob(10))
+			new /obj/effect/decal/cleanable/blood/old(src)
+		else if (prob(5))
+			switch(rand(1,5))
+				if (1)
+					new /obj/item/trash/chips(src)
+				if (2)
+					new /obj/item/trash/sosjerky(src)
+				if (3)
+					new /obj/item/trash/can(src)
+				if (4)
+					new /obj/item/trash/can/food/beans(src)
+				if (5)
+					new /obj/item/cigbutt(src)
+
 	return TRUE

--- a/code/game/turfs/open/dirtystation.dm
+++ b/code/game/turfs/open/dirtystation.dm
@@ -22,7 +22,7 @@
 		return
 
 	//The code below here isn't exactly optimal, but because of the individual decals that each area uses it's still applicable.
-
+	
 				//high dirt - 1/3 chance.
 	var/static/list/high_dirt_areas = typecacheof(list(/area/science/test_area,
 														/area/mine/production,
@@ -33,8 +33,22 @@
 		new /obj/effect/decal/cleanable/dirt(src)	//vanilla, but it works
 		return
 
-
-	if(prob(80))	//mid dirt  - 1/15
+	if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
+		if (prob(50))
+			return		
+		if (prob(5))
+			switch(rand(1,5))
+				if (1)
+					new /obj/item/trash/chips(src)
+				if (2)
+					new /obj/item/trash/sosjerky(src)
+				if (3)
+					new /obj/item/trash/can(src)
+				if (4)
+					new /obj/item/trash/can/food/beans(src)
+				if (5)
+					new /obj/item/cigbutt(src)			
+	else if(prob(80))	//mid dirt  - 1/15
 		return
 
 		//Construction zones. Blood, sweat, and oil.  Oh, and dirt.
@@ -126,25 +140,5 @@
 		if(prob(20))
 			new /obj/effect/decal/cleanable/greenglow/filled(src)	//this cleans itself up but it might startle you when you see it.
 		return
-
-	if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
-		if (prob(30))
-			new /obj/effect/decal/cleanable/dirt(src)
-		else if (prob(10))
-			new /obj/effect/decal/cleanable/vomit/old(src)
-		else if (prob(10))
-			new /obj/effect/decal/cleanable/blood/old(src)
-		else if (prob(5))
-			switch(rand(1,5))
-				if (1)
-					new /obj/item/trash/chips(src)
-				if (2)
-					new /obj/item/trash/sosjerky(src)
-				if (3)
-					new /obj/item/trash/can(src)
-				if (4)
-					new /obj/item/trash/can/food/beans(src)
-				if (5)
-					new /obj/item/cigbutt(src)
 
 	return TRUE

--- a/code/game/turfs/open/dirtystation.dm
+++ b/code/game/turfs/open/dirtystation.dm
@@ -35,19 +35,25 @@
 
 	if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
 		if (prob(50))
-			return		
+			return	
+		else if (prob(30))
+			new /obj/effect/decal/cleanable/dirt(src)	//plain old dirt
+			return
 		if (prob(5))
-			switch(rand(1,5))
-				if (1)
-					new /obj/item/trash/chips(src)
-				if (2)
-					new /obj/item/trash/sosjerky(src)
-				if (3)
-					new /obj/item/trash/can(src)
-				if (4)
-					new /obj/item/trash/can/food/beans(src)
-				if (5)
-					new /obj/item/cigbutt(src)			
+			if (prob(5))
+				new /mob/living/simple_animal/mouse(src)
+			else
+				switch(rand(1,5))
+					if (1)
+						new /obj/item/trash/chips(src)
+					if (2)
+						new /obj/item/trash/sosjerky(src)
+					if (3)
+						new /obj/item/trash/can(src)
+					if (4)
+						new /obj/item/trash/can/food/beans(src)
+					if (5)
+						new /obj/item/cigbutt(src)			
 	else if(prob(80))	//mid dirt  - 1/15
 		return
 

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -54,8 +54,24 @@
 		icon_regular_floor = "floor"
 	else
 		icon_regular_floor = icon_state
-	if(mapload && prob(33))
-		MakeDirty()
+	if(mapload)
+		if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
+			if (prob(45))
+				MakeDirty()
+			if (prob(5))
+				switch(rand(1,5))
+					if (1)
+						new /obj/item/trash/chips(src)
+					if (2)
+						new /obj/item/trash/sosjerky(src)
+					if (3)
+						new /obj/item/trash/can(src)
+					if (4)
+						new /obj/item/trash/can/food/beans(src)
+					if (5)
+						new /obj/item/cigbutt(src)
+		else if (prob(33))
+			MakeDirty()
 	if(is_station_level(z))
 		GLOB.station_turfs += src
 

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -54,24 +54,8 @@
 		icon_regular_floor = "floor"
 	else
 		icon_regular_floor = icon_state
-	if(mapload)
-		if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
-			if (prob(45))
-				MakeDirty()
-			if (prob(3))
-				switch(rand(1,5))
-					if (1)
-						new /obj/item/trash/chips(src)
-					if (2)
-						new /obj/item/trash/sosjerky(src)
-					if (3)
-						new /obj/item/trash/can(src)
-					if (4)
-						new /obj/item/trash/can/food/beans(src)
-					if (5)
-						new /obj/item/cigbutt(src)
-		else if (prob(33))
-			MakeDirty()
+	if(mapload && prob(33))
+		MakeDirty()
 	if(is_station_level(z))
 		GLOB.station_turfs += src
 

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -58,7 +58,7 @@
 		if (HAS_TRAIT(SSstation, STATION_TRAIT_FILTHY))
 			if (prob(45))
 				MakeDirty()
-			if (prob(5))
+			if (prob(3))
 				switch(rand(1,5))
 					if (1)
 						new /obj/item/trash/chips(src)

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -6,7 +6,7 @@
 /datum/round_event/mice_migration
 	var/minimum_mice = 5
 	var/maximum_mice = 15
-
+	
 /datum/round_event/mice_migration/announce(fake)
 	var/cause = pick("space-winter", "budget-cuts", "Ragnarok",
 		"space being cold", "\[REDACTED\]", "climate change",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Trait that makes station filthy, with a chance to cause trash and even mice to spawn.

## Why It's Good For The Game

Maybe janitors have a job to do?

## Changelog
:cl:
add: Filthy station trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
