### PR TITLE
Revert "RPG Loot Bug on various storages"

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -294,10 +294,10 @@
 	for(var/obj/item/I in real_location.contents)
 		if(QDELETED(I))
 			continue
-		if(!.["[I.type]"])
-			.["[I.type]"] = new /datum/numbered_display(I, 1)
+		if(!.["[I.type]-[I.name]"])
+			.["[I.type]-[I.name]"] = new /datum/numbered_display(I, 1)
 		else
-			var/datum/numbered_display/ND = .["[I.type]"]
+			var/datum/numbered_display/ND = .["[I.type]-[I.name]"]
 			ND.number++
 
 //This proc determines the size of the inventory to be displayed. Please touch it only if you know what you're doing.


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#3978

This PR breaks stacking multiple things of different name, as seen in https://github.com/BeeStation/BeeStation-Hornet/issues/4067.

This problem's persisted for months now, and I think letting object names get fucked over a small percent of times on the lowest rarity gamemode is worth fixing chemical bags.