### PR TITLE
Increases midround morph chance

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -326,7 +326,7 @@
 /datum/round_event_control/morph
 	name = "Spawn Morph"
 	typepath = /datum/round_event/ghost_role/morph
-	weight = 2
+	weight = 10
 	max_occurrences = 1
 
 /datum/round_event/ghost_role/morph

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -326,7 +326,7 @@
 /datum/round_event_control/morph
 	name = "Spawn Morph"
 	typepath = /datum/round_event/ghost_role/morph
-	weight = 10
+	weight = 5
 	max_occurrences = 1
 
 /datum/round_event/ghost_role/morph

--- a/code/modules/antagonists/morph/morph_antag.dm
+++ b/code/modules/antagonists/morph/morph_antag.dm
@@ -2,5 +2,6 @@
 	name = "Morph"
 	show_name_in_check_antagonists = TRUE
 	show_in_antagpanel = FALSE
+	show_to_ghosts = TRUE
 
 //It does nothing! (Besides tracking)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the morph midround event chance to 10 and puts it on the Ghost Visible Antagonists list.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Probability for Morph is now equal to Nightmare. Additionally, it would show up in the living creatures list as "morphling" so no real point in it not being ghost-visible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The Morph midround event has been increased in probability and is now equal to Nightmare. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
