### PR TITLE
Fix silicons being unable to interact with intercoms

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -73,7 +73,10 @@
 	ui_interact(user)
 
 /obj/item/radio/intercom/ui_state(mob/user)
-	return GLOB.physical_state
+	if(issilicon(user)) // Silicons can't use physical state remotely
+		return GLOB.default_state
+
+	return GLOB.physical_state // But monkeys can't use default state, and they can already use hotkeys
 
 /obj/item/radio/intercom/can_receive(freq, level)
 	if(!on)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bug introduced by me in https://github.com/BeeStation/BeeStation-Hornet/pull/5111
Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/5310
Thanks for commenting on the PR @AnCopper, I didn't notice the issue :pensive:
Sorry for not testing it better

In my previous PR I changed the intercoms to use physical state instead of default state to allow non-dexterous mobs to interact with the interface. The reason for this change was that non-dexterous mobs could already use hotkeys on intercoms and interact with radios, monkeys in particular. However, physical state quite reasonably prevents remote access - this means borgs could only interact with them when adjacent and AIs couldn't interact at all.

I think this most likely isn't the best way to solve the issue, but it should at the *very least* not make things anymore broken than they were before my previous PR. That said, I did rudimentary testing to make sure it works for humans, monkeys, borgs and AI and am too tired to think of a better way right now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Silicons can once again interact with intercoms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
