### PR TITLE
Levelling up projectile spells makes the projectiles stronger.

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -633,6 +633,11 @@
 	var/chain
 	var/mob/living/caster
 
+/obj/item/projectile/magic/aoe/lightning/New(loc, spell_level)
+	. = ..()
+	tesla_power += 5000 * spell_level
+	tesla_range += 2 * spell_level
+
 /obj/item/projectile/magic/aoe/lightning/fire(setAngle)
 	if(caster)
 		chain = caster.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
@@ -665,6 +670,13 @@
 	var/exp_light = 2
 	var/exp_flash = 3
 	var/exp_fire = 2
+
+/obj/item/projectile/magic/aoe/fireball/New(loc, spell_level)
+	. = ..()
+	exp_fire += spell_level
+	exp_flash += spell_level
+	exp_light += spell_level
+	exp_heavy = max(spell_level - 2, 0)
 
 /obj/item/projectile/magic/aoe/fireball/on_hit(target)
 	. = ..()

--- a/code/modules/projectiles/projectile/magic/spellcard.dm
+++ b/code/modules/projectiles/projectile/magic/spellcard.dm
@@ -4,3 +4,7 @@
 	icon_state = "spellcard"
 	damage_type = BRUTE
 	damage = 2
+
+/obj/item/projectile/spellcard/New(loc, spell_level)
+	. = ..()
+	damage += spell_level

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -77,7 +77,7 @@
 	if(!projectile_type)
 		return
 	for(var/i in 1 to projectiles_per_fire)
-		var/obj/item/projectile/P = new projectile_type(user.loc)
+		var/obj/item/projectile/P = new projectile_type(user.loc, spell_level)
 		P.firer = user
 		P.preparePixelProjectile(target, user)
 		for(var/V in projectile_var_overrides)

--- a/code/modules/spells/spell_types/projectile.dm
+++ b/code/modules/spells/spell_types/projectile.dm
@@ -58,11 +58,11 @@
 	name = "Projectile"
 	desc = "This spell summons projectiles which try to hit the targets."
 
-	
+
 
 	var/proj_type =  /obj/item/projectile/magic/spell //IMPORTANT use only subtypes of this
-	
-	
+
+
 	var/update_projectile = FALSE //So you want to admin abuse magic bullets ? This is for you
 	//Below only apply if update_projectile is true
 	var/proj_icon = 'icons/obj/projectiles.dmi'
@@ -83,8 +83,8 @@
 	var/check_holy = FALSE
 
 /obj/effect/proc_holder/spell/targeted/projectile/proc/fire_projectile(atom/target, mob/user)
-	var/obj/item/projectile/magic/spell/projectile = new proj_type()
-	
+	var/obj/item/projectile/magic/spell/projectile = new proj_type(null, spell_level)
+
 	if(update_projectile)
 		//Generally these should already be set on the projectile, this is mostly here for varedited spells.
 		projectile.icon = proj_icon

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -28,6 +28,10 @@
 	trail_lifespan = 5
 	trail_icon_state = "magicmd"
 
+/obj/item/projectile/magic/spell/magic_missile/New(loc, spell_level)
+	. = ..()
+	paralyze += spell_level * 10
+
 /obj/effect/proc_holder/spell/targeted/genetic/mutate
 	name = "Mutate"
 	desc = "This spell causes you to turn into a hulk and gain laser vision for a short while."
@@ -65,7 +69,6 @@
 	smoke_amt = 4
 
 	action_icon_state = "smoke"
-
 
 /obj/effect/proc_holder/spell/targeted/smoke/lesser //Chaplain smoke book
 	name = "Smoke"

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -253,6 +253,9 @@
 		for(var/atom/movable/AM in T)
 			thrownatoms += AM
 
+	stun_amt += 10 * spell_level
+	maxthrow = 5 + spell_level
+
 	for(var/am in thrownatoms)
 		var/atom/movable/AM = am
 		if(AM == user || AM.anchored)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Taking more levels in projectile spells will make them stronger.

## Why It's Good For The Game

While you get a shorter cooldown, upgrading spells doesn't do much else on projectile spells. This allows relatively weak spells to become a lot more powerful when levelled up, making the choice between a new spell and an upgraded spell more something to consider.

## Changelog
:cl:
balance: Levelling up projectile spells (Fireball, spellcards, tesla spell, magic missile) makes the projectiles more powerful.
balance: Upgrading repulse makes the effect stronger (larger throw distance, longer paralyze)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
