### PR TITLE
Blocking is now disabled in help intent instead of harm intent.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -491,7 +491,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	else if(HAS_TRAIT(owner, TRAIT_NOLIMBDISABLE) && owner.getStaminaLoss() >= 30)
 		to_chat(owner, "<span_class='danger'>You're too exausted to block the attack!</span>")
 		return 0
-	if(owner.a_intent == INTENT_HARM) //you can choose not to block an attack
+	if(owner.a_intent == INTENT_HELP) //you can choose not to block an attack
 		return 0
 	if(block_flags & BLOCKING_ACTIVE && owner.get_active_held_item() != src) //you can still parry with the offhand
 		return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Why is the combat intent the thing that disables blocking. That's just stupid if you ask me.
Changes it so that blocking is disabled on help intent instead of harm intent.

## Why It's Good For The Game

Extremely confusing to anyone who isn't familiar with the code, the mode that is used almost exclusively for combat and hitting things (Hitting tables, hitting racks, hitting people etc.) is the single mode that doesn't let you block. It makes so much more sense that blocking is disabled on help intent, the intent you use primarilly outside of combat.

## Changelog
:cl:
tweak: Blocking now works on harm intent and no longer works on help intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
 