### PR TITLE
Ports remaining time estimation on tend wounds from /tg/

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -162,6 +162,30 @@
 	missinghpbonus = 5
 
 /***************************BURN***************************/
+/datum/surgery/healing/burn
+	name = "Tend Wounds (Burn)"
+
+/datum/surgery/healing/burn/basic
+	name = "Tend Wounds (Burn, Basic)"
+	replaced_by = /datum/surgery/healing/burn/upgraded
+	healing_step_type = /datum/surgery_step/heal/burn/basic
+	desc = "A surgical procedure that provides basic treatment for a patient's burns. Heals slightly more when the patient is severely injured."
+
+/datum/surgery/healing/burn/upgraded
+	name = "Tend Wounds (Burn, Adv.)"
+	replaced_by = /datum/surgery/healing/burn/upgraded/femto
+	requires_tech = TRUE
+	healing_step_type = /datum/surgery_step/heal/burn/upgraded
+	desc = "A surgical procedure that provides advanced treatment for a patient's burns. Heals more when the patient is severely injured."
+
+/datum/surgery/healing/burn/upgraded/femto
+	name = "Tend Wounds (Burn, Exp.)"
+	replaced_by = /datum/surgery/healing/combo/upgraded/femto
+	requires_tech = TRUE
+	healing_step_type = /datum/surgery_step/heal/burn/upgraded/femto
+	desc = "A surgical procedure that provides experimental treatment for a patient's burns. Heals considerably more when the patient is severely injured."
+
+/********************BURN STEPS********************/
 /datum/surgery_step/heal/burn/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
 	if(!burn_healed)
 		return
@@ -189,30 +213,6 @@
 
 	return progress_text
 
-/datum/surgery/healing/burn
-	name = "Tend Wounds (Burn)"
-
-/datum/surgery/healing/burn/basic
-	name = "Tend Wounds (Burn, Basic)"
-	replaced_by = /datum/surgery/healing/burn/upgraded
-	healing_step_type = /datum/surgery_step/heal/burn/basic
-	desc = "A surgical procedure that provides basic treatment for a patient's burns. Heals slightly more when the patient is severely injured."
-
-/datum/surgery/healing/burn/upgraded
-	name = "Tend Wounds (Burn, Adv.)"
-	replaced_by = /datum/surgery/healing/burn/upgraded/femto
-	requires_tech = TRUE
-	healing_step_type = /datum/surgery_step/heal/burn/upgraded
-	desc = "A surgical procedure that provides advanced treatment for a patient's burns. Heals more when the patient is severely injured."
-
-/datum/surgery/healing/burn/upgraded/femto
-	name = "Tend Wounds (Burn, Exp.)"
-	replaced_by = /datum/surgery/healing/combo/upgraded/femto
-	requires_tech = TRUE
-	healing_step_type = /datum/surgery_step/heal/burn/upgraded/femto
-	desc = "A surgical procedure that provides experimental treatment for a patient's burns. Heals considerably more when the patient is severely injured."
-
-/********************BURN STEPS********************/
 /datum/surgery_step/heal/burn/basic
 	name = "tend burn wounds"
 	burnhealing = 5
@@ -227,6 +227,27 @@
 	missinghpbonus = 5
 
 /***************************COMBO***************************/
+/datum/surgery/healing/combo
+	name = "Tend Wounds (Mixture, Basic)"
+	replaced_by = /datum/surgery/healing/combo/upgraded
+	requires_tech = TRUE
+	healing_step_type = /datum/surgery_step/heal/combo
+	desc = "A surgical procedure that provides basic treatment for a patient's burns and brute traumas. Heals slightly more when the patient is severely injured."
+
+/datum/surgery/healing/combo/upgraded
+	name = "Tend Wounds (Mixture, Adv.)"
+	replaced_by = /datum/surgery/healing/combo/upgraded/femto
+	healing_step_type = /datum/surgery_step/heal/combo/upgraded
+	desc = "A surgical procedure that provides advanced treatment for a patient's burns and brute traumas. Heals more when the patient is severely injured."
+
+
+/datum/surgery/healing/combo/upgraded/femto //no real reason to type it like this except consistency, don't worry you're not missing anything
+	name = "Tend Wounds (Mixture, Exp.)"
+	replaced_by = null
+	healing_step_type = /datum/surgery_step/heal/combo/upgraded/femto
+	desc = "A surgical procedure that provides experimental treatment for a patient's burns and brute traumas. Heals considerably more when the patient is severely injured."
+
+/********************COMBO STEPS********************/
 /datum/surgery_step/heal/combo/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
 	var/estimated_remaining_steps = 0
 	if(brute_healed > 0)
@@ -260,27 +281,6 @@
 
 	return progress_text
 
-/datum/surgery/healing/combo
-	name = "Tend Wounds (Mixture, Basic)"
-	replaced_by = /datum/surgery/healing/combo/upgraded
-	requires_tech = TRUE
-	healing_step_type = /datum/surgery_step/heal/combo
-	desc = "A surgical procedure that provides basic treatment for a patient's burns and brute traumas. Heals slightly more when the patient is severely injured."
-
-/datum/surgery/healing/combo/upgraded
-	name = "Tend Wounds (Mixture, Adv.)"
-	replaced_by = /datum/surgery/healing/combo/upgraded/femto
-	healing_step_type = /datum/surgery_step/heal/combo/upgraded
-	desc = "A surgical procedure that provides advanced treatment for a patient's burns and brute traumas. Heals more when the patient is severely injured."
-
-
-/datum/surgery/healing/combo/upgraded/femto //no real reason to type it like this except consistency, don't worry you're not missing anything
-	name = "Tend Wounds (Mixture, Exp.)"
-	replaced_by = null
-	healing_step_type = /datum/surgery_step/heal/combo/upgraded/femto
-	desc = "A surgical procedure that provides experimental treatment for a patient's burns and brute traumas. Heals considerably more when the patient is severely injured."
-
-/********************COMBO STEPS********************/
 /datum/surgery_step/heal/combo
 	name = "tend physical wounds"
 	brutehealing = 3

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -30,6 +30,9 @@
 	var/burnhealing = 0
 	var/missinghpbonus = 0 //heals an extra point of damager per X missing damage of type (burn damage for burn healing, brute for brute). Smaller Number = More Healing!
 
+/datum/surgery_step/heal/proc/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	return
+
 /datum/surgery_step/heal/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/woundtype
 	if(brutehealing && burnhealing)
@@ -70,6 +73,8 @@
 		umsg += " as best as you can while they have clothing on"
 		tmsg += " as best as they can while [target] has clothing on"
 	target.heal_bodypart_damage(urhealedamt_brute,urhealedamt_burn)
+	umsg += get_progress(user, target, urhealedamt_brute, urhealedamt_burn)
+
 	display_results(user, target, "<span class='notice'>[umsg].</span>",
 		"[tmsg].",
 		"[tmsg].")
@@ -116,6 +121,33 @@
 	desc = "A surgical procedure that provides experimental treatment for a patient's brute traumas. Heals considerably more when the patient is severely injured."
 
 /********************BRUTE STEPS********************/
+/datum/surgery_step/heal/brute/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!brute_healed)
+		return
+
+	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed
+	var/progress_text
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", stitching up the last few scrapes"
+			if(3 to 6)
+				progress_text = ", counting down the last few bruises left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive rupturing"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like ground beef than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] pulped body"
+
+	return progress_text
+
 /datum/surgery_step/heal/brute/basic
 	name = "tend bruises"
 	brutehealing = 5
@@ -130,6 +162,33 @@
 	missinghpbonus = 5
 
 /***************************BURN***************************/
+/datum/surgery_step/heal/burn/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	if(!burn_healed)
+		return
+
+	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
+	var/progress_text
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		progress_text = ". Remaining brute: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few singe marks"
+			if(3 to 6)
+				progress_text = ", counting down the last few blisters left to treat"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] thorough roasting"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like burnt steak than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] charred body"
+
+	return progress_text
+
 /datum/surgery/healing/burn
 	name = "Tend Wounds (Burn)"
 
@@ -168,8 +227,38 @@
 	missinghpbonus = 5
 
 /***************************COMBO***************************/
-/datum/surgery/healing/combo
+/datum/surgery_step/heal/combo/get_progress(mob/user, mob/living/carbon/target, brute_healed, burn_healed)
+	var/estimated_remaining_steps = 0
+	if(brute_healed > 0)
+		estimated_remaining_steps = max(0, (target.getBruteLoss() / brute_healed))
+	if(burn_healed > 0)
+		estimated_remaining_steps = max(estimated_remaining_steps, (target.getFireLoss() / burn_healed)) // whichever is higher between brute or burn steps
 
+	var/progress_text
+
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		if(target.getBruteLoss())
+			progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
+		if(target.getFireLoss())
+			progress_text += ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
+	else
+		switch(estimated_remaining_steps)
+			if(-INFINITY to 1)
+				return
+			if(1 to 3)
+				progress_text = ", finishing up the last few signs of damage"
+			if(3 to 6)
+				progress_text = ", counting down the last few patches of trauma"
+			if(6 to 9)
+				progress_text = ", continuing to plug away at [target.p_their()] extensive injuries"
+			if(9 to 12)
+				progress_text = ", steadying yourself for the long surgery ahead"
+			if(12 to 15)
+				progress_text = ", though [target.p_they()] still look[target.p_s()] more like smooshed baby food than a person"
+			if(15 to INFINITY)
+				progress_text = ", though you feel like you're barely making a dent in treating [target.p_their()] broken body"
+
+	return progress_text
 
 /datum/surgery/healing/combo
 	name = "Tend Wounds (Mixture, Basic)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports [tgstation#58682](https://github.com/tgstation/tgstation/pull/58682)
Surgery now estimates how long you have left to fix someone's wounds
You get their exact health values each time you patch them up if you have a health analyzer too
![image](https://user-images.githubusercontent.com/85033680/122687262-1a0c7880-d1db-11eb-9427-94dea8929fb6.png)
tend wounds mixed with analyzer

![image](https://user-images.githubusercontent.com/85033680/122687425-0a416400-d1dc-11eb-9607-a4588748eef2.png)
tend wounds burns without analyzer
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer have to stop surgery and check
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Tend wounds estimates remaining time, even better with an analyzer in hand
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
