### PR TITLE
Head Revs can now convert Roundstart blind personnel

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -246,6 +246,8 @@
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
 			to_chat(user, "<span class='warning'>You fail to blind [M] with the flash!</span>")
 			to_chat(M, "<span class='danger'>[user] fails to blind you with the flash!</span>")
+			if(HAS_TRAIT_FROM(M,TRAIT_BLIND, ROUNDSTART_TRAIT))
+				terrible_conversion_proc(M,user)
 		else
 			to_chat(M, "<span class='danger'>[src] fails to blind you!</span>")
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Flashing a person who has the Blind trait as a **Roundstart** quirk will convert them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When revs reach a certain stage (or even earlier depending on the headrev), they start murdering everyone they can't convert, which sadly includes blind people. Additionally, this allows blind people to partake in the fun (Editor's note: rev rounds being fun is subjective) of a revs round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Headrevs can now convert people with the Blind quirk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
