### PR TITLE
Meteor storm inbound

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3077,6 +3077,7 @@
 #include "code\modules\shuttle\super_cruise\orbital_map_components\orbital_objects\beacon.dm"
 #include "code\modules\shuttle\super_cruise\orbital_map_components\orbital_objects\custom_shuttle.dm"
 #include "code\modules\shuttle\super_cruise\orbital_map_components\orbital_objects\lavaland.dm"
+#include "code\modules\shuttle\super_cruise\orbital_map_components\orbital_objects\meteor.dm"
 #include "code\modules\shuttle\super_cruise\orbital_map_components\orbital_objects\phobos.dm"
 #include "code\modules\shuttle\super_cruise\orbital_map_components\orbital_objects\shuttle.dm"
 #include "code\modules\shuttle\super_cruise\orbital_map_components\orbital_objects\space_station.dm"

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -80,6 +80,9 @@
 #define LARGE_MOB_LAYER 4.4
 #define ABOVE_ALL_MOB_LAYER 4.5
 
+#define METEOR_SHADOW_LAYER 4.69
+#define METEOR_LAYER 4.7
+
 #define SPACEVINE_LAYER 4.8
 #define SPACEVINE_MOB_LAYER 4.9
 //#define FLY_LAYER 5 //For easy recordkeeping; this is a byond define

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -121,6 +121,10 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	GLOB.meteor_list -= src
 	SSaugury.unregister_doom(src)
 	walk(src,0) //this cancels the walk_towards() proc
+	if(istype(loc, /obj/effect/falling_meteor))
+		var/obj/effect/falling_meteor/holder = loc
+		holder.contained_meteor = null
+		qdel(holder)
 	. = ..()
 
 /obj/effect/meteor/Initialize(mapload, target)
@@ -407,7 +411,8 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	INVOKE_ASYNC(src, .proc/fall_animation)
 
 /obj/effect/falling_meteor/Destroy(force)
-	QDEL_NULL(contained_meteor)
+	if(contained_meteor)
+		QDEL_NULL(contained_meteor)
 	QDEL_NULL(shadow)
 	. = ..()
 

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -388,6 +388,7 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	var/obj/effect/meteor_shadow/shadow
 	var/falltime = 2 SECONDS
 	var/prefalltime = 8 SECONDS
+	layer = HIGH_OBJ_LAYER
 
 /obj/effect/falling_meteor/Initialize(loc, meteor_type)
 	. = ..()
@@ -429,6 +430,7 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	name = "shadow"
 	desc = "What the hell? Is something falling out the sky???"
 	alpha = 0
+	layer = NOT_HIGH_OBJ_LAYER
 
 /obj/effect/meteor_shadow/Initialize()
 	. = ..()

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -388,7 +388,7 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	var/obj/effect/meteor_shadow/shadow
 	var/falltime = 2 SECONDS
 	var/prefalltime = 8 SECONDS
-	layer = HIGH_OBJ_LAYER
+	layer = METEOR_LAYER
 
 /obj/effect/falling_meteor/Initialize(loc, meteor_type)
 	. = ..()
@@ -430,7 +430,7 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	name = "shadow"
 	desc = "What the hell? Is something falling out the sky???"
 	alpha = 0
-	layer = NOT_HIGH_OBJ_LAYER
+	layer = METEOR_SHADOW_LAYER
 
 /obj/effect/meteor_shadow/Initialize()
 	. = ..()

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -21,17 +21,17 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 //Meteor spawning global procs
 ///////////////////////////////
 
-/proc/spawn_meteors(number = 10, list/meteortypes)
+/proc/spawn_meteors(number = 10, list/meteortypes, z = 0)
 	for(var/i = 0; i < number; i++)
-		spawn_meteor(meteortypes)
+		spawn_meteor(meteortypes, z)
 
