### PR TITLE
Ports "Nanotransen Legal Liability Initiative - Weapon Stats but more RP" from /tg/

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -458,6 +458,7 @@
 #include "code\datums\components\twohanded.dm"
 #include "code\datums\components\uplink.dm"
 #include "code\datums\components\waddling.dm"
+#include "code\datums\elements\weapon_description.dm"
 #include "code\datums\components\wearertargeting.dm"
 #include "code\datums\components\wet_floor.dm"
 #include "code\datums\components\crafting\crafting.dm"

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -68,6 +68,8 @@
 
 	init_subtypes(/datum/crafting_recipe, GLOB.crafting_recipes)
 
+	init_subtypes_w_path_keys(/obj/item/projectile, GLOB.proj_by_path_key)
+
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.
 /proc/init_subtypes(prototype, list/L)
@@ -85,3 +87,11 @@
 		for(var/path in subtypesof(prototype))
 			L+= path
 		return L
+
+/// Functions like init_subtypes, but uses the subtype's path as a key for easy access
+/proc/init_subtypes_w_path_keys(prototype, list/L)
+	if(!istype(L))
+		L = list()
+	for(var/path as anything in subtypesof(prototype))
+		L[path] = new path()
+	return L

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -38,3 +38,5 @@ GLOBAL_LIST_EMPTY(topic_tokens)
 GLOBAL_PROTECT(topic_tokens)
 GLOBAL_LIST_EMPTY(topic_servers)
 GLOBAL_PROTECT(topic_servers)
