### PR TITLE
Corg AI Cams are no longer public network

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -2,12 +2,66 @@
 "aaa" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
+"aab" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/porta_turret/ai{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("aicore")
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"aac" = (
+/obj/structure/bed/dogbed/renault,
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/mob/living/simple_animal/pet/fox/Renault,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"aad" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/carpet/orange,
+/area/crew_quarters/heads/chief)
+"aae" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "aaf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engine_room)
+"aag" = (
+/obj/structure/bed/dogbed/ian,
+/obj/machinery/camera/autoname,
+/mob/living/simple_animal/pet/dog/corgi/Ian,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/hop)
 "aah" = (
 /obj/structure/dresser,
 /obj/item/flashlight/lamp/green{
@@ -31,12 +85,115 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"aaj" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/landmark/event_spawn,
+/mob/living/simple_animal/kalo,
+/turf/open/floor/plasteel,
+/area/janitor)
+"aak" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/bed/roller,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/freezer,
+/area/medical/genetics)
 "aal" = (
 /obj/structure/transit_tube/curved{
 	dir = 1
 	},
 /turf/open/space/basic,
 /area/space)
+"aam" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/mob/living/simple_animal/bot/floorbot{
+	locked = 0;
+	on = 0
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/aft)
+"aan" = (
+/obj/structure/bed/roller,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/freezer,
+/area/medical/genetics)
+"aao" = (
+/obj/machinery/light/small,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/freezer,
+/area/medical/genetics)
+"aap" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/retaliate/goat{
+	name = "Pete"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/kitchen/coldroom)
+"aaq" = (
+/obj/structure/bed/dogbed/vector,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/mob/living/simple_animal/pet/hamster/vector,
+/turf/open/floor/plasteel/dark,
+/area/medical/virology)
+"aar" = (
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/crab,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness/recreation)
+"aas" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/porta_turret/ai{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 4;
+	network = list("aicore")
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "aat" = (
 /obj/structure/rack,
 /obj/structure/cable/yellow{
@@ -53,6 +210,69 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
+"aau" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "aicore";
+	pixel_y = 36;
+	range = 2
+	},
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/camera/autoname{
+	network = list("aicore")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"aav" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("aicore")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"aaw" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname{
+	network = list("aicore")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
+"aax" = (
+/obj/machinery/camera/autoname{
+	dir = 4;
+	network = list("aicore")
+	},
+/turf/open/space/basic,
+/area/space)
+"aay" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("aicore")
+	},
+/turf/open/space/basic,
+/area/space)
 "aaz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -376,15 +596,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/bridge)
-"adM" = (
-/obj/structure/bed/dogbed/renault,
-/mob/living/simple_animal/pet/fox/Renault,
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "adN" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/blue{
@@ -3958,11 +4169,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"aQu" = (
-/mob/living/carbon/monkey,
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/freezer,
-/area/medical/genetics)
 "aQv" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -6110,13 +6316,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
-"bsd" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/autoname{
-	network = list("aisat")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "bse" = (
 /obj/structure/chair/sofa/left,
 /obj/effect/landmark/start/assistant,
@@ -6869,38 +7068,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
-"bFw" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "aicore";
-	pixel_y = 36;
-	range = 2
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/camera/autoname{
-	network = list("aisat")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "bFD" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -7190,11 +7357,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/library)
-"bHO" = (
-/mob/living/simple_animal/crab,
-/obj/structure/bed/dogbed,
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
 "bHS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9634,16 +9796,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"csm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("aisat")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
 "cso" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -10860,12 +11012,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/toilet)
-"cKz" = (
-/obj/structure/bed/dogbed/ian,
-/mob/living/simple_animal/pet/dog/corgi/Ian,
-/obj/machinery/camera/autoname,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop)
 "cKK" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/delivery,
@@ -18505,11 +18651,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"eWW" = (
-/mob/living/carbon/monkey,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/freezer,
-/area/medical/genetics)
 "eWX" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8
@@ -31527,16 +31668,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"iwN" = (
-/mob/living/simple_animal/bot/floorbot{
-	locked = 0;
-	on = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
 "iwP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -36280,21 +36411,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"jMT" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "jNh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -44420,21 +44536,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"lYr" = (
-/mob/living/simple_animal/bot/secbot{
-	arrest_type = 1;
-	health = 45;
-	icon_state = "secbot1";
-	idcheck = 1;
-	name = "Sergeant-at-Armsky";
-	weaponscheck = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "lYy" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/tile/purple{
@@ -46988,21 +47089,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
-"mPw" = (
-/mob/living/simple_animal/hostile/retaliate/goat{
-	name = "Pete"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/kitchen/coldroom)
 "mPy" = (
 /obj/structure/window/reinforced/spawner{
 	dir = 4
@@ -53286,15 +53372,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"oDH" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/mob/living/carbon/monkey,
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/freezer,
-/area/medical/genetics)
 "oDJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -57286,14 +57363,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"pGL" = (
-/obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/Poly,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/carpet/orange,
-/area/crew_quarters/heads/chief)
 "pHc" = (
 /obj/structure/transit_tube/curved,
 /obj/effect/spawner/structure/window/reinforced,
@@ -64981,21 +65050,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"rZo" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "rZt" = (
 /obj/effect/spawner/room/threexthree,
 /turf/open/floor/plating,
@@ -69667,23 +69721,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"tsM" = (
-/mob/living/simple_animal/kalo,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/janitor)
 "tsP" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -69976,27 +70013,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"tzM" = (
-/obj/structure/bed/dogbed/vector,
-/mob/living/simple_animal/pet/hamster/vector,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/virology)
 "tzS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -111543,7 +111559,7 @@ cWH
 hXO
 mvn
 vSB
-pGL
+aad
 hAq
 rou
 hqr
@@ -112916,7 +112932,7 @@ lxO
 puc
 gth
 eNH
-bHO
+aar
 iOL
 iQt
 vhc
@@ -119193,7 +119209,7 @@ rKn
 rKn
 fsB
 nFh
-jMT
+aas
 nzl
 nzl
 pLK
@@ -119305,7 +119321,7 @@ lmK
 fHC
 ccy
 hbw
-tsM
+aaj
 aVO
 uwy
 wDh
@@ -119468,7 +119484,7 @@ pGB
 alS
 aMT
 ykP
-gjY
+aax
 aMT
 ykP
 aMT
@@ -119718,7 +119734,7 @@ xpK
 yiS
 ose
 alS
-bsd
+aaw
 ygd
 rsX
 iqZ
@@ -120225,7 +120241,7 @@ wgl
 wRP
 wrS
 rKn
-bFw
+aau
 ulN
 gCP
 qGs
@@ -120744,7 +120760,7 @@ bsC
 nzl
 iex
 kkP
-csm
+aav
 alS
 uCC
 pZe
@@ -121010,7 +121026,7 @@ hNp
 alS
 aMT
 ykP
-uwe
+aay
 aMT
 ykP
 aMT
@@ -121050,7 +121066,7 @@ eAp
 uKr
 aRL
 hjN
-adM
+aac
 fwO
 ddu
 qio
@@ -121249,7 +121265,7 @@ rKn
 rKn
 thf
 xTa
-rZo
+aab
 nzl
 nzl
 azZ
@@ -122088,7 +122104,7 @@ seE
 jsO
 xUk
 uGg
-cKz
+aag
 xTR
 aEy
 xvC
@@ -124198,7 +124214,7 @@ kfy
 pTS
 pTS
 uqv
-iwN
+aam
 fXM
 boA
 dFt
@@ -124722,7 +124738,7 @@ ntu
 nSl
 vUC
 vUr
-mPw
+aap
 nss
 bJK
 vUC
@@ -124910,7 +124926,7 @@ vgb
 aMT
 oXI
 htD
-lYr
+aae
 stF
 uyv
 jkd
@@ -130622,8 +130638,8 @@ hsh
 gqY
 uYV
 umj
-oDH
-aQu
+aak
+aan
 vBf
 qSI
 eCC
@@ -130880,7 +130896,7 @@ igk
 igk
 sdt
 xef
-eWW
+aao
 vBf
 kBi
 bjq
@@ -137572,7 +137588,7 @@ aMT
 kiV
 anT
 lvw
-tzM
+aaq
 vDh
 pbS
 vNy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes AI cams in the core and leading to the core to AICORE, instead of SS13.

## Why It's Good For The Game

Removes oversight.

## Changelog
:cl:
fix: Corg cameras in ai sat are now on the ai sat network.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
