### PR TITLE
Spybug kit revision + traitor spybug kit

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -429,6 +429,7 @@
 #include "code\datums\components\spikes.dm"
 #include "code\datums\components\spill.dm"
 #include "code\datums\components\spooky.dm"
+#include "code\datums\components\spybug.dm"
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stationloving.dm"
 #include "code\datums\components\swarming.dm"

--- a/code/datums/components/spybug.dm
+++ b/code/datums/components/spybug.dm
@@ -39,6 +39,7 @@
 		spyglasses.linked_bug = null
 	qdel(cam_screen)
 	QDEL_LIST(cam_plane_masters)
+	qdel(tracker)
 	return ..()
 
 /datum/spybug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj

--- a/code/datums/components/spybug.dm
+++ b/code/datums/components/spybug.dm
@@ -1,15 +1,21 @@
-/datum/component/spybug
-	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
+/datum/spybug
+	var/obj/item/spybug
+	var/obj/item/clothing/glasses/sunglasses/spy/spyglasses
+
 	var/atom/movable/screen/map_view/cam_screen
 	var/list/cam_plane_masters
 	// Ranges higher than one can be used to see through walls.
 	var/cam_range = 1
 	var/datum/movement_detector/tracker
 
-/datum/component/spybug/Initialize()
-	. = ..()
-	tracker = new /datum/movement_detector(parent, CALLBACK(src, .proc/update_view))
+/datum/spybug/proc/link_spyglasses_to_spybug(obj/item/clothing/glasses/sunglasses/spy/g, obj/item/b)
+	spybug = b
+	spyglasses = g
 
+	//assign moevement detector
+	tracker = new /datum/movement_detector(spybug, CALLBACK(src, .proc/update_view))
+
+	//instantiate camera
 	cam_screen = new
 	cam_screen.name = "screen"
 	cam_screen.assigned_map = "spypopup_map"
@@ -28,15 +34,14 @@
 		instance.screen_loc = "spypopup_map:CENTER"
 		cam_plane_masters += instance
 
-/datum/component/spybug/Destroy()
-	if(linked_glasses)
-		linked_glasses.linked_bug = null
+/datum/spybug/Destroy()	//destroying the glasses or the object deletes this datum
+	if(spyglasses)
+		spyglasses.linked_bug = null
 	qdel(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(tracker)
 	return ..()
 
-/datum/component/spybug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj
+/datum/spybug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj
 	cam_screen.vis_contents.Cut()
-	for(var/turf/visible_turf in view(1,get_turf(parent)))//fuck you usr
+	for(var/turf/visible_turf in view(1,get_turf(spybug)))
 		cam_screen.vis_contents += visible_turf

--- a/code/datums/components/spybug.dm
+++ b/code/datums/components/spybug.dm
@@ -1,0 +1,42 @@
+/datum/component/spybug
+	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
+	var/atom/movable/screen/map_view/cam_screen
+	var/list/cam_plane_masters
+	// Ranges higher than one can be used to see through walls.
+	var/cam_range = 1
+	var/datum/movement_detector/tracker
+
+/datum/component/spybug/Initialize()
+	. = ..()
+	tracker = new /datum/movement_detector(parent, CALLBACK(src, .proc/update_view))
+
+	cam_screen = new
+	cam_screen.name = "screen"
+	cam_screen.assigned_map = "spypopup_map"
+	cam_screen.del_on_map_removal = FALSE
+	cam_screen.set_position(1, 1)
+
+	// We need to add planesmasters to the popup, otherwise
+	// blending fucks up massively. Any planesmaster on the main screen does
+	// NOT apply to map popups. If there's ever a way to make planesmasters
+	// omnipresent, then this wouldn't be needed.
+	cam_plane_masters = list()
+	for(var/plane in subtypesof(/atom/movable/screen/plane_master))
+		var/atom/movable/screen/instance = new plane()
+		instance.assigned_map = "spypopup_map"
+		instance.del_on_map_removal = FALSE
+		instance.screen_loc = "spypopup_map:CENTER"
+		cam_plane_masters += instance
+
+/datum/component/spybug/Destroy()
+	if(linked_glasses)
+		linked_glasses.linked_bug = null
+	qdel(cam_screen)
+	QDEL_LIST(cam_plane_masters)
+	qdel(tracker)
+	return ..()
+
+/datum/component/spybug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj
+	cam_screen.vis_contents.Cut()
+	for(var/turf/visible_turf in view(1,get_turf(parent)))//fuck you usr
+		cam_screen.vis_contents += visible_turf

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -1,14 +1,17 @@
-//detective spyglasses. meant to be an example for map_popups.dm
+// **********************
+//  DETECTIVE SPYGLASSES
+// **********************
+
 /obj/item/clothing/glasses/sunglasses/spy
 	desc = "Made by Nerd. Co's infiltration and surveillance department. Upon closer inspection, there's a small screen in each lens."
 	actions_types = list(/datum/action/item_action/activate_remote_view)
-	var/datum/component/spybug/linked_bug
+	var/datum/spybug/linked_bug
 
 /obj/item/clothing/glasses/sunglasses/spy/proc/show_to_user(mob/user)//this is the meat of it. most of the map_popup usage is in this.
 	if(!user?.client)
 		return
 	if(!linked_bug)
-		user.audible_message("<span class='warning'>Spybug destroyed or no longer available!</span>")
+		user.audible_message("<span class='warning'>Spybug destroyed or no longer functional!</span>")
 	if("spypopup_map" in user.client.screen_maps) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
 		return
 	user.client.setup_popup("spypopup", 3, 3, 2)
@@ -34,30 +37,28 @@
 
 /obj/item/clothing/glasses/sunglasses/spy/Destroy()
 	if(linked_bug)
-		linked_bug.linked_glasses = null
+		qdel(linked_bug)
 	return ..()
 
+// *******************
+//  DETECTIVE SPYÅPEN
+// *******************
 
 /obj/item/pen/spy_bug
+	var/datum/spybug/bug
 	desc = "An advanced piece of espionage equipment in the shape of a pen. It has a built in 360 degree camera for all your \"admirable\" needs. Microphone not included."
-	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
-	var/atom/movable/screen/map_view/cam_screen
-	var/list/cam_plane_masters
-	// Ranges higher than one can be used to see through walls.
-	var/cam_range = 1
-	var/datum/movement_detector/tracker
 
-/obj/item/pen/spy_bug/ComponentInitialize()
+/obj/item/pen/spy_bug/Initialize()
 	..()
-	AddComponent(/datum/component/spybug)
+	bug = new (src)
 
 /obj/item/pen/spy_bug/Destroy()
-	if(linked_glasses)
-		linked_glasses.linked_bug = null
-	qdel(cam_screen)
-	QDEL_LIST(cam_plane_masters)
-	qdel(tracker)
+	qdel(bug)
 	return ..()
+
+// **************
+//  SPYGLASS KIT
+// **************
 
 //it needs to be linked, hence a kit.
 /obj/item/storage/box/rxglasses/spyglasskit
@@ -65,13 +66,15 @@
 	desc = "this box contains <i>cool</i> nerd glasses; with built-in displays to view a linked camera."
 
 /obj/item/storage/box/rxglasses/spyglasskit/PopulateContents()
+	//fluff
+	new /obj/item/paper/fluff/nerddocs(src)
+	//items
 	var/obj/item/clothing/accessory/pocketprotector/protector = new (src)
 	var/obj/item/pen/spy_bug/newbug = new(protector)
-	var/datum/component/spybug/spy_bug_component = newbug.GetComponent(/datum/component/spybug)
 	var/obj/item/clothing/glasses/sunglasses/spy/newglasses = new(src)
-	spy_bug_component.linked_glasses = newglasses
-	newglasses.linked_bug = spy_bug_component
-	new /obj/item/paper/fluff/nerddocs(src)
+	//datum
+	var/datum/spybug/spy_bug_component = newbug.bug
+	spy_bug_component.link_spyglasses_to_spybug(newglasses,newbug)
 
 /obj/item/paper/fluff/nerddocs
 	name = "Espionage For Dummies"
@@ -84,6 +87,10 @@ Step Three: Press the "Activate Remote View" Button on the side of your SpySpeks
 My SpySpeks <small>tm</small> Make a shrill beep while attempting to use!
 A shrill beep coming from your SpySpeks means that they can't connect to the included ProfitProtektor <small>tm</small>, please make sure your ProfitProtektor is still active, and functional!
 	"}
+
+// **********************
+//  CHAMELEON SPYGLASSES
+// **********************
 
 /obj/item/clothing/glasses/sunglasses/spy/chameleon
 	var/datum/action/item_action/chameleon/change/chameleon_action
@@ -102,6 +109,17 @@ A shrill beep coming from your SpySpeks means that they can't connect to the inc
 		return
 	chameleon_action.emp_randomise()
 
-/obj/item/throwing_star/spy_bug/ComponentInitialize()
-	..()	
-	AddComponent(/datum/component/spybug)
+// **************
+//  NINJA SPYBUG
+// **************
+
+/obj/item/throwing_star/spy_bug
+	var/datum/spybug/bug
+
+/obj/item/throwing_star/spy_bug/Initialize()
+	..()
+	bug = new (src)
+
+/obj/item/throwing_star/spy_bug/Destroy()
+	qdel(bug)
+	return ..()

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -2,13 +2,13 @@
 /obj/item/clothing/glasses/sunglasses/spy
 	desc = "Made by Nerd. Co's infiltration and surveillance department. Upon closer inspection, there's a small screen in each lens."
 	actions_types = list(/datum/action/item_action/activate_remote_view)
-	var/obj/item/clothing/accessory/spy_bug/linked_bug
+	var/datum/component/spybug/linked_bug
 
 /obj/item/clothing/glasses/sunglasses/spy/proc/show_to_user(mob/user)//this is the meat of it. most of the map_popup usage is in this.
 	if(!user?.client)
 		return
 	if(!linked_bug)
-		user.audible_message("<span class='warning'>[src] lets off a shrill beep!</span>")
+		user.audible_message("<span class='warning'>Spybug destroyed or no longer available!</span>")
 	if("spypopup_map" in user.client.screen_maps) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
 		return
 	user.client.setup_popup("spypopup", 3, 3, 2)
@@ -38,11 +38,8 @@
 	return ..()
 
 
-/obj/item/clothing/accessory/spy_bug
-	name = "pocket protector"
-	icon = 'icons/obj/clothing/accessories.dmi'
-	icon_state = "pocketprotector"
-	desc = "An advanced piece of espionage equipment in the shape of a pocket protector. It has a built in 360 degree camera for all your \"admirable\" needs. Microphone not included."
+/obj/item/pen/spy_bug
+	desc = "An advanced piece of espionage equipment in the shape of a pen. It has a built in 360 degree camera for all your \"admirable\" needs. Microphone not included."
 	var/obj/item/clothing/glasses/sunglasses/spy/linked_glasses
 	var/atom/movable/screen/map_view/cam_screen
 	var/list/cam_plane_masters
@@ -50,29 +47,11 @@
 	var/cam_range = 1
 	var/datum/movement_detector/tracker
 
-/obj/item/clothing/accessory/spy_bug/Initialize()
-	. = ..()
-	tracker = new /datum/movement_detector(src, CALLBACK(src, .proc/update_view))
+/obj/item/pen/spy_bug/ComponentInitialize()
+	..()
+	AddComponent(/datum/component/spybug)
 
-	cam_screen = new
-	cam_screen.name = "screen"
-	cam_screen.assigned_map = "spypopup_map"
-	cam_screen.del_on_map_removal = FALSE
-	cam_screen.set_position(1, 1)
-
-	// We need to add planesmasters to the popup, otherwise
-	// blending fucks up massively. Any planesmaster on the main screen does
-	// NOT apply to map popups. If there's ever a way to make planesmasters
-	// omnipresent, then this wouldn't be needed.
-	cam_plane_masters = list()
-	for(var/plane in subtypesof(/atom/movable/screen/plane_master))
-		var/atom/movable/screen/instance = new plane()
-		instance.assigned_map = "spypopup_map"
-		instance.del_on_map_removal = FALSE
-		instance.screen_loc = "spypopup_map:CENTER"
-		cam_plane_masters += instance
-
-/obj/item/clothing/accessory/spy_bug/Destroy()
+/obj/item/pen/spy_bug/Destroy()
 	if(linked_glasses)
 		linked_glasses.linked_bug = null
 	qdel(cam_screen)
@@ -80,15 +59,19 @@
 	qdel(tracker)
 	return ..()
 
-/obj/item/clothing/accessory/spy_bug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj
-	cam_screen.vis_contents.Cut()
-	for(var/turf/visible_turf in view(1,get_turf(src)))//fuck you usr
-		cam_screen.vis_contents += visible_turf
-
 //it needs to be linked, hence a kit.
 /obj/item/storage/box/rxglasses/spyglasskit
 	name = "spyglass kit"
 	desc = "this box contains <i>cool</i> nerd glasses; with built-in displays to view a linked camera."
+
+/obj/item/storage/box/rxglasses/spyglasskit/PopulateContents()
+	var/obj/item/clothing/accessory/pocketprotector/protector = new (src)
+	var/obj/item/pen/spy_bug/newbug = new(protector)
+	var/datum/component/spybug/spy_bug_component = newbug.GetComponent(/datum/component/spybug)
+	var/obj/item/clothing/glasses/sunglasses/spy/newglasses = new(src)
+	spy_bug_component.linked_glasses = newglasses
+	newglasses.linked_bug = spy_bug_component
+	new /obj/item/paper/fluff/nerddocs(src)
 
 /obj/item/paper/fluff/nerddocs
 	name = "Espionage For Dummies"
@@ -102,9 +85,23 @@ My SpySpeks <small>tm</small> Make a shrill beep while attempting to use!
 A shrill beep coming from your SpySpeks means that they can't connect to the included ProfitProtektor <small>tm</small>, please make sure your ProfitProtektor is still active, and functional!
 	"}
 
-/obj/item/storage/box/rxglasses/spyglasskit/PopulateContents()
-	var/obj/item/clothing/accessory/spy_bug/newbug = new(src)
-	var/obj/item/clothing/glasses/sunglasses/spy/newglasses = new(src)
-	newbug.linked_glasses = newglasses
-	newglasses.linked_bug = newbug
-	new /obj/item/paper/fluff/nerddocs(src)
+/obj/item/clothing/glasses/sunglasses/spy/chameleon
+	var/datum/action/item_action/chameleon/change/chameleon_action
+
+/obj/item/clothing/glasses/sunglasses/spy/chameleon/Initialize()
+	. = ..()
+	chameleon_action = new(src)
+	chameleon_action.chameleon_type = /obj/item/clothing/glasses
+	chameleon_action.chameleon_name = "Glasses"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/clothing/glasses/changeling, only_root_path = TRUE)
+	chameleon_action.initialize_disguises()
+
+/obj/item/clothing/glasses/sunglasses/spy/chameleon/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	chameleon_action.emp_randomise()
+
+/obj/item/throwing_star/spy_bug/ComponentInitialize()
+	..()	
+	AddComponent(/datum/component/spybug)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -590,3 +590,14 @@
 		group.register(i)
 	desc += " The implants are registered to the \"[group.name]\" group."
   
