### PR TITLE
Cult pylons heal at the same rate again

### DIFF
--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -172,19 +172,20 @@
 	if(last_heal <= world.time)
 		last_heal = world.time + heal_delay
 		for(var/mob/living/L in range(5, src))
-			if(iscultist(L) || isshade(L) || isconstruct(L))
-				if(L.health != L.maxHealth)
-					new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
-					if(ishuman(L))
-						L.adjustBruteLoss(-0.5*delta_time, 0)
-						L.adjustFireLoss(-0.5*delta_time, 0)
-						L.updatehealth()
-					if(isshade(L) || isconstruct(L))
-						var/mob/living/simple_animal/M = L
-						if(M.health < M.maxHealth)
-							M.adjustHealth(-1.5*delta_time)
-				if(ishuman(L) && L.blood_volume < BLOOD_VOLUME_NORMAL)
+			if(L.health == L.maxHealth)
+				continue
+			if(!iscultist(L) && !isshade(L) && !isconstruct(L))
+				continue
+			new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
+			if(ishuman(L))
+				L.adjustBruteLoss(-0.5*delta_time, 0)
+				L.adjustFireLoss(-0.5*delta_time, 0)
+				L.updatehealth()
+				if(L.blood_volume < BLOOD_VOLUME_NORMAL)
 					L.blood_volume += 1.0
+			else if(isshade(L) || isconstruct(L))
+				var/mob/living/simple_animal/M = L
+				M.adjustHealth(-1.5*delta_time)
 			CHECK_TICK
 	if(last_corrupt <= world.time)
 		var/list/validturfs = list()

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -185,7 +185,7 @@
 					L.blood_volume += 1.0
 			else if(isshade(L) || isconstruct(L))
 				var/mob/living/simple_animal/M = L
-				M.adjustHealth(-1.5*delta_time)
+				M.adjustHealth(-15*delta_time)
 			CHECK_TICK
 	if(last_corrupt <= world.time)
 		var/list/validturfs = list()

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -178,8 +178,8 @@
 				continue
 			new /obj/effect/temp_visual/heal(get_turf(src), "#960000")
 			if(ishuman(L))
-				L.adjustBruteLoss(-0.5*delta_time, 0)
-				L.adjustFireLoss(-0.5*delta_time, 0)
+				L.adjustBruteLoss(-5*delta_time, 0)
+				L.adjustFireLoss(-5*delta_time, 0)
 				L.updatehealth()
 				if(L.blood_volume < BLOOD_VOLUME_NORMAL)
 					L.blood_volume += 1.0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Delta time is 0.2, they healed 1 before.
Also small refactor to the code

closes: #4814

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cult pylons heal 1 damage per tick again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
