### PR TITLE
Deadchat controlled Birdboat (and Singularity)

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -413,6 +413,7 @@
 #include "code\datums\components\caltrop.dm"
 #include "code\datums\components\chasm.dm"
 #include "code\datums\components\construction.dm"
+#include "code\datums\components\deadchat_control.dm"
 #include "code\datums\components\edit_complainer.dm"
 #include "code\datums\components\embedded.dm"
 #include "code\datums\components\empprotection.dm"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -89,6 +89,8 @@
 	#define COMPONENT_BLOCK_REACH 1
 #define COMSIG_ATOM_INTERCEPT_TELEPORT "intercept_teleport"		//! called when teleporting into a protected turf: (channel, turf/origin)
 	#define COMPONENT_BLOCK_TELEPORT 1
+#define COMSIG_ATOM_ORBIT_BEGIN "atom_orbit_begin"           //called when an atom starts orbiting another atom: (atom)
+#define COMSIG_ATOM_ORBIT_STOP "atom_orbit_stop"           //called when an atom stops orbiting another atom: (atom)
 /////////////////
 /* Attack signals. They should share the returned flags, to standardize the attack chain. */
 /// tool_act -> pre_attack -> target.attackby (item.attack) -> afterattack
@@ -199,6 +201,8 @@
 #define COMSIG_MOB_EMOTE "mob_emote" // from /mob/living/emote(): ()
 #define COMSIG_MOB_SWAP_HANDS "mob_swap_hands"        //from base of mob/swap_hand()
   #define COMPONENT_BLOCK_SWAP 1
+#define COMSIG_MOB_DEADSAY "mob_deadsay" // from /mob/say_dead(): (mob/speaker, message)
+	#define MOB_DEADSAY_SIGNAL_INTERCEPT 1
 
 ///from base of /obj/item/mmi/set_brainmob(): (mob/living/brain/new_brainmob)
 #define COMSIG_MMI_SET_BRAINMOB "mmi_set_brainmob"

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -1,0 +1,106 @@
+#define DEMOCRACY_MODE "democracy"
+#define ANARCHY_MODE "anarchy"
+
+/datum/component/deadchat_control
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	var/timerid
+
+	var/list/datum/callback/inputs = list()
+	var/list/ckey_to_cooldown = list()
+	var/orbiters = list()
+	var/deadchat_mode
+	var/input_cooldown
+
+/datum/component/deadchat_control/Initialize(_deadchat_mode, _inputs, _input_cooldown = 12 SECONDS)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	RegisterSignal(parent, COMSIG_ATOM_ORBIT_BEGIN, .proc/orbit_begin)
+	RegisterSignal(parent, COMSIG_ATOM_ORBIT_STOP, .proc/orbit_stop)
+	deadchat_mode = _deadchat_mode
+	inputs = _inputs
+	input_cooldown = _input_cooldown
+	if(deadchat_mode == DEMOCRACY_MODE)
+		timerid = addtimer(CALLBACK(src, .proc/democracy_loop), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
+	notify_ghosts("[parent] is now deadchat controllable!", source = parent, action = NOTIFY_ORBIT, header="Something Interesting!")
+
+
+/datum/component/deadchat_control/Destroy(force, silent)
+	inputs = null
+	orbiters = null
+	ckey_to_cooldown = null
+	return ..()
+
+/datum/component/deadchat_control/proc/deadchat_react(mob/source, message)
+	message = lowertext(message)
+	if(!inputs[message])
+		return 
+	if(deadchat_mode == ANARCHY_MODE)
+		var/cooldown = ckey_to_cooldown[source.ckey]
+		if(cooldown)
+			return MOB_DEADSAY_SIGNAL_INTERCEPT
+		inputs[message].Invoke()
+		ckey_to_cooldown[source.ckey] = TRUE
+		addtimer(CALLBACK(src, .proc/remove_cooldown, source.ckey), input_cooldown)
+	else if(deadchat_mode == DEMOCRACY_MODE)
+		ckey_to_cooldown[source.ckey] = message
+	return MOB_DEADSAY_SIGNAL_INTERCEPT
+
+/datum/component/deadchat_control/proc/remove_cooldown(ckey)
+	ckey_to_cooldown.Remove(ckey)
+	
+/datum/component/deadchat_control/proc/democracy_loop()
+	if(QDELETED(parent) || deadchat_mode != DEMOCRACY_MODE)
+		deltimer(timerid)
+		return
+	var/result = count_democracy_votes()
+	if(!isnull(result))
+		inputs[result].Invoke()
+		var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown/10] seconds.</span>"
+		for(var/M in orbiters)
+			to_chat(M, message)
+	else
+		var/message = "<span class='deadsay italics bold'>No votes were cast this cycle.</span>"
+		for(var/M in orbiters)
+			to_chat(M, message)
+			
+/datum/component/deadchat_control/proc/count_democracy_votes()
+	if(!length(ckey_to_cooldown))
+		return
+	var/list/votes = list()
+	for(var/command in inputs)
+		votes["[command]"] = 0
+	for(var/vote in ckey_to_cooldown)
+		votes[ckey_to_cooldown[vote]]++
+		ckey_to_cooldown.Remove(vote)
+	
+	// Solve which had most votes.
+	var/prev_value = 0
+	var/result
+	for(var/vote in votes)
+		if(votes[vote] > prev_value)
+			prev_value = votes[vote]
+			result = vote
+	
+	if(result in inputs)
+		return result
+
+/datum/component/deadchat_control/vv_edit_var(var_name, var_value)
+	. = ..()
+	if(!.)
+		return
+	if(var_name != NAMEOF(src, deadchat_mode))
+		return
+	ckey_to_cooldown = list()
+	if(var_value == DEMOCRACY_MODE)
+		timerid = addtimer(CALLBACK(src, .proc/democracy_loop), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
+	else
+		deltimer(timerid)
+
+/datum/component/deadchat_control/proc/orbit_begin(atom/source, atom/orbiter)
+	RegisterSignal(orbiter, COMSIG_MOB_DEADSAY, .proc/deadchat_react)
+	orbiters |= orbiter
+
+/datum/component/deadchat_control/proc/orbit_stop(atom/source, atom/orbiter)
+	if(orbiter in orbiters)
+		UnregisterSignal(orbiter, COMSIG_MOB_DEADSAY)
+		orbiters -= orbiter

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -62,7 +62,7 @@
 	orbiters[orbiter] = TRUE
 	orbiter.orbiting = src
 	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
-
+	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_BEGIN, orbiter)
 	var/matrix/initial_transform = matrix(orbiter.transform)
 	orbiters[orbiter] = initial_transform
 
