### PR TITLE
Nerfs the disabler

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -70,7 +70,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 35
+	damage = 28
 	damage_type = STAMINA
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reduces base disabler damage from 35 to 28.

## Why It's Good For The Game

The disabler is one of the best weapons in the game, dealing 35 base damage, costing only 40 energy (This allows for 25 shots before requiring a recharge).
In addition to this, armour that protects against disabler beams (Energy armor flag) is quite rare and generally a pretty low value.
The disabler can output 875 stamina damage before needing to recharge on an unarmoured target.

This PR lowers the damage to 28, reducing the total stamina damage output to 700. It's not much of a nerf but on unarmoured targets it will take an extra shot, and will take a lot more shots on armoured targets.

Keep in mind that the lethal lasers deal only 20 damage and cost 100 energy, meaning only 10 lethal shots can be fired totally 200 damage output, so this will not result in security being encouraged to go full lethals on any criminal and definitely isn't an excuse.

This PR is a pretty small nerf, but it's much better to take small steps and continue adjusting if needed than to go way too far and create undesired events.

I may also increase the energy cost too.

## Changelog
:cl:
balance: Disabler beams reduced from 35 damage to 28.(-7)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
