### PR TITLE
Delta Exploration shuttle tweaks

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -118309,6 +118309,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_prep)
 "eCM" = (
@@ -118629,6 +118630,9 @@
 	dir = 8
 	},
 /obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_prep)
 "fuY" = (
@@ -118909,6 +118913,9 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_prep)
@@ -123887,6 +123894,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_prep)
 "vUG" = (

--- a/_maps/shuttles/exploration_delta.dmm
+++ b/_maps/shuttles/exploration_delta.dmm
@@ -1,91 +1,73 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 1
-	},
-/turf/open/floor/plating,
+"aR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/template_noop,
 /area/shuttle/exploration)
-"b" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+"cg" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/exploration)
-"c" = (
-/turf/template_noop,
-/area/template_noop)
-"d" = (
-/obj/machinery/holopad,
+/obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
-"e" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 4;
-	initialize_directions = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/exploration)
-"f" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/exploration)
-"g" = (
-/obj/effect/turf_decal/bot,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"h" = (
+"cu" = (
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/template_noop,
 /area/shuttle/exploration)
-"j" = (
-/obj/machinery/atmospherics/components/unary/plasma_refiner{
+"cH" = (
+/obj/item/radio/intercom{
+	frequency = 1453;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"da" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/exploration)
+"fr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/shuttle/exploration)
-"k" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"l" = (
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/exploration)
-"m" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/exploration)
-"n" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"o" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 8
+"fF" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
-"p" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"q" = (
+"hl" = (
 /obj/machinery/shuttle/engine/plasma{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/exploration)
-"r" = (
+"hY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"ir" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"jR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -94,84 +76,187 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
-"s" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
+"kp" = (
+/mob/living/simple_animal/chicken/turkey{
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	desc = "A veteran of Nanotrasen's Animal Experimentation Program that attempted to replicate the organic space suit that some hostile entities are known to have exhibited, Tom now serves Nanotrasen as the mascot of the Exploration Crew.";
+	health = 200;
+	maxHealth = 200;
+	melee_damage = 5;
+	minbodytemp = 2.7;
+	name = "Tom"
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"ll" = (
+/obj/machinery/telecomms/relay/preset/exploration,
+/obj/effect/turf_decal/delivery,
 /obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"t" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/exploration)
-"u" = (
-/obj/machinery/atmospherics/pipe/manifold/dark/hidden{
-	dir = 4
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/exploration)
-"v" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/exploration)
-"w" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
-	dir = 9
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/exploration)
-"x" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/exploration)
-"y" = (
-/obj/machinery/computer/objective,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"A" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/port_gen/pacman,
-/obj/item/wrench,
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/turf/open/floor/plating,
-/area/shuttle/exploration)
-"B" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"C" = (
-/obj/machinery/computer/shuttle_flight/custom_shuttle/exploration,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/exploration)
-"D" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"E" = (
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
-	dir = 5
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/exploration)
-"F" = (
-/obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
-"G" = (
+"oC" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/exploration)
+"oH" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"po" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"pG" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"qa" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4;
+	initialize_directions = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"qi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/exploration)
+"qX" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"rQ" = (
+/obj/structure/table,
+/obj/item/trash/syndi_cakes{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/broken_bottle{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/gps/mining/exploration,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"sz" = (
+/obj/machinery/computer/objective,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"sE" = (
+/obj/machinery/computer/shuttle_flight/custom_shuttle/exploration,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"sT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"sY" = (
+/obj/structure/table,
+/obj/item/trash/sosjerky,
+/obj/item/trash/popcorn{
+	pixel_y = 11
+	},
+/obj/item/paper/crumpled{
+	info = "<p>I bought you some food, but I ate it all before you came, sorry.</p><p>- RTH</p>";
+	name = "scribbled note"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"tq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"ts" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"tz" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/exploration)
+"vc" = (
+/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"vd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"vi" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"zN" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"Ax" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/exploration)
+"BF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"CU" = (
+/obj/machinery/atmospherics/components/unary/plasma_refiner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/exploration)
+"Dl" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/shuttle/exploration)
+"DM" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"GH" = (
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"Hf" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"HD" = (
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 6;
@@ -183,25 +268,150 @@
 	width = 16
 	},
 /obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
-"H" = (
+"In" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"IP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/purple/visible,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
-"I" = (
-/obj/machinery/door/airlock/shuttle,
+"IQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"IS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"KU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/item/wrench,
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/turf/open/floor/plating,
+/area/shuttle/exploration)
+"Nc" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"Nx" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	frequency = 1453;
+	pixel_y = -30
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
-"J" = (
+"NT" = (
+/obj/structure/table,
+/obj/item/trash/pistachios,
+/obj/item/trash/can/food/beans{
+	pixel_y = 10
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"OE" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/machinery/advanced_airlock_controller/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"OU" = (
+/obj/effect/turf_decal/bot,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"PA" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"Qb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/exploration)
+"Qy" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 6
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"Rk" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/exploration)
+"Rp" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/exploration)
+"RQ" = (
+/turf/template_noop,
+/area/template_noop)
+"SA" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"Vj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/exploration)
+"Vl" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/exploration)
+"Xj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/exploration)
+"Yi" = (
 /obj/structure/closet/crate,
 /obj/item/circuitboard/computer/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/five,
@@ -212,248 +422,156 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/gps/mining,
 /turf/open/floor/plating,
 /area/shuttle/exploration)
-"K" = (
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/exploration)
-"L" = (
-/obj/structure/lattice,
-/turf/template_noop,
-/area/shuttle/exploration)
-"M" = (
-/mob/living/simple_animal/chicken/turkey{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
-	desc = "A veteran of Nanotrasen's Animal Experimentation Program that attempted to replicate the organic space suit that some hostile entities are known to have exhibited, Tom now serves Nanotrasen as the mascot of the Exploration Crew.";
-	health = 200;
-	maxHealth = 200;
-	melee_damage = 5;
-	minbodytemp = 2.7;
-	name = "Tom"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"N" = (
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/exploration)
-"O" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/exploration)
-"P" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/exploration)
-"Q" = (
-/obj/machinery/door/airlock/shuttle,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"R" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/exploration)
-"S" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"T" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"U" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/chair/comfy/shuttle{
+"ZX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"V" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/microwave,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"W" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"X" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"Y" = (
-/obj/machinery/telecomms/relay/preset/exploration,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/exploration)
-"Z" = (
-/obj/machinery/computer/arcade/orion_trail,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 
 (1,1,1) = {"
-N
-N
-N
-N
-m
-O
-m
-m
-m
-m
-m
-m
-m
-R
-t
-c
+da
+da
+da
+da
+Ax
+oC
+Ax
+oC
+Ax
+Ax
+Ax
+Ax
+Ax
+tz
+Vl
+RQ
 "}
 (2,1,1) = {"
-O
-x
-l
-I
-B
-B
-B
-Q
-B
-Z
-m
-A
-J
-j
-R
-t
+oC
+sE
+Nx
+da
+sz
+sT
+qX
+Hf
+Hf
+ll
+Ax
+KU
+Yi
+CU
+tz
+Vl
 "}
 (3,1,1) = {"
-O
-C
-f
-N
-y
-D
-V
-m
-T
-U
-m
-r
-p
-k
-a
-q
+oC
+po
+ir
+Rp
+Hf
+Hf
+ts
+Hf
+Hf
+vi
+Ax
+jR
+zN
+GH
+Rk
+hl
 "}
 (4,1,1) = {"
-O
-O
-O
-N
-m
-m
-m
-m
-M
-B
-Q
-r
-p
-k
-a
-q
+oC
+oC
+oC
+da
+cH
+Nc
+PA
+In
+kp
+ZX
+DM
+Vj
+SA
+GH
+Rk
+hl
 "}
 (5,1,1) = {"
-c
-c
-c
-N
-Y
-B
-B
-Q
-B
-B
-m
-X
-g
-k
-a
-q
+RQ
+RQ
+RQ
+da
+cg
+rQ
+sT
+vc
+IS
+tq
+Qb
+hY
+OU
+GH
+Rk
+hl
 "}
 (6,1,1) = {"
-h
-L
-L
-O
-S
-d
-B
-m
-m
-P
-v
-E
-s
-H
-a
-q
+cu
+aR
+aR
+Dl
+IQ
+sY
+sT
+Ax
+Ax
+fF
+Ax
+Xj
+Qy
+IP
+Rk
+hl
 "}
 (7,1,1) = {"
-c
-c
-c
-O
-W
-F
-W
-m
-K
-o
-e
-b
-n
-n
-R
-t
+RQ
+RQ
+RQ
+oC
+BF
+NT
+vd
+Ax
+OE
+oH
+qa
+Xj
+pG
+pG
+tz
+Vl
 "}
 (8,1,1) = {"
-c
-c
-c
-N
-N
-O
-m
-m
-m
-G
-u
-w
-m
-R
-t
-c
+RQ
+RQ
+RQ
+da
+da
+oC
+Ax
+Ax
+Ax
+HD
+fr
+qi
+Ax
+tz
+Vl
+RQ
 "}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the Delta exploration shuttle layout to be less cramped.
![image](https://user-images.githubusercontent.com/34888552/132265527-40148dc6-440d-4407-abf2-7d17eb137f05.png)

Also adds lights to the exploration office on Delta.

## Why It's Good For The Game

Current Delta Exploration shuttle for some reason feels even more cramped than the default one despite being bigger.

## Changelog
:cl:
tweak: Changed the layout of the Deltastation exploration shuttle.
fix: Added lights to Deltastation exploration office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