+
+GLOBAL_LIST_EMPTY_TYPED(proj_by_path_key, /obj/item/projectile) // A list of projectile objects, which are keyed by their path

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -1,0 +1,127 @@
+/**
+ *
+ * The purpose of this element is to widely provide the ability to examine an object and determine its damage, with the ability to add
+ * additional notes or information based on type or other factors
+ *
+ */
+/datum/element/weapon_description
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH
+	id_arg_index = 2
+
+	// Additional proc to be run for specific object types
+	var/attached_proc
+
+	// Flavor text crimes used in build_weapon_text()
+	var/list/crimes = list("Assaults", "Third Degree Murders", "Robberies", "Terrorist Attacks", "Different Felonies", "Felinies", "Counts of Tax Evasion", "Mutinies")
+	var/list/victims = list("a human", "a moth", "a felinid", "a lizard", "a particularly resilient slime", "a syndicate Aagent", "a clown", "a mime", "a mortal foe", "an innocent bystander")
+
+/datum/element/weapon_description/Attach(datum/target, attached_proc)
+	. = ..()
+	if(!isitem(target)) // Do not attach this to anything that isn't an item
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/warning_label)
+	RegisterSignal(target, COMSIG_TOPIC, .proc/topic_handler)
+	// Don't perform the assignment if there is nothing to assign, or if we already have something for this bespoke element
+	if(attached_proc && !src.attached_proc)
+		src.attached_proc = attached_proc
+
+/datum/element/weapon_description/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, list(COMSIG_PARENT_EXAMINE, COMSIG_TOPIC))
+
+/**
+ *
+ * This proc is called when the user examines an object with the associated element. This produces a hyperlinked
+ * text line provided that the given item meets the weapon-determining criteria (Sufficient force or notes)
+ *
+ * Arguments:
+ * 	* source - Object being examined, cast into an item variable
+ *  * user - Unused
+ *  * examine_texts - The output text list of the original examine function
+ */
+/datum/element/weapon_description/proc/warning_label(obj/item/item, mob/user, list/examine_texts)
+	SIGNAL_HANDLER
+
+	if(item.force >= 5 || item.throwforce >= 5 || item.override_notes || item.offensive_notes) /// Only show this tag for items that could feasibly be weapons, shields, or those that have special notes
+		examine_texts += "<span class='notice'>It appears to have an ever-updating bluespace <a href='?src=[REF(item)];examine=1'>warning label.</a></span>"
+
+/**
+ *
+ * Details the stats of the examined weapon
+ *
+ * This function is called when the user clicks the hyperlink provided by
+ * warning_label(). It calls build_label_text() and outputs its return value to the user
+ *
+ * Arguments:
+ *  * source - Object being examined, sent to build_label_text()
+ *  * href-list - List provided by the href of input values, used to know what hyperlinked action is being attempted
+ */
+
+/datum/element/weapon_description/proc/topic_handler(atom/source, user, href_list)
+	SIGNAL_HANDLER
+
+	if(href_list["examine"])
+		to_chat(user, "<span class='notice'>[build_label_text(source)]</span>")
+
+/**
+ *
+ * Compiles a warning label detailing various statistics of the examined weapon
+ *
+ * This function is called by the "examine" function of Topic(), and compiles a number of relevant
+ * weapon stats into a message that is then shown to the user
+ * Arguments:
+ *  * source - The object whose stats are being examined
+ */
+/datum/element/weapon_description/proc/build_label_text(obj/item/source)
+	var/list/readout = list("") // Readout is used to store the text block output to the user so it all can be sent in one message
+
+	// Meaningless flavor text. The number of crimes is constantly changing because of the complex Nanotrasen legal system and the esoteric nature of time itself!
+	readout += "<span class='warning'>WARNING:</span> This item has been marked as dangerous by the NT legal team because of its use in <span class='warning'>[rand(2,99)] [crimes[rand(1, crimes.len)]]</span> in the past hour.\n"
+
+	// Doesn't show the base notes for items that have the override notes variable set to true
+	if(!source.override_notes)
+		// Make sure not to divide by 0 on accident
+		if(source.force > 0)
+			readout += "Our extensive research has shown that it takes a mere <span class='warning'>[round((100 / source.force), 0.1)]</span> hit\s to beat down [victims[rand(1, victims.len)]] with no armor."
+		else
+			readout += "Our extensive research found that you couldn't beat anyone to death with this if you tried."
+
+		if(source.throwforce > 0)
+			readout += "If you decide to throw this object instead, one will take <span class='warning'>[round((100 / source.throwforce), 0.1)]</span> hit\s before collapsing."
+		else
+			readout += "If you decide to throw this object instead, then you will have trouble damaging anything."
+		if(source.armour_penetration > 0 || source.block_chance > 0)
+			readout += "This item has proven itself <span class='warning'>[weapon_tag_convert(source.armour_penetration)]</span> of piercing armor and <span class='warning'>[weapon_tag_convert(source.block_chance)]</span> of blocking attacks."
+	// Custom manual notes
+	if(source.offensive_notes)
+		readout += source.offensive_notes
+
+	// Check if we have an additional proc, if so, add it to the readout
+	if(attached_proc)
+		readout += call(source, attached_proc)()
+
+	// Finally bringing the fields together
+	return readout.Join("\n")
+
+/**
+ *
+ * Converts percentile based stats to an adjective appropriate for the
+ * examined warning label
+ *
+ * Arguments:
+ *  * tag_val: The value of the item to be added to the tag
+ */
+/datum/element/weapon_description/proc/weapon_tag_convert(tag_val)
+	switch(tag_val)
+		if(0)
+			return "INCAPABLE"
+		if(1 to 25)
+			return "BARELY CAPABLE"
+		if(26 to 50)
+			return "CAPABLE"
+		if(51 to 75)
+			return "VERY CAPABLE"
+		if(76 to INFINITY)
+			return "EXTREMELY CAPABLE"
+		else
+			return "STRANGELY CAPABLE"

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -97,15 +97,16 @@
 			readout += "It also shows to have a blocking arc of <span class='warning'>[source.block_level]</span>."
 		if(source.block_upgrade_walk > 0)
 			readout += "It has a blocking arc of <span class='warning'>[source.block_level + source.block_upgrade_walk]</span> while the user is walking."
