### PR TITLE
Makes alarm manager update even while off and fire alarms clear

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -38,4 +38,4 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
-GLOBAL_LIST_INIT(alarms, list("Fire" = list(), "Atmosphere" = list(), "Power" = list()))
+GLOBAL_LIST_INIT(alarms, list("Fire" = list(), "Atmosphere" = list(), "Power" = list())) //all engineering alerts for station alert consoles and alarm manager

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -38,3 +38,4 @@ GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert
+GLOBAL_LIST_INIT(alarms, list("Fire" = list(), "Atmosphere" = list(), "Power" = list()))

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -6,7 +6,6 @@
 	circuit = /obj/item/circuitboard/computer/stationalert
 
 
-	var/alarms = list("Fire" = list(), "Atmosphere" = list(), "Power" = list())
 
 	light_color = LIGHT_COLOR_CYAN
 
@@ -32,9 +31,9 @@
 	var/list/data = list()
 
 	data["alarms"] = list()
-	for(var/class in alarms)
+	for(var/class in GLOB.alarms)
 		data["alarms"][class] = list()
-		for(var/area in alarms[class])
+		for(var/area in GLOB.alarms[class])
 			data["alarms"][class] += area
 
 	return data
@@ -45,7 +44,7 @@
 	if(stat & (BROKEN))
 		return
 
-	var/list/our_sort = alarms[class]
+	var/list/our_sort = GLOB.alarms[class]
 	for(var/areaname in our_sort)
 		if (areaname == home.name)
 			var/list/alarm = our_sort[areaname]
@@ -66,8 +65,8 @@
 	return TRUE
 
 /obj/machinery/computer/station_alert/proc/freeCamera(area/home, obj/machinery/camera/cam)
-	for(var/class in alarms)
-		var/our_area = alarms[class][home.name]
+	for(var/class in GLOB.alarms)
+		var/our_area = GLOB.alarms[class][home.name]
 		if(!our_area)
 			continue
 		var/cams = our_area[2] //Get the cameras
@@ -83,7 +82,7 @@
 /obj/machinery/computer/station_alert/proc/cancelAlarm(class, area/A, obj/origin)
 	if(stat & (BROKEN))
 		return
-	var/list/L = alarms[class]
+	var/list/L = GLOB.alarms[class]
 	var/cleared = 0
 	for (var/I in L)
 		if (I == A.name)
@@ -93,7 +92,7 @@
 				srcs -= origin
 			if (srcs.len == 0)
 				cleared = 1
-				L -= I
+				GLOB.alarms[class] -= I
 	return !cleared
 
 /obj/machinery/computer/station_alert/update_icon()
@@ -101,8 +100,8 @@
 	if(stat & (NOPOWER|BROKEN))
 		return
 	var/active_alarms = FALSE
-	for(var/cat in alarms)
-		var/list/L = alarms[cat]
+	for(var/cat in GLOB.alarms)
+		var/list/L = GLOB.alarms[cat]
 		if(L.len)
 			active_alarms = TRUE
 	if(active_alarms)

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -92,7 +92,7 @@
 				srcs -= origin
 			if (srcs.len == 0)
 				cleared = 1
-				GLOB.alarms[class] -= I
+				L -= I
 	return !cleared
 
 /obj/machinery/computer/station_alert/update_icon()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -138,7 +138,7 @@
 	if(!is_operational())
 		return
 	var/area/A = get_area(src)
-	A.firereset()
+	A.firereset(src)
 	if(user)
 		log_game("[user] reset a fire alarm at [COORD(src)]")
 

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -12,7 +12,6 @@
 
 
 	var/has_alert = 0
-	var/alarms = list("Fire" = list(), "Atmosphere" = list(), "Power" = list())
 
 /datum/computer_file/program/alarm_monitor/process_tick()
 	..()
@@ -32,9 +31,9 @@
 	var/list/data = get_header_data()
 
 	data["alarms"] = list()
-	for(var/class in alarms)
+	for(var/class in GLOB.alarms)
 		data["alarms"][class] = list()
-		for(var/area in alarms[class])
+		for(var/area in GLOB.alarms[class])
 			data["alarms"][class] += area
 
 	return data
@@ -46,7 +45,7 @@
 	else if(!is_mining_level(source.z) || istype(home, /area/ruin))
 		return
 
-	var/list/our_sort = alarms[class]
+	var/list/our_sort = GLOB.alarms[class]
 	for(var/areaname in our_sort)
 		if (areaname == home.name)
 			var/list/alarm = our_sort[areaname]
@@ -69,8 +68,8 @@
 	return TRUE
 
 /datum/computer_file/program/alarm_monitor/proc/freeCamera(area/home, obj/machinery/camera/cam)
-	for(var/class in alarms)
-		var/our_area = alarms[class][home.name]
+	for(var/class in GLOB.alarms)
+		var/our_area = GLOB.alarms[class][home.name]
 		if(!our_area)
 			continue
 		var/cams = our_area[2] //Get the cameras
@@ -84,7 +83,7 @@
 			our_area[2] = null
 
 /datum/computer_file/program/alarm_monitor/proc/cancelAlarm(class, area/A, obj/origin)
-	var/list/L = alarms[class]
+	var/list/L = GLOB.alarms[class]
 	var/cleared = 0
 	for (var/I in L)
 		if (I == A.name)
@@ -101,8 +100,8 @@
 
 /datum/computer_file/program/alarm_monitor/proc/update_alarm_display()
 	has_alert = FALSE
-	for(var/cat in alarms)
-		var/list/L = alarms[cat]
+	for(var/cat in GLOB.alarms)
+		var/list/L = GLOB.alarms[cat]
 		if(L.len)
 			has_alert = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Closes #4559
Closes #4523
Alarm manager on modular computers shares the same alarms list as the station alert console so that they show changes from when they were off
Fire alarms clear on alarm manager/alert consoles when you toggle them off
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the app more useful and accurate
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: alarm manager now shows alarm changes from when it was off
fix: fire alarms clear when you pull them up now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
