### PR TITLE
Thrownthing refactor, you can now throw stuff at mobs lying on the floor

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -42,6 +42,7 @@ SUBSYSTEM_DEF(throwing)
 /datum/thrownthing
 	var/atom/movable/thrownthing
 	var/turf/target_turf
+	var/datum/weakref/initial_target
 	var/target_zone
 	var/init_dir
 	var/maxrange
@@ -63,11 +64,13 @@ SUBSYSTEM_DEF(throwing)
 	var/last_move = 0
 
 
-/datum/thrownthing/New(thrownthing, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, force, callback, target_zone)
+/datum/thrownthing/New(thrownthing, target, init_dir, maxrange, speed, thrower, diagonals_first, force, callback, target_zone)
 	. = ..()
 	src.thrownthing = thrownthing
 	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, .proc/on_thrownthing_qdel)
-	src.target_turf = target_turf
+	src.target_turf = get_turf(target)
+	if(target_turf != target)
+		src.initial_target = WEAKREF(target)
 	src.init_dir = init_dir
 	src.maxrange = maxrange
 	src.speed = speed
@@ -84,6 +87,7 @@ SUBSYSTEM_DEF(throwing)
 	thrownthing.throwing = null
 	thrownthing = null
 	thrower = null
+	initial_target = null
 	if(callback)
 		QDEL_NULL(callback) //It stores a reference to the thrownthing, its source. Let's clean that.
 	return ..()
@@ -106,9 +110,15 @@ SUBSYSTEM_DEF(throwing)
 		delayed_time += world.time - last_move
 		return
 
-	if (dist_travelled && hitcheck()) //to catch sneaky things moving on our tile while we slept
-		finalize()
-		return
+	var/atom/movable/actual_target = initial_target?.resolve()
+
+	if(dist_travelled) //to catch sneaky things moving on our tile while we slept
+		for(var/atom/movable/obstacle as anything in get_turf(thrownthing))
+			if (obstacle == thrownthing || (obstacle == thrower && !ismob(thrownthing)))
+				continue
+			if (obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1)))
+				finalize(TRUE, obstacle)
+				return
 
 	var/atom/step
 
@@ -135,13 +145,16 @@ SUBSYSTEM_DEF(throwing)
 			finalize()
 			return
 
-		AM.Move(step, get_dir(AM, step))
-
-		if (!AM.throwing) // we hit something during our move
-			finalize(hit = TRUE)
+		if(!AM.Move(step, get_dir(AM, step))) // we hit something during our move...
+			if(AM.throwing) // ...but finalize() wasn't called on Bump() because of a higher level definition that doesn't always call parent.
+				finalize()
 			return
 
 		dist_travelled++
+
+		if(actual_target && !(actual_target.pass_flags & LETPASSTHROW) && actual_target.loc == AM.loc) // we crossed a movable with no density (e.g. a mouse or APC) we intend to hit anyway.
+			finalize(TRUE, actual_target)
+			return
 
 		if (dist_travelled > MAX_THROWING_DIST)
 			finalize()
@@ -154,11 +167,10 @@ SUBSYSTEM_DEF(throwing)
 		return
 	thrownthing.throwing = null
 	if (!hit)
-		for (var/thing in get_turf(thrownthing)) //looking for our target on the turf we land on.
-			var/atom/A = thing
-			if (A == target)
+		for (var/atom/movable/obstacle as anything in get_turf(thrownthing)) //looking for our target on the turf we land on.
+			if (obstacle == target)
 				hit = TRUE
-				thrownthing.throw_impact(A, src)
+				thrownthing.throw_impact(obstacle, src)
 				if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing
 					return //deletion should already be handled by on_thrownthing_qdel()
 				break
@@ -184,15 +196,3 @@ SUBSYSTEM_DEF(throwing)
 			T.zFall(thrownthing)
 
 	qdel(src)
-
-/datum/thrownthing/proc/hit_atom(atom/A)
-	finalize(hit=TRUE, target=A)
-
-/datum/thrownthing/proc/hitcheck()
-	for (var/thing in get_turf(thrownthing))
-		var/atom/movable/AM = thing
-		if (AM == thrownthing || (AM == thrower && !ismob(thrownthing)))
-			continue
-		if (AM.density && !(AM.pass_flags & LETPASSTHROW) && !(AM.flags_1 & ON_BORDER_1))
-			finalize(hit=TRUE, target=AM)
-			return TRUE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -462,7 +462,7 @@
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUMP, A)
 	. = ..()
 	if(!QDELETED(throwing))
-		throwing.hit_atom(A)
+		throwing.finalize(hit = TRUE, target = A)
 		. = TRUE
 		if(QDELETED(A))
 			return
@@ -637,7 +637,7 @@
 	else
 		target_zone = thrower.zone_selected
 
-	var/datum/thrownthing/TT = new(src, get_turf(target), get_dir(src, target), range, speed, thrower, diagonals_first, force, callback, target_zone)
+	var/datum/thrownthing/TT = new(src, target, get_dir(src, target), range, speed, thrower, diagonals_first, force, callback, target_zone)
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -76,7 +76,8 @@
 			skipcatch = TRUE
 			hitpush = FALSE
 
-		dtype = I.damtype
+		if(blocked)
+			return TRUE
 
 		if (I.throwforce > 0) //If the weapon's throwforce is greater than zero...
 			if (I.throwhitsound) //...and throwhitsound is defined...
@@ -95,9 +96,12 @@
 							"<span class='userdanger'>You're hit by [I]!</span>")
 			var/armor = run_armor_check(zone, "melee", "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].",I.armour_penetration)
 			apply_damage(I.throwforce, dtype, zone, armor)
+
 			var/mob/thrown_by = I.thrownby?.resolve()
 			if(thrown_by)
 				log_combat(thrown_by, src, "threw and hit", I)
+			if(!incapacitated(FALSE, TRUE)) // physics says it's significantly harder to push someone by constantly chucking random furniture at them if they are down on the floor.
+				hitpush = FALSE
 		else
 			return 1
 	else


### PR DESCRIPTION
## About The Pull Request

Ports:

- https://github.com/tgstation/tgstation/pull/60604

## Why It's Good For The Game

Quality of life. Thrown projectiles currently only hit movables that a character can bump into, and that sucks.

Knocks a PR off the "Things to port" project

## Changelog
:cl:
tweak: You can now throw stuff at movables with no density, such as mobs on the floor, mice, APCs etc etc
refactor: Refactored thrownthing datum
/:cl: