### PR TITLE
Increases Space Budget

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -374,7 +374,7 @@
 	min_val = 0
 
 /datum/config_entry/number/space_budget
-	config_entry_value = 40
+	config_entry_value = 120
 	integer = FALSE
 	min_val = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases space budget

## Why It's Good For The Game

Before the budget revisions, the game spawned a fixed number of space ruins, no matter what. This caused space ruins to go overbudget.

Budget revision was meant to account for that, and slightly increase the number of ruins while managing budget better.

However, budget number is too low and larger ruins, like the delerict, whiteship and charlie to almost never spawn.

## Changelog
:cl:
tweak: Increased space budget
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
