### PR TITLE
Clock cult brass sword emp changes and plasmaman clockwork armaments

### DIFF
--- a/code/modules/antagonists/clock_cult/clockwork_outfits.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_outfits.dm
@@ -16,7 +16,7 @@
 		var/weapon_to_spawn = new weapon(get_turf(H))
 		H.put_in_inactive_hand(weapon_to_spawn)
 
-/datum/outfit/clockcult/plasmaman
+/datum/outfit/clockcult_plasmaman
 	name = "Servant of Ratvar Plasmaman"
 	head = /obj/item/clothing/head/chameleon/envirohelm/ratvar
 	uniform = /obj/item/clothing/under/chameleon/envirosuit/ratvar

--- a/code/modules/antagonists/clock_cult/clockwork_outfits.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_outfits.dm
@@ -16,6 +16,11 @@
 		var/weapon_to_spawn = new weapon(get_turf(H))
 		H.put_in_inactive_hand(weapon_to_spawn)
 
+/datum/outfit/clockcult/plasmaman
+	name = "Servant of Ratvar Plasmaman"
+	head = /obj/item/clothing/head/chameleon/envirohelm/ratvar
+	uniform = /obj/item/clothing/under/chameleon/envirosuit/ratvar
+
 /datum/outfit/clockcult/armaments
 	name = "Servant of Ratvar - Armaments"
 

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -133,12 +133,12 @@
 		return
 	if(!COOLDOWN_FINISHED(src, emp_cooldown))
 		return
-	COOLDOWN_START(src, emp_cooldown, 30 SECONDS)
+	COOLDOWN_START(src, emp_cooldown, 20 SECONDS)
 
 	var/obj/mecha/target = O
-	target.emp_act(EMP_LIGHT)
+	target.emp_act(EMP_HEAVY)
 	new /obj/effect/temp_visual/emp/pulse(target.loc)
-	addtimer(CALLBACK(src, .proc/send_message, user), 30 SECONDS)
+	addtimer(CALLBACK(src, .proc/send_message, user), 20 SECONDS)
 	to_chat(user, "<span class='brass'>You strike [target] with an electromagnetic pulse!</span>")
 	playsound(user, 'sound/magic/lightningshock.ogg', 40)
 

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -114,15 +114,33 @@
 	armour_penetration = 12
 	attack_verb = list("attacked", "slashed", "cut", "torn", "gored")
 	clockwork_hint = "Targets will be struck with a powerful electromagnetic pulse while on Reebe."
-	var/emp_cooldown = 0
+	COOLDOWN_DECLARE(emp_cooldown)
 
 /obj/item/clockwork/weapon/brass_sword/hit_effect(mob/living/target, mob/living/user, thrown)
-	if(world.time > emp_cooldown)
-		target.emp_act(EMP_LIGHT)
-		emp_cooldown = world.time + 300
-		addtimer(CALLBACK(src, .proc/send_message, user), 300)
-		to_chat(user, "<span class='brass'>You strike [target] with an electromagnetic pulse!</span>")
-		playsound(user, 'sound/magic/lightningshock.ogg', 40)
+	if(!COOLDOWN_FINISHED(src, emp_cooldown))
+		return
+	COOLDOWN_START(src, emp_cooldown, 30 SECONDS)
+
+	target.emp_act(EMP_LIGHT)
+	new /obj/effect/temp_visual/emp/pulse(target.loc)
+	addtimer(CALLBACK(src, .proc/send_message, user), 30 SECONDS)
+	to_chat(user, "<span class='brass'>You strike [target] with an electromagnetic pulse!</span>")
+	playsound(user, 'sound/magic/lightningshock.ogg', 40)
+
+/obj/item/clockwork/weapon/brass_sword/attack_obj(obj/O, mob/living/user)
+	..()
+	if(!(istype(O, /obj/mecha) && is_reebe(user.z)))
+		return
+	if(!COOLDOWN_FINISHED(src, emp_cooldown))
+		return
+	COOLDOWN_START(src, emp_cooldown, 30 SECONDS)
+
+	var/obj/mecha/target = O
+	target.emp_act(EMP_LIGHT)
+	new /obj/effect/temp_visual/emp/pulse(target.loc)
+	addtimer(CALLBACK(src, .proc/send_message, user), 30 SECONDS)
+	to_chat(user, "<span class='brass'>You strike [target] with an electromagnetic pulse!</span>")
+	playsound(user, 'sound/magic/lightningshock.ogg', 40)
 
 /obj/item/clockwork/weapon/brass_sword/proc/send_message(mob/living/target)
 	to_chat(target, "<span class='brass'>[src] glows, indicating the next attack will disrupt electronics of the target.</span>")

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -56,7 +56,7 @@
 	force += force_buff
 	. = ..()
 	force -= force_buff
