### PR TITLE
fix static in ai multicameramode

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -42,12 +42,12 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 // Returns the chunk in the x, y, z.
 // If there is no chunk, it creates a new chunk and returns that.
-/datum/cameranet/proc/getCameraChunk(x, y, z)
+/datum/cameranet/proc/getCameraChunk(x, y, z, a)
 	x &= ~(CHUNK_SIZE - 1)
 	y &= ~(CHUNK_SIZE - 1)
 	var/key = "[x],[y],[z]"
 	. = chunks[key]
-	if(!.)
+	if(!. && !(istype(a, /area/ai_multicam_room)))
 		chunks[key] = . = new /datum/camerachunk(x, y, z)
 
 // Updates what the ai_eye can see. It is recommended you use this when the ai_eye moves or it's location is set.
@@ -169,7 +169,8 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 
 /datum/cameranet/proc/checkTurfVis(turf/position)
-	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z)
+	var/a = get_area(position)
+	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z, a)
 	if(chunk)
 		if(chunk.changed)
 			chunk.hasChanged(1) // Update now, no matter if it's visible or not.

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -169,8 +169,7 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 
 /datum/cameranet/proc/checkTurfVis(turf/position)
-	var/a = get_area(position)
-	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z, a)
+	var/datum/camerachunk/chunk = getCameraChunk(position.x, position.y, position.z, get_area(position))
 	if(chunk)
 		if(chunk.changed)
 			chunk.hasChanged(1) // Update now, no matter if it's visible or not.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->This fixes a bug that would cause the multicamera area for the ai when clicked to get registered in camera chunk and thus as there are no camera's there it would add the static overlayer to those turfs.
This was caused by https://github.com/BeeStation/BeeStation-Hornet/pull/3432 as getCameraChunk unlike chunkGenerated would also add a new chunk entry for camerachunk datums if those did not exist on those coordinates.
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/4125

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> AI actually can use the mulitcamera mode again without it suddenly turning all static

## Changelog
:cl:
fix: fixes ai multicamera mode turn static
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
