### PR TITLE
Supermatter Surge

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1934,6 +1934,7 @@
 #include "code\modules\events\special_antag_event.dm"
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"
+#include "code\modules\events\supermatter_surge.dm"
 #include "code\modules\events\vent_clog.dm"
 #include "code\modules\events\wormholes.dm"
 #include "code\modules\events\holiday\halloween.dm"

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -1,0 +1,23 @@
+/datum/round_event_control/supermatter_surge
+	name = "Supermatter Surge"
+	typepath = /datum/round_event/supermatter_surge
+	weight = 20
+	max_occurrences = 4
+	earliest_start = 10 MINUTES
+
+/datum/round_event_control/supermatter_surge/canSpawnEvent()
+	if(GLOB.main_supermatter_engine?.has_been_powered)
+		return ..()
+
+/datum/round_event/supermatter_surge
+	var/power = 2000
+
+/datum/round_event/supermatter_surge/setup()
+	power = rand(200,4000)
+
+/datum/round_event/supermatter_surge/announce()
+	if(power > 800 || prob(round(power/8)))
+		priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert")
+
+/datum/round_event/supermatter_surge/start()
+	GLOB.main_supermatter_engine.matter_power += power

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -10,6 +10,7 @@
 		return ..()
 
 /datum/round_event/supermatter_surge
+	announceWhen = 1
 	var/power = 2000
 
 /datum/round_event/supermatter_surge/setup()

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -18,7 +18,7 @@
 
 /datum/round_event/supermatter_surge/announce()
 	if(power > 800 || prob(round(power/8)))
-		priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert")
+		priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())
 
 /datum/round_event/supermatter_surge/start()
 	GLOB.main_supermatter_engine.matter_power += power


### PR DESCRIPTION
### About The Pull Request
Adds the supermatter surge random event which, when triggered, increases the power of the SM for a time.
### Why It's Good For The Game
It is fun to stress test an otherwise extremely safe engine and give it a bit more gameplay.

Ports: https://github.com/Citadel-Station-13/Citadel-Station-13/pull/14307
## Changelog AnCopper, Putnam3145
:cl:
cadd: Adds a new random event which increases the power level of the sm for a bit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
