### PR TITLE
Overhauled spiders and new spider venom. 

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -182,10 +182,18 @@
 		amount_grown += rand(0,2)
 		if(amount_grown >= 100)
 			if(!grow_as)
-				if(prob(3))
-					grow_as = pick(/mob/living/simple_animal/hostile/poison/giant_spider/tarantula, /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper, /mob/living/simple_animal/hostile/poison/giant_spider/nurse)
-				else
-					grow_as = pick(/mob/living/simple_animal/hostile/poison/giant_spider, /mob/living/simple_animal/hostile/poison/giant_spider/hunter, /mob/living/simple_animal/hostile/poison/giant_spider/nurse)
+				switch(rand(1,20))
+					if(1)
+						grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse			//5%
+					if(2 to 8)
+						grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/				//35%
+					if(9 to 12)
+						grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/tarantula		//20%
+					if(13 to 16)
+						grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter			//20%
+					if(17 to 20)
+						grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper	//20%
+
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(src.loc)
 			S.faction = faction.Copy()
 			S.directive = directive

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -109,9 +109,6 @@
 /obj/structure/spider/spiderling/nurse
 	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
 
-/obj/structure/spider/spiderling/midwife
-	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife
-
 /obj/structure/spider/spiderling/viper
 	grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper
 
@@ -186,7 +183,7 @@
 		if(amount_grown >= 100)
 			if(!grow_as)
 				if(prob(3))
-					grow_as = pick(/mob/living/simple_animal/hostile/poison/giant_spider/tarantula, /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper, /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife)
+					grow_as = pick(/mob/living/simple_animal/hostile/poison/giant_spider/tarantula, /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper, /mob/living/simple_animal/hostile/poison/giant_spider/nurse)
 				else
 					grow_as = pick(/mob/living/simple_animal/hostile/poison/giant_spider, /mob/living/simple_animal/hostile/poison/giant_spider/hunter, /mob/living/simple_animal/hostile/poison/giant_spider/nurse)
 			var/mob/living/simple_animal/hostile/poison/giant_spider/S = new grow_as(src.loc)

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -195,7 +195,7 @@
 	name = "spiderling"
 	desc = "It's slightly twitching in your hand. Ew..."
 	icon_state = "spiderling"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin = 4)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/spidervenom = 4)
 	filling_color = "#00800"
 	tastes = list("cobwebs" = 1, "guts" = 2)
 	foodtype = MEAT | TOXIC
@@ -204,7 +204,7 @@
 	name = "spider lollipop"
 	desc = "Still gross, but at least it has a mountain of sugar on it."
 	icon_state = "spiderlollipop"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin = 1, /datum/reagent/iron = 10, /datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/omnizine = 2) //lollipop, but vitamins = toxins
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/toxin/spidervenom = 1, /datum/reagent/iron = 10, /datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/omnizine = 2) //lollipop, but vitamins = toxins
 	filling_color = "#00800"
 	tastes = list("cobwebs" = 1, "sugar" = 2)
 	foodtype = JUNKFOOD | SUGAR
@@ -656,4 +656,4 @@
 	list_reagents = list(/datum/reagent/consumable/beefbroth = 50)
 	filling_color = "#100800"
 	tastes = list("disgust" = 7, "tin" = 1)
-	foodtype = MEAT | GROSS | JUNKFOOD 
+	foodtype = MEAT | GROSS | JUNKFOOD

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -40,7 +40,6 @@
 	faction = list("spiders")
 	var/busy = SPIDER_IDLE
 	pass_flags = PASSTABLE
-	move_to_delay = 6
 	speed = 1
 	ventcrawler = VENTCRAWLER_ALWAYS
 	attacktext = "bites"
@@ -130,7 +129,6 @@
 	melee_damage = 5
 	obj_damage = 20
 	poison_per_bite = 6
-	move_to_delay = 5
 	speed = 0
 
 //vipers move quickly, do more damage and inject heparin instead of normal venom, but have even less health than normal huntsman spiders
