### PR TITLE
Security (Officer and detective) will very rarely be antagonists.

### DIFF
--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -13,6 +13,8 @@
 	<span class='danger'>Blood Brothers</span>: Accomplish your objectives.\n\
 	<span class='notice'>Crew</span>: Do not let the traitors or brothers succeed!"
 
+	allowed_special = list(/datum/special_role/traitor/infiltrator)
+
 	var/list/datum/team/brother_team/pre_brother_teams = list()
 	var/const/team_amount = 2 //hard limit on brother teams if scaling is turned off
 	var/const/min_team_size = 2

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -10,6 +10,8 @@
 	recommended_enemies = 3
 	reroll_friendly = 1
 
+	allowed_special = list(/datum/special_role/traitor/infiltrator)
+
 	var/list/possible_changelings = list()
 	var/list/changelings = list()
 	var/const/changeling_amount = 1 //hard limit on changelings if scaling is turned off

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -19,6 +19,8 @@
 	reroll_friendly = 1
 	enemy_minimum_age = 0
 
+	allowed_special = list(/datum/special_role/traitor/infiltrator)
+
 	announce_span = "danger"
 	announce_text = "There are Syndicate agents on the station!\n\
 	<span class='danger'>Traitors</span>: Accomplish your objectives.\n\

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -14,6 +14,7 @@
 	var/should_equip = TRUE
 	var/traitor_kind = TRAITOR_HUMAN //Set on initial assignment
 	var/datum/contractor_hub/contractor_hub
+	var/telecrystals = 20
 
 /datum/antagonist/traitor/on_gain()
 	if(owner.current && isAI(owner.current))
@@ -282,7 +283,7 @@
 
 /datum/antagonist/traitor/proc/equip(var/silent = FALSE)
 	if(traitor_kind == TRAITOR_HUMAN)
-		owner.equip_traitor(employer, silent, src)
+		owner.equip_traitor(employer, silent, src, telecrystals)
 
 /datum/antagonist/traitor/proc/assign_exchange_role()
 	//set faction

--- a/code/modules/antagonists/traitor/traitor_spawner.dm
+++ b/code/modules/antagonists/traitor/traitor_spawner.dm
@@ -32,7 +32,7 @@
 
 /datum/special_role/traitor/infiltrator
 	attached_antag_datum = /datum/antagonist/traitor/infiltrator
-	probability = 8			//8% chance for this to occur. Kind of rare, but something that HOS's and wardens need to consider.
+	probability = 5			//5% chance for this to occur. Kind of rare, but something that HOS's and wardens need to consider.
 	min_players = 20		//Give us 20 players minimum.
 	proportion = 1			//This is limited by max amount anyway.
 	max_amount = 1			//Only 1, we don't want insane chaos

--- a/code/modules/antagonists/traitor/traitor_spawner.dm
+++ b/code/modules/antagonists/traitor/traitor_spawner.dm
@@ -40,6 +40,14 @@
 
 /datum/special_role/traitor/infiltrator/New()
 	. = ..()
+	//Make sure HOS or warden exists
+	var/allowed = FALSE
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.mind?.assigned_role in list("Head of Security", "Warden"))
+			allowed = TRUE
+			break
+	if(!allowed)
+		probability = 0
 	protected_jobs = get_all_jobs()
 	protected_jobs -= list("Detective", "Security Officer")
 

--- a/code/modules/antagonists/traitor/traitor_spawner.dm
+++ b/code/modules/antagonists/traitor/traitor_spawner.dm
@@ -17,8 +17,6 @@
 	special_role_flag = ROLE_TRAITOR
 	role_name = ROLE_TRAITOR
 
-	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
-
 /datum/special_role/traitor/higher_chance
 	probability = 60
 
@@ -31,3 +29,25 @@
 	A.forge_objectives(M)
 	A.equip()
 	return A
+
+/datum/special_role/traitor/infiltrator
+	attached_antag_datum = /datum/antagonist/traitor/infiltrator
+	probability = 8			//8% chance for this to occur. Kind of rare, but something that HOS's and wardens need to consider.
+	min_players = 20		//Give us 20 players minimum.
+	proportion = 1			//This is limited by max amount anyway.
+	max_amount = 1			//Only 1, we don't want insane chaos
+	telecrystals = 16		//You are in security and have gear. You get slightly less to work with.
+
+/datum/special_role/traitor/infiltrator/New()
+	. = ..()
+	protected_jobs = get_all_jobs()
+	protected_jobs -= list("Detective", "Security Officer")
+
+/datum/antagonist/traitor/infiltrator
+	name = "Infiltrator"
+	telecrystals = 16
+
+/datum/antagonist/traitor/infiltrator/on_gain()
+	. = ..()
+	to_chat(owner.current, "<span class='syndradio italics'>It's taken a lot of work from a lot of people to get you in this possition. Don't mess this up, we are counting on you.</span>")
+	to_chat(owner.current, "<span class='warning'>You have been inserted into the security detail of [station_name()]. You have a strong resiliance against the effects of the mindshield and have been cleared past Nanotrasen's background checks. You have a reduced supply of telecrystals, but have a lot to work with in terms of your environment. Good luck.</span>")

--- a/code/modules/antagonists/traitor/traitor_spawner.dm
+++ b/code/modules/antagonists/traitor/traitor_spawner.dm
@@ -36,7 +36,6 @@
 	min_players = 20		//Give us 20 players minimum.
 	proportion = 1			//This is limited by max amount anyway.
 	max_amount = 1			//Only 1, we don't want insane chaos
-	telecrystals = 16		//You are in security and have gear. You get slightly less to work with.
 
 /datum/special_role/traitor/infiltrator/New()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Edit:
Ill change this to changeling since its 100x better than sec traitors.
Security should have at least 1 antagonist role that they can be and I think changeling is the best (and a good one) for it.

## About The Pull Request

Very rarely (1/20 rounds), a member of security (Detective or Security off.) will be a traitor.
They will start with 16 TC, however are in a very powerful position for gaining trust and items.
This will not spawn without a HOS or Warden, see below.
This can only spawn on gamemodes that spawn traitors normally (traitorbros, traitor, traitorchan).

## Why It's Good For The Game

This removes the 100% guaranteed protection from security officers or detectives. While still incredibly rare, the small chance is enough to mean that the HOS and warden will have a more active role in monitoring the behaviour of security and ensuring that gear isn't given out excessively.
While security being full on shitsec is of course against the rules and will be punished by the admins, there are cases which are a lot more borderline that should be dealt IC. Currently as a HOS, many players (myself included) find it difficult to deal with situations like this in an IC manner with the knowledge that you know they aren't bad or simply don't care since the antagonists are now defeated.
This PR aims to increase the responsibility of the HOS' job in managing the actions of security and makes security more in line with other members of the crew in that they will too need to be monitored for suspicious activity.
Additionally warden will have a larger responsibility in determining that a threat is great enough to give out weapons to all members of security, as you could be empowering the very people you aim to defeat.
The main goal is more to make it less abnormal for HOS or wardens to check up on security, check them for illegal items and make sure they aren't doing anything they shouldn't be rather than allowing for security to go on a rampage as the ultimate shitsec.

This shouldn't act as a nerf to security, the role itself is extremely rare and mainly makes it easier for HOS and the warden to inspect their own security members and ensure good behaviour all round.
Regular security officers sneaking contraband from captured traitors will no longer get a free all-clear pass on the premise that they are security so have to be good but instead will need to be questioned like any other member of the crew.

## Changelog
:cl:
refactor: Adds in the infiltrator antagonist role, a regular traitor with 16 TC however will be detective or security officer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
 