### PR TITLE
Fixes metastation engineering being named "Gas to Filter"

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19513,9 +19513,7 @@
 	name = "Waste to Filter"
 	},
 /turf/open/floor/engine,
-/area/engine/engineering{
-	name = "Gas to Filter"
-	})
+/area/engine/engineering)
 "aMj" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bug introduced in https://github.com/BeeStation/BeeStation-Hornet/pull/4249

The area `/area/engine/engineering` has its name set to "Gas to Filter" in the metastation map, somehow carried over from a pump's name. This causes the area to be renamed, along with its air alarm, vents and scrubbers. This PR removes the area name.
**The name was likely supposed to be on some pump instead; this PR does not fix any pump naming.**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Metastation engineering is now named more accurately
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
