### PR TITLE
Magboots prevent unsafe pipe wrenching from throwing you

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -232,7 +232,7 @@
 	if(ishuman(user)) //other carbons like monkeys can unwrench but cant wear magboots
 		if(istype(user.shoes, /obj/item/clothing/shoes/magboots))
 			var/obj/item/clothing/shoes/magboots/M = user.shoes
-			if(M.magpulse)
+			if(M.negates_gravity())
 				return
 	if(!pressures)
 		var/datum/gas_mixture/int_air = return_air()

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -226,9 +226,14 @@
 	return can_unwrench
 
 // Throws the user when they unwrench a pipe with a major difference between the internal and environmental pressure.
-/obj/machinery/atmospherics/proc/unsafe_pressure_release(mob/user, pressures = null)
+/obj/machinery/atmospherics/proc/unsafe_pressure_release(mob/living/carbon/user, pressures = null)
 	if(!user)
 		return
+	if(ishuman(user)) //other carbons like monkeys can unwrench but cant wear magboots
+		if(istype(user.shoes, /obj/item/clothing/shoes/magboots))
+			var/obj/item/clothing/shoes/magboots/M = user.shoes
+			if(M.magpulse)
+				return
 	if(!pressures)
 		var/datum/gas_mixture/int_air = return_air()
 		var/datum/gas_mixture/env_air = loc.return_air()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Like spacewind, when you are wearing magboots when unwrenching a pipe over double atmospheric pressure, you no longer get thrown if they are on
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer will atmos techs have to place a holofan and grit their teeth as clearing the pipe before unwrenching is unreasonably hassling
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Magboots keep you from being flung by high pressure pipes when unwrenching
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
