### PR TITLE
Round time starts counting from round-start, not world-start

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -11,15 +11,15 @@
 /proc/gameTimestamp(format = "hh:mm:ss", wtime=null)
 	if(!wtime)
 		wtime = world.time
-	return time2text(wtime - GLOB.timezoneOffset, format)
+	return time2text(wtime, format, 0)
 
 /// Returns the station time in deciseconds
 /proc/station_time(display_only = FALSE, wtime=world.time)
-	return ((((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000) - (display_only? GLOB.timezoneOffset : 0)
+	return (((wtime - SSticker.round_start_time) * SSticker.station_time_rate_multiplier) + SSticker.gametime_offset) % 864000
 
 /// Returns the station time in hh:mm:ss
 /proc/station_time_timestamp(format = "hh:mm:ss", wtime)
-	return time2text(station_time(TRUE, wtime), format)
+	return time2text(station_time(TRUE, wtime), format, 0)
 
 /proc/station_time_debug(force_set)
 	if(isnum_safe(force_set))

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -1,7 +1,5 @@
 GLOBAL_VAR_INIT(admin_notice, "") //! Admin notice that all clients see when joining the server
 
-GLOBAL_VAR_INIT(timezoneOffset, 0) //! The difference betwen midnight (of the host computer) and 0 world.ticks.
-
 GLOBAL_VAR_INIT(fileaccess_timer, 0) //! For FTP requests. (i.e. downloading runtime logs.) However it'd be ok to use for accessing attack logs and such too, which are even laggier.
 
 GLOBAL_VAR_INIT(TAB, "&nbsp;&nbsp;&nbsp;&nbsp;")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -46,8 +46,6 @@ GLOBAL_VAR(restart_counter)
 	if(CONFIG_GET(flag/usewhitelist))
 		load_whitelist()
 
-	GLOB.timezoneOffset = text2num(time2text(0,"hh")) * 36000
-
 	if(fexists(RESTART_COUNTER_PATH))
 		GLOB.restart_counter = text2num(trim(rustg_file_read(RESTART_COUNTER_PATH)))
 		fdel(RESTART_COUNTER_PATH)

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -134,7 +134,10 @@
 		tab_data["Next Map"] = GENERATE_STAT_TEXT(cached.map_name)
 	tab_data["Round ID"] = GENERATE_STAT_TEXT("[GLOB.round_id ? GLOB.round_id : "Null"]")
 	tab_data["Server Time"] = GENERATE_STAT_TEXT(time2text(world.timeofday,"YYYY-MM-DD hh:mm:ss"))
-	tab_data["Round Time"] = GENERATE_STAT_TEXT(worldtime2text())
+	if (SSticker.round_start_time)
+		tab_data["Round Time"] = GENERATE_STAT_TEXT(gameTimestamp("hh:mm:ss", (world.time - SSticker.round_start_time)))
+	else
+		tab_data["Lobby Time"] = GENERATE_STAT_TEXT(worldtime2text())
 	tab_data["Station Time"] = GENERATE_STAT_TEXT(station_time_timestamp())
 	tab_data["Time Dilation"] = GENERATE_STAT_TEXT("[round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
 	tab_data["Players Connected"] = GENERATE_STAT_TEXT("[GLOB.clients.len]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/48273

Round-time starts counting from the moment the round actually starts, before the round starts "Lobby time" is displayed counting from server start instead.

Refactors the way time displaying works, removes `GLOB.timezoneOffset` and instead uses a new `time2text` param that allows you to specify the offset from UTC. When the offset is set to `0`, the number `0` corresponds to the time of `00:00:00` (of current date?), which is just perfect.

The reason for the refactor is that the previous method just didn't fucking work for me, instead starting the timer at 23:00:00 *on current master*, which I only noticed while testing things for this. I don't know why that happens, and this definitely needs a proper review and probably a simple testmerge to verify I don't mess it up with it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The round time is no longer awkwardly offset by however long the lobby lasts, instead 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Round start timer in the stat-panel now tracks time accurately from actual start of round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