@@ -144,7 +142,6 @@
 	health = 45
 	melee_damage = 10
 	poison_per_bite = 4
-	move_to_delay = 4
 	poison_type = /datum/reagent/toxin/heparin
 	speed = -1
 	gold_core_spawnable = NO_SPAWN
@@ -161,7 +158,6 @@
 	melee_damage = 20
 	obj_damage = 80
 	poison_per_bite = 0
-	move_to_delay = 8
 	speed = 2
 	status_flags = NONE
 	mob_size = MOB_SIZE_LARGE

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -158,7 +158,8 @@
 	icon_dead = "tarantula_dead"
 	maxHealth = 160
 	health = 160
-	melee_damage = 40
+	melee_damage = 20
+	obj_damage = 80
 	poison_per_bite = 0
 	move_to_delay = 8
 	speed = 2

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -50,7 +50,7 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	var/datum/action/innate/spider/lay_web/lay_web
 	var/directive = "" //Message passed down to children, to relay the creator's orders
-
+	poison_type = /datum/reagent/toxin/spidervenom
 	do_footstep = TRUE
 
 /mob/living/simple_animal/hostile/poison/giant_spider/Initialize()
@@ -153,9 +153,9 @@
 	maxHealth = 40
 	health = 40
 	melee_damage = 1
-	poison_per_bite = 12
+	poison_per_bite = 4
 	move_to_delay = 4
-	poison_type = /datum/reagent/toxin/venom //all in venom, glass cannon. you bite 5 times and they are DEFINITELY dead, but 40 health and you are extremely obvious. Ambush, maybe?
+	poison_type = /datum/reagent/toxin/heparin
 	speed = 1
 	gold_core_spawnable = NO_SPAWN
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -6,7 +6,7 @@
 
 /mob/living/simple_animal/hostile/poison
 	mobchatspan = "researchdirector"
-	var/poison_per_bite = 5
+	var/poison_per_bite = 4
 	var/poison_type = /datum/reagent/toxin
 
 /mob/living/simple_animal/hostile/poison/AttackingTarget()
@@ -16,9 +16,9 @@
 		if(L.reagents)
 			L.reagents.add_reagent(poison_type, poison_per_bite)
 
-//basic spider mob, these generally guard nests
+//basic spider mob, these generally guard nests and have no special qualities.
 /mob/living/simple_animal/hostile/poison/giant_spider
-	name = "giant spider"
+	name = "webspinner"
 	desc = "Furry and black, it makes you shudder to look at it. This one has deep red eyes."
 	icon_state = "guard"
 	icon_living = "guard"
@@ -33,14 +33,15 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
-	maxHealth = 200
-	health = 200
-	obj_damage = 60
-	melee_damage = 15
+	maxHealth = 100
+	health = 100
+	obj_damage = 40
+	melee_damage = 5
 	faction = list("spiders")
 	var/busy = SPIDER_IDLE
 	pass_flags = PASSTABLE
 	move_to_delay = 6
+	speed = 1
 	ventcrawler = VENTCRAWLER_ALWAYS
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -76,18 +77,20 @@
 		log_game("[key_name(src)] took control of [name] with the objective: '[directive]'.")
 	return TRUE
 
-//nursemaids - these create webs and eggs
+//Queen of the spiders, can send messages to all other spiders, wrap targets and reproduce to create more spiders.
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse
+	name = "broodmother"
 	desc = "Furry and black, it makes you shudder to look at it. This one has brilliant green eyes."
-	icon_state = "nurse"
-	icon_living = "nurse"
-	icon_dead = "nurse_dead"
+	icon_state = "midwife"
+	icon_living = "midwife"
+	icon_dead = "midwife_dead"
 	gender = FEMALE
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/spider = 2, /obj/item/reagent_containers/food/snacks/spiderleg = 8, /obj/item/reagent_containers/food/snacks/spidereggs = 4)
-	maxHealth = 40
-	health = 40
-	melee_damage = 10
-	poison_per_bite = 3
+	maxHealth = 80
+	health = 80
+	melee_damage = 5
+	obj_damage = 20
+	poison_per_bite = 4
 	var/atom/movable/cocoon_target
 	var/fed = 0
 	var/obj/effect/proc_holder/wrap/wrap
@@ -95,6 +98,7 @@
 	var/datum/action/innate/spider/set_directive/set_directive
 	var/static/list/consumed_mobs = list() //the tags of mobs that have been consumed by nurse spiders to lay eggs
 	gold_core_spawnable = NO_SPAWN
+	var/datum/action/innate/spider/comm/letmetalkpls
 
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/Initialize()
 	. = ..()
@@ -104,85 +108,64 @@
 	lay_eggs.Grant(src)
 	set_directive = new
 	set_directive.Grant(src)
+	letmetalkpls = new
+	letmetalkpls.Grant(src)
 
 /mob/living/simple_animal/hostile/poison/giant_spider/nurse/Destroy()
 	RemoveAbility(wrap)
 	QDEL_NULL(lay_eggs)
 	QDEL_NULL(set_directive)
-	return ..()
-
-//midwives are the queen of the spiders, can send messages to all them and web faster. That rare round where you get a queen spider and turn your 'for honor' players into 'r6siege' players will be a fun one.
-/mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife
-	name = "midwife"
-	desc = "Furry and black, it makes you shudder to look at it. This one has scintillating green eyes."
-	icon_state = "midwife"
-	icon_living = "midwife"
-	icon_dead = "midwife_dead"
-	maxHealth = 40
-	health = 40
-	var/datum/action/innate/spider/comm/letmetalkpls
-
-/mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife/Initialize()
-	. = ..()
-	letmetalkpls = new
-	letmetalkpls.Grant(src)
-
-/mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife/Destroy()
 	QDEL_NULL(letmetalkpls)
 	return ..()
 
-//hunters have the most poison and move the fastest, so they can find prey
+//huntsmans move slightly faster and inject more venom than other spiders, but have low health.
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter
+	name = "huntsman"
 	desc = "Furry and black, it makes you shudder to look at it. This one has sparkling purple eyes."
 	icon_state = "hunter"
 	icon_living = "hunter"
 	icon_dead = "hunter_dead"
-	maxHealth = 120
-	health = 120
-	melee_damage = 20
-	poison_per_bite = 5
+	maxHealth = 65
+	health = 65
+	melee_damage = 5
+	obj_damage = 20
+	poison_per_bite = 6
 	move_to_delay = 5
+	speed = 0
 
-//vipers are the rare variant of the hunter, no IMMEDIATE damage but so much poison medical care will be needed fast.
+//vipers move quickly, do more damage and inject heparin instead of normal venom, but have even less health than normal huntsman spiders
 /mob/living/simple_animal/hostile/poison/giant_spider/hunter/viper
 	name = "viper"
 	desc = "Furry and black, it makes you shudder to look at it. This one has effervescent purple eyes."
 	icon_state = "viper"
 	icon_living = "viper"
 	icon_dead = "viper_dead"
-	maxHealth = 40
-	health = 40
-	melee_damage = 1
+	maxHealth = 45
+	health = 45
+	melee_damage = 10
 	poison_per_bite = 4
 	move_to_delay = 4
 	poison_type = /datum/reagent/toxin/heparin
-	speed = 1
+	speed = -1
 	gold_core_spawnable = NO_SPAWN
 
-//tarantulas are really tanky, regenerating (maybe), hulky monster but are also extremely slow, so.
+//tarantulas are really tanky, hulky monster but are also slow.
 /mob/living/simple_animal/hostile/poison/giant_spider/tarantula
 	name = "tarantula"
 	desc = "Furry and black, it makes you shudder to look at it. This one has abyssal red eyes."
 	icon_state = "tarantula"
 	icon_living = "tarantula"
 	icon_dead = "tarantula_dead"
