### PR TITLE
Moves Adrenaline nanites back to the Augmentation tab

### DIFF
--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -256,7 +256,7 @@
 	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
 	id = "adrenaline_nanites"
 	program_type = /datum/nanite_program/adrenaline
-	category = list("Augmentation")
+	category = list("Augmentation Nanites")
 
 ////////////////////DEFECTIVE NANITES//////////////////////////////////////
 

--- a/code/modules/research/designs/nanite_designs.dm
+++ b/code/modules/research/designs/nanite_designs.dm
@@ -251,6 +251,13 @@
 	program_type = /datum/nanite_program/mindshield
 	category = list("Augmentation Nanites")
 
+/datum/design/nanites/adrenaline
+	name = "Adrenaline Burst"
+	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
+	id = "adrenaline_nanites"
+	program_type = /datum/nanite_program/adrenaline
+	category = list("Augmentation")
+
 ////////////////////DEFECTIVE NANITES//////////////////////////////////////
 
 /datum/design/nanites/glitch
@@ -380,13 +387,6 @@
 	desc = "The nanites imprint an absolute directive onto the host's brain while they're active."
 	id = "mindcontrol_nanites"
 	program_type = /datum/nanite_program/comm/mind_control
-	category = list("Weaponized Nanites")
-
-/datum/design/nanites/adrenaline
-	name = "Adrenaline Burst"
-	desc = "The nanites cause a burst of adrenaline when triggered, waking the host from stuns and temporarily increasing their speed."
-	id = "adrenaline_nanites"
-	program_type = /datum/nanite_program/adrenaline
 	category = list("Weaponized Nanites")
 
 ////////////////////SUPPRESSION NANITES//////////////////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. This doesnt change the unlock requirements.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes absolutely zero sense Adrenaline is in **WEAPONIZED** nanite programs. Its a completely defensive tool, and belongs back where it came from.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Moves Adrenaline Nanites back to Augmentation tab. (Doesn't change unlock requirement)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
