### PR TITLE
Admins can choose to instantly trigger meteors when they select it.

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -178,6 +178,7 @@
 						return
 					if("No")
 						event.announceChance = 0
+				event.on_admin_trigger()
 				event.processing = TRUE
 			message_admins("[key_name_admin(usr)] has triggered an event. ([E.name])")
 			log_admin("[key_name(usr)] has triggered an event. ([E.name])")

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -215,6 +215,9 @@
 
 	activeFor++
 
+// Called when an admin triggers the event.
+/datum/round_event/proc/on_admin_trigger()
+	return
 
 //Garbage collects the event by removing it from the global events list,
 //which should be the only place it's referenced.

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -21,7 +21,6 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/on_admin_trigger()
-	var/instant = FALSE
 	if(alert(usr, "Trigger meteors instantly? (This will not change the alert, just send them quicker. Nobody will ever notice!)", "Meteor Trigger", "Yes", "No") == "Yes")
 		startWhen = 30
 		endWhen = 90

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -20,6 +20,12 @@
 	if(!wave_type)
 		determine_wave_type()
 
+/datum/round_event/meteor_wave/on_admin_trigger()
+	var/instant = FALSE
+	if(alert(usr, "Trigger meteors instantly? (This will not change the alert, just send them quicker. Nobody will ever notice!)", "Meteor Trigger", "Yes", "No") == "Yes")
+		startWhen = 30
+		endWhen = 90
+
 /datum/round_event/meteor_wave/proc/determine_wave_type()
 	if(!wave_name)
 		wave_name = pickweight(list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Admins can choose to instantly trigger meteors when they select it.
Also adds in support for other things to override the new proc and implement custom behaviours when an admin calls an event.

## Why It's Good For The Game

Useful for admins.

## Changelog
:cl:
tweak: admins can choose to instantly trigger meteors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
