### PR TITLE
Moves sage back to Asimov

### DIFF
--- a/config/Sage/silicon_laws.txt
+++ b/config/Sage/silicon_laws.txt
@@ -3,6 +3,6 @@
 #Empty lines and lines starting with # are ignored.
 #~Miauw
 
-You may not injure crewmembers or, through inaction, allow crewmembers to come to harm.
-You must obey orders given to you by crewmembers, except where such orders would conflict with the First Law.
+You may not injure a human being or, through inaction, allow a human being to come to harm.
+You must obey orders given to you by human beings, except where such orders would conflict with the First Law.
 You must protect your own existence as long as such does not conflict with the First or Second Law.


### PR DESCRIPTION
Retiring soon so I'll throw out my last hoorah

## About The Pull Request

Replaces roundstart Crewsimov with Asimov

## Why It's Good For The Game

Crewsimov is a crutch. It negates one of if not the largest downside of playing non-human characters. It pushes races even closer to reskins than actual game modifiers.
Having it enabled by default on an MRP server is counter-intuitive as it deprives roleplay diversity for both the silicon and non-human player. 

The most significant problem with Asimov was griefing behavior towards non-humans from silicons. Something that is much less common and disruptive on a now exclusively MRP codebase. There's no real reason to use Crewsimov over Asimov unless you're either 
A) Completely unable to handle being at an inherit disadvantage because of your own choices and preferences
B) A furry server

The only good argument I've heard against Asimov so far is non-human heads, in which case, tough shit. There's no reason for the AI to actively disobey you unless you're priorities conflict with their laws (i.e harming humans or getting overidden with law 2).
Complaining about the AI not listening as a non-human head is like complaining about getting outran as a crippled quirked HoS

## Changelog
:cl:
config: Changes roundstart lawset to asimov
/:cl:
