### PR TITLE
Fix badge for headmin

### DIFF
--- a/config/badges.json
+++ b/config/badges.json
@@ -6,7 +6,7 @@
     "Badmin": "badmin",
     "Admin": "admin",
     "Game Master": "seniormin",
-    "Headmin": "headmin",
+    "Head Admin": "headmin",
     "Host": "host",
     "Coder": "coder",
     "Codermin": "admin",


### PR DESCRIPTION
## About The Pull Request

Headmin was wrongly defined or smth, so this may fix it

## Why It's Good For The Game

llol needs to flex his orange color.

## Changelog
:cl:
fix: Headmin chat badge now shows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
