### PR TITLE
Laptops and tablets no longer drop a battery when destroyed

### DIFF
--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -13,15 +13,13 @@
 		battery = new battery_type(src)
 
 /obj/item/computer_hardware/battery/Destroy()
-	battery = null
+	QDEL_NULL(battery)
 	return ..()
 
 ///What happens when the battery is removed (or deleted) from the module, through try_eject() or not.
 /obj/item/computer_hardware/battery/Exited(atom/A, atom/newloc)
 	if(A == battery)
-		battery = null
-		if(holder?.enabled && !holder.use_power())
-			holder.shutdown_computer()
+		try_eject(0, null, TRUE)
 	return ..()
 
 /obj/item/computer_hardware/battery/try_insert(obj/item/I, mob/living/user = null)


### PR DESCRIPTION
## About The Pull Request

Laptops and tablets no longer drop a battery when destroyed, as this was most likely not intended in the first place and causes a weird bug with necro seed.

- https://github.com/tgstation/tgstation/pull/45342

## Why It's Good For The Game

Bugs are kind of bad 😳 

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/4972 

## Changelog
:cl:
tweak: Laptops and tablets no longer drop batteries when deleted
fix: Necro seed stealth 8 ability now works as intended
/:cl:
