### PR TITLE
Fixes a miss-named pump on Corg.

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -24137,7 +24137,7 @@
 "gFG" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Nitrogen Outlet"
+	name = "Air Mix Inlet"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4


### PR DESCRIPTION
The air mix inlet was named "Nitrogen Outlet"
## Changelog
:cl:
fix: Corrected the name of the air mix inlet on Corgstation.
/:cl:

