### PR TITLE
fixes biobag reproductive extract interaction bug

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -178,7 +178,7 @@
 
 	if(!isitem(O) || !click_gather || SEND_SIGNAL(O, COMSIG_CONTAINS_STORAGE))
 		return FALSE
-	if(!istype(O,/obj/item/slimecross/reproductive))
+	if(!istype(O, /obj/item/slimecross/reproductive))
 		. = COMPONENT_NO_ATTACK
 	if(locked)
 		var/atom/host = parent

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -178,7 +178,8 @@
 
 	if(!isitem(O) || !click_gather || SEND_SIGNAL(O, COMSIG_CONTAINS_STORAGE))
 		return FALSE
-	. = COMPONENT_NO_ATTACK
+	if(!istype(O,/obj/item/slimecross/reproductive))
+		. = COMPONENT_NO_ATTACK
 	if(locked)
 		var/atom/host = parent
 		host.balloon_alert(M, "It's locked")

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -178,8 +178,7 @@
 
 	if(!isitem(O) || !click_gather || SEND_SIGNAL(O, COMSIG_CONTAINS_STORAGE))
 		return FALSE
-	if(!istype(O, /obj/item/slimecross/reproductive))
-		. = COMPONENT_NO_ATTACK
+	. = COMPONENT_NO_ATTACK
 	if(locked)
 		var/atom/host = parent
 		host.balloon_alert(M, "It's locked")

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -392,7 +392,7 @@
 	STR.can_hold = typecacheof(list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube, /obj/item/organ, /obj/item/bodypart))
 
 /obj/item/storage/bag/bio/pre_attack(atom/A, mob/living/user, params)
-	if(SEND_SIGNAL(src, COMSIG_ITEM_PRE_ATTACK, A, user, params) & COMPONENT_NO_ATTACK & !istype(A, /obj/item/slimecross/reproductive))
+	if(SEND_SIGNAL(src, COMSIG_ITEM_PRE_ATTACK, A, user, params) & COMPONENT_NO_ATTACK && !istype(A, /obj/item/slimecross/reproductive))
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -391,6 +391,11 @@
 	STR.insert_preposition = "in"
 	STR.can_hold = typecacheof(list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube, /obj/item/organ, /obj/item/bodypart))
 
+/obj/item/storage/bag/bio/pre_attack(atom/A, mob/living/user, params)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_PRE_ATTACK, A, user, params) & COMPONENT_NO_ATTACK & !istype(A, /obj/item/slimecross/reproductive))
+		return FALSE
+	return TRUE
+
 /obj/item/storage/bag/construction
 	name = "construction bag"
 	icon = 'icons/obj/tools.dmi'

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -392,7 +392,7 @@
 	STR.can_hold = typecacheof(list(/obj/item/slime_extract, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/blood, /obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/food/snacks/deadmouse, /obj/item/reagent_containers/food/snacks/monkeycube, /obj/item/organ, /obj/item/bodypart))
 
 /obj/item/storage/bag/bio/pre_attack(atom/A, mob/living/user, params)
-	if(SEND_SIGNAL(src, COMSIG_ITEM_PRE_ATTACK, A, user, params) & COMPONENT_NO_ATTACK && !istype(A, /obj/item/slimecross/reproductive))
+	if((SEND_SIGNAL(src, COMSIG_ITEM_PRE_ATTACK, A, user, params) & COMPONENT_NO_ATTACK) && !istype(A, /obj/item/slimecross/reproductive))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes a bug that would not allow you to feed monkey cubes to the reproductive extract directly with the biobag.
I am not completly sure how this broke trough the only thing that changed in the call chain for this interaction in the last few months was from https://github.com/BeeStation/BeeStation-Hornet/pull/3883 and i guess https://github.com/BeeStation/BeeStation-Hornet/pull/4623 too trough thats purly specuation at this point.
closes: https://github.com/BeeStation/BeeStation-Hornet/issues/4566
closes: https://github.com/BeeStation/BeeStation-Hornet/issues/4701

## Why It's Good For The Game

You can feed monkeycubes to reproductive extracts directly with the biobag again

## Changelog
:cl:
fix: fixes biobag not allowing you to feed reproductive extract directly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
