### PR TITLE
Budget cards are indestructible

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -648,7 +648,8 @@ update_label("John Doe", "Clowny")
 	icon_state = "budget"
 	var/department_ID = ACCOUNT_CIV
 	var/department_name = ACCOUNT_CIV_NAME
-
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	
 /obj/item/card/id/departmental_budget/Initialize()
 	. = ..()
 	var/datum/bank_account/B = SSeconomy.get_dep_account(department_ID)
@@ -773,7 +774,7 @@ update_label("John Doe", "Clowny")
 	if (!proximity)
 		return .
 	var/obj/item/card/id/idcard = target
-	if(istype(idcard))		
+	if(istype(idcard))
 		for(var/give_access in access)
 			idcard.access |= give_access
 		if(assignment!=initial(assignment))


### PR DESCRIPTION

## About The Pull Request

Budget cards are indestructible.

## Why It's Good For The Game

Very important and irreplaceable item.

## Changelog
:cl:
tweak: budget cards are indestructible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
