### PR TITLE
Replaces get_hearers with range

### DIFF
--- a/code/game/objects/structures/musician.dm
+++ b/code/game/objects/structures/musician.dm
@@ -66,7 +66,7 @@
 	var/turf/source = get_turf(instrumentObj)
 	if((world.time - MUSICIAN_HEARCHECK_MINDELAY) > last_hearcheck)
 		LAZYCLEARLIST(hearing_mobs)
-		for(var/mob/M in get_hearers_in_view(15, source))
+		for(var/mob/M in range(11, source))
 			LAZYADD(hearing_mobs, M)
 		last_hearcheck = world.time
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Musical instruments can now be heard through walls.
Musical instruments uses the much cheaper range() over get_hearers.

## Why It's Good For The Game

Should be less laggy.

## Changelog
:cl:
code: Replaces get_hearers_in_view with range for musical instruments.
tweak: Musical instrument range reduced from 15 to 11
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
