### PR TITLE
Fixes Shuttles Leaving With Multiple Prisoners

### DIFF
--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -104,12 +104,10 @@
 	id_tag = "prisonshuttle";
 	name = "Labor Shuttle Airlock"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/laborshuttle{
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = "laborcamp";
-	name = "labor camp shuttle";
 	port_direction = 4;
 	width = 9
 	},

--- a/_maps/shuttles/labour_corg.dmm
+++ b/_maps/shuttles/labour_corg.dmm
@@ -92,12 +92,10 @@
 	id_tag = "prisonshuttle";
 	name = "Labor Shuttle Airlock"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/laborshuttle{
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = "laborcamp";
-	name = "labor camp shuttle";
 	port_direction = 4;
 	width = 8
 	},

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -240,12 +240,10 @@
 	id_tag = "prisonshuttle";
 	name = "Labor Shuttle Airlock"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/laborshuttle{
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = "laborcamp";
-	name = "labor camp shuttle";
 	port_direction = 4;
 	width = 9
 	},

--- a/_maps/shuttles/labour_kilo.dmm
+++ b/_maps/shuttles/labour_kilo.dmm
@@ -222,12 +222,10 @@
 	id_tag = "prisonshuttle";
 	name = "Labor Shuttle Airlock"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/laborshuttle{
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = "laborcamp";
-	name = "labor camp shuttle";
 	port_direction = 4;
 	width = 9
 	},

--- a/code/modules/mining/laborcamp/laborshuttle.dm
+++ b/code/modules/mining/laborcamp/laborshuttle.dm
@@ -25,3 +25,22 @@
 			to_chat(usr, "<span class='warning'>Shuttle is already at the outpost!</span>")
 			return 0
 	..()
+	
+	
+/obj/docking_port/mobile/laborshuttle
+	id = "laborcamp";
+	name = "labor camp shuttle";
+	
+/obj/docking_port/mobile/laborshuttle/canMove()
+	if (!is_station_level(z))	
+		var/nWorkers = 0
+		for(var/mob/living/carbon/human/happy_worker in GLOB.alive_mob_list)
+			if(!istype(happy_worker))	//type check
+				continue		
+			var/area/larea = get_area(happy_worker) //area check
+			for(var/place in shuttle_areas)
+				if (larea == place)
+					nWorkers++
+			if (nWorkers>1)
+				return FALSE
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Standardizes labor shuttle.
Adds a little check that prevents shuttle from moving with more labor prisoners.

## Why It's Good For The Game

Fixes #4784

## Changelog
:cl:
fix: Labor shuttle no longer leaves with more than 1 prisoner
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
