### PR TITLE
Stop shuttles squashing mobs that shouldn't be squashed

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -26,6 +26,8 @@ All ShuttleMove procs go here
 		if(ismob(thing))
 			if(isliving(thing))
 				var/mob/living/M = thing
+				if(M.incorporeal_move)
+					return
 				if(M.buckled)
 					M.buckled.unbuckle_mob(M, 1)
 				if(M.pulledby)


### PR DESCRIPTION
shuttle move now checks if the crushed mob is incorporeal to prevent it from crashing into revs or the eminence.

:cl:
fix: Prevented shuttles from colliding with incorporal mobs
/:cl: