### PR TITLE
fixes the photobooth holodeck breaking the holodeck

### DIFF
--- a/_maps/holodeck/photobooth.dmm
+++ b/_maps/holodeck/photobooth.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/open/floor/white,
+/turf/open/floor/holofloor/white,
 /area/template_noop)
 "c" = (
 /obj/structure/dresser,

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -174,3 +174,8 @@
 
 /turf/open/floor/holofloor/clown
 	icon_state = "bananium"
+
+/turf/open/floor/holofloor/white
+	name = "white floor"
+	desc = "A tile in a pure white color."
+	icon_state = "pure_white"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

floors used by holodeck must always have `/turf/open/floor/holofloor` paths

## Why It's Good For The Game

closes #4873

## Changelog
:cl:
fix: fixed photobooth deck breaking the entire holodeck
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
