### PR TITLE
Takes out the wand of death from the wand belt.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -576,7 +576,6 @@
 		))
 
 /obj/item/storage/belt/wands/full/PopulateContents()
-	new /obj/item/gun/magic/wand/death(src)
 	new /obj/item/gun/magic/wand/resurrection(src)
 	new /obj/item/gun/magic/wand/polymorph(src)
 	new /obj/item/gun/magic/wand/teleport(src)


### PR DESCRIPTION
## About The Pull Request

Takes out the instant death wand from the wand belt.

This differs from #5357 as that pull request took out everything related to the wand and its bolt, this pull request takes it out from the purchaseble wand belt.

## Why It's Good For The Game

This change is good for the game because it takes out an instant death item from the hands of the players.

Every round with Wizards that I observe is just them instantly killing everyone with this thing, there is a reason it was rated as the worst antagonist on this server on a forum poll.
## Changelog
:cl:
tweak: Took out the instant death wand from the wand belt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
