### PR TITLE
Fixes global proc calls using Advanced ProcCall and SDQL

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -119,7 +119,7 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 //adv proc call this, ya nerds
 /world/proc/WrapAdminProcCall(datum/target, procname, list/arguments)
 	if(target == GLOBAL_PROC)
-		return call(procname)(arglist(arguments))
+		return call("/proc/[procname]")(arglist(arguments))
 	else if(target != world)
 		return call(target, procname)(arglist(arguments))
 	else

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -769,7 +769,7 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 		new_args[++new_args.len] = SDQL_expression(source, arg)
 	if(object == GLOB) // Global proc.
 		procname = "/proc/[procname]"
-		return superuser? (call(procname)(new_args)) : (WrapAdminProcCall(GLOBAL_PROC, procname, new_args))
+		return superuser? (call("/proc/[procname]")(new_args)) : (WrapAdminProcCall(GLOBAL_PROC, procname, new_args))
 	return superuser? (call(object, procname)(new_args)) : (WrapAdminProcCall(object, procname, new_args))
 
 /datum/SDQL2_query/proc/SDQL_function_async(datum/object, procname, list/arguments, source)


### PR DESCRIPTION
```proc name: WrapAdminProcCall (/world/proc/WrapAdminProcCall)
usr: Cenrus/(Wall Runner)
usr.loc: (Bridge (109, 140, 2))
src: world
call stack:
world: WrapAdminProcCall("some_magic_bullshit", "LoadReebe", /list (/list))
WrapAdminProcCall("some_magic_bullshit", "LoadReebe", /list (/list))
Cenrus (/client): callproc blocking(null)
Cenrus (/client): Advanced ProcCall()