### PR TITLE
Removes /client/MouseMove()

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -88,16 +88,6 @@
 /atom/movable/screen/click_catcher/IsAutoclickable()
 	. = 1
 
-//Please don't roast me too hard
-/client/MouseMove(object,location,control,params)
-	if(mob && LAZYLEN(mob.mousemove_intercept_objects))
-		for(var/datum/D as() in mob.mousemove_intercept_objects)
-			D.onMouseMove(object, location, control, params)
-	..()
-
-/datum/proc/onMouseMove(object, location, control, params)
-	return
-
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
 	var/list/L = params2list(params)
 	if (L["middle"])

--- a/code/datums/components/lockon_aiming.dm
+++ b/code/datums/components/lockon_aiming.dm
@@ -47,14 +47,10 @@
 	if(icon_state)
 		lock_icon_state = icon_state
 	generate_lock_visuals()
-	var/mob/M = parent
-	LAZYOR(M.mousemove_intercept_objects, src)
 	START_PROCESSING(SSfastprocess, src)
 
 /datum/component/lockon_aiming/Destroy()
-	var/mob/M = parent
 	clear_visuals()
-	LAZYREMOVE(M.mousemove_intercept_objects, src)
 	STOP_PROCESSING(SSfastprocess, src)
 	return ..()
 
@@ -119,28 +115,6 @@
 	if(!A.weak_reference || !immune_weakrefs)		//if A doesn't have a weakref how did it get on the immunity list?
 		return
 	LAZYREMOVE(immune_weakrefs, A.weak_reference)
-
-/datum/component/lockon_aiming/onMouseMove(object,location,control,params)
-	var/mob/M = parent
-	if(!istype(M) || !M.client)
-		return
-	aiming_params = params
-	var/datum/position/P = mouse_absolute_datum_map_position_from_client(M.client, aiming_params)
-	if(!P)
-		return
-	var/turf/T = P.return_turf()
-	LAZYINITLIST(last_location)
-	if(length(last_location) == 3 && last_location[1] == T.x && last_location[2] == T.y && last_location[3] == T.z)
-		return			//Same turf, don't bother.
-	if(last_location)
-		last_location.Cut()
-	else
-		last_location = list()
-	last_location.len = 3
-	last_location[1] = T.x
-	last_location[2] = T.y
-	last_location[3] = T.z
-	autolock()
 
 /datum/component/lockon_aiming/process()
 	if(update_disabled)

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -41,6 +41,7 @@
 			buckled_mob.client.view_size.resetToDefault()
 	anchored = FALSE
 	. = ..()
+	STOP_PROCESSING(SSfastprocess, src)
 	LAZYREMOVE(buckled_mob, src)
 
 /obj/machinery/manned_turret/user_buckle_mob(mob/living/M, mob/living/carbon/user)
@@ -66,11 +67,11 @@
 	anchored = TRUE
 	if(M.client)
 		M.client.view_size.setTo(view_range)
-	LAZYOR(M.mousemove_intercept_objects, src)
+	START_PROCESSING(SSfastprocess, src)
 
-/obj/machinery/manned_turret/onMouseMove(object, location, control, params)
-	. = ..()
-	update_positioning(object, params)
+/obj/machinery/manned_turret/process()
+	if (!update_positioning())
+		return PROCESS_KILL
 
 /obj/machinery/manned_turret/proc/update_positioning(mouseObject, params)
 	if (!LAZYLEN(buckled_mobs))
@@ -147,6 +148,7 @@
 /obj/machinery/manned_turret/proc/fire_helper(mob/user)
 	if(user.incapacitated() || !(user in buckled_mobs))
 		return
+	update_positioning()
 	var/turf/targets_from = get_turf(src)
 	if(QDELETED(target))
 		target = target_turf

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -196,8 +196,6 @@
 	///For storing what do_after's someone has, in case we want to restrict them to only one of a certain do_after at a time
 	var/list/do_afters	
 
-	var/list/mousemove_intercept_objects
-
 	///Allows a datum to intercept all click calls this mob is the source of
 	var/datum/click_intercept
 

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -266,11 +266,9 @@
 		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
 		listeningTo = null
 	if(istype(current_user))
-		LAZYREMOVE(current_user.mousemove_intercept_objects, src)
 		current_user = null
 	if(istype(user))
 		current_user = user
-		LAZYOR(current_user.mousemove_intercept_objects, src)
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/on_mob_move)
 		listeningTo = user
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`/client/MouseMove()` is one of the laggiest procs in the game... despite being essentially unused for anything. TG removed it at some point, so we're also removing it.

## Changelog
:cl:
code: Nuked /client/MouseMove() for a massive amount of free performance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
