### PR TITLE
Fixes/adds? clown, mime, and miner envirohelm welding screens and clown drawn on smile usage

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -283,12 +283,15 @@
 	desc = "A black and white envirosuit helmet, specially made for the mime. Rattling bones won't stop your silent shinanigains!"
 	icon_state = "mime_envirohelm"
 	item_state = "mime_envirohelm"
+	visor_icon = "mime_envisor"
 
 /obj/item/clothing/head/helmet/space/plasmaman/honk
 	name = "clowns envirosuit helmet"
 	desc = "A multicolor helmet that smellls of bananium and securitys tears."
 	icon_state = "honk_envirohelm"
 	item_state = "honk_envirohelm"
+	visor_icon = "clown_envisor"
+	smile_state = "clown_smile"
 
 //command helms
 
@@ -403,6 +406,7 @@
 	desc = "A khaki replacement helmet given to plasmamen miners operating on lavaland."
 	icon_state = "explorer_envirohelm"
 	item_state = "explorer_envirohelm"
+	visor_icon = "explorer_envisor"
 
 /obj/item/clothing/head/helmet/space/plasmaman/replacement/chaplain
 	name = "chaplain's replace envirosuit helmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the usage of unused envirohelm welding screen sprites
Adds the usage of the clown's unique drawn on smile (if you don't know what it is, try using a crayon on an envirohelm)
![image](https://user-images.githubusercontent.com/85033680/120818435-3db39b80-c518-11eb-8da7-ab2d23398900.png)
and yes, the mime welding screen side view does look a little shit

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes unused sprites used
Makes welding screens fit more
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed clown mime and non replacement miner envirohelms using the wrong welding screen sprites
fix: fixed drawing a smile on a clown envirosuit helmet using the wrong sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