-		if(source.block_level + source.block_upgrade_walk > 0 && source.block_power)
-			readout += "Blocking is <span class='warning'>[source.block_power]% [source.block_power > 0 ? "less" : "more"]</span> tiring."
-		if(source.block_flags)
-			if(source.block_flags & BLOCKING_PROJECTILE)
-				readout += "Through various tests this item has been found to be capable of <span class='warning'>blocking projectiles</span>."
-			if(source.block_flags & BLOCKING_NASTY)
-				readout += "This weapon is capable of <span class='warning'>parrying</span> unarmed assailants."
-			if(source.block_flags & BLOCKING_HUNTER)
-				readout += "This item is more suited for guarding attacks from <span class='warning'>non-humanoids</span>."
+		if(source.block_level + source.block_upgrade_walk > 0)
+			if(source.block_power)
+				readout += "Blocking is <span class='warning'>[source.block_power]% [source.block_power > 0 ? "less" : "more"]</span> tiring."
+			if(source.block_flags)
+				if(source.block_flags & BLOCKING_PROJECTILE)
+					readout += "Through various tests this item has been found to be capable of <span class='warning'>blocking projectiles</span>."
+				if(source.block_flags & BLOCKING_NASTY)
+					readout += "This weapon is capable of <span class='warning'>parrying</span> unarmed assailants."
+				if(source.block_flags & BLOCKING_HUNTER)
+					readout += "This item is more suited for guarding attacks from <span class='warning'>non-humanoids</span>."
 	// Custom manual notes
 	if(source.offensive_notes)
 		readout += source.offensive_notes

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -1,6 +1,7 @@
+#define HITS_TO_CRIT(damage) round(100 / damage, 0.1)
 /**
  *
- * The purpose of this element is to widely provide the ability to examine an object and determine its damage, with the ability to add
+ * The purpose of this element is to widely provide the ability to examine an object and determine its stats, with the ability to add
  * additional notes or information based on type or other factors
  *
  */
@@ -42,7 +43,7 @@
 /datum/element/weapon_description/proc/warning_label(obj/item/item, mob/user, list/examine_texts)
 	SIGNAL_HANDLER
 
-	if(item.force >= 5 || item.throwforce >= 5 || item.override_notes || item.offensive_notes) /// Only show this tag for items that could feasibly be weapons, shields, or those that have special notes
+	if(item.force >= 5 || item.throwforce >= 5 || item.override_notes || item.offensive_notes || attached_proc) /// Only show this tag for items that could feasibly be weapons, shields, or those that have special notes
 		examine_texts += "<span class='notice'>It appears to have an ever-updating bluespace <a href='?src=[REF(item)];examine=1'>warning label.</a></span>"
 
 /**
@@ -82,16 +83,29 @@
 	if(!source.override_notes)
 		// Make sure not to divide by 0 on accident
 		if(source.force > 0)
-			readout += "Our extensive research has shown that it takes a mere <span class='warning'>[round((100 / source.force), 0.1)]</span> hit\s to beat down [victims[rand(1, victims.len)]] with no armor."
+			readout += "Our extensive research has shown that it takes a mere <span class='warning'>[HITS_TO_CRIT(source.force)]</span> hit\s to beat down [victims[rand(1, victims.len)]] with no armor."
 		else
 			readout += "Our extensive research found that you couldn't beat anyone to death with this if you tried."
 
 		if(source.throwforce > 0)
-			readout += "If you decide to throw this object instead, one will take <span class='warning'>[round((100 / source.throwforce), 0.1)]</span> hit\s before collapsing."
+			readout += "If you decide to throw this object instead, one will take <span class='warning'>[HITS_TO_CRIT(source.throwforce)]</span> hit\s before collapsing."
 		else
 			readout += "If you decide to throw this object instead, then you will have trouble damaging anything."
-		if(source.armour_penetration > 0 || source.block_chance > 0)
-			readout += "This item has proven itself <span class='warning'>[weapon_tag_convert(source.armour_penetration)]</span> of piercing armor and <span class='warning'>[weapon_tag_convert(source.block_chance)]</span> of blocking attacks."
+		if(source.armour_penetration > 0)
+			readout += "This item has proven itself <span class='warning'>[weapon_tag_convert(source.armour_penetration)]</span> of piercing armor."
+		if(source.block_level > 0)
+			readout += "It also shows to have a blocking arc of <span class='warning'>[source.block_level]</span>."
+		if(source.block_upgrade_walk > 0)
+			readout += "It has a blocking arc of <span class='warning'>[source.block_level + source.block_upgrade_walk]</span> while the user is walking."
+		if(source.block_level + source.block_upgrade_walk > 0 && source.block_power)
+			readout += "Blocking is <span class='warning'>[source.block_power]% [source.block_power > 0 ? "less" : "more"]</span> tiring."
+		if(source.block_flags)
+			if(source.block_flags & BLOCKING_PROJECTILE)
+				readout += "Through various tests this item has been found to be capable of <span class='warning'>blocking projectiles</span>."
+			if(source.block_flags & BLOCKING_NASTY)
+				readout += "This weapon is capable of <span class='warning'>parrying</span> upon blocking."
+			if(source.block_flags & BLOCKING_HUNTER)
+				readout += "This item is more suited for guarding attacks from <span class='warning'>non-humanoids</span>."
 	// Custom manual notes
 	if(source.offensive_notes)
 		readout += source.offensive_notes

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -103,7 +103,7 @@
 			if(source.block_flags & BLOCKING_PROJECTILE)
 				readout += "Through various tests this item has been found to be capable of <span class='warning'>blocking projectiles</span>."
 			if(source.block_flags & BLOCKING_NASTY)
-				readout += "This weapon is capable of <span class='warning'>parrying</span> upon blocking."
+				readout += "This weapon is capable of <span class='warning'>parrying</span> unarmed assailants."
 			if(source.block_flags & BLOCKING_HUNTER)
 				readout += "This item is more suited for guarding attacks from <span class='warning'>non-humanoids</span>."
 	// Custom manual notes

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -242,10 +242,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	QDEL_NULL(rpg_loot)
 	return ..()
 
-/*
- * Adds the weapon_description element, which shows the warning label for especially dangerous objects.
- * Made to be overridden by item subtypes that require specific notes outside of the scope of offensive_notes
- */
+/// Adds the weapon_description element, which shows the 'warning label' for especially dangerous objects. Override this for item types with special notes.
 /obj/item/proc/add_weapon_description()
 	AddElement(/datum/element/weapon_description)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -187,6 +187,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/list/juice_results
 
 
+	/// Used in obj/item/examine to give additional notes on what the weapon does, separate from the predetermined output variables
+	var/offensive_notes
+	/// Used in obj/item/examine to determines whether or not to detail an item's statistics even if it does not meet the force requirements
+	var/override_notes = FALSE
+
 /obj/item/Initialize()
 
 	materials =	typelist("materials", materials)
@@ -225,6 +230,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(LAZYLEN(embedding))
 		updateEmbedding()
 
+	add_weapon_description()
+
 /obj/item/Destroy()
 	item_flags &= ~DROPDEL	//prevent reqdels
 	if(ismob(loc))
@@ -234,6 +241,13 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		qdel(X)
 	QDEL_NULL(rpg_loot)
 	return ..()
+
+/*
+ * Adds the weapon_description element, which shows the warning label for especially dangerous objects.
+ * Made to be overridden by item subtypes that require specific notes outside of the scope of offensive_notes
+ */
+/obj/item/proc/add_weapon_description()
+	AddElement(/datum/element/weapon_description)
 
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
 	if(((src in target) && !target_self) || (!isturf(target.loc) && !isturf(target) && not_inside))

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -188,6 +188,10 @@
 	var/force_off // Damage when off - not stunning
 	var/weight_class_on // What is the new size class when turned on
 
+/obj/item/melee/classic_baton/Initialize()
+	. = ..()
+	if(stamina_damage != 0)
+		offensive_notes = "\nVarious interviewed security forces report being able to beat criminals into exhaustion with only <span class='warning'>[round(100 / stamina_damage, 0.1)] hit\s!</span>"
 // Description for trying to stun when still on cooldown.
 /obj/item/melee/classic_baton/proc/get_wait_description()
 	return

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -166,7 +166,6 @@
 	icon_locking = "safeb"
 	icon_sparking = "safespark"
 	desc = "Excellent for securing things away from grubby hands."
-	force = 8
 	w_class = WEIGHT_CLASS_GIGANTIC
 	anchored = TRUE
 	density = FALSE

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -31,8 +31,8 @@
 /obj/item/melee/baton/Initialize()
 	. = ..()
 	// Adding an extra break for the sake of presentation
-	if(stamina_loss_amt != 0)
-		offensive_notes = "\nVarious interviewed security forces report being able to beat criminals into exhaustion with only <span class='warning'>[round(100 / stamina_loss_amt, 0.1)] hit\s!</span>"
+	if(stunforce != 0)
+		offensive_notes = "\nVarious interviewed security forces report being able to beat criminals into exhaustion with only <span class='warning'>[round(100 / stunforce, 0.1)] hit\s</span>!"
 	if(preload_cell_type)
 		if(!ispath(preload_cell_type,/obj/item/stock_parts/cell))
 			log_mapping("[src] at [AREACOORD(src)] had an invalid preload_cell_type: [preload_cell_type].")

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -30,6 +30,9 @@
 
 /obj/item/melee/baton/Initialize()
 	. = ..()
+	// Adding an extra break for the sake of presentation
+	if(stamina_loss_amt != 0)
+		offensive_notes = "\nVarious interviewed security forces report being able to beat criminals into exhaustion with only <span class='warning'>[round(100 / stamina_loss_amt, 0.1)] hit\s!</span>"
 	if(preload_cell_type)
 		if(!ispath(preload_cell_type,/obj/item/stock_parts/cell))
 			log_mapping("[src] at [AREACOORD(src)] had an invalid preload_cell_type: [preload_cell_type].")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -176,6 +176,8 @@
 
 /obj/structure/closet/proc/take_contents()
 	var/atom/L = drop_location()
+	if(!L)
+		return
 	for(var/atom/movable/AM in L)
 		if(AM != src && insert(AM) == -1) // limit reached
 			break

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -8,6 +8,7 @@
 	throwforce = 0
 	w_class = WEIGHT_CLASS_TINY
 	materials = list(/datum/material/iron = 500)
+	override_notes = TRUE
 	var/fire_sound = null						//What sound should play when this ammo is fired
 	var/caliber = null							//Which kind of guns it can be loaded into
 	var/projectile_type = null					//The bullet type to create when New() is called
@@ -40,6 +41,31 @@
 		SSblackbox.record_feedback("tally", "station_mess_destroyed", 1, name)
 	QDEL_NULL(BB)
 	return ..()
+
+/obj/item/ammo_casing/add_weapon_description()
+	AddElement(/datum/element/weapon_description, attached_proc = .proc/add_notes_ammo)
+
+/**
+ *
+ * Outputs type-specific weapon stats for ammunition based on the projectile loaded inside the casing.
+ * Distinguishes between critting and stam-critting in separate lines
+ *
+ */
+/obj/item/ammo_casing/proc/add_notes_ammo()
+	// Make sure there is actually something IN the casing
+	if(loaded_projectile)
+		var/list/readout = list("")
+		// No dividing by 0
+		if(loaded_projectile.damage > 0)
+			readout += "Most monkeys our legal team subjected to these rounds succumbed to their wounds after <span class='warning'>[round(100 / (loaded_projectile.damage * pellets), 0.1)]</span> discharge\s at point-blank, taking <span class='warning'>[pellets]</span> shot\s per round"
+		if(loaded_projectile.stamina > 0)
+			readout += "[loaded_projectile.damage == 0 ? "Most Monkeys" : "More Fortunate Monkeys" ] collapsed from exhaustion after <span class='warning'>[round(100 / ((loaded_projectile.damage + loaded_projectile.stamina) * pellets), 0.1)]</span> of these rounds"
+		if(loaded_projectile.damage == 0 && loaded_projectile.stamina == 0)
+			return "Our legal team has determined the offensive nature of these rounds to be esoteric"
+		return readout.Join("\n") // Sending over a single string, rather than the whole list
+	else
+		// Labels don't do well with extreme forces
+		return "The warning label was blown away..."
 
 /obj/item/ammo_casing/update_icon()
 	..()

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -52,20 +52,20 @@
  *
  */
 /obj/item/ammo_casing/proc/add_notes_ammo()
-	// Make sure there is actually something IN the casing
-	if(loaded_projectile)
-		var/list/readout = list("")
-		// No dividing by 0
-		if(loaded_projectile.damage > 0)
-			readout += "Most monkeys our legal team subjected to these rounds succumbed to their wounds after <span class='warning'>[round(100 / (loaded_projectile.damage * pellets), 0.1)]</span> discharge\s at point-blank, taking <span class='warning'>[pellets]</span> shot\s per round"
-		if(loaded_projectile.stamina > 0)
-			readout += "[loaded_projectile.damage == 0 ? "Most Monkeys" : "More Fortunate Monkeys" ] collapsed from exhaustion after <span class='warning'>[round(100 / ((loaded_projectile.damage + loaded_projectile.stamina) * pellets), 0.1)]</span> of these rounds"
-		if(loaded_projectile.damage == 0 && loaded_projectile.stamina == 0)
-			return "Our legal team has determined the offensive nature of these rounds to be esoteric"
-		return readout.Join("\n") // Sending over a single string, rather than the whole list
-	else
-		// Labels don't do well with extreme forces
-		return "The warning label was blown away..."
+	// Try to get a projectile to derive stats from
+	var/obj/item/projectile/exam_proj = GLOB.proj_by_path_key[projectile_type]
+	if(!istype(exam_proj) || pellets == 0)
+		return
+
+	var/list/readout = list()
+	// No dividing by 0
+	if(exam_proj.damage > 0)
+		readout += "Most monkeys our legal team subjected to these <span class='warning'>[caliber] rounds</span> succumbed to their wounds after <span class='warning'>[HITS_TO_CRIT(exam_proj.damage * pellets)]</span> shot\s at point-blank, taking <span class='warning'>[pellets] shot\s</span> per round"
+	if(exam_proj.stamina > 0)
+		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after <span class='warning'>[HITS_TO_CRIT(exam_proj.stamina * pellets)]</span> impact\s of these <span class='warning'>[caliber]</span> rounds"
+	if(!readout.len) // Everything else failed, give generic text
+		return "Our legal team has determined the offensive nature of these <span class='warning'>[caliber] rounds</span> to be esoteric"
+	return readout.Join("\n") // Sending over a single string, rather than the whole list
 
 /obj/item/ammo_casing/update_icon()
 	..()

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -13,6 +13,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 7
+	override_notes = TRUE
 	var/list/stored_ammo = list()
 	var/ammo_type = /obj/item/ammo_casing
 	var/max_ammo = 7
