### PR TITLE
Remove duplicate mindshield message in gang code

### DIFF
--- a/code/game/gamemodes/gangs/implant_gang.dm
+++ b/code/game/gamemodes/gangs/implant_gang.dm
@@ -59,7 +59,5 @@
 			qdel(src)
 			return FALSE
 		target.mind.remove_antag_datum(/datum/antagonist/gang)
-		if(!silent)
-			to_chat(target, "<span class='notice'>You feel a sense of peace and security. You are now protected from brainwashing.</span>")
 		return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

While adding gangs, in https://github.com/BeeStation/BeeStation-Hornet/pull/200, an additional implementation of mindshield implanting was added. This was done to handle removing gang-specific antag while keeping it properly modularised. However, in doing so, the "sense of peace and security" message was repeated in that code, causing it to be displayed twice upon a successful implanting.

This PR removes the "sense of peace and security" message from gang code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Duplicate message is a bug, this fixes bug, bug fixes are good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mindshield no longer gives duplicate message when implanted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
