### PR TITLE
Last fix to gamemode setup failing

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -27,8 +27,6 @@ SUBSYSTEM_DEF(ticker)
 	var/admin_delay_notice = ""				//a message to display to anyone who tries to restart the world after a delay
 	var/ready_for_reboot = FALSE			//all roundend preparation done with, all that's left is reboot
 
-	var/gamemode_setup_completed = FALSE
-
 	var/triai = 0							//Global holder for Triumvirate
 	var/tipped = 0							//Did we broadcast the tip of the day yet?
 	var/selected_tip						// What will be the tip of the day?
@@ -200,22 +198,18 @@ SUBSYSTEM_DEF(ticker)
 					fire()
 
 		if(GAME_STATE_SETTING_UP)
-			if(!gamemode_setup_completed)
-				if(!pre_setup())
-					//setup failed
-					fail_counter++
-					current_state = GAME_STATE_STARTUP
-					start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 10)
-					timeLeft = null
-					Master.SetRunLevel(RUNLEVEL_LOBBY)
-				else
-					gamemode_setup_completed = TRUE
-					fail_counter = null
+			if(!pre_setup())
+				//setup failed
+				fail_counter++
+				current_state = GAME_STATE_STARTUP
+				start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 5)
+				timeLeft = null
+				Master.SetRunLevel(RUNLEVEL_LOBBY)
 			else if(!setup())
 				//setup failed
 				fail_counter++
 				current_state = GAME_STATE_STARTUP
-				start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 10)
+				start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 5)
 				timeLeft = null
 				Master.SetRunLevel(RUNLEVEL_LOBBY)
 			else
@@ -224,7 +218,6 @@ SUBSYSTEM_DEF(ticker)
 			if(fail_counter >= 3)
 				log_game("Failed setting up [GLOB.master_mode] [fail_counter] times, defaulting to extended.")
 				message_admins("Failed setting up [GLOB.master_mode] [fail_counter] times, defaulting to extended.")
-				gamemode_setup_completed = FALSE
 				GLOB.master_mode = null		//this makes it pick extended
 				fail_counter = null
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -224,7 +224,8 @@ SUBSYSTEM_DEF(ticker)
 			if(fail_counter >= 3)
 				log_game("Failed setting up [GLOB.master_mode] [fail_counter] times, defaulting to extended.")
 				message_admins("Failed setting up [GLOB.master_mode] [fail_counter] times, defaulting to extended.")
-				GLOB.master_mode = new /datum/game_mode/extended()
+				gamemode_setup_completed = FALSE
+				GLOB.master_mode = null		//this makes it pick extended
 				fail_counter = null
 
 		if(GAME_STATE_PLAYING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gamemode may be deleted if it fails its own pre_setup but passes pre setup that initializes new one. This makes pre_setup always run before setup and that should stop null gamemode runtime.
