### PR TITLE
Runtime fix for Spirit Realm rune

### DIFF
--- a/code/modules/mob/living/living_sentience.dm
+++ b/code/modules/mob/living/living_sentience.dm
@@ -1,5 +1,5 @@
 /mob/living/ghostize(can_reenter_corpse, sentience_retention)
-	..()
+	. = ..()
 	switch(sentience_retention)
 		if (SENTIENCE_RETAIN)
 			if (playable)	//so the alert goes through for observing ghosts
@@ -8,7 +8,7 @@
 			set_playable()
 		if (SENTIENCE_ERASE)
 			playable = FALSE
-	
+
 /mob/living/attack_ghost(mob/user)
 	. = ..()
 	if(.)
@@ -22,7 +22,7 @@
 		var/mob/dead/observer/ghost = usr
 		if(istype(ghost) && playable)
 			give_mind(ghost)
-			
+
 /mob/living/proc/give_mind(mob/user)
 	if(key || !playable || stat)
 		return 0
@@ -36,11 +36,11 @@
 	log_game("[key_name(src)] took control of [name].")
 	remove_form_spawner_menu()
 	return TRUE
-			
+
 /mob/living/proc/set_playable()
 	playable = TRUE
 	if (!key)	//check if there is nobody already inhibiting this mob
-		notify_ghosts("[name] can be controlled", null, enter_link="<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source=src, action=NOTIFY_ATTACK, ignore_key = name)		
+		notify_ghosts("[name] can be controlled", null, enter_link="<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source=src, action=NOTIFY_ATTACK, ignore_key = name)
 		LAZYADD(GLOB.mob_spawners["[name]"], src)
 		GLOB.poi_list |= src
 


### PR DESCRIPTION
## About The Pull Request

Fixes #4468
One line of `..()` gets changed to `. = ..()` and as a result fixes the second function of the Spirit Realm rune. (and maybe other things too)

Runtime:

```
runtime error: Cannot read null.vars
 - proc name: invoke (/obj/effect/rune/manifest/invoke)
 -   source file: runes.dm,908
 -   usr: Enters-The-Rift (/mob/living/carbon/human)
 -   src: the rune (/obj/effect/rune/manifest)
```

`var/mob/dead/observer/G = affecting.ghostize(1)` G stays null because `/mob/living/ghostize()` doesn't return the ghost it's parent proc `/mob/proc/ghostize()` returns

## Why It's Good For The Game

Runtimes bad. Fixes good.

## Changelog
:cl:
fix: Ascend as a Dark Spirit function of the Spirit Realm rune is working correctly again
/:cl: