### PR TITLE
Fixes toy swords dealing esword damage

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -27,6 +27,7 @@
 	max_integrity = 200
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70, "stamina" = 0)
 	resistance_flags = FIRE_PROOF
+	var/twohand_force = 34
 	var/hacked = FALSE
 	var/brightness_on = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
 	var/list/possible_colors = list("red", "blue", "green", "purple")
@@ -53,7 +54,7 @@
 
 /obj/item/dualsaber/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=3, force_wielded=34, block_power_unwielded=70, block_power_wielded=75, \
+	AddComponent(/datum/component/two_handed, force_unwielded=force, force_wielded=twohand_force, block_power_unwielded=70, block_power_wielded=75, \
 					wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg', icon_wielded="dualsaber[item_color]1")
 
 /// Triggered on wield of two handed item

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -368,13 +368,10 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 5
+	twohand_force = 0
 	attack_verb = list("attacked", "struck", "hit")
 	block_upgrade_walk = 1
 	block_power = -100
-
-/obj/item/dualsaber/toy/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/two_handed, force_wielded = 0, force_unwielded = 0, wieldsound='sound/weapons/saberon.ogg', unwieldsound='sound/weapons/saberoff.ogg')
 
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0


### PR DESCRIPTION
Minor refactor to dual sabers to prevent the 34 force damage being inherited in the toy version

literally 1984

:cl:
fix: Fixed toy dual sabers dealing damage
/:cl: