### PR TITLE
EMP damage holosigns and holobarriers

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -11,7 +11,7 @@
 	var/obj/item/holosign_creator/projector
 
 /obj/structure/holosign/emp_act(severity)
-	take_damage(src.max_integrity/severity, BRUTE, "melee", 1)
+	take_damage(max_integrity/severity, BRUTE, "melee", 1)
 
 /obj/structure/holosign/New(loc, source_projector)
 	if(source_projector)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -10,6 +10,9 @@
 	layer = BELOW_OBJ_LAYER
 	var/obj/item/holosign_creator/projector
 
+/obj/structure/holosign/emp_act(severity)
+	take_damage(src.max_integrity/severity, BRUTE, "melee", 1)
+
 /obj/structure/holosign/New(loc, source_projector)
 	if(source_projector)
 		projector = source_projector


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Implemented emp_act() (triggers on getting hit by emp) for /obj/structure/holosign, from which all holosigns and barriers inherit.  Holosigns are affected in the same way as charge for machinery: weak emp will deal half of its health worth of damage, strong emp will destroy it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As it stands now the holosigns are an extremely powerful magical tool bound only by number of projectors you are ready to print.
Atmos holosigns, looking at you.
Anyways, this adds a bit of complexity to interactions without adding complexity to logic. A ling breaking through barriers by emping or a security accidentally opening fusion box with irresponsible grenade usage will all lead to fun stories.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: /obj/structure/holosign/emp_act()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
