### PR TITLE
Blind player's screens stuck with blurry effect after being pied and cleaning it off

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -110,7 +110,7 @@
 		else
 			adjust_blindness(-1)
 		//If you have blindness from a trait, heal blurryness too, otherwise return and ignore that.
-		if(!(HAS_TRAIT(src, TRAIT_BLIND))
+		if(!(HAS_TRAIT(src, TRAIT_BLIND)))
 			return
 	if(eye_blurry)			//blurry eyes heal slowly
 		adjust_blurriness(-1)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -99,18 +99,21 @@
 
 
 /mob/living/carbon/human/handle_traits()
+	if (getOrganLoss(ORGAN_SLOT_BRAIN) >= 60)
+		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "brain_damage", /datum/mood_event/brain_damage)
+	else
+		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "brain_damage")
+
 	if(eye_blind)			//blindness, heals slowly over time
 		if(HAS_TRAIT_FROM(src, TRAIT_BLIND, EYES_COVERED)) //covering your eyes heals blurry eyes faster
 			adjust_blindness(-3)
 		else
 			adjust_blindness(-1)
-	else if(eye_blurry)			//blurry eyes heal slowly
+		//If you have blindness from a trait, heal blurryness too, otherwise return and ignore that.
+		if(!(HAS_TRAIT(src, TRAIT_BLIND))
+			return
+	if(eye_blurry)			//blurry eyes heal slowly
 		adjust_blurriness(-1)
-
-	if (getOrganLoss(ORGAN_SLOT_BRAIN) >= 60)
-		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "brain_damage", /datum/mood_event/brain_damage)
-	else
-		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "brain_damage")
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
 	if(!dna || !dna.species.handle_mutations_and_radiation(src))

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -109,9 +109,11 @@
 			if(client && !eye_blind)
 				clear_alert("blind")
 				clear_fullscreen("blind")
+			//Prevents healing blurryness while blind from normal means
+			return
 		else
 			eye_blind = max(eye_blind-1,1)
-	else if(eye_blurry)			//blurry eyes heal slowly
+	if(eye_blurry)			//blurry eyes heal slowly
 		eye_blurry = max(eye_blurry-1, 0)
 		if(client)
 			update_eye_blur()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

closes https://github.com/BeeStation/BeeStation-Hornet/issues/5400

## About The Pull Request

Apparently if you are eye_blind you can never heal eye blurriness, so if your eye blind comes from blindness, you cannot heal blurry eyes since the blindness only goes as low as 1.

## Why It's Good For The Game

People with the blind trait will no longer be stuck with a blurry screen forever when their screen blurs.

## Changelog
:cl:
fix: Trait induced blindness will no longer cause your screen to be blurry forever if you get blurred.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
