### PR TITLE
Bluespace bag of holdings now require line of site to dump contents at range.

### DIFF
--- a/code/datums/components/storage/concrete/bluespace.dm
+++ b/code/datums/components/storage/concrete/bluespace.dm
@@ -10,16 +10,22 @@
 		var/turf/bagT = get_turf(parent)
 		var/turf/destT = get_turf(dumping_location)
 		var/valid = TRUE
+		if(!destT || !bagT || get_dist(M, dumping_location) >= dumping_range || bagT.get_virtual_z_level() != destT.get_virtual_z_level())
+			valid = FALSE
 		//Check density LOS.
-		for(var/turf/T as() in getline(bagT, destT))
-			if(!T.density)
-				valid = FALSE
-				break
-			for(var/atom/A as() in T)
-				if(A.density)
+		if(valid)
+			for(var/turf/T as() in getline(bagT, destT))
+				if(!T.density)
 					valid = FALSE
 					break
-		if(destT && valid && bagT && bagT.get_virtual_z_level() == destT.get_virtual_z_level() && get_dist(M, dumping_location) < dumping_range)
+				for(var/atom/A as() in T)
+					if(A.density)
+						valid = FALSE
+						break
+				if(!valid)
+					break
+		//Check still valid
+		if(valid)
 			if(dumping_location.storage_contents_dump_act(src, M))
 				if(alt_sound && prob(1))
 					playsound(src, alt_sound, 40, 1)

--- a/code/datums/components/storage/concrete/bluespace.dm
+++ b/code/datums/components/storage/concrete/bluespace.dm
@@ -18,8 +18,8 @@
 				if(T.density)
 					valid = FALSE
 					break
-				for(var/atom/A as() in T)
-					if(A.density)
+				for(var/atom/thing as() in T)
+					if(thing.density)
 						valid = FALSE
 						break
 				if(!valid)

--- a/code/datums/components/storage/concrete/bluespace.dm
+++ b/code/datums/components/storage/concrete/bluespace.dm
@@ -12,7 +12,7 @@
 		var/valid = TRUE
 		//Check density LOS.
 		for(var/turf/T as() in getline(bagT, destT))
-			if(!T.density)
+			if(T.density)
 				valid = FALSE
 				break
 			for(var/atom/A as() in T)
@@ -30,4 +30,3 @@
 		to_chat(M, "The [A.name] buzzes.")
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
 	return FALSE
-

--- a/code/datums/components/storage/concrete/bluespace.dm
+++ b/code/datums/components/storage/concrete/bluespace.dm
@@ -9,7 +9,17 @@
 		var/atom/dumping_location = dest.get_dumping_location()
 		var/turf/bagT = get_turf(parent)
 		var/turf/destT = get_turf(dumping_location)
-		if(destT && bagT && bagT.get_virtual_z_level() == destT.get_virtual_z_level() && get_dist(M, dumping_location) < dumping_range)
+		var/valid = TRUE
+		//Check density LOS.
+		for(var/turf/T as() in getline(bagT, destT))
+			if(!T.density)
+				valid = FALSE
+				break
+			for(var/atom/A as() in T)
+				if(A.density)
+					valid = FALSE
+					break
+		if(destT && valid && bagT && bagT.get_virtual_z_level() == destT.get_virtual_z_level() && get_dist(M, dumping_location) < dumping_range)
 			if(dumping_location.storage_contents_dump_act(src, M))
 				if(alt_sound && prob(1))
 					playsound(src, alt_sound, 40, 1)

--- a/code/datums/components/storage/concrete/bluespace.dm
+++ b/code/datums/components/storage/concrete/bluespace.dm
@@ -18,12 +18,7 @@
 				if(T.density)
 					valid = FALSE
 					break
-				for(var/atom/thing as() in T)
-					if(thing.density)
-						valid = FALSE
-						break
-				if(!valid)
-					break
+	
 		//Check still valid
 		if(valid)
 			if(dumping_location.storage_contents_dump_act(src, M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just saw someone use a BOH to dump a grenade straight into a pirate shuttle through walls which I think is pretty dumb. Dumping through dense objects should not be allowed.

## Why It's Good For The Game

No more teleporting bombs through walls to instantly kill some antags.

## Changelog
:cl:
balance: Bag of holding's can no longer teleport their contents through walls when dumped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
