### PR TITLE
Ports rebindable locking movement key and move intent toggle hotkey from /tg/ again again

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -150,6 +150,20 @@
 		M.toggle_move_intent()
 		return TRUE
 
+/datum/keybinding/mob/toggle_move_intent_alternative
+	key = "Unbound"
+	name = "toggle_move_intent_alt"
+	full_name = "press to cycle move intent"
+	description = "Pressing this cycle to the opposite move intent, does not cycle back"
+
+/datum/keybinding/mob/toggle_move_intent_alternative/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/M = user.mob
+	M.toggle_move_intent()
+	return TRUE
+
 /datum/keybinding/mob/target_head_cycle
 	key = "Numpad8"
 	name = "target_head_cycle"
@@ -226,3 +240,21 @@
 	if(!user.mob) return
 	user.body_l_leg()
 	return TRUE
+
+/datum/keybinding/mob/prevent_movement
+	key = "Ctrl"
+	name = "block_movement"
+	full_name = "Block movement"
+	description = "Prevents you from moving"
+
+/datum/keybinding/mob/prevent_movement/down(client/user)
+	. = ..()
+	if(.)
+		return
+	user.movement_locked = TRUE
+
+/datum/keybinding/mob/prevent_movement/up(client/user)
+	. = ..()
+	if(.)
+		return
+	user.movement_locked = FALSE

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -245,7 +245,7 @@
 	key = "Ctrl"
 	name = "block_movement"
 	full_name = "Block movement"
-	description = "Prevents you from moving"
+	description = "While pressed, prevents movement when pressing directional keys; instead just changes your facing direction"
 
 /datum/keybinding/mob/prevent_movement/down(client/user)
 	. = ..()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -34,6 +34,7 @@
 	/// The client's preferences
 	var/datum/preferences/prefs = null
 	var/list/keybindings[0]
+	var/movement_locked = FALSE
 
 	/// The last world.time that the client's mob turned
 	var/last_turn = 0

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -2,7 +2,7 @@
 // Only way to do that is to tie the behavior into the focus's keyLoop().
 
 /atom/movable/keyLoop(client/user)
-	if(!user.keys_held["Ctrl"])
+	if(!user.movement_locked)
 		var/movement_dir = NONE
 		for(var/_key in user.keys_held)
 			movement_dir = movement_dir | SSinput.movement_keys[_key]

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_INIT(valid_keys, list(
 
 	keys_held[_key] = world.time
 	var/movement = SSinput.movement_keys[_key]
-	if(!(next_move_dir_sub & movement) && !keys_held["Ctrl"])
+	if(!(next_move_dir_sub & movement) && !movement_locked)
 		next_move_dir_add |= movement
 
 	// Client-level keybindings are ones anyone should be able to do at any time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/BeeStation/BeeStation-Hornet/pull/4460
#4775
Ports https://github.com/tgstation/tgstation/pull/53771
Ports https://github.com/tgstation/tgstation/pull/47569
Makes the locking movement to turn direction key rebindable (by default Ctrl)
Adds a new hotkey that lets you toggle walking (unbound by default)
Note: You still have to rebind your look direction hotkeys individually along with the locking movement hotkey or you won't turn

review this time please
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
no longer have to go to the corner of your screen and click to toggle walking in the middle of combat to block
locking movement is more free and can be put where you want
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added hotkey to toggle walking/running
add: Ability to rebind locking movement hotkey
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
