### PR TITLE
Revert "Adds a preference to switch walk hotkey toggle."

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -145,10 +145,9 @@
 
 /datum/keybinding/mob/toggle_move_intent/up(client/user)
 	if(!user.mob) return
-	if(user.prefs.held_walk)
-		var/mob/M = user.mob
-		M.toggle_move_intent()
-		return TRUE
+	var/mob/M = user.mob
+	M.toggle_move_intent()
+	return TRUE
 
 /datum/keybinding/mob/target_head_cycle
 	key = "Numpad8"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -62,7 +62,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	// Custom Keybindings
 	var/list/key_bindings = null
 
-	var/held_walk = TRUE
 
 	var/uses_glasses_colour = 0
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -208,8 +208,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	READ_FILE(S["key_bindings"], key_bindings)
 
-	READ_FILE(S["held_walk"], held_walk)
-
 	READ_FILE(S["purchased_gear"], purchased_gear)
 	READ_FILE(S["equipped_gear"], equipped_gear)
 
@@ -314,7 +312,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["show_credits"], show_credits)
 	WRITE_FILE(S["purchased_gear"], purchased_gear)
 	WRITE_FILE(S["equipped_gear"], equipped_gear)
-	WRITE_FILE(S["held_walk"], held_walk)
 
 	if (!key_bindings)
 		key_bindings = deepCopyList(GLOB.keybinding_list_by_key)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -306,8 +306,8 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 
 /client/verb/toggle_inquisition() // warning: unexpected inquisition
 	set name = "Toggle Inquisitiveness"
-	set category = "Preferences"
 	set desc = "Sets whether your ghost examines everything on click by default"
+	set category = "Preferences"
 
 	prefs.inquisitive_ghost = !prefs.inquisitive_ghost
 	prefs.save_preferences()
@@ -316,16 +316,6 @@ GLOBAL_LIST_INIT(ghost_orbits, list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	else
 		to_chat(src, "<span class='notice'>You will no longer examine things you click on.</span>")
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Ghost Inquisitiveness", "[prefs.inquisitive_ghost ? "Enabled" : "Disabled"]"))
-
-/client/verb/toggle_walk_intent()
-	set name = "Hold Down/Press Walk Hotkey"
-	set category = "Preferences"
-	set desc = "Switches walk hotkey toggle between holding it down and pressing it once"
-
-	prefs.held_walk = !prefs.held_walk
-	prefs.save_preferences()
-	to_chat(usr, "You will now walk by [(prefs.held_walk) ? "holding" : "pressing"] the walk hotkey.")
-	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Walk Intent", "[prefs.held_walk ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 //Admin Preferences
 /client/proc/toggleadminhelpsound()


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#4389

Toggle walk hotkey mode cannot work in this game, since alt is used for buttons. Alt clicking an inventory to open it toggles you to walk mode which is a huge oversight that makes playing the game by default difficult.

:cl:
del: Reverts the preference to switch walk hotkey toggle
/:cl: