### PR TITLE
Updates the max compile version to 1556

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -56,7 +56,7 @@
 
 //Update this whenever the byond version is stable so people stop updating to hilariously broken versions
 #define MAX_COMPILER_VERSION 514
-#define MAX_COMPILER_BUILD 1554
+#define MAX_COMPILER_BUILD 1556
 #if DM_VERSION > MAX_COMPILER_VERSION || DM_BUILD > MAX_COMPILER_BUILD
 #warn WARNING: Your BYOND version is over the recommended version (514.1554)! Stability is not guaranteed.
 #endif


### PR DESCRIPTION
Tested 1556 and all's good. 

## Changelog
:cl:
code: Max compile version bumped to 514.1556
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
