### PR TITLE
Improves BR loot

### DIFF
--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_INIT(battle_royale_basic_loot, list(
 		/obj/item/gun/energy/disabler,
 		/obj/item/construction/rcd,
 		/obj/item/clothing/glasses/chameleon/flashproof,
-		/obj/item/clothing/glasses/clockwork/wraith_spectacles,
+		/obj/item/book/granter/spell/knock,
 		/obj/item/clothing/glasses/sunglasses/advanced,
 		/obj/item/clothing/glasses/thermal/eyepatch,
 		/obj/item/clothing/glasses/thermal/syndi,
@@ -208,11 +208,11 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 //Trigger random events and shit, update the world border
 /datum/battle_royale_controller/process()
 	process_num++
-	//Once every 50 seconds
-	if(prob(2))
+	//Once every 25 seconds
+	if(prob(4))
 		generate_basic_loot(5)
-	//Once every 100 seconds.
-	if(prob(1))
+	//Once every 50 seconds.
+	if(prob(2))
 		generate_good_drop()
 	var/living_victims = 0
 	var/mob/winner
@@ -366,11 +366,11 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	var/list/good_drops = list()
 	for(var/i in 1 to rand(1,3))
 		good_drops += pick(GLOB.battle_royale_good_loot)
-	send_item(good_drops, announce = "Incoming extended supply materials.", force_time = 600)
+	send_item(good_drops, announce = "Incoming extended supply materials.", force_time = 150)
 
 /datum/battle_royale_controller/proc/generate_endgame_drop()
 	var/obj/item = pick(GLOB.battle_royale_insane_loot)
-	send_item(item, announce = "We found a weird looking package in the back of our warehouse. We have no idea what is in it, but it is marked as incredibily dangerous and could be a superweapon.", force_time = 9000)
+	send_item(item, announce = "We found a weird looking package in the back of our warehouse. We have no idea what is in it, but it is marked as incredibily dangerous and could be a superweapon.", force_time = 600)
 
 /datum/battle_royale_controller/proc/send_item(item_path, style = STYLE_BOX, announce=FALSE, force_time = 0)
 	if(!item_path)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces Wraith Spectacles with Book of Knock on the loot table, you can't use wraith spectacles if you're not a clockie.
Doubles the loot drop spawn rate.
Reduces the landing time of good drops from 60 seconds to 15.
Reduces the landing time of endgame drops from 900 seconds to 60.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unusable loot bad.
The BR itself often lasts less than 900 seconds, and is often cut short by admins finishing the end of round tickets. This increases the intensity, and makes the good drops actually show up before the end of the BR, which encourages fighting over them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Battle Royale loot has had some loot buffs, most notably the spawn rate of loot drops has doubled and the landing time of packages has been decreased.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
