### PR TITLE
Makes the handheld crew pinpointer display who it's pinpointing.

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -38,6 +38,12 @@
 	toggle_on()
 	user.visible_message("<span class='notice'>[user] [active ? "" : "de"]activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You [active ? "" : "de"]activate your pinpointer.</span>")
 
+/obj/item/pinpointer/examine(mob/user)
+	. = ..()
+	if(!active || !target)
+		return
+	. += "It is currently tracking <b>[target]</b>."
+
 /obj/item/pinpointer/proc/toggle_on()
 	active = !active
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -38,12 +38,6 @@
 	toggle_on()
 	user.visible_message("<span class='notice'>[user] [active ? "" : "de"]activates [user.p_their()] pinpointer.</span>", "<span class='notice'>You [active ? "" : "de"]activate your pinpointer.</span>")
 
-/obj/item/pinpointer/examine(mob/user)
-	. = ..()
-	if(!active || !target)
-		return
-	. += "It is currently tracking <b>[target]</b>."
-
 /obj/item/pinpointer/proc/toggle_on()
 	active = !active
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, 1)
@@ -99,6 +93,12 @@
 	custom_price = 150
 	var/has_owner = FALSE
 	var/pinpointer_owner = null
+
+/obj/item/pinpointer/crew/examine(mob/user)
+	. = ..()
+	if(!active || !target)
+		return
+	. += "It is currently tracking <b>[target]</b>."
 
 /obj/item/pinpointer/crew/proc/trackable(mob/living/carbon/human/H)
 	var/turf/here = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title. Why was this not in the game before I have no idea.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The pinpointer should realistically show who it's tracking.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: handheld pinpointer now shows the name of the person it's tracking
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
