### PR TITLE
Gives meta and pubby proper exploration comms setup.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -43537,9 +43537,6 @@
 "bGd" = (
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"bGe" = (
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "bGf" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -80809,6 +80806,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"esP" = (
+/obj/machinery/telecomms/hub/preset/exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "etr" = (
 /obj/effect/turf_decal/pool{
 	dir = 8
@@ -80870,6 +80871,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"eId" = (
+/obj/machinery/telecomms/broadcaster/preset_exploration,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "eLn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -81101,6 +81110,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"fEL" = (
+/obj/machinery/telecomms/relay/preset/exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "fEQ" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -81224,10 +81237,6 @@
 	},
 /turf/closed/wall,
 /area/janitor)
-"gcu" = (
-/obj/machinery/telecomms/allinone/exploration,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "ggI" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -82610,6 +82619,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"kNS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/tcommsat/server)
 "kOt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -84363,6 +84379,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
+"slE" = (
+/obj/machinery/telecomms/receiver/preset_exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "sql" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -84885,6 +84905,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"utH" = (
+/obj/machinery/telecomms/processor/preset_exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "uun" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
@@ -86004,6 +86028,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"yih" = (
+/obj/machinery/telecomms/bus/preset_exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "yjF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -138334,8 +138362,8 @@ anT
 anT
 anT
 anT
-aaa
-aaa
+anT
+anT
 aaa
 aaa
 aaa
@@ -138584,6 +138612,8 @@ aNw
 aNw
 aNw
 aNw
+aNw
+aNw
 bJl
 aNw
 aNw
@@ -138591,8 +138621,6 @@ aNw
 aTQ
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -138843,13 +138871,13 @@ bMt
 bMt
 bMt
 bMt
+bMt
+bMt
 aOT
 aOT
 bUK
 bBb
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -139101,12 +139129,12 @@ aOY
 aOY
 aOY
 aOY
+aOY
+aOY
 bcQ
 aNy
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -139358,12 +139386,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aMq
 aNy
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -139612,6 +139640,8 @@ aRy
 aRy
 bvt
 bvt
+bvt
+bvt
 aaa
 aaa
 aaa
@@ -139619,8 +139649,6 @@ aMq
 aNy
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -139870,6 +139898,8 @@ aRy
 aRy
 aRy
 aRy
+aRy
+aRy
 aaa
 aaa
 aMq
@@ -139878,8 +139908,6 @@ bBb
 anT
 anT
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -140124,6 +140152,8 @@ bGd
 bGd
 bJm
 bNX
+bGd
+yih
 bMo
 bOc
 aRy
@@ -140135,8 +140165,6 @@ bAT
 aNw
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -140377,10 +140405,12 @@ bzo
 bAV
 bCD
 bEh
-gcu
+bGd
 bGd
 bKL
 bNY
+bGd
+esP
 bGd
 ceC
 aRy
@@ -140392,8 +140422,6 @@ bpn
 cpO
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -140639,6 +140667,8 @@ bHD
 bGd
 bGd
 bGd
+slE
+bGd
 bUL
 aRy
 bvt
@@ -140649,8 +140679,6 @@ cmK
 bpr
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -140895,6 +140923,8 @@ lWY
 bHE
 bKM
 bKO
+bGd
+bGd
 bMp
 bNZ
 aRz
@@ -140906,8 +140936,6 @@ ckT
 cmX
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -141152,6 +141180,8 @@ bCE
 bHF
 bJk
 bJk
+kNS
+eId
 bMq
 cgy
 aRy
@@ -141163,8 +141193,6 @@ cmK
 bpr
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -141405,10 +141433,12 @@ bzs
 bJi
 bCD
 bEj
-bGe
+bGd
 bGd
 bKP
 bOb
+bGd
+fEL
 bMr
 cho
 aRy
@@ -141420,8 +141450,6 @@ bpq
 bzv
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -141666,6 +141694,8 @@ bGd
 bGd
 bKN
 bOa
+bGd
+utH
 bMs
 chn
 aRy
@@ -141677,8 +141707,6 @@ aVk
 aOY
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -141926,6 +141954,8 @@ aRy
 aRy
 aRy
 aRy
+aRy
+aRy
 aaa
 aaa
 aMq
@@ -141934,8 +141964,6 @@ bBb
 anT
 anT
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -142182,6 +142210,8 @@ aRy
 aRy
 bvt
 bvt
+bvt
+bvt
 aaa
 aaa
 aaa
@@ -142189,8 +142219,6 @@ aMq
 bez
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -142442,12 +142470,12 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aMq
 bez
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -142699,12 +142727,12 @@ aNw
 aNw
 aNw
 aNw
+aNw
+aNw
 bly
 bez
 bgn
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -142957,11 +142985,11 @@ bMt
 bMt
 bMt
 bMt
+bMt
+bMt
 bUM
 bBb
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -143214,11 +143242,11 @@ aOY
 aOY
 aOY
 aOY
+aOY
+aOY
 aNC
 aaa
 anT
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -143474,8 +143502,8 @@ anT
 anT
 anT
 anT
-aaa
-aaa
+anT
+anT
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -54961,6 +54961,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gtN" = (
+/obj/machinery/telecomms/broadcaster/preset_exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "gue" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -56219,6 +56223,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"iye" = (
+/obj/machinery/camera/motion{
+	c_tag = "Telecomms Server Room";
+	dir = 1;
+	network = list("tcomms")
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/tcommsat/server)
 "iyg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59321,15 +59333,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"nXj" = (
-/obj/machinery/camera/motion{
-	c_tag = "Telecomms Server Room";
-	dir = 1;
-	network = list("tcomms")
-	},
-/obj/machinery/telecomms/allinone/exploration,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
 "nXU" = (
 /obj/structure/chair{
 	dir = 1
@@ -60962,6 +60965,10 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"qAS" = (
+/obj/machinery/telecomms/receiver/preset_exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "qDJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
@@ -61797,6 +61804,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"rVB" = (
+/obj/machinery/telecomms/processor/preset_exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "rWE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -62697,6 +62708,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tHO" = (
+/obj/machinery/telecomms/hub/preset/exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "tIm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -63767,6 +63782,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"vOW" = (
+/obj/machinery/telecomms/bus/preset_exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "vRi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -64254,6 +64273,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"wJG" = (
+/obj/machinery/telecomms/relay/preset/exploration,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "wKa" = (
 /obj/machinery/light/small,
 /obj/machinery/advanced_airlock_controller{
@@ -92153,7 +92176,7 @@ aaa
 aaa
 abI
 aaa
-aaa
+abI
 aaa
 aaa
 aaa
@@ -92411,10 +92434,10 @@ adR
 adR
 adR
 adR
-aaa
+adR
 adR
 aaa
-aaa
+adR
 aaa
 aaa
 aaa
@@ -92667,11 +92690,11 @@ aaa
 aaa
 abI
 aaa
+abI
+aaa
 aaa
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -92925,11 +92948,11 @@ cmB
 cmB
 cmB
 cmB
+cmB
+cmB
 cny
 adR
 abI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93180,12 +93203,12 @@ cna
 cmR
 cnj
 cmK
+vOW
+cmR
 cnr
 cmB
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93437,12 +93460,12 @@ cnb
 cmK
 cnk
 cmK
+tHO
+cmK
 cns
 cmB
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93694,12 +93717,12 @@ cmK
 cmK
 cnl
 cmK
+qAS
+cmK
 cnt
 cmB
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -93951,13 +93974,13 @@ cnc
 cmK
 cmK
 cmK
-nXj
+cmK
+cmK
+iye
 cmB
 abI
 adR
 abI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94208,12 +94231,12 @@ cmK
 cmK
 cnm
 cmK
+gtN
+cmK
 cnv
 cmB
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94465,12 +94488,12 @@ cnd
 cmK
 cnn
 cmK
+wJG
+cmK
 cnw
 cmB
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94722,12 +94745,12 @@ cne
 cmU
 cno
 cmK
+rVB
+cmU
 cnx
 cmB
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -94981,11 +95004,11 @@ cmB
 cmB
 cmB
 cmB
+cmB
+cmB
 cnz
 adR
 abI
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -95237,11 +95260,11 @@ aaa
 aaa
 abI
 aaa
+abI
+aaa
 aaa
 aaa
 adR
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -95495,10 +95518,10 @@ adR
 adR
 adR
 adR
-aaa
+adR
 adR
 aaa
-aaa
+adR
 aaa
 aaa
 aaa
@@ -95751,7 +95774,7 @@ aaa
 aaa
 abI
 aaa
-aaa
+abI
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to lazyness on my part meta and pubby station used mainframes instead of normal exploration comms setups. This changes that and gives them full communication setups.

## Why It's Good For The Game

Proper comms setups are fixable, less lazy.
Will fix meta and pubby relays not working, but this is due to a different problem.

## Changelog
:cl:
tweak: Changes exploration mainframes to proper exploration communication setups on pubby and metastation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
