### PR TITLE
Ports fix iron duplication bug with reinforced floors and disposals

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -91,11 +91,11 @@
 	var/eject_range = 5
 	var/turf/open/floor/floorturf
 
-	if(isfloorturf(T)) //intact floor, pop the tile
+	if(isfloorturf(T) && T.intact) //intact floor, pop the tile
 		floorturf = T
 		if(floorturf.floor_tile)
 			new floorturf.floor_tile(T)
-		floorturf.make_plating()
+		floorturf.make_plating(TRUE)
 
 	if(direction)		// direction is specified
 		if(isspaceturf(T)) // if ended in space, then range is unlimited


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports: https://github.com/tgstation/tgstation/pull/56246
This Ports a fix to a dublication glitch involving disposal pipes and reinforced floor.
~~Also i am not completly sure why it has to give an argument like TRUE to the make_plating proc as this proc does not use it in any way trough.~~ Figured it out VSC did not actually show me the right proc define for reinforced floor that actually uses the argument and just showed the parent itself and that caused some confusion.

## Why It's Good For The Game

One dublication glitch less
Also this apparently caused quite some lag on golden 

## Changelog
:cl: AlinaStarkova, MNarath1
fix: fixes iron dublication glitch involving reinforced floor and disposal pipes
fix: fixes reinforced floor not breaking properly on ejection of content
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
