### PR TITLE
No more roundstart blob zombie

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/sos4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/sos4.dmm
@@ -26,10 +26,6 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/effect/mob_spawn/human/corpse/assistant{
-	brute_damage = 120;
-	oxy_damage = 75
-	},
 /obj/item/storage/pod{
 	pixel_y = -30
 	},


### PR DESCRIPTION
Removes the sentient blob zombie from that one pod ruin.

There is nothing for it to do, the only option is to meta the stations location and float to it, then break windows.