### PR TITLE
Emergency Shuttle Call Changes

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -547,6 +547,15 @@
 	integer = FALSE
 	min_val = 0
 
+/datum/config_entry/flag/head_transfer_vote
+
+/datum/config_entry/flag/ai_transfer_vote
+
+/datum/config_entry/number/vote_transfer_cooldown //length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)
+	config_entry_value = 9000
+	integer = FALSE
+	min_val = 0
+
 /datum/config_entry/flag/respect_upstream_bans
 
 /datum/config_entry/flag/respect_upstream_permabans

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -6,6 +6,8 @@ SUBSYSTEM_DEF(autotransfer)
 	var/starttime
 	var/targettime
 
+	var/cooldown_time
+
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
 	starttime = world.time
 	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
@@ -19,3 +21,14 @@ SUBSYSTEM_DEF(autotransfer)
 	if(world.time > targettime)
 		SSvote.initiate_vote("transfer", null)
 		targettime = targettime + CONFIG_GET(number/vote_autotransfer_interval)
+
+/datum/controller/subsystem/autotransfer/proc/try_vote(mob/user, vote_name)
+	if(!CONFIG_GET(flag/head_transfer_vote))
+		return
+	if(!SSshuttle.canEvac(user))
+		return
+	if(world.time < cooldown_time)
+		to_chat(user, "<span class='warning'>A transfer vote has been triggered recently. Please wait [DisplayTimeText(cooldown_time - world.time)] or contact your station's captain for emergency evacuation.</span>")
+		return
+	cooldown_time = world.time + CONFIG_GET(number/vote_transfer_cooldown)
+	SSvote.initiate_vote("transfer", vote_name)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -660,7 +660,10 @@
 			dat += "<BR><BR><B>General Functions</B>"
 			dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=ai-messagelist'>Message List</A> \]"
 			if(SSshuttle.emergency.mode == SHUTTLE_IDLE)
-				dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=ai-callshuttle'>Call Emergency Shuttle</A> \]"
+				if(CONFIG_GET(flag/ai_transfer_vote))
+					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=ai-callshuttle2'>Request Crew Transfer</A> \]"
+				else
+					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=ai-callshuttle'>Call Emergency Shuttle</A> \]"
 			dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=ai-status'>Set Status Display</A> \]"
 			dat += "<BR><BR><B>Special Functions</B>"
 			dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=ai-announce'>Make an Announcement</A> \]"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -293,6 +293,12 @@
 		to_chat(usr, "<span class='warning'>Wireless control is disabled!</span>")
 		return
 
+	if(CONFIG_GET(flag/ai_transfer_vote))
+		if(alert(src, "Are you sure you would like to initiate a crew transfer vote?", "Confirm Transfer Request", "Yes", "No") == "No")
+			return
+		SSautotransfer.try_vote(usr, src)
+		return
+
 	var/reason = input(src, "What is the nature of your emergency? ([CALL_SHUTTLE_REASON_LENGTH] characters required.)", "Confirm Shuttle Call") as null|text
 
 	if(incapacitated())

--- a/config/config.txt
+++ b/config/config.txt
@@ -552,6 +552,12 @@ VOTE_AUTOTRANSFER_ENABLED
 VOTE_AUTOTRANSFER_INITIAL 54000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000
+## Do non-captain heads initiate a transfer vote rather than a shuttle call?
+HEAD_TRANSFER_VOTE
+## Time (in deciseconds) between communication console triggered transfer votes (9000: 15 minutes)
+VOTE_TRANSFER_COOLDOWN 9000
+## Does the AI trigger a transfer vote instead of a shuttle call
+AI_TRANSFER_VOTE
 
 ## Ghost role cooldown time after death (In deciseconds)
 GHOST_ROLE_COOLDOWN 3000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heads of staff (And the AI) can no longer call the emergency shuttle instantly. Instead they are given the option to start a crew transfer vote, which will call the shuttle if successfuly.
The captain can bypass the vote and call the emergency shuttle immediately.

![image](https://user-images.githubusercontent.com/26465327/131873504-10af3322-a0be-4904-ade6-387163b9ebbb.png)

![image](https://user-images.githubusercontent.com/26465327/131873538-602fc81a-7b73-48ab-926b-bcdc60435e07.png)

All of this is configs so is modifyable by downstreams.

## Why It's Good For The Game

Due to being the round ender, the captain gets the ultimate decision of when to call the shuttle and end the round.
All of command can now trigger crew transfer votes, so that if the crew want to leave they can have a formal vote rather than 'shuttle call? y/n'.
Non-captain heads can no longer call the shuttle against the will of the crew.
All in the config so easilly modifyable and changeable by downstreams.

## Changelog
:cl:
tweak: Heads and the AI can no longer call the shuttle. Instead they can initiate transfer votes with a 15 minute cooldown. The captain can still bypass the vote and call the shuttle instantly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
