### PR TITLE
Ops get an ion carbine instead of an ion rifle

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -8738,12 +8738,10 @@
 /area/syndicate_mothership/control)
 "zy" = (
 /obj/structure/table,
-/obj/item/gun/energy/ionrifle{
-	pin = /obj/item/firing_pin
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/gun/energy/ionrifle/carbine,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/control)
 "zz" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -8741,7 +8741,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/item/gun/energy/ionrifle/carbine,
+/obj/item/gun/energy/ionrifle/carbine/pin,
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/control)
 "zz" = (

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -27,6 +27,9 @@
 	flight_x_offset = 18
 	flight_y_offset = 11
 
+/obj/item/gun/energy/ionrifle/carbine/pin
+	pin = /obj/item/firing_pin
+
 /obj/item/gun/energy/decloner
 	name = "biological demolecularisor"
 	desc = "A gun that discharges high amounts of controlled radiation to slowly break a target into component elements."


### PR DESCRIPTION
Unlike the other operative weapons the ion rifle is bulky, so nobody really uses it. This PR replaces it with a carbine which can fit in bags.

:cl:
tweak: Changed the ion rifle on the syndicate base to an ion carbine
/:cl: