### PR TITLE
Heretic blade shatter now uses magic channel

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -54,7 +54,7 @@
 
 /datum/action/innate/heretic_shatter/Activate()
 	var/turf/safe_turf = find_safe_turf(zlevels = sword.z, extended_safety_checks = TRUE)
-	do_teleport(holder,safe_turf,forceMove = TRUE)
+	do_teleport(holder,safe_turf,forceMove = TRUE,channel = TELEPORT_CHANNEL_MAGIC)
 	to_chat(holder,"<span class='warning'>You feel a gust of energy flow through your body... the Rusted Hills heard your call...</span>")
 	qdel(sword)
 


### PR DESCRIPTION
Channel defaults to bluespace so BOH will interfere.

:cl:
fix: BOH Interfering with blade teleport
/:cl: