### PR TITLE
fixes empty statpanels before init

### DIFF
--- a/code/modules/tgui_panel/stat.dm
+++ b/code/modules/tgui_panel/stat.dm
@@ -23,8 +23,6 @@
  * Sets the different available tabs.
  */
 /datum/tgui_panel/proc/set_tab_info(payload)
-	if(!is_ready())
-		return
 	window.send_message("stat/setStatTabs", payload)
 
 /**
@@ -33,8 +31,6 @@
  * Sends TGUI the data of every single verb accessable to the user.
  */
 /datum/tgui_panel/proc/set_verb_infomation(payload)
-	if(!is_ready())
-		return
 	window.send_message("stat/setVerbInfomation", payload)
 
 /**
@@ -43,8 +39,6 @@
  * Sets the infomation to be displayed of the current tab. (For non verb tabs)
  */
 /datum/tgui_panel/proc/set_panel_infomation(payload)
-	if(!is_ready())
-		return
 	window.send_message("stat/setPanelInfomation", payload)
 
 /**
@@ -53,8 +47,6 @@
  * Sets the current tab.
  */
 /datum/tgui_panel/proc/set_stat_tab(new_tab)
-	if(!is_ready())
-		return
 	window.send_message("stat/setTab", new_tab)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

## Why It's Good For The Game

stats shouldn't check for is_ready during init because it obviously returns false and nothing gets updated
Closes #4686

## Changelog
:cl:
fix: fixed statpanel being empty during init
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
