### PR TITLE
Fix missing equipment for mecha

### DIFF
--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -48,10 +48,10 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/try_attach_part(mob/user, obj/mecha/M)
+	if(!do_mob(user, M, 15))
+		return FALSE
 	if(!can_attach(M))
 		to_chat(user, "<span class='warning'>You are unable to attach [src] to [M]!</span>")
-		return FALSE
-	if(!do_mob(user, M, 15))
 		return FALSE
 	if(!user.temporarilyRemoveItemFromInventory(src))
 		return FALSE

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -54,6 +54,7 @@
 		return FALSE
 	if(!can_attach(M))
 		to_chat(user, "<span class='warning'>You are unable to attach [src] to [M]!</span>")
+		user.put_in_hands(src)
 		return FALSE
 	attach(M)
 	user.visible_message("[user] attaches [src] to [M].", "<span class='notice'>You attach [src] to [M].</span>")

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -48,13 +48,12 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/try_attach_part(mob/user, obj/mecha/M)
+	if(!can_attach(M))
+		to_chat(user, "<span class='warning'>You are unable to attach [src] to [M]!</span>")
+		return FALSE
 	if(!do_mob(user, M, 15))
 		return FALSE
 	if(!user.temporarilyRemoveItemFromInventory(src))
-		return FALSE
-	if(!can_attach(M))
-		to_chat(user, "<span class='warning'>You are unable to attach [src] to [M]!</span>")
-		user.put_in_hands(src)
 		return FALSE
 	attach(M)
 	user.visible_message("[user] attaches [src] to [M].", "<span class='notice'>You attach [src] to [M].</span>")


### PR DESCRIPTION
## About The Pull Request
Fixing the disappearance of equipment when trying to install it in the wrong type of mecha.

## Changelog
:cl:
fix: Equipment no longer disappears when you try to install it in the wrong type of mecha.
/:cl:
