### PR TITLE
Allow clockers to summon their basic outfit loadout

### DIFF
--- a/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
@@ -14,7 +14,7 @@
 
 /datum/clockcult/scripture/clockwork_armaments/invoke_success()
 	var/mob/living/M = invoker
-	var/choice = input(M,"What weapon do you want to call upon?", "Clockwork Armaments") as anything in list("Brass Spear","Brass Battlehammer","Brass Sword", "Brass Bow", "Basic Loadout")
+	var/choice = input(M,"What weapon do you want to call upon?", "Clockwork Armaments") as anything in list("Brass Spear","Brass Battlehammer","Brass Sword", "Brass Bow", "Standard Equipment (Unarmed)")
 	var/datum/antagonist/servant_of_ratvar/servant = is_servant_of_ratvar(M)
 	if(!servant)
 		return FALSE
@@ -33,5 +33,5 @@
 			armaments_sword.equip(M)
 		if("Brass Bow")
 			armaments_bow.equip(M)
-		if("Basic Loadout")
+		if("Standard Equipment (Unarmed)")
 			default.equip(M)

--- a/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
@@ -14,7 +14,7 @@
 
 /datum/clockcult/scripture/clockwork_armaments/invoke_success()
 	var/mob/living/M = invoker
-	var/choice = input(M,"What weapon do you want to call upon?", "Clockwork Armaments") as anything in list("Brass Spear","Brass Battlehammer","Brass Sword", "Brass Bow")
+	var/choice = input(M,"What weapon do you want to call upon?", "Clockwork Armaments") as anything in list("Brass Spear","Brass Battlehammer","Brass Sword", "Brass Bow", "Basic Loadout")
 	var/datum/antagonist/servant_of_ratvar/servant = is_servant_of_ratvar(M)
 	if(!servant)
 		return FALSE
@@ -23,6 +23,7 @@
 	var/static/datum/outfit/clockcult/armaments/hammer/armaments_hammer = new
 	var/static/datum/outfit/clockcult/armaments/sword/armaments_sword = new
 	var/static/datum/outfit/clockcult/armaments/bow/armaments_bow = new
+	var/static/datum/outfit/clockcult/default = new
 	switch(choice)
 		if("Brass Spear")
 			armaments_spear.equip(M)
@@ -32,3 +33,5 @@
 			armaments_sword.equip(M)
 		if("Brass Bow")
 			armaments_bow.equip(M)
+		if("Basic Loadout")
+			default.equip(M)


### PR DESCRIPTION
## About The Pull Request

Allows clock cultists to summon their basic servant of ratvar outfit with the insulated gloves, belt, ID, and chameleon clothes.

## Why It's Good For The Game

Summon armaments already does this, but the gloves and boots are overridden by the clockwork armour ones. Good for getting the full stealth appearance

## Changelog
:cl:
add: Clock cultists can now summon their basic loudout using summon armaments
/:cl: