### PR TITLE
[Station Objective] Drone Dispenser

### DIFF
--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -47,6 +47,7 @@
 
 	var/break_message = "lets out a tinny alarm before falling dark."
 	var/break_sound = 'sound/machines/warning-buzzer.ogg'
+	var/drones_produced = 0
 
 /obj/machinery/droneDispenser/Initialize()
 	. = ..()
@@ -72,6 +73,12 @@
 	desc = "A suspicious machine that will create Syndicate exterminator drones when supplied with iron and glass. Disgusting. This one seems ominous."
 	dispense_type = /obj/effect/mob_spawn/drone/syndrone/badass
 	end_create_message = "dispenses an ominous suspicious drone shell."
+
+/obj/machinery/droneDispenser/objective
+	iron_cost = 5000
+	glass_cost = 2000
+	power_used = 2500
+	starting_amount = 0
 
 // I don't need your forgiveness, this is awesome.
 /obj/machinery/droneDispenser/snowflake
@@ -168,6 +175,7 @@
 				use_power(power_used)
 
 			var/atom/A = new dispense_type(loc)
+			drones_produced++
 			A.flags_1 |= (flags_1 & ADMIN_SPAWNED_1)
 
 			if(create_sound)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -958,7 +958,7 @@
 	build_path = /obj/machinery/droneDispenser/objective
 	req_components = list(
 		/obj/item/stock_parts/matter_bin/bluespace = 2,
-		/obj/item/stock_parts/manipulator/femt = 2,
+		/obj/item/stock_parts/manipulator/femto = 2,
 		/obj/item/stack/ore/bluespace_crystal = 5)
 
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -951,6 +951,15 @@
 	name = "departmental techfab - science (Machine Board)"
 	icon_state = "science"
 	build_path = /obj/machinery/rnd/production/techfab/department/science
+	
+/obj/item/circuitboard/machine/drone_dispenser
+	name = "drone dispenser (Machine Board)"
+	icon_state = "science"
+	build_path = /obj/machinery/droneDispenser/objective
+	req_components = list(
+		/obj/item/stock_parts/matter_bin/bluespace = 2,
+		/obj/item/stock_parts/manipulator/femt = 2,
+		/obj/item/stack/ore/bluespace_crystal = 5)
 
 
 //Security

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -909,7 +909,7 @@
 
 /datum/supply_pack/engineering/drone_dispenser
 	name = "Drone Dispenser Board"
-	desc = "Secure the longevity of the current state of humanity within this massive library of scientific knowledge, capable of granting superhuman powers and abilities. Highly advanced research is required for proper construction. Also contains five DNA probes."
+	desc = "Are your superiors throwing buzzwords like 'autonomy' and 'self sustaining'? Satisfy their needs with a drone dispenser, the latest solution for autonomous facilities. Highly advanced research is required for proper construction."
 	cost = 15000
 	special = TRUE
 	contains = list(/obj/item/circuitboard/machine/drone_dispenser)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -907,6 +907,14 @@
 					)
 	crate_name= "bluespace artillery parts crate"
 
+/datum/supply_pack/engineering/drone_dispenser
+	name = "Drone Dispenser Board"
+	desc = "Secure the longevity of the current state of humanity within this massive library of scientific knowledge, capable of granting superhuman powers and abilities. Highly advanced research is required for proper construction. Also contains five DNA probes."
+	cost = 15000
+	special = TRUE
+	contains = list(/obj/item/circuitboard/machine/drone_dispenser)
+	crate_name= "drone dispenser board crate"
+
 /datum/supply_pack/engineering/dna_vault
 	name = "DNA Vault Parts"
 	desc = "Secure the longevity of the current state of humanity within this massive library of scientific knowledge, capable of granting superhuman powers and abilities. Highly advanced research is required for proper construction. Also contains five DNA probes."

--- a/code/modules/station_goals/drone_dispenser.dm
+++ b/code/modules/station_goals/drone_dispenser.dm
@@ -17,7 +17,7 @@
 	 The Drone Dispenser needs to be operational at the end of the shift,
 	 and must have dispensed at least [drones_produced] drone shells.
 
-	 Base vault parts are available for shipping via cargo."}
+	 Dispenser circuitry are available for shipping via cargo."}
 
 
 /datum/station_goal/drone_dispenser/on_report()
@@ -31,4 +31,3 @@
 	for(var/obj/machinery/droneDispenser/M in GLOB.machines)
 		production_count += M.drones_produced
 	return production_count>=drones_produced
-

--- a/code/modules/station_goals/drone_dispenser.dm
+++ b/code/modules/station_goals/drone_dispenser.dm
@@ -1,0 +1,38 @@
+//Crew has to create dna vault
+// Cargo can order DNA samplers + DNA vault boards
+// DNA vault requires x animals ,y plants, z human dna
+// DNA vaults require high tier stock parts and cold
+// After completion each crewmember can receive single upgrade chosen out of 2 for the mob.
+
+/datum/station_goal/drone_dispenser
+	name = "Drone Dispenser"
+	var/drones_produced
+
+/datum/station_goal/drone_dispenser/New()
+	..()
+	drones_produced = rand(1,5)
+
+/datum/station_goal/drone_dispenser/get_report()
+	return {"Our long term prediction systems indicate a 99% chance of system-wide cataclysm in the near future.
+	 We need you to construct a DNA Vault aboard your station.
+
+	 The DNA Vault needs to contain samples of:
+	 [animal_count] unique animal data
+	 [plant_count] unique non-standard plant data
+	 [human_count] unique sapient humanoid DNA data
+
+	 Base vault parts are available for shipping via cargo."}
+
+
+/datum/station_goal/drone_dispenser/on_report()
+	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/drone_dispenser]
+	P.special_enabled = TRUE
+
+/datum/station_goal/drone_dispenser/check_completion()
+	if(..())
+		return TRUE
+	var/production_count = 0
+	for(var/obj/machinery/droneDispenser/M in GLOB.machines)
+		production_count += M.drones_produced
+	return production_count>=drones_produced
+

--- a/code/modules/station_goals/drone_dispenser.dm
+++ b/code/modules/station_goals/drone_dispenser.dm
@@ -1,8 +1,6 @@
-//Crew has to create dna vault
-// Cargo can order DNA samplers + DNA vault boards
-// DNA vault requires x animals ,y plants, z human dna
-// DNA vaults require high tier stock parts and cold
-// After completion each crewmember can receive single upgrade chosen out of 2 for the mob.
+//Crew has to create drone dispenser
+// Cargo can order the board
+// The station needs to dispense N number of drones
 
 /datum/station_goal/drone_dispenser
 	name = "Drone Dispenser"
@@ -13,13 +11,11 @@
 	drones_produced = rand(1,5)
 
 /datum/station_goal/drone_dispenser/get_report()
-	return {"Our long term prediction systems indicate a 99% chance of system-wide cataclysm in the near future.
-	 We need you to construct a DNA Vault aboard your station.
+	return {"We want you to construct the requirements for a self-sustaining, autonomous research facility.
+	 This would require you to construct a Drone Dispenser aboard your station.
 
-	 The DNA Vault needs to contain samples of:
-	 [animal_count] unique animal data
-	 [plant_count] unique non-standard plant data
-	 [human_count] unique sapient humanoid DNA data
+	 The Drone Dispenser needs to be operational at the end of the shift,
+	 and must have dispensed at least [drones_produced] drone shells.
 
 	 Base vault parts are available for shipping via cargo."}
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new station objective; Drone Dispenser. This needs machine board bought with cargo, the parts and enough mats to produce N number of drone shells.

## Why It's Good For The Game

People have been enjoying drone roles for a while. This may be a good idea. 

Maybe I should add the option to disable it in config (LRP), but I'm not sure.

## Changelog
:cl:
add: Added Drone Dispenser Station Objective
tweak: Drone Dispensers track how many drones they produced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
