### PR TITLE
Removes a sleepless while loop

### DIFF
--- a/code/game/objects/effects/decals/cleanable/food.dm
+++ b/code/game/objects/effects/decals/cleanable/food.dm
@@ -32,9 +32,8 @@
 
 /obj/effect/decal/cleanable/food/salt/Crossed(mob/living/L)
 	if(is_species(L, /datum/species/snail) || is_species(L, /datum/species/squid))
-		while(L.loc == src.loc)
-			L.adjustFireLoss(2, TRUE)
-			to_chat(L, "<span class='danger'>The salt! It burns!</span>")
+		L.adjustFireLoss(10, TRUE)
+		to_chat(L, "<span class='danger'>The salt! It burns!</span>")
 
 /obj/effect/decal/cleanable/food/flour
 	name = "flour"


### PR DESCRIPTION
Archanial removed the sleep during the `SIGNAL_HANDLER` refactor. BYOND treats loops like this differently and gives them way too much CPU.

## Changelog
:cl:
fix: Squids and snails will no longer set the CPU on fire when they stand on salt.
tweak: Squids and snails receive a flat 10 burn damage for stepping on salt, rather than continuously taking damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
