### PR TITLE
Reduces price of the M-90Gl Carbine

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -603,7 +603,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fully-loaded, specialized three-round burst carbine that fires 5.56mm ammunition from a 30 round magazine \
 			with a toggleable 40mm underbarrel grenade launcher."
 	item = /obj/item/gun/ballistic/automatic/m90
-	cost = 18
+	cost = 14
 	surplus = 50
 	include_modes = list(/datum/game_mode/nuclear)
 
@@ -914,11 +914,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/a40mm
-	name = "40mm Grenade"
-	desc = "A 40mm HE grenade for use with the M-90gl's under-barrel grenade launcher. \
+	name = "40mm Grenade Box"
+	desc = "A box of 40mm HE grenades for use with the M-90gl's under-barrel grenade launcher. \
 			Your teammates will ask you to not shoot these down small hallways."
-	item = /obj/item/ammo_casing/a40mm
-	cost = 2
+	item = /obj/item/ammo_box/a40mm
+	cost = 6
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/smg/bag
@@ -964,7 +964,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An additional 30-round 5.56mm magazine; suitable for use with the M-90gl carbine. \
 			These bullets pack less punch than 7.12x82mm rounds, but they still offer more power than .45 ammo."
 	item = /obj/item/ammo_box/magazine/m556
-	cost = 4
+	cost = 3
 	include_modes = list(/datum/game_mode/nuclear)
 	illegal_tech = FALSE
 


### PR DESCRIPTION
## About The Pull Request

The m90 is one of the lesser used ops weapon, it costs the same amount as the L6 while being far less ammo efficient.

* Changed 5.56 toploader mags from 4TC to 3TC
* Slashed price of the M90 from 18TC to 14TC
* M90 grenades are now sold in boxes instead of individually, price raised to 6 TC

These changes should hopefully bring the M90 in between the c20-r and the L6 which is what I'm aiming for with this PR.

## Why It's Good For The Game

Gives love to a gun with a neat gimmick that needs it.

## Changelog
:cl:
balance: M-90Gl Carbine 18TC to 14TC
balance: 5.56mm Toploader Magazine 4TC to 3TC
balance: Grenades for the M-90Gl are now sold in boxes of 4 at a 6TC cost
/:cl: