### PR TITLE
Makes the black pill contain enough mutation toxin to transform

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -229,7 +229,7 @@
 	desc = "I wouldn't eat this if I were you."
 	icon_state = "pill9"
 	color = "#454545"
-	list_reagents = list(/datum/reagent/mutationtoxin/shadow = 1)
+	list_reagents = list(/datum/reagent/mutationtoxin/shadow = 5)
 
 //////////////////////////////////////// drugs
 /obj/item/reagent_containers/pill/zoom


### PR DESCRIPTION
## About The Pull Request

amount of shadowperson mutation toxin in the black pill increased to 5 from 1

## Why It's Good For The Game

the pill works again

## Changelog
:cl:
fix: fixed black pill not working
/:cl:
