### PR TITLE
You can now print multiple wanted/missing posters

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -620,16 +620,17 @@ What a mess.*/
 								default_description += "[c.crimeDetails]\n"
 
 						var/headerText = stripped_input(usr, "Please enter Poster Heading (Max 7 Chars):", "Print Wanted Poster", "WANTED", 8)
-
+						var/posternum = max(min((input("Number of posters to print (Max 5):","Number:",1) as num|null), 5), 1)
 						var/info = stripped_multiline_input(usr, "Please input a description for the poster:", "Print Wanted Poster", default_description, null)
 						if(info)
-							playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
-							printing = 1
-							sleep(30)
-							if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
-								var/obj/item/photo/photo = active1.fields["photo_front"]
-								new /obj/item/poster/wanted(loc, photo.picture.picture_image, wanted_name, info, headerText)
-							printing = 0
+							while(posternum--)
+								playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
+								printing = 1
+								sleep(30)
+								if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
+									var/obj/item/photo/photo = active1.fields["photo_front"]
+									new /obj/item/poster/wanted(loc, photo.picture.picture_image, wanted_name, info, headerText)
+								printing = 0
 			if("Print Missing")
 				if(!( printing ))
 					var/missing_name = stripped_input(usr, "Please enter an alias for the missing person:", "Print Missing Persons Poster", active1.fields["name"])
@@ -637,16 +638,17 @@ What a mess.*/
 						var/default_description = "A poster declaring [missing_name] to be a missing individual, missed by Nanotrasen. Report any sightings to security immediately."
 
 						var/headerText = stripped_input(usr, "Please enter Poster Heading (Max 7 Chars):", "Print Missing Persons Poster", "MISSING", 8)
-
+						var/posternum = max(min((input("Number of posters to print (Max 5):","Number:",1) as num|null), 5), 1)
 						var/info = stripped_multiline_input(usr, "Please input a description for the poster:", "Print Missing Persons Poster", default_description, null)
 						if(info)
-							playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
-							printing = 1
-							sleep(30)
-							if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
-								var/obj/item/photo/photo = active1.fields["photo_front"]
-								new /obj/item/poster/wanted/missing(loc, photo.picture.picture_image, missing_name, info, headerText)
-							printing = 0
+							while(posternum--)
+								playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
+								printing = 1
+								sleep(30)
+								if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
+									var/obj/item/photo/photo = active1.fields["photo_front"]
+									new /obj/item/poster/wanted/missing(loc, photo.picture.picture_image, missing_name, info, headerText)
+								printing = 0
 
 //RECORD DELETE
 			if("Delete All Records")

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -620,17 +620,18 @@ What a mess.*/
 								default_description += "[c.crimeDetails]\n"
 
 						var/headerText = stripped_input(usr, "Please enter Poster Heading (Max 7 Chars):", "Print Wanted Poster", "WANTED", 8)
-						var/posternum = max(min((input("Number of posters to print (Max 5):","Number:",1) as num|null), 5), 1)
+						var/posternum = CLAMP((input("Number of posters to print (Max 5):","Number:",1) as num|null), 1, 5)
 						var/info = stripped_multiline_input(usr, "Please input a description for the poster:", "Print Wanted Poster", default_description, null)
 						if(info)
-							while(posternum--)
+							printing = 1
+							for(var/i in 1 to posternum)
 								playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
-								printing = 1
+								
 								sleep(30)
 								if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
 									var/obj/item/photo/photo = active1.fields["photo_front"]
 									new /obj/item/poster/wanted(loc, photo.picture.picture_image, wanted_name, info, headerText)
-								printing = 0
+							printing = 0
 			if("Print Missing")
 				if(!( printing ))
 					var/missing_name = stripped_input(usr, "Please enter an alias for the missing person:", "Print Missing Persons Poster", active1.fields["name"])
@@ -638,17 +639,17 @@ What a mess.*/
 						var/default_description = "A poster declaring [missing_name] to be a missing individual, missed by Nanotrasen. Report any sightings to security immediately."
 
 						var/headerText = stripped_input(usr, "Please enter Poster Heading (Max 7 Chars):", "Print Missing Persons Poster", "MISSING", 8)
-						var/posternum = max(min((input("Number of posters to print (Max 5):","Number:",1) as num|null), 5), 1)
+						var/posternum = CLAMP((input("Number of posters to print (Max 5):","Number:",1) as num|null), 1, 5)
 						var/info = stripped_multiline_input(usr, "Please input a description for the poster:", "Print Missing Persons Poster", default_description, null)
 						if(info)
-							while(posternum--)
+							printing = 1
+							for(var/i in 1 to posternum)
 								playsound(loc, 'sound/items/poster_being_created.ogg', 100, 1)
-								printing = 1
 								sleep(30)
 								if((istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1)))//make sure the record still exists.
 									var/obj/item/photo/photo = active1.fields["photo_front"]
 									new /obj/item/poster/wanted/missing(loc, photo.picture.picture_image, missing_name, info, headerText)
-								printing = 0
+							printing = 0
 
 //RECORD DELETE
 			if("Delete All Records")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a prompt to select how many Wanted or Missing posters you want, between one and five.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Printing one at a time is lame.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now print multiple Wanted or Missing posters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
