### PR TITLE
Converts Slime processor process to a Proximity Monitor

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -154,6 +154,7 @@
 /obj/machinery/processor/slime
 	name = "slime processor"
 	desc = "An industrial grinder with a sticker saying appropriated for science department. Keep hands clear of intake area while operating."
+	var/sbacklogged = FALSE
 
 /obj/machinery/processor/slime/Initialize()
 	. = ..()
@@ -177,15 +178,20 @@
 
 /obj/machinery/processor/slime/interact(mob/user)
 	. = ..()
-	for(var/mob/living/simple_animal/slime/AM in hearers(1,src)) //fallback in case slimes got placed while processor was active
-		if(AM.stat == DEAD)
-			visible_message("[AM] is sucked into [src].")
-			AM.forceMove(src)
+	if(sbacklogged)
+		for(var/mob/living/simple_animal/slime/AM in hearers(1,src)) //fallback in case slimes got placed while processor was active
+			if(AM.stat == DEAD)
+				visible_message("[AM] is sucked into [src].")
+				AM.forceMove(src)
+				sbacklogged = FALSE
 
 /obj/machinery/processor/slime/HasProximity(mob/AM)
-	if(!processing && istype(AM, /mob/living/simple_animal/slime) && AM.stat == DEAD)
-		visible_message("[AM] is sucked into [src].")
-		AM.forceMove(src)
+	if(!sbacklogged && istype(AM, /mob/living/simple_animal/slime) && AM.stat == DEAD)
+		if(processing)
+			sbacklogged = TRUE
+		else
+			visible_message("[AM] is sucked into [src].")
+			AM.forceMove(src)
 
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	var/mob/living/simple_animal/slime/S = what

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -179,7 +179,7 @@
 /obj/machinery/processor/slime/interact(mob/user)
 	. = ..()
 	if(sbacklogged)
-		for(var/mob/living/simple_animal/slime/AM in hearers(1,src)) //fallback in case slimes got placed while processor was active
+		for(var/mob/living/simple_animal/slime/AM in hearers(1,src)) //fallback in case slimes got placed while processor was active triggers only after processing!!!!
 			if(AM.stat == DEAD)
 				visible_message("[AM] is sucked into [src].")
 				AM.forceMove(src)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -179,7 +179,7 @@
 /obj/machinery/processor/slime/interact(mob/user)
 	. = ..()
 	if(sbacklogged)
-		for(var/mob/living/simple_animal/slime/AM in hearers(1,src)) //fallback in case slimes got placed while processor was active triggers only after processing!!!!
+		for(var/mob/living/simple_animal/slime/AM in ohearers(1,src)) //fallback in case slimes got placed while processor was active triggers only after processing!!!!
 			if(AM.stat == DEAD)
 				visible_message("[AM] is sucked into [src].")
 				AM.forceMove(src)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -183,7 +183,7 @@
 			if(AM.stat == DEAD)
 				visible_message("[AM] is sucked into [src].")
 				AM.forceMove(src)
-				sbacklogged = FALSE
+		sbacklogged = FALSE
 
 /obj/machinery/processor/slime/HasProximity(mob/AM)
 	if(!sbacklogged && istype(AM, /mob/living/simple_animal/slime) && AM.stat == DEAD)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -176,7 +176,7 @@
 	return i
 
 /obj/machinery/processor/slime/HasProximity(mob/AM)
-	if(!processing && istype(AM,/mob/living/simple_animal/slime) && AM.stat == DEAD)
+	if(!processing && istype(AM, /mob/living/simple_animal/slime) && AM.stat == DEAD)
 		visible_message("[AM] is sucked into [src].")
 		AM.forceMove(src)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -184,10 +184,6 @@
 	var/mob/living/simple_animal/slime/S = what
 	if (istype(S))
 		var/C = S.cores
-		if(S.stat != DEAD)
-			S.forceMove(drop_location())
-			S.visible_message("<span class='notice'>[C] crawls free of the processor!</span>")
-			return
 		for(var/i in 1 to (C+rating_amount-1))
 			var/obj/item/slime_extract/item = new S.coretype(drop_location())
 			if(S.transformeffects & SLIME_EFFECT_GOLD)

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -176,7 +176,7 @@
 	return i
 
 /obj/machinery/processor/slime/HasProximity(mob/AM)
-	if(!processing && AM.stat == DEAD && istype(AM,/mob/living/simple_animal/slime))
+	if(!processing && istype(AM,/mob/living/simple_animal/slime) && AM.stat == DEAD)
 		visible_message("[AM] is sucked into [src].")
 		AM.forceMove(src)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -14,6 +14,7 @@
 	var/processing = FALSE
 	var/rating_speed = 1
 	var/rating_amount = 1
+	processing_flags = NONE
 
 /obj/machinery/processor/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
@@ -158,6 +159,7 @@
 	. = ..()
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/processor/slime(null)
 	B.apply_default_parts(src)
+	proximity_monitor = new(src, 1)
 
 /obj/machinery/processor/slime/adjust_item_drop_location(atom/movable/AM)
 	var/static/list/slimecores = subtypesof(/obj/item/slime_extract)
@@ -173,22 +175,10 @@
 	AM.pixel_y = -8 + (round(ii/3)*8)
 	return i
 
-/obj/machinery/processor/slime/process()
-	if(processing)
-		return
-	var/mob/living/simple_animal/slime/picked_slime
-	for(var/mob/living/simple_animal/slime/slime in ohearers(1,src))
-		if(slime.stat)
-			picked_slime = slime
-			break
-	if(!picked_slime)
-		return
-	var/datum/food_processor_process/P = select_recipe(picked_slime)
-	if (!P)
-		return
-
-	visible_message("[picked_slime] is sucked into [src].")
-	picked_slime.forceMove(src)
+/obj/machinery/processor/slime/HasProximity(mob/AM)
+	if(!processing && AM.stat == DEAD && istype(AM,/mob/living/simple_animal/slime))
+		visible_message("[AM] is sucked into [src].")
+		AM.forceMove(src)
 
 /obj/machinery/processor/slime/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	var/mob/living/simple_animal/slime/S = what

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -175,6 +175,13 @@
 	AM.pixel_y = -8 + (round(ii/3)*8)
 	return i
 
+/obj/machinery/processor/slime/interact(mob/user)
+	. = ..()
+	for(var/mob/living/simple_animal/slime/AM in hearers(1,src)) //fallback in case slimes got placed while processor was active
+		if(AM.stat == DEAD)
+			visible_message("[AM] is sucked into [src].")
+			AM.forceMove(src)
+
 /obj/machinery/processor/slime/HasProximity(mob/AM)
 	if(!processing && istype(AM, /mob/living/simple_animal/slime) && AM.stat == DEAD)
 		visible_message("[AM] is sucked into [src].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes: #4384
This PR converts the current process of the slime processor to a Proximity Monitor as it is way faster and also means one object less thats processing also sets the parent of the slime processors processing_flags to none as it also called processing despite it not even having a process proc.

~~Only drawback is that if the slime processor is currently active and you put additional slimes down you will have to pick those up again and place them down or move them around so that it calls hasproximity again.~~ Now there is a fallback to hearers after it finishes to process the slimes so thats no longer a problem.
## Why It's Good For The Game

Ike wants this

## Changelog
:cl:
code: Rewrote the slime processor to be more performant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
