### PR TITLE
Lowers Riot Armor Volume (V2)

### DIFF
--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -44,7 +44,7 @@
 	if(!istype(H) || H.wear_suit != src)
 		return
 	if(world.time > footstep)
-		playsound(src, pick(move_sound), 100, 1)
+		playsound(src, pick(move_sound), 65, 1)
 		footstep = world.time + FOOTSTEP_COOLDOWN
 
 /obj/item/clothing/suit/equipped(mob/user, slot)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes the volume of riot armor footsteps, bringing the volume down from 100 to 65. Now using a code-based solution instead of asset modification. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Assaulting one's ears to disperse a riot is probably against the Geneva Conventions. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: reduced riot armor volume from 100 to 65
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
