### PR TITLE
Ports wing reconstruction surgery from /tg/

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3128,6 +3128,7 @@
 #include "code\modules\surgery\advanced\pacification.dm"
 #include "code\modules\surgery\advanced\revival.dm"
 #include "code\modules\surgery\advanced\viral_bonding.dm"
+#include "code\modules\surgery\advanced\wingreconstruction.dm"
 #include "code\modules\surgery\advanced\bioware\bioware.dm"
 #include "code\modules\surgery\advanced\bioware\bioware_surgery.dm"
 #include "code\modules\surgery\advanced\bioware\experimental_dissection.dm"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -653,6 +653,8 @@
 				if(wings.flight_level <= WINGS_FLIGHTLESS)
 					wings.flight_level += 1 //upgrade the flight level
 					wings.Refresh(H) //they need to insert to get the flight emote
+				if(!exposed_carbon.dna.features["original_moth_wings"]) //Stores their wings for later possible reconstruction
+					exposed_carbon.dna.features["original_moth_wings"] = exposed_carbon.dna.features["moth_wings"]
 			else
 				if(MOB_ROBOTIC in H.mob_biotypes)
 					var/obj/item/organ/wings/cybernetic/newwings = new()

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -40,3 +40,11 @@
 	if(istype(weapon, /obj/item/melee/flyswatter))
 		return 9 //flyswatters deal 10x damage to moths
 	return 0
+
+/datum/species/moth/spec_fully_heal(mob/living/carbon/human/H)
+	. = ..()
+	if(H.dna.features["original_moth_wings"] != null)
+		H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
+	if(H.dna.features["original_moth_wings"] == null && H.dna.features["moth_wings"] == "Burnt Off")
+		H.dna.features["moth_wings"] = "Plain"
+	handle_mutant_bodyparts(H)

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -712,3 +712,10 @@
 	id = "surgery_zombie"
 	surgery = /datum/surgery/advanced/necrotic_revival
 	research_icon_state = "surgery_head"
+
+/datum/design/surgery/wing_reconstruction
+	name = "Wing Reconstruction"
+	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Synthflesh."
+	id = "surgery_wing_reconstruction"
+	surgery = /datum/surgery/advanced/wing_reconstruction
+	research_icon_state = "surgery_chest"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -94,7 +94,7 @@
 	display_name = "Advanced Surgery"
 	description = "When simple medicine doesn't cut it."
 	prereq_ids = list("imp_wt_surgery")
-	design_ids = list("surgery_lobotomy","surgery_heal_brute_upgrade_femto","surgery_heal_burn_upgrade_femto","surgery_heal_combo","surgery_exp_dissection")
+	design_ids = list("surgery_lobotomy","surgery_heal_brute_upgrade_femto","surgery_heal_burn_upgrade_femto","surgery_heal_combo","surgery_exp_dissection,"surgery_wing_reconstruction")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 4000
 

--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -1,0 +1,37 @@
+/datum/surgery/advanced/wing_reconstruction
+	name = "Wing Reconstruction"
+	desc = "An experimental surgical procedure that reconstructs the damaged wings of moth people. Requires Synthflesh."
+	steps = list(/datum/surgery_step/incise,
+				/datum/surgery_step/retract_skin,
+				/datum/surgery_step/clamp_bleeders,
+				/datum/surgery_step/wing_reconstruction)
+	possible_locs = list(BODY_ZONE_CHEST)
+	target_mobtypes = list(/mob/living/carbon/human)
+
+/datum/surgery/advanced/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
+	return ..() && target.dna.features["moth_wings"] == "Burnt Off" && ismoth(target)
+
+/datum/surgery_step/wing_reconstruction
+	name = "start wing reconstruction"
+	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
+	time = 200
+	chems_needed = list(/datum/reagent/medicine/synthflesh)
+	require_all_chems = FALSE
+
+/datum/surgery_step/wing_reconstruction/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You begin to fix [target]'s charred wing membranes...</span>",
+		"<span class='notice'>[user] begins to fix [target]'s charred wing membranes.</span>",
+		"<span class='notice'>[user] begins to perform surgery on [target]'s charred wing membranes.</span>")
+
+/datum/surgery_step/wing_reconstruction/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		display_results(user, target, "<span class='notice'>You succeed in reconstructing [target]'s wings.</span>",
+			"<span class='notice'>[user] successfully reconstructs [target]'s wings!</span>",
+			"<span class='notice'>[user] completes the surgery on [target]'s wings.</span>")
+		if(H.dna.features["original_moth_wings"] != null)
+			H.dna.features["moth_wings"] = H.dna.features["original_moth_wings"]
+		else
+			H.dna.features["moth_wings"] = "Plain"
+		H.update_mutant_bodyparts()
+	return ..()

--- a/code/modules/surgery/organs/wings.dm
+++ b/code/modules/surgery/organs/wings.dm
@@ -122,6 +122,8 @@
 			flight_level = WINGS_COSMETIC
 			to_chat(H, "<span class='danger'>Your precious wings burn to a crisp!</span>")
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "burnt_wings", /datum/mood_event/burnt_wings)
+			if(!H.dna.features["original_moth_wings"]) //Fire apparently destroys DNA, so let's preserve that elsewhere, checks if an original was already stored to prevent bugs
+				H.dna.features["original_moth_wings"] = H.dna.features["moth_wings"]
 			H.dna.features["moth_wings"] = "Burnt Off"
 			wing_type = "Burnt Off"
 			H.dna.species.handle_mutant_bodyparts(H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports wing reconstruction surgery, a surgery that lets you fix ruined moth wings with synthflesh
Magical heals and aheals also restore wings with this
Ports [tgstation/tgstation#51963](https://github.com/tgstation/tgstation/pull/51963)
Ports [tgstation/tgstation#55672](https://github.com/tgstation/tgstation/pull/55672)
disclaimer: I didn't test this code
Also part of Things to Port apparently
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another way to fix moth wings without stealing them from another moth and replacing them
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Ports moth wing reconstruction from tg
add: Healing moths magically restores their wings if burnt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
