### PR TITLE
Increases plasma consumption in radiation collectors from 0.001 moles to 0.01 moles

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -243,7 +243,6 @@
 		flick("ca_deactive", src)
 	update_icon()
 	return
-/obj/machinery/power/rad_collector/proc/full()
 
 #undef RAD_COLLECTOR_EFFICIENCY
 #undef RAD_COLLECTOR_COEFFICIENT

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -23,7 +23,7 @@
 	var/active = 0
 	var/locked = FALSE
 	var/drainratio = 0.5
-	var/powerproduction_drain = 0.001
+	var/powerproduction_drain = 0.01
 
 	var/bitcoinproduction_drain = 0.15
 	var/bitcoinmining = FALSE

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -28,7 +28,6 @@
 	var/bitcoinproduction_drain = 0.15
 	var/bitcoinmining = FALSE
 	var/obj/item/radio/radio
-	var/radio_key = /obj/item/encryptionkey/headset_eng
 	var/radio_channel = RADIO_CHANNEL_ENGINEERING
 
 /obj/machinery/power/rad_collector/Initialize()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -28,7 +28,6 @@
 	var/bitcoinproduction_drain = 0.15
 	var/bitcoinmining = FALSE
 	var/obj/item/radio/radio
-	var/radio_channel = RADIO_CHANNEL_ENGINEERING
 
 /obj/machinery/power/rad_collector/Initialize()
 	. = ..()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -54,14 +54,13 @@
 		if(loaded_tank.air_contents.get_moles(GAS_PLASMA) < 0.0001)
 			investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_ENGINES)
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
+			var/msg = "Plasma depleted, recommend replacing tank."
+			radio.talk_into(src, msg, radio_channel)
 			eject()
 		else
 			var/gasdrained = min(powerproduction_drain*drainratio*delta_time,loaded_tank.air_contents.get_moles(GAS_PLASMA))
 			loaded_tank.air_contents.adjust_moles(GAS_PLASMA, -gasdrained)
 			loaded_tank.air_contents.adjust_moles(GAS_TRITIUM, gasdrained)
-			var/msg = "Plasma depleted, recommend replacing tank."
-			radio.talk_into(src, msg, radio_channel)
-
 			var/power_produced = RAD_COLLECTOR_OUTPUT
 			add_avail(power_produced)
 			stored_energy-=power_produced

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -35,7 +35,7 @@
 	. = ..()
 
 	radio = new(src)
-	radio.keyslot = new radio_key
+	radio.keyslot = new /obj/item/encryptionkey/headset_eng
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -54,7 +54,7 @@
 			investigate_log("<font color='red'>out of fuel</font>.", INVESTIGATE_ENGINES)
 			playsound(src, 'sound/machines/ding.ogg', 50, 1)
 			var/msg = "Plasma depleted, recommend replacing tank."
-			radio.talk_into(src, msg, radio_channel)
+			radio.talk_into(src, msg, RADIO_CHANNEL_ENGINEERING)
 			eject()
 		else
 			var/gasdrained = min(powerproduction_drain*drainratio*delta_time,loaded_tank.air_contents.get_moles(GAS_PLASMA))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

increase plasma consumption in radiation collectors by 1000% or whatever so their fullness actually MATTERS
with a 0.01 mole usage per process (generally occur every 2 seconds according to round timer) a radiation collector will have burnt through 10 moles of plasma or ~303 kpa in just over 30 minutes, with filled plasma tanks lasting roughly 90 minutes before needing to be refilled or replaced, with cooled tanks being able to hold more plasma and therefore lasting even longer.
all plasma consumed by this is transformed into tritium which can be mixed with oxygen in a rad collector to make research points as if that even matters. The consumption of trit/oxygen has not been changed.

## Why It's Good For The Game

more engine maintenance = more for engineers to do when not sticking thumb in ass

Ports: https://github.com/yogstation13/Yogstation/pull/11063 
## Changelog
:cl: SomeguyManperson AnCopper
tweak: Increased plasma to tritium rate in radiation collectors from 0.001 to 0.01, this means that a standard plasma tank at 303 kPA (or 10 moles) will be completely converted into tritium at just over 30 minutes, requiring it to be replaced in order to generate electricity, fill the plasma tanks or make the plasma colder to fit more into the tank.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
