### PR TITLE
Crew Manifest is now actually consistently organized

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -164,7 +164,8 @@
 					"rank" = rank
 				))
 				has_department = TRUE
-				break
+				if(department != "Command") //List heads in both command and their own department.
+					break
 		if(!has_department)
 			if(!manifest_out["Misc"])
 				manifest_out["Misc"] = list()
@@ -172,7 +173,12 @@
 				"name" = name,
 				"rank" = rank
 			))
-	return manifest_out
+	//Sort the list by 'departments' primarily so command is on top.
+	var/list/sorted_out = list()
+	for(var/department in (departments += "Misc"))
+		if(!isnull(manifest_out[department]))
+			sorted_out[department] = manifest_out[department]
+	return sorted_out
 
 /datum/datacore/proc/get_manifest_html(monochrome = FALSE)
 	var/list/manifest = get_manifest()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Crew Manifest is now organized by job, the order is mostly arbitrary but based on an existing list from this section of the code.

## Why It's Good For The Game

This thing is kinda a pain to read right now.

## Changelog
:cl:
tweak: Crew Manifest is now sorted with command at the top.
tweak: Heads of Staff are listed in both the Command block and their relevant department block of the crew manifest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
