### PR TITLE
Tells roundstart observers what the game mode is.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -339,6 +339,9 @@ SUBSYSTEM_DEF(ticker)
 			var/datum/holiday/holiday = SSevents.holidays[holidayname]
 			to_chat(world, "<h4>[holiday.greet()]</h4>")
 
+	if(hide_mode)
+		deadchat_broadcast("<span class='deadsay'>The gamemode is: <b>[mode.name]</b></span>")
+
 	PostSetup()
 	SSstat.clear_global_alert()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tells people who are observers at roundstart what the actual game mode is, not just secret.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Observers can already tell what the game mode is by either checking the ghost-visible antagonists in the orbit menu, or using the Observe verb to check antag moodlets. This makes it so that roundstart observers don't have to go through 30 people's moodlets just to figure out what the mode is.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Roundstart observers are now told what the game mode is.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