@@ -37,6 +38,23 @@
 		for(var/i = 1, i <= max_ammo, i++)
 			stored_ammo += new ammo_type(src)
 	update_icon()
+
+/obj/item/ammo_box/add_weapon_description()
+	AddElement(/datum/element/weapon_description, attached_proc = .proc/add_notes_box)
+
+/obj/item/ammo_box/proc/add_notes_box()
+	var/list/readout = list()
+
+	if(caliber && max_ammo) // Text references a 'magazine' as only magazines generally have the caliber variable initialized
+		readout += "Up to <span class='warning'>[max_ammo] [caliber] rounds</span> can be found within this magazine. \
+		\nAccidentally discharging any of these projectiles may void your insurance contract."
+
+	var/obj/item/ammo_casing/mag_ammo = get_round(TRUE)
+
+	if(istype(mag_ammo))
+		readout += "\n[mag_ammo.add_notes_ammo()]"
+
+	return readout.Join("\n")
 
 /obj/item/ammo_box/proc/get_round(keep = FALSE)
 	if (!stored_ammo.len)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -76,8 +76,8 @@
  *
  */
 /obj/item/gun/ballistic/proc/add_notes_ballistic()
-	if(magazine) // Make sure you have a magazine, thats where the warning is!
-		return "\nBe especially careful around this device, as it can be loaded with <span class='warning'>[magazine.caliber]</span> rounds, which you can inspect for more information."
+	if(magazine) // Make sure you have a magazine, to get the notes from
+		return "\n[magazine.add_notes_box()]"
 	else
 		return "\nThe warning attached to the magazine is missing..."
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -66,6 +66,21 @@
 	chamber_round()
 	update_icon()
 
+/obj/item/gun/ballistic/add_weapon_description()
+	AddElement(/datum/element/weapon_description, attached_proc = .proc/add_notes_ballistic)
+
+/**
+ *
+ * Outputs type-specific weapon stats for ballistic weaponry based on its magazine and its caliber.
+ * It contains extra breaks for the sake of presentation
+ *
+ */
+/obj/item/gun/ballistic/proc/add_notes_ballistic()
+	if(magazine) // Make sure you have a magazine, thats where the warning is!
+		return "\nBe especially careful around this device, as it can be loaded with <span class='warning'>[magazine.caliber]</span> rounds, which you can inspect for more information."
+	else
+		return "\nThe warning attached to the magazine is missing..."
+
 /obj/item/gun/ballistic/update_icon()
 	if (QDELETED(src))
 		return

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -57,19 +57,25 @@
  *
  */
 /obj/item/gun/energy/proc/add_notes_energy()
-	var/list/readout = list("")
+	var/list/readout = list()
 	// Make sure there is something to actually retrieve
-	if(!ammo_type)
+	if(!ammo_type.len)
 		return
-	var/obj/projectile/exam_proj
-	readout += "Standard models of this projectile weapon have <span class='warning'>[ammo_type.len]</span> mode\s"
+	var/obj/item/projectile/exam_proj
+	readout += "\nStandard models of this projectile weapon have <span class='warning'>[ammo_type.len] mode\s</span>"
 	readout += "Our heroic interns have shown that one can theoretically stay standing after..."
