### PR TITLE
Reduce unnecessary tgui updates

### DIFF
--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -271,6 +271,7 @@
 		return
 	// Update through a normal call to ui_interact
 	if(status != UI_DISABLED && (autoupdate || force || src_object.ui_requires_update(user, src)))
+		needs_update = FALSE
 		src_object.ui_interact(user, src)
 		return
 	// Update status only


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updating an interface in the tgui datum's `process` now sets `needs_update` to `FALSE`, even if `needs_update` was not the reason the update occured. This runs when autoupdating, updating due to `ui_update()` and updating after `ui_act`.

The reasoning for is that the new `ui_update` is being used in a lot of procs that are called both from `ui_act` and other user input. The result of this is that when called from `ui_act`, the interface will update immediately due to return value from `ui_act`, then will update again on the next `process` due to `needs_update` being set.
This reduces the amount of updates done in those cases and allows us to put `ui_update` more carelessly into anything that affects state without the UI updating needlessly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less interface updating hopefully means *some* gains to performance, however small. This also allows coders to put `ui_update` into procs that modify state directly without worrying about double updates when they are called from something that updates the UI immediately.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: TGUI interfaces updating from ui_act will not update again due to ui_update
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
