### PR TITLE
Adds .38 Rubbers To Autolathes

### DIFF
--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -35,7 +35,7 @@
 	damage = 10
 	stamina = 30
 	armour_penetration = -30
-	ricochets_max = 1
+	ricochets_max = 6
 	ricochet_incidence_leeway = 70
 	ricochet_chance = 130
 	ricochet_decay_damage = 0.8

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -35,7 +35,7 @@
 	damage = 10
 	stamina = 30
 	armour_penetration = -30
-	ricochets_max = 6
+	ricochets_max = 1
 	ricochet_incidence_leeway = 70
 	ricochet_chance = 130
 	ricochet_decay_damage = 0.8

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -567,12 +567,12 @@
 	build_path = /obj/item/ammo_casing/shotgun/rubbershot
 	category = list("initial", "Security")
 
-/datum/design/c38
+/datum/design/c38b
 	name = "Speed Loader (.38)"
-	id = "c38"
+	id = "c38b"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 20000)
-	build_path = /obj/item/ammo_box/c38
+	materials = list(/datum/material/iron = 16000)
+	build_path = /obj/item/ammo_box/c38/match/bouncy
 	category = list("initial", "Security")
 
 /datum/design/recorder
@@ -848,6 +848,14 @@
 	build_type = AUTOLATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c9mm
+	category = list("hacked", "Security")
+
+/datum/design/c38
+	name = "Speed Loader (.38)"
+	id = "c38"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 20000)
+	build_path = /obj/item/ammo_box/c38
 	category = list("hacked", "Security")
 
 /datum/design/cleaver


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rubber .38s replace .38 speedloaders in autolathe. This allows detective to have the option to go non lethal, and makes the pistol a little bit more interesting, as bullets bounce of solid walls.

## Why It's Good For The Game

Expands a little and allows detective's gun to do trickshots.

## Changelog
:cl:
add: .38 Rubber Speedloaders Replaced At Autholate (.38 lethals still available at hacked autolathe)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
