### PR TITLE
Fixes bug with orion trail dropping a radio when the monitor gets disconnected

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1183,6 +1183,10 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	newgame()
 	obj_flags |= EMAGGED
 
+/obj/machinery/computer/arcade/orion_trail/Destroy()
+	qdel(Radio)
+	. = ..()
+
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/orion
 	name = "spaceport security"
 	desc = "Premier corporate security forces for all spaceports found along the Orion Trail."

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1184,7 +1184,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	obj_flags |= EMAGGED
 
 /obj/machinery/computer/arcade/orion_trail/Destroy()
-	qdel(Radio)
+	QDEL_NULL(Radio)
 	. = ..()
 
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/orion


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes bug with orion trail dropping a radio when the monitor gets disconnected by just deleting the radio upon deconstruction.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bug bad. Closes #4746

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: orion trail no longer drops station bounced radios upon monitor deconstruction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
