### PR TITLE
Adds the combat hypo

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -88,6 +88,7 @@
 	volume = 90
 	possible_transfer_amounts = list(10,15,30,45)
 	self_only = 1
+	ignore_flags = 0
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/tricordrazine = 15)
 
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -14,6 +14,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	var/ignore_flags = 0
 	var/infinite = FALSE
+	var/self_only = 0
 
 /obj/item/reagent_containers/hypospray/attack_paw(mob/user)
 	return attack_hand(user)
@@ -32,7 +33,7 @@
 	var/contained = english_list(injected)
 	log_combat(user, M, "attempted to inject", src, "([contained])")
 
-	if(reagents.total_volume && (ignore_flags || M.can_inject(user, 1))) // Ignore flag should be checked first or there will be an error message.
+	if(reagents.total_volume && (ignore_flags || M.can_inject(user, 1)) && (!self_only || user == M)) // Ignore flag should be checked first or there will be an error message.
 		to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
 		to_chat(user, "<span class='notice'>You inject [M] with [src].</span>")
 		playsound(loc, 'sound/items/hypospray.ogg', 50, 1)
@@ -77,6 +78,19 @@
 	possible_transfer_amounts = list(10,15,30,45)
 	ignore_flags = 1 // So they can heal their comrades.
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/stabilizing_nanites = 15)
+
+/obj/item/reagent_containers/hypospray/combat/weaker
+	name = "combat stimulant injector"
+	desc = "A modified air-needle autoinjector, used by syndicate operatives to quickly patch their own wounds in combat."
+	amount_per_transfer_from_this = 15
+	item_state = "combat_hypo"
+	icon_state = "combat_hypo"
+	volume = 90
+	possible_transfer_amounts = list(10,15,30,45)
+	ignore_flags = 1
+	self_only = 1
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 20, /datum/reagent/medicine/stabilizing_nanites = 10)
+
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	name = "experimental combat stimulant injector"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -87,9 +87,8 @@
 	icon_state = "combat_hypo"
 	volume = 90
 	possible_transfer_amounts = list(10,15,30,45)
-	ignore_flags = 1
 	self_only = 1
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 20, /datum/reagent/medicine/stabilizing_nanites = 10)
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/tricordrazine = 15)
 
 
 /obj/item/reagent_containers/hypospray/combat/nanites

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1581,6 +1581,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/belt/military
 	cost = 1
 
+/datum/uplink_item/device_tools/combat_hypo
+	name = "Combat Medical Injector"
+	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat. Comes with six doses by default, dosage can be adjusted."
+	item = /obj/item/reagent_containers/hypospray/combat
+	cost = 3
+
 /datum/uplink_item/device_tools/emag
 	name = "Cryptographic Sequencer"
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1583,8 +1583,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/combat_hypo
 	name = "Combat Medical Injector"
-	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat. Comes with six doses by default, dosage can be adjusted."
-	item = /obj/item/reagent_containers/hypospray/combat
+	desc = "A modified air-needle autoinjector, used by syndicate operatives to quickly patch their own wounds in combat. Comes with six doses by default, dosage can be adjusted."
+	item = /obj/item/reagent_containers/hypospray/combat/weaker
 	cost = 3
 
 /datum/uplink_item/device_tools/emag


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the combat hypospray  to the uplink for 3TC.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The combat hypo is normally found in the 4TC medkit during Nuke Ops, along with brute/burn patches, atropine, and a combat defib. This implements the suggestion in #4695 made by Bacon, to make just the hypo available for traitors. I wavered between prices before eventually landing on 3TC, if that's too much or too little I'll change it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Traitors can now purchase the Combat Hypospray for 3TC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
