### PR TITLE
More circuit entity outputs

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3275,6 +3275,7 @@
 #include "code\modules\wiremod\shell\controller.dm"
 #include "code\modules\wiremod\shell\drone.dm"
 #include "code\modules\wiremod\shell\moneybot.dm"
+#include "code\modules\wiremod\shell\scanner.dm"
 #include "code\modules\wiremod\shell\server.dm"
 #include "code\modules\wiremod\shell\shell_items.dm"
 #include "code\modules\zombie\items.dm"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -461,6 +461,9 @@
 #define COMSIG_AIRLOCK_CLOSE "airlock_close"
 ///from /obj/machinery/door/airlock/set_bolt():
 #define COMSIG_AIRLOCK_SET_BOLT "airlock_set_bolt"
+///Sent from /obj/machinery/door/airlock when its touched. (mob/user)
+#define COMSIG_AIRLOCK_TOUCHED "airlock_touched"
+	#define COMPONENT_PREVENT_OPEN 1
 
 // /obj/machinery/atmospherics/components/binary/valve signals
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -416,6 +416,8 @@
 				if(G.siemens_coefficient)//not insulated
 					new /datum/hallucination/shock(H)
 					return
+	if(SEND_SIGNAL(src, COMSIG_AIRLOCK_TOUCHED, user) & COMPONENT_PREVENT_OPEN)
+		return
 	if (cyclelinkedairlock)
 		if (!shuttledocked && !emergency && !cyclelinkedairlock.shuttledocked && !cyclelinkedairlock.emergency && allowed(user))
 			if(cyclelinkedairlock.operating)
@@ -824,6 +826,8 @@
 	return attack_hand(user)
 
 /obj/machinery/door/airlock/attack_hand(mob/user)
+	if(SEND_SIGNAL(src, COMSIG_AIRLOCK_TOUCHED, user) & COMPONENT_PREVENT_OPEN)
+		return
 	if(locked && allowed(user) && aac)
 		aac.request_from_door(src)
 		. = TRUE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -827,8 +827,8 @@
 
 /obj/machinery/door/airlock/attack_hand(mob/user)
 	if(SEND_SIGNAL(src, COMSIG_AIRLOCK_TOUCHED, user) & COMPONENT_PREVENT_OPEN)
-		return
-	if(locked && allowed(user) && aac)
+		. = TRUE
+	else if(locked && allowed(user) && aac)
 		aac.request_from_door(src)
 		. = TRUE
 	else

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -226,6 +226,15 @@
 	materials = list(/datum/material/glass = 2000, /datum/material/iron = 7000)
 	category = list("Circuitry", "Shells")
 
+/datum/design/scanner_shell
+	name = "Scanner Shell"
+	desc = "A handheld shell with a scanner."
+	id = "scanner_shell"
+	build_path = /obj/item/scanner
+	build_type = PROTOLATHE | COMPONENT_PRINTER
+	materials = list(/datum/material/glass = 4000, /datum/material/iron = 5000)
+	category = list("Circuitry", "Shells")
+
 /datum/design/bot_shell
 	name = "Bot Shell"
 	desc = "An immobile shell that can store more components. Has a USB port to be able to connect to computers and machines."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -303,7 +303,7 @@
 	display_name = "Advanced Shell Research"
 	description = "Grants access to more complicated shell designs."
 	prereq_ids = list("basic_circuitry", "engineering")
-	design_ids = list("controller_shell", "bot_shell", "door_shell", "money_bot_shell")
+	design_ids = list("controller_shell", "scanner_shell", "bot_shell", "door_shell", "money_bot_shell")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/movable_shells_tech

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -45,6 +45,11 @@
 	/// Called when the airlock is unbolted
 	var/datum/port/output/unbolted
 
+	/// Contains the last person to touch the airlock
+	var/datum/port/output/user_port
+	/// Called when the airlock is touched
+	var/datum/port/output/trigger_port
+
 /obj/item/circuit_component/airlock/Initialize()
 	. = ..()
 	// Input Signals
@@ -60,6 +65,8 @@
 	closed = add_output_port("Closed", PORT_TYPE_SIGNAL)
 	bolted = add_output_port("Bolted", PORT_TYPE_SIGNAL)
 	unbolted = add_output_port("Unbolted", PORT_TYPE_SIGNAL)
+	user_port = add_output_port("User", PORT_TYPE_ATOM)
+	trigger_port = add_output_port("Triggered", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/airlock/Destroy()
 	bolt = null
@@ -72,6 +79,8 @@
 	closed = null
 	bolted = null
 	unbolted = null
+	user_port = null
+	trigger_port = null
 	attached_airlock = null
 	return ..()
 
@@ -82,6 +91,7 @@
 		RegisterSignal(shell, COMSIG_AIRLOCK_SET_BOLT, .proc/on_airlock_set_bolted)
 		RegisterSignal(shell, COMSIG_AIRLOCK_OPEN, .proc/on_airlock_open)
 		RegisterSignal(shell, COMSIG_AIRLOCK_CLOSE, .proc/on_airlock_closed)
+		RegisterSignal(shell, COMSIG_AIRLOCK_TOUCHED, .proc/on_airlock_touched)
 
 /obj/item/circuit_component/airlock/unregister_shell(atom/movable/shell)
 	attached_airlock = null
@@ -89,6 +99,7 @@
 		COMSIG_AIRLOCK_SET_BOLT,
 		COMSIG_AIRLOCK_OPEN,
 		COMSIG_AIRLOCK_CLOSE,
+		COMSIG_AIRLOCK_TOUCHED,
 	))
 	return ..()
 
