### PR TITLE
Adds Coffee the Crab to BoxStation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -42695,6 +42695,16 @@
 	dir = 9
 	},
 /area/science/shuttledock)
+"cxs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -20
+	},
+/mob/living/simple_animal/crab/Coffee,
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "cxA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -45799,15 +45809,6 @@
 	dir = 10
 	},
 /area/science/research)
-"dgS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "dhq" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 25
@@ -109020,7 +109021,7 @@ biU
 pDJ
 blI
 bnn
-dgS
+cxs
 bpZ
 brt
 bta


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Coffee the Crab to the Science main room on BoxStation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Science has no pet on BoxStation, and Coffee needs more love.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Coffee the Crab is now present in BoxStation Science
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
