### PR TITLE
Fixes soulstoning people with no soul.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -91,7 +91,7 @@
 		return
 	if(!ishuman(M))//If target is not a human.
 		return ..()
-	if(!M.mind?.hasSoul)
+	if(M.mind && !M.mind.hasSoul)
 		to_chat(user, "<span class='warning'>That person has no soul!</span>")
 		return
 	if(iscultist(M))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -89,6 +89,9 @@
 	if(spent)
 		to_chat(user, "<span class='warning'>There is no power left in the shard.</span>")
 		return
+	if(!M.mind.hasSoul)
+		to_chat(user, "<span class='warning'>That person has no soul!</span>")
+		return
 	if(!ishuman(M))//If target is not a human.
 		return ..()
 	if(iscultist(M))

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -89,11 +89,11 @@
 	if(spent)
 		to_chat(user, "<span class='warning'>There is no power left in the shard.</span>")
 		return
-	if(!M.mind.hasSoul)
-		to_chat(user, "<span class='warning'>That person has no soul!</span>")
-		return
 	if(!ishuman(M))//If target is not a human.
 		return ..()
+	if(!M.mind?.hasSoul)
+		to_chat(user, "<span class='warning'>That person has no soul!</span>")
+		return
 	if(iscultist(M))
 		if(iscultist(user))
 			to_chat(user, "<span class='cultlarge'>\"Come now, do not capture your bretheren's soul.\"</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can no longer be soul-stoned if you lack a soul. (Bind Soul, etc.) Closes #4834 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If you don't have a soul, your soul shouldn't be able to be captured.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can no longer use a soulstone on soulless targets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