-/proc/spawn_meteor(list/meteortypes)
+/proc/spawn_meteor(list/meteortypes, z = 0)
 	var/turf/pickedstart
 	var/turf/pickedgoal
 	var/max_i = 10//number of tries to spawn meteor.
 	while(!isspaceturf(pickedstart))
 		var/startSide = pick(GLOB.cardinals)
-		var/startZ = pick(SSmapping.levels_by_trait(ZTRAIT_STATION))
+		var/startZ = (z || pick(SSmapping.levels_by_trait(ZTRAIT_STATION)))
 		pickedstart = spaceDebrisStartLoc(startSide, startZ)
 		pickedgoal = spaceDebrisFinishLoc(startSide, startZ)
 		max_i--

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -43,6 +43,9 @@
 		meteor.start_y = start_y + rand(-600, 600)
 		meteor.position.x = meteor.start_x
 		meteor.position.y = meteor.start_y
+		//Calculate velocity
+		meteor.velocity.x = (station_target.position.x - meteor.start_x * 10) / meteor_time
+		meteor.velocity.y = (station_target.position.y - meteor.start_y * 10) / meteor_time
 		meteor.end_tick = world.time + meteor_time
 		meteor.target = station_target
 

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -29,7 +29,6 @@
 	station_target = locate(/datum/orbital_object/z_linked/station) in SSorbits.orbital_map.bodies
 	if(!station_target)
 		CRASH("Meteor failed to locate a target.")
-		return
 
 /datum/round_event/meteor_wave/Destroy(force, ...)
 	station_target = null
@@ -42,6 +41,8 @@
 		meteor.meteor_types = wave_type
 		meteor.start_x = start_x + rand(-600, 600)
 		meteor.start_y = start_y + rand(-600, 600)
+		meteor.position.x = meteor.start_x
+		meteor.position.y = meteor.start_y
 		meteor.end_tick = world.time + meteor_time
 		meteor.target = station_target
 

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -10,21 +10,44 @@
 	can_malf_fake_alert = TRUE
 
 /datum/round_event/meteor_wave
-	startWhen		= 300
-	endWhen			= 360
-	announceWhen	= 1
+	announceWhen	= 300
+	startWhen = 1
+	endWhen = 301
 	var/list/wave_type
 	var/wave_name = "normal"
+	var/start_x
+	var/start_y
+	var/datum/orbital_object/station_target
+	var/meteor_time = 15 MINUTES
 
 /datum/round_event/meteor_wave/New()
 	..()
 	if(!wave_type)
 		determine_wave_type()
+	start_x = sin(rand(0, 360)) * 9000
+	start_y = cos(rand(0, 360)) * 9000
+	station_target = locate(/datum/orbital_object/z_linked/station) in SSorbits.orbital_map.bodies
+	if(!station_target)
+		return
+
+/datum/round_event/meteor_wave/Destroy(force, ...)
+	station_target = null
+	. = ..()
+
+/datum/round_event/meteor_wave/tick()
+	if(ISMULTIPLE(activeFor, 3) && activeFor < 61 && station_target)
+		var/datum/orbital_object/meteor/meteor = new()
+		meteor.name = "Meteor ([wave_name])"
+		meteor.meteor_types = wave_type
+		meteor.start_x = start_x + rand(-600, 600)
+		meteor.start_y = start_y + rand(-600, 600)
+		meteor.end_tick = world.time + meteor_time
+		meteor.target = station_target
 
 /datum/round_event/meteor_wave/on_admin_trigger()
 	if(alert(usr, "Trigger meteors instantly? (This will not change the alert, just send them quicker. Nobody will ever notice!)", "Meteor Trigger", "Yes", "No") == "Yes")
-		startWhen = 30
-		endWhen = 90
+		announceWhen = 1
+		meteor_time = 1 MINUTES
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
 	if(!wave_name)
@@ -59,10 +82,6 @@
 		P.special_enabled = TRUE
 		P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat_control]
 		P.special_enabled = TRUE
-
-/datum/round_event/meteor_wave/tick()
-	if(ISMULTIPLE(activeFor, 3))
-		spawn_meteors(5, wave_type) //meteor list types defined in gamemode/meteor/meteors.dm
 
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -10,9 +10,9 @@
 	can_malf_fake_alert = TRUE
 
 /datum/round_event/meteor_wave
-	announceWhen	= 300
+	announceWhen	= 150
 	startWhen = 1
-	endWhen = 301
+	endWhen = 151
 	var/list/wave_type
 	var/wave_name = "normal"
 	var/start_x

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -28,6 +28,7 @@
 	start_y = cos(rand(0, 360)) * 9000
 	station_target = locate(/datum/orbital_object/z_linked/station) in SSorbits.orbital_map.bodies
 	if(!station_target)
+		CRASH("Meteor failed to locate a target.")
 		return
 
 /datum/round_event/meteor_wave/Destroy(force, ...)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -14,6 +14,9 @@
 	start_tick = world.time
 	end_tick = world.time + 10 MINUTES
 	radius = rand(10, 50)
+	//Prevent instant lavaland collisions.
+	position.x = 9999
+	position.y = 9999
 	start_x = 9999
 	start_y = 9999
 

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -58,7 +58,7 @@
 				meteor_impact(locate(rand(10, world.maxx - 10), rand(10, world.maxx-10), space_level.z_value))
 		else
 			//Spawn meteor wave
-			spawn_meteors(5, meteor_types)
+			spawn_meteors(5, meteor_types, space_level.z_value)
 	qdel(src)
 
 /datum/orbital_object/meteor/proc/impact_turfs(list/valid_turfs)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -1,0 +1,71 @@
+/datum/orbital_object/meteor
+	name = "Meteor"
+	var/datum/orbital_object/target
+	var/list/meteor_types
+	var/start_tick
+	var/end_tick
+	var/start_x
+	var/start_y
+	var/end_x
+	var/end_y
+
+/datum/orbital_object/meteor/New()
+	. = ..()
+	start_tick = world.time
+	end_tick = world.time + 10 MINUTES
+	radius = rand(10, 50)
+
+/datum/orbital_object/meteor/Destroy()
+	target = null
+	meteor_types = null
+	. = ..()
+
+/datum/orbital_object/meteor/process()
+	. = ..()
+	if(!QDELETED(target))
+		end_x = target.position.x
+		end_y = target.position.y
+	var/current_tick = world.time
+	var/tick_proportion = (current_tick - start_tick) / (end_tick - start_tick)
+	var/current_x = (end_x * tick_proportion) + (start_x * (1 - tick_proportion))
+	var/current_y = (end_y * tick_proportion) + (start_y * (1 - tick_proportion))
+	var/prev_x = position.x
+	var/prev_y = position.y
+	position.x = current_x
+	position.y = current_y
+	velocity.x = current_x - prev_x
+	velocity.y = current_y - prev_y
+	if(abs(position.x) > 10000 || abs(position.y) > 10000)
+		qdel(src)
+
+/datum/orbital_object/meteor/collision(datum/orbital_object/other)
+	//If we collide with a shuttle, do a little explosion
+	if(istype(other, /datum/orbital_object/shuttle))
+		var/datum/orbital_object/shuttle/shuttleobj = other
+		if(shuttleobj.port)
+			for(var/i in 1 to 5)
+				impact_turfs(shuttleobj.port.return_turfs())
+	//If we collide with a z-linked, spawn a meteor on that z-level
+	if(istype(other, /datum/orbital_object/z_linked))
+		var/datum/orbital_object/z_linked/z_linked = other
+		if(!z_linked.can_dock_anywhere && !z_linked.random_docking)
+			return
+		if(!LAZYLEN(z_linked.linked_z_level))
+			return
+		var/datum/space_level/space_level = pick(z_linked.linked_z_level)
+		//Check level flags for planetary bodies
+		if(space_level.traits[ZTRAIT_MINING])
+			for(var/i in 1 to 5)
+				meteor_impact(locate(rand(10, world.maxx - 10), rand(10, world.maxx-10), space_level.z_value))
+		else
+			//Spawn meteor wave
+			spawn_meteors(5, meteor_types)
+	qdel(src)
+
+/datum/orbital_object/meteor/proc/impact_turfs(list/valid_turfs)
+	if(length(valid_turfs))
+		meteor_impact(pick(valid_turfs))
+
+//Fall from the sky
+/datum/orbital_object/meteor/proc/meteor_impact(turf/T)
+	new /obj/effect/falling_meteor(T, meteor_types ? pick(meteor_types) : null)

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -14,11 +14,6 @@
 	start_tick = world.time
 	end_tick = world.time + 10 MINUTES
 	radius = rand(10, 50)
