### PR TITLE
Automatable Cooking

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -313,6 +313,14 @@ All foods are distributed among various categories. Use common sense.
 
 	return result
 
+/obj/item/reagent_containers/food/snacks/burn()
+	if(prob(25))
+		microwave_act()
+	else
+		var/turf/T = get_turf(src)
+		new /obj/item/reagent_containers/food/snacks/badrecipe(T)
+		qdel(src)
+
 /obj/item/reagent_containers/food/snacks/Destroy()
 	if(contents)
 		for(var/atom/movable/something in contents)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -260,7 +260,7 @@
 		var/copy_amount = T.volume * part
 		if(preserve_data)
 			trans_data = T.data
-		R.add_reagent(T.type, copy_amount * multiplier, trans_data)
+		R.add_reagent(T.type, copy_amount * multiplier, trans_data, chem_temp)
 
 	src.update_total()
 	R.update_total()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lighting food on fire has a 25% chance to cook it, otherwise it makes a burned mess. 
The reagent copy_to proc now also copies the temperature of the chemical which means foam/smoke (and a few other things) keeps the temperature of it's reagents, this allows cooking oil to be applied through these methods.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes more sense for food to cook than turn to ash and means that other mechanics can be used to automate cooking. copy_to not keeping the reagent's temperature seems like an oversight.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Food has a chance to be cooked when set on fire
fix: The temperature of reagents in smoke/foam isn't reset
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
