### PR TITLE
Nerfs scatter laser shotgun damage

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -39,7 +39,8 @@
 /obj/item/projectile/beam/weak
 	damage = 8
 
-/obj/item/projectile/beam/weak/penetrator
+/obj/item/projectile/beam/weak/penetrator //laser gatling and centcom shuttle turret
+	damage = 15
 	armour_penetration = 50
 
 /obj/item/projectile/beam/practice

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -37,7 +37,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/item/projectile/beam/weak
-	damage = 15
+	damage = 8
 
 /obj/item/projectile/beam/weak/penetrator
 	armour_penetration = 50


### PR DESCRIPTION
## About The Pull Request

weak beam projectile damage reduced from 15 to 8 bringing it in line with buckshot.

## Why It's Good For The Game

Almost crits an unarmoured target in one shot and a fully armoured individual in two, they can also pass through windows.

## Changelog
:cl:
balance: scatter laser shotgun damage down to 8 from 15
/:cl: