### PR TITLE
Mobs no longer create blood trails while being thrown

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define VENTCRAWLING	(1<<2)
 #define FLOATING		(1<<3)
 #define UNSTOPPABLE		(1<<4)			//! When moving, will Bump()/Cross()/Uncross() everything, but won't be stopped.
-#define THROWN			(1<<5) //! while an atom is being thrown. applied to and is used only by mobs for now
+#define THROWN			(1<<5) //! while an atom is being thrown
 
 //! ## Fire and Acid stuff, for resistance_flags
 #define LAVA_PROOF		(1<<0)

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -86,6 +86,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define VENTCRAWLING	(1<<2)
 #define FLOATING		(1<<3)
 #define UNSTOPPABLE		(1<<4)			//! When moving, will Bump()/Cross()/Uncross() everything, but won't be stopped.
+#define THROWN			(1<<5) //! while an atom is being thrown. applied to and is used only by mobs for now
 
 //! ## Fire and Acid stuff, for resistance_flags
 #define LAVA_PROOF		(1<<0)
@@ -120,7 +121,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define MOBILITY_UI				(1<<4)		//! can use interfaces like machinery
 #define MOBILITY_STORAGE		(1<<5)		//! can use storage item
 #define MOBILITY_PULL			(1<<6)		//! can pull things
-#define MOBILITY_THROWN			(1<<7)		//! is being thrown
 
 #define MOBILITY_FLAGS_DEFAULT (MOBILITY_MOVE | MOBILITY_STAND | MOBILITY_PICKUP | MOBILITY_USE | MOBILITY_UI | MOBILITY_STORAGE | MOBILITY_PULL)
 #define MOBILITY_FLAGS_INTERACTION (MOBILITY_USE | MOBILITY_PICKUP | MOBILITY_UI | MOBILITY_STORAGE)

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -120,6 +120,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define MOBILITY_UI				(1<<4)		//! can use interfaces like machinery
 #define MOBILITY_STORAGE		(1<<5)		//! can use storage item
 #define MOBILITY_PULL			(1<<6)		//! can pull things
+#define MOBILITY_THROWN			(1<<7)		//! is being thrown
 
 #define MOBILITY_FLAGS_DEFAULT (MOBILITY_MOVE | MOBILITY_STAND | MOBILITY_PICKUP | MOBILITY_USE | MOBILITY_UI | MOBILITY_STORAGE | MOBILITY_PULL)
 #define MOBILITY_FLAGS_INTERACTION (MOBILITY_USE | MOBILITY_PICKUP | MOBILITY_UI | MOBILITY_STORAGE)

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -183,9 +183,7 @@ SUBSYSTEM_DEF(throwing)
 		if(T && thrownthing.has_gravity(T))
 			T.zFall(thrownthing)
 
-	if(istype(thrownthing, /mob/living))
-		var/mob/living/thrown_mob = thrownthing
-		thrown_mob.mobility_flags &= ~MOBILITY_THROWN
+	thrownthing.movement_type &= ~THROWN
 
 	qdel(src)
 

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -182,8 +182,10 @@ SUBSYSTEM_DEF(throwing)
 		var/turf/T = get_turf(thrownthing)
 		if(T && thrownthing.has_gravity(T))
 			T.zFall(thrownthing)
-	var/mob/living/thrown_mob = thrownthing
-	thrown_mob.mobility_flags &= ~MOBILITY_THROWN
+
+	if(istype(thrownthing, /mob/living))
+		var/mob/living/thrown_mob = thrownthing
+		thrown_mob.mobility_flags &= ~MOBILITY_THROWN
 
 	qdel(src)
 

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -182,6 +182,8 @@ SUBSYSTEM_DEF(throwing)
 		var/turf/T = get_turf(thrownthing)
 		if(T && thrownthing.has_gravity(T))
 			T.zFall(thrownthing)
+	var/mob/living/thrown_mob = thrownthing
+	thrown_mob.mobility_flags &= ~MOBILITY_THROWN
 
 	qdel(src)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -663,6 +663,7 @@
 
 	if(pulledby)
 		pulledby.stop_pulling()
+	movement_type |= THROWN
 
 	throwing = TT
 	if(spin)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -659,7 +659,7 @@
 		makeTrail(newloc, T, old_direction)
 
 /mob/living/proc/makeTrail(turf/target_turf, turf/start, direction)
-	if(!has_gravity() || movement_type & THROWN)
+	if(!has_gravity() || (movement_type & THROWN))
 		return
 	var/blood_exists = FALSE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -659,7 +659,7 @@
 		makeTrail(newloc, T, old_direction)
 
 /mob/living/proc/makeTrail(turf/target_turf, turf/start, direction)
-	if(!has_gravity())
+	if(!has_gravity() || mobility_flags & MOBILITY_THROWN)
 		return
 	var/blood_exists = FALSE
 
@@ -1017,6 +1017,8 @@
 /mob/living/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force = MOVE_FORCE_STRONG, quickstart = TRUE)
 	stop_pulling()
 	. = ..()
+	if(.)
+		mobility_flags |= MOBILITY_THROWN
 
 // Called when we are hit by a bolt of polymorph and changed
 // Generally the mob we are currently in is about to be deleted

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1017,8 +1017,6 @@
 /mob/living/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force = MOVE_FORCE_STRONG, quickstart = TRUE)
 	stop_pulling()
 	. = ..()
-	if(.)
-		movement_type |= THROWN
 
 // Called when we are hit by a bolt of polymorph and changed
 // Generally the mob we are currently in is about to be deleted

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -659,7 +659,7 @@
 		makeTrail(newloc, T, old_direction)
 
 /mob/living/proc/makeTrail(turf/target_turf, turf/start, direction)
-	if(!has_gravity() || mobility_flags & MOBILITY_THROWN)
+	if(!has_gravity() || movement_type & THROWN)
 		return
 	var/blood_exists = FALSE
 
@@ -1018,7 +1018,7 @@
 	stop_pulling()
 	. = ..()
 	if(.)
-		mobility_flags |= MOBILITY_THROWN
+		movement_type |= THROWN
 
 // Called when we are hit by a bolt of polymorph and changed
 // Generally the mob we are currently in is about to be deleted


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
they get a little flag while being thrown that prevents the creation of trails
new `THROWN` flag that goes under `movement_type` for all moveables
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
trying to move bodies but it keeps making streaks
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: throwing creatures doesn't make blood trails anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
