### PR TITLE
Doors no longer chain paralyze.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -361,7 +361,7 @@
 				L.Paralyze(60)
 		else if(ismonkey(L)) //For monkeys
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-			if(L.IsParalyzed())
+			if(!L.IsParalyzed())
 				L.Paralyze(60)
 		else //for simple_animals & borgs
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -357,7 +357,7 @@
 			var/multiplier = CLAMP(1 - (armour * 0.01), 0, 1)
 			L.adjustBruteLoss(multiplier * DOOR_CRUSH_DAMAGE)
 			L.emote("scream")
-			if(L.IsParalyzed())
+			if(!L.IsParalyzed())
 				L.Paralyze(60)
 		else if(ismonkey(L)) //For monkeys
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -353,7 +353,9 @@
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE * 1.5) //Xenos go into crit after aproximately the same amount of crushes as humans.
 			L.emote("roar")
 		else if(ishuman(L)) //For humans
-			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
+			var/armour = L.run_armor_check(BODY_ZONE_CHEST, "melee")
+			var/multiplier = CLAMP(1 - (armour * 0.01), 0, 1)
+			L.adjustBruteLoss(multiplier * DOOR_CRUSH_DAMAGE)
 			L.emote("scream")
 			if(L.IsParalyzed())
 				L.Paralyze(60)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -355,10 +355,12 @@
 		else if(ishuman(L)) //For humans
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
 			L.emote("scream")
-			L.Paralyze(100)
+			if(L.IsParalyzed())
+				L.Paralyze(60)
 		else if(ismonkey(L)) //For monkeys
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
-			L.Paralyze(100)
+			if(L.IsParalyzed())
+				L.Paralyze(60)
 		else //for simple_animals & borgs
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
 		var/turf/location = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Alternative to https://github.com/BeeStation/BeeStation-Hornet/pull/4914
Closes https://github.com/BeeStation/BeeStation-Hornet/pull/4914

## About The Pull Request

Reduces door stun time to 6 seconds.
Doors will only paralyze when crushed if you are not already paralyzed. (The initial crush will stun you hard for 6 seconds, allowing you to get some free hits on them, however any crushes after that will not stack the stun allowing the trapped person to get away if they are still alive after 6 seconds.)
Additionally damage caused by door crushing is reduced by chest armour.

## Why It's Good For The Game

Prevents being chain stunned by doors while still keeping the danger of being caught under them.

## Changelog
:cl:
balance: Door crushing no longer stuns if you are already stunned, preventing chain stunning.
balance: Door crushing stun time reduced from 10 seconsd to 6 seconds.
balance: Door crushing damage reduced by chest armour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
