### PR TITLE
Makes the Ore Silo admin only

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11682,7 +11682,6 @@
 /area/ai_monitored/nuke_storage)
 "aGb" = (
 /obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -10078,10 +10078,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"cta" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/plasteel/dark,
-/area/security/nuke_storage)
 "ctc" = (
 /obj/structure/sign/poster/random{
 	pixel_x = 32
@@ -135330,7 +135326,7 @@ bIn
 qVB
 dvw
 vXQ
-cta
+vXQ
 vac
 wYh
 dmG

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -119755,20 +119755,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"hsX" = (
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/nuke_storage)
 "htd" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -172132,7 +172118,7 @@ bvT
 bvP
 byz
 bvP
-hsX
+bvP
 but
 aad
 bHq

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -11104,7 +11104,6 @@
 "aqX" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/ore_silo,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14522,7 +14522,6 @@
 "aCd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7469,7 +7469,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1189,7 +1189,11 @@
 	name = "ore silo (Machine Board)"
 	icon_state = "supply"
 	build_path = /obj/machinery/ore_silo
-	req_components = list()
+	req_components = list(
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stock_parts/matter_bin/bluespace = 3,
+		/obj/item/stack/ore/bluespace_crystal = 5
+	)
 
 /obj/item/circuitboard/machine/protolathe/department/cargo
 	name = "departmental protolathe - cargo (Machine Board)"

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -21,5 +21,4 @@
 	new /obj/item/door_remote/quartermaster(src)
 	new /obj/item/circuitboard/machine/techfab/department/cargo(src)
 	new /obj/item/storage/photo_album/QM(src)
-	new /obj/item/circuitboard/machine/ore_silo(src)
 	new /obj/item/card/id/departmental_budget/car(src)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -274,9 +274,20 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "bluespacebodybag", "phasic_scanning", "roastingstick", "ore_silo", "antivirus3")
+	design_ids = list("bs_rped","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "bluespacebodybag", "phasic_scanning", "roastingstick", "antivirus3")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
+
+/datum/techweb_node/material_distribution
+	id = "material_distribution"
+	tech_tier = 5
+	display_name = "Bluespace Material Distribution"
+	description = "Using bluespace to replace the Quartermaster."
+	prereq_ids = list("practical_bluespace", "bluespace_travel")
+	design_ids = list("ore_silo")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 8000)
+	export_price = 10000
+	hidden = TRUE
 
 /datum/techweb_node/bluespace_power
 	id = "bluespace_power"
@@ -772,9 +783,10 @@
 	display_name = "Advanced RCD designs upgrade"
 	description = "Unlocks new RCD designs."
 	design_ids = list("rcd_upgrade_silo_link")
-	prereq_ids = list("rcd_upgrade", "bluespace_travel")
+	prereq_ids = list("rcd_upgrade", "material_distribution")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
+	hidden = TRUE
 
 
 /////////////////////////weaponry tech/////////////////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the Ore Silo from all standard maps, the board from the QM locker, and hides all designs related to the system from the tech web.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It might not be, Let's try it for a bit and find out.

This gives cargo a dedicated task beyond breaking the economy, making money (or not, up to them) on the distribution of material supplies to the rest of the station.

This also fixes the fact that the Ore Silo was this kinda awful lynchpin that broke the balance of a few specific antags.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Ore Silo has been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
