### PR TITLE
Intercomms are above windows

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -7,6 +7,7 @@
 	canhear_range = 2
 	dog_fashion = null
 	unscrewed = FALSE
+	layer = ABOVE_WINDOW_LAYER
 
 /obj/item/radio/intercom/unscrewed
 	unscrewed = TRUE


### PR DESCRIPTION
So you can actually click on the intercom if they're both on the same tile.

## Changelog
:cl:
tweak: intercomms are above windows.
/:cl:
