### PR TITLE
Prevents TK moving objects with people in or buckled to it

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -137,11 +137,12 @@
 		return
 	
 	if(focus.buckled_mobs)
-			to_chat(user, "<span class='notice'>This object is too heavy to move with something buckled to it!</span>")
-			return
-		if(length(focus.client_mobs_in_contents))
-			to_chat(user, "<span class='notice'>This object is too heavy to move with something inside of it!</span>")
-			return
+		to_chat(user, "<span class='notice'>This object is too heavy to move with something buckled to it!</span>")
+		return
+
+	if(length(focus.client_mobs_in_contents))
+		to_chat(user, "<span class='notice'>This object is too heavy to move with something inside of it!</span>")
+		return
 
 	if(!isturf(target) && isitem(focus) && target.Adjacent(focus))
 		apply_focus_overlay()

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -135,7 +135,13 @@
 		target.attack_self_tk(user)
 		update_icon()
 		return
-
+	
+	if(focus.buckled_mobs)
+			to_chat(user, "<span class='notice'>This object is too heavy to move with something buckled to it!</span>")
+			return
+		if(length(focus.client_mobs_in_contents))
+			to_chat(user, "<span class='notice'>This object is too heavy to move with something inside of it!</span>")
+			return
 
 	if(!isturf(target) && isitem(focus) && target.Adjacent(focus))
 		apply_focus_overlay()
@@ -145,12 +151,6 @@
 			focus.do_attack_animation(target, null, focus)
 	else
 
-		if(focus.buckled_mobs)
-			to_chat(user, "<span class='notice'>This object is too heavy to move with something buckled to it!</span>")
-			return
-		if(length(focus.client_mobs_in_contents))
-			to_chat(user, "<span class='notice'>This object is too heavy to move with something inside of it!</span>")
-			return
 		apply_focus_overlay()
 		focus.throw_at(target, 10, 1,user)
 	user.changeNext_move(CLICK_CD_MELEE)

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -144,6 +144,13 @@
 		if(check_if_focusable(focus))
 			focus.do_attack_animation(target, null, focus)
 	else
+
+		if(focus.buckled_mobs)
+			to_chat(user, "<span class='notice'>This object is too heavy to move with something buckled to it!</span>")
+			return
+		if(length(focus.client_mobs_in_contents))
+			to_chat(user, "<span class='notice'>This object is too heavy to move with something inside of it!</span>")
+			return
 		apply_focus_overlay()
 		focus.throw_at(target, 10, 1,user)
 	user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a check to TK, that checks if the object being thrown has a mob in it, or buckled to it. If either of these cases are true, the object will not be able to be thrown.

## Why It's Good For The Game

This PR is good for the game, as it stops people throwing themself around on chairs at mach 10 with TK, going faster than most other objects, being insanely fast at navigating space, and great at escaping things like Xenos after smacking them with a crowbar 50 times in a row rapidly.

https://github.com/ParadiseSS13/Paradise/pull/16160

Now, while you can still move around 99% of objects still, you can not abuse it as a speed / mobility method.
## Changelog
:cl: Qwertytoforty AnCopper
tweak: Telekinesis can no longer throw objects with people in them, or buckled to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