-	//Prevent instant lavaland collisions.
-	position.x = 9999
-	position.y = 9999
-	start_x = 9999
-	start_y = 9999
 
 /datum/orbital_object/meteor/Destroy()
 	target = null
@@ -34,12 +29,10 @@
 	var/tick_proportion = (current_tick - start_tick) / (end_tick - start_tick)
 	var/current_x = (end_x * tick_proportion) + (start_x * (1 - tick_proportion))
 	var/current_y = (end_y * tick_proportion) + (start_y * (1 - tick_proportion))
-	var/prev_x = position.x
-	var/prev_y = position.y
+	velocity.x = current_x - position.x
+	velocity.y = current_y - position.y
 	position.x = current_x
 	position.y = current_y
-	velocity.x = current_x - prev_x
-	velocity.y = current_y - prev_y
 	if(abs(position.x) > 10000 || abs(position.y) > 10000)
 		qdel(src)
 

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -14,6 +14,8 @@
 	start_tick = world.time
 	end_tick = world.time + 10 MINUTES
 	radius = rand(10, 50)
+	start_x = 9999
+	start_y = 9999
 
 /datum/orbital_object/meteor/Destroy()
 	target = null

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/meteor.dm
@@ -29,8 +29,6 @@
 	var/tick_proportion = (current_tick - start_tick) / (end_tick - start_tick)
 	var/current_x = (end_x * tick_proportion) + (start_x * (1 - tick_proportion))
 	var/current_y = (end_y * tick_proportion) + (start_y * (1 - tick_proportion))
-	velocity.x = current_x - position.x
-	velocity.y = current_y - position.y
 	position.x = current_x
 	position.y = current_y
 	if(abs(position.x) > 10000 || abs(position.y) > 10000)
@@ -51,6 +49,9 @@
 		if(!LAZYLEN(z_linked.linked_z_level))
 			return
 		var/datum/space_level/space_level = pick(z_linked.linked_z_level)
+		//Check protected levels
+		if(space_level.traits[ZTRAIT_CENTCOM] || space_level.traits[ZTRAIT_REEBE])
+			return
 		//Check level flags for planetary bodies
 		if(space_level.traits[ZTRAIT_MINING])
 			for(var/i in 1 to 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Non-admin meteor storms will now last for 15 minutes.
The first 5 minutes there will be no warning as to the incomming meteors, then the meteors will be announced and there will be a 10 minute delay before impact.
Meteors are now an orbital object, meaning they appear on orbital maps.
Meteor objects on the map can collide with orbital bodies and shuttles, if you want to save the station you can fly your shuttle into the meteor storm and take the hits. Additionally, meteors may impact lavaland if coming from the opposite side of the station.

There is an awesome effect for falling meteors.

https://user-images.githubusercontent.com/26465327/131897689-b861ba70-f9e2-4f16-a9bb-8a53c922bcd8.mp4

https://user-images.githubusercontent.com/26465327/131899302-acb5ac94-7c9d-416a-a5ca-80d70c98b634.mp4

## Why It's Good For The Game

More stuff on orbital maps, see the meteors coming if you are observant and you can ram your shuttle into them as a noble sacrafice (being a dumbass).

## Changelog
:cl:
refactor: Refactors meteors, they are now orbital map components and will fly towards the station, colliding with orbital bodies and flying shuttles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