@@ -109,6 +120,12 @@
 	SIGNAL_HANDLER
 	is_open.set_output(FALSE)
 	closed.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/airlock/proc/on_airlock_touched(datum/source, user)
+	SIGNAL_HANDLER
+	. = COMPONENT_PREVENT_OPEN
+	user_port.set_output(user)
+	trigger_port.set_output(COMPONENT_SIGNAL)
 
 /obj/item/circuit_component/airlock/input_received(datum/port/input/port)
 	. = ..()

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -91,6 +91,8 @@
 	var/datum/port/output/total_money
 	/// Amount of the last money inputted into the shell
 	var/datum/port/output/money_input
+	/// Person that inserted the money
+	var/datum/port/output/payer
 	/// Trigger for when money is inputted into the shell
 	var/datum/port/output/money_trigger
 
@@ -98,6 +100,7 @@
 	. = ..()
 	total_money = add_output_port("Total Money", PORT_TYPE_NUMBER)
 	money_input = add_output_port("Last Input Money", PORT_TYPE_NUMBER)
+	payer = add_output_port("Payer", PORT_TYPE_ATOM)
 	money_trigger = add_output_port("Money Input", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/money_bot/register_shell(atom/movable/shell)
@@ -121,6 +124,7 @@
 	attached_bot = null
 	total_money = null
 	money_input = null
+	payer = null
 	money_trigger = null
 	return ..()
 
@@ -137,6 +141,7 @@
 	attached_bot.add_money(amount_to_insert)
 	balloon_alert(attacker, "inserted [amount_to_insert] credits.")
 	money_input.set_output(amount_to_insert)
+	payer.set_output(attacker)
 	money_trigger.set_output(COMPONENT_SIGNAL)
 	qdel(item)
 

--- a/code/modules/wiremod/shell/scanner.dm
+++ b/code/modules/wiremod/shell/scanner.dm
@@ -8,7 +8,6 @@
 	icon = 'icons/obj/assemblies/electronic_setups.dmi'
 	icon_state = "setup_small_hook"
 	item_state = "electronic"
-	//worn_icon_state = "electronic"		//remember to change it later lol
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	light_range = FALSE

--- a/code/modules/wiremod/shell/scanner.dm
+++ b/code/modules/wiremod/shell/scanner.dm
@@ -1,0 +1,56 @@
+/**
+ * # Scanner
+ *
+ * A handheld device which scans things.
+ */
+/obj/item/scanner
+	name = "scanner"
+	icon = 'icons/obj/assemblies/electronic_setups.dmi'
+	icon_state = "setup_small_hook"
+	item_state = "electronic"
+	//worn_icon_state = "electronic"		//remember to change it later lol
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	light_range = FALSE
+
+/obj/item/scanner/Initialize()
+	. = ..()
+	AddComponent(/datum/component/shell, list(
+		new /obj/item/circuit_component/scanner()
+	), SHELL_CAPACITY_SMALL)
+
+/obj/item/circuit_component/scanner
+	display_name = "Scanner"
+	display_desc = "Used to receive inputs from the scanner shell. Use the shell on something to scan it."
+
+	/// Atom that was scanned.
+	var/datum/port/output/scanned
+	/// Called when scanner is used.
+	var/datum/port/output/signal
+
+/obj/item/circuit_component/scanner/Initialize()
+	. = ..()
+	scanned = add_output_port("Scanned", PORT_TYPE_ATOM)
+	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/scanner/Destroy()
+	scanned = null
+	signal = null
+	return ..()
+
+/obj/item/circuit_component/scanner/register_shell(atom/movable/shell)
+	RegisterSignal(shell, COMSIG_ITEM_PRE_ATTACK, .proc/send_trigger)
+
+/obj/item/circuit_component/scanner/unregister_shell(atom/movable/shell)
+	UnregisterSignal(shell, COMSIG_ITEM_PRE_ATTACK)
+
+/**
+ * Called when the shell item is used on something.
+ */
+/obj/item/circuit_component/scanner/proc/send_trigger(atom/source, atom/target, mob/user)
+	SIGNAL_HANDLER
+	target.balloon_alert(user, "scanned [target]")
+	playsound(user, get_sfx("terminal_type"), 25, FALSE)
+	. = COMPONENT_NO_ATTACK
+	scanned.set_output(target)
+	signal.set_output(COMPONENT_SIGNAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a scanner shell which outputs an atom when used on something. Adds a user and triggered port to airlock shells which output when the airlock is touched. Adds a payer port to the moneybot shell.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right now the only way to output an atom is to use a voice activator circuit, a circuit multitool or an mmi which is quite limiting, this PR adds more so that circuits can be more versatile.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added scanner circuit shell
tweak: Added a user and triggered port to airlock shells
tweak: Added a payer port to moneybot shells
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
