### PR TITLE
fix glowstick lootdrop runtimes

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -555,9 +555,9 @@
 	found.on = TRUE
 	found.icon_state = "[initial(found.icon_state)]-on"
 	if(found.light_power)
-		found.set_light(l_range = found.light_range, l_power = found.light_power)
+		found.set_light_on(TRUE)
 	else
-		found.set_light(found.light_range)
+		found.set_light_on(FALSE)
 	for(var/X in found.actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Something wasn't done properly, making runtimes when these things spawn. 
Might have been the original overlay port, or maybe bacon's flashlight changes were afterward, and it's not the kind of thing that would merge conflict, who knows w.e. 

## Why It's Good For The Game
🐛


## Changelog
:cl:Froststahr
fix: lootdrop glowsticks won't generate runtimes and will glow properly on spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