-	maxHealth = 300 // woah nelly
-	health = 300
+	maxHealth = 160
+	health = 160
 	melee_damage = 40
 	poison_per_bite = 0
 	move_to_delay = 8
-	speed = 7
+	speed = 2
 	status_flags = NONE
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 
-/mob/living/simple_animal/hostile/poison/giant_spider/tarantula/movement_delay()
-	var/turf/T = get_turf(src)
-	if(locate(/obj/structure/spider/stickyweb) in T)
-		speed = 2
-	else
-		speed = 7
-	. = ..()
 
 /mob/living/simple_animal/hostile/poison/giant_spider/ice //spiders dont usually like tempatures of 140 kelvin who knew
 	name = "giant ice spider"
@@ -356,7 +339,7 @@
 /obj/effect/proc_holder/wrap
 	name = "Wrap"
 	panel = "Spider"
-	desc = "Wrap something or someone in a cocoon. If it's a living being, you'll also consume them, allowing you to lay eggs."
+	desc = "Wrap something or someone in a cocoon. If it's an edible being, you'll also consume them, allowing you to lay eggs."
 	ranged_mousepointer = 'icons/effects/wrap_target.dmi'
 	action_icon = 'icons/mob/actions/actions_animal.dmi'
 	action_icon_state = "wrap_0"
@@ -406,7 +389,7 @@
 
 /datum/action/innate/spider/lay_eggs
 	name = "Lay Eggs"
-	desc = "Lay a cluster of eggs, which will soon grow into more spiders. You must have a directive set and wrap a living being to do this."
+	desc = "Lay a cluster of eggs, which will soon grow into more spiders. You must have a directive set and wrap an edible lifeform to do this."
 	button_icon_state = "lay_eggs"
 
 /datum/action/innate/spider/lay_eggs/IsAvailable()
@@ -490,7 +473,7 @@
 	button_icon_state = "command"
 
 /datum/action/innate/spider/comm/IsAvailable()
-	return ..() && istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife)
+	return ..() && istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse)
 
 /datum/action/innate/spider/comm/Trigger()
 	var/input = stripped_input(owner, "Input a command for your legions to follow.", "Command", "")

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -447,6 +447,23 @@
 	else
 		..()
 
+/datum/reagent/toxin/spidervenom
+	name = "Spider Venom"
+	description = "Venom extracted from alien spiders with paralytic properties"
+	color = "#00a080"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	toxpwr = 0.2								//Venom is weak to start so a single bite isn't an eventual death sentence without treatment
+
+/datum/reagent/toxin/spidervenom/on_mob_life(mob/living/carbon/M)
+	if(M.getStaminaLoss() <= 70)				//Should not stamcrit under most conditions, but will greatly slow down given some time.
+		M.adjustStaminaLoss(volume/2*REM, 0)
+	if(prob(current_cycle + volume/2)) 			//The longer it is in your system and the more of it you have the more frequently you drop
+		M.Paralyze(60, 0)
+		toxpwr += 0.1							//The venom gets stronger until completely purged.
+	if(holder.has_reagent(/datum/reagent/medicine/calomel) || holder.has_reagent(/datum/reagent/medicine/pen_acid) || holder.has_reagent(/datum/reagent/medicine/charcoal))
+		current_cycle += 8						//The venom will still be purged, but paralysis will onset very rapidly. This makes amping up on purge chems ahead of dealing with spiders a risky endeavor, but has no noteworthy effect on trying to purge the venom outside of active combat.
+	..()
+
 /datum/reagent/toxin/fentanyl
 	name = "Fentanyl"
 	description = "Fentanyl will inhibit brain function and cause toxin damage before eventually incapacitating its victim."

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -139,7 +139,7 @@
 
 /datum/chemical_reaction/slime/slimemobspawn/spider/summon_mobs(datum/reagents/holder, turf/T)
 	T.visible_message("<span class='danger'>The slime extract begins to vibrate crikey-ingly!</span>")
