### PR TITLE
fix door timer UI update

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -262,7 +262,7 @@
 				activation_time = world.time
 		else
 			. = FALSE
-	ui_update()
+	
 
 
 #undef PRESET_SHORT

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -156,7 +156,7 @@
 	if(!ui)
 		ui = new(user, src, "BrigTimer")
 		ui.open()
-
+		ui.set_autoupdate(TRUE)
 //icon update function
 // if NOPOWER, display blank
 // if BROKEN, display blue screen of death icon AI uses

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -262,6 +262,7 @@
 				activation_time = world.time
 		else
 			. = FALSE
+	ui_update()
 
 
 #undef PRESET_SHORT


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the UI for brig timers so you can actually see the time you're setting it to. 85% sure the indentation is right (webedit, sorry)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sec can properly give 15 minute timers for simple theft without hassle again. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed brig timer's UI not updating properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
