### PR TITLE
Removes colossus cheese.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -256,7 +256,9 @@ Difficulty: Very Hard
 
 /obj/item/projectile/colossus/can_hit_target(atom/target, direct_target = FALSE, ignore_loc = FALSE, cross_failed = FALSE)
 	if(isliving(target))
-		direct_target = TRUE
+		var/mob/living/L = target
+		if(L.stat != DEAD)
+			direct_target = TRUE
 	return ..(target, direct_target, ignore_loc, cross_failed)
 
 /obj/item/projectile/colossus/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -253,7 +253,7 @@ Difficulty: Very Hard
 	pass_flags = PASSTABLE
 	var/explode_hit_objects = TRUE
 
-/obj/projectile/colossus/can_hit_target(atom/target, direct_target = FALSE, ignore_loc = FALSE, cross_failed = FALSE)
+/obj/item/projectile/colossus/can_hit_target(atom/target, direct_target = FALSE, ignore_loc = FALSE, cross_failed = FALSE)
 	if(isliving(target))
 		direct_target = TRUE
 	return ..(target, direct_target, ignore_loc, cross_failed)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -243,17 +243,30 @@ Difficulty: Very Hard
 	return ..()
 
 /obj/item/projectile/colossus
-	name ="death bolt"
-	icon_state= "chronobolt"
+	name = "death bolt"
+	icon_state = "chronobolt"
 	damage = 25
 	armour_penetration = 100
 	speed = 2
 	eyeblur = 0
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
+	var/explode_hit_objects = TRUE
+
+/obj/projectile/colossus/can_hit_target(atom/target, direct_target = FALSE, ignore_loc = FALSE, cross_failed = FALSE)
+	if(isliving(target))
+		direct_target = TRUE
+	return ..(target, direct_target, ignore_loc, cross_failed)
 
 /obj/item/projectile/colossus/on_hit(atom/target, blocked = FALSE)
 	. = ..()
+	if(isliving(target))
+		var/mob/living/dust_mob = target
+		if(dust_mob.stat == DEAD)
+			dust_mob.dust()
+		return
+	if(!explode_hit_objects)
+		return
 	if(isturf(target) || isobj(target))
 		if(isobj(target))
 			SSexplosions.med_mov_atom += target

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -251,6 +251,7 @@ Difficulty: Very Hard
 	eyeblur = 0
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
+	movement_type = FLYING | UNSTOPPABLE
 	var/explode_hit_objects = TRUE
 
 /obj/item/projectile/colossus/can_hit_target(atom/target, direct_target = FALSE, ignore_loc = FALSE, cross_failed = FALSE)
@@ -260,13 +261,6 @@ Difficulty: Very Hard
 
 /obj/item/projectile/colossus/on_hit(atom/target, blocked = FALSE)
 	. = ..()
-	if(isliving(target))
-		var/mob/living/dust_mob = target
-		if(dust_mob.stat == DEAD)
-			dust_mob.dust()
-		return
-	if(!explode_hit_objects)
-		return
 	if(isturf(target) || isobj(target))
 		if(isobj(target))
 			SSexplosions.med_mov_atom += target


### PR DESCRIPTION
## About The Pull Request

Colossus projectiles now penetrate everything

Colossus-type projectiles are always considered a direct target projectile now so you cannot lay down and ignore them anymore.

https://github.com/tgstation/tgstation/pull/60758

## Why It's Good For The Game

Defeating megafauna with corpses in chairs and laying on the ground is kinda stupid.

## Changelog
:cl: Whoneedspacee AnCopper
fix: Megafauna are no longer stopped by corpses and chairs.
/:cl:
 