### PR TITLE
Makes spray cans recyclable again

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -629,10 +629,10 @@
 
 	if(is_capped)
 		if(istype(target, /obj/machinery/modular_fabricator/autolathe))
-			. = ..()
+			return ..()
 		else
 			to_chat(user, "<span class='warning'>Take the cap off first!</span>")
-		return
+			return
 
 	if(check_empty(user))
 		return

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -627,6 +627,9 @@
 	if(!proximity)
 		return
 
+	if(is_capped && istype(target, /obj/machinery/modular_fabricator/autolathe))
+		. = ..()
+
 	if(is_capped)
 		to_chat(user, "<span class='warning'>Take the cap off first!</span>")
 		return

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -627,11 +627,11 @@
 	if(!proximity)
 		return
 
-	if(is_capped && istype(target, /obj/machinery/modular_fabricator/autolathe))
-		. = ..()
-
 	if(is_capped)
-		to_chat(user, "<span class='warning'>Take the cap off first!</span>")
+		if(istype(target, /obj/machinery/modular_fabricator/autolathe))
+			. = ..()
+		else
+			to_chat(user, "<span class='warning'>Take the cap off first!</span>")
 		return
 
 	if(check_empty(user))


### PR DESCRIPTION
## About The Pull Request

Makes spray cans able to be recycled again, after some PR had made them also paint storages, which made them ignore autolathe recycling.
You can now recycle a spray can when the cap is off, and paint autolathe when the cap is off.

## Why It's Good For The Game

Speaks for itself.

## Changelog
:cl:
tweak: make spray cans recyclable again, while preserving the ability to paint autolathe
/:cl:
