### PR TITLE
Fix beer nuke paper

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -372,12 +372,11 @@
 	
 /obj/item/paper/crumpled/beernuke/Initialize()
 	. = ..()
-	var/code = random_nukecode()
+	var/code
 	for(var/obj/machinery/nuclearbomb/beer/beernuke in GLOB.nuke_list)
 		if(beernuke.r_code == "ADMIN")
-			beernuke.r_code = code
-		else 
-			code = beernuke.r_code
+			beernuke.r_code = random_nukecode()
+		code = beernuke.r_code
 	info = "important party info, DONT FORGET: <b>[code]</b>" 
 
 /obj/item/paper/troll

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -369,6 +369,16 @@
 
 /obj/item/paper/crumpled/beernuke
 	name = "beer-stained note"
+	
+/obj/item/paper/crumpled/beernuke/Initialize()
+	. = ..()
+	var/code = random_nukecode()
+	for(var/obj/machinery/nuclearbomb/beer/beernuke in GLOB.nuke_list)
+		if(beernuke.r_code == "ADMIN")
+			beernuke.r_code = code
+		else 
+			code = beernuke.r_code
+	info = "important party info, DONT FORGET: <b>[code]</b>" 
 
 /obj/item/paper/troll
 	name = "very special note"


### PR DESCRIPTION
#2035 deleted the initialization for the beer nuke paper so it didn't have a code on it.

:cl: Beer nuke operatives
fix: Beer stained paper now has the beer nuke code written on it
/:cl: