### PR TITLE
Gives layer manifolds volume

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -7,7 +7,7 @@
 	initialize_directions = NORTH|SOUTH
 	pipe_flags = PIPING_ALL_LAYER | PIPING_DEFAULT_LAYER_ONLY | PIPING_CARDINAL_AUTONORMALIZE
 	piping_layer = PIPING_LAYER_DEFAULT
-	device_type = 8 //260 isn't divisible by 35 bull
+	device_type = 8 //260 isn't divisible by 35 bull this is 280L
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "manifoldlayer"
 	FASTDMM_PROP(\

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -7,8 +7,7 @@
 	initialize_directions = NORTH|SOUTH
 	pipe_flags = PIPING_ALL_LAYER | PIPING_DEFAULT_LAYER_ONLY | PIPING_CARDINAL_AUTONORMALIZE
 	piping_layer = PIPING_LAYER_DEFAULT
-	device_type = 0
-	volume = 260
+	device_type = 8 //260 isn't divisible by 35 bull
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "manifoldlayer"
 	FASTDMM_PROP(\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #5162
volume is calculated from device type when you wrench a device with the formula `35 * device_type` and the variable is simply a holder
device type being 1 for unary 2 for binary 3 for trinary and 4 for quaternary 
not gonna bother defining a device type for the only hexanary component that doesn't even use hexanary volume

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
you'd think these have volume, probably were meant to have volume, and never got it for 5 years
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: layer manifolds have a 280L volume
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
