### PR TITLE
Moves borg apparatus drop from alt z to alt click so it works

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -810,10 +810,13 @@
 /obj/item/borg/apparatus/attack_self(mob/living/silicon/robot/user)
 	if(!stored)
 		return ..()
-	if(user.client?.keys_held["Alt"])
-		stored.forceMove(get_turf(user))
-		return
 	stored.attack_self(user)
+
+//Alt click drops stored item
+/obj/item/borg/apparatus/AltClick(mob/living/silicon/robot/user)
+	if(!stored)
+		return ..()
+	stored.forceMove(get_turf(user))
 
 /obj/item/borg/apparatus/pre_attack(atom/A, mob/living/user, params)
 	if(!stored)
@@ -846,7 +849,7 @@
 
 /obj/item/borg/apparatus/beaker
 	name = "beaker storage apparatus"
-	desc = "A special apparatus for carrying beakers without spilling the contents. Alt-Z or right-click to drop the beaker."
+	desc = "A special apparatus for carrying beakers without spilling the contents."
 	icon_state = "borg_beaker_apparatus"
 	storable = list(/obj/item/reagent_containers/glass/beaker,
 				/obj/item/reagent_containers/glass/bottle)
@@ -874,6 +877,7 @@
 				. += "[R.volume] units of [R.name]"
 		else
 			. += "Nothing."
+		. += "<span class='notice'<i>Alt-click</i> will drop the currently stored [stored].</span>"
 
 /obj/item/borg/apparatus/beaker/update_icon()
 	cut_overlays()
@@ -911,7 +915,7 @@
 
 /obj/item/borg/apparatus/circuit
 	name = "circuit manipulation apparatus"
-	desc = "A special apparatus for carrying and manipulating circuit boards. Alt-Z or right-click to drop the stored object."
+	desc = "A special apparatus for carrying and manipulating circuit boards."
 	icon_state = "borg_hardware_apparatus"
 	storable = list(/obj/item/circuitboard,
 				/obj/item/electronics)
@@ -943,6 +947,7 @@
 	. = ..()
 	if(stored)
 		. += "The apparatus currently has [stored] secured."
+		. += "<span class='notice'<i>Alt-click</i> will drop the currently stored [stored].</span>"
 
 /obj/item/borg/apparatus/circuit/pre_attack(atom/A, mob/living/user, params)
 	. = ..()
@@ -955,7 +960,7 @@
 
 /obj/item/borg/apparatus/beaker/service
 	name = "versatile service grasper"
-	desc = "Specially designed for carrying glasses, food and seeds. Alt-Z or right-click to drop the stored object."
+	desc = "Specially designed for carrying glasses, food and seeds."
 	storable = list(/obj/item/reagent_containers/food,
 	/obj/item/seeds,
 	/obj/item/storage/fancy/donut_box,
@@ -971,3 +976,4 @@
 	. = ..()
 	if(stored)
 		. += "You are currently holding [stored]."
+		. += "<span class='notice'<i>Alt-click</i> will drop the currently stored [stored].</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/tgstation/tgstation/pull/58494
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
dont have to right click and dropdown
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: borg appartus drop work with alt click now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
