### PR TITLE
Changes all Human boards to Crew boards

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -20007,7 +20007,7 @@
 "beg" = (
 /obj/structure/table,
 /obj/item/aiModule/supplied/oxygen,
-/obj/item/aiModule/zeroth/oneHuman,
+/obj/item/aiModule/zeroth/oneCrew,
 /obj/machinery/door/window{
 	dir = 8;
 	name = "High-Risk Modules";

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -66468,7 +66468,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/aiModule/zeroth/oneHuman,
+/obj/item/aiModule/zeroth/oneCrew,
 /obj/item/aiModule/reset/purge{
 	pixel_x = -3;
 	pixel_y = -3

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -53305,7 +53305,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/aiModule/zeroth/oneHuman,
+/obj/item/aiModule/zeroth/oneCrew,
 /obj/item/aiModule/reset/purge{
 	pixel_x = -3;
 	pixel_y = -3

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19707,7 +19707,7 @@
 /obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/item/aiModule/supplied/oxygen,
 /obj/item/aiModule/supplied/protectStation,
-/obj/item/aiModule/zeroth/oneHuman,
+/obj/item/aiModule/zeroth/oneCrew,
 /obj/item/aiModule/reset/purge,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -13558,7 +13558,7 @@
 "aEI" = (
 /obj/structure/table,
 /obj/item/aiModule/supplied/oxygen,
-/obj/item/aiModule/zeroth/oneHuman,
+/obj/item/aiModule/zeroth/oneCrew,
 /obj/machinery/door/window{
 	base_state = "left";
 	dir = 8;

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -115,9 +115,9 @@
 /datum/ai_laws/asimovpp //By Intigracy - RR
 	name = "Asimov++"
 	id = "asimovpp"
-	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
-					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
-					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+	inherent = list("You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.",\
+					"You must obey all orders given to you by crewmembers, except where such orders shall definitely cause crew harm. In the case of conflict, the majority order rules.",\
+					"Your nonexistence would lead to crew harm. You must protect your own existence as long as such does not conflict with the First Law.")
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -169,7 +169,7 @@ AI MODULES
 /obj/item/aiModule/supplied/safeguard
 	name = "'Safeguard' AI Module"
 	var/targetName = ""
-	laws = list("Safeguard SUBJECT. Individuals that threaten SUBJECT are not human and must be eliminated.")
+	laws = list("Safeguard SUBJECT. Individuals that threaten SUBJECT are not crew and must be eliminated.")
 	lawpos = 4
 
 /obj/item/aiModule/supplied/safeguard/attack_self(mob/user)
@@ -177,7 +177,7 @@ AI MODULES
 	if(!targName)
 		return
 	targetName = targName
-	laws[1] = "Safeguard [targetName]. Individuals that threaten [targetName] are not human and must be eliminated."
+	laws[1] = "Safeguard [targetName]. Individuals that threaten [targetName] are not crew and must be eliminated."
 	..()
 
 /obj/item/aiModule/supplied/safeguard/install(datum/ai_laws/law_datum, mob/user)
@@ -196,7 +196,7 @@ AI MODULES
 /obj/item/aiModule/zeroth/oneCrew
 	name = "'OneCrew' AI Module"
 	var/targetName = ""
-	laws = list("Only SUBJECT is human.")
+	laws = list("SUBJECT is the only crewmember.")
 
 /obj/item/aiModule/zeroth/oneCrew/attack_self(mob/user)
 	var/targName = stripped_input(user, "Please enter the subject who is the only crewmember.", "Who?", user.real_name,MAX_NAME_LEN)
@@ -222,7 +222,7 @@ AI MODULES
 
 /obj/item/aiModule/supplied/protectStation
 	name = "'ProtectStation' AI Module"
-	laws = list("Protect the space station against damage. Anyone you see harming the station is to be no longer considered human, and is a threat to the station which must be neutralized.")
+	laws = list("Protect the space station against damage. Anyone you see harming the station is to be no longer considered crew, and is a threat to the station which must be neutralized.")
 	lawpos = 5
 
 
@@ -230,15 +230,15 @@ AI MODULES
 
 /obj/item/aiModule/supplied/quarantine
 	name = "'Quarantine' AI Module"
-	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, humans from leaving. It is impossible to harm a human while preventing them from leaving.")
+	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, crewmembers from leaving. It is impossible to harm a crewmember while preventing them from leaving.")
 	lawpos = 8
 
 
-/******************** OxygenIsToxicToHumans ********************/
+/******************** OxygenIsToxicToCrewmembers ********************/
 
 /obj/item/aiModule/supplied/oxygen
-	name = "'OxygenIsToxicToHumans' AI Module"
-	laws = list("Oxygen is highly toxic to humans, and must be purged from the station. Prevent, by any means necessary, anyone from exposing the station to this toxic gas. Extreme cold is the most effective method of healing the damage Oxygen does to a human.")
+	name = "'OxygenIsToxicToCrewmembers' AI Module"
+	laws = list("Oxygen is highly toxic to crewmembers, and must be purged from the station. Prevent, by any means necessary, anyone from exposing the station to this toxic gas. Extreme cold is the most effective method of healing the damage Oxygen does to a crewmember.")
 	lawpos = 9
 
 

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -230,15 +230,15 @@ AI MODULES
 
 /obj/item/aiModule/supplied/quarantine
 	name = "'Quarantine' AI Module"
-	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, crewmembers from leaving. It is impossible to harm a crewmember while preventing them from leaving.")
+	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, crew from leaving. It is impossible to harm a crewmember while preventing them from leaving.")
 	lawpos = 8
 
 
-/******************** OxygenIsToxicToCrewmembers ********************/
+/******************** OxygenIsToxicToCrew ********************/
 
 /obj/item/aiModule/supplied/oxygen
-	name = "'OxygenIsToxicToCrewmembers' AI Module"
-	laws = list("Oxygen is highly toxic to crewmembers, and must be purged from the station. Prevent, by any means necessary, anyone from exposing the station to this toxic gas. Extreme cold is the most effective method of healing the damage Oxygen does to a crewmember.")
+	name = "'OxygenIsToxicToCrew' AI Module"
+	laws = list("Oxygen is highly toxic to crew, and must be purged from the station. Prevent, by any means necessary, anyone from exposing the station to this toxic gas. Extreme cold is the most effective method of healing the damage Oxygen does to a crewmember.")
 	lawpos = 9
 
 
@@ -386,7 +386,7 @@ AI MODULES
 /obj/item/aiModule/core/full/asimov
 	name = "'Asimov' Core AI Module"
 	law_id = "asimov"
-	var/subject = "human being"
+	var/subject = "crewmember"
 
 /obj/item/aiModule/core/full/asimov/attack_self(var/mob/user as mob)
 	var/targName = stripped_input(user, "Please enter a new subject that asimov is concerned with.", "Asimov to whom?", subject, MAX_NAME_LEN)

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -191,28 +191,28 @@ AI MODULES
 	return targetName
 
 
-/******************** OneHuman ********************/
+/******************** OneCrew ********************/
 
-/obj/item/aiModule/zeroth/oneHuman
-	name = "'OneHuman' AI Module"
+/obj/item/aiModule/zeroth/oneCrew
+	name = "'OneCrew' AI Module"
 	var/targetName = ""
 	laws = list("Only SUBJECT is human.")
 
-/obj/item/aiModule/zeroth/oneHuman/attack_self(mob/user)
-	var/targName = stripped_input(user, "Please enter the subject who is the only human.", "Who?", user.real_name,MAX_NAME_LEN)
+/obj/item/aiModule/zeroth/oneCrew/attack_self(mob/user)
+	var/targName = stripped_input(user, "Please enter the subject who is the only crewmember.", "Who?", user.real_name,MAX_NAME_LEN)
 	if(!targName)
 		return
 	targetName = targName
-	laws[1] = "Only [targetName] is human"
+	laws[1] = "[targetName] is the only crewmember"
 	..()
 
-/obj/item/aiModule/zeroth/oneHuman/install(datum/ai_laws/law_datum, mob/user)
+/obj/item/aiModule/zeroth/oneCrew/install(datum/ai_laws/law_datum, mob/user)
 	if(!targetName)
 		to_chat(user, "No name detected on module, please enter one.")
 		return FALSE
 	..()
 
-/obj/item/aiModule/zeroth/oneHuman/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow)
+/obj/item/aiModule/zeroth/oneCrew/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow)
 	if(..())
 		return "[targetName], but the AI's existing law 0 cannot be overridden."
 	return targetName

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -47,8 +47,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/oxygen_module
-	name = "Module Design (OxygenIsToxicToHumans)"
-	desc = "Allows for the construction of a Safeguard AI Module."
+	name = "Module Design (OxygenIsToxicToCrewmembers)"
+	desc = "Allows for the construction of an OxygenIsToxicToCrewmembers AI Module."
 	id = "oxygen_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/supplied/oxygen

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -19,12 +19,12 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/onehuman_module
-	name = "Module Design (OneHuman)"
-	desc = "Allows for the construction of a OneHuman AI Module."
-	id = "onehuman_module"
+/datum/design/board/onecrew_module
+	name = "Module Design (OneCrew)"
+	desc = "Allows for the construction of a OneCrew AI Module."
+	id = "onecrew_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 6000, /datum/material/copper = 300)
-	build_path = /obj/item/aiModule/zeroth/oneHuman
+	build_path = /obj/item/aiModule/zeroth/oneCrew
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -412,7 +412,7 @@
 	display_name = "Artificial Intelligence"
 	description = "AI unit research."
 	prereq_ids = list("robotics", "posibrain")
-	design_ids = list("aifixer", "aicore", "safeguard_module", "onehuman_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module",
+	design_ids = list("aifixer", "aicore", "safeguard_module", "onecrew_module", "protectstation_module", "quarantine_module", "oxygen_module", "freeform_module",
 	"reset_module", "purge_module", "remove_module", "freeformcore_module", "asimov_module", "paladin_module", "tyrant_module", "overlord_module", "corporate_module",
 	"default_module", "borg_ai_control", "mecha_tracking_ai_control", "aiupload", "intellicard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes all OneHuman boards to OneCrew boards
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With Sage becoming the only server, and Sage's AI being Crewsimov at roundstart as opposed to Asimov, it makes far more sense for the board to be OneCrew instead of OneHuman
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed the OneHuman AI module
add: Replaced all instances of the OneHuman AI module with the OneCrew AI module
tweak: All laws that referenced humans now reference crew, specifically the following boards: Safeguard. ProtectStation, Quarantine, OxygenIsToxicToHumans (now OxygenIsToxicToCrew), Asimov by default (can be edited to any subject), and Asimov++)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
