### PR TITLE
Fixes midround spawning

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -62,8 +62,6 @@
 		return FALSE
 	if(cannot_spawn_after_shuttlecall && !EMERGENCY_IDLE_OR_RECALLED)
 		return FALSE
-	if(ispath(typepath, /datum/round_event/ghost_role) && GHOSTROLE_MIDROUND_EVENT)
-		return FALSE
 
 	var/datum/game_mode/dynamic/dynamic = SSticker.mode
 	if (istype(dynamic) && dynamic_should_hijack && dynamic.random_event_hijacked != HIJACKED_NOTHING)

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -62,6 +62,8 @@
 		return FALSE
 	if(cannot_spawn_after_shuttlecall && !EMERGENCY_IDLE_OR_RECALLED)
 		return FALSE
+	if(ispath(typepath, /datum/round_event/ghost_role) && !(GLOB.ghost_role_flags & GHOSTROLE_MIDROUND_EVENT))
+		return FALSE
 
 	var/datum/game_mode/dynamic/dynamic = SSticker.mode
 	if (istype(dynamic) && dynamic_should_hijack && dynamic.random_event_hijacked != HIJACKED_NOTHING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Midrounds have been broken since the 5th march.

## Why It's Good For The Game

Midrounds can now spawn again.

## Changelog
:cl:
fix: Fixes midround antags not existing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
