### PR TITLE
Adds the ability to catch thrown people.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -80,7 +80,6 @@
 				visible_message("<span class='danger'>[victim] catches [src]!</span>",\
 					"<span class='userdanger'>[victim] catches you!</span>")
 				grabbedby(victim, TRUE)
-				victim.setGrabState(GRAB_AGGRESSIVE)
 				victim.throw_mode_off()
 				log_combat(victim, src, "caught (thrown mob)")
 				return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -69,10 +69,32 @@
 	return ..()
 
 /mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	. = ..()
 	var/hurt = TRUE
 	if(throwingdatum.force <= MOVE_FORCE_WEAK)
 		hurt = FALSE
+
+	if(iscarbon(hit_atom) && hit_atom != src)
+		var/mob/living/carbon/victim = hit_atom
+		if(!(victim.movement_type & FLYING))
+			if(victim.can_catch_item())
+				visible_message("<span class='danger'>[victim] catches [src]!</span>",\
+					"<span class='userdanger'>[victim] catches you!</span>")
+				grabbedby(victim, TRUE)
+				victim.setGrabState(GRAB_AGGRESSIVE)
+				victim.throw_mode_off()
+				log_combat(victim, src, "caught (thrown mob)")
+				return
+			if(hurt)
+				victim.take_bodypart_damage(10,check_armor = TRUE)
+				take_bodypart_damage(10,check_armor = TRUE)
+				victim.Paralyze(20)
+				Paralyze(20)
+				visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>",\
+					"<span class='userdanger'>You violently crash into [victim]!</span>")
+			playsound(src,'sound/weapons/punch1.ogg',50,1)
+
+	. = ..()
+
 	if(istype(throwingdatum, /datum/thrownthing))
 		var/datum/thrownthing/D = throwingdatum
 		if(iscyborg(D.thrower))
@@ -83,19 +105,6 @@
 		if(hurt)
 			Paralyze(20)
 			take_bodypart_damage(10,check_armor = TRUE)
-	if(iscarbon(hit_atom) && hit_atom != src)
-		var/mob/living/carbon/victim = hit_atom
-		if(victim.movement_type & FLYING)
-			return
-		if(hurt)
-			victim.take_bodypart_damage(10,check_armor = TRUE)
-			take_bodypart_damage(10,check_armor = TRUE)
-			victim.Paralyze(20)
-			Paralyze(20)
-			visible_message("<span class='danger'>[src] crashes into [victim], knocking them both over!</span>",\
-				"<span class='userdanger'>You violently crash into [victim]!</span>")
-		playsound(src,'sound/weapons/punch1.ogg',50,1)
-
 
 //Throwing stuff
 /mob/living/carbon/proc/toggle_throw_mode()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements the ability to catch thrown people.

## Why It's Good For The Game

Currently thrown carbon mobs deal a completely unblockable stun and force you to drop all your weapons. This adds in a counter, increasing the ceiling for achieving full-tier robustness.

If you have your active hand free and are on throw mode, when a carbon mob hits you from being thrown you will catch it, aggressively grabbing the thrown carbon and disabling throw mode. From there you can throw the carbon back at the aggressor, punishing them if they are unprepared.

## Changelog
:cl:
tweak: Thrown humans can now be caught.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
