### PR TITLE
Adds cyborg recharger to delta dorms bathroom

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -82282,14 +82282,11 @@
 /area/crew_quarters/toilet/restrooms)
 "cIa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit/old,
-/obj/structure/toilet{
-	dir = 8
-	},
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
 /obj/machinery/light/small,
+/obj/machinery/recharge_station,
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/restrooms)
 "cIb" = (


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

Bulbs and borgs can charge

## Changelog
:cl:
add: Added cyborg recharger to Deltastation dorms bathroom
/:cl:
