### PR TITLE
Spiders: Prevents player-controlled spiders from reproducing without a directive. 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -416,6 +416,8 @@
 		var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/S = owner
 		if(S.fed && S.directive)
 			return 1
+		if(S.fed && !S.ckey)
+			return 1
 		return 0
 
 /datum/action/innate/spider/lay_eggs/Activate()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -414,7 +414,7 @@
 		if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse))
 			return 0
 		var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/S = owner
-		if(S.fed)
+		if(S.fed && S.directive)
 			return 1
 		return 0
 
@@ -428,6 +428,8 @@
 		to_chat(S, "<span class='warning'>There is already a cluster of eggs here!</span>")
 	else if(!S.fed)
 		to_chat(S, "<span class='warning'>You are too hungry to do this!</span>")
+	else if(!S.directive && S.ckey)
+		to_chat(S, "<span class='warning'>You need to set a directive to do this!</span>")
 	else if(S.busy != LAYING_EGGS)
 		S.busy = LAYING_EGGS
 		S.visible_message("<span class='notice'>[S] begins to lay a cluster of eggs.</span>","<span class='notice'>You begin to lay a cluster of eggs.</span>")
@@ -472,6 +474,7 @@
 			S.directive = new_directive
 			message_admins("[ADMIN_LOOKUPFLW(owner)] set its directive to: '[S.directive]'.")
 			log_game("[key_name(owner)] set its directive to: '[S.directive]'.")
+			S.lay_eggs.UpdateButtonIcon(TRUE)
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Login()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -467,14 +467,11 @@
 		return
 	var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/S = owner
 	if(!S.playable)
-		S.directive = stripped_input(S, "Enter the new directive, hitting cancel will clear the directive", "Create directive", "[S.directive]")
-		if(S.directive)
+		var/new_directive = stripped_input(S, "Enter the new directive", "Create directive", "[S.directive]")
+		if(new_directive)
+			S.directive = new_directive
 			message_admins("[ADMIN_LOOKUPFLW(owner)] set its directive to: '[S.directive]'.")
-		else
-			message_admins("[ADMIN_LOOKUPFLW(owner)] has cleared its directive.")
-		log_game("[key_name(owner)] set its directive to: '[S.directive]'.")
-		if(!S.directive)
-			to_chat(S, "<span class='spider'>You have cleared your directive, your children will act of their own volition spreading misery and chaos! Do not reproduce without a directive unless you are prepared to face the repercussions of this!</span>")
+			log_game("[key_name(owner)] set its directive to: '[S.directive]'.")
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Login()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -212,14 +212,14 @@
 
 /mob/living/simple_animal/hostile/poison/giant_spider/handle_automated_action()
 	if(!..()) //AIStatus is off
-		return 0
+		return FALSE
 	if(AIStatus == AI_IDLE)
 		//1% chance to skitter madly away
 		if(!busy && prob(1))
 			stop_automated_movement = TRUE
 			Goto(pick(urange(20, src, 1)), move_to_delay)
 			addtimer(CALLBACK(src, .proc/do_action), 5 SECONDS)
-		return 1
+		return TRUE
 
 /mob/living/simple_animal/hostile/poison/giant_spider/proc/do_action()
 	stop_automated_movement = FALSE
@@ -381,7 +381,7 @@
 	else
 		message = "<span class='notice'>You prepare to wrap something in a cocoon. <B>Left-click your target to start wrapping!</B></span>"
 		add_ranged_ability(user, message, TRUE)
-		return 1
+		return TRUE
 
 /obj/effect/proc_holder/wrap/InterceptClickOn(mob/living/caller, params, atom/target)
 	if(..())
@@ -412,13 +412,11 @@
 /datum/action/innate/spider/lay_eggs/IsAvailable()
 	if(..())
 		if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse))
-			return 0
+			return FALSE
 		var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/S = owner
-		if(S.fed && S.directive)
-			return 1
-		if(S.fed && !S.ckey)
-			return 1
-		return 0
+		if(S.fed && (S.directive || !S.ckey))
+			return TRUE
+		return FALSE
 
 /datum/action/innate/spider/lay_eggs/Activate()
 	if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -406,7 +406,7 @@
 
 /datum/action/innate/spider/lay_eggs
 	name = "Lay Eggs"
-	desc = "Lay a cluster of eggs, which will soon grow into more spiders. You must wrap a living being to do this."
+	desc = "Lay a cluster of eggs, which will soon grow into more spiders. You must have a directive set and wrap a living being to do this."
 	button_icon_state = "lay_eggs"
 
 /datum/action/innate/spider/lay_eggs/IsAvailable()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -467,9 +467,14 @@
 		return
 	var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/S = owner
 	if(!S.playable)
-		S.directive = stripped_input(S, "Enter the new directive", "Create directive", "[S.directive]")
-		message_admins("[ADMIN_LOOKUPFLW(owner)] set its directive to: '[S.directive]'.")
+		S.directive = stripped_input(S, "Enter the new directive, hitting cancel will clear the directive", "Create directive", "[S.directive]")
+		if(S.directive)
+			message_admins("[ADMIN_LOOKUPFLW(owner)] set its directive to: '[S.directive]'.")
+		else
+			message_admins("[ADMIN_LOOKUPFLW(owner)] has cleared its directive.")
 		log_game("[key_name(owner)] set its directive to: '[S.directive]'.")
+		if(!S.directive)
+			to_chat(S, "<span class='spider'>You have cleared your directive, your children will act of their own volition spreading misery and chaos! Do not reproduce without a directive unless you are prepared to face the repercussions of this!</span>")
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Login()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Completely prevents player controlled spiders from reproducing with a null directive and also prevents accidentally clearing directive

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Spiders without directives cause mass mayhem and chaos, often times without a clear path of blame. Without a way to return to a null directive, bad directives can always be traced back to someone intentionally setting a new one. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Reproductive spiders may no longer accidentally clear their directives, and may not reproduce without one set. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
