### PR TITLE
Changes the trauma lines that reference tgstation servers

### DIFF
--- a/strings/traumas.json
+++ b/strings/traumas.json
@@ -100,12 +100,12 @@
 		"e"
 	],
 	"servers": [
-		"bager",
-		"sybl",
-		"mrs sybil",
-		"mr basil",
-		"mr terry",
-		"berry"
+		"saeg",
+		"sege",
+		"sayge",
+		"glond",
+		"glodne",
+		"geldno"
 	],
 	"create_verbs": [
 		"spawn",

--- a/strings/traumas.json
+++ b/strings/traumas.json
@@ -105,7 +105,8 @@
 		"sayge",
 		"glond",
 		"glodne",
-		"geldno"
+		"geldno",
+		"clover"
 	],
 	"create_verbs": [
 		"spawn",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the gibbering brain trauma lines about /tg/station server names to Beestation server names.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is more funni to reference the server you're on.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Brain trauma lines now reference Beestation servers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
