### PR TITLE
Removes the soul from chaplain.dm (Removes banbait religions)

### DIFF
--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -65,8 +65,6 @@
 			B.name = "The Necronomicon"
 		if("hinduism")
 			B.name = "The Vedas"
-		if("homosexuality")
-			B.name = pick("Guys Gone Wild","Coming Out of The Closet")
 		if("imperium")
 			B.name = "Uplifting Primer"
 		if("islam")
@@ -75,9 +73,6 @@
 			B.name = "The Torah"
 		if("lampism")
 			B.name = "Fluorescent Incandescence"
-		if("lol", "wtf", "gay", "penis", "ass", "poo", "badmin", "shitmin", "deadmin", "cock", "cocks", "meme", "memes")
-			B.name = pick("Woodys Got Wood: The Aftermath", "War of the Cocks", "Sweet Bro and Hella Jef: Expanded Edition","F.A.T.A.L. Rulebook")
-			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 100) // starts off intellectually disabled as fuck
 		if("monkeyism","apism","gorillism","primatism")
 			B.name = pick("Going Bananas", "Bananas Out For Harambe")
 		if("mormonism")
@@ -98,10 +93,6 @@
 			B.desc = "Happy, Full, Clean. Live it and give it."
 		if("subgenius")
 			B.name = "Book of the SubGenius"
-		if("toolboxia","greytide")
-			B.name = pick("Toolbox Manifesto","iGlove Assistants")
-		if("weeaboo","kawaii")
-			B.name = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
 		else
 			B.name = "The Holy Book of [new_religion]"
 

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -93,6 +93,10 @@
 			B.desc = "Happy, Full, Clean. Live it and give it."
 		if("subgenius")
 			B.name = "Book of the SubGenius"
+		if("toolboxia","greytide")
+			B.name = pick("Toolbox Manifesto","iGlove Assistants")
+		if("weeaboo","kawaii")
+			B.name = pick("Fanfiction Compendium","Japanese for Dummies","The Manganomicon","Establishing Your O.T.P")
 		else
 			B.name = "The Holy Book of [new_religion]"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deletes the religions Ruko cleaned out from 
https://wiki.beestation13.com/view/Religion

which could get you banned if you used them already.

No more brain damage religion either. 

## Why It's Good For The Game

Banbait bad, with the current server rules there's no good reason to pick any of those religions. 

## Side note: I left two religions in that are not on that page. One is "lampism" and the other "servicianism," neither of them seemed bad enough for me to delete, but if anyone's up for listing them on the wiki, it'd be fantastic. 

## Changelog
:cl:Froststahr
del: A few religions whose use would result in risking a ban have been deleted. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
