### PR TITLE
Adds hearable/visible emotes again

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -417,15 +417,15 @@
 	if(is_banned_from(user.ckey, "Emote"))
 		to_chat(user, "You cannot send custom emotes (banned).")
 		return FALSE
-	else if(QDELETED(user))
+	if(QDELETED(user))
 		return FALSE
-	else if(user.client && user.client.prefs.muted & MUTE_IC)
+	if(user?.client.prefs.muted & MUTE_IC)
 		to_chat(user, "You cannot send IC messages (muted).")
 		return FALSE
-	else
-		message = params
-		if(type_override)
-			emote_type = type_override
+
+	message = params
+	if(type_override)
+		emote_type = type_override
 	. = ..()
 	message = null
 	emote_type = EMOTE_VISIBLE

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -34,7 +34,15 @@
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 
-	usr.emote("me",1,message,TRUE)
+	var/m_type = alert(usr, "Choose the emote type", "Emote type", "Audible emote", "Visible emote")
+
+	switch(m_type)
+		if("Audible emote")
+			m_type = EMOTE_AUDIBLE
+		if("Visible emote")
+			m_type = EMOTE_VISIBLE
+
+	usr.emote("me", m_type, message, TRUE)
 
 ///Speak as a dead person (ghost etc)
 /mob/proc/say_dead(var/message)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -34,6 +34,9 @@
 
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 
+	if(!message)
+		return
+
 	var/m_type = alert(usr, "Choose the emote type", "Emote type", "Audible emote", "Visible emote")
 
 	switch(m_type)


### PR DESCRIPTION
## Changelog
:cl:
add: You can now choose whether your emote is visible or audible whem using "me speak".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
