### PR TITLE
Corrects the resources.txt file for local dev

### DIFF
--- a/config/resources.txt
+++ b/config/resources.txt
@@ -16,14 +16,14 @@ EXTERNAL_RSC_URLS http://rsc.beestation13.buzz/beestation.zip
 # The normal way of getting assets to clients is to use the internal byond system. This can be slow and delay the opening of interface windows. It also doesn't allow the internal IE windows byond uses to cache anything.
 # You can instead have the server save them to a website via a folder within the game server that the web server can read. This could be a simple webserver or something backed by a CDN.
 # Valid values: simple, webroot. Simple is the default.
-ASSET_TRANSPORT webroot
+#ASSET_TRANSPORT webroot
 
 
 # Simple asset transport configurable values.
 
 # Uncomment this to have the server passively send all browser assets to each client in the background. (instead of waiting for them to be needed)
 # This should be uncommented in production and commented in development
-ASSET_SIMPLE_PRELOAD
+#ASSET_SIMPLE_PRELOAD
 
 
 # Webroot asset transport configurable values.


### PR DESCRIPTION
This was missed during review for #4996 , leaving these uncommented will cause TGUI to crash during local development.