### PR TITLE
Buckling from adjacent tiles from /tg/

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -40,14 +40,9 @@
 	if(!buckled_mobs)
 		buckled_mobs = list()
 
-	if(!istype(M))
+	if(!is_buckle_possible(M, force, check_loc))
 		return FALSE
 
-	if(check_loc && M.loc != loc)
-		return FALSE
-
-	if((!can_buckle && !force) || M.buckled || (buckled_mobs.len >= max_buckled_mobs) || (buckle_requires_restraints && !M.restrained()) || M == src)
-		return FALSE
 	M.buckling = src
 	if(!M.can_buckle() && !force)
 		if(M == usr)
@@ -110,18 +105,94 @@
 //same but for unbuckle
 /atom/movable/proc/post_unbuckle_mob(mob/living/M)
 
+/**
+  * Simple helper proc that runs a suite of checks to test whether it is possible or not to buckle the target mob to src.
+  *
+  * Returns FALSE if any conditions that should prevent buckling are satisfied. Returns TRUE otherwise.
+  * Arguments:
+  * * target - Target mob to check against buckling to src.
+  * * force - Whether or not the buckle should be forced. If TRUE, ignores src's can_buckle var.
+  * * check_loc - Whether to do a proximity check or not. The proximity check looks for target.loc == src.loc.
+  */
+/atom/movable/proc/is_buckle_possible(mob/living/target, force = FALSE, check_loc = TRUE)
+	// Make sure target is mob/living
+	if(!istype(target))
+		return FALSE
+
+	// No bucking you to yourself.
+	if(target == src)
+		return FALSE
+
+	// Check if this atom can have things buckled to it.
+	if(!can_buckle && !force)
+		return FALSE
+
+	// If we're checking the loc, make sure the target is on the thing we're bucking them to.
+	if(check_loc && target.loc != loc)
+		return FALSE
+
+	// Make sure the target isn't already buckled to something.
+	if(target.buckled)
+		return FALSE
+
+	// Make sure this atom can still have more things buckled to it.
+	if(LAZYLEN(buckled_mobs) >= max_buckled_mobs)
+		return FALSE
+
+	// If the buckle requires restraints, make sure the target is actually restrained while ignoring grab restraint.
+	if(buckle_requires_restraints && !target.restrained(TRUE))
+		return FALSE
+
+	return TRUE
+
+/**
+  * Simple helper proc that runs a suite of checks to test whether it is possible or not for user to buckle target mob to src.
+  *
+  * Returns FALSE if any conditions that should prevent buckling are satisfied. Returns TRUE otherwise.
+  * Arguments:
+  * * target - Target mob to check against buckling to src.
+  * * user - The mob who is attempting to buckle the target to src.
+  * * check_loc - Whether to do a proximity check or not when calling is_buckle_possible().
+  */
+/atom/movable/proc/is_user_buckle_possible(mob/living/target, mob/user, check_loc = TRUE)
+	// Standard adjacency and other checks.
+	if(!Adjacent(user) || !Adjacent(target) || !isturf(user.loc) || user.incapacitated() || target.anchored)
+		return FALSE
+
+	// In buckling even possible in the first place?
+	if(!is_buckle_possible(target, FALSE, check_loc))
+		return FALSE
+
+	// If the person attempting to buckle is stood on this atom's turf and they're not buckling themselves,
+	// buckling shouldn't be possible as they're blocking it.
+	if((target != user) && (get_turf(user) == get_turf(src)))
+		to_chat(target, "<span class='warning'>You are unable to buckle [target] to [src] while it is blocked!</span>")
+		return FALSE
+
+	return TRUE
+
 //Wrapper procs that handle sanity and user feedback
 /atom/movable/proc/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if(!Adjacent(user) || !Adjacent(M) || !isturf(user.loc) || user.incapacitated() || M.anchored)
+	// Is buckling even possible? Do a full suite of checks.
+	if(!is_user_buckle_possible(M, user, check_loc))
 		return FALSE
 
 	add_fingerprint(user)
-	if (M != user)
+
+	// If the mob we're attempting to buckle is not stood on this atom's turf and it isn't the user buckling themselves,
+	// we'll try it with a 2 second do_after delay.
+	if(M != user && (get_turf(M) != get_turf(src)))
 		M.visible_message("<span class='warning'>[user] starts buckling [M] to [src]!</span>",\
-					"<span class='userdanger'>[user] starts buckling you to [src]!</span>",\
-					"<span class='hear'>You hear metal clanking.</span>")
-		if(!do_after(user, 3 SECONDS, TRUE, M))
+			"<span class='userdanger'>[user] starts buckling you to [src]!</span>",\
+			"<span class='hear'>You hear metal clanking.</span>")
+		if(!do_after(user, 2 SECONDS, TRUE, M))
 			return FALSE
+
+		// Sanity check before we attempt to buckle. Is everything still in a kosher state for buckling after the 3 seconds have elapsed?
+		// Covers situations where, for example, the chair was moved or there's some other issue.
+		if(!is_user_buckle_possible(M, user, check_loc))
+			return FALSE
+
 	. = buckle_mob(M, check_loc = check_loc)
 	if(.)
 		if(M == user)
@@ -131,7 +202,8 @@
 				"<span class='italics'>You hear metal clanking.</span>")
 		else
 			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
-				"<span class='warning'>[user] buckles you to [src]!</span>")
+				"<span class='warning'>[user] buckles you to [src]!</span>",\
+				"<span class='hear'>You hear metal clanking.</span>")
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -112,10 +112,16 @@
 
 //Wrapper procs that handle sanity and user feedback
 /atom/movable/proc/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if(!in_range(user, src) || !isturf(user.loc) || user.incapacitated() || M.anchored)
+	if(!Adjacent(user) || !Adjacent(M) || !isturf(user.loc) || user.incapacitated() || M.anchored)
 		return FALSE
 
 	add_fingerprint(user)
+	if (M != user)
+		M.visible_message("<span class='warning'>[user] starts buckling [M] to [src]!</span>",\
+					"<span class='userdanger'>[user] starts buckling you to [src]!</span>",\
+					"<span class='hear'>You hear metal clanking.</span>")
+		if(!do_after(user, 3 SECONDS, TRUE, M))
+			return FALSE
 	. = buckle_mob(M, check_loc = check_loc)
 	if(.)
 		if(M == user)
@@ -124,10 +130,8 @@
 				"<span class='notice'>You buckle yourself to [src].</span>",\
 				"<span class='italics'>You hear metal clanking.</span>")
 		else
-			M.visible_message(\
-				"<span class='warning'>[user] buckles [M] to [src]!</span>",\
-				"<span class='warning'>[user] buckles you to [src]!</span>",\
-				"<span class='italics'>You hear metal clanking.</span>")
+			M.visible_message("<span class='warning'>[user] buckles [M] to [src]!</span>",\
+				"<span class='warning'>[user] buckles you to [src]!</span>")
 
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
 	var/mob/living/M = unbuckle_mob(buckled_mob)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -236,6 +236,9 @@
 		usr.put_in_hands(C)
 		qdel(src)
 
+/obj/structure/chair/user_buckle_mob(mob/living/M, force, check_loc = FALSE)
+	return ..()
+
 /obj/structure/chair/stool/bar
 	name = "bar stool"
 	desc = "It has some unsavory stains on it..."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/53255 and https://github.com/tgstation/tgstation/pull/53363
Lets you buckle to things from another tile
2 seconds for buckling other mobs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more probing for pixels while trying to buckle to a chair
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: lordScrubling, uomo91, Timberpoes
add: ability to buckle from next to a chair
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
