### PR TITLE
Fixing Jellypeople

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -548,16 +548,17 @@
 
 /datum/action/innate/use_extract/ApplyIcon(atom/movable/screen/movable/action_button/current_button, force)
 	..(current_button, TRUE)
-	var/datum/species/jelly/luminescent/species = owner
+	var/mob/living/carbon/human/H = owner
+	var/datum/species/jelly/luminescent/species = H.dna.species
 	if(species && species.current_extract)
 		current_button.add_overlay(mutable_appearance(species.current_extract.icon, species.current_extract.icon_state))
 
 /datum/action/innate/use_extract/Activate()
 	var/mob/living/carbon/human/H = owner
-	var/datum/species/jelly/luminescent/species = owner
+	CHECK_DNA_AND_SPECIES(H)
+	var/datum/species/jelly/luminescent/species = H.dna.species
 	if(!is_species(H, /datum/species/jelly/luminescent) || !species)
 		return
-	CHECK_DNA_AND_SPECIES(H)
 
 	if(species.current_extract)
 		species.extract_cooldown = world.time + 100
@@ -607,6 +608,8 @@
 /datum/species/jelly/stargazer/spec_death(gibbed, mob/living/carbon/human/H)
 	..()
 	for(var/mob/living/link_to_clear as anything in linked_mobs)
+		if(link_to_clear == H)
+			continue
 		unlink_mob(link_to_clear)
 
 /datum/species/jelly/stargazer/on_species_gain(mob/living/carbon/C, datum/species/old_species)
@@ -748,7 +751,7 @@
 		return
 
 	var/mob/living/target = H.pulling
-	var/datum/species/jelly/stargazer/species = target
+	var/datum/species/jelly/stargazer/species = H.dna.species
 
 	to_chat(H, "<span class='notice'>You begin linking [target]'s mind to yours...</span>")
 	to_chat(target, "<span class='warning'>You feel a foreign presence within your mind...</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This should fix some issues with luminescents and stargazers that came from https://github.com/BeeStation/BeeStation-Hornet/pull/4598

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I wanna be luminescent thanos again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Luminescents and stargazers have their actions working again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