-	for(var/obj/item/ammo_casing/energy/for_ammo in ammo_type)
-		exam_proj = for_ammo.loaded_projectile
+	for(var/obj/item/ammo_casing/energy/for_ammo as anything in ammo_type)
+		exam_proj = GLOB.proj_by_path_key[for_ammo?.projectile_type]
+		if(!istype(exam_proj))
+			continue
+
 		if(exam_proj.damage > 0) // Don't divide by 0!!!!!
-			readout += "<span class='warning'>[round(100 / exam_proj.damage, 0.1)]</span> shot\s on <span class='warning'>[for_ammo.select_name]</span> mode before collapsing from [exam_proj.damage_type == STAMINA ? "immense pain" : "their wounds"]."
+			readout += "<span class='warning'>[HITS_TO_CRIT(exam_proj.damage)] shot\s</span> on <span class='warning'>[for_ammo.select_name]</span> mode before collapsing from [exam_proj.damage_type == STAMINA ? "immense pain" : "their wounds"]."
+			if(exam_proj.stamina > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
+				readout += "<span class='warning'>[HITS_TO_CRIT(exam_proj.stamina)] shot\s</span> on <span class='warning'>[for_ammo.select_name]</span> mode before collapsing from immense pain."
 		else
-			readout += "an infinite number of shots on <span class='warning'>[for_ammo.select_name] mode</span>."
+			readout += "a theoretically infinite number of shots on <span class='warning'>[for_ammo.select_name]</span> mode."
+
 	return readout.Join("\n") // Sending over the singular string, rather than the whole list
 
 /obj/item/gun/energy/proc/update_ammo_types()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -46,6 +46,32 @@
 		START_PROCESSING(SSobj, src)
 	update_icon()
 
+/obj/item/gun/energy/add_weapon_description()
+	AddElement(/datum/element/weapon_description, attached_proc = .proc/add_notes_energy)
+
+/**
+ *
+ * Outputs type-specific weapon stats for energy-based firearms based on its firing modes
+ * and the stats of those firing modes. Esoteric firing modes like ion are currently not supported
+ * but can be added easily
+ *
+ */
+/obj/item/gun/energy/proc/add_notes_energy()
+	var/list/readout = list("")
+	// Make sure there is something to actually retrieve
+	if(!ammo_type)
+		return
+	var/obj/projectile/exam_proj
+	readout += "Standard models of this projectile weapon have <span class='warning'>[ammo_type.len]</span> mode\s"
+	readout += "Our heroic interns have shown that one can theoretically stay standing after..."
+	for(var/obj/item/ammo_casing/energy/for_ammo in ammo_type)
+		exam_proj = for_ammo.loaded_projectile
+		if(exam_proj.damage > 0) // Don't divide by 0!!!!!
+			readout += "<span class='warning'>[round(100 / exam_proj.damage, 0.1)]</span> shot\s on <span class='warning'>[for_ammo.select_name]</span> mode before collapsing from [exam_proj.damage_type == STAMINA ? "immense pain" : "their wounds"]."
+		else
+			readout += "an infinite number of shots on <span class='warning'>[for_ammo.select_name] mode</span>."
+	return readout.Join("\n") // Sending over the singular string, rather than the whole list
+
 /obj/item/gun/energy/proc/update_ammo_types()
 	var/obj/item/ammo_casing/energy/shot
 	for (var/i = 1, i <= ammo_type.len, i++)


### PR DESCRIPTION
Part of things to port https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-61676747
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ports https://github.com/tgstation/tgstation/pull/58865
ports https://github.com/tgstation/tgstation/pull/59778

modified for zeskoblocking
![image](https://user-images.githubusercontent.com/85033680/130338583-fe4299ce-ae11-4718-9347-5397185d4a5e.png)
![image](https://user-images.githubusercontent.com/85033680/130338699-035979be-3a6a-473c-ac65-215429f85c17.png)


nonlethal ballistics don't say how effective they are at paralyzing shh (wyci)
kinda a sister pr to armor tags
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
now i won't be the only person to know that advanced mops have 12 force and passive blocking + block upgrade walk
and that most armory guns have block upgrade walk while eguns don't
maybe people will stop using stun batons when they realize they do 5 brute which is less than half of what using your bare hands on someone who's down does
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: lordScrubling, SpaceDragon00
add: weapon tags showing combat stats on weapons, magazines, guns, casings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
