### PR TITLE
Power monitors now report 100% power on cogged APCs

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -311,7 +311,10 @@ Code:
 //would be to use <span style="width: NNNpx; overflow: none;">[A.area.name]</span>
 					for(var/obj/machinery/power/apc/A in L)
 						menu += copytext_char(add_trailing(A.area.name, 30, " "), 1, 30)
-						menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_leading(DisplayPower(A.lastused_total), 6, " ")]  [A.cell ? "[add_leading("[round(A.cell.percent())]", 3, " ")]% [chg[A.charging+1]]" : "  N/C"]<BR>"
+						if(A.integration_cog)
+							menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_leading(DisplayPower(A.lastused_total), 6, " ")]  100% F<BR>"
+						else
+							menu += " [S[A.equipment+1]] [S[A.lighting+1]] [S[A.environ+1]] [add_leading(DisplayPower(A.lastused_total), 6, " ")]  [A.cell ? "[add_leading("[round(A.cell.percent())]", 3, " ")]% [chg[A.charging+1]]" : "  N/C"]<BR>"
 
 				menu += "</FONT></PRE>"
 
@@ -457,7 +460,7 @@ Code:
 			else
 				menu += "<b>No ore silo detected!</b>"
 			menu = jointext(menu, "")
-      
+
 		if (53) // Newscaster
 			menu = "<h4>[PDAIMG(notes)] Newscaster Access</h4>"
 			menu += "<br> Current Newsfeed: <A href='byond://?src=[REF(src)];choice=Newscaster Switch Channel'>[current_channel ? current_channel : "None"]</a> <br>"

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -92,7 +92,7 @@
 			if(istype(A))
 				data["areas"] += list(list(
 					"name" = A.area.name,
-					"charge" = A.cell ? A.cell.percent() : 0,
+					"charge" = A.integration_cog ? 100 : A.cell ? A.cell.percent() : 0,
 					"load" = DisplayPower(A.lastused_total),
 					"charging" = A.charging,
 					"eqp" = A.equipment,

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -113,6 +113,8 @@
 				var/cell_charge
 				if(!A.cell)
 					cell_charge = 0
+				else if(A.integration_cog)
+					cell_charge = 100
 				else
 					cell_charge = A.cell.percent()
 				data["areas"] += list(list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Another PR for my little cogchamps, power monitors will no longer report 50% power on cogged APCs and will instead always show them as having 100% power.

## Why It's Good For The Game

Less metaing the gamemode by mass scanning all APC power charges. Find the APCs that are incorrect.

## Changelog
:cl:
balance: Cogged APCs will now report 100% charge on power monitors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
