### PR TITLE
Improves the Functionality of Advanced Mimery Gun

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -67,5 +67,5 @@
 	caliber = "mime"
 	projectile_type = /obj/item/projectile/bullet/c38/mime
 
-/obj/item/ammo_casing/caseless/mime/lethals
-	projectile_type = /obj/item/projectile/bullet/c38
+/obj/item/ammo_casing/caseless/mime/lethal
+	projectile_type = /obj/item/projectile/bullet/c38/mime/lethal

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -68,4 +68,4 @@
 	projectile_type = /obj/item/projectile/bullet/c38/mime
 
 /obj/item/ammo_casing/caseless/mime/lethal
-	projectile_type = /obj/item/projectile/bullet/c38/mime/lethal
+	projectile_type = /obj/item/projectile/bullet/c38/mime_lethal

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -55,7 +55,7 @@
 	max_ammo = 6
 	desc = "Designed to quickly reload your fingers with lethal rounds."
 	item_flags = DROPDEL
-	ammo_type = /obj/item/ammo_casing/caseless/mime/lethals
+	ammo_type = /obj/item/ammo_casing/caseless/mime/lethal
 
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -53,3 +53,7 @@
 	ammo_type = /obj/item/ammo_casing/caseless/mime
 	caliber = "mime"
 	max_ammo = 6
+
+/obj/item/ammo_box/magazine/internal/cylinder/mime/lethal
+	ammo_type = /obj/item/ammo_casing/caseless/mime/lethal
+	max_ammo = 3 //Because that's how many this is supposed to have from what I gather

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -286,3 +286,7 @@
 
 /obj/item/gun/ballistic/revolver/mime/attack_self(mob/user)
 	qdel(src)
+
+//The Lethal Version from Advanced Mimery
+/obj/item/gun/ballistic/revolver/mime/magic
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/mime/lethal

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -112,7 +112,7 @@
 	damage = 20
 
 /obj/item/projectile/bullet/c38/mime_lethal/on_hit(atom/target, blocked)
-	..()
+	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.silent = max(M.silent, 10)

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -112,10 +112,10 @@
 	damage = 20
 
 /obj/item/projectile/bullet/c38/mime_lethal/on_hit(atom/target, blocked)
+	..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.silent = max(M.silent, 10)
-	..()
 // .357 (Syndie Revolver)
 
 /obj/item/projectile/bullet/a357

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -106,14 +106,16 @@
 		else
 			to_chat(M, "<span class='userdanger'>You get shot with the finger gun!</span>")
 
-/obj/item/projectile/bullet/c38/mime/lethal
+/obj/item/projectile/bullet/c38/mime_lethal
+	name = "invisible .38 bullet"
+	icon_state = null
 	damage = 20
 
-/obj/item/projectile/bullet/c38/mime/lethal/on_hit(atom/target, blocked)
+/obj/item/projectile/bullet/c38/mime_lethal/on_hit(atom/target, blocked)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.silent = max(M.silent, 10)
-
+	..()
 // .357 (Syndie Revolver)
 
 /obj/item/projectile/bullet/a357

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -106,6 +106,14 @@
 		else
 			to_chat(M, "<span class='userdanger'>You get shot with the finger gun!</span>")
 
+/obj/item/projectile/bullet/c38/mime/lethal
+	damage = 20
+
+/obj/item/projectile/bullet/c38/mime/lethal/on_hit(atom/target, blocked)
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.silent = max(M.silent, 10)
+
 // .357 (Syndie Revolver)
 
 /obj/item/projectile/bullet/a357

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -180,6 +180,7 @@
 	school = "mime"
 	panel = "Mime"
 	charge_max = 300
+	range = -1
 	clothes_req = FALSE
 	antimagic_allowed = TRUE
 	include_user = TRUE

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -174,7 +174,7 @@
 		invocation_type ="none"
 	..()
 
-/obj/effect/proc_holder/spell/aimed/finger_guns
+/obj/effect/proc_holder/spell/targeted/mime/finger_guns
 	name = "Finger Guns"
 	desc = "Shoot a mimed bullet from your fingers that stuns and does some damage."
 	school = "mime"
@@ -182,36 +182,27 @@
 	charge_max = 300
 	clothes_req = FALSE
 	antimagic_allowed = TRUE
+	include_user = TRUE
 	invocation_type = "emote"
 	invocation_emote_self = "<span class='dangers'>You fire your finger gun!</span>"
-	range = 20
-	projectile_type = /obj/item/projectile/bullet/mime
-	projectile_amount = 3
 	sound = null
-	active_msg = "You draw your fingers!"
-	deactive_msg = "You put your fingers at ease. Another time."
-	active = FALSE
 
 	action_icon = 'icons/mob/actions/actions_mime.dmi'
 	action_icon_state = "finger_guns0"
 	action_background_icon_state = "bg_mime"
-	base_icon_state = "finger_guns"
 
-
-/obj/effect/proc_holder/spell/aimed/finger_guns/Click()
-	var/mob/living/carbon/human/owner = usr
-	if(owner.incapacitated())
-		to_chat(owner, "<span class='warning'>You can't properly point your fingers while incapacitated.</span>")
+/obj/effect/proc_holder/spell/targeted/mime/finger_guns/Click()
+	if(!usr)
 		return
-	if(usr?.mind)
-		if(!usr.mind.miming)
-			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
-			return
-		invocation = "<B>[usr.real_name]</B> fires [usr.p_their()] finger gun!"
+	if(!ishuman(usr))
+		return
+	var/obj/item/gun/ballistic/revolver/mime/magic/N = new(usr)
+	if(usr.put_in_hands(N))
+		to_chat(usr, "<span class='notice'>You form your fingers into a gun.</span>")
 	else
-		invocation_type ="none"
+		qdel(N)
+		to_chat(usr, "<span class='warning'>You don't have any free hands to make fingerguns with.</span>")
 	..()
-
 
 /obj/item/book/granter/spell/mimery_blockade
 	spell = /obj/effect/proc_holder/spell/targeted/forcewall/mime
@@ -229,7 +220,7 @@
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/mime/speak)
 
 /obj/item/book/granter/spell/mimery_guns
-	spell = /obj/effect/proc_holder/spell/aimed/finger_guns
+	spell = /obj/effect/proc_holder/spell/targeted/mime/finger_guns
 	spellname = "Finger Guns"
 	name = "Guide to Advanced Mimery Vol 2"
 	desc = "There aren't any words written..."

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -196,6 +196,10 @@
 		return
 	if(!ishuman(usr))
 		return
+	if(usr?.mind)
+		if(!usr.mind.miming)
+			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
+			return
 	var/obj/item/gun/ballistic/revolver/mime/magic/N = new(usr)
 	if(usr.put_in_hands(N))
 		to_chat(usr, "<span class='notice'>You form your fingers into a gun.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Closes These Issues:
closes #4382
closes #4616

Cause(s): 
Shitcode

Fix: 
Reimplementation Similar to the Finger Gun Emote

Effects:
Spell Typology Changed
Cooldown starts when gun is initially created
Gun is destroyed when you attempt to fire while empty
Gun is destroyed by dropping
Gun can now be fired multiple times as intended

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes the feature actually work closer to how it is intended to
Removes some really weird code that didn't work properly
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
fix: Advanced Mimery Gun now able to be fired multiple times without issues
fix: You can now dispell the advanced mimery gun properly
code: Added a subtype of the finger gun that is lethal. This is used by advanced mimery only.
refactor: Advanced Mimery now does a finger gun variant instead of some weird magical projectile stuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
