### PR TITLE
mech pilots no longer get fucked by explosions

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -10,7 +10,7 @@
 	layer = BELOW_MOB_LAYER//icon draw layer
 	infra_luminosity = 15 //byond implementation is bugged.
 	force = 5
-	flags_1 = HEAR_1
+	flags_1 = HEAR_1 | PREVENT_CONTENTS_EXPLOSION_1
 	var/ruin_mecha = FALSE //if the mecha starts on a ruin, don't automatically give it a tracking beacon to prevent metagaming.
 	var/can_move = 0 //time of next allowed movement
 	var/mob/living/carbon/occupant = null

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -3,6 +3,7 @@
 	name = "\improper APLU MK-I \"Ripley\""
 	icon_state = "ripley"
 	silicon_icon_state = "ripley-empty"
+	flags_1 = HEAR_1
 	step_in = 1.5 //Move speed, lower is faster.
 	var/fast_pressure_step_in = 1.5 //step_in while in low pressure conditions
 	var/slow_pressure_step_in = 2.0 //step_in while in normal pressure conditions
@@ -84,6 +85,7 @@
 	enclosed = TRUE
 	enter_delay = 40
 	silicon_icon_state = null
+	flags_1 = HEAR_1 | PREVENT_CONTENTS_EXPLOSION_1
 	opacity = TRUE
 
 /obj/mecha/working/ripley/firefighter
@@ -103,6 +105,7 @@
 	enclosed = TRUE
 	enter_delay = 40
 	silicon_icon_state = null
+	flags_1 = HEAR_1 | PREVENT_CONTENTS_EXPLOSION_1
 	opacity = TRUE
 
 
@@ -121,6 +124,7 @@
 	enclosed = TRUE
 	enter_delay = 40
 	silicon_icon_state = null
+	flags_1 = HEAR_1 | PREVENT_CONTENTS_EXPLOSION_1
 	opacity = TRUE
 
 /obj/mecha/working/ripley/deathripley/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

disclaimer: un-upgraded ripley pilots can still be fucked, who even uses an un-upgraded ripley anyways

## Why It's Good For The Game

![download](https://user-images.githubusercontent.com/56778689/123066021-0a976480-d453-11eb-9524-999e92a18861.jpeg)

## Changelog
:cl:
fix: mech pilots can no longer be fucked by explosions, except for ripley mk1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
