### PR TITLE
Corgi Related Fixes

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -328,13 +328,13 @@
 	var/mob/your_pet = new mob_choice(pod)
 	pod.explosionSize = list(0,0,0,0)
 	your_pet.name = name
+	your_pet.real_name = name
 	var/msg = "<span class=danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(istype(H.ears, /obj/item/radio/headset))
 			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>One pet delivery straight from Central Command. Stand clear!</span> Message ends.\""
 	to_chat(M, msg)
-
 	new /obj/effect/pod_landingzone(get_turf(src), pod)
 
 /obj/item/choice_beacon/pet/cat

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -283,7 +283,7 @@
 //Many  hats added, Some will probably be removed, just want to see which ones are popular.
 // > some will probably be removed
 
-/mob/living/simple_animal/pet/dog/corgi/proc/place_on_head(obj/item/item_to_add, mob/user)
+/mob/living/simple_animal/pet/dog/corgi/proc/place_on_head(obj/item/item_to_add, mob/user, drop = TRUE)
 
 	if(istype(item_to_add, /obj/item/grenade/plastic)) // last thing he ever wears, I guess
 		item_to_add.afterattack(src,user,1)
@@ -323,7 +323,8 @@
 		regenerate_icons()
 	else
 		to_chat(user, "<span class='warning'>You set [item_to_add] on [src]'s head, but it falls off!</span>")
-		item_to_add.forceMove(drop_location())
+		if (drop)
+			item_to_add.forceMove(drop_location())
 		if(prob(25))
 			step_rand(item_to_add)
 		for(var/i in list(1,2,4,8,4,8,4,dir))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -157,7 +157,7 @@
 	// HACK - drop all corgi inventory
 	var/turf/T = get_turf(new_corgi)
 	if (new_corgi.inventory_head)
-		if(!L.equip_to_slot(new_corgi.inventory_head, ITEM_SLOT_HEAD))
+		if(!L.equip_to_slot_if_possible(new_corgi.inventory_head, ITEM_SLOT_HEAD,disable_warning = TRUE, bypass_equip_delay_self=TRUE))
 			new_corgi.inventory_head.forceMove(T)
 	new_corgi.inventory_back?.forceMove(T)
 	qdel(new_corgi)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -124,8 +124,8 @@
 	. = ..()
 	new_corgi = new(get_turf(L))
 	new_corgi.key = L.key
-	new_corgi.name = L.name
-	new_corgi.real_name = L.name
+	new_corgi.name = L.real_name
+	new_corgi.real_name = L.real_name
 	ADD_TRAIT(L, TRAIT_NOBREATH, CORGIUM_TRAIT)
 	//hack - equipt current hat
 	var/mob/living/carbon/C = L
@@ -158,8 +158,10 @@
 	var/turf/T = get_turf(new_corgi)
 	if (new_corgi.inventory_head)
 		if(!L.equip_to_slot_if_possible(new_corgi.inventory_head, ITEM_SLOT_HEAD,disable_warning = TRUE, bypass_equip_delay_self=TRUE))
-			new_corgi.inventory_head.forceMove(T)
-	new_corgi.inventory_back?.forceMove(T)
+			new_corgi.inventory_head.forceMove(T)		
+	new_corgi.inventory_back?.forceMove(T)	
+	new_corgi.inventory_head = null
+	new_corgi.inventory_back = null
 	qdel(new_corgi)
 
 /datum/reagent/water

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -128,9 +128,11 @@
 	new_corgi.real_name = L.name
 	ADD_TRAIT(L, TRAIT_NOBREATH, CORGIUM_TRAIT)
 	//hack - equipt current hat
-	var/obj/item/hat = L.head
-	if (hat)
-		new_corgi.place_on_head(hat)
+	var/mob/living/carbon/C = L
+	if (istype(C))
+		var/obj/item/hat = C.head
+		if (hat)
+			new_corgi.place_on_head(hat)
 	L.forceMove(new_corgi)
 
 /datum/reagent/corgium/on_mob_life(mob/living/carbon/M)
@@ -155,7 +157,7 @@
 	// HACK - drop all corgi inventory
 	var/turf/T = get_turf(new_corgi)
 	if (new_corgi.inventory_head)
-		if(!H.equip_to_slot_if_possible(new_corgi.inventory_head, ITEM_SLOT_HEAD))
+		if(!L.equip_to_slot(new_corgi.inventory_head, ITEM_SLOT_HEAD))
 			new_corgi.inventory_head.forceMove(T)
 	new_corgi.inventory_back?.forceMove(T)
 	qdel(new_corgi)
@@ -575,7 +577,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/moth
 	taste_description = "clothing"
-	
+
 /datum/reagent/mutationtoxin/apid
 	name = "Apid Mutation Toxin"
 	description = "A sweet-smelling toxin."
@@ -640,7 +642,7 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/ipc
 	taste_description = "silicon and copper"
-	
+
 /datum/reagent/mutationtoxin/ethereal
 	name = "Ethereal Mutation Toxin"
 	description = "A positively electric toxin."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -132,7 +132,7 @@
 	if (istype(C))
 		var/obj/item/hat = C.head
 		if (hat)
-			new_corgi.place_on_head(hat)
+			new_corgi.place_on_head(hat,null,FALSE)
 	L.forceMove(new_corgi)
 
 /datum/reagent/corgium/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -125,7 +125,12 @@
 	new_corgi = new(get_turf(L))
 	new_corgi.key = L.key
 	new_corgi.name = L.name
+	new_corgi.real_name = L.name
 	ADD_TRAIT(L, TRAIT_NOBREATH, CORGIUM_TRAIT)
+	//hack - equipt current hat
+	var/obj/item/hat = L.head
+	if (hat)
+		new_corgi.place_on_head(hat)
 	L.forceMove(new_corgi)
 
 /datum/reagent/corgium/on_mob_life(mob/living/carbon/M)
@@ -147,6 +152,12 @@
 	L.adjustBruteLoss(new_corgi.getBruteLoss())
 	L.adjustFireLoss(new_corgi.getFireLoss())
 	L.forceMove(get_turf(new_corgi))
+	// HACK - drop all corgi inventory
+	var/turf/T = get_turf(new_corgi)
+	if (new_corgi.inventory_head)
+		if(!H.equip_to_slot_if_possible(new_corgi.inventory_head, ITEM_SLOT_HEAD))
+			new_corgi.inventory_head.forceMove(T)
+	new_corgi.inventory_back?.forceMove(T)
 	qdel(new_corgi)
 
 /datum/reagent/water

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -130,7 +130,7 @@
 	//hack - equipt current hat
 	var/mob/living/carbon/C = L
 	if (istype(C))
-		var/obj/item/hat = C.head
+		var/obj/item/hat = C.get_item_by_slot(ITEM_SLOT_HEAD)
 		if (hat)
 			new_corgi.place_on_head(hat,null,FALSE)
 	L.forceMove(new_corgi)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Corgium corgis will now wear your hat, and have your name as their real name. You will get your hat back when you return to human.
Pet beacon pets no longer get renamed when they change hats/states.

## Why It's Good For The Game

Consistency?

## Changelog
:cl:
tweak: Corgium corgis will now wear your hat. You will get your hat back when you return to human.
fix: Corgium corgis will keep your name when they put on a hat
fix: Pet beacon pets' real name is now the name you assign them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
