### PR TITLE
Significantly reduces the ability to conclusively metagame the karate/tribal claw/sleeping carp granters

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -565,6 +565,12 @@
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 5, /obj/item/paper = 20)
 	category = CAT_MISC
 
+/datum/crafting_recipe/scroll
+	name = "Blank Scroll"
+	result = /obj/item/book/granter/fake_scroll
+	time = 10
+	reqs = list(/obj/item/paper = 2)
+	category = CAT_MISC
 /datum/crafting_recipe/naturalpaper
 	name = "Hand-Pressed Paper"
 	time = 30

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -571,6 +571,7 @@
 	time = 10
 	reqs = list(/obj/item/paper = 2)
 	category = CAT_MISC
+	
 /datum/crafting_recipe/naturalpaper
 	name = "Hand-Pressed Paper"
 	time = 30

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -468,3 +468,10 @@
 	icon_state = "cooking_learing_sweets"
 	oneuse = FALSE
 	remarks = list("So that is how icing is made!", "Placing fruit on top? How simple...", "Huh layering cake seems harder then this...", "This book smells like candy", "A clown must have made this page, or they forgot to spell check it before printing...", "Wait, a way to cook slime to be safe?")
+
+/obj/item/book/granter/fake_scroll
+	name = "empty scroll"
+	desc = "It's completely blank."
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "blankscroll"
+	used = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now craft a Blank Scroll identical to a used martial granter with 2 paper.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cool decoration
Also less metagaming of blank scrolls as currently they exclusively come from uplink items.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Blank Scrolls are now craftable with two pieces of paper.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
 