### PR TITLE
removes add 127.0.0.1 to all_ips for telemetry

### DIFF
--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -55,6 +55,7 @@
 		return
 	telemetry_connections = payload["connections"]
 	var/len = length(telemetry_connections)
+	var/len_noip = 0
 	if(len == 0)
 		return
 	if(len > TGUI_TELEMETRY_MAX_CONNECTIONS)
@@ -87,6 +88,7 @@
 				LAZYADD(telemetry_notices, "<span class='highlight'>Telemetry Entry [i] has no address. User may be a developer.</span>")
 				LAZYADD(all_ckeys, row["ckey"])
 				LAZYADD(all_cids, row["computer_id"])
+				len_noip = len_noip + 1
 				continue
 			LAZYADD(telemetry_notices, "<span class='highlight'>Telemetry Entry [i] corrupt. Data may be damaged or tampered with.</span>")
 			skipped_entries++
@@ -121,7 +123,7 @@
 				LAZYADD(telemetry_notices, "<span class='bad'>User has multiple CKEYs in history!</span>")
 	switch(length(all_ips))
 		if(2 to INFINITY)
-			if(length(all_ips) == len)
+			if(length(all_ips) == (len - len_noip)) //we substract the amount of localhost entries so they won't influence the list size so no 127.0.0.1 placeholder is needed
 				LAZYADD(telemetry_notices, "<span class='bad'><b>EVERY ENTRY IN HISTORY HAS A DIFFERENT IP!</b></span>")
 			else
 				LAZYADD(telemetry_notices, "<span class='average'>User has changed IPs at least once in history.</span>")

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -86,7 +86,6 @@
 			if(row && row["ckey"] && row["computer_id"]) //Is the address the only invalid field?
 				LAZYADD(telemetry_notices, "<span class='highlight'>Telemetry Entry [i] has no address. User may be a developer.</span>")
 				LAZYADD(all_ckeys, row["ckey"])
-				LAZYADD(all_ips, "127.0.0.1")
 				LAZYADD(all_cids, row["computer_id"])
 				continue
 			LAZYADD(telemetry_notices, "<span class='highlight'>Telemetry Entry [i] corrupt. Data may be damaged or tampered with.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adding localhost to all_ips might have looked like a good idea for tidykeeping but if localhost and an actual connection to the servers are the only thing in there it will cause the logging of LAZYADD(telemetry_notices, "<span class='bad'><b>EVERY ENTRY IN HISTORY HAS A DIFFERENT IP!</b></span>")
even trough one of the ip's is litterally localhost and should be ignored for this check anyways.


Edit: I realized there is a reason for the localhost entries as they are needed as placeholders to make sure they can be matched up in the all_ips length check. To fix this i definied another variable that saves the amount of empty entries aka all entries that would be caused by localhost and substracts those from the len var inside the check.

## Why It's Good For The Game

Avoid Confusion 

## Changelog
:cl:
fix: 127.0.0.1 won't cause telemetry warnings for different ip's to go off anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
