### PR TITLE
makes soporific ammo not apply it's effect to non-human targets

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,7 +17,7 @@
 	damage = 0
 
 /obj/item/projectile/bullet/sleepy/on_hit(atom/target, blocked = FALSE)
-	if((blocked != 100) && isliving(target) && !issilicon(target))
+	if((blocked != 100) && ishuman(target))
 		var/mob/living/L = target
 		if(L.confused)
 			L.Sleeping(50)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,7 +17,7 @@
 	damage = 0
 
 /obj/item/projectile/bullet/sleepy/on_hit(atom/target, blocked = FALSE)
-	if((blocked != 100) && isliving(target))
+	if((blocked != 100) && isliving(target) && !issilicon(target))
 		var/mob/living/L = target
 		if(L.confused)
 			L.Sleeping(50)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

## Why It's Good For The Game

Closes #4723

## Changelog
:cl:
fix: fixed soporific ammo breaking borg movements
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
