### PR TITLE
Fixes animals not being able to move after being tabled

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -131,7 +131,8 @@
 
 /obj/structure/table/proc/tableplace(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.forceMove(loc)
-	pushed_mob.set_resting(TRUE, TRUE)
+	if(!isanimal(pushed_mob))
+		pushed_mob.set_resting(TRUE, TRUE)
 	pushed_mob.visible_message("<span class='notice'>[user] places [pushed_mob] onto [src].</span>", \
 								"<span class='notice'>[user] places [pushed_mob] onto [src].</span>")
 	log_combat(user, pushed_mob, "places", null, "onto [src]")
@@ -514,7 +515,8 @@
 
 /obj/structure/table/optable/tablepush(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.forceMove(loc)
-	pushed_mob.set_resting(TRUE, TRUE)
+	if(!isanimal(pushed_mob))
+		pushed_mob.set_resting(TRUE, TRUE)
 	visible_message("<span class='notice'>[user] has laid [pushed_mob] on [src].</span>")
 	get_patient()
 
@@ -536,7 +538,7 @@
 /obj/structure/table/optable/proc/patient_deleted(datum/source)
 	SIGNAL_HANDLER
 	set_patient(null)
-	
+
 /obj/structure/table/optable/proc/check_eligible_patient()
 	get_patient()
 	if(!patient)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -131,7 +131,7 @@
 
 /obj/structure/table/proc/tableplace(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.forceMove(loc)
-	if(!isanimal(pushed_mob))
+	if(!isanimal(pushed_mob) || iscat(pushed_mob))
 		pushed_mob.set_resting(TRUE, TRUE)
 	pushed_mob.visible_message("<span class='notice'>[user] places [pushed_mob] onto [src].</span>", \
 								"<span class='notice'>[user] places [pushed_mob] onto [src].</span>")
@@ -515,7 +515,7 @@
 
 /obj/structure/table/optable/tablepush(mob/living/user, mob/living/pushed_mob)
 	pushed_mob.forceMove(loc)
-	if(!isanimal(pushed_mob))
+	if(!isanimal(pushed_mob) || iscat(pushed_mob))
 		pushed_mob.set_resting(TRUE, TRUE)
 	visible_message("<span class='notice'>[user] has laid [pushed_mob] on [src].</span>")
 	get_patient()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -42,17 +42,6 @@
 	. = ..()
 	add_verb(/mob/living/proc/lay_down)
 
-/mob/living/simple_animal/pet/cat/update_mobility()
-	..()
-	if(stat != DEAD)
-		if (resting)
-			icon_state = "[icon_living]_rest"
-			collar_type = "[initial(collar_type)]_rest"
-		else
-			icon_state = "[icon_living]"
-			collar_type = "[initial(collar_type)]"
-	regenerate_icons()
-
 /mob/living/simple_animal/pet/cat/space
 	name = "space cat"
 	desc = "It's a cat... in space!"
@@ -192,9 +181,13 @@
 
 /mob/living/simple_animal/pet/cat/update_resting()
 	. = ..()
-	if(!resting)
-		icon_state = "[icon_living]"
-		collar_type = "[initial(collar_type)]"
+	if(stat != DEAD)
+		if (resting)
+			icon_state = "[icon_living]_rest"
+			collar_type = "[initial(collar_type)]_rest"
+		else
+			icon_state = "[icon_living]"
+			collar_type = "[initial(collar_type)]"
 
 /mob/living/simple_animal/pet/cat/Life()
 	if(!stat && !buckled && !client)
@@ -202,19 +195,15 @@
 			switch(rand(1, 3))
 				if (1)
 					INVOKE_ASYNC(src, /mob.proc/emote, "me", 1, pick("stretches out for a belly rub.", "wags its tail.", "lies down."))
-					icon_state = "[icon_living]_rest"
-					collar_type = "[initial(collar_type)]_rest"
 					set_resting(TRUE)
 				if (2)
 					INVOKE_ASYNC(src, /mob.proc/emote, "me", 1, pick("sits down.", "crouches on its hind legs.", "looks alert."))
+					set_resting(TRUE)
 					icon_state = "[icon_living]_sit"
 					collar_type = "[initial(collar_type)]_sit"
-					set_resting(TRUE)
 				if (3)
 					if (resting)
 						INVOKE_ASYNC(src, /mob.proc/emote, "me", 1, pick("gets up and meows.", "walks around.", "stops resting."))
-						icon_state = "[icon_living]"
-						collar_type = "[initial(collar_type)]"
 						set_resting(FALSE)
 					else
 						INVOKE_ASYNC(src, /mob.proc/emote, "me", 1, pick("grooms its fur.", "twitches its whiskers.", "shakes out its coat."))

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -44,7 +44,7 @@
 
 /mob/living/simple_animal/pet/cat/update_mobility()
 	..()
-	if(client && stat != DEAD)
+	if(stat != DEAD)
 		if (resting)
 			icon_state = "[icon_living]_rest"
 			collar_type = "[initial(collar_type)]_rest"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simple animals can't move while resting and since most animals can't stop resting they would be unable to move for the rest of the round. Also fixes cat icons not updating when resting is changed from outside of their Life.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being able to move is nice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Animals can move after being tabled
fix: Cats look like they're resting when changed outside of Life
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
