### PR TITLE
Ability for plasmamen to wear utility hoods

### DIFF
--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -9,6 +9,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE
 	resistance_flags = ACID_PROOF
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	envirosealed = TRUE
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -71,7 +71,7 @@
 	equip_delay_other = 70
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = NONE
-
+	envirosealed = TRUE
 
 /obj/item/clothing/suit/bomb_suit
 	name = "bomb suit"
@@ -129,6 +129,7 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	resistance_flags = NONE
 	rad_flags = RAD_PROTECT_CONTENTS
+	envirosealed = TRUE
 
 /obj/item/clothing/suit/radiation
 	name = "radiation suit"

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -34,7 +34,7 @@
 					atmos_sealed = TRUE
 			if(H.w_uniform)
 				var/obj/item/clothing/CU = H.w_uniform
-				if(CU.envirosealed)
+				if(CU.envirosealed || CU.clothing_flags & STOPSPRESSUREDAMAGE)
 					atmos_sealed = TRUE
 	if(!atmos_sealed && (!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) || !istype(H.gloves, /obj/item/clothing/gloves)))
 		var/datum/gas_mixture/environment = H.loc.return_air()

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -25,16 +25,17 @@
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)
 	var/atmos_sealed = FALSE
-	if (H.wear_suit && H.head && isclothing(H.wear_suit) && isclothing(H.head))
-		var/obj/item/clothing/CS = H.wear_suit
+	if(H.head)
 		var/obj/item/clothing/CH = H.head
-		if (CS.clothing_flags & CH.clothing_flags & STOPSPRESSUREDAMAGE)
-			atmos_sealed = TRUE
-	if(H.w_uniform && H.head)
-		var/obj/item/clothing/CU = H.w_uniform
-		var/obj/item/clothing/CH = H.head
-		if (CU.envirosealed && (CH.clothing_flags & STOPSPRESSUREDAMAGE))
-			atmos_sealed = TRUE
+		if(CH.clothing_flags & STOPSPRESSUREDAMAGE || CH.envirosealed)
+			if(H.wear_suit)
+				var/obj/item/clothing/CS = H.wear_suit
+				if(CS.clothing_flags & STOPSPRESSUREDAMAGE)
+					atmos_sealed = TRUE
+			if(H.w_uniform)
+				var/obj/item/clothing/CU = H.w_uniform
+				if(CU.envirosealed)
+					atmos_sealed = TRUE
 	if(!atmos_sealed && (!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) || !istype(H.gloves, /obj/item/clothing/gloves)))
 		var/datum/gas_mixture/environment = H.loc.return_air()
 		if(environment)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes bomb hoods, bio hoods, and radiation hoods envirosealed for plasmamen
Sacrifices pressure protecting helmets for other protection
Whether this is a species change is debatable, but I got permission from Bacon

Also fixes/adds? pressure proofing potions on jumpsuits not sealing plasmamen after https://github.com/BeeStation/BeeStation-Hornet/pull/4817
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better utility for plasmamen at niche things, in trade for their pressure protection
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: plasmamen can now wear utility hoods
fix: pressure proofing potion not making jumpsuits plasmamen safe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
