### PR TITLE
Nuclear particles no longer directly deal toxin damage through radiation protection

### DIFF
--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -3,8 +3,6 @@
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	flag = "rad"
-	irradiate = 5000 //more than enough to knockdown and induce vomiting
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'
 	impact_type = /obj/effect/projectile/impact/xray

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -3,9 +3,8 @@
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 10
-	damage_type = TOX
-	irradiate = 2500 //enough to knockdown and induce vomiting
+	flag = "rad"
+	irradiate = 5000 //more than enough to knockdown and induce vomiting
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'
 	impact_type = /obj/effect/projectile/impact/xray


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nuclear particles currently just do ten toxin damage to you directly regardless of if you're in a radproof suit or not. This PR makes them Not Do That, and in exchange makes them more radioactive. They still do burn damage, though.

Technically a port but I have no idea what of since I only noticed basically ever tg downstream has these exact changes, and it's like two lines man? 

Please keep all complains about what things are and are not immune to radiation on pull requests that alter the radiation resistance status of those things, I am not up for the task of dealing with that. This PR is just to make the game consistent and sensical
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
being immune to radiation should actually make you immune to being hit with nuclear particles which is what being irradiated is
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: nuclear particles no longer deal direct toxin damage, but do more regular irradiating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
