### PR TITLE
Instanced shuttles - Allows the creation of infinite mobile docking ports with the same ID without them interfering.

### DIFF
--- a/_maps/shuttles/hunter_bounty.dmm
+++ b/_maps/shuttles/hunter_bounty.dmm
@@ -202,7 +202,7 @@
 	name = "Deep Space";
 	width = 17
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	dheight = 3;
 	dwidth = 3;
 	height = 13;

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -195,7 +195,7 @@
 	name = "Deep Space";
 	width = 17
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	dheight = 3;
 	dir = 1;
 	dwidth = 3;

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -18,7 +18,7 @@
 	name = "Deep Space";
 	width = 7
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	dheight = 0;
 	dir = 4;
 	dwidth = 3;

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -845,7 +845,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/docking_port/mobile/pirate{
+/obj/docking_port/mobile/instance/pirate{
 	callTime = 100;
 	dheight = 0;
 	dir = 1;

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -1045,7 +1045,7 @@
 /obj/machinery/door/airlock/external{
 	id_tag = "caravantrade1_bolt"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	callTime = 250;
 	dir = 2;
 	dwidth = 5;

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -848,7 +848,7 @@
 /obj/machinery/door/airlock/external{
 	id_tag = "caravanpirate_bolt_port"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	callTime = 150;
 	dir = 2;
 	dwidth = 14;

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -69,7 +69,7 @@
 	normalspeed = 0;
 	req_access_txt = "150"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	dir = 2;
 	dwidth = 6;
 	height = 7;

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -87,7 +87,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	callTime = 50;
 	dir = 4;
 	dwidth = 4;

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -15,7 +15,7 @@
 "ae" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	callTime = 250;
 	dheight = 0;
 	dir = 2;

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -10,7 +10,7 @@
 	name = "mech bay external airlock"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	dheight = 0;
 	dir = 2;
 	dwidth = 8;

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -17,7 +17,7 @@
 "ad" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	callTime = 250;
 	dheight = 0;
 	dir = 2;

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -34,7 +34,7 @@
 "ah" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	callTime = 250;
 	can_move_docking_ports = 1;
 	dir = 2;

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -84,7 +84,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Shuttle Airlock"
 	},
-/obj/docking_port/mobile{
+/obj/docking_port/mobile/instance{
 	dheight = 0;
 	dir = 8;
 	dwidth = 4;

--- a/beestation.dme
+++ b/beestation.dme
@@ -3064,6 +3064,7 @@
 #include "code\modules\shuttle\emergency.dm"
 #include "code\modules\shuttle\ferry.dm"
 #include "code\modules\shuttle\manipulator.dm"
+#include "code\modules\shuttle\mobile_instance.dm"
 #include "code\modules\shuttle\monastery.dm"
 #include "code\modules\shuttle\on_move.dm"
 #include "code\modules\shuttle\ripple.dm"

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -8,7 +8,6 @@ SUBSYSTEM_DEF(shuttle)
 	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
 
 	var/list/consoles = list()		//A list of things that link to instanced shuttles. Use /proc/connect_to_shuttle()
-	var/list/ports_to_init = list()
 	var/list/mobile = list()
 	var/list/stationary = list()
 	var/list/beacons = list()
@@ -901,8 +900,3 @@ SUBSYSTEM_DEF(shuttle)
 					message_admins("[key_name_admin(usr)] loaded [mdp] with the shuttle manipulator.")
 					log_admin("[key_name(usr)] loaded [mdp] with the shuttle manipulator.</span>")
 					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[mdp.name]")
-
-/datum/controller/subsystem/shuttle/StopLoadingMap()
-	for(var/obj/docking_port/mobile/instance/thing in ports_to_init)
-		thing.generate_unique_id()
-	ports_to_init.Cut()

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -7,6 +7,8 @@ SUBSYSTEM_DEF(shuttle)
 	flags = SS_KEEP_TIMING|SS_NO_TICK_CHECK
 	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
 
+	var/list/consoles = list()		//A list of things that link to instanced shuttles. Use /proc/connect_to_shuttle()
+	var/list/ports_to_init = list()
 	var/list/mobile = list()
 	var/list/stationary = list()
 	var/list/beacons = list()
@@ -61,6 +63,8 @@ SUBSYSTEM_DEF(shuttle)
 	var/datum/map_template/shuttle/preview_template
 
 	var/datum/turf_reservation/preview_reservation
+
+	var/shuttle_docking_jammed = FALSE
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	ordernum = rand(1, 9000)
@@ -897,3 +901,8 @@ SUBSYSTEM_DEF(shuttle)
 					message_admins("[key_name_admin(usr)] loaded [mdp] with the shuttle manipulator.")
 					log_admin("[key_name(usr)] loaded [mdp] with the shuttle manipulator.</span>")
 					SSblackbox.record_feedback("text", "shuttle_manipulator", 1, "[mdp.name]")
+
+/datum/controller/subsystem/shuttle/StopLoadingMap()
+	for(var/obj/docking_port/mobile/instance/thing in ports_to_init)
+		thing.generate_unique_id()
+	ports_to_init.Cut()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1168,6 +1168,10 @@
 /atom/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	return
 
+///Get the shuttle this atom is attached to
+/atom/proc/get_linked_shuttle()
+	return ""
+
 /// Generic logging helper
 /atom/proc/log_message(message, message_type, color=null, log_globally=TRUE)
 	if(!log_globally)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -298,7 +298,7 @@
 	name = "salvage pod recall control (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle_flight/white_ship/pod/recall
 
-/obj/item/circuitboard/computer/shuttle_flight/shuttle/flight_control
+/obj/item/circuitboard/computer/shuttle/flight_control
 	name = "shuttle flight control (Computer Board)"
 	icon_state = "generic"
 	build_path = /obj/machinery/computer/shuttle_flight/custom_shuttle

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -285,20 +285,20 @@
 	icon_state = "generic"
 	build_path = /obj/machinery/computer/pod/old/syndicate
 
-/obj/item/circuitboard/computer/white_ship
+/obj/item/circuitboard/computer/shuttle_flight/white_ship
 	name = "white ship control (Computer Board)"
 	icon_state = "generic"
 	build_path = /obj/machinery/computer/shuttle_flight/white_ship
 
-/obj/item/circuitboard/computer/white_ship/pod
+/obj/item/circuitboard/computer/shuttle_flight/white_ship/pod
 	name = "salvage pod control (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle_flight/white_ship/pod
 
-/obj/item/circuitboard/computer/white_ship/pod/recall
+/obj/item/circuitboard/computer/shuttle_flight/white_ship/pod/recall
 	name = "salvage pod recall control (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle_flight/white_ship/pod/recall
 
-/obj/item/circuitboard/computer/shuttle/flight_control
+/obj/item/circuitboard/computer/shuttle_flight/shuttle/flight_control
 	name = "shuttle flight control (Computer Board)"
 	icon_state = "generic"
 	build_path = /obj/machinery/computer/shuttle_flight/custom_shuttle

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -234,6 +234,12 @@
 	else
 		return ..()
 
+/obj/item/circuitboard/computer/shuttle_flight
+	name = "generic shuttle console (Computer Board)"
+	icon_state = "generic"
+	build_path = /obj/machinery/computer/shuttle_flight
+	var/linked_shuttle_id
+
 /obj/item/circuitboard/computer/monastery_shuttle
 	name = "monastery shuttle console (Computer Board)"
 	icon_state = "generic"

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -58,7 +58,7 @@
 		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
 		board.challenge = TRUE
 
-	GLOB.shuttle_docking_jammed = TRUE
+	SSshuttle.shuttle_docking_jammed = TRUE
 
 	var/list/orphans = list()
 	var/list/uplinks = list()

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -133,7 +133,7 @@
 /datum/supply_pack/emergency/firefighting
 	name = "Firefighting Crate"
 	desc = "Only you can prevent station fires. Partner up with three firefighter suits, gas masks, flashlights, large oxygen tanks, extinguishers, and hardhats!"
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/clothing/suit/fire/firefighter,
 					/obj/item/clothing/suit/fire/firefighter,
 					/obj/item/clothing/suit/fire/firefighter,
@@ -206,7 +206,7 @@
 /datum/supply_pack/emergency/plasmaman
 	name = "Plasmaman Supply Kit"
 	desc = "Keep those Plasmamen alive with three sets of Plasmaman outfits. Each set contains a plasmaman jumpsuit, internals tank, and helmet."
-	cost = 700 //50 credits per suit. 
+	cost = 700 //50 credits per suit.
 	contains = list(/obj/item/clothing/under/plasmaman,
 					/obj/item/clothing/under/plasmaman,
 					/obj/item/clothing/under/plasmaman,
@@ -453,7 +453,7 @@
 /datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains five wall-mounted flashes. Requires Security access to open."
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash,
 					/obj/item/storage/box/wall_flash,
@@ -1701,7 +1701,7 @@
 /datum/supply_pack/service/cargo_supples
 	name = "Cargo Supplies Crate"
 	desc = "Sold everything that wasn't bolted down? You can get right back to work with this crate containing stamps, an export scanner, destination tagger, hand labeler and some package wrapping."
-	cost = 700    
+	cost = 700
 	contains = list(/obj/item/stamp,
 					/obj/item/stamp/denied,
 					/obj/item/export_scanner,
@@ -1833,7 +1833,7 @@
 /datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights"
 	desc = "May the light of Aether shine upon this station! Or at least, the light of fifty six light tubes and twenty eight light bulbs."
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/storage/box/lights/mixed,
 					/obj/item/storage/box/lights/mixed,
 					/obj/item/storage/box/lights/mixed,
@@ -2051,7 +2051,7 @@
 /datum/supply_pack/organic/hydroponics
 	name = "Hydroponics Crate"
 	desc = "Supplies for growing a great garden! Contains two bottles of ammonia, two Plant-B-Gone spray bottles, a hatchet, cultivator, plant analyzer, as well as a pair of leather gloves and a botanist's apron."
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/spray/plantbgone,
 					/obj/item/reagent_containers/glass/bottle/ammonia,
@@ -2626,7 +2626,7 @@
 /datum/supply_pack/costumes_toys/chess_white
 	name = "White Chess Piece Crate"
 	desc = "Look at you, playing a nerd game within a nerd game!"
-	cost = 800 
+	cost = 800
 	contains = list(
 		/obj/item/cardboard_cutout/adaptive/chess/king,
 		/obj/item/cardboard_cutout/adaptive/chess/queen,
@@ -2678,21 +2678,21 @@
 /datum/supply_pack/costumes_toys/wardrobes/autodrobe
 	name = "Autodrobe Supply Crate"
 	desc = "Autodrobe missing your favorite dress? Solve that issue today with this autodrobe refill."
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/vending_refill/autodrobe)
 	crate_name = "autodrobe supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/cargo
 	name = "Cargo Wardrobe Supply Crate"
 	desc = "This crate contains a refill for the CargoDrobe."
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
 	crate_name = "cargo department supply crate"
 
 /datum/supply_pack/costumes_toys/wardrobes/engineering
 	name = "Engineering Wardrobe Supply Crate"
 	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/vending_refill/wardrobe/engi_wardrobe,
 					/obj/item/vending_refill/wardrobe/atmos_wardrobe)
 	crate_name = "engineering department wardrobe supply crate"
@@ -2798,7 +2798,7 @@
 /datum/supply_pack/misc/bigband
 	name = "Big Band Instrument Collection"
 	desc = "Get your sad station movin' and groovin' with this fine collection! Contains nine different instruments!"
-	cost = 800 
+	cost = 800
 	crate_name = "Big band musical instruments collection"
 	contains = list(/obj/item/instrument/violin,
 					/obj/item/instrument/guitar,
@@ -2861,7 +2861,7 @@
 /datum/supply_pack/misc/wrapping_paper
 	name = "Festive Wrapping Paper Crate"
 	desc = "Want to mail your loved ones gift-wrapped chocolates, stuffed animals, the Clown's severed head? You can do all that, with this crate full of wrapping paper."
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/stack/wrapping_paper)
 	crate_type = /obj/structure/closet/crate/wooden
 	crate_name = "festive wrapping paper crate"
@@ -2893,7 +2893,7 @@
 /datum/supply_pack/misc/toner
 	name = "Toner Crate"
 	desc = "Spent too much ink printing butt pictures? Fret not, with these eight toner refills, you'll be printing butts 'till the cows come home!'"
-	cost = 800 
+	cost = 800
 	contains = list(/obj/item/toner,
 					/obj/item/toner,
 					/obj/item/toner,

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -184,7 +184,7 @@
 	light_color = LIGHT_COLOR_RED
 	possible_destinations = "pirateship_away;pirateship_home;pirateship_custom"
 
-/obj/docking_port/mobile/pirate
+/obj/docking_port/mobile/instance/pirate
 	name = "pirate shuttle"
 	id = "pirateship"
 	rechargeTime = 3 MINUTES

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -49,7 +49,7 @@
 /obj/machinery/computer/shuttle_flight/caravan/trade1
 	name = "Small Freighter Shuttle Console"
 	desc = "Used to control the Small Freighter."
-	circuit = /obj/item/circuitboard/computer/caravan/trade1
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/caravan/trade1
 	shuttleId = "caravantrade1"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;caravantrade1_custom;caravantrade1_ambush"
 
@@ -59,7 +59,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	light_color = LIGHT_COLOR_RED
-	circuit = /obj/item/circuitboard/computer/caravan/pirate
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/caravan/pirate
 	shuttleId = "caravanpirate"
 	possible_destinations = "caravanpirate_custom;caravanpirate_ambush"
 
@@ -70,7 +70,7 @@
 	icon_keyboard = "syndie_key"
 	light_color = LIGHT_COLOR_RED
 	req_access = list(ACCESS_SYNDICATE)
-	circuit = /obj/item/circuitboard/computer/caravan/syndicate1
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/caravan/syndicate1
 	shuttleId = "caravansyndicate1"
 	possible_destinations = "caravansyndicate1_custom;caravansyndicate1_ambush;caravansyndicate1_listeningpost"
 
@@ -81,7 +81,7 @@
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
 	light_color = LIGHT_COLOR_RED
-	circuit = /obj/item/circuitboard/computer/caravan/syndicate2
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/caravan/syndicate2
 	shuttleId = "caravansyndicate2"
 	possible_destinations = "caravansyndicate2_custom;caravansyndicate2_ambush;caravansyndicate1_listeningpost"
 
@@ -92,6 +92,6 @@
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
 	light_color = LIGHT_COLOR_RED
-	circuit = /obj/item/circuitboard/computer/caravan/syndicate3
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/caravan/syndicate3
 	shuttleId = "caravansyndicate3"
 	possible_destinations = "caravansyndicate3_custom;caravansyndicate3_ambush;caravansyndicate3_listeningpost"

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -28,22 +28,22 @@
 
 /obj/machinery/computer/shuttle_flight/caravan
 
-/obj/item/circuitboard/computer/caravan
+/obj/item/circuitboard/computer/shuttle_flight/caravan
 	build_path = /obj/machinery/computer/shuttle_flight/caravan
 
-/obj/item/circuitboard/computer/caravan/trade1
+/obj/item/circuitboard/computer/shuttle_flight/caravan/trade1
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/trade1
 
-/obj/item/circuitboard/computer/caravan/pirate
+/obj/item/circuitboard/computer/shuttle_flight/caravan/pirate
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/pirate
 
-/obj/item/circuitboard/computer/caravan/syndicate1
+/obj/item/circuitboard/computer/shuttle_flight/caravan/syndicate1
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/syndicate1
 
-/obj/item/circuitboard/computer/caravan/syndicate2
+/obj/item/circuitboard/computer/shuttle_flight/caravan/syndicate2
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/syndicate2
 
-/obj/item/circuitboard/computer/caravan/syndicate3
+/obj/item/circuitboard/computer/shuttle_flight/caravan/syndicate3
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/syndicate3
 
 /obj/machinery/computer/shuttle_flight/caravan/trade1

--- a/code/modules/ruins/spaceruin_code/whiteshipruin_box.dm
+++ b/code/modules/ruins/spaceruin_code/whiteshipruin_box.dm
@@ -5,4 +5,4 @@
 
 /obj/machinery/computer/shuttle_flight/white_ship/ruin
 	shuttleId = "whiteship_ruin"
-	circuit = /obj/item/circuitboard/computer/white_ship/ruin
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/white_ship/ruin

--- a/code/modules/ruins/spaceruin_code/whiteshipruin_box.dm
+++ b/code/modules/ruins/spaceruin_code/whiteshipruin_box.dm
@@ -1,6 +1,6 @@
 ///////////	ruined whiteship
 
-/obj/item/circuitboard/computer/white_ship/ruin
+/obj/item/circuitboard/computer/shuttle_flight/white_ship/ruin
 	build_path = /obj/machinery/computer/shuttle_flight/white_ship/ruin
 
 /obj/machinery/computer/shuttle_flight/white_ship/ruin

--- a/code/modules/shuttle/mobile_instance.dm
+++ b/code/modules/shuttle/mobile_instance.dm
@@ -1,0 +1,24 @@
+
+//ID is a temp ID that links shuttles in the map file.
+//Port and consoles must be on the same map file, will not work if the shuttle console is placed on a different map.
+//After map load, the shuttle will be given a new unique ID and any consoles with the old port will be given the new unique ID.
+//Used for making ships that can spawn multiple times and are fully contained in 1 file.
+//
+//Works for shuttles carrying other shuttles too.
+/obj/docking_port/mobile/instance/New(loc, ...)
+	. = ..()
+	SSshuttle.ports_to_init += src
+
+/obj/docking_port/mobile/instance/proc/generate_unique_id()
+	var/static/number = 0
+	//Generate a unique ID
+	var/old_id = id
+	id = "[id]_[number++]"
+	//Find attached flight consoles
+	for(var/atom/thing as() in SSshuttle.consoles)
+		if(!thing)
+			stack_trace("Warning: Null value in SSshuttle.consoles!")
+			continue
+		//Update anything thats linked to us to use our new unique ID.
+		if(thing.get_linked_shuttle() == old_id)
+			thing.connect_to_shuttle(src, override = TRUE)

--- a/code/modules/shuttle/mobile_instance.dm
+++ b/code/modules/shuttle/mobile_instance.dm
@@ -5,11 +5,11 @@
 //Used for making ships that can spawn multiple times and are fully contained in 1 file.
 //
 //Works for shuttles carrying other shuttles too.
-/obj/docking_port/mobile/instance/New(loc, ...)
+/obj/docking_port/mobile/instance/Initialize(mapload)
 	. = ..()
-	SSshuttle.ports_to_init += src
+	return INITIALIZE_HINT_LATELOAD
 
-/obj/docking_port/mobile/instance/proc/generate_unique_id()
+/obj/docking_port/mobile/instance/LateInitialize()
 	var/static/number = 0
 	//Generate a unique ID
 	var/old_id = id

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/z_linked.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/z_linked.dm
@@ -41,7 +41,7 @@
 		//send them to the place
 		var/datum/orbital_object/shuttle/shuttle = other
 		//Check if shuttle can dock at this location.
-		if(!random_docking && !(can_dock_anywhere && (!GLOB.shuttle_docking_jammed || shuttle.stealth || !istype(src, /datum/orbital_object/z_linked/station))))
+		if(!random_docking && !(can_dock_anywhere && (!SSshuttle.shuttle_docking_jammed || shuttle.stealth || !istype(src, /datum/orbital_object/z_linked/station))))
 			var/can_dock_here = FALSE
 			for(var/port_name in shuttle.valid_docks)
 				var/obj/docking_port/port = SSshuttle.getDock(port_name)

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -33,7 +33,10 @@
 	//Our orbital body.
 	var/datum/orbital_object/shuttle/shuttleObject
 
-/obj/machinery/computer/shuttle_flight/Initialize(mapload, obj/item/circuitboard/C)
+/obj/machinery/computer/shuttle_flight/Initialize(mapload, obj/item/circuitboard/computer/shuttle_flight/C)
+	//Recover the shuttle Id
+	if(istype(C) && C.linked_shuttle_id)
+		shuttleId = C.linked_shuttle_id
 	. = ..()
 	valid_docks = params2list(possible_destinations)
 	if(shuttleId)

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
@@ -296,11 +296,6 @@
 		current_user.client.images -= remove_images
 		current_user.client.images += add_images
 
-/obj/machinery/computer/shuttle_flight/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
-	if(port && (shuttleId == initial(shuttleId) || override))
-		shuttleId = port.id
-		shuttlePortId = "[shuttleId]_custom"
-
 /mob/camera/ai_eye/remote/shuttle_docker
 	visible_icon = FALSE
 	use_static = USE_STATIC_NONE

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -1,21 +1,21 @@
 /obj/machinery/computer/shuttle_flight/white_ship
 	name = "White Ship Console"
 	desc = "Used to control the White Ship."
-	circuit = /obj/item/circuitboard/computer/white_ship
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/white_ship
 	shuttleId = "whiteship"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;whiteship_custom"
 
 /obj/machinery/computer/shuttle_flight/white_ship/pod
 	name = "Salvage Pod Console"
 	desc = "Used to control the Salvage Pod."
-	circuit = /obj/item/circuitboard/computer/white_ship/pod
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/white_ship/pod
 	shuttleId = "whiteship_pod"
 	possible_destinations = "whiteship_pod_home;whiteship_pod_custom"
 
 /obj/machinery/computer/shuttle_flight/white_ship/pod/recall
 	name = "Salvage Pod Recall Console"
 	desc = "Used to recall the Salvage Pod."
-	circuit = /obj/item/circuitboard/computer/white_ship/pod/recall
+	circuit = /obj/item/circuitboard/computer/shuttle_flight/white_ship/pod/recall
 	possible_destinations = "whiteship_pod_home"
 
 /obj/effect/spawner/lootdrop/whiteship_cere_ripley


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds instanced mobile ports, when spawned they will generate a unique ID and any shuttle console referencing them will be updated.
This means that 1 map shuttle can be created and spawned multiple times.

Previously if you spawn 2 pirate ships or whatever, the controls for both will only control the first one spawned.

## Why It's Good For The Game

More than 1 of the same shuttle can be loaded, as many pirate ships as you want can spawn and they won't interfere with each other.

## Changelog
:cl:
tweak: Shuttle flight consoles now have a circuit board which stores the shuttle ID in them.
code: Adds instanced shuttles which will generate a unique ID and link consoles to them on spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
