### PR TITLE
Sec, Warden, HoS, Cap, and Brig Phys hats can no longer be knocked off by another hat

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -34,13 +34,13 @@
 	armor = list("melee" = 25, "bullet" = 15, "laser" = 25, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 30)
 	strip_delay = 60
 	dog_fashion = /datum/dog_fashion/head/captain
+	clothing_flags = SNUG_FIT
 
 //Captain: This is no longer space-worthy
 /obj/item/clothing/head/caphat/parade
 	name = "captain's parade cap"
 	desc = "Worn only by Captains with an abundance of class."
 	icon_state = "capcap"
-
 	dog_fashion = null
 
 
@@ -153,6 +153,7 @@
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 30, "bomb" = 25, "bio" = 10, "rad" = 0, "fire" = 50, "acid" = 60, "stamina" = 30)
 	strip_delay = 80
 	dynamic_hair_suffix = ""
+	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/HoS/syndicate
 	name = "syndicate cap"
@@ -174,6 +175,7 @@
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60, "stamina" = 30)
 	strip_delay = 60
 	dog_fashion = /datum/dog_fashion/head/warden
+	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/warden/drill
 	name = "warden's campaign hat"
@@ -250,6 +252,7 @@
 	icon_state = "beret_corporate_warden"
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60, "stamina" = 30)
 	strip_delay = 60
+	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/beret/sec
 	name = "security beret"
@@ -258,6 +261,7 @@
 	armor = list("melee" = 35, "bullet" = 30, "laser" = 30,"energy" = 40, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 30)
 	strip_delay = 60
 	dog_fashion = null
+	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/beret/corpsec
 	name = "corporate security beret"
@@ -265,6 +269,7 @@
 	icon_state = "beret_corporate_officer"
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 50, "stamina" = 30)
 	strip_delay = 60
+	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/beret/sec/navyhos
 	name = "head of security's beret"

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -320,6 +320,7 @@
 	armor = list("melee" = 15, "bullet" = 0, "laser" = 0,"energy" = 15, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "stamina" = 40)
 	resistance_flags = FIRE_PROOF
 	dynamic_hair_suffix = ""
+	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/crown/fancy
 	name = "magnificent crown"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -121,6 +121,7 @@
 	armor = list("melee" = 30, "bullet" = 25, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 50, "stamina" = 30)
 	strip_delay = 60
 	dog_fashion = null
+	clothing_flags = SNUG_FIT
 
 /obj/item/clothing/head/soft/sec/brig_phys
 	name = "security medic cap"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The hats of the Captain, HoS, Brig Phys, and Warden can no longer be knocked off by another hat. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They are armored and shouldn't be able to be knocked off by a top hat or anything else. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Phil Smith
balance: Nanotrasen has installed transparent straps into the Captain, HoS, Warden, Sec, and Brig Phys hats to prevent individuals from removing their hats by throwing another one on their head. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
