### PR TITLE
Security blue shirt uniform fix

### DIFF
--- a/code/modules/client/loadout/loadout_uniform.dm
+++ b/code/modules/client/loadout/loadout_uniform.dm
@@ -355,7 +355,7 @@
 
 /datum/gear/uniform/rank/security/blueshift
 	display_name = "security jumpsuit, blue shirt and tie"
-	path = /obj/item/clothing/under/rank/security/blueshirt
+	path = /obj/item/clothing/under/rank/security/officer/blueshirt
 	cost = 7500
 
 /datum/gear/uniform/rank/security/blart

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -233,18 +233,6 @@
 	alt_covers_chest = TRUE
 
 /*
- *Blueshirt
- */
-
-/obj/item/clothing/under/rank/security/blueshirt
-	name = "blue shirt and tie"
-	desc = "I'm a little busy right now, Calhoun."
-	icon_state = "blueshift"
-	item_state = "blueshift"
-	item_color = "blueshift"
-	can_adjust = FALSE
-
-/*
  *Spacepol
  */
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Theres 2 versions for no reason and one has no armor and is in the beecoin shop, yet is security restricted, and the officer one that inherits armor is in the vending machine
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the beecoin shop entry useful and less bloat
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: blue shirt and tie security uniform in beeshop now has armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
