### PR TITLE
Allows the captain to get their gun out of the display case

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -223,12 +223,11 @@
 	else
 		return ..()
 
-//The captains display case requiring specops ID access is intentional.
-//The lab cage and captains display case do not spawn with electronics, which is why req_access is needed.
+//Used to have CC access needed, but I changed it
 /obj/structure/displaycase/captain
 	alert = TRUE
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CENT_SPECOPS)
+	req_access = list(ACCESS_CAPTAIN))
 
 /obj/structure/displaycase/labcage
 	name = "lab cage"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the access needed for the captain's gun display case

## Why It's Good For The Game
The captain does not need to break the case to get their gun out anymore

## Changelog
:cl:

tweak: Changed the access needed for the captain's gun display case

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
