### PR TITLE
Ports suit storage quickdraw and rest hotkeys from /tg/

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -93,3 +93,30 @@
 		return
 	stored.attack_hand(H) // take out thing from backpack
 	return
+
+/datum/keybinding/human/quick_equip_suit_storage
+	key = "Shift-Q"
+	name = "quick_equip_suit_storage"
+	full_name = "Put Item In Suit Storage"
+	description = ""
+
+/datum/keybinding/human/quick_equip_suit_storage/down(client/user)
+	if(!ishuman(user.mob) || user.mob.incapacitated())
+		return
+	var/mob/living/carbon/human/H = user.mob
+	var/obj/item/thing = H.get_active_held_item()
+	var/obj/item/stored = H.get_item_by_slot(ITEM_SLOT_SUITSTORE)
+	if(!stored)
+		if(!thing)
+			to_chat(user, "<span class='notice'>There's nothing in your suit storage to take out.")
+			return TRUE
+		if(H.equip_to_slot_if_possible(thing, ITEM_SLOT_SUITSTORE))
+			H.update_inv_hands()
+			return TRUE
+	if(thing && stored)
+		to_chat(user, "<span class='notice'>There's already something in your suit storage!")
+		return TRUE
+	if(!stored || stored.on_found(H))
+		return TRUE
+	stored.attack_hand(H)
+	return TRUE

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -14,3 +14,16 @@
 	var/mob/living/L = user.mob
 	L.resist()
 	return TRUE
+
+/datum/keybinding/living/rest
+	key = "V"
+	name = "rest"
+	full_name = "Rest"
+	description = "Lay down, or get up."
+
+/datum/keybinding/living/rest/down(client/user)
+	if(!isliving(user.mob))
+		return
+	var/mob/living/L = user.mob
+	L.lay_down()
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports [tgstation/#53709](https://github.com/tgstation/tgstation/pull/53709)
Ports [tgstation/#52040](https://github.com/tgstation/tgstation/pull/52040)
Adds the ability to draw or store an item from suit storage with a hotkey which is shift + Q by default
Adds the ability to rest or get up with a hotkey which is V by default
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More convenient ways to perform actions that required you to previously take your mouse to the corner of the screen and click
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: keybind for resting
add: keybind for suit storage quickdraw
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
