### PR TITLE
Fixes ChemPress.js which is used for the plumbing pill press

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemPress.js
+++ b/tgui/packages/tgui/interfaces/ChemPress.js
@@ -31,11 +31,10 @@ export const ChemPress = (props, context) => {
                 })} />
             </LabeledList.Item>
             <LabeledList.Item label="Pill Name">
-              <Input
-                value={pill_name}
-                onChange={(e, value) => act('change_pill_name', {
-                  name: value,
-                })} />
+              <Button
+                icon="pencil-alt"
+                content={pill_name}
+                onClick={() => act('change_pill_name')} />
             </LabeledList.Item>
             <LabeledList.Item label="Pill Style">
               {pill_styles.map(pill => (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A bit little change to fix ChemPress.js which is used for the plumbing pill press machine.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When you give a name to a pill at the press, you think you are trying to write a name in the text input box, but it doesn't actually work and the popup window is the real one. You are easily confused to think the popup window is fake and then you click a cancel button, which sends a null name value to the press, eventually getting " pill" name. This pull is a fix for it.
This is not a real fix for the issue, but at least it lifts people's confusion. the plumbing system needs more maintenance, until then it is just a temporary fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The naming component at the pill press(the plumbing machine) is now a button instead of a text input, to prevent you to get a blank named pill(i.e. " pill").
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
