### PR TITLE
Minor radio/intercom fixes and improvements

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -58,6 +58,9 @@
 /obj/item/radio/intercom/attack_ai(mob/user)
 	interact(user)
 
+/obj/item/radio/intercom/attack_paw(mob/user)
+	return attack_hand(user)
+
 /obj/item/radio/intercom/attack_hand(mob/user)
 	. = ..()
 	if(.)
@@ -69,7 +72,7 @@
 	ui_interact(user)
 
 /obj/item/radio/intercom/ui_state(mob/user)
-	return GLOB.default_state
+	return GLOB.physical_state
 
 /obj/item/radio/intercom/can_receive(freq, level)
 	if(!on)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -108,6 +108,7 @@
 	else if(user.canUseTopic(src, !issilicon(user), TRUE, FALSE))
 		broadcasting = !broadcasting
 		to_chat(user, "<span class='notice'>You toggle broadcasting [broadcasting ? "on" : "off"].</span>")
+		ui_update()
 
 /obj/item/radio/CtrlShiftClick(mob/user)
 	if(headset)
@@ -115,6 +116,7 @@
 	else if(user.canUseTopic(src, !issilicon(user), TRUE, FALSE))
 		listening = !listening
 		to_chat(user, "<span class='notice'>You toggle speaker [listening ? "on" : "off"].</span>")
+		ui_update()
 
 /obj/item/radio/interact(mob/user)
 	if(unscrewed && !isAI(user))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -105,14 +105,14 @@
 /obj/item/radio/AltClick(mob/user)
 	if(headset)
 		. = ..()
-	else
+	else if(user.canUseTopic(src, !issilicon(user), FALSE, FALSE))
 		broadcasting = !broadcasting
 		to_chat(user, "<span class='notice'>You toggle broadcasting [broadcasting ? "on" : "off"].</span>")
 
 /obj/item/radio/CtrlShiftClick(mob/user)
 	if(headset)
 		. = ..()
-	else
+	else if(user.canUseTopic(src, !issilicon(user), FALSE, FALSE))
 		listening = !listening
 		to_chat(user, "<span class='notice'>You toggle speaker [listening ? "on" : "off"].</span>")
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -105,14 +105,14 @@
 /obj/item/radio/AltClick(mob/user)
 	if(headset)
 		. = ..()
-	else if(user.canUseTopic(src, !issilicon(user), FALSE, FALSE))
+	else if(user.canUseTopic(src, !issilicon(user), TRUE, FALSE))
 		broadcasting = !broadcasting
 		to_chat(user, "<span class='notice'>You toggle broadcasting [broadcasting ? "on" : "off"].</span>")
 
 /obj/item/radio/CtrlShiftClick(mob/user)
 	if(headset)
 		. = ..()
-	else if(user.canUseTopic(src, !issilicon(user), FALSE, FALSE))
+	else if(user.canUseTopic(src, !issilicon(user), TRUE, FALSE))
 		listening = !listening
 		to_chat(user, "<span class='notice'>You toggle speaker [listening ? "on" : "off"].</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, radios can have broadcasting and speaker toggled with alt-click and ctrl-shift-click at a distance, even through cameras, due to a lack of checks in relevant procs.

This PR adds `user.canUseTopic` checks to those procs.

Additionally, while hand-held radios are able to be used by monkeys, wall-mounted ones were not due to the lack of `attack_paw`. This PR adds `attack_paw` and makes monkeys able to interact with wall-mounted intercoms.

While doing this I discovered another discrepancy. While monkeys were able to use shortcuts to toggle both radios and intercoms, and able to use the interface in-hand, they were still unable to change settings on the wall-mounted intercom due to not being humans.

Because most things currently already allow it, and it's simpler, **monkeys can also use wall-mounted intercom interface now.** The only actual change this brings is them being able to change the frequency, since they were already able to affect both other settings. I achieved this behavior by changing the intercom state from `default_state` to `physical_state`.

That said, it would be possible to make non-dexterous mobs unable to use one or both radios completely if preferred.

I also discovered the UI wasn't updating when using hotkeys, so I added `ui_update` in their procs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfixes and consistency good, magical telekinesis bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Radios and intercoms can no longer be toggled from a distance by non-silicons using hotkeys
fix: Monkeys can now interact with wall-mounted intercoms
fix: Radio and intercom UIs now update when toggled via hotkey
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
