### PR TITLE
Makes the ghost arrows on the spectre inspector goggles a toggle

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -291,18 +291,15 @@
 	flash_protect = 1
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	glass_colour_type = /datum/client_colour/glass_colour/green
-	var/ghost_vision
 
 /obj/item/clothing/glasses/welding/ghostbuster/ComponentInitialize()
 	. = ..()
-	ghost_vision = AddComponent(/datum/component/team_monitor, "ghost", 1)
+	AddComponent(/datum/component/team_monitor, "ghost", 1)
 
 /obj/item/clothing/glasses/welding/ghostbuster/visor_toggling()
 	..()
-	if(ghost_vision)
-		QDEL_NULL(ghost_vision)
-	else
-		ghost_vision = AddComponent(/datum/component/team_monitor, "ghost", 1)
+	var/datum/component/team_monitor/ghost_vision = GetComponent(/datum/component/team_monitor)
+	ghost_vision.toggle_hud(!ghost_vision.hud_visible, usr)
 
 /obj/item/clothing/glasses/blindfold
 	name = "blindfold"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -291,10 +291,14 @@
 	flash_protect = 1
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | VISOR_INVISVIEW
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	var/ghost_vision
 
-/obj/item/clothing/glasses/welding/ghostbuster/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/team_monitor, "ghost", 1)
+/obj/item/clothing/glasses/welding/ghostbuster/visor_toggling()
+	..()
+	if(ghost_vision)
+		QDEL_NULL(ghost_vision)
+	else
+		ghost_vision = AddComponent(/datum/component/team_monitor, "ghost", 1)
 
 /obj/item/clothing/glasses/blindfold
 	name = "blindfold"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -289,9 +289,13 @@
 	icon_state = "bustin-g"
 	item_state = "bustin-g"
 	flash_protect = 1
-	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT | VISOR_INVISVIEW
+	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	glass_colour_type = /datum/client_colour/glass_colour/green
 	var/ghost_vision
+
+/obj/item/clothing/glasses/welding/ghostbuster/ComponentInitialize()
+	. = ..()
+	ghost_vision = AddComponent(/datum/component/team_monitor, "ghost", 1)
 
 /obj/item/clothing/glasses/welding/ghostbuster/visor_toggling()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It was a toggle before until it got turned into team tracking arrows
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Arrows no longer on screen all the time, toggle also has a use other than flash protection again
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: spectre inspector goggles ghost tracking is toggled again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
