### PR TITLE
Fixes double ids on eject

### DIFF
--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -10,7 +10,7 @@
 	var/obj/item/card/id/stored_card2
 
 /obj/item/computer_hardware/card_slot/Exited(atom/A, atom/newloc)
-	if(A == stored_card || A == stored_card2)
+	if(A == (stored_card | stored_card2))
 		stored_card = null
 		if(holder)
 			if(holder.active_program)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -6,14 +6,25 @@
 	w_class = WEIGHT_CLASS_TINY
 	device_type = MC_CARD
 
-	var/obj/item/card/id/stored_card = null
-	var/obj/item/card/id/stored_card2 = null
+	var/obj/item/card/id/stored_card
+	var/obj/item/card/id/stored_card2
 
 /obj/item/computer_hardware/card_slot/Exited(atom/A, atom/newloc)
-	if(A == stored_card)
-		try_eject(1, null, TRUE)
-	if(A == stored_card2)
-		try_eject(2, null, TRUE)
+	if(A == stored_card || A == stored_card2)
+		stored_card = null
+		if(holder)
+			if(holder.active_program)
+				holder.active_program.event_idremoved(0)
+			for(var/p in holder.idle_threads)
+				var/datum/computer_file/program/computer_program = p
+				computer_program.event_idremoved(1)
+
+			holder.update_slot_icon()
+
+			if(ishuman(holder.loc))
+				var/mob/living/carbon/human/human_wearer = holder.loc
+				if(human_wearer.wear_id == holder)
+					human_wearer.sec_hud_set_ID()
 	return ..()
 
 /obj/item/computer_hardware/card_slot/Destroy()

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -10,21 +10,23 @@
 	var/obj/item/card/id/stored_card2
 
 /obj/item/computer_hardware/card_slot/Exited(atom/A, atom/newloc)
-	if(A == (stored_card | stored_card2))
-		stored_card = null
-		if(holder)
-			if(holder.active_program)
-				holder.active_program.event_idremoved(0)
-			for(var/p in holder.idle_threads)
-				var/datum/computer_file/program/computer_program = p
-				computer_program.event_idremoved(1)
+	if(!(A == (stored_card | stored_card2)))
+		return ..()
+	stored_card = null
+	if(holder)
+		if(holder.active_program)
+			holder.active_program.event_idremoved(0)
+		for(var/p in holder.idle_threads)
+			var/datum/computer_file/program/computer_program = p
+			computer_program.event_idremoved(1)
 
-			holder.update_slot_icon()
+		holder.update_slot_icon()
 
-			if(ishuman(holder.loc))
-				var/mob/living/carbon/human/human_wearer = holder.loc
-				if(human_wearer.wear_id == holder)
-					human_wearer.sec_hud_set_ID()
+		if(!ishuman(get_turf(holder)))
+			return ..()
+		var/mob/living/carbon/human/human_wearer = get_turf(holder)
+		if(human_wearer.wear_id == holder)
+			human_wearer.sec_hud_set_ID()
 	return ..()
 
 /obj/item/computer_hardware/card_slot/Destroy()

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -10,7 +10,7 @@
 	var/obj/item/card/id/stored_card2
 
 /obj/item/computer_hardware/card_slot/Exited(atom/A, atom/newloc)
-	if(!(A == (stored_card | stored_card2)))
+	if(!(A == stored_card || A == stored_card2))
 		return ..()
 	stored_card = null
 	if(holder)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -21,9 +21,9 @@
 
 		holder.update_slot_icon()
 
-		if(!ishuman(get_turf(holder)))
+		if(!ishuman(holder.loc))
 			return ..()
-		var/mob/living/carbon/human/human_wearer = get_turf(holder)
+		var/mob/living/carbon/human/human_wearer = holder.loc
 		if(human_wearer.wear_id == holder)
 			human_wearer.sec_hud_set_ID()
 	return ..()

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -12,7 +12,6 @@
 /obj/item/computer_hardware/card_slot/Exited(atom/A, atom/newloc)
 	if(!(A == stored_card || A == stored_card2))
 		return ..()
-	stored_card = null
 	if(holder)
 		if(holder.active_program)
 			holder.active_program.event_idremoved(0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
good one #4270
code from [tgtation#57387](https://github.com/tgstation/tgstation/pull/57387)
no more double ids when you eject from a modular pc
closes #4299
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: phantom ids when you eject an id from a modular pc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
