### PR TITLE
Mediborg's Amputation Adventure - Emag Edition

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1259,7 +1259,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 						BP.dismember()
 						qdel(BP)
 			playsound(loc, 'sound/arcade/win.ogg', 50, 1, extrarange = -3, falloff_exponent = 10)
-			for(var/i=1; i<=rand(20,30); i++)
+			for(var/i=1 to rand(20, 30))
 				prizevend(user)
 		else
 			to_chat(c_user, "<span class='notice'>You (wisely) decide against putting your hand in the machine.</span>")

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1245,23 +1245,51 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	if(!iscarbon(user))
 		return
 	var/mob/living/carbon/c_user = user
-	if(!c_user.get_bodypart(BODY_ZONE_L_ARM) && !c_user.get_bodypart(BODY_ZONE_R_ARM))
-		return
-	to_chat(c_user, "<span class='warning'>You move your hand towards the machine, and begin to hesitate as a bloodied guillotine emerges from inside of it...</span>")
-	if(do_after(c_user, 50, target = src))
-		to_chat(c_user, "<span class='userdanger'>The guillotine drops on your arm, and the machine sucks it in!</span>")
-		playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
-		var/which_hand = BODY_ZONE_L_ARM
-		if(!(c_user.active_hand_index % 2))
-			which_hand = BODY_ZONE_R_ARM
-		var/obj/item/bodypart/chopchop = c_user.get_bodypart(which_hand)
-		chopchop.dismember()
-		qdel(chopchop)
-		playsound(loc, 'sound/arcade/win.ogg', 50, 1, extrarange = -3, falloff_exponent = 10)
-		for(var/i=1; i<=rand(3,5); i++)
-			prizevend(user)
+	if(obj_flags & EMAGGED)
+		if(!c_user.get_bodypart(BODY_ZONE_L_ARM) && !c_user.get_bodypart(BODY_ZONE_R_ARM))
+			return
+		to_chat(c_user, "<span class='warning'>You move your hand towards the machine, and begin to hesitate as an extra-bloodied guillotine emerges from inside of it...</span>")
+		if(do_after(c_user, 50, target = src))
+			to_chat(c_user, "<span class='userdanger'>Robotic arms shoot out of the machine, remove all your limbs, and suck them in!</span>")
+			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
+			for(var/X in c_user.bodyparts)
+				var/obj/item/bodypart/BP = X
+				if(BP.body_part != HEAD && BP.body_part != CHEST)
+					if(BP.dismemberable)
+						BP.dismember()
+						qdel(BP)
+			playsound(loc, 'sound/arcade/win.ogg', 50, 1, extrarange = -3, falloff_exponent = 10)
+			for(var/i=1; i<=rand(20,30); i++)
+				prizevend(user)
+		else
+			to_chat(c_user, "<span class='notice'>You (wisely) decide against putting your hand in the machine.</span>")
 	else
-		to_chat(c_user, "<span class='notice'>You (wisely) decide against putting your hand in the machine.</span>")
+		if(!c_user.get_bodypart(BODY_ZONE_L_ARM) && !c_user.get_bodypart(BODY_ZONE_R_ARM))
+			return
+		to_chat(c_user, "<span class='warning'>You move your hand towards the machine, and begin to hesitate as a bloodied guillotine emerges from inside of it...</span>")
+		if(do_after(c_user, 50, target = src))
+			to_chat(c_user, "<span class='userdanger'>The guillotine drops on your arm, and the machine sucks it in!</span>")
+			playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
+			var/which_hand = BODY_ZONE_L_ARM
+			if(!(c_user.active_hand_index % 2))
+				which_hand = BODY_ZONE_R_ARM
+			var/obj/item/bodypart/chopchop = c_user.get_bodypart(which_hand)
+			chopchop.dismember()
+			qdel(chopchop)
+			playsound(loc, 'sound/arcade/win.ogg', 50, 1, extrarange = -3, falloff_exponent = 10)
+			for(var/i=1; i<=rand(3,5); i++)
+				prizevend(user)
+		else
+			to_chat(c_user, "<span class='notice'>You (wisely) decide against putting your hand in the machine.</span>")
+
+
+/obj/machinery/computer/arcade/amputation/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	to_chat(user, "<span class='notice'>You override the safety systems on the arcade machine.</span>")
+	name = "Mediborg's Amputation Adventure: Deluxe Edition"
+	desc = "A picture of a blood-soaked medical cyborg flashes on the screen. The mediborg has glowing red eyes, and a speech bubble that says, \"Put your hand in the machine if you aren't a <b>coward!</b>\""
+	obj_flags |= EMAGGED
 
 #undef ORION_TRAIL_WINTURN
 #undef ORION_TRAIL_RAIDERS

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1277,7 +1277,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 			chopchop.dismember()
 			qdel(chopchop)
 			playsound(loc, 'sound/arcade/win.ogg', 50, 1, extrarange = -3, falloff_exponent = 10)
-			for(var/i=1; i<=rand(3,5); i++)
+			for(var/i=1 to rand(3, 5))
 				prizevend(user)
 		else
 			to_chat(c_user, "<span class='notice'>You (wisely) decide against putting your hand in the machine.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now emag Mediborg's Amputation Adventure, instead of taking one limb it will take all of them, and dispense 20-30 tokens if you choose to do so.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The other two arcade machines have emag functions, why not this one?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Mediborg's Amputation Adventure can now be emagged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
