### PR TITLE
fixes light explosions not being able to delimb someone if they have no bomb armor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -418,6 +418,12 @@
 		var/max_limb_loss = 0
 		var/probability = 0
 		switch(severity)
+			if(EXPLODE_NONE)
+				max_limb_loss = 1
+				probability = 20
+			if(EXPLODE_LIGHT)
+				max_limb_loss = 2
+				probability = 30
 			if(EXPLODE_HEAVY)
 				max_limb_loss = 3
 				probability = 40


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

tgstation/tgstation#60261

## Why It's Good For The Game

i don't have to talk about it

## Changelog
:cl: watermelon914
fix: Fixed light explosions having 0 chance to delimb someone if they have no bomb resist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
