### PR TITLE
Gives the traitor capsule a refinery and pickaxe.

### DIFF
--- a/_maps/shuttles/capsule_traitor.dmm
+++ b/_maps/shuttles/capsule_traitor.dmm
@@ -3,6 +3,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/pod_shuttle)
+"b" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/item/pickaxe/emergency,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/pod_shuttle)
 "c" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/line{
@@ -22,6 +32,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/pod_shuttle)
+"f" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/modular_fabricator/autolathe/hacked,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/pod_shuttle)
 "h" = (
@@ -132,15 +147,6 @@
 /obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/pod_shuttle)
-"y" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/pod_shuttle)
 "z" = (
 /obj/machinery/computer/shuttle_flight/custom_shuttle/bluespace_pod/traitor,
 /turf/open/floor/mineral/plastitanium/red,
@@ -174,17 +180,6 @@
 "D" = (
 /obj/machinery/computer/crew/syndie,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/pod_shuttle)
-"E" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 6
-	},
-/obj/structure/cable/yellow,
-/mob/living/simple_animal/hostile/carp/cayenne,
-/turf/open/floor/plating,
 /area/shuttle/pod_shuttle)
 "K" = (
 /obj/structure/cable/yellow{
@@ -220,14 +215,27 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/pod_shuttle)
-"O" = (
-/obj/machinery/modular_fabricator/autolathe/hacked,
+"P" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/plasma_refiner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/pod_shuttle)
+"Q" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/mob/living/simple_animal/hostile/carp/cayenne,
 /turf/open/floor/plating,
 /area/shuttle/pod_shuttle)
 "S" = (
@@ -295,10 +303,10 @@ T
 k
 s
 i
+f
 a
 a
-a
-O
+P
 m
 m
 "}
@@ -311,7 +319,7 @@ e
 h
 h
 Z
-E
+Q
 x
 A
 "}
@@ -322,7 +330,7 @@ t
 h
 n
 B
-y
+b
 p
 W
 x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The traitor capsule shuttle now gets a refinery and pickaxe.
![image](https://user-images.githubusercontent.com/26465327/133304072-c6b4c663-2d0b-4ac0-9f02-4762055a35c2.png)

## Why It's Good For The Game

Prevents people running out of fuel and getting stuck in space.

## Changelog
:cl:
tweak: Traitor capsule shuttle gets a plasma refinery and an emergency pickaxe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
