### PR TITLE
[PORT] Lavaland generation fixes

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -151,7 +151,7 @@
 	. = ..()
 	if (prob(mineralChance))
 		var/path = pickweight(mineralSpawnChanceList)
-		if(isturf(path))
+		if(ispath(path, /turf))
 			var/turf/T = ChangeTurf(path,null,CHANGETURF_IGNORE_AIR)
 
 			T.baseturfs = src.baseturfs

--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -20,6 +20,8 @@
 
 		for(var/i in get_affected_turfs(central_turf, 1))
 			var/turf/T = i
+			for(var/obj/structure/spawner/nest in T)
+				qdel(nest)
 			for(var/mob/living/simple_animal/monster in T)
 				qdel(monster)
 			for(var/obj/structure/flora/ash/plant in T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/46455
- https://github.com/tgstation/tgstation/pull/49372

Issues introduced by my own PR: https://github.com/BeeStation/BeeStation-Hornet/pull/4800

Fixes **part of** https://github.com/BeeStation/BeeStation-Hornet/issues/5180

Apparently tg already had code in place that removed tendrils that spawned inside ruins, but we didn't have the same issue until my PR porting the new cavegen. This adds `obj/structure/spawner`, which tendrils are a subtype of, into the things removed from every turf on which a ruin is spawned.

Also, the original PR reworking random ore generation was broken for full turf replacements, which gibtonite does, and I missed a later fix.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfixesgood.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Fox McCloud, Buggy123
fix: Tendrils no longer spawn inside ruins
fix: Gibtonite will now spawn properly, as well as any other potential full turf replacements for random ores
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
