### PR TITLE
[MDB Ignore] Removes the rest of the remaining fastmos airlocks, fixes a delta map mistake.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -242,12 +242,6 @@
 	},
 /turf/open/floor/carpet,
 /area/ruin/space/has_grav/powered/cat_man)
-"aO" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/powered/cat_man)
 "aP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -629,7 +623,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/cat_man)
 "bN" = (
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/cat_man)
 "bO" = (
@@ -1342,7 +1336,7 @@ ah
 ar
 aw
 aI
-aO
+bN
 aI
 bc
 bq

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -28067,8 +28067,8 @@
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7";
-	luminosity = 2;
-	initial_temperature = 2.7
+	initial_temperature = 2.7;
+	luminosity = 2
 	},
 /area/security/prison)
 "aZP" = (
@@ -29314,16 +29314,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"bci" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
 "bcj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -29788,8 +29778,8 @@
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=0.01;n2=0.01;TEMP=2.7";
-	luminosity = 2;
-	initial_temperature = 2.7
+	initial_temperature = 2.7;
+	luminosity = 2
 	},
 /area/security/prison)
 "bcX" = (
@@ -123982,10 +123972,6 @@
 	name = "Kitchen Counter Shutters"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -8
 	},
@@ -123994,6 +123980,7 @@
 	pixel_y = 5
 	},
 /obj/item/reagent_containers/food/drinks/britcup,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "tub" = (
@@ -124856,6 +124843,7 @@
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "vJu" = (
@@ -162466,7 +162454,7 @@ aVq
 aLL
 aNi
 aKz
-bci
+bcj
 bdI
 bdJ
 bdI

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2201,12 +2201,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "jX" = (
@@ -2236,10 +2231,7 @@
 "kf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "kg" = (
@@ -3212,12 +3204,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ot" = (
@@ -3755,10 +3742,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "up" = (
@@ -3930,10 +3914,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "wz" = (
@@ -4193,12 +4174,7 @@
 /turf/open/floor/plasteel,
 /area/mine/science)
 "AL" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "AS" = (
@@ -4306,12 +4282,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Cd" = (
@@ -4394,12 +4365,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "CM" = (
@@ -4413,12 +4379,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "CY" = (
@@ -4455,12 +4416,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Dy" = (
@@ -4779,15 +4735,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "GS" = (
@@ -5064,12 +5015,7 @@
 	name = "Processing Area";
 	req_access_txt = "48"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "JJ" = (
@@ -5117,12 +5063,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Kv" = (
@@ -5857,12 +5798,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "TU" = (
@@ -5871,10 +5807,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "TW" = (
@@ -6412,10 +6345,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "YT" = (

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -76,7 +76,6 @@
 /area/lavaland/surface/outdoors)
 "ao" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/lavaland/surface/outdoors)
 "ap" = (
@@ -194,7 +193,6 @@
 /area/lavaland/surface/outdoors)
 "aK" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "aM" = (
@@ -224,7 +222,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "aU" = (
@@ -863,7 +860,6 @@
 /area/mine/eva)
 "dA" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/mine/eva)
 "dB" = (
@@ -883,11 +879,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"dE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "dF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -1253,11 +1244,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"eP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/mine/production)
 "eQ" = (
 /obj/structure/closet/crate,
 /obj/item/dice/d4,
@@ -1443,11 +1429,6 @@
 "fy" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp/security)
-"fA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/mine/laborcamp/security)
 "fB" = (
 /obj/structure/frame/machine,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1541,7 +1522,6 @@
 "fU" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/mine/production)
 "fV" = (
@@ -1560,7 +1540,6 @@
 /area/mine/production)
 "fY" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2092,7 +2071,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "jo" = (
-/obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
@@ -3207,11 +3185,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"ot" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/mine/science)
 "ov" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 8
@@ -3524,11 +3497,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
-"rB" = (
-/obj/machinery/door/firedoor/window,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/mine/laborcamp/security)
 "rE" = (
 /obj/machinery/computer/security/labor,
 /obj/machinery/light{
@@ -4567,7 +4535,6 @@
 /area/mine/living_quarters)
 "EG" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -4674,7 +4641,6 @@
 /area/mine/eva)
 "Gh" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
@@ -4851,7 +4817,6 @@
 /area/lavaland/surface/outdoors)
 "Im" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
@@ -4984,7 +4949,6 @@
 /area/mine/science)
 "Jx" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
@@ -5020,7 +4984,6 @@
 /area/mine/production)
 "JJ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
@@ -6315,10 +6278,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"YF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/mine/science)
 "YJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -6384,7 +6343,6 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Zf" = (
-/obj/machinery/door/firedoor/window,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/mine/science)
@@ -11809,11 +11767,11 @@ ap
 fy
 fy
 fy
-fA
+tf
 fy
-dE
-dE
-dE
+jo
+jo
+jo
 cM
 ab
 ab
@@ -12587,7 +12545,7 @@ bb
 ME
 cM
 aQ
-dE
+jo
 cM
 ab
 ab
@@ -13861,7 +13819,7 @@ aG
 aG
 aG
 aj
-rB
+tf
 rU
 HP
 QV
@@ -14118,10 +14076,10 @@ aG
 aG
 aG
 aj
-rB
-rB
-rB
-rB
+tf
+tf
+tf
+tf
 fy
 WA
 Cw
@@ -15665,7 +15623,7 @@ aj
 aj
 aj
 ab
-dE
+jo
 qj
 JG
 Pz
@@ -15688,7 +15646,7 @@ aj
 aj
 aj
 aj
-ot
+Zf
 Tn
 Tn
 Tn
@@ -15922,7 +15880,7 @@ aj
 aj
 aj
 ab
-dE
+jo
 ps
 lb
 zN
@@ -15945,7 +15903,7 @@ aj
 aj
 aj
 aj
-ot
+Zf
 Iq
 fH
 sw
@@ -16195,14 +16153,14 @@ dn
 Jc
 GK
 dn
-dE
+jo
 aj
 aj
 aj
 aj
 aj
 aj
-ot
+Zf
 xt
 gh
 ec
@@ -16452,14 +16410,14 @@ Cs
 HX
 ho
 Kv
-dE
+jo
 aj
 aj
 aj
 aj
 aj
 aj
-ot
+Zf
 Mn
 fi
 fN
@@ -16716,7 +16674,7 @@ ab
 ab
 aj
 aj
-ot
+Zf
 Py
 Lm
 jy
@@ -16973,7 +16931,7 @@ ai
 ab
 ab
 ab
-ot
+Zf
 Pt
 fI
 OX
@@ -17227,9 +17185,9 @@ ab
 aj
 Tn
 Tn
-ot
-ot
-ot
+Zf
+Zf
+Zf
 Tn
 Tn
 Mz
@@ -18238,7 +18196,7 @@ ab
 ab
 aj
 aj
-dE
+jo
 bb
 Ll
 bb
@@ -18495,15 +18453,15 @@ ab
 ab
 ab
 aj
-dE
+jo
 bm
 TW
 qx
 cM
-dE
-dE
-dE
-dE
+jo
+jo
+jo
+jo
 cM
 ai
 ai
@@ -18752,11 +18710,11 @@ ab
 ab
 ab
 aj
-dE
-dE
+jo
+jo
 Cb
-dE
-dE
+jo
+jo
 ab
 ab
 ab
@@ -18777,8 +18735,8 @@ RM
 tG
 oI
 oZ
-ot
-ot
+Zf
+Zf
 aj
 aj
 aj
@@ -19010,9 +18968,9 @@ ab
 ab
 aj
 ab
-dE
+jo
 EA
-dE
+jo
 ab
 ab
 aj
@@ -19035,8 +18993,8 @@ Fe
 Yu
 qC
 vs
-ot
-ot
+Zf
+Zf
 aj
 aj
 aj
@@ -19267,9 +19225,9 @@ ab
 aj
 aj
 aj
-dE
+jo
 Wd
-dE
+jo
 ab
 aj
 aj
@@ -19293,7 +19251,7 @@ jY
 Io
 Wn
 Hn
-ot
+Zf
 aj
 aj
 ab
@@ -19524,9 +19482,9 @@ ab
 aj
 aj
 aj
-dE
+jo
 Wd
-dE
+jo
 aj
 aj
 Zf
@@ -19550,8 +19508,8 @@ jY
 Fy
 Sw
 jr
-ot
-ot
+Zf
+Zf
 aj
 aj
 ab
@@ -19781,7 +19739,7 @@ ab
 ab
 aj
 aj
-dE
+jo
 Wd
 jo
 Zf
@@ -19808,7 +19766,7 @@ Ud
 si
 jr
 Ov
-ot
+Zf
 aj
 aj
 aj
@@ -20038,7 +19996,7 @@ ab
 ab
 aj
 aj
-eP
+vO
 IX
 FX
 GX
@@ -20065,7 +20023,7 @@ Jh
 mT
 Mm
 DI
-ot
+Zf
 aj
 aj
 aj
@@ -20295,9 +20253,9 @@ ab
 aj
 aj
 aj
-eP
+vO
 YX
-eP
+vO
 Zf
 Zf
 Zf
@@ -20322,7 +20280,7 @@ wz
 qa
 KI
 Ov
-ot
+Zf
 aj
 aj
 aj
@@ -20545,16 +20503,16 @@ ab
 ab
 fU
 vM
-eP
+vO
 ab
 ab
 aj
 aj
 aj
 ab
-eP
+vO
 YX
-eP
+vO
 aj
 aj
 Zf
@@ -20578,8 +20536,8 @@ jY
 zR
 Sw
 KI
-ot
-ot
+Zf
+Zf
 aj
 aj
 aj
@@ -20809,9 +20767,9 @@ aj
 aj
 aj
 ab
-eP
+vO
 tp
-eP
+vO
 ab
 aj
 aj
@@ -20835,7 +20793,7 @@ Be
 xY
 Wn
 QB
-ot
+Zf
 aj
 aj
 aj
@@ -21056,20 +21014,20 @@ aj
 aj
 aj
 aj
-eP
+vO
 fY
 yu
 JJ
-eP
+vO
 ab
 aj
 aj
 ab
-eP
-eP
+vO
+vO
 GP
-eP
-eP
+vO
+vO
 ab
 Il
 WE
@@ -21091,8 +21049,8 @@ AC
 JA
 Be
 Qx
-ot
-ot
+Zf
+Zf
 aj
 aj
 aj
@@ -21313,20 +21271,20 @@ aj
 aj
 aj
 OZ
-eP
+vO
 gc
 yL
 JM
-eP
+vO
 OZ
 OZ
 OZ
 OZ
-eP
+vO
 RO
 BM
 bo
-eP
+vO
 OZ
 jd
 Uh
@@ -21347,8 +21305,8 @@ RM
 yU
 ZX
 WM
-ot
-ot
+Zf
+Zf
 aj
 aj
 aj
@@ -21592,11 +21550,11 @@ Uh
 Uh
 Uh
 Uh
-ot
+Zf
 BT
 BT
 BT
-YF
+Zf
 BT
 el
 gi
@@ -21826,7 +21784,7 @@ aj
 aj
 aj
 ab
-eP
+vO
 eQ
 gY
 zu
@@ -21859,7 +21817,7 @@ WX
 BT
 gi
 va
-ot
+Zf
 aj
 aj
 aj
@@ -22083,7 +22041,7 @@ aj
 aj
 ab
 ab
-eP
+vO
 eZ
 ie
 zV
@@ -22098,7 +22056,7 @@ BB
 NU
 De
 PT
-eP
+vO
 jd
 Uh
 Uh
@@ -22110,13 +22068,13 @@ Jl
 Pl
 gd
 eD
-YF
+Zf
 eU
 gu
 vF
 Nu
 CH
-ot
+Zf
 aj
 aj
 aj
@@ -22355,7 +22313,7 @@ Ms
 bf
 zV
 Yz
-eP
+vO
 jd
 Uh
 Uh
@@ -22373,7 +22331,7 @@ SM
 vG
 vJ
 wF
-ot
+Zf
 aj
 aj
 aj
@@ -22869,7 +22827,7 @@ yL
 bg
 bo
 bt
-eP
+vO
 jd
 Uh
 Uh
@@ -22887,7 +22845,7 @@ Ee
 BT
 Lc
 Pg
-ot
+Zf
 aj
 aj
 aj
@@ -23134,7 +23092,7 @@ Uh
 Uh
 Uh
 Uh
-ot
+Zf
 BT
 fJ
 eH
@@ -23144,7 +23102,7 @@ tN
 BT
 sz
 Pg
-ot
+Zf
 aj
 aj
 aj
@@ -23401,7 +23359,7 @@ At
 tx
 qR
 lA
-ot
+Zf
 aj
 aj
 aj
@@ -23648,11 +23606,11 @@ WY
 WY
 WY
 II
-ot
-ot
+Zf
+Zf
 em
-ot
-ot
+Zf
+Zf
 Tn
 Tn
 Tn
@@ -23906,7 +23864,7 @@ ab
 ab
 ab
 aj
-ot
+Zf
 fJ
 Zf
 aj
@@ -24163,16 +24121,16 @@ aj
 aj
 aj
 aj
-ot
+Zf
 fJ
-ot
+Zf
 aj
 aj
-ot
+Zf
 Wk
 rP
 Rd
-ot
+Zf
 aj
 aj
 aj
@@ -24422,14 +24380,14 @@ aj
 aj
 Im
 lx
-ot
+Zf
 aj
 aj
-ot
-ot
-ot
-ot
-ot
+Zf
+Zf
+Zf
+Zf
+Zf
 aj
 aj
 aj
@@ -24676,11 +24634,11 @@ aj
 aj
 ab
 aj
-ot
+Zf
 Gh
 ov
-ot
-ot
+Zf
+Zf
 ab
 aj
 aj
@@ -25447,11 +25405,11 @@ aj
 ab
 ab
 aj
-ot
-ot
+Zf
+Zf
 JX
-ot
-ot
+Zf
+Zf
 ab
 ab
 ab

--- a/_maps/shuttles/arrival_corg.dmm
+++ b/_maps/shuttles/arrival_corg.dmm
@@ -421,7 +421,6 @@
 /area/shuttle/arrival)
 "V" = (
 /obj/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "W" = (

--- a/_maps/shuttles/arrival_corg.dmm
+++ b/_maps/shuttles/arrival_corg.dmm
@@ -219,10 +219,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
-"z" = (
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "A" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
@@ -531,7 +527,7 @@ T
 d
 K
 T
-z
+V
 a
 G
 M

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -5,15 +5,6 @@
 "ac" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ad" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"ah" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "am" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
@@ -637,7 +628,7 @@ aB
 aJ
 at
 aZ
-ah
+VO
 aK
 at
 aL
@@ -652,7 +643,7 @@ Gw
 at
 at
 aZ
-ah
+VO
 aK
 at
 bP
@@ -667,7 +658,7 @@ aB
 bK
 at
 aZ
-ah
+VO
 aK
 at
 bw
@@ -682,7 +673,7 @@ qO
 aK
 at
 aZ
-ah
+VO
 aK
 at
 aZ
@@ -712,7 +703,7 @@ qO
 aK
 at
 aZ
-ah
+VO
 aK
 at
 aZ
@@ -727,7 +718,7 @@ aB
 bK
 at
 aZ
-ah
+VO
 aK
 at
 bx
@@ -742,7 +733,7 @@ Gw
 at
 at
 aZ
-ah
+VO
 aK
 at
 bP
@@ -757,7 +748,7 @@ aB
 aL
 at
 aZ
-ah
+VO
 aK
 at
 by
@@ -799,13 +790,13 @@ aa
 ac
 ac
 ac
-ad
+qO
 JJ
-ad
+qO
 bi
-ad
+qO
 Zz
-ad
+qO
 ac
 ac
 ac
@@ -832,7 +823,7 @@ aw
 aw
 aw
 aw
-ad
+qO
 Jx
 Jx
 Jx
@@ -860,11 +851,11 @@ ac
 ac
 ac
 ac
-ad
+qO
 JJ
 ac
 rp
-ad
+qO
 JM
 ac
 ac
@@ -877,7 +868,7 @@ ac
 ac
 aQ
 aw
-ad
+qO
 Jx
 bs
 ac

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -381,13 +381,11 @@
 "qg" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "qO" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "rp" = (
@@ -464,7 +462,6 @@
 /area/shuttle/escape)
 "VO" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "YJ" = (

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -395,12 +395,7 @@
 	name = "Escape Shuttle Infirmary";
 	req_access_txt = "5"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "xE" = (
@@ -414,30 +409,12 @@
 /obj/machinery/door/airlock/mining{
 	name = "Emergency Shuttle Storage"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "Gw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"IJ" = (
-/obj/machinery/door/airlock{
-	name = "Emergency Shuttle Restroom"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Jx" = (
 /turf/open/floor/mineral/titanium/white,
@@ -447,12 +424,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "JM" = (
@@ -473,12 +445,7 @@
 /obj/machinery/door/airlock{
 	name = "Emergency Shuttle Restroom"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "RU" = (
@@ -505,24 +472,14 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Zz" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 
@@ -597,7 +554,7 @@ bd
 bl
 ac
 bN
-IJ
+RT
 bE
 qO
 "}
@@ -627,7 +584,7 @@ bf
 bn
 ac
 Jx
-IJ
+RT
 bE
 qO
 "}

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -613,7 +613,6 @@
 /area/shuttle/escape)
 "CM" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "FR" = (

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -583,10 +583,7 @@
 /obj/machinery/door/airlock{
 	name = "Unit B"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "kK" = (
@@ -611,10 +608,7 @@
 /obj/machinery/door/airlock{
 	name = "Unit 2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "CM" = (
@@ -626,10 +620,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "GY" = (
@@ -637,10 +628,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "LQ" = (
@@ -669,10 +657,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "UQ" = (
@@ -684,12 +669,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Yn" = (
@@ -703,10 +683,7 @@
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -5,10 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ac" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ad" = (
 /obj/structure/table,
 /obj/item/scalpel,
@@ -331,7 +327,7 @@ ab
 ah
 aq
 ak
-ac
+MN
 aB
 aH
 aH
@@ -410,7 +406,7 @@ aa
 ab
 ab
 xJ
-ac
+MN
 ab
 aC
 aC
@@ -427,7 +423,7 @@ ab
 al
 at
 at
-ac
+MN
 aB
 aC
 aC
@@ -459,7 +455,7 @@ ab
 am
 at
 at
-ac
+MN
 aC
 aC
 aN
@@ -513,7 +509,7 @@ aC
 aw
 ab
 Hy
-ac
+MN
 ab
 ab
 "}

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -293,7 +293,6 @@
 /area/shuttle/escape)
 "MN" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Ti" = (

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -264,46 +264,17 @@
 /obj/item/defibrillator/loaded,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"mv" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "bridge door";
-	req_access_txt = "19"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
 "xJ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "bridge door";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Cf" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Hy" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Mg" = (
@@ -317,12 +288,7 @@
 	port_direction = 4;
 	width = 14
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "MN" = (
@@ -332,12 +298,7 @@
 /area/shuttle/escape)
 "Ti" = (
 /obj/machinery/door/airlock/titanium,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Wn" = (
@@ -345,10 +306,7 @@
 	name = "security airlock";
 	req_access_txt = "63"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 
@@ -390,7 +348,7 @@ ab
 ai
 ar
 aC
-mv
+xJ
 aC
 aC
 aC
@@ -555,7 +513,7 @@ aC
 aC
 aw
 ab
-Cf
+Hy
 ac
 ab
 ab

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -2,10 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ac" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ad" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -482,9 +478,9 @@ ag
 aC
 as
 ad
-ac
+JW
 RE
-ac
+JW
 bj
 aC
 aT
@@ -541,7 +537,7 @@ aS
 aS
 aS
 aC
-ac
+JW
 XC
 bs
 XC
@@ -589,7 +585,7 @@ aC
 aC
 aC
 aC
-ac
+JW
 ga
 ga
 ga
@@ -613,7 +609,7 @@ am
 am
 am
 aR
-ac
+JW
 bd
 be
 bd

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -340,7 +340,6 @@
 /area/shuttle/escape)
 "JW" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Km" = (

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -327,10 +327,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Cargo"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Gx" = (
@@ -360,10 +357,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "RE" = (
@@ -371,12 +365,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Ta" = (
@@ -384,10 +373,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "XC" = (

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -5,10 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ac" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ad" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
@@ -1877,7 +1873,7 @@ aZ
 aZ
 aZ
 aZ
-ac
+Ev
 cU
 da
 dh
@@ -1921,7 +1917,7 @@ ba
 ba
 ba
 bc
-ac
+Ev
 cU
 bc
 da
@@ -1942,9 +1938,9 @@ ao
 ab
 ab
 ab
-ac
+Ev
 YO
-ac
+Ev
 ab
 bF
 bR
@@ -2009,7 +2005,7 @@ bX
 bX
 bX
 bR
-ac
+Ev
 cU
 bc
 bc
@@ -2033,7 +2029,7 @@ be
 be
 be
 bw
-ac
+Ev
 bH
 bR
 bT
@@ -2077,7 +2073,7 @@ be
 be
 be
 by
-ac
+Ev
 bI
 bR
 bT
@@ -2097,7 +2093,7 @@ bW
 bW
 bW
 bR
-ac
+Ev
 cW
 db
 bc
@@ -2121,7 +2117,7 @@ be
 be
 be
 bw
-ac
+Ev
 bJ
 bR
 bT
@@ -2205,10 +2201,10 @@ aC
 aO
 ab
 ab
-ac
+Ev
 LM
 LM
-ac
+Ev
 ad
 aZ
 bc
@@ -2397,7 +2393,7 @@ bW
 bW
 bW
 bR
-ac
+Ev
 cj
 cq
 cw
@@ -2485,7 +2481,7 @@ aZ
 aZ
 aZ
 bc
-ac
+Ev
 cl
 cs
 cp

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1718,7 +1718,6 @@
 /area/shuttle/escape)
 "Ev" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "GI" = (

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -1339,12 +1339,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
-"cQ" = (
-/obj/machinery/door/airlock{
-	name = "Bathroom"
-	},
-/turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
 "cR" = (
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
@@ -1633,12 +1627,7 @@
 /area/shuttle/escape)
 "eb" = (
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ez" = (
@@ -1656,10 +1645,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "jG" = (
@@ -1682,10 +1668,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "pf" = (
@@ -1709,12 +1692,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "uv" = (
@@ -1731,38 +1709,11 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"Du" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Emergency Shuttle Medbay"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/shuttle/escape)
 "Ed" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "Ev" = (
@@ -1784,10 +1735,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "LM" = (
@@ -1795,12 +1743,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "YO" = (
@@ -1808,12 +1751,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 
@@ -2330,7 +2268,7 @@ bW
 bR
 ad
 ab
-Du
+GI
 ab
 ab
 ab
@@ -2600,9 +2538,9 @@ cp
 cp
 cM
 ab
-cQ
+Ed
 ab
-cQ
+Ed
 ab
 ab
 ab

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -102,6 +102,7 @@
 /obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Premium Lounge"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "at" = (
@@ -137,6 +138,7 @@
 /obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Greentext"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aC" = (
@@ -324,20 +326,14 @@
 /obj/machinery/door/airlock/bananium/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "KO" = (
 /obj/machinery/door/airlock/bananium{
 	name = "Emergency Shuttle Cargo"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "LN" = (

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -5,10 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ac" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ad" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/escape)
@@ -458,9 +454,9 @@ af
 ak
 ap
 ab
-ac
+Nn
 aA
-ac
+Nn
 aF
 ak
 aO
@@ -517,7 +513,7 @@ aN
 aN
 aN
 ak
-ac
+Nn
 Zf
 aY
 Zf
@@ -565,7 +561,7 @@ ak
 ak
 ak
 ak
-ac
+Nn
 aV
 aV
 aV
@@ -589,7 +585,7 @@ aM
 aM
 aM
 aL
-ac
+Nn
 aX
 bb
 aX

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -348,7 +348,6 @@
 /area/shuttle/escape)
 "Nn" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Zf" = (

--- a/_maps/shuttles/emergency_construction.dmm
+++ b/_maps/shuttles/emergency_construction.dmm
@@ -181,7 +181,6 @@
 /area/shuttle/escape)
 "U" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_corg.dmm
+++ b/_maps/shuttles/emergency_corg.dmm
@@ -1599,7 +1599,6 @@
 /area/shuttle/escape)
 "RR" = (
 /obj/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Sl" = (

--- a/_maps/shuttles/emergency_corg.dmm
+++ b/_maps/shuttles/emergency_corg.dmm
@@ -29,12 +29,7 @@
 	id_tag = "Dorm4";
 	name = "Long Term Stay Cabin 4"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "bR" = (
@@ -160,6 +155,7 @@
 	name = "Morgue";
 	req_access_txt = "6"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "fG" = (
@@ -181,10 +177,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "fO" = (
@@ -254,10 +247,7 @@
 /obj/machinery/door/airlock/wood{
 	name = "VIP Lounge"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "iN" = (
@@ -346,9 +336,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "nf" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -357,6 +344,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -378,10 +368,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "nI" = (
@@ -404,12 +391,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "oI" = (
@@ -482,14 +464,11 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Medical Bay"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "qv" = (
@@ -555,14 +534,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "sB" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -632,10 +611,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "ux" = (
@@ -682,12 +658,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "uP" = (
@@ -717,7 +688,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "vl" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -725,6 +695,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "vM" = (
@@ -755,16 +726,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Emergency Shuttle Engineering";
 	req_one_access_txt = "32;19"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "wj" = (
@@ -833,12 +799,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "xH" = (
@@ -957,12 +918,7 @@
 	id_tag = "Dorm3";
 	name = "Long Term Stay Cabin 3"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "AF" = (
@@ -1103,14 +1059,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Emergency Shuttle Engineering";
 	req_one_access_txt = "32;19"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Ei" = (
@@ -1289,12 +1242,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Km" = (
@@ -1544,12 +1492,7 @@
 	id_tag = "Dorm2";
 	name = "Long Term Stay Cabin 2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Qt" = (
@@ -1696,12 +1639,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Td" = (
@@ -1768,12 +1706,7 @@
 	id_tag = "Dorm1";
 	name = "Long Term Stay Cabin 1"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "Vx" = (
@@ -1792,18 +1725,13 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Medical Bay"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "WY" = (
@@ -1858,7 +1786,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ZL" = (
-/obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -1866,6 +1793,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ZN" = (

--- a/_maps/shuttles/emergency_corg.dmm
+++ b/_maps/shuttles/emergency_corg.dmm
@@ -1597,10 +1597,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"RR" = (
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Sl" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -1840,9 +1836,9 @@ GK
 Tw
 IK
 Tw
-RR
-RR
-RR
+UQ
+UQ
+UQ
 Tw
 QQ
 Tw
@@ -1871,8 +1867,8 @@ MH
 MH
 Tw
 Tw
-RR
-RR
+UQ
+UQ
 Tw
 Bt
 Pu
@@ -2027,7 +2023,7 @@ JU
 "}
 (6,1,1) = {"
 MH
-RR
+UQ
 Bt
 pB
 Bt
@@ -2066,8 +2062,8 @@ BQ
 BQ
 "}
 (7,1,1) = {"
-RR
-RR
+UQ
+UQ
 uP
 Fp
 fK
@@ -2106,7 +2102,7 @@ BQ
 MH
 "}
 (8,1,1) = {"
-RR
+UQ
 MN
 mI
 Fp
@@ -2140,13 +2136,13 @@ Xo
 bR
 wl
 Xo
-RR
+UQ
 ar
 MH
 MH
 "}
 (9,1,1) = {"
-RR
+UQ
 tb
 Fp
 Rj
@@ -2180,13 +2176,13 @@ kF
 kF
 kF
 Br
-RR
+UQ
 ar
 Ju
 MH
 "}
 (10,1,1) = {"
-RR
+UQ
 xi
 AF
 ci
@@ -2220,13 +2216,13 @@ Vx
 Vx
 Vx
 KW
-RR
+UQ
 ar
 MH
 MH
 "}
 (11,1,1) = {"
-RR
+UQ
 DL
 AF
 yL
@@ -2260,13 +2256,13 @@ Vx
 Vx
 Vx
 pW
-RR
+UQ
 ar
 MH
 MH
 "}
 (12,1,1) = {"
-RR
+UQ
 tb
 Fp
 iN
@@ -2300,13 +2296,13 @@ kF
 kF
 kF
 Br
-RR
+UQ
 ar
 Ju
 MH
 "}
 (13,1,1) = {"
-RR
+UQ
 oI
 Hh
 Fp
@@ -2340,14 +2336,14 @@ JL
 hP
 Ht
 JL
-RR
+UQ
 ar
 MH
 MH
 "}
 (14,1,1) = {"
-RR
-RR
+UQ
+UQ
 Dn
 Fp
 fK
@@ -2387,7 +2383,7 @@ MH
 "}
 (15,1,1) = {"
 MH
-RR
+UQ
 Bt
 pB
 Bt
@@ -2551,8 +2547,8 @@ MH
 MH
 Tw
 Tw
-RR
-RR
+UQ
+UQ
 Tw
 Bt
 Ln
@@ -2600,9 +2596,9 @@ Xk
 Tw
 Xk
 Tw
-RR
-RR
-RR
+UQ
+UQ
+UQ
 Tw
 Xk
 Tw
@@ -2614,8 +2610,8 @@ MH
 Tw
 Tw
 Tw
-RR
-RR
+UQ
+UQ
 Tw
 Tw
 Tw

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -142,7 +142,6 @@
 /area/shuttle/escape)
 "Q" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1301,28 +1301,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "hB" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"uQ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "zd" = (
 /obj/machinery/door/airlock/command{
@@ -1332,12 +1316,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ay" = (
@@ -1355,12 +1334,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Ey" = (
@@ -1370,12 +1344,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Hh" = (
@@ -1386,10 +1355,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ky" = (
@@ -1431,10 +1397,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 
@@ -1519,7 +1482,7 @@ ao
 ao
 ao
 bo
-uQ
+Ej
 bw
 bw
 bw

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1360,7 +1360,6 @@
 /area/shuttle/escape)
 "Ky" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "KD" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1360,6 +1360,7 @@
 /area/shuttle/escape)
 "Ky" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "KD" = (

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -216,10 +216,7 @@
 /obj/machinery/door/airlock/gold{
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape)
 "Y" = (

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -7,7 +7,6 @@
 /area/shuttle/escape)
 "c" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/shuttle/escape)
 "d" = (

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -7,6 +7,7 @@
 /area/shuttle/escape)
 "c" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel/elevatorshaft,
 /area/shuttle/escape)
 "d" = (

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -447,10 +447,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "hl" = (
@@ -458,10 +455,7 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "pk" = (
@@ -500,12 +494,7 @@
 	name = "Containment Cell";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "JF" = (
@@ -513,12 +502,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -475,7 +475,6 @@
 /area/shuttle/escape)
 "Dr" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "FX" = (

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -475,6 +475,7 @@
 /area/shuttle/escape)
 "Dr" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "FX" = (

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -29,24 +29,14 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "k" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "l" = (
@@ -194,12 +184,7 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "P" = (

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -119,6 +119,7 @@
 /area/shuttle/escape)
 "C" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "D" = (

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -119,7 +119,6 @@
 /area/shuttle/escape)
 "C" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "D" = (

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -1604,10 +1604,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "jK" = (
@@ -1638,10 +1635,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "uO" = (
@@ -1654,12 +1648,7 @@
 	name = "Shuttle Control";
 	req_one_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "zT" = (
@@ -1668,12 +1657,7 @@
 	name = "Holding Area";
 	req_one_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Bo" = (
@@ -1709,20 +1693,14 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Oa" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Airlock"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Tp" = (
@@ -1733,10 +1711,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Vz" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -795,10 +795,7 @@
 	name = "Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "fr" = (
@@ -824,10 +821,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "BN" = (
@@ -859,25 +853,8 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"GG" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Shuttle Infirmary"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Li" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -905,10 +882,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Vs" = (
@@ -919,10 +893,7 @@
 	name = "Emergency Shuttle Cargo Bay Airlock"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Yo" = (
@@ -1215,7 +1186,7 @@ aE
 ba
 ad
 ac
-GG
+PE
 ba
 ad
 "}

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -858,6 +858,7 @@
 /area/shuttle/escape)
 "Li" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "LY" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -858,7 +858,6 @@
 /area/shuttle/escape)
 "Li" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "LY" = (

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -149,10 +149,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "D" = (
@@ -265,10 +262,7 @@
 	name = "Escape Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Z" = (
@@ -276,10 +270,7 @@
 	name = "Escape Shuttle Cell";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -245,6 +245,7 @@
 /area/shuttle/escape)
 "U" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "W" = (

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -245,7 +245,6 @@
 /area/shuttle/escape)
 "U" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "W" = (

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -771,10 +771,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "sC" = (
@@ -788,10 +785,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "wN" = (
@@ -823,10 +817,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ls" = (
@@ -874,12 +865,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "Ui" = (
@@ -892,10 +878,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -804,7 +804,6 @@
 "Dr" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Eg" = (

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -804,6 +804,7 @@
 "Dr" = (
 /obj/structure/window/shuttle,
 /obj/structure/grille,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Eg" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -655,20 +655,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "First Class"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"lO" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Service"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ub" = (
@@ -680,10 +667,7 @@
 /obj/machinery/door/airlock/public/glass{
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "xt" = (
@@ -697,10 +681,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Service"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "IC" = (
@@ -737,10 +718,7 @@
 	name = "Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "XN" = (
@@ -748,20 +726,14 @@
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Zi" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Economy Class"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 
@@ -936,7 +908,7 @@ ar
 ar
 Zi
 xt
-lO
+yT
 au
 au
 au
@@ -984,7 +956,7 @@ ar
 ar
 Zi
 Uu
-lO
+yT
 au
 au
 au

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -648,7 +648,6 @@
 "kK" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lf" = (
@@ -660,7 +659,6 @@
 /area/shuttle/escape)
 "ub" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "wl" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -648,6 +648,7 @@
 "kK" = (
 /obj/structure/window/plastitanium,
 /obj/structure/grille,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lf" = (
@@ -659,6 +660,7 @@
 /area/shuttle/escape)
 "ub" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "wl" = (

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -1913,36 +1913,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"jH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Holding Area";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "kr" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ks" = (
@@ -1973,10 +1949,7 @@
 	name = "Emergency Shutle Engineering"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lz" = (
@@ -2076,10 +2049,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "xF" = (
@@ -2140,12 +2110,7 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Dl" = (
@@ -2252,12 +2217,7 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Emergency Shuttle Cargo Bay"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Mk" = (
@@ -2310,6 +2270,7 @@
 	name = "Emergency Shuttle Seating"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "PE" = (
@@ -2345,10 +2306,7 @@
 	name = "Cockpit";
 	req_one_access_txt = "2;19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "QD" = (
@@ -2462,12 +2420,7 @@
 	name = "Escape Shuttle Infirmary";
 	req_one_access_txt = "2;19"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "YG" = (
@@ -2505,10 +2458,7 @@
 	name = "Emergency Shuttle Seating"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 
@@ -2694,7 +2644,7 @@ aY
 aY
 aY
 bE
-jH
+Bo
 bX
 ci
 yl

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -1657,6 +1657,7 @@
 	id = "escape_cockpit_windows";
 	name = "Cockpit Blast Door"
 	},
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dO" = (
@@ -2134,6 +2135,7 @@
 "DU" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Et" = (

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -1657,7 +1657,6 @@
 	id = "escape_cockpit_windows";
 	name = "Cockpit Blast Door"
 	},
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dO" = (
@@ -2135,7 +2134,6 @@
 "DU" = (
 /obj/structure/grille,
 /obj/structure/window/plastitanium,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Et" = (

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -555,10 +555,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Cargo"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Ge" = (
@@ -572,10 +569,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Emergency Shuttle Infirmary"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "OT" = (
@@ -583,10 +577,7 @@
 	name = "Glorious Leaders";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "SF" = (
@@ -594,12 +585,7 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Vh" = (
@@ -614,10 +600,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Xw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -543,6 +543,7 @@
 /area/shuttle/escape)
 "sP" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "wq" = (

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -543,7 +543,6 @@
 /area/shuttle/escape)
 "sP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "wq" = (

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -370,18 +370,12 @@
 /obj/machinery/door/airlock{
 	name = "Unit 2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "cq" = (
 /obj/structure/grille/broken,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "gl" = (
@@ -406,20 +400,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "mJ" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "mN" = (
@@ -434,27 +422,18 @@
 	name = "Emergency Shuttle Airlock";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Gw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "KJ" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "NP" = (
@@ -462,20 +441,14 @@
 	name = "Emergency Shuttle Cockpit";
 	req_access_txt = "19"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "Ow" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "Uc" = (

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -453,7 +453,6 @@
 /area/shuttle/escape)
 "Uc" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -453,6 +453,7 @@
 /area/shuttle/escape)
 "Uc" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -287,6 +287,7 @@
 /area/shuttle/escape)
 "lT" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "my" = (

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -287,7 +287,6 @@
 /area/shuttle/escape)
 "lT" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "my" = (

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -473,18 +473,12 @@
 	name = "Emergency Shuttle Brig";
 	req_access_txt = "2"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "el" = (
 /obj/machinery/door/airlock/titanium,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ft" = (
@@ -509,10 +503,7 @@
 "uR" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/titanium,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "AO" = (
@@ -548,10 +539,7 @@
 /area/shuttle/escape)
 "Re" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "RB" = (

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -484,7 +484,6 @@
 "ft" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle/tinted,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ji" = (
@@ -544,7 +543,6 @@
 /area/shuttle/escape)
 "RB" = (
 /obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -484,6 +484,7 @@
 "ft" = (
 /obj/structure/grille,
 /obj/structure/window/shuttle/tinted,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ji" = (
@@ -543,6 +544,7 @@
 /area/shuttle/escape)
 "RB" = (
 /obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -17,10 +17,7 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_port"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
 "af" = (
@@ -28,10 +25,7 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_port"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
 "ag" = (
@@ -404,10 +398,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/crew)
 "aK" = (
@@ -425,10 +416,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/crew)
 "aL" = (
@@ -486,16 +474,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "aS" = (
@@ -587,18 +570,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/crew)
 "aW" = (
@@ -703,18 +681,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/crew)
 "ba" = (
@@ -991,10 +964,7 @@
 /obj/machinery/door/airlock{
 	name = "Restroom"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/abandoned/crew)
 "bu" = (
@@ -1050,16 +1020,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "bz" = (
@@ -1142,12 +1109,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bar)
 "bF" = (
@@ -1778,12 +1742,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bridge)
 "cs" = (
@@ -2261,10 +2220,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bar)
 "cU" = (
@@ -2576,18 +2532,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "du" = (
@@ -2653,18 +2604,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bar)
 "dx" = (
@@ -2761,18 +2707,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bar)
 "dB" = (
@@ -2799,18 +2740,13 @@
 /obj/machinery/door/airlock/glass{
 	name = "Hydroponics"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/shuttle/abandoned/bar)
 "dE" = (
@@ -3180,10 +3116,7 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_starboard"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
 "ei" = (
@@ -3192,10 +3125,7 @@
 /obj/machinery/door/poddoor{
 	id = "whiteship_starboard"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
 "ej" = (
@@ -3369,12 +3299,9 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "wM" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #4910 

closes #4912 

The difference between the two is that I hit every map, so lavaland, white ship, etc.
And I fixed a problematic area on delta
![unknown 2](https://user-images.githubusercontent.com/40812746/126852174-66f02651-4961-4388-b279-3f3a82989d96.png)

## Why It's Good For The Game

There were a lot of missed maps on the old PR, so I cleared them out

The only place they were really fitting to leave was a spot in corg, border_only is ancient code so it doesn't have to be bleached from *every* spot, but in these cases corg's shuttle had the only reasonable case. 
## Changelog
:cl: Froststahr
tweak: The map airlocks have now been fully reverted to the old system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
