### PR TITLE
Makes the nuclear operative ship turrets normal instead of instakill penetrators.

### DIFF
--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -2,12 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ab" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
-	dir = 9
-	},
-/turf/closed/wall/r_wall/syndicate,
-/area/shuttle/syndicate/bridge)
 "ac" = (
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/bridge)
@@ -1161,15 +1155,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/syndicate/armory)
-"dp" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
+"qG" = (
+/obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/bridge)
-"pd" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
-	dir = 5
+"vm" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 9
 	},
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/bridge)
@@ -1178,8 +1172,26 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/syndicate/eva)
-"MJ" = (
-/obj/machinery/porta_turret/syndicate/shuttle{
+"vV" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 6
+	},
+/turf/closed/wall/r_wall/syndicate,
+/area/shuttle/syndicate/armory)
+"yk" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 10
+	},
+/turf/closed/wall/r_wall/syndicate,
+/area/shuttle/syndicate/medical)
+"IX" = (
+/obj/machinery/porta_turret/syndicate{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/syndicate,
+/area/shuttle/syndicate/bridge)
+"MW" = (
+/obj/machinery/porta_turret/syndicate{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/syndicate,
@@ -1199,7 +1211,7 @@ aa
 aa
 aa
 aa
-ab
+vm
 aJ
 aJ
 aJ
@@ -1208,7 +1220,7 @@ aJ
 aJ
 aJ
 aJ
-aJ
+yk
 "}
 (2,1,1) = {"
 aa
@@ -1218,7 +1230,7 @@ aa
 aa
 aa
 aa
-ab
+vm
 ax
 ax
 ax
@@ -1286,7 +1298,7 @@ cu
 cB
 "}
 (5,1,1) = {"
-ab
+vm
 ac
 ac
 ac
@@ -1308,7 +1320,7 @@ cb
 aK
 aJ
 aJ
-MJ
+MW
 "}
 (6,1,1) = {"
 ac
@@ -1316,7 +1328,7 @@ ag
 an
 at
 ac
-dp
+qG
 aa
 ax
 aN
@@ -1466,7 +1478,7 @@ am
 as
 at
 ac
-MJ
+MW
 aa
 aB
 aO
@@ -1486,7 +1498,7 @@ aa
 aa
 "}
 (13,1,1) = {"
-pd
+IX
 ac
 ac
 ac
@@ -1508,7 +1520,7 @@ cf
 bj
 bm
 bm
-dp
+qG
 "}
 (14,1,1) = {"
 aa
@@ -1568,7 +1580,7 @@ aa
 aa
 aa
 aa
-pd
+IX
 aB
 aB
 aY
@@ -1599,7 +1611,7 @@ aa
 aa
 aa
 aa
-pd
+IX
 bm
 bm
 bm
@@ -1608,5 +1620,5 @@ bm
 bm
 bm
 bm
-bm
+vV
 "}

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1277,33 +1277,6 @@
 			<ul class="changes bgimages16">
 				<li class="bugfix">makes machines work as intended again</li>
 			</ul>
-
-			<h2 class="date">01 June 2021</h2>
-			<h3 class="author">Archanial updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed runtime in config related to testmerges</li>
-			</ul>
-			<h3 class="author">Crossedfall updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Being on staff grants you access to donor items</li>
-			</ul>
-			<h3 class="author">Mothblocks, froststahr port updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="admin">Added the "Check Timer Sources" debug command to help isolate problematic cases of addtimer.</li>
-			</ul>
-			<h3 class="author">ike709 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="refactor">Minor optimizations to powernet propagation.</li>
-			</ul>
-			<h3 class="author">jupyterkat updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">ethereals can charge via borg chargers again</li>
-			</ul>
-			<h3 class="author">steelslayer updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="code_imp">Updates various machines, which currently use SSfastprocess, so that they only start processing when it's necessary. Some of these updated machines have been changed so that they don't ever need to process.</li>
-				<li class="refactor">Replaces the speed_process var with two new variables. The processing_flags variable stores bitflags with information about a machine's preferences on when it should start processing. The subsystem_type var holds the path to which type of subsystem that machine should use.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1279,6 +1279,33 @@
 			</ul>
 		</div>
 
+			<h2 class="date">01 June 2021</h2>
+			<h3 class="author">Archanial updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">Fixed runtime in config related to testmerges</li>
+			</ul>
+			<h3 class="author">Crossedfall updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Being on staff grants you access to donor items</li>
+			</ul>
+			<h3 class="author">Mothblocks, froststahr port updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="admin">Added the "Check Timer Sources" debug command to help isolate problematic cases of addtimer.</li>
+			</ul>
+			<h3 class="author">ike709 updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="refactor">Minor optimizations to powernet propagation.</li>
+			</ul>
+			<h3 class="author">jupyterkat updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">ethereals can charge via borg chargers again</li>
+			</ul>
+			<h3 class="author">steelslayer updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="code_imp">Updates various machines, which currently use SSfastprocess, so that they only start processing when it's necessary. Some of these updated machines have been changed so that they don't ever need to process.</li>
+				<li class="refactor">Replaces the speed_process var with two new variables. The processing_flags variable stores bitflags with information about a machine's preferences on when it should start processing. The subsystem_type var holds the path to which type of subsystem that machine should use.</li>
+			</ul>
+
 <b>GoonStation 13 Development Team</b>
 	<div class = "top">
 	<b>Coders:</b> Stuntwaffle, Showtime, Pantaloons, Nannek, Keelin, Exadv1, hobnob, Justicefries, 0staf, sniperchance, AngriestIBM, BrianOBlivion<br>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -1277,7 +1277,6 @@
 			<ul class="changes bgimages16">
 				<li class="bugfix">makes machines work as intended again</li>
 			</ul>
-		</div>
 
 			<h2 class="date">01 June 2021</h2>
 			<h3 class="author">Archanial updated:</h3>
@@ -1305,6 +1304,7 @@
 				<li class="code_imp">Updates various machines, which currently use SSfastprocess, so that they only start processing when it's necessary. Some of these updated machines have been changed so that they don't ever need to process.</li>
 				<li class="refactor">Replaces the speed_process var with two new variables. The processing_flags variable stores bitflags with information about a machine's preferences on when it should start processing. The subsystem_type var holds the path to which type of subsystem that machine should use.</li>
 			</ul>
+		</div>
 
 <b>GoonStation 13 Development Team</b>
 	<div class = "top">


### PR DESCRIPTION

## About The Pull Request

Merely changes all of the turrets on the nukie ship to normal ones. Also adds 2 more to the back in a blindspot.
![image](https://user-images.githubusercontent.com/41198990/131036589-8cea65c6-a697-4841-9f96-e16956252252.png)


## Why It's Good For The Game

As it is now, the nuclear operatives ship near instantly kills any non-nukies that get even remotely near it.

Its possible to land the nuclear operatives ship right next to the brig and the penetrator turrets will shoot through the glass and walls and kill everyone inside.

The ship is still powerful with normal turrets and can be landed further away from the station so it is not easy to find either.

## Changelog
:cl:
balance: Nuclear operative ship gets normal syndicate turrets instead of instakill penetrator ones.
/:cl:
