### PR TITLE
Anomalies can now be created by attaching a trigger to an Anomaly Core

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -25,11 +25,10 @@
 	var/wire_type = WIRE_RECEIVE | WIRE_PULSE
 	var/attachable = FALSE // can this be attached to wires
 	var/datum/wires/connected = null
-
+	var/mob/living/carbon/assembler = null //who put it together
 	var/next_activate = 0 //When we're next allowed to activate - for spam control
 	var/activate_delay = 30
 
-	var/attacher = null
 
 /obj/item/assembly/Destroy()
 	holder = null
@@ -101,8 +100,8 @@
 		if((!A.secured) && (!secured))
 			holder = new/obj/item/assembly_holder(get_turf(src))
 			holder.assemble(src,A,user)
-			attacher = user
 			to_chat(user, "<span class='notice'>You attach and secure \the [A] to \the [src]!</span>")
+			assembler = user
 			if(istype(A, /obj/item/assembly/signaler/anomaly) || istype(src, /obj/item/assembly/signaler/anomaly))
 				message_admins("[ADMIN_LOOKUPFLW(user)] has attached an anomaly core to a trigger assembly at [ADMIN_VERBOSEJMP(src)]")
 		else

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -100,6 +100,8 @@
 			holder = new/obj/item/assembly_holder(get_turf(src))
 			holder.assemble(src,A,user)
 			to_chat(user, "<span class='notice'>You attach and secure \the [A] to \the [src]!</span>")
+			if(istype(A, /obj/item/assembly/signaler/anomaly) || istype(src, /obj/item/assembly/signaler/anomaly))
+				message_admins("[ADMIN_LOOKUPFLW(user)] has attached an anomaly core to a trigger assembly at [ADMIN_VERBOSEJMP(src)]")
 		else
 			to_chat(user, "<span class='warning'>Both devices must be in attachable mode to be attached together.</span>")
 		return

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -29,6 +29,8 @@
 	var/next_activate = 0 //When we're next allowed to activate - for spam control
 	var/activate_delay = 30
 
+	var/attacher = null
+
 /obj/item/assembly/Destroy()
 	holder = null
 	return ..()
@@ -99,6 +101,7 @@
 		if((!A.secured) && (!secured))
 			holder = new/obj/item/assembly_holder(get_turf(src))
 			holder.assemble(src,A,user)
+			attacher = user
 			to_chat(user, "<span class='notice'>You attach and secure \the [A] to \the [src]!</span>")
 			if(istype(A, /obj/item/assembly/signaler/anomaly) || istype(src, /obj/item/assembly/signaler/anomaly))
 				message_admins("[ADMIN_LOOKUPFLW(user)] has attached an anomaly core to a trigger assembly at [ADMIN_VERBOSEJMP(src)]")

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -241,6 +241,14 @@
 	icon_state = "vortex core"
 	anomaly_type = /obj/effect/anomaly/bhole
 
+/obj/item/assembly/signaler/anomaly/activate()
+	. = ..()
+	var/obj/effect/anomaly/anomaly_path = anomaly_type
+	var/newAnomaly
+	newAnomaly = new anomaly_path(get_turf(src))
+	if(newAnomaly)
+		qdel(src)
+
 /obj/item/assembly/signaler/anomaly/attack_self()
 	return
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -247,6 +247,7 @@
 	var/newAnomaly
 	newAnomaly = new anomaly_path(get_turf(src))
 	if(newAnomaly)
+		message_admins("An anomaly has been created via trigger assembly at [ADMIN_VERBOSEJMP(src)]")
 		qdel(src)
 
 /obj/item/assembly/signaler/anomaly/attack_self()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -243,12 +243,9 @@
 
 /obj/item/assembly/signaler/anomaly/activate()
 	. = ..()
-	var/obj/effect/anomaly/anomaly_path = anomaly_type
-	var/newAnomaly
-	newAnomaly = new anomaly_path(get_turf(src))
-	if(newAnomaly)
-		message_admins("An anomaly has been created via trigger assembly at [ADMIN_VERBOSEJMP(src)]")
-		qdel(src)
+	new anomaly_type(get_turf(src))
+	message_admins("An anomaly has been created via trigger assembly at [ADMIN_VERBOSEJMP(src)], assembled by [ADMIN_LOOKUPFLW(assembler)]")
+	qdel(src.holder)
 
 /obj/item/assembly/signaler/anomaly/attack_self()
 	return

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -244,8 +244,7 @@
 /obj/item/assembly/signaler/anomaly/activate()
 	. = ..()
 	var/obj/effect/anomaly/anomaly_path = anomaly_type
-	var/newAnomaly
-	newAnomaly = new anomaly_path(get_turf(src))
+	var/newAnomaly = new anomaly_path(get_turf(src))
 	if(newAnomaly)
 		message_admins("An anomaly has been created via trigger assembly at [ADMIN_VERBOSEJMP(src)]")
 		qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You could already attach a core to a signaler/prox sensor/etc so I said why not make it spawn an anomaly when signaled.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
An anomaly in the wrong place at the wrong time can cause a really bad day. Also nice as a land mine, deterrent, etc.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Anomaly Cores can now be attached to remote signalers and other triggers, activating them will create a new anomaly of the core's type
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
 