### PR TITLE
Fixes crafting UI not updating after crafting

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -332,6 +332,7 @@
 			cur_subcategory = CAT_NONE
 		ui = new(user, src, "PersonalCrafting")
 		ui.open()
+		ui.set_autoupdate(TRUE)
 
 /datum/component/personal_crafting/ui_data(mob/user)
 	var/list/data = list()

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -332,7 +332,6 @@
 			cur_subcategory = CAT_NONE
 		ui = new(user, src, "PersonalCrafting")
 		ui.open()
-		ui.set_autoupdate(TRUE)
 
 /datum/component/personal_crafting/ui_data(mob/user)
 	var/list/data = list()
@@ -404,6 +403,7 @@
 			else
 				to_chat(user, "<span class='warning'>Construction failed[result]</span>")
 			busy = FALSE
+			ui_update()
 		if("toggle_recipes")
 			display_craftable_only = !display_craftable_only
 			. = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Not having  the crafting UI update after crafting sucks for items in bulk, i.e. shotgun shells.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Crafting UI updates after crafting

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
