### PR TITLE
Some Exploration Gear fits in Exploration Webbing

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -356,7 +356,11 @@
 		/obj/item/stack/marker_beacon,
 		/obj/item/restraints/legcuffs/bola/watcher,
 		/obj/item/claymore/bone,
-		/obj/item/skeleton_key
+		/obj/item/skeleton_key,
+		/obj/item/discovery_scanner,
+		/obj/item/gun/energy/e_gun/mini/exploration,
+		/obj/item/grenade/exploration,
+		/obj/item/exploration_detonator
 		))
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives a few exploration items the ability to be put into the explorer's webbing that is sold in the vendor.

Otherwise, it feels kinda moot to have around.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why is it sold in the vendor if not meant to store at least some of the available items explorers will have on them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
tweak: Tweaked Mining Webbing to also allow storage of exploration gear due to also being available to explorers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