@@ -88,6 +88,7 @@
 	if(!orbiters[orbiter])
 		return
 	UnregisterSignal(orbiter, COMSIG_MOVABLE_MOVED)
+	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_STOP, orbiter)
 	orbiter.SpinAnimation(0, 0)
 	if(istype(orbiters[orbiter],/matrix)) //This is ugly.
 		orbiter.transform = orbiters[orbiter]

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -57,6 +57,9 @@
 	goosevomit = new
 	goosevomit.Grant(src)
 	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/goosement)
+	if(prob(50))
+		desc = "[initial(desc)] It's waddling more than usual. It seems to be possessed."
+		deadchat_plays_goose()
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/Destroy()
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
@@ -152,6 +155,16 @@
 		vomit_prestart(vomitTimeBonus + 25)
 		vomitCoefficient = 1
 		vomitTimeBonus = 0
+
+/// A proc to make it easier for admins to make the goose playable by deadchat.
+/mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/deadchat_plays_goose()
+	stop_automated_movement = TRUE
+	AddComponent(/datum/component/deadchat_control, ANARCHY_MODE, list(
+	 "up" = CALLBACK(GLOBAL_PROC, .proc/_step, src, NORTH),
+	 "down" = CALLBACK(GLOBAL_PROC, .proc/_step, src, SOUTH),
+	 "left" = CALLBACK(GLOBAL_PROC, .proc/_step, src, WEST),
+	 "right" = CALLBACK(GLOBAL_PROC, .proc/_step, src, EAST),
+	 "vomit" = CALLBACK(src, .proc/vomit_prestart, 25)), 12 SECONDS, 4 SECONDS)
 
 /mob/living/simple_animal/hostile/retaliate/goose/vomit/proc/eat()
 	var/turf/currentTurf = get_turf(src)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -77,6 +77,8 @@
 	var/spanned = say_quote(message)
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[emoji_parse(spanned)]</span></span>"
 	log_talk(message, LOG_SAY, tag="DEAD")
+	if(SEND_SIGNAL(src, COMSIG_MOB_DEADSAY, message) & MOB_DEADSAY_SIGNAL_INTERCEPT)
+		return
 	deadchat_broadcast(rendered, follow_target = src, speaker_key = key)
 
 ///Check if this message is an emote

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -455,3 +455,15 @@
 
 	investigate_log("has been shot by bluespace artillery and destroyed.", INVESTIGATE_ENGINES)
 	qdel(src)
+
+/obj/singularity/deadchat_controlled
+	move_self = FALSE
+
+/obj/singularity/deadchat_controlled/Initialize(mapload, starting_energy)
+	. = ..()
+	AddComponent(/datum/component/deadchat_control, DEMOCRACY_MODE, list(
+	 "up" = CALLBACK(GLOBAL_PROC, .proc/_step, src, NORTH),
+	 "down" = CALLBACK(GLOBAL_PROC, .proc/_step, src, SOUTH),
+	 "left" = CALLBACK(GLOBAL_PROC, .proc/_step, src, WEST),
+	 "right" = CALLBACK(GLOBAL_PROC, .proc/_step, src, EAST)))
+	 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ports [tgstation#47710](https://github.com/tgstation/tgstation/pull/47110)

Adds a deadchat controlled variant of the singularity for admins to spawn.
birdboat can turn into deadchat controlled variant now

this is also a card on things-to-port https://github.com/BeeStation/BeeStation-Hornet/projects/2#card-29397654
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives deadchat something to do.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ivniinvi, TheChosenEvilOne
add: Birdboat now has a chance to be controllable by dead chat, think twitch plays pokemon but goose and deadchat.
add: Deadchat controlled singularity variant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