+//it needs to be linked, hence a kit.
+/obj/item/storage/box/syndie_kit/spyninjakit
+	name = "spider clan espionage kit"
+	desc = "Contains a pair of glasses with in-built camera, and an attached spybug ninja start that can emblem in flesh."
+
+/obj/item/storage/box/syndie_kit/spyninjakit/PopulateContents()
+	var/obj/item/throwing_star/spy_bug/newbug = new(src)
+	var/datum/component/spybug/spy_bug_component = newbug.GetComponent(/datum/component/spybug)
+	var/obj/item/clothing/glasses/sunglasses/spy/newglasses = new /obj/item/clothing/glasses/sunglasses/spy/chameleon(src)
+	spy_bug_component.linked_glasses = newglasses
+	newglasses.linked_bug = spy_bug_component

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -589,15 +589,16 @@
 	for(var/i in implants)
 		group.register(i)
 	desc += " The implants are registered to the \"[group.name]\" group."
-  
+
 //it needs to be linked, hence a kit.
 /obj/item/storage/box/syndie_kit/spyninjakit
 	name = "spider clan espionage kit"
-	desc = "Contains a pair of glasses with in-built camera, and an attached spybug ninja start that can emblem in flesh."
+	desc = "Contains a pair of glasses with in-built camera, and an attached spybug ninja start that can emblem itself for a long duration."
 
 /obj/item/storage/box/syndie_kit/spyninjakit/PopulateContents()
