### PR TITLE
Lighting Quickfixes, Seclights and Swarmers

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -96,6 +96,8 @@
 	loot = list(/obj/effect/decal/cleanable/robot_debris, /obj/item/stack/ore/bluespace_crystal)
 	del_on_death = TRUE
 	deathmessage = "explodes with a sharp pop!"
+	light_system = MOVABLE_LIGHT
+	light_range = 0
 	light_color = LIGHT_COLOR_CYAN
 	hud_type = /datum/hud/swarmer
 	speech_span = SPAN_ROBOT
@@ -666,9 +668,9 @@
 
 /mob/living/simple_animal/hostile/swarmer/proc/ToggleLight()
 	if(!light_range)
-		set_light(3)
+		set_light_range(3)
 	else
-		set_light(0)
+		set_light_range(0)
 
 /mob/living/simple_animal/hostile/swarmer/proc/swarmer_chat(msg)
 	var/rendered = "<B>Swarm communication - [src]</b> [say_quote(msg)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

reverts this https://github.com/tgstation/tgstation/pull/57058
adds this as I noticed the same runtime
https://github.com/tgstation/tgstation/pull/54614

closes https://github.com/BeeStation/BeeStation-Hornet/issues/4597

I did this tired as fuck since I cant leave seclights broken before going to bed, there's probably more work that needs done later. (The hud icons still dont even update but I don't think they did before either.)
## Why It's Good For The Game
mounted seclights should work
Swarmer also uses the new lighting system properly. 


## Changelog
:cl:Froststahr
fix: Mounted Seclights and swarmers should light up properly again. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
