### PR TITLE
Makes station traits config option

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -466,3 +466,5 @@
 /datum/config_entry/flag/bsminer_researchable
 
 /datum/config_entry/flag/spare_enforce_coc
+
+/datum/config_entry/flag/station_traits

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -19,7 +19,8 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 	//If doing unit tests we don't do none of that trait shit ya know?
 	#ifndef UNIT_TESTS
-	SetupTraits()
+	if(CONFIG_GET(flag/station_traits))
+		SetupTraits()
 	#endif
 
 	announcer = new announcer() //Initialize the station's announcer datum

--- a/config/Sage/config.txt
+++ b/config/Sage/config.txt
@@ -551,3 +551,6 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 
 ## Ghost role cooldown time after death (In deciseconds)
 GHOST_ROLE_COOLDOWN 3000
+
+## Enable/disable roundstart station traits
+#STATION_TRAITS

--- a/config/config.txt
+++ b/config/config.txt
@@ -556,3 +556,6 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 
 ## Ghost role cooldown time after death (In deciseconds)
 GHOST_ROLE_COOLDOWN 3000
+
+## Enable/disable roundstart station traits
+#STATION_TRAITS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Station traits are config option.
Note to anyone who merges it - they are supposed to be enabled on live servers while disabled in the repo so they are not rolled while debugging.

## Why It's Good For The Game

requested by ike

## Changelog
:cl:
add: Station traits are config option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
