### PR TITLE
Wabbajack shuttle is now illegal on Sage

### DIFF
--- a/config/Sage/shuttles_illegal.txt
+++ b/config/Sage/shuttles_illegal.txt
@@ -27,5 +27,5 @@ _maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_russiafightpit.dmm
 #_maps/shuttles/emergency_scrapheap.dmm
 _maps/shuttles/emergency_supermatter.dmm
-#_maps/shuttles/emergency_wabbajack.dmm
+_maps/shuttles/emergency_wabbajack.dmm
 _maps/shuttles/emergency_discoinferno.dmm

--- a/config/Sage/shuttles_unbuyable.txt
+++ b/config/Sage/shuttles_unbuyable.txt
@@ -26,5 +26,5 @@ _maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_russiafightpit.dmm
 #_maps/shuttles/emergency_scrapheap.dmm
 _maps/shuttles/emergency_supermatter.dmm
-#_maps/shuttles/emergency_wabbajack.dmm
+_maps/shuttles/emergency_wabbajack.dmm
 _maps/shuttles/emergency_discoinferno.dmm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Wabbajack shuttle only available to people with an emag to buy on Sage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Wabbajack is too chaotic, and it's always a shitshow when people turn into xenos and syndieborgs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Wabbajack shuttle is now illegal on Sage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
