### PR TITLE
Ports ability to upload honk virus to airlocks

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -425,6 +425,7 @@
 #include "code\datums\components\sizzle.dm"
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\snail_crawl.dm"
+#include "code\datums\components\soundplayer.dm"
 #include "code\datums\components\spawner.dm"
 #include "code\datums\components\spikes.dm"
 #include "code\datums\components\spill.dm"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -405,3 +405,10 @@
 
 //Heretics stuff
 #define COMSIG_HUMAN_VOID_MASK_ACT "void_mask_act"
+
+// /obj/machinery/door/airlock signals
+
+//from /obj/machinery/door/airlock/open(): (forced)
+#define COMSIG_AIRLOCK_OPEN "airlock_open"
+//from /obj/machinery/door/airlock/close(): (forced)
+#define COMSIG_AIRLOCK_CLOSE "airlock_close"

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -366,9 +366,9 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 			new /datum/chatmessage/balloon_alert(text, src, viewer)
 		if(BALLOON_ALERT_WITH_CHAT)
 			new /datum/chatmessage/balloon_alert(text, src, viewer)
-			to_chat(viewer, "<span class='notice'>[text]</span>")
+			to_chat(viewer, "<span class='notice'>[text].</span>")
 		if(BALLOON_ALERT_NEVER)
-			to_chat(viewer, text)
+			to_chat(viewer, "<span class='notice'>[text].</span>")
 
 /atom/proc/balloon_alert_to_viewers(message, self_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs)
 	var/list/hearers = get_hearers_in_view(vision_distance, src)

--- a/code/datums/components/soundplayer.dm
+++ b/code/datums/components/soundplayer.dm
@@ -1,0 +1,41 @@
+/*This is the sound_player component. It can be attached to any datum and register any signal to play the sound(s) you want, when you want. Used for the honk virus as an example
+	Usage :
+		target.AddComponent(/datum/component/sound_player, args)
+	Arguments :
+		custom_volume : Used to define a custom volume. Default : 30
+		custom_sounds : Used to define a list of custom sounds that will be picked at random when play_sound() is triggered. Default : list('sound/items/bikehorn.ogg')
+		amount : Used to define an amount of time the component will work before deleting itself. Default : -1
+		signal_or_sig_list : Used to register the signal(s) you want to play the sound when they are sent. Default : None
+*/
+/datum/component/sound_player
+	var/volume = 30
+	var/list/sounds = list('sound/items/bikehorn.ogg')
+	var/amount_left = -1
+
+/datum/component/sound_player/Initialize(custom_volume, custom_sounds, amount, signal_or_sig_list)
+	if(!isnull(custom_volume))
+		volume = custom_volume
+
+	if(!isnull(custom_sounds))
+		sounds = custom_sounds
+
+	if(!isnull(amount))
+		amount_left = amount
+
+	RegisterSignal(parent, signal_or_sig_list, .proc/play_sound) //Registers all the signals in signal_or_sig_list.
+
+
+
+/*play_sound() os the proc that actually plays the sound.
+	If amount_left is equal to -1, the component is infinite and will never delete itself.
+*/
+/datum/component/sound_player/proc/play_sound()
+	playsound(parent, pickweight(sounds), volume, TRUE)
+	switch(amount_left)
+		if(-1)
+			return
+		if(1) //Last use.
+			qdel(src)
+			return
+		else
+			amount_left --

--- a/code/datums/components/soundplayer.dm
+++ b/code/datums/components/soundplayer.dm
@@ -38,4 +38,4 @@
 			qdel(src)
 			return
 		else
-			amount_left --
+			amount_left--

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1189,6 +1189,7 @@
 
 	if(!density)
 		return TRUE
+	SEND_SIGNAL(src, COMSIG_AIRLOCK_OPEN, forced)
 	operating = TRUE
 	update_icon(AIRLOCK_OPENING, 1)
 	sleep(1)
@@ -1234,6 +1235,7 @@
 	if(killthis)
 		SSexplosions.med_mov_atom += killthis
 
+	SEND_SIGNAL(src, COMSIG_AIRLOCK_CLOSE, forced)
 	operating = TRUE
 	update_icon(AIRLOCK_CLOSING, 1)
 	layer = CLOSED_DOOR_LAYER

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -918,7 +918,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		return ..()
 	balloon_alert(user, "Virus uploaded")
 	var/list/sig_list = list()
-	if(istype(target,/obj/machinery/door/airlock))
+	if(istype(target, /obj/machinery/door/airlock))
 		sig_list += list(COMSIG_AIRLOCK_OPEN, COMSIG_AIRLOCK_CLOSE)
 	else
 		sig_list += list(COMSIG_ATOM_ATTACK_HAND)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -916,6 +916,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 	if(installed_cartridge.charges <=0)
 		balloon_alert(user, "Out of charges")
 		return ..()
+
+	if(target.GetComponent(/datum/component/sound_player))
+		return
+
 	balloon_alert(user, "Virus uploaded")
 	var/list/sig_list = list()
 	if(istype(target, /obj/machinery/door/airlock))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -918,6 +918,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		return ..()
 
 	if(target.GetComponent(/datum/component/sound_player))
+		balloon_alert(user, "This is already hacked")
 		return
 
 	balloon_alert(user, "Virus uploaded")

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -914,15 +914,15 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/obj/item/cartridge/virus/installed_cartridge = cartridge
 
 	if(installed_cartridge.charges <=0)
-		to_chat(user, "<span class='notice'>Out of charges.</span>")
+		balloon_alert(user, "Out of charges")
 		return ..()
-	to_chat(user, "<span class='notice'>You upload the virus to the airlock controller!</span>")
+	balloon_alert(user, "Virus uploaded")
 	var/sig_list
 	if(istype(target,/obj/machinery/door/airlock))
 		sig_list += list(COMSIG_AIRLOCK_OPEN, COMSIG_AIRLOCK_CLOSE)
 	else
 		sig_list += list(COMSIG_ATOM_ATTACK_HAND)
-	target.AddComponent(/datum/component/sound_player, amount = (rand(15,20)), signal_or_sig_list = sig_list)
+	target.AddComponent(/datum/component/sound_player, amount = (rand(30,50)), signal_or_sig_list = sig_list)
 	installed_cartridge.charges --
 	return TRUE
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -923,7 +923,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	else
 		sig_list += list(COMSIG_ATOM_ATTACK_HAND)
 	target.AddComponent(/datum/component/sound_player, amount = (rand(15,20)), signal_or_sig_list = sig_list)
-	installed_cartridge.charges --
+	installed_cartridge.charges--
 	return TRUE
 
 // access to status display signals

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -903,6 +903,29 @@ GLOBAL_LIST_EMPTY(PDAs)
 		playsound(src, 'sound/machines/pda_button1.ogg', 50, TRUE)
 	return TRUE
 
+/obj/item/pda/pre_attack(obj/target, mob/living/user, params)
+	if(!ismachinery(target))
+		return ..()
+	var/obj/machinery/target_machine = target
+	if(!target_machine.panel_open && !istype(target, /obj/machinery/computer))
+		return ..()
+	if(!istype(cartridge, /obj/item/cartridge/virus/clown))
+		return ..()
+	var/obj/item/cartridge/virus/installed_cartridge = cartridge
+
+	if(installed_cartridge.charges <=0)
+		to_chat(user, "<span class='notice'>Out of charges.</span>")
+		return ..()
+	to_chat(user, "<span class='notice'>You upload the virus to the airlock controller!</span>")
+	var/sig_list
+	if(istype(target,/obj/machinery/door/airlock))
+		sig_list += list(COMSIG_AIRLOCK_OPEN, COMSIG_AIRLOCK_CLOSE)
+	else
+		sig_list += list(COMSIG_ATOM_ATTACK_HAND)
+	target.AddComponent(/datum/component/sound_player, amount = (rand(15,20)), signal_or_sig_list = sig_list)
+	installed_cartridge.charges --
+	return TRUE
+
 // access to status display signals
 /obj/item/pda/attackby(obj/item/C, mob/user, params)
 	if(istype(C, /obj/item/cartridge))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -917,7 +917,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(user, "<span class='notice'>Out of charges.</span>")
 		return ..()
 	to_chat(user, "<span class='notice'>You upload the virus to the airlock controller!</span>")
-	var/sig_list
+	var/list/sig_list = list()
 	if(istype(target,/obj/machinery/door/airlock))
 		sig_list += list(COMSIG_AIRLOCK_OPEN, COMSIG_AIRLOCK_CLOSE)
 	else

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -18,6 +18,7 @@
 		var/obj/item/cartridge/virus/clown/cart = cartridge
 		if(istype(cart) && cart.charges < 5)
 			cart.charges++
+			playsound(src,'sound/machines/ping.ogg', 30, TRUE)
 
 //Mime PDA sends "silent" messages.
 /obj/item/pda/mime


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

funny I liked it and signals are used in wiremod

ported pr:
https://github.com/tgstation/tgstation/pull/52593


## Changelog  
:cl: KathyRyals 
add: The Honkworks 5.0 cartridge's software has been updated to be able to hack machines, computers and airlocks to make them honk for a while.
code: Added a new sound_player component to be able to play any sound with any signals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
