### PR TITLE
Fixes a bug that causes infinite z-levels to be created and eventual crashing.

### DIFF
--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -139,7 +139,7 @@ SUBSYSTEM_DEF(zclear)
 	var/datum/space_level/picked_level = SSmapping.add_new_zlevel("Dynamic free level [LAZYLEN(free_levels)]", ZTRAITS_SPACE, orbital_body_type = null)
 	addtimer(CALLBACK(src, .proc/begin_tracking, picked_level), 60 SECONDS)
 	message_admins("SSORBITS: Created a new dynamic free level ([LAZYLEN(free_levels)] now created) as none were available at the time.")
-
+	return picked_level
 
 /datum/controller/subsystem/zclear/proc/begin_tracking(datum/space_level/sl)
 	LAZYOR(autowipe, sl)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If enough z-levels are in use, when a new one is called to be reserved a new one should be created and reserved. The created z-level however was not properly returned, resulting in the proc returning null which caused a runtime on assign_z_level, resulting in its assigned space level not being set. This caused the next update of SSorbits to call the assign z-level proc again which created a new z-level and failed to return it. This resulted in eventual crashing.

## Why It's Good For The Game

Prevents a crash exploit.

## Changelog
:cl:
fix: Resolves a crash exploit related to z-levels and supercruise.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
