### PR TITLE
Fix cult pylons

### DIFF
--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -176,8 +176,8 @@
 				if(L.health != L.maxHealth)
 					new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
 					if(ishuman(L))
-						L.adjustBruteLoss(-0.5*delta_time, 0)
-						L.adjustFireLoss(-0.5*delta_time, 0)
+						L.adjustBruteLoss(-1, 0)
+						L.adjustFireLoss(-1, 0)
 						L.updatehealth()
 					if(isshade(L) || isconstruct(L))
 						var/mob/living/simple_animal/M = L


### PR DESCRIPTION
Reverts delta_time change to the cult pylon, fixing the healing effect that has been broken since this was added.

:cl:
fix: Fixed cult pylons not healing cultists
/:cl: