### PR TITLE
Cheap lighter no longer costs more than Zippo

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -554,7 +554,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	heat = 1500
 	resistance_flags = FIRE_PROOF
 	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/oil = 5)
-	custom_price = 55
 	light_system = MOVABLE_LIGHT
 	light_range = 2
 	light_power = 0.6


### PR DESCRIPTION
## About The Pull Request

What the fuck is this
![image](https://user-images.githubusercontent.com/81387903/128810423-595897fd-551e-417f-a85f-5a357a878191.png)
(Butchered commit name and I'm not fixing it, cry)

## Why It's Good For The Game

Game make sense, game good

## Changelog
:cl:
balance: Cheap lighter no longer costs more than a Zippo lighter
/:cl:
