### PR TITLE
Removes positive stage speed threshold from DNA saboteur 

### DIFF
--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -36,7 +36,7 @@ Bonus
 
 /datum/symptom/genetic_mutation/severityset(datum/disease/advance/A)
 	. = ..()
-	else if(A.resistance >= 8)
+	if(A.resistance >= 8)
 		severity += 1
 
 /datum/symptom/genetic_mutation/Activate(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -32,13 +32,10 @@ Bonus
 	var/no_reset = FALSE
 	threshold_desc = "<b>Resistance 8:</b> Causes two harmful mutations at once.<br>\
 					  <b>Stage Speed 10:</b> Increases mutation frequency.<br>\
-					  <b>Stage Speed 14:</b> Mutations will be beneficial.<br>\
 					  <b>Stealth 5:</b> The mutations persist even if the virus is cured."
 
 /datum/symptom/genetic_mutation/severityset(datum/disease/advance/A)
 	. = ..()
-	if(A.stage_rate >= 14)
-		severity = 0
 	else if(A.resistance >= 8)
 		severity += 1
 

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -63,8 +63,7 @@ Bonus
 		symptom_delay_max = 60
 	if(A.resistance >= 8) //mutate twice
 		power = 2
-	else
-		possible_mutations = (GLOB.bad_mutations | GLOB.not_good_mutations) - GLOB.all_mutations[RACEMUT]
+	possible_mutations = (GLOB.bad_mutations | GLOB.not_good_mutations) - GLOB.all_mutations[RACEMUT]
 	var/mob/living/carbon/M = A.affected_mob
 	if(M)
 		if(!M.has_dna())

--- a/code/datums/diseases/advance/symptoms/genetics.dm
+++ b/code/datums/diseases/advance/symptoms/genetics.dm
@@ -66,8 +66,6 @@ Bonus
 		symptom_delay_max = 60
 	if(A.resistance >= 8) //mutate twice
 		power = 2
-	if(A.stage_rate >= 14)
-		possible_mutations = (GLOB.good_mutations) //This should never have contained not good mutations
 	else
 		possible_mutations = (GLOB.bad_mutations | GLOB.not_good_mutations) - GLOB.all_mutations[RACEMUT]
 	var/mob/living/carbon/M = A.affected_mob


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the threshold which allowed the DNA saboteur symptom to give positive mutations. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to sidestep a part of medbay (genetics) with a single disease is bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: DNA saboteur can no longer give positive mutations
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
