### PR TITLE
Changes Dynamic Config, round 2.

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -32,8 +32,32 @@
 			"restricted_roles": [
 				"Cyborg"
 			]
+		},
+		"Wizard": {
+			"cost": 35,
+			"weight": 5
+		},
+		"Nuclear Emergency": {
+			"cost": 30
+		},
+		"Blood Cult": {
+			"cost": 25
 		}
 	},
-	"Midround": {},
+	"Midround": {
+		"Wizard": {
+			"cost": 35,
+			"weight": 5
+		},
+		"Nuclear Assault": {
+			"cost": 30
+		},
+		"Blob": {
+			"cost": 20
+		},
+		"Alien Infestation": {
+			"cost": 20
+		}
+	},
 	"Latejoin": {}
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Raises the following dynamic threat levels per admin discussion:
Wizard 20->35 (Wizard's weight has been increased to make it more likely to roll at high threat levels.)
Nukies 20->30
Blob 10->20
Xenos 10->20
Cult 20->25

Now using the config and not the base code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins decided that round ending and team antags should be higher cost. Additionally, following internal discussion, it has been decided that Wizard the mode will not be returning.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: The cost of the following rulesets for Dynamic have been increased: Wizard, Nuclear Operatives, Blob, Xenomorphs, Blood Cult.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
