### PR TITLE
Ratvar clockifies more stuff

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -408,6 +408,9 @@
 		animate(src, color = previouscolor, time = 8)
 		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
+/obj/machinery/door/window/clockwork/ratvar_act()
+	return FALSE
+
 /obj/machinery/door/window/clockwork/attackby(obj/item/I, mob/living/user, params)
 
 	if(operating)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -65,6 +65,11 @@
 	W.setDir(dir)
 	qdel(src)
 
+/obj/structure/chair/ratvar_act()
+	var/obj/structure/chair/brass/B = new(get_turf(src))
+	B.setDir(dir)
+	qdel(src)
+
 /obj/structure/chair/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
 		W.play_tool_sound(src)
@@ -384,6 +389,9 @@
 	setDir(direction)
 	playsound(src, 'sound/effects/servostep.ogg', 50, FALSE)
 	return FALSE
+
+/obj/structure/chair/brass/ratvar_act()
+	return
 
 /obj/structure/chair/brass/AltClick(mob/living/user)
 	turns = 0

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -71,6 +71,11 @@
 	qdel(src)
 	new /obj/structure/table/wood(A)
 
+/obj/structure/table/ratvar_act()
+	var/atom/A = loc
+	qdel(src)
+	new /obj/structure/table/brass(A)
+
 /obj/structure/table/attack_paw(mob/user)
 	return attack_hand(user)
 
@@ -448,6 +453,9 @@
 	framestackamount = 1
 	buildstackamount = 1
 	canSmoothWith = list(/obj/structure/table/brass, /obj/structure/table/bronze)
+
+/obj/structure/table/brass/ratvar_act()
+	return
 
 /obj/structure/table/brass/tablepush(mob/living/user, mob/living/pushed_mob)
 	. = ..()

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -86,6 +86,13 @@
 /obj/structure/window/narsie_act()
 	add_atom_colour(NARSIE_WINDOW_COLOUR, FIXED_COLOUR_PRIORITY)
 
+/obj/structure/window/ratvar_act()
+	if(!fulltile)
+		new/obj/structure/window/reinforced/clockwork(get_turf(src), dir)
+	else
+		new/obj/structure/window/reinforced/clockwork/fulltile(get_turf(src))
+	qdel(src)
+
 /obj/structure/window/singularity_pull(S, current_size)
 	..()
 	if(current_size >= STAGE_FIVE)

--- a/code/modules/antagonists/clock_cult/clockwork_turfs.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_turfs.dm
@@ -549,6 +549,9 @@
 		animate(src, color = previouscolor, time = 8)
 		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 
+/obj/structure/window/reinforced/clockwork/ratvar_act()
+	return FALSE
+
 /obj/structure/window/reinforced/clockwork/unanchored
 	anchored = FALSE
 


### PR DESCRIPTION
Ratvar now turns tables chairs and windows into brass variants. Fixed brass windoors deleting over and over again when in the presence of ratvar.

:cl:
add: Ratvar will now convert more station objects
/:cl: