### PR TITLE
Make the plating examine() message more accurate

### DIFF
--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -28,7 +28,7 @@
 		. += "<span class='notice'>It looks like the dents could be <i>welded</i> smooth.</span>"
 		return
 	if(attachment_holes)
-		. += "<span class='notice'>There are a few attachment holes for a new <i>tile</i> or reinforcement <i>rods</i>.</span>"
+		. += "<span class='notice'>There are a few attachment holes for a new <i>tile</i>, reinforcement <i>sheets</i> or catwalk <i>rods</i>.</span>"
 	else
 		. += "<span class='notice'>You might be able to build ontop of it with some <i>tiles</i>...</span>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It would seem that since 2019, due to https://github.com/BeeStation/BeeStation-Hornet/pull/626, the plating examine message has been inaccurate, stating that it has attachment holes for reinforcement *rods*. However, since that PR was merged, *sheets* are used for reinforcement, *rods* instead being used for catwalks. This PR changes the message to reflect those changes.

The message is up for discussion if somebody has a better phrasing, but I wanted to bring the issue up before I forget again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Reliable examine messages describing actions that can be done are very useful for newer players to not have to check everything on the wiki, particularly players coming from similar codebases with minor differences like this one.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Plating examine message now reflects rods for catwalks and sheets for reinforcement accurately
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
