### PR TITLE
Paramedic Nitrile Gloves Commit

### DIFF
--- a/code/modules/jobs/job_types/emt.dm
+++ b/code/modules/jobs/job_types/emt.dm
@@ -31,6 +31,7 @@
 	id = /obj/item/card/id/job/med
 	belt = /obj/item/pda/medical
 	ears = /obj/item/radio/headset/headset_med
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	uniform = /obj/item/clothing/under/rank/medical/emt
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	head = /obj/item/clothing/head/soft/emt


### PR DESCRIPTION
## About The Pull Request

This adds one line of code, altering paramedics to have nitrile gloves when they begin a round.

## Why It's Good For The Game

Paramedics had good reason to want nitrile gloves, with the lifting ability making particular sense for them, but had no access to them or where they were stored without outside intervention. This just adds them to their roundstart uniform.

## Changelog
:cl: Inithis

tweak: added nitrile gloves to the Paramedic's default, roundstart loadout. 

/:cl:
