### PR TITLE
Fixes QM headset having and defaulting exploration access.

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -229,8 +229,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	name = "quartermaster radio headset"
 	desc = "A headset used by the QM."
 	icon_state = "cargo_headset"
-	keyslot = new /obj/item/encryptionkey/headset_exp
-	keyslot2 = new /obj/item/encryptionkey/headset_cargo
+	keyslot = new /obj/item/encryptionkey/headset_cargo
 
 /obj/item/radio/headset/headset_exploration
 	name = "exploration radio headset"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A relic from a time when exploration were part of cargo.

## Why It's Good For The Game

Fixes QM headset defaulting to exploration on :q

## Changelog
:cl:
fix: Fixes QM headset having exploration access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
