### PR TITLE
You can build shuttles on asteroids

### DIFF
--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -309,6 +309,8 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 			overwritten_area = /area/space
 		else if(istype(place, /area/lavaland/surface/outdoors))
 			overwritten_area = /area/lavaland/surface/outdoors
+		else if(istype(place, /area/asteroid/generated))
+			overwritten_area = /area/asteroid/generated
 		else
 			to_chat(usr, "<span class='warning'>Caution, shuttle must not use any material connected to the station. Your shuttle is currenly overlapping with [place.name].</span>")
 			return FALSE

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/asteroid_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/asteroid_generator.dm
@@ -82,3 +82,4 @@
 
 /area/asteroid/generated
 	dynamic_lighting = DYNAMIC_LIGHTING_IFSTARLIGHT
+	outdoors = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows custom shuttles to be made on asteriods.

## Why It's Good For The Game

Allows building shuttles and areas on asteriods.

## Changelog
:cl:
tweak: Custom shuttles and rooms can be made on asteriods.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
