### PR TITLE
Gives pAIs the ability to have ID cards and door access.

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -52,6 +52,8 @@
 		else
 			dat += "<b>Radio Uplink</b><br>"
 			dat += "<font color=red><i>Radio firmware not loaded. Please install a pAI personality to load firmware.</i></font><br>"
+		if(pai.aiPDA.id)
+			dat += "<A href='byond://?src=[REF(src)];ejectid=1'>\[Eject ID\]</a><br>"
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(H.real_name == pai.master || H.dna.unique_enzymes == pai.master_dna)
@@ -98,6 +100,8 @@
 					to_chat(pai, "<span class='userdanger'>Your mental faculties leave you.</span>")
 					to_chat(pai, "<span class='rose'>oblivion... </span>")
 					qdel(pai)
+		if(href_list["ejectid"])
+			pai.aiPDA.do_remove_id()
 		if(href_list["clear_zero"])
 			if((input("Are you CERTAIN you wish to remove this pAI's Prime directive? This action cannot be undone.", "Clear Directive") in list("Yes", "No")) == "Yes")
 				if(pai)

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -6,7 +6,11 @@
 		return TRUE
 	if(issilicon(M))
 		if(ispAI(M))
-			return FALSE
+			var/mob/living/silicon/pai/P = M
+			if(check_access(P.aiPDA))
+				return TRUE
+			else
+				return FALSE
 		return TRUE	//AI can do whatever it wants
 	if(IsAdminGhost(M))
 		//Access can't stop the abuse

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -7,9 +7,7 @@
 	if(issilicon(M))
 		if(ispAI(M))
 			var/mob/living/silicon/pai/P = M
-			if(check_access(P.aiPDA))
-				return TRUE
-			else
+			if(!check_access(P.aiPDA))
 				return FALSE
 		return TRUE	//AI can do whatever it wants
 	if(IsAdminGhost(M))

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -300,7 +300,7 @@
 			pai.radio.attackby(W, user, params)
 	else if(istype(W, /obj/item/encryptionkey))
 		to_chat(user, "Encryption Key ports not configured.")
-	if(istype(W, /obj/item/card/id))
+	else if(istype(W, /obj/item/card/id))
 		var/obj/item/card/id/idcard = W
 		if(!pai?.aiPDA.owner) //just in case no name has been set for the PDA
 			pai?.aiPDA.owner = pai.real_name

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -302,12 +302,12 @@
 		to_chat(user, "Encryption Key ports not configured.")
 	if(istype(W, /obj/item/card/id))
 		var/obj/item/card/id/idcard = W
-		if(!pai?.aiPDA.owner) //just in case no name has been set for the PDA
-			pai?.aiPDA.owner = pai.real_name
-			pai?.aiPDA.ownjob = "pAI"
-			pai?.aiPDA.name = pai.real_name + " (pAI)"
+		if(!pai.aiPDA.owner) //just in case no name has been set for the PDA
+			pai.aiPDA.owner = pai.real_name
+			pai.aiPDA.ownjob = "pAI"
+			pai.aiPDA.name = pai.real_name + " (pAI)"
 		if(((idcard.registered_name == pai?.real_name) || (idcard.assignment == "pAI")) && idcard.registered_name)
-			pai?.aiPDA.attackby(W, user, params)
+			pai.aiPDA.attackby(W, user, params)
 		else
 			to_chat(user, "The pAI card's ID port rejects the ID.")
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -125,8 +125,8 @@
 	//PDA
 	aiPDA = new/obj/item/pda/ai(src)
 	aiPDA.owner = real_name
-	aiPDA.ownjob = "pAI Messenger"
-	aiPDA.name = real_name + " (" + aiPDA.ownjob + ")"
+	aiPDA.ownjob = "pAI"
+	aiPDA.name = real_name + " (pAI)"
 
 	. = ..()
 
@@ -298,8 +298,18 @@
 			pai.radio.attackby(W, user, params)
 		else if(istype(W, /obj/item/encryptionkey))
 			pai.radio.attackby(W, user, params)
-	else
+	else if(istype(W, /obj/item/encryptionkey))
 		to_chat(user, "Encryption Key ports not configured.")
+	if(istype(W, /obj/item/card/id))
+		var/obj/item/card/id/idcard = W
+		if(!pai?.aiPDA.owner) //just in case no name has been set for the PDA
+			pai?.aiPDA.owner = pai.real_name
+			pai?.aiPDA.ownjob = "pAI"
+			pai?.aiPDA.name = pai.real_name + " (pAI)"
+		if(((idcard.registered_name == pai?.real_name) || (idcard.assignment == "pAI")) && idcard.registered_name)
+			pai?.aiPDA.attackby(W, user, params)
+		else
+			to_chat(user, "The pAI card's ID port rejects the ID.")
 
 /obj/item/paicard/emag_act(mob/user) // Emag to wipe the master DNA and supplemental directive
 	if(!pai)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -50,6 +50,8 @@
 				left_part = ""
 			if("directives")
 				left_part = directives()
+			if("id_config")
+				left_part = id_config()
 			if("pdamessage")
 				left_part = pdamessage()
 			if("buy")
@@ -217,11 +219,16 @@
 						to_chat(src, "You are not being carried by anyone!")
 						return 0 // FALSE ? If you return here you won't call paiinterface() below
 
+			if("id_config")
+				if(href_list["eject"])
+					aiPDA.do_remove_id()
+
 			if("pdamessage")
 				if(!isnull(aiPDA))
 					if(!aiPDA.owner)
 						aiPDA.owner = src.real_name
 						aiPDA.ownjob = "pAI"
+						aiPDA.name = src.real_name + " (pAI)"
 					if(href_list["toggler"])
 						aiPDA.toff = !aiPDA.toff
 					else if(href_list["ringer"])
@@ -314,6 +321,7 @@
 	dat += "<A href='byond://?src=[REF(src)];software=directives'>Directives</A><br>"
 	dat += "<A href='byond://?src=[REF(src)];software=radio;sub=0'>Radio Configuration</A><br>"
 	dat += "<A href='byond://?src=[REF(src)];software=image'>Screen Display</A><br>"
+	dat += "<A href='byond://?src=[REF(src)];software=id_config'>ID Card</A><br>"
 	//dat += "Text Messaging <br>"
 	dat += "<br>"
 
@@ -409,6 +417,21 @@
 			 simply discarding this inconsistency, ignoring the conflicting supplemental directive and continuing to fulfill your
 			 prime directive to the best of your ability.</b></p><br><br>-
 			"}
+	return dat
+
+/mob/living/silicon/pai/proc/id_config()
+	var/dat = ""
+
+	dat += "ID Card Configuration:"
+	dat += "<br><br>"
+	if(aiPDA.id)
+		dat += "ID Card Name:<br>"
+		dat += "[aiPDA.id.registered_name]<br>"
+		dat += "ID Card Assignment:<br>"
+		dat += "[aiPDA.id.assignment]<br>"
+		dat += "<a href='byond://?src=[REF(src)];software=id_config;eject=1'>Eject ID</a><br>"
+	else
+		dat += "No ID Card Inserted.<br>"
 	return dat
 
 /mob/living/silicon/pai/proc/CheckDNA(mob/living/carbon/M, mob/living/silicon/pai/P)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
pAIs can be given access to doors by slotting an ID card into their pAI card. The card must either have the card's name be the pAI's name, or the card's job be "pAI", or it will reject the card.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
pAIs can now go ask the HoP for an ID that lets them get in and out of the workspace of their master. The card will reject IDs that are not intended for them (either in name or job), so this cannot be used as spare ID storage.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: pAIs can now be given ID cards to allow them to access doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
