### PR TITLE
Fixes EMP spell not working if the user has antimagic protection

### DIFF
--- a/code/modules/spells/spell_types/emplosion.dm
+++ b/code/modules/spells/spell_types/emplosion.dm
@@ -11,7 +11,7 @@
 /obj/effect/proc_holder/spell/targeted/emplosion/cast(list/targets,mob/user = usr)
 	playsound(get_turf(user), sound, 50,1)
 	for(var/mob/living/target in targets)
-		if(target.anti_magic_check())
+		if(target.anti_magic_check() && !user == target)
 			continue
 		empulse(target.loc, emp_heavy, emp_light)
 

--- a/code/modules/spells/spell_types/emplosion.dm
+++ b/code/modules/spells/spell_types/emplosion.dm
@@ -11,8 +11,7 @@
 /obj/effect/proc_holder/spell/targeted/emplosion/cast(list/targets,mob/user = usr)
 	playsound(get_turf(user), sound, 50,1)
 	for(var/mob/living/target in targets)
-		if(target.anti_magic_check() && !user == target)
+		if(target.anti_magic_check() && target != user)
 			continue
 		empulse(target.loc, emp_heavy, emp_light)
-
 	return


### PR DESCRIPTION
:cl:
fix: fixed EMP spell not doing anything if the user has anti magic
/:cl: