### PR TITLE
ERT Commanders get an Omni Door remote.

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -37,6 +37,7 @@
 		/obj/item/melee/baton/loaded=1,
 		/obj/item/aiModule/core/full/ert=1)
 	l_pocket = /obj/item/switchblade
+	r_pocket = /obj/item/door_remote/omni
 
 /datum/outfit/ert/commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -197,7 +198,8 @@
 	l_hand = /obj/item/nullrod/scythe/talking/chainsword
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal
 	backpack_contents = list(/obj/item/storage/box/engineer=1,
-		/obj/item/aiModule/core/full/ert=1)
+		/obj/item/aiModule/core/full/ert=1,
+		/obj/item/door_remote/omni=1)
 
 /datum/outfit/ert/security/inquisitor
 	name = "Inquisition Security"
@@ -435,7 +437,8 @@
 		/obj/item/storage/firstaid/regular=1,\
 		/obj/item/storage/box/flashbangs=1,\
 		/obj/item/flashlight=1,\
-		/obj/item/grenade/plastic/x4=1)
+		/obj/item/grenade/plastic/x4=1,
+		/obj/item/door_remote/omni=1)
 
 /datum/outfit/death_commando/doomguy
 	name = "The Juggernaut"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ERT Commanders get an Omni Door remote.

## Why It's Good For The Game

Seems like a good idea to give ERT Commanders an item that lets them Command.

## Changelog
:cl:
tweak: ERT Commanders get an Omni Door remote.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
