### PR TITLE
Holodeck - Emergency Medical is no longer restricted

### DIFF
--- a/code/modules/holodeck/holodeck_map_templates.dm
+++ b/code/modules/holodeck/holodeck_map_templates.dm
@@ -113,14 +113,13 @@
 	description = "benis"
 	mappath = "_maps/templates/holodeck_skatepark.dmm"
 
-//bad evil no good programs
-
 /datum/map_template/holodeck/medicalsim
 	name = "Holodeck - Emergency Medical"
 	template_id = "holodeck_medicalsim"
 	description = "benis"
 	mappath = "_maps/templates/holodeck_medicalsim.dmm"
-	restricted = TRUE
+
+//bad evil no good programs
 
 /datum/map_template/holodeck/thunderdome1218
 	name = "Holodeck - 1218 AD"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Holodeck - Emergency Medical is no longer a restricted program that requires safeties removed.

## Why It's Good For The Game

The holodeck map PR set HEM to restricted/emergency only. But, before this, it used to be public, and had the exact same arsenal available, including surgery tools, surgery saw and operating computer.

I believe it was changed as an oversight (it is restricted on TG) and should be reverted.

## Changelog
:cl:
balance: Holodeck - Emergency Medical is no longer a restricted program that requires safeties removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
