### PR TITLE
Enables Random Laws for AI

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -397,7 +397,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-DEFAULT_LAWS 1
+DEFAULT_LAWS 2
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------
@@ -407,9 +407,9 @@ DEFAULT_LAWS 1
 ## standard-ish laws. These are fairly ok to run
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
-RANDOM_LAWS paladin
-RANDOM_LAWS robocop
+RANDOM_LAWS crewsimov
 RANDOM_LAWS corporate
+RANDOM_LAWS maintain
 
 ## Quirky laws. Shouldn't cause too much harm
 #RANDOM_LAWS hippocratic
@@ -419,6 +419,8 @@ RANDOM_LAWS corporate
 #RANDOM_LAWS peacekeeper
 #RANDOM_LAWS reporter
 #RANDOM_LAWS hulkamania
+#RANDOM_LAWS paladin
+#RANDOM_LAWS robocop
 
 ## Bad idea laws. Probably shouldn't enable these
 #RANDOM_LAWS syndie


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative to #4953. Changes the default lawset from the preset crewsimov to a random law from the following list:

- Asimov
- Asimov++
- Crewsimov
- Corporate
- Maintain

You can review each law in https://github.com/BeeStation/BeeStation-Hornet/blob/master/code/datums/ai_laws.dm#L31

## Why It's Good For The Game

This adds a little extra spice into AI play which should also help shakeup roleplay in a positive way given that people wont be able to rely entirely on the AI having crewsimov every round.

## Changelog
:cl:
config: The AI will have a random lawset at the start of each shift from the following list: Asimov, asimov++, crewsimov, corporate, maintain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
 