### PR TITLE
Fix "Target Cyborgs" for Turret Control Panel + Fix for syndicate turrets not shooting

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -61,6 +61,7 @@
 	var/stun_all = 0		//if this is active, the turret shoots everything that isn't security or head of staff
 	var/check_anomalies = 1	//checks if it can shoot at unidentified lifeforms (ie xenos)
 	var/shoot_unloyal = 0	//checks if it can shoot people that aren't loyalty implantd
+	var/target_cyborgs = 0	//checks if it can shoot cyborgs regardless of faction
 
 	var/attacked = 0		//if set to 1, the turret gets pissed off and shoots at people nearby (unless they have sec access!)
 
@@ -184,6 +185,7 @@
 		dat += "Neutralize All Non-Security and Non-Command Personnel: <A href='?src=[REF(src)];operation=shootall'>[stun_all ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Unidentified Life Signs: <A href='?src=[REF(src)];operation=checkxenos'>[check_anomalies ? "Yes" : "No"]</A><BR>"
 		dat += "Neutralize All Non-Loyalty Implanted Personnel: <A href='?src=[REF(src)];operation=checkloyal'>[shoot_unloyal ? "Yes" : "No"]</A><BR>"
+		dat += "Neutralize All Cyborgs: <A href='?src=[REF(src)];operation=checkborg'>[target_cyborgs ? "Yes" : "No"]</A><BR>"
 	if(issilicon(user))
 		if(!manual_control)
 			var/mob/living/silicon/S = user
@@ -225,6 +227,8 @@
 				check_anomalies = !check_anomalies
 			if("checkloyal")
 				shoot_unloyal = !shoot_unloyal
+			if("checkborg")
+				target_cyborgs = !target_cyborgs
 			if("manual")
 				if(issilicon(usr) && !manual_control)
 					give_control(usr)
@@ -393,6 +397,10 @@
 			var/mob/living/silicon/sillycone = A
 
 			if(ispAI(A))
+				continue
+
+			if(target_cyborgs && sillycone.stat != DEAD && iscyborg(sillycone))
+				targets += sillycone
 				continue
 
 			if(sillycone.stat || in_faction(sillycone))
@@ -581,13 +589,14 @@
 	A.fire()
 	return A
 
-/obj/machinery/porta_turret/proc/setState(on, mode)
+/obj/machinery/porta_turret/proc/setState(on, mode, shoot_cyborgs)
 	if(controllock)
 		return
 	src.on = on
 	if(!on && !always_up)
 		popDown()
 	src.mode = mode
+	src.target_cyborgs = shoot_cyborgs
 	power_change()
 
 
@@ -600,7 +609,7 @@
 	var/obj/machinery/porta_turret/P = target
 	if(!istype(P))
 		return
-	P.setState(P.on,!P.mode)
+	P.setState(P.on, !P.mode, P.target_cyborgs)
 
 /datum/action/turret_quit
 	name = "Release Control"
@@ -659,7 +668,7 @@
 	installation = null
 	always_up = TRUE
 	use_power = NO_POWER_USE
-	has_cover = TRUE
+	has_cover = FALSE
 	scan_range = 9
 	req_access = list(ACCESS_SYNDICATE)
 	uses_stored = FALSE
@@ -974,7 +983,7 @@
 
 /obj/machinery/turretid/proc/updateTurrets()
 	for (var/obj/machinery/porta_turret/aTurret in turrets)
-		aTurret.setState(enabled, lethal)
+		aTurret.setState(enabled, lethal, shoot_cyborgs)
 	update_icon()
 
 /obj/machinery/turretid/power_change()


### PR DESCRIPTION
## About The Pull Request

Fixes #2370 
Makes a new variable that checks if turrets can fire at cyborgs regardless of their faction.
Code inside the Turret Control Panel was already there, it just didn't do anything.

Removed the cover for syndicate turrets. (They will not fire if they have one, was changed in #4333)

## Why It's Good For The Game

Makes the "Target Cyborgs" thing actually functional.
Fixes syndicate turrets being useless decoration for syndicate ships.

## Changelog
:cl:
fix: "Target Cyborgs" for Turret Control Panels is working. Additionally adds it to the interface of turrets
fix: Syndicate turrets have lost their cover and can fire once again
/:cl: