### PR TITLE
Fixes deaf people being able to see runechat messages.

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -287,7 +287,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	animate(message, alpha = 0, pixel_y = message.pixel_y + MESSAGE_FADE_PIXEL_Y, time = fadetime, flags = ANIMATION_PARALLEL)
 	enter_subsystem(eol_complete) // re-enter the runechat SS with the EOL completion time to QDEL self
 
-/mob/proc/should_show_chat_message(atom/movable/speaker, datum/language/message_language, raw_message, is_emote = FALSE, is_heard = FALSE)
+/mob/proc/should_show_chat_message(atom/movable/speaker, datum/language/message_language, is_emote = FALSE, is_heard = FALSE)
 	if(!client)
 		return CHATMESSAGE_CANNOT_HEAR
 	if(!client.prefs.chat_on_map || (!client.prefs.see_chat_non_mob && !ismob(speaker)))
@@ -313,7 +313,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		return CHATMESSAGE_SHOW_LANGUAGE_ICON
 	return CHATMESSAGE_HEAR
 
-/mob/living/should_show_chat_message(atom/movable/speaker, datum/language/message_language, raw_message, is_emote = FALSE)
+/mob/living/should_show_chat_message(atom/movable/speaker, datum/language/message_language, is_emote = FALSE, is_heard = FALSE)
 	if(stat != CONSCIOUS && stat != DEAD)
 		return CHATMESSAGE_CANNOT_HEAR
 	return ..()

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -287,12 +287,14 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	animate(message, alpha = 0, pixel_y = message.pixel_y + MESSAGE_FADE_PIXEL_Y, time = fadetime, flags = ANIMATION_PARALLEL)
 	enter_subsystem(eol_complete) // re-enter the runechat SS with the EOL completion time to QDEL self
 
-/mob/proc/should_show_chat_message(atom/movable/speaker, datum/language/message_language, raw_message, is_emote = FALSE)
+/mob/proc/should_show_chat_message(atom/movable/speaker, datum/language/message_language, raw_message, is_emote = FALSE, is_heard = FALSE)
 	if(!client)
 		return CHATMESSAGE_CANNOT_HEAR
 	if(!client.prefs.chat_on_map || (!client.prefs.see_chat_non_mob && !ismob(speaker)))
 		return CHATMESSAGE_CANNOT_HEAR
 	if(!client.prefs.see_rc_emotes && is_emote)
+		return CHATMESSAGE_CANNOT_HEAR
+	if(is_heard && !can_hear())
 		return CHATMESSAGE_CANNOT_HEAR
 	//If the speaker is a virtual speaker, check to make sure we couldnt hear the original message.
 	if(istype(speaker, /atom/movable/virtualspeaker))

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -424,7 +424,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		var/datum/holocall/HC = I
 		if(HC.connected_holopad == src && speaker != HC.hologram)
 			HC.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
-			if(HC.user.should_show_chat_message(speaker, message_language, FALSE))
+			if(HC.user.should_show_chat_message(speaker, message_language, FALSE, is_heard = TRUE))
 				create_chat_message(speaker, message_language, list(HC.user), raw_message, spans, message_mods)
 
 	if(outgoing_call && speaker == outgoing_call.user)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -190,7 +190,7 @@
 	for(var/atom/movable/hearer in receive)
 		if(ismob(hearer))
 			var/mob/M = hearer
-			if(M.should_show_chat_message(virt, language, FALSE))
+			if(M.should_show_chat_message(virt, language, FALSE, is_heard = TRUE))
 				show_overhead_message_to += M
 		hearer.Hear(rendered, virt, language, message, frequency, spans, message_mods)
 	if(length(show_overhead_message_to))

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	for(var/atom/movable/AM as() in get_hearers_in_view(range, source))
 		if(ismob(AM))
 			var/mob/M = AM
-			if(M.should_show_chat_message(source, message_language, FALSE))
+			if(M.should_show_chat_message(source, message_language, FALSE, is_heard = TRUE))
 				show_overhead_message_to += M
 		AM.Hear(rendered, src, message_language, message, , spans, message_mods)
 	if(length(show_overhead_message_to))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -264,13 +264,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(eavesdrop_range && get_dist(source, AM) > message_range && !(the_dead[AM]))
 			if(ismob(AM))
 				var/mob/M = AM
-				if(should_show_chat_message(M, message_language, FALSE))
+				if(should_show_chat_message(M, message_language, FALSE, is_heard = TRUE))
 					show_overhead_message_to_eavesdrop += M
 			AM.Hear(eavesrendered, src, message_language, eavesdropping, , spans, message_mods)
 		else
 			if(ismob(AM))
 				var/mob/M = AM
-				if(should_show_chat_message(M, message_language, FALSE))
+				if(should_show_chat_message(M, message_language, FALSE, is_heard = TRUE))
 					show_overhead_message_to += M
 			AM.Hear(rendered, src, message_language, message, , spans, message_mods)
 	if(length(show_overhead_message_to))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -254,7 +254,7 @@
 
 	var/list/show_to = list()
 	for(var/mob/M in hearers)
-		if(is_emote && M.should_show_chat_message(src, null, TRUE) && M.can_hear())
+		if(is_emote && M.should_show_chat_message(src, null, TRUE, is_heard = TRUE))
 			show_to += M
 		M.show_message(message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deaf people can no longer see audible runechat messages.

## Why It's Good For The Game

Bug fix, deaf people should not be able to see messages they cannot hear.

## Changelog
:cl:
fix: Deaf people can no longer see runechat messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
