### PR TITLE
Cult master registers a hostile environment, chaplain can track them down when the shuttle is called.

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -141,9 +141,14 @@
 	on_remove_on_mob_delete = TRUE
 	var/alive = TRUE
 
+/datum/status_effect/cult_master/on_apply()
+	. = ..()
+	SSshuttle.registerHostileEnvironment(owner)
+
 /datum/status_effect/cult_master/proc/deathrattle()
 	if(!QDELETED(GLOB.cult_narsie))
 		return //if Nar'Sie is alive, don't even worry about it
+	SSshuttle.clearHostileEnvironment(owner)
 	var/area/A = get_area(owner)
 	for(var/datum/mind/B in SSticker.mode.cult)
 		if(isliving(B.current))

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -65,6 +65,17 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			dat += {"<tr><td><img src="[nicename]"></td><td><a href="?src=[REF(src)];seticon=[i]">[nicename]</a></td></tr>"}
 		dat += "</table></body></html>"
 		H << browse(dat, "window=editicon;can_close=0;can_minimize=0;size=250x650")
+	else if(H.mind.holy_role)
+		//Point towards cult leaders if shuttle is stuck
+		if(SSshuttle.emergency.mode == SHUTTLE_STRANDED)
+			//Locate the cult leader
+			var/datum/game_mode/gamemode = SSticker.mode
+			if(gamemode?.cult)
+				for(var/datum/mind/M as() in gamemode.cult)
+					var/datum/antagonist/cult/master/master = M.has_antag_datum(/datum/antagonist/cult/master)
+					if(master && isliving(M.current))
+						to_chat(H, "<span class='notice'>Holy energies guide you [dir2text(H.get_dir(M.current))]</span>")
+						return
 
 /obj/item/storage/book/bible/Topic(href, href_list)
 	if(!usr.canUseTopic(src, BE_CLOSE))

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -74,7 +74,12 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 				for(var/datum/mind/M as() in gamemode.cult)
 					var/datum/antagonist/cult/master/master = M.has_antag_datum(/datum/antagonist/cult/master)
 					if(master && isliving(M.current))
-						to_chat(H, "<span class='notice'>Holy energies guide you [dir2text(H.get_dir(M.current))]</span>")
+						var/turf/ourTurf = get_turf(H)
+						var/turf/theirTurf = get_turf(M.current)
+						if(ourTurf.z != theirTurf.z)
+							to_chat(H, "<span class='notice'><i>They</i> are not around here...</span>")
+							return
+						to_chat(H, "<span class='notice'>Holy energies guide you [dir2text(get_dir(ourTurf, theirTurf))].</span>")
 						return
 
 /obj/item/storage/book/bible/Topic(href, href_list)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -212,10 +212,9 @@
 	throwing.Grant(current)
 	current.update_action_buttons_icon()
 	current.apply_status_effect(/datum/status_effect/cult_master)
-	if(cult_team.cult_risen)
-		cult_team.rise(current)
-		if(cult_team.cult_ascendent)
-			cult_team.ascend(current)
+	//Permanently Ascended
+	cult_team.rise(current)
+	cult_team.ascend(current)
 
 /datum/antagonist/cult/master/remove_innate_effects(mob/living/mob_override)
 	. = ..()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -467,6 +467,8 @@
 	color = "#333333"
 	list_reagents = list(/datum/reagent/fuel/unholywater = 50)
 
+GLOBAL_VAR_INIT(shuttle_purified, FALSE)
+
 /obj/item/shuttle_curse
 	name = "cursed orb"
 	desc = "You peer within this smokey orb and glimpse terrible fates befalling the escape shuttle."
@@ -479,6 +481,9 @@
 		user.dropItemToGround(src, TRUE)
 		user.Paralyze(100)
 		to_chat(user, "<span class='warning'>A powerful force shoves you away from [src]!</span>")
+		return
+	if(GLOB.shuttle_purified)
+		to_chat(user, "<span class='notice'>The shuttle has been purified and cannot be cursed!</span>")
 		return
 	if(curselimit > 1)
 		to_chat(user, "<span class='notice'>We have exhausted our ability to curse the shuttle.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the cult master ascends they will be given a permanent halo and cult effects.
Cult master will register a hostile environment, delaynig the shuttle.
The chaplain can use any bible in the world to be pointed in the direction of the cult master.
20 minutes after ascending, the hostile environment will be revoked.

## Why It's Good For The Game

Cult = Instant shuttle call subverting a large portion of the fun of the game, calling the shuttle to avoid the main part of gamemodes kind of ruins the point of them. That being said, one person shouldn't be able to hold the entire round hostage so the cult leader cannot leave the z-level, die or take longer than 20 minutes or the shuttle will be 'purified' preventing further shuttle curses and clearning the hostile env.

## Changelog
:cl:
balance: The cult leader will now block the shuttle from leaving for 20 minutes. This effect is reverted if the cult leader leaves the z-level, or dies.
balance: The chaplain can use a bible in hand to get the direction of the cult leader.
balance: After 20 minutes of the cult leader ascending, the shuttle will be purified preventing the cultists from delaying the shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