+	//items
 	var/obj/item/throwing_star/spy_bug/newbug = new(src)
-	var/datum/component/spybug/spy_bug_component = newbug.GetComponent(/datum/component/spybug)
-	var/obj/item/clothing/glasses/sunglasses/spy/newglasses = new /obj/item/clothing/glasses/sunglasses/spy/chameleon(src)
-	spy_bug_component.linked_glasses = newglasses
-	newglasses.linked_bug = spy_bug_component
+	var/obj/item/clothing/glasses/sunglasses/spy/chameleon/newglasses = new (src)
+	//datum
+	var/datum/spybug/spy_bug_component = newbug.bug
+	spy_bug_component.link_spyglasses_to_spybug(newglasses,newbug)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2346,3 +2346,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 4
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/implants/spyninjakit
+	name = "Spider Clan Espionage Kit"
+	desc = "Contains a espionage kit, perfected by the Spider Clan. /
+	The shuriken is an advanced piece of tech that incorporates a built in camera, /
+	while the chameleon glasses can interface with the camera and show you its location."
+	item = /obj/item/storage/box/syndie_kit/spyninjakit
+	cost = 2
+	surplus = 0

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2349,8 +2349,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/implants/spyninjakit
 	name = "Spider Clan Espionage Kit"
-	desc = "Contains a espionage kit, perfected by the Spider Clan. /
-	The shuriken is an advanced piece of tech that incorporates a built in camera, /
+	desc = "Contains a espionage kit, perfected by the Spider Clan. \
+	The shuriken is an advanced piece of tech that incorporates a built in camera, \
 	while the chameleon glasses can interface with the camera and show you its location."
 	item = /obj/item/storage/box/syndie_kit/spyninjakit
 	cost = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Spybug is now a item component.
Spykit camera bug is now a pen inside the pocket protector.
Added new uplink kit, Spider Clan Espionage Kit, containing Chameleon spyglassed + spybug shuriken.

## Why It's Good For The Game

Spybug component was required for the ninja item.

Camera pen makes the chameleon kit a lot more versatile; it's a lot less obvious (who ever uses a pocket protector?), it can be hidden in smaller places or even a PDA.

The uplink kit has a little more offensive use; the shuriken embeds and can be used as a tracker, which will reveal the position of your target until ejected.

## Changelog
:cl:
tweak: Spybug is a component
tweak: Spykit camera bug is now a pen inside the pocket protector
add: Chameleon spyglass + spybug shuriken Uplink Kit
/:cl:
