### PR TITLE
Increase Borg Light Replacer Restock Rate

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -59,7 +59,6 @@
 	var/increment = 5
 	// How much to take from the glass?
 	var/decrement = 1
-	var/charge = 1
 
 	// Eating used bulbs gives us bulb shards
 	var/bulb_shards = 0

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -179,10 +179,7 @@
 	return new_bulbs
 
 /obj/item/lightreplacer/proc/Charge(var/mob/user)
-	charge += 1
-	if(charge > 3)
-		AddUses(1)
-		charge = 1
+	AddUses(1)
 
 /obj/item/lightreplacer/proc/ReplaceLight(obj/machinery/light/target, mob/living/U)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the restock rate for bulbs in the janitor borg light replacers from 1 bulb per 3 seconds to 1 bulb per 1 second
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With the old rate, it would take over a minutes worth of sitting in the recharger just to restock 20 bulbs in the light replacer. This increases the rate three fold, to one bulb a second. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Increase Janitor borg light replacer restock rate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
