### PR TITLE
Adds service and cargo techfabs instead of protolathes on Corg

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -30708,7 +30708,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ikZ" = (
-/obj/machinery/rnd/production/protolathe/department/service,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -30718,6 +30717,7 @@
 /obj/structure/sign/departments/restroom{
 	pixel_x = -32
 	},
+/obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "ile" = (
@@ -36217,8 +36217,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/rnd/production/protolathe/department/cargo,
 /obj/machinery/camera/autoname,
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "jKL" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

closes #4628

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being unable to print everything service/cargo needs is not good. Example is the express supply console.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Cargo and service now have techfabs instead of protolathes on corg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
