### PR TITLE
Fixes igniters and sparks failing to ignite flammable gases

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -43,6 +43,7 @@
 	var/temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 	var/bypassing = FALSE
 	var/visual_update_tick = 0
+	var/first_cycle = TRUE
 
 /obj/effect/hotspot/Initialize(mapload, starting_volume, starting_temperature)
 	. = ..()
@@ -62,7 +63,9 @@
 
 	location.active_hotspot = src
 
-	bypassing = volume > CELL_VOLUME*0.95 || location.air.return_temperature() > FUSION_TEMPERATURE_THRESHOLD
+	bypassing = !first_cycle && volume > CELL_VOLUME*0.95 || location.air.return_temperature() > FUSION_TEMPERATURE_THRESHOLD
+	if(first_cycle)
+		first_cycle = FALSE
 
 	if(bypassing)
 		volume = location.air.reaction_results["fire"]*FIRE_GROWTH_RATE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Igniters and sparks have their volume argument for `hotspot_expose()` set much higher than lighters and welding tools, so they fail the volume check for `bypassing` in `perform_exposure()` on the very first cycle, leading to them never changing the temperature of the gas mixture and instead just showing a flaming sprite. Previously, before auxmos, it would check if the hotspot was just created by checking if the turf was still being processed and ignore the bypass, but the `current_cycle` var on turfs was removed and `just_created` on hotspots along with it

this just makes it so that hotspots change temperature at least once just like before which is how igniters worked previously

closes https://github.com/BeeStation/BeeStation-Hornet/issues/4923
closes https://github.com/BeeStation/BeeStation-Hornet/issues/4989
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
igniters and sparks ignite again and don't just make a flaming effect that makes you think the gas is getting hotter
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: sparks and igniters not igniting gas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
