### PR TITLE
Hides mentor badge if admin badge shows

### DIFF
--- a/code/modules/badges/badges.dm
+++ b/code/modules/badges/badges.dm
@@ -54,8 +54,9 @@ GLOBAL_LIST_EMPTY(badge_data)
 		if(holder?.rank?.badge_icon)
 			badges += holder.rank.badge_icon
 	//Add the mentor rank
-	if(mentor_datum && GLOB.badge_data["Mentor"])
-		badges += GLOB.badge_data["Mentor"]
+	else
+		if(mentor_datum && GLOB.badge_data["Mentor"])
+			badges += GLOB.badge_data["Mentor"]
 	//Add the donator rank
 	if(IS_PATRON(ckey) && GLOB.badge_data["Donator"])
 		badges += GLOB.badge_data["Donator"]


### PR DESCRIPTION
If a client has an active `holder` they will not show the mentor badge, as they will by definition be both.

## Changelog
:cl:
tweak: Admins will only show their admin badge, the mentor badge will be dropped to reduce clutter.
/:cl:
