### PR TITLE
Eat through the explorer mask. Better explorer gear descriptions.

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -1,7 +1,7 @@
 /****************Explorer's Suit and Mask****************/
 /obj/item/clothing/suit/hooded/explorer
 	name = "explorer suit"
-	desc = "A suit made for hostile environments. Its toughness can be further upgraded with goliath hide."
+	desc = "A suit made for hostile environments that can easily be strengthened further."
 	icon_state = "explorer"
 	item_state = "explorer"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
@@ -18,7 +18,7 @@
 
 /obj/item/clothing/head/hooded/explorer
 	name = "explorer hood"
-	desc = "A hood made for hostile environments. Its toughness can be further upgraded with goliath hide."
+	desc = "A hood made for hostile environments that can easily be strengthened further."
 	icon_state = "explorer"
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -1,7 +1,7 @@
 /****************Explorer's Suit and Mask****************/
 /obj/item/clothing/suit/hooded/explorer
 	name = "explorer suit"
-	desc = "An armoured suit for exploring harsh environments."
+	desc = "A suit made for hostile environments. Its toughness can be further upgraded with goliath hide."
 	icon_state = "explorer"
 	item_state = "explorer"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
@@ -18,7 +18,7 @@
 
 /obj/item/clothing/head/hooded/explorer
 	name = "explorer hood"
-	desc = "An armoured hood for exploring harsh environments."
+	desc = "A hood made for hostile environments. Its toughness can be further upgraded with goliath hide."
 	icon_state = "explorer"
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
@@ -38,26 +38,14 @@
 
 /obj/item/clothing/mask/gas/explorer
 	name = "explorer gas mask"
-	desc = "A military-grade gas mask that can be connected to an air supply."
+	desc = "A specialized gas mask offering both protection and convenience."
 	icon_state = "gas_mining"
-	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
+	flags_cover = MASKCOVERSEYES
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR
-	visor_flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
-	actions_types = list(/datum/action/item_action/adjust)
+	visor_flags_cover = MASKCOVERSEYES
 	armor = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 0, "bio" = 50, "rad" = 0, "fire" = 20, "acid" = 40, "stamina" = 10)
 	resistance_flags = FIRE_PROOF
-
-/obj/item/clothing/mask/gas/explorer/attack_self(mob/user)
-	adjustmask(user)
-
-/obj/item/clothing/mask/gas/explorer/adjustmask(user)
-	..()
-	w_class = mask_adjusted ? WEIGHT_CLASS_SMALL : WEIGHT_CLASS_NORMAL
-
-/obj/item/clothing/mask/gas/explorer/folded/Initialize()
-	. = ..()
-	adjustmask()
 
 /obj/item/clothing/suit/space/hostile_environment
 	name = "H.E.C.K. suit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> This lets you eat through the explorer gas mask and removes the toggle made redundant by the change. On the side, it also changes its description and the explorer suit/hood description.

**History/notes:** This change was already approved and merged once though it kept the mask toggle. Ivanmixo would then go on to revert the change without citing a reason. They'd later reveal it was to maintain realism. I will take a moment to note that we have other masks that allow eating, as well as wizards. With this in mind, here's a better version of the change. 

This PR originally also contained jetpack changes, but those are now pending as a [poll](https://forums.beestation13.com/t/jetpacks-for-exploration-mining-crew-opinions-needed) is ongoing.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->  

Mask change: Miners are the only crew members that regularly harvest, make and eat food while being on internals 24/7. Out of all crew, it makes the most sense for them to have masks with this feature. There's no downside to giving the masks this feature, and it will also make miners stop replacing their masks with welding gas masks specifically so they can eat easier, which is steadily rising in the miner meta. 

In conclusion, this change will be appreciated by the respective playerbase, as shown by their current actions, and doesn't bring anything even potentially negative to the game.

Descriptions: The mask doesn't reference the military anymore, and the suit upgrading is made more obvious.

## Changelog
:cl:
tweak: tweaked a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
