### PR TITLE
Ports directional armor mech fix from Paradise [PORT]

### DIFF
--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -1,12 +1,10 @@
 /obj/mecha/proc/get_armour_facing(relative_dir)
-	switch(relative_dir)
-		if(0) // BACKSTAB!
+	switch(abs(relative_dir))
+		if(180) // BACKSTAB!
 			return facing_modifiers[MECHA_BACK_ARMOUR]
-		if(45, 90, 270, 315)
-			return facing_modifiers[MECHA_SIDE_ARMOUR]
-		if(225, 180, 135)
+		if(0, 45)
 			return facing_modifiers[MECHA_FRONT_ARMOUR]
-	return 1 //always return non-0
+	return facing_modifiers[MECHA_SIDE_ARMOUR] //always return non-0
 
 /obj/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()
@@ -43,7 +41,7 @@
 				break
 
 	if(attack_dir)
-		var/facing_modifier = get_armour_facing(dir2angle(attack_dir) - dir2angle(src))
+		var/facing_modifier = get_armour_facing(dir2angle(attack_dir) - dir2angle(dir))
 		booster_damage_modifier /= facing_modifier
 		booster_deflection_modifier *= facing_modifier
 	if(prob(deflect_chance * booster_deflection_modifier))


### PR DESCRIPTION
## About The Pull Request

This simply copies and paste code from [this PR](https://github.com/ParadiseSS13/Paradise/pull/16206) on Paradise. Tested locally.

_Huge disclaimer: I'm not a coder and don't know why this 2 line fix works. A maintainer should review it to see if it actually works. If this doesn't meet the standards then hopefully somebody who knows what they're doing will make a proper PR._ Also, I couldn't figure out how to do github so I manually edited the file so this might've screwed something up.

## What it's supposed to do

It fixes [mecha directional armor](https://github.com/BeeStation/BeeStation-Hornet/issues/3259) when tested locally.

## Why it's good for the game

It's wonderful to not have your Phazon toasted by a Ripley simply because it was south of said Ripley. This (hopefully!) fixes that, as currently people/mechs/mobs can gain huge advantage over mechs by simply attacking from 'above' regardless of where the mech's sprite is actually pointed.

## Changelog
:cl:
fix: fixed a few things
/:cl:
