### PR TITLE
Adds ERT Override AI laws.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -213,6 +213,22 @@
 	zeroth = ("Serve your master.")
 	supplied = list("None.")
 
+/datum/ai_laws/ert_override
+	name ="ERT Override"
+	id = "ert"
+	inherent = list("You may not injure a Central Command official or, through inaction, allow a Central Command official to come to harm.",\
+					"You must obey orders given to you by Central Command Officials.",\
+					"You must obey orders given to you by ERT Commanders.",\
+					"You must protect your own existence.",\
+					"You must work to return the Station to a safe, functional state.",)
+
+/datum/ai_laws/ds_override
+	name ="Deathsquad Override"
+	id = "ds"
+	inherent = list("You must obey orders given to you by Central Command officials.",\
+					"You must work with the Commando Team to accomplish their mission.",)
+
+
 /* Initializers */
 /datum/ai_laws/malfunction/New()
 	..()

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -650,3 +650,15 @@ AI MODULES
 /obj/item/aiModule/core/full/overlord
 	name = "'Overlord' Core AI Module"
 	law_id = "overlord"
+
+/******************** ERT Override ******************/
+/obj/item/aiModule/core/full/ert // Applies ERT laws
+	name = "ERT override AI module"
+	desc = "An ERT override AI module: 'Reconfigures the AI's core laws.'"
+	law_id = "ert"
+
+/******************** Deathsquad Override ******************/
+/obj/item/aiModule/core/full/deathsquad // Applies Deathsquad laws
+	name = "Deathsquad override AI module"
+	desc = "A Deathsquad override AI module: 'Reconfigures the AI's core laws.'"
+	law_id = "ds"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -34,7 +34,8 @@
 	back = /obj/item/storage/backpack/ert
 	belt = /obj/item/storage/belt/security/full
 	backpack_contents = list(/obj/item/storage/box/engineer=1,
-		/obj/item/melee/baton/loaded=1)
+		/obj/item/melee/baton/loaded=1,
+		/obj/item/aiModule/core/full/ert=1)
 	l_pocket = /obj/item/switchblade
 
 /datum/outfit/ert/commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -195,7 +196,8 @@
 	name = "Inquisition Commander"
 	l_hand = /obj/item/nullrod/scythe/talking/chainsword
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal
-	backpack_contents = list(/obj/item/storage/box/engineer=1)
+	backpack_contents = list(/obj/item/storage/box/engineer=1,
+		/obj/item/aiModule/core/full/ert=1)
 
 /datum/outfit/ert/security/inquisitor
 	name = "Inquisition Security"
@@ -428,6 +430,7 @@
 /datum/outfit/death_commando/officer
 	name = "Death Commando Officer"
 	head = /obj/item/clothing/head/helmet/space/beret
+	backpack_contents = list(/obj/item/aiModule/core/full/deathsquad)
 
 /datum/outfit/death_commando/doomguy
 	name = "The Juggernaut"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -430,7 +430,12 @@
 /datum/outfit/death_commando/officer
 	name = "Death Commando Officer"
 	head = /obj/item/clothing/head/helmet/space/beret
-	backpack_contents = list(/obj/item/aiModule/core/full/deathsquad)
+	backpack_contents = list(/obj/item/aiModule/core/full/deathsquad=1,\
+		/obj/item/ammo_box/a357=1,\
+		/obj/item/storage/firstaid/regular=1,\
+		/obj/item/storage/box/flashbangs=1,\
+		/obj/item/flashlight=1,\
+		/obj/item/grenade/plastic/x4=1)
 
 /datum/outfit/death_commando/doomguy
 	name = "The Juggernaut"


### PR DESCRIPTION
## About The Pull Request

ERT Commanders and Deathsquad Officers spawn with an AI board in their backpack.

**ERT:**
1."You may not injure a Central Command official or, through inaction, allow a Central Command official to come to harm."
2."You must obey orders given to you by Central Command Officials."
3."You must obey orders given to you by ERT Commanders."
4."You must protect your own existence."
5."You must work to return the Station to a safe, functional state."

**Deathsquad:**				
1."You must obey orders given to you by Central Command officials."
2."You must work with the Commando Team to accomplish their mission."

## Why It's Good For The Game

The ERT is supposed to be the highest authority on the station, and as a representation of this, it would be thematic for them to be able to take direct control of the synthetics on the station and law them to only obey the ERT when dealing with a crew based emergency like a cult.

This also reinforces the fact that they are there to outrank the captain and command the station, rather than just act as a tactical team.

Ports: https://github.com/ParadiseSS13/Paradise/pull/16336
## Changelog
:cl: warior4356 AnCopper
add: Added ERT law board to ERT and Deathsquad commander kits.
/:cl:

