### PR TITLE
Adds a few items to exploration shuttles.

### DIFF
--- a/_maps/shuttles/exploration_corg.dmm
+++ b/_maps/shuttles/exploration_corg.dmm
@@ -281,6 +281,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
+"ml" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
 "mr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -786,6 +791,8 @@
 /obj/item/toy/cards/deck/cas/black{
 	pixel_y = 3
 	},
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/exploration)
 "QG" = (
@@ -831,6 +838,7 @@
 /area/shuttle/exploration)
 "Tz" = (
 /obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/exploration)
 "TU" = (
@@ -1089,7 +1097,7 @@ pT
 (8,1,1) = {"
 ka
 jB
-kH
+ml
 Dn
 Dn
 df

--- a/_maps/shuttles/exploration_delta.dmm
+++ b/_maps/shuttles/exploration_delta.dmm
@@ -212,6 +212,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/gps/mining,
 /turf/open/floor/plating,
 /area/shuttle/exploration)
 "K" = (
@@ -243,6 +244,10 @@
 "R" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/exploration)
+"S" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
 "T" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -259,8 +264,9 @@
 "V" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/item/gps/mining,
-/obj/item/multitool,
+/obj/machinery/microwave,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "W" = (
@@ -390,7 +396,7 @@ h
 L
 L
 O
-B
+S
 d
 B
 m

--- a/_maps/shuttles/exploration_shuttle.dmm
+++ b/_maps/shuttles/exploration_shuttle.dmm
@@ -97,6 +97,7 @@
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "o" = (
@@ -275,6 +276,13 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
+"O" = (
+/obj/machinery/microwave,
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
 "P" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -406,7 +414,7 @@ R
 m
 P
 z
-g
+O
 q
 g
 a

--- a/_maps/shuttles/exploration_shuttle.dmm
+++ b/_maps/shuttles/exploration_shuttle.dmm
@@ -209,6 +209,9 @@
 /obj/structure/closet/crate/science,
 /obj/item/circuitboard/computer/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/five,
+/obj/item/gps/mining,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "D" = (
@@ -222,9 +225,9 @@
 /area/shuttle/exploration)
 "F" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/obj/item/gps/mining,
+/obj/machinery/microwave,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "G" = (
@@ -274,13 +277,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"O" = (
-/obj/machinery/microwave,
-/obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "P" = (
@@ -414,7 +410,7 @@ R
 m
 P
 z
-O
+g
 q
 g
 a


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the following to every exploration shuttle:
One Microwave.
Two packs of Donkpockets.
An oxygen tank dispenser.

## Why It's Good For The Game

So the Exploration crew doesn't have to go loot moldy food from the abandoned stations, and so they aren't immediately fucked when they forget their oxygen tanks on the station, or need a new one.

## Changelog
:cl:
add: added microwaves, donk pockets, and oxygen tank dispensers to exploration shuttles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