-	if(!QDELETED(target) && target.stat != DEAD && !is_servant_of_ratvar(target) && !target.anti_magic_check(major=FALSE) && ISWIELDED(src))
+	if(!QDELETED(target) && target.stat != DEAD && !is_servant_of_ratvar(target) && !target.anti_magic_check(major=FALSE))
 		hit_effect(target, user)
 
 /obj/item/clockwork/weapon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -99,6 +99,8 @@
 	AddComponent(/datum/component/two_handed, force_unwielded=15, force_wielded=28, block_power_wielded=25)
 
 /obj/item/clockwork/weapon/brass_battlehammer/hit_effect(mob/living/target, mob/living/user, thrown=FALSE)
+	if(!ISWIELDED(src))
+		return
 	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
 	target.throw_at(throw_target, thrown ? 2 : 1, 4)
 

--- a/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
@@ -24,6 +24,9 @@
 	var/static/datum/outfit/clockcult/armaments/sword/armaments_sword = new
 	var/static/datum/outfit/clockcult/armaments/bow/armaments_bow = new
 	var/static/datum/outfit/clockcult/default = new
+	var/static/datum/outfit/clockcult/plasmaman/plasmaman = new
+	if(is_species(M, /datum/species/plasmaman))
+		plasmaman.equip(M)
 	switch(choice)
 		if("Brass Spear")
 			armaments_spear.equip(M)

--- a/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/clockwork_armaments.dm
@@ -24,7 +24,7 @@
 	var/static/datum/outfit/clockcult/armaments/sword/armaments_sword = new
 	var/static/datum/outfit/clockcult/armaments/bow/armaments_bow = new
 	var/static/datum/outfit/clockcult/default = new
-	var/static/datum/outfit/clockcult/plasmaman/plasmaman = new
+	var/static/datum/outfit/clockcult_plasmaman/plasmaman = new
 	if(is_species(M, /datum/species/plasmaman))
 		plasmaman.equip(M)
 	switch(choice)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -453,6 +453,7 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	bang_protect = 1
+	flash_protect = 1
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 /obj/item/clothing/head/chameleon/envirohelm/ratvar

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -277,6 +277,13 @@
 	item_state = "engi_suit"
 	item_color = "engine"
 
+/obj/item/clothing/under/chameleon/envirosuit/ratvar
+	name = "ratvarian engineer's envirosuit"
+	desc = "A tough envirosuit woven from alloy threads. It can take on the appearance of other jumpsuits."
+	icon_state = "engineer_envirosuit"
+	item_state = "engineer_envirosuit"
+	item_color = "engineer_envirosuit"
+
 /obj/item/clothing/under/chameleon/Initialize()
 	. = ..()
 	chameleon_action = new(src)
@@ -447,6 +454,12 @@
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	bang_protect = 1
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+
+/obj/item/clothing/head/chameleon/envirohelm/ratvar
+	name = "ratvarian engineer's envirosuit helmet"
+	desc = "A tough envirohelm woven from alloy threads. It can take on the appearance of other headgear."
+	icon_state = "engineer_envirohelm"
+	item_state = "engineer_envirohelm"
 
 /obj/item/clothing/head/chameleon/drone
 	// The camohat, I mean, holographic hat projection, is part of the

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -453,7 +453,6 @@
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	bang_protect = 1
-	flash_protect = 1
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 /obj/item/clothing/head/chameleon/envirohelm/ratvar
@@ -461,6 +460,7 @@
 	desc = "A tough envirohelm woven from alloy threads. It can take on the appearance of other headgear."
 	icon_state = "engineer_envirohelm"
 	item_state = "engineer_envirohelm"
+	flash_protect = 1
 
 /obj/item/clothing/head/chameleon/drone
 	// The camohat, I mean, holographic hat projection, is part of the


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Emp ability of brass sword only worked on throw because their ability to be wielded was removed before
Now it can emp mechs as well when hitting them
Also a little emp visual effect
Clockwork armaments now gives plasmamen a ratvar chameleon outfit
Armaments still requires for their clothing areas to not have anything to prevent deletion, but what kind of plasmaman is afraid of burning for a few seconds
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes brass sword useful again, and makes clockies a little more plasmamen friendly (even if they have a magic mirror)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: brass sword emp works on mechs
add: clockwork armaments envirosuit compatibility for plasmamen
add: visual effect on brass sword emp
fix: brass sword emp not working
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
