### PR TITLE
Update Emergency Shuttles for New Atmos [MDB Ignore]

### DIFF
--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -381,26 +381,14 @@
 "qg" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"qO" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "rp" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary";
 	req_access_txt = "5"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "xE" = (
@@ -414,30 +402,8 @@
 /obj/machinery/door/airlock/mining{
 	name = "Emergency Shuttle Storage"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"Gw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"IJ" = (
-/obj/machinery/door/airlock{
-	name = "Emergency Shuttle Restroom"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Jx" = (
 /turf/open/floor/mineral/titanium/white,
@@ -447,12 +413,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "JM" = (
@@ -473,12 +434,7 @@
 /obj/machinery/door/airlock{
 	name = "Emergency Shuttle Restroom"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "RU" = (
@@ -495,34 +451,19 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"VO" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "YJ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Zz" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 
@@ -532,8 +473,8 @@ aa
 ac
 am
 ac
-qO
-qO
+ad
+ad
 qg
 ac
 am
@@ -587,7 +528,7 @@ ac
 ac
 "}
 (5,1,1) = {"
-qO
+ad
 ap
 aq
 bJ
@@ -597,9 +538,9 @@ bd
 bl
 ac
 bN
-IJ
+RT
 bE
-qO
+ad
 "}
 (6,1,1) = {"
 xE
@@ -617,7 +558,7 @@ ac
 ac
 "}
 (7,1,1) = {"
-qO
+ad
 ar
 aq
 aq
@@ -627,9 +568,9 @@ bf
 bn
 ac
 Jx
-IJ
+RT
 bE
-qO
+ad
 "}
 (8,1,1) = {"
 ac
@@ -677,8 +618,8 @@ aa
 aa
 "}
 (11,1,1) = {"
-VO
-VO
+ah
+ah
 aB
 aJ
 at
@@ -694,7 +635,7 @@ aa
 (12,1,1) = {"
 QG
 at
-Gw
+at
 at
 at
 aZ
@@ -707,8 +648,8 @@ aa
 aa
 "}
 (13,1,1) = {"
-VO
-VO
+ah
+ah
 aB
 bK
 at
@@ -724,7 +665,7 @@ aa
 (14,1,1) = {"
 aa
 aa
-qO
+ad
 aK
 at
 aZ
@@ -732,14 +673,14 @@ ah
 aK
 at
 aZ
-qO
+ad
 aa
 aa
 "}
 (15,1,1) = {"
 aa
 aa
-qO
+ad
 aK
 at
 at
@@ -747,14 +688,14 @@ at
 at
 at
 aZ
-qO
+ad
 aa
 aa
 "}
 (16,1,1) = {"
 aa
 aa
-qO
+ad
 aK
 at
 aZ
@@ -762,13 +703,13 @@ ah
 aK
 at
 aZ
-qO
+ad
 aa
 aa
 "}
 (17,1,1) = {"
-VO
-VO
+ah
+ah
 aB
 bK
 at
@@ -784,7 +725,7 @@ aa
 (18,1,1) = {"
 RU
 at
-Gw
+at
 at
 at
 aZ
@@ -797,8 +738,8 @@ aa
 aa
 "}
 (19,1,1) = {"
-VO
-VO
+ah
+ah
 aB
 aL
 at
@@ -884,7 +825,7 @@ Jx
 Jx
 Jx
 bG
-qO
+ad
 "}
 (25,1,1) = {"
 ac
@@ -937,9 +878,9 @@ aa
 aa
 ac
 ac
-qO
+ad
 ac
-qO
+ad
 ac
 ac
 aa

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -583,10 +583,7 @@
 /obj/machinery/door/airlock{
 	name = "Unit B"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "kK" = (
@@ -611,25 +608,14 @@
 /obj/machinery/door/airlock{
 	name = "Unit 2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"CM" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "FR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "GY" = (
@@ -637,10 +623,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "LQ" = (
@@ -669,10 +652,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "UQ" = (
@@ -684,12 +664,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Yn" = (
@@ -703,10 +678,7 @@
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 
@@ -722,9 +694,9 @@ LQ
 ab
 PE
 ab
-CM
-CM
-CM
+ac
+ac
+ac
 ab
 pT
 ab
@@ -783,7 +755,7 @@ bC
 bE
 "}
 (4,1,1) = {"
-CM
+ac
 af
 am
 ar
@@ -807,7 +779,7 @@ bC
 bE
 "}
 (5,1,1) = {"
-CM
+ac
 ag
 an
 as
@@ -831,7 +803,7 @@ bC
 bE
 "}
 (6,1,1) = {"
-CM
+ac
 ah
 an
 at
@@ -855,7 +827,7 @@ bC
 bE
 "}
 (7,1,1) = {"
-CM
+ac
 ag
 an
 an
@@ -879,7 +851,7 @@ bC
 bE
 "}
 (8,1,1) = {"
-CM
+ac
 ai
 ao
 ao
@@ -956,21 +928,21 @@ aa
 aa
 aa
 ab
-CM
+ac
 ab
-CM
-ab
-ab
-ab
-CM
-CM
-CM
+ac
 ab
 ab
 ab
-CM
+ac
+ac
+ac
 ab
-CM
+ab
+ab
+ac
+ab
+ac
 ab
 aa
 "}

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -264,46 +264,17 @@
 /obj/item/defibrillator/loaded,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"mv" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "bridge door";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "xJ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "bridge door";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Cf" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Hy" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Mg" = (
@@ -317,27 +288,17 @@
 	port_direction = 4;
 	width = 14
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "MN" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Ti" = (
 /obj/machinery/door/airlock/titanium,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Wn" = (
@@ -345,10 +306,7 @@
 	name = "security airlock";
 	req_access_txt = "63"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 
@@ -357,13 +315,13 @@ aa
 aa
 ab
 ab
-MN
+ac
 ab
-MN
-MN
-MN
-MN
-MN
+ac
+ac
+ac
+ac
+ac
 ab
 aa
 aa
@@ -390,7 +348,7 @@ ab
 ai
 ar
 aC
-mv
+xJ
 aC
 aC
 aC
@@ -402,7 +360,7 @@ aa
 "}
 (4,1,1) = {"
 aa
-MN
+ac
 aj
 aC
 av
@@ -418,7 +376,7 @@ aa
 "}
 (5,1,1) = {"
 aa
-MN
+ac
 aj
 aC
 aV
@@ -494,7 +452,7 @@ aP
 aC
 aC
 aW
-MN
+ac
 "}
 (10,1,1) = {"
 aa
@@ -510,7 +468,7 @@ aP
 aC
 aC
 aW
-MN
+ac
 "}
 (11,1,1) = {"
 aa
@@ -526,7 +484,7 @@ aP
 aC
 aC
 aW
-MN
+ac
 "}
 (12,1,1) = {"
 aa
@@ -555,7 +513,7 @@ aC
 aC
 aw
 ab
-Cf
+Hy
 ac
 ab
 ab
@@ -631,7 +589,7 @@ ap
 au
 ab
 ab
-Ti
+MN
 Mg
 ab
 ab

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -327,10 +327,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Cargo"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Gx" = (
@@ -340,11 +337,6 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"JW" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "Km" = (
 /obj/machinery/door/airlock/titanium{
@@ -360,10 +352,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "RE" = (
@@ -371,12 +360,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Ta" = (
@@ -384,10 +368,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "XC" = (
@@ -407,9 +388,9 @@ Gx
 ad
 Km
 ad
-JW
-JW
-JW
+ac
+ac
+ac
 ad
 mA
 ad
@@ -468,7 +449,7 @@ bi
 bk
 "}
 (4,1,1) = {"
-JW
+ac
 af
 am
 ar
@@ -492,7 +473,7 @@ bi
 bk
 "}
 (5,1,1) = {"
-JW
+ac
 ag
 aC
 as
@@ -516,7 +497,7 @@ bi
 bk
 "}
 (6,1,1) = {"
-JW
+ac
 ah
 aC
 at
@@ -540,7 +521,7 @@ bi
 bk
 "}
 (7,1,1) = {"
-JW
+ac
 ag
 aC
 aC
@@ -564,7 +545,7 @@ bi
 bk
 "}
 (8,1,1) = {"
-JW
+ac
 ai
 ao
 ao
@@ -641,21 +622,21 @@ aa
 aa
 aa
 ad
-JW
+ac
 ad
-JW
-ad
-ad
-ad
-JW
-JW
-JW
+ac
 ad
 ad
 ad
-JW
+ac
+ac
+ac
 ad
-JW
+ad
+ad
+ac
+ad
+ac
 ad
 aa
 "}

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1339,12 +1339,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"cQ" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
 "cR" = (
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
@@ -1633,12 +1627,7 @@
 /area/shuttle/escape)
 "eb" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ez" = (
@@ -1656,10 +1645,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "jG" = (
@@ -1682,10 +1668,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "pf" = (
@@ -1709,12 +1692,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "uv" = (
@@ -1731,44 +1709,12 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"Du" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Emergency Shuttle Medbay"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "Ed" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"Ev" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "GI" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -1784,10 +1730,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "LM" = (
@@ -1795,12 +1738,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "YO" = (
@@ -1808,12 +1746,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 
@@ -1847,11 +1780,11 @@ aa
 aa
 ab
 ab
-Ev
-Ev
-Ev
-Ev
-Ev
+ac
+ac
+ac
+ac
+ac
 ab
 ab
 ab
@@ -1879,9 +1812,9 @@ be
 ab
 bc
 ad
-Ev
-Ev
-Ev
+ac
+ac
+ac
 ad
 bc
 bZ
@@ -2084,7 +2017,7 @@ dz
 (7,1,1) = {"
 aa
 aa
-Ev
+ac
 af
 aq
 ap
@@ -2128,7 +2061,7 @@ dz
 (8,1,1) = {"
 aa
 aa
-Ev
+ac
 ag
 ar
 aA
@@ -2172,7 +2105,7 @@ dz
 (9,1,1) = {"
 aa
 aa
-Ev
+ac
 ah
 as
 aB
@@ -2216,7 +2149,7 @@ dz
 (10,1,1) = {"
 aa
 aa
-Ev
+ac
 ai
 at
 aC
@@ -2260,7 +2193,7 @@ ad
 (11,1,1) = {"
 aa
 aa
-Ev
+ac
 aj
 at
 aC
@@ -2304,7 +2237,7 @@ ad
 (12,1,1) = {"
 aa
 aa
-Ev
+ac
 ak
 au
 aD
@@ -2330,7 +2263,7 @@ bW
 bR
 ad
 ab
-Du
+GI
 ab
 ab
 ab
@@ -2348,7 +2281,7 @@ dz
 (13,1,1) = {"
 aa
 aa
-Ev
+ac
 al
 av
 aE
@@ -2392,7 +2325,7 @@ dz
 (14,1,1) = {"
 aa
 aa
-Ev
+ac
 am
 aw
 ax
@@ -2600,9 +2533,9 @@ cp
 cp
 cM
 ab
-cQ
+Ed
 ab
-cQ
+Ed
 ab
 ab
 ab
@@ -2628,13 +2561,13 @@ bD
 bP
 ab
 ab
-Ev
-Ev
-Ev
-Ev
-Ev
-Ev
-Ev
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 ab
 ab
 pf
@@ -2683,9 +2616,9 @@ aa
 aa
 ab
 ab
-Ev
-Ev
-Ev
+ac
+ac
+ac
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -102,6 +102,7 @@
 /obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Premium Lounge"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "at" = (
@@ -137,6 +138,7 @@
 /obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Greentext"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aC" = (
@@ -324,20 +326,14 @@
 /obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "KO" = (
 /obj/machinery/door/airlock/bananium{
 	name = "Emergency Shuttle Cargo"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "LN" = (
@@ -348,11 +344,6 @@
 	name = "Snappop(tm)!"
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Nn" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Zf" = (
@@ -373,9 +364,9 @@ ab
 ab
 LN
 ab
-Nn
-Nn
-Nn
+ac
+ac
+ac
 ab
 eU
 ab
@@ -434,7 +425,7 @@ bf
 bg
 "}
 (4,1,1) = {"
-Nn
+ac
 ae
 aj
 ao
@@ -458,7 +449,7 @@ bf
 bg
 "}
 (5,1,1) = {"
-Nn
+ac
 af
 ak
 ap
@@ -482,7 +473,7 @@ bf
 bg
 "}
 (6,1,1) = {"
-Nn
+ac
 ag
 ak
 aq
@@ -506,7 +497,7 @@ bf
 bg
 "}
 (7,1,1) = {"
-Nn
+ac
 af
 ak
 ak
@@ -530,7 +521,7 @@ bf
 bg
 "}
 (8,1,1) = {"
-Nn
+ac
 ah
 al
 al
@@ -607,21 +598,21 @@ aa
 aa
 aa
 ab
-Nn
+ac
 ab
-Nn
-ab
-ab
-ab
-Nn
-Nn
-Nn
+ac
 ab
 ab
 ab
-Nn
+ac
+ac
+ac
 ab
-Nn
+ab
+ab
+ac
+ab
+ac
 ab
 aa
 "}

--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -181,7 +181,6 @@
 /area/shuttle/escape)
 "U" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_corg.dmm
+++ b/_maps/shuttles/emergency_corg.dmm
@@ -29,12 +29,7 @@
 	id_tag = "Dorm4";
 	name = "Long Term Stay Cabin 4"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "bR" = (
@@ -160,6 +155,7 @@
 	name = "Morgue";
 	req_access_txt = "6"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "fG" = (
@@ -181,10 +177,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "fO" = (
@@ -254,10 +247,7 @@
 /obj/machinery/door/airlock/wood{
 	name = "VIP Lounge"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "iN" = (
@@ -346,9 +336,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "nf" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -378,10 +365,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "nI" = (
@@ -403,12 +386,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -482,14 +459,11 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Medical Bay"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "qv" = (
@@ -555,9 +529,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "sB" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -632,10 +603,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "ux" = (
@@ -682,12 +650,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "uP" = (
@@ -717,7 +680,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "vl" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -755,16 +717,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Emergency Shuttle Engineering";
 	req_one_access_txt = "32;19"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "wj" = (
@@ -833,12 +790,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "xH" = (
@@ -957,12 +909,7 @@
 	id_tag = "Dorm3";
 	name = "Long Term Stay Cabin 3"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "AF" = (
@@ -1103,14 +1050,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Emergency Shuttle Engineering";
 	req_one_access_txt = "32;19"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Ei" = (
@@ -1287,12 +1231,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -1544,12 +1482,7 @@
 	id_tag = "Dorm2";
 	name = "Long Term Stay Cabin 2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Qt" = (
@@ -1654,11 +1587,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"RR" = (
-/obj/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Sl" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -1696,12 +1624,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Td" = (
@@ -1768,12 +1691,7 @@
 	id_tag = "Dorm1";
 	name = "Long Term Stay Cabin 1"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Vx" = (
@@ -1792,18 +1710,13 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Medical Bay"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "WY" = (
@@ -1858,7 +1771,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ZL" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -1913,9 +1825,9 @@ GK
 Tw
 IK
 Tw
-RR
-RR
-RR
+UQ
+UQ
+UQ
 Tw
 QQ
 Tw
@@ -1944,8 +1856,8 @@ MH
 MH
 Tw
 Tw
-RR
-RR
+UQ
+UQ
 Tw
 Bt
 Pu
@@ -2100,7 +2012,7 @@ JU
 "}
 (6,1,1) = {"
 MH
-RR
+UQ
 Bt
 pB
 Bt
@@ -2139,8 +2051,8 @@ BQ
 BQ
 "}
 (7,1,1) = {"
-RR
-RR
+UQ
+UQ
 uP
 Fp
 fK
@@ -2179,7 +2091,7 @@ BQ
 MH
 "}
 (8,1,1) = {"
-RR
+UQ
 MN
 mI
 Fp
@@ -2213,13 +2125,13 @@ Xo
 bR
 wl
 Xo
-RR
+UQ
 ar
 MH
 MH
 "}
 (9,1,1) = {"
-RR
+UQ
 tb
 Fp
 Rj
@@ -2253,13 +2165,13 @@ kF
 kF
 kF
 Br
-RR
+UQ
 ar
 Ju
 MH
 "}
 (10,1,1) = {"
-RR
+UQ
 xi
 AF
 ci
@@ -2293,13 +2205,13 @@ Vx
 Vx
 Vx
 KW
-RR
+UQ
 ar
 MH
 MH
 "}
 (11,1,1) = {"
-RR
+UQ
 DL
 AF
 yL
@@ -2333,13 +2245,13 @@ Vx
 Vx
 Vx
 pW
-RR
+UQ
 ar
 MH
 MH
 "}
 (12,1,1) = {"
-RR
+UQ
 tb
 Fp
 iN
@@ -2373,13 +2285,13 @@ kF
 kF
 kF
 Br
-RR
+UQ
 ar
 Ju
 MH
 "}
 (13,1,1) = {"
-RR
+UQ
 oI
 Hh
 Fp
@@ -2413,14 +2325,14 @@ JL
 hP
 Ht
 JL
-RR
+UQ
 ar
 MH
 MH
 "}
 (14,1,1) = {"
-RR
-RR
+UQ
+UQ
 Dn
 Fp
 fK
@@ -2460,7 +2372,7 @@ MH
 "}
 (15,1,1) = {"
 MH
-RR
+UQ
 Bt
 pB
 Bt
@@ -2624,8 +2536,8 @@ MH
 MH
 Tw
 Tw
-RR
-RR
+UQ
+UQ
 Tw
 Bt
 Ln
@@ -2673,9 +2585,9 @@ Xk
 Tw
 Xk
 Tw
-RR
-RR
-RR
+UQ
+UQ
+UQ
 Tw
 Xk
 Tw
@@ -2687,8 +2599,8 @@ MH
 Tw
 Tw
 Tw
-RR
-RR
+UQ
+UQ
 Tw
 Tw
 Tw

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -142,7 +142,6 @@
 /area/shuttle/escape)
 "Q" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1301,28 +1301,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "hB" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"uQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "zd" = (
 /obj/machinery/door/airlock/command{
@@ -1332,12 +1316,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ay" = (
@@ -1355,12 +1334,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Ey" = (
@@ -1370,12 +1344,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Hh" = (
@@ -1386,16 +1355,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/shuttle/escape)
-"Ky" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "KD" = (
 /obj/machinery/door/airlock/shuttle{
@@ -1431,10 +1392,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 
@@ -1444,17 +1402,17 @@ ac
 ae
 af
 af
-Ky
-Ky
+hB
+hB
 af
 af
 Ay
 aT
 TQ
 af
-Ky
-Ky
-Ky
+hB
+hB
+hB
 af
 Ay
 af
@@ -1503,7 +1461,7 @@ aa
 (3,1,1) = {"
 ab
 ad
-Ky
+hB
 ai
 ao
 ao
@@ -1519,12 +1477,12 @@ ao
 ao
 ao
 bo
-uQ
+Ej
 bw
 bw
 bw
 bU
-Ky
+hB
 aa
 aa
 aa
@@ -1534,7 +1492,7 @@ aa
 (4,1,1) = {"
 ab
 ad
-Ky
+hB
 ai
 ao
 aw
@@ -1589,7 +1547,7 @@ bU
 af
 af
 aT
-Ky
+hB
 af
 af
 "}
@@ -1627,7 +1585,7 @@ af
 (7,1,1) = {"
 ab
 ad
-Ky
+hB
 ai
 ao
 ao
@@ -1653,7 +1611,7 @@ cb
 cf
 cf
 cr
-Ky
+hB
 "}
 (8,1,1) = {"
 ac
@@ -1684,12 +1642,12 @@ cc
 cc
 cl
 cs
-Ky
+hB
 "}
 (9,1,1) = {"
 ab
 ad
-Ky
+hB
 ai
 ao
 ax
@@ -1715,12 +1673,12 @@ cc
 cc
 cm
 ct
-Ky
+hB
 "}
 (10,1,1) = {"
 ab
 ad
-Ky
+hB
 ai
 ao
 av
@@ -1746,7 +1704,7 @@ cc
 cc
 cn
 cu
-Ky
+hB
 "}
 (11,1,1) = {"
 ac
@@ -1777,12 +1735,12 @@ cc
 cg
 cl
 cv
-Ky
+hB
 "}
 (12,1,1) = {"
 ab
 ad
-Ky
+hB
 ah
 ap
 aw
@@ -1808,7 +1766,7 @@ cb
 ch
 ch
 cw
-Ky
+hB
 "}
 (13,1,1) = {"
 ab
@@ -1868,14 +1826,14 @@ af
 af
 af
 aT
-Ky
+hB
 af
 af
 "}
 (15,1,1) = {"
 ab
 ad
-Ky
+hB
 ak
 as
 az
@@ -1906,7 +1864,7 @@ aa
 (16,1,1) = {"
 ab
 ad
-Ky
+hB
 al
 at
 aA
@@ -1927,7 +1885,7 @@ bC
 bJ
 ai
 bZ
-Ky
+hB
 aa
 aa
 aa
@@ -1970,25 +1928,25 @@ aa
 ac
 ae
 af
-Ky
-Ky
-Ky
-Ky
+hB
+hB
+hB
+hB
 af
 af
 aT
 af
-Ky
-Ky
-Ky
-Ky
-Ky
+hB
+hB
+hB
+hB
+hB
 af
 af
-Ky
+hB
 bL
 bL
-Ky
+hB
 af
 aa
 aa

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -7,7 +7,6 @@
 /area/shuttle/escape)
 "c" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/shuttle/escape)
 "d" = (
@@ -216,10 +215,7 @@
 /obj/machinery/door/airlock/gold{
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape)
 "Y" = (

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -447,10 +447,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "hl" = (
@@ -458,10 +455,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "pk" = (
@@ -477,11 +471,6 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Dr" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "FX" = (
@@ -500,12 +489,7 @@
 	name = "Containment Cell";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "JF" = (
@@ -513,12 +497,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 
@@ -545,7 +524,7 @@ aa
 aa
 ab
 uu
-Dr
+ac
 uu
 ab
 aa
@@ -576,9 +555,9 @@ aC
 ab
 ak
 ab
-Dr
-Dr
-Dr
+ac
+ac
+ac
 ad
 ak
 ak
@@ -597,8 +576,8 @@ ab
 (3,1,1) = {"
 aa
 ab
-Dr
-Dr
+ac
+ac
 ab
 ab
 ab
@@ -703,7 +682,7 @@ bs
 bt
 "}
 (6,1,1) = {"
-Dr
+ac
 af
 al
 am
@@ -739,7 +718,7 @@ bs
 bt
 "}
 (7,1,1) = {"
-Dr
+ac
 ag
 al
 am
@@ -775,7 +754,7 @@ bs
 bt
 "}
 (8,1,1) = {"
-Dr
+ac
 ah
 al
 am
@@ -811,7 +790,7 @@ bs
 bt
 "}
 (9,1,1) = {"
-Dr
+ac
 ai
 al
 am
@@ -921,8 +900,8 @@ bt
 (12,1,1) = {"
 aa
 ab
-Dr
-Dr
+ac
+ac
 ab
 ad
 ax
@@ -972,9 +951,9 @@ ak
 ak
 ak
 ad
-Dr
-Dr
-Dr
+ac
+ac
+ac
 ad
 ak
 ak
@@ -1005,7 +984,7 @@ aa
 ab
 ab
 uu
-Dr
+ac
 uu
 ab
 aa
@@ -1013,7 +992,7 @@ aa
 aa
 ab
 uu
-Dr
+ac
 uu
 ab
 aa

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -29,24 +29,14 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "k" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "l" = (
@@ -127,11 +117,6 @@
 /obj/item/radio,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"C" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "D" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -194,12 +179,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "P" = (
@@ -345,7 +325,7 @@ a
 "}
 (7,1,1) = {"
 a
-C
+m
 s
 r
 s
@@ -353,7 +333,7 @@ s
 s
 r
 s
-C
+m
 a
 "}
 (8,1,1) = {"
@@ -410,7 +390,7 @@ d
 "}
 (12,1,1) = {"
 a
-C
+m
 s
 s
 s
@@ -418,12 +398,12 @@ r
 s
 s
 s
-C
+m
 a
 "}
 (13,1,1) = {"
 a
-C
+m
 s
 s
 s
@@ -431,7 +411,7 @@ r
 s
 s
 s
-C
+m
 a
 "}
 (14,1,1) = {"
@@ -463,13 +443,13 @@ a
 (16,1,1) = {"
 a
 a
-C
+m
 y
 A
 F
 A
 L
-C
+m
 a
 a
 "}
@@ -490,11 +470,11 @@ a
 a
 a
 a
-C
+m
 B
 G
 I
-C
+m
 a
 a
 a
@@ -504,9 +484,9 @@ a
 a
 a
 d
-C
-C
-C
+m
+m
+m
 d
 a
 a

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -1604,10 +1604,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "jK" = (
@@ -1638,10 +1635,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "uO" = (
@@ -1654,12 +1648,7 @@
 	name = "Shuttle Control";
 	req_one_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "zT" = (
@@ -1668,12 +1657,7 @@
 	name = "Holding Area";
 	req_one_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Bo" = (
@@ -1709,20 +1693,14 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Oa" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Tp" = (
@@ -1733,10 +1711,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Vz" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -795,10 +795,7 @@
 	name = "Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "fr" = (
@@ -824,10 +821,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "BN" = (
@@ -859,30 +853,8 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"GG" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Li" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "LY" = (
 /turf/open/floor/mineral/titanium,
@@ -905,10 +877,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Vs" = (
@@ -919,10 +888,7 @@
 	name = "Emergency Shuttle Cargo Bay Airlock"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Yo" = (
@@ -980,7 +946,7 @@ ad
 ad
 "}
 (4,1,1) = {"
-Li
+ac
 al
 aw
 aB
@@ -993,10 +959,10 @@ bd
 bd
 bd
 DK
-Li
+ac
 "}
 (5,1,1) = {"
-Li
+ac
 am
 aq
 aC
@@ -1012,7 +978,7 @@ Yo
 bf
 "}
 (6,1,1) = {"
-Li
+ac
 an
 ax
 LY
@@ -1028,7 +994,7 @@ fr
 bf
 "}
 (7,1,1) = {"
-Li
+ac
 ao
 ay
 LY
@@ -1041,7 +1007,7 @@ cb
 ad
 by
 by
-Li
+ac
 "}
 (8,1,1) = {"
 ad
@@ -1076,7 +1042,7 @@ bD
 ad
 "}
 (10,1,1) = {"
-Li
+ac
 LY
 LY
 LY
@@ -1089,7 +1055,7 @@ bU
 bU
 bU
 bE
-Li
+ac
 "}
 (11,1,1) = {"
 ad
@@ -1105,7 +1071,7 @@ bi
 bU
 bU
 bF
-Li
+ac
 "}
 (12,1,1) = {"
 cO
@@ -1169,10 +1135,10 @@ bk
 Vs
 Vs
 bI
-Li
+ac
 "}
 (16,1,1) = {"
-Li
+ac
 ar
 LY
 LY
@@ -1185,10 +1151,10 @@ Vs
 Vs
 Vs
 bJ
-Li
+ac
 "}
 (17,1,1) = {"
-Li
+ac
 ar
 LY
 aE
@@ -1204,7 +1170,7 @@ bK
 ad
 "}
 (18,1,1) = {"
-Li
+ac
 ar
 LY
 aE
@@ -1215,7 +1181,7 @@ aE
 ba
 ad
 ac
-GG
+PE
 ba
 ad
 "}
@@ -1265,7 +1231,7 @@ bo
 be
 be
 bO
-Li
+ac
 "}
 (22,1,1) = {"
 cO
@@ -1281,7 +1247,7 @@ bp
 be
 bw
 bP
-Li
+ac
 "}
 (23,1,1) = {"
 ad
@@ -1318,16 +1284,16 @@ ad
 (25,1,1) = {"
 ad
 ad
-Li
+ac
 ad
-Li
+ac
 ad
-Li
+ac
 ad
 ad
 ad
-Li
-Li
+ac
+ac
 ad
 ad
 "}

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -149,10 +149,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "D" = (
@@ -246,11 +243,6 @@
 /obj/item/crowbar,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"U" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "W" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/surgical,
@@ -265,10 +257,7 @@
 	name = "Escape Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Z" = (
@@ -276,10 +265,7 @@
 	name = "Escape Shuttle Cell";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 
@@ -292,9 +278,9 @@ b
 b
 b
 b
-U
-U
-U
+n
+n
+n
 b
 b
 b
@@ -350,7 +336,7 @@ b
 K
 K
 Q
-U
+n
 "}
 (4,1,1) = {"
 c
@@ -373,7 +359,7 @@ H
 t
 f
 R
-U
+n
 "}
 (5,1,1) = {"
 c
@@ -396,7 +382,7 @@ Y
 f
 f
 S
-U
+n
 "}
 (6,1,1) = {"
 c
@@ -419,7 +405,7 @@ b
 L
 f
 R
-U
+n
 "}
 (7,1,1) = {"
 c
@@ -442,7 +428,7 @@ b
 M
 M
 T
-U
+n
 "}
 (8,1,1) = {"
 b
@@ -477,7 +463,7 @@ b
 w
 b
 b
-U
+n
 b
 b
 u

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -771,10 +771,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "sC" = (
@@ -788,10 +785,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "wN" = (
@@ -807,12 +801,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
-"Dr" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Eg" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
@@ -823,10 +811,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ls" = (
@@ -874,12 +859,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ui" = (
@@ -892,10 +872,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 
@@ -907,9 +884,9 @@ Ls
 ac
 Mg
 aa
-Dr
-Dr
-Dr
+ab
+ab
+ab
 aa
 wN
 ac
@@ -942,7 +919,7 @@ br
 bv
 "}
 (3,1,1) = {"
-Dr
+ab
 ae
 al
 al
@@ -958,12 +935,12 @@ Ui
 aW
 be
 bk
-Dr
+ab
 bs
 bv
 "}
 (4,1,1) = {"
-Dr
+ab
 ae
 al
 al
@@ -979,7 +956,7 @@ Ui
 aX
 bf
 bl
-Dr
+ab
 bt
 bv
 "}
@@ -1047,7 +1024,7 @@ bt
 bv
 "}
 (8,1,1) = {"
-Dr
+ab
 ah
 ao
 an
@@ -1063,12 +1040,12 @@ Eg
 bb
 bb
 bo
-Dr
+ab
 bt
 bv
 "}
 (9,1,1) = {"
-Dr
+ab
 ai
 an
 at
@@ -1084,12 +1061,12 @@ Eg
 bb
 bb
 bp
-Dr
+ab
 bt
 bv
 "}
 (10,1,1) = {"
-Dr
+ab
 aj
 ap
 au
@@ -1111,16 +1088,16 @@ bv
 "}
 (11,1,1) = {"
 aa
-Dr
-Dr
+ab
+ab
 aa
 ac
 aa
-Dr
-Dr
-Dr
-Dr
-Dr
+ab
+ab
+ab
+ab
+ab
 aa
 ac
 aa

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -648,42 +648,24 @@
 "kK" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lf" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "First Class"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"lO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Service"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ub" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "wl" = (
 /obj/machinery/door/airlock/public/glass{
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "xt" = (
@@ -697,10 +679,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Service"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "IC" = (
@@ -737,10 +716,7 @@
 	name = "Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "XN" = (
@@ -748,20 +724,14 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Zi" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Economy Class"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 
@@ -936,7 +906,7 @@ ar
 ar
 Zi
 xt
-lO
+yT
 au
 au
 au
@@ -984,7 +954,7 @@ ar
 ar
 Zi
 Uu
-lO
+yT
 au
 au
 au

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -1657,7 +1657,6 @@
 	id = "escape_cockpit_windows";
 	name = "Cockpit Blast Door"
 	},
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dO" = (
@@ -1913,36 +1912,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"jH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "kr" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ks" = (
@@ -1973,10 +1948,7 @@
 	name = "Emergency Shutle Engineering"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lz" = (
@@ -2076,10 +2048,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "xF" = (
@@ -2140,12 +2109,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Dl" = (
@@ -2166,12 +2130,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"DU" = (
-/obj/structure/grille,
-/obj/structure/window/plastitanium,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "Et" = (
 /obj/structure/window/reinforced{
@@ -2252,12 +2210,6 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Emergency Shuttle Cargo Bay"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Mk" = (
@@ -2310,6 +2262,7 @@
 	name = "Emergency Shuttle Seating"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "PE" = (
@@ -2345,10 +2298,7 @@
 	name = "Cockpit";
 	req_one_access_txt = "2;19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "QD" = (
@@ -2462,12 +2412,7 @@
 	name = "Escape Shuttle Infirmary";
 	req_one_access_txt = "2;19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "YG" = (
@@ -2505,10 +2450,7 @@
 	name = "Emergency Shuttle Seating"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 
@@ -2556,7 +2498,7 @@ aa
 aa
 aa
 aH
-DU
+br
 ax
 ax
 bU
@@ -2565,7 +2507,7 @@ Mk
 kI
 cE
 ax
-DU
+br
 ax
 cT
 Ic
@@ -2694,7 +2636,7 @@ aY
 aY
 aY
 bE
-jH
+Bo
 bX
 ci
 yl
@@ -3168,7 +3110,7 @@ aa
 aa
 aa
 aN
-DU
+br
 ax
 ax
 cc
@@ -3177,7 +3119,7 @@ PJ
 ED
 cE
 ax
-DU
+br
 ax
 cE
 Xx

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -541,11 +541,6 @@
 /obj/item/clothing/gloves/fingerless,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"sP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "wq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/optable,
@@ -555,10 +550,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Cargo"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Ge" = (
@@ -572,10 +564,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "OT" = (
@@ -583,10 +572,7 @@
 	name = "Glorious Leaders";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "SF" = (
@@ -594,12 +580,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Vh" = (
@@ -612,13 +593,6 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"Xw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -633,9 +607,9 @@ hP
 ab
 Vh
 ad
-sP
-sP
-sP
+ac
+ac
+ac
 ad
 Ge
 ad
@@ -742,7 +716,7 @@ bK
 bL
 "}
 (6,1,1) = {"
-sP
+ac
 ae
 aj
 ao
@@ -766,7 +740,7 @@ bK
 bL
 "}
 (7,1,1) = {"
-sP
+ac
 af
 ak
 ak
@@ -790,7 +764,7 @@ bK
 bL
 "}
 (8,1,1) = {"
-sP
+ac
 ag
 ak
 ap
@@ -814,7 +788,7 @@ bK
 bL
 "}
 (9,1,1) = {"
-sP
+ac
 af
 al
 aq
@@ -824,7 +798,7 @@ aK
 aQ
 aA
 aZ
-Xw
+ax
 ax
 bl
 ax
@@ -838,7 +812,7 @@ bK
 bL
 "}
 (10,1,1) = {"
-sP
+ac
 ah
 ak
 aq
@@ -969,13 +943,13 @@ aE
 aE
 aE
 ad
-sP
-sP
-sP
+ac
+ac
+ac
 ad
 ad
 ad
-sP
+ac
 ad
 aa
 aa

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -370,18 +370,12 @@
 /obj/machinery/door/airlock{
 	name = "Unit 2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "cq" = (
 /obj/structure/grille/broken,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "gl" = (
@@ -406,20 +400,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "mJ" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "mN" = (
@@ -434,27 +422,18 @@
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Gw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "KJ" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "NP" = (
@@ -462,26 +441,15 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "Ow" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"Uc" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -496,9 +464,9 @@ gl
 ab
 jr
 ab
-Uc
-Uc
-Uc
+ac
+ac
+ac
 ab
 mN
 ab
@@ -657,7 +625,7 @@ ac
 ah
 al
 aa
-Uc
+ac
 ac
 aB
 bo
@@ -705,8 +673,8 @@ aa
 aa
 aa
 aa
-Uc
-Uc
+ac
+ac
 aB
 aH
 aw

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -285,11 +285,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/shuttle/escape)
-"lT" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "my" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
@@ -369,10 +364,10 @@ aa
 (2,1,1) = {"
 aw
 ae
-lT
+ad
 ac
 ae
-lT
+ad
 aw
 ai
 aD
@@ -415,7 +410,7 @@ bc
 be
 "}
 (4,1,1) = {"
-lT
+ad
 ah
 ai
 al
@@ -439,7 +434,7 @@ aa
 aa
 "}
 (5,1,1) = {"
-lT
+ad
 ag
 aj
 am
@@ -463,7 +458,7 @@ aU
 aX
 "}
 (6,1,1) = {"
-lT
+ad
 ag
 aj
 an
@@ -487,7 +482,7 @@ bd
 aY
 "}
 (7,1,1) = {"
-lT
+ad
 ag
 aj
 ao
@@ -511,7 +506,7 @@ aW
 aZ
 "}
 (8,1,1) = {"
-lT
+ad
 ah
 ai
 ap
@@ -561,10 +556,10 @@ be
 (10,1,1) = {"
 aw
 ae
-lT
+ad
 ac
 ae
-lT
+ad
 aw
 ai
 aE

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -473,24 +473,17 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "el" = (
 /obj/machinery/door/airlock/titanium,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ft" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle/tinted,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ji" = (
@@ -509,10 +502,7 @@
 "uR" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/titanium,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "AO" = (
@@ -548,16 +538,8 @@
 /area/shuttle/escape)
 "Re" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"RB" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -572,9 +554,9 @@ AO
 ab
 JM
 ab
-RB
-RB
-RB
+as
+as
+as
 ab
 oh
 ab
@@ -806,19 +788,19 @@ aa
 aa
 aa
 ab
-RB
+as
 ab
-RB
-ab
-ab
-ab
-RB
-RB
-RB
+as
 ab
 ab
 ab
-RB
+as
+as
+as
+ab
+ab
+ab
+as
 ab
 ab
 ab


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Throws out the directional firelocks and the window firelocks, replaces the directional firelocks with fulltile firelocks. Wasn't sure if this is enough edited to qualify for MDB ignore or not, but figured better safe than sorry. Also closes #4910 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Works with new atmos.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Emergency shuttles updated for new atmos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