-	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Traitor Spider Slime", /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife, "neutral", FALSE), 50)
+	addtimer(CALLBACK(src, .proc/chemical_mob_spawn, holder, 3, "Traitor Spider Slime", /mob/living/simple_animal/hostile/poison/giant_spider/nurse, "neutral", FALSE), 50)
 
 
 //Silver


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Overhauls spiders, giving them a new venom type and better balanced stats, and also re-balances the spawnrate of the various spiders from spiderlings. 

**Broodmother** (previously Midwife)
80 HP
5 Brute
4 spider venom per bite
Movespeed 1 (Normal)
Produces baby spiders
Communicates telepathically to all other spiders
20 Object Damage
5% of spiderlings become Broodmothers

**Tarantula**
160 HP
20 Brute
No venom
Movespeed 2 (Slower)
80 Object Damage
20% of spiderlings become Tarantulas

**Webspinner**
100 HP
5 Brute
4 Venom per bite
Movespeed 1 (Normal)
40 Object Damage
35% of spiderlings become Webspinners

**Huntsman**
65 HP
5 Brute
6 Venom per bite
Speed 0 (Faster)
20 Object damage
20% of spiderlings become Huntsman

**Viper**
45 HP
10 Brute
4 _Heparin_ per bite
Speed -1 (As fast as running human)
20 Object damage
20% of spiderlings become Vipers

**Nursemaid spiders were merged with midwife into the broodmother listed above**

*** 

**Spider Venom**
* Starts out by doing a measly 0.2 toxin per cycle, but this increases by 0.1 every time paralysis activates
* Does stamina damage up to a soft cap of 70, which means it will eventually slow but will not stamcrit. 
* Paralysis is checked every reagent tick (two seconds) and drops you for three seconds if you fail the check. The check is calculated via current tick number + half the current volume of venom. The longer you have been processing venom, or the more of it you are processing the more likely you are to be paralyzed, eventually being fully paralyzed until you either die or the venom is totally purged.
* When purging chemicals are present,  the venom's paralytic properties rapidly accelerate *but the venom is still purged at full speed, so the venom will not remain for very long*. In effect this means purging the venom should be done in a safe location and not in the middle of a spider nest, or during active combat with a spider. 

***

Minor change but still worth mentioning: Spiderlings become edible when killed, and now also confer spider venom, even if they're turned into a spider lollipop. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Spiders are super bland right now and a missed opportunity at being a primarily venom-oriented enemy. Default "giant spiders" and tarantulas have *way* too much HP, and most spiders are more physically destructive than they need to be while having very weak venom. *On the far other end of the spectrum, Vipers had absurdly OP venom and almost no physical damage*

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Spider venom - a complex toxin with effects that gradually worsen over time. Worsens faster at higher doses like standard venom, but is primarily focused on slowing and incapacitation rather than damage. 
tweak: Spiderlings and Spider Lollipops now contain Spider venom instead of toxin.
del: Nursemaid spiders were removed for being largely redundant with the midwife/broodmother
balance: Most spiders have had their mob and object damage reduced, but now inject spider venom instead of a very weak normal toxin.
balance: Midwife spiders have been renamed to broodmother and have had their base HP doubled to (now 80)
balance: Standard "giant spiders" have been renamed to Webspinners have had their HP halved (now 100). Webspinners do 2x as much object damage as most other spiders.
balance: Huntsman spiders have reduced HP (now 65) and increased movement speed. They inject 50% more spider venom per bite than other spiders. 
balance: Viper spiders have had their HP slightly increased (now 45) and move as fast as running humanoids. They now do twice as much brute per bite as other spiders and inject Heparin (destroys blood, low brute over time) instead of Venom.
balance: Tarantulas have had their HP roughly halved (160 now) and movespeed dramatically increased, but still slightly slower than other spiders. Tarantulas do 4x as much brute AND object damage as most other spiders, but have no venom at all. 


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
