### PR TITLE
fixes instruments not beeing hearable by mobs in content lists etc.

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -66,7 +66,7 @@
 	var/turf/source = get_turf(instrumentObj)
 	if((world.time - MUSICIAN_HEARCHECK_MINDELAY) > last_hearcheck)
 		LAZYCLEARLIST(hearing_mobs)
-		for(var/mob/M as() in hearers(15, source))
+		for(var/mob/M as() in get_hearers_in_view(15, source))
 			LAZYADD(hearing_mobs, M)
 		last_hearcheck = world.time
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently mobs that either are in a locker or a pai inside the inventory or item slot of its owner will not hear their own instruments simply because ```hearers``` will not check for those unlike ```get_hearers_in_view``` as this one will perform a recursive check trough all the mobs content lists etc. now the latter is obviously less performant thats the exact reason why it got replaced with hearers in https://github.com/BeeStation/BeeStation-Hornet/pull/3340 but this causes issues like pai's not beeing able to hear their own instrument inside lockers or player inventorslots and while i did not specifically test this i am pretty sure it will also cause other mobs inside locker to not beeing able to hear instruments played outside simply because of how this check works.
closes: https://github.com/BeeStation/BeeStation-Hornet/issues/4797

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes mobs not beeing able to hear instruments in lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
