### PR TITLE
A couple plumbing fixes

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -98,9 +98,9 @@
 	for(var/D in GLOB.cardinals)
 		var/color
 		var/direction
-		if(D & demand_connects)
+		if(D & initial(demand_connects))
 			color = "red" //red because red is mean and it takes
-		else if(D & supply_connects)
+		else if(D & initial(supply_connects))
 			color = "blue" //blue is nice and gives
 		else
 			continue
@@ -182,6 +182,7 @@
 	var/new_supply_connects
 	var/new_dir = AM.dir
 	var/angle = 180 - dir2angle(new_dir)
+
 	if(new_dir == SOUTH)
 		demand_connects = initial(demand_connects)
 		supply_connects = initial(supply_connects)

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -155,6 +155,7 @@ All the important duct code:
 	update_icon()
 	if(ispath(drop_on_wrench))
 		new drop_on_wrench(drop_location())
+		drop_on_wrench = null
 	if(!QDELETED(src))
 		qdel(src)
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PR:
- https://github.com/tgstation/tgstation/pull/50352

Also fixes a duplication bug where unwrenched ducts would drop twice. The issue stemmed from the disconnect qdel'ing the duct, and destroy calling disconnect, where each call to disconnect would spawn a duct.

Now the typepath of object to create when deconstructing is nulled after one is created.

<details>

<summary>Pictures of boxstation bug</summary>

### Before: 

![image](https://user-images.githubusercontent.com/6917698/129054418-79ca1423-d264-4478-918a-d8cac9311257.png)

### After:

![image](https://user-images.githubusercontent.com/6917698/129054522-bcf4539a-7c04-4d9f-90fc-bf51ba02dcb3.png)

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfixes are good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Plumbing port visuals are now more reliable, fixing a bug with boxstation's roundstart bottlers and presses
fix: Unwrenching ducts no longer doubles them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
