### PR TITLE
Ruins no longer spam the It's Loose notification

### DIFF
--- a/code/modules/antagonists/clock_cult/clockwork_massive.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_massive.dm
@@ -217,6 +217,7 @@ GLOBAL_VAR(cult_ratvar)
 	desc = "Oh, that's ratvar!"
 	icon = 'icons/effects/512x512.dmi'
 	icon_state = "ratvar"
+	is_real = FALSE
 	density = FALSE
 	current_size = STAGE_SIX
 	allowed_size = STAGE_SIX

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -106,6 +106,7 @@
 	desc = "This isn't right."
 	icon = 'icons/effects/224x224.dmi'
 	icon_state = "reality"
+	is_real = FALSE
 	pixel_x = -96
 	pixel_y = -96
 	dissipate = 0

--- a/code/modules/power/singularity/boh_tear.dm
+++ b/code/modules/power/singularity/boh_tear.dm
@@ -6,6 +6,7 @@
 	desc = "Your own comprehension of reality starts bending as you stare this."
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "boh_tear"
+	is_real = FALSE
 	pixel_x = -32
 	pixel_y = -32
 	dissipate = 0

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -330,7 +330,7 @@ field_generator power level display
 	spawn(1)
 		var/temp = 1 //stops spam
 		for(var/obj/singularity/O in GLOB.singularities)
-			if(O.last_warning && temp)
+			if(O.last_warning && temp && !istype(O, /obj/singularity/wizard/mapped))
 				if((world.time - O.last_warning) > 50) //to stop message-spam
 					temp = 0
 					var/turf/T = get_turf(src)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -330,7 +330,7 @@ field_generator power level display
 	spawn(1)
 		var/temp = 1 //stops spam
 		for(var/obj/singularity/O in GLOB.singularities)
-			if(O.last_warning && temp && !istype(O, /obj/singularity/wizard/mapped))
+			if(O.last_warning && temp && O.is_real))
 				if((world.time - O.last_warning) > 50) //to stop message-spam
 					temp = 0
 					var/turf/T = get_turf(src)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -330,7 +330,7 @@ field_generator power level display
 	spawn(1)
 		var/temp = 1 //stops spam
 		for(var/obj/singularity/O in GLOB.singularities)
-			if(O.last_warning && temp && O.is_real))
+			if(O.last_warning && temp && O.is_real)
 				if((world.time - O.last_warning) > 50) //to stop message-spam
 					temp = 0
 					var/turf/T = get_turf(src)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -2,6 +2,7 @@
 	name = "Nar'Sie's Avatar"
 	desc = "Your mind begins to bubble and ooze as it tries to comprehend what it sees."
 	icon = 'icons/obj/magic_terror.dmi'
+	is_real = FALSE
 	pixel_x = -89
 	pixel_y = -85
 	density = FALSE

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -7,6 +7,7 @@
 	icon_state = "singularity_s1"
 	anchored = TRUE
 	density = TRUE
+	var/is_real = TRUE
 	move_resist = INFINITY
 	layer = MASSIVE_OBJ_LAYER
 	light_range = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
The Tear in the Fabric of Reality was causing field gens on ruins to think there was an active singulo.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
smh baiting the ghosts
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ghosts no longer get spammed with It's Loose notifications when there's no singulo or tesla.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
