### PR TITLE
[s] Excludes clients in advanced proccall to prevent bypassing of permissions for coders in-game.

### DIFF
--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -15,7 +15,7 @@
 	switch(alert("Proc owned by something?",,"Yes","No"))
 		if("Yes")
 			targetselected = TRUE
-			var/list/value = vv_get_value(default_class = VV_ATOM_REFERENCE, classes = list(VV_ATOM_REFERENCE, VV_DATUM_REFERENCE, VV_MOB_REFERENCE, VV_CLIENT, VV_MARKED_DATUM, VV_TEXT_LOCATE, VV_PROCCALL_RETVAL))
+			var/list/value = vv_get_value(default_class = VV_ATOM_REFERENCE, classes = list(VV_ATOM_REFERENCE, VV_DATUM_REFERENCE, VV_MOB_REFERENCE, VV_MARKED_DATUM, VV_TEXT_LOCATE, VV_PROCCALL_RETVAL))
 			if (!value["class"] || !value["value"])
 				return
 			target = value["value"]


### PR DESCRIPTION
## About The Pull Request

Makes clients no longer targetable by the debug verb `advanced proccall` which allowed coders to use admin permissions illegally.

## Why It's Good For The Game

Letting people use things they shouldn't be able to use is a bad thing.

## Changelog
:cl:
admin: Fixed a security issue with the advanced proccall
/:cl:

