### PR TITLE
Fixes instant surgery in poor conditions

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -364,7 +364,7 @@
 	desc = "An outdated helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment, still kept in use as replacement helmets."
 
 /obj/item/clothing/head/helmet/space/plasmaman/replacement/security
-	name = "security replacementenvirosuit helmet"
+	name = "security replacement envirosuit helmet"
 	desc = "An outdated containment helmet designed for security officers."
 	icon_state = "security_envirohelm"
 	item_state = "security_envirohelm"

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -78,7 +78,7 @@
 	else if(locate(/obj/structure/bed, T))
 		propability = 0.5
 
-	return propability + sleepbonus - selfpenalty
+	return max(propability + sleepbonus - selfpenalty, 0.1)
 
 /datum/surgery_step/proc/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	surgery.step_in_progress = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #5141
doesn't let modifier be negative or too low
i couldn't be bothered to tune the min too much but .05 made glass shard surgery on a bed take like 72 seconds unclamped and had the failure chance clamp to 99% even though glass shards have a .45 mod for organ manipulation so i tuned it up to .1

i also didn't want to make a pr that added a single space so i just fixed the replacement securohelm's name here
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no more self-surgery exploit
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: self surgery being instantly successful in poor conditions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
