### PR TITLE
[PORT] Another fix for laggy tgui tooltips -- Turn off popper event listener…

### DIFF
--- a/tgui/packages/tgui/components/Tooltip.tsx
+++ b/tgui/packages/tgui/components/Tooltip.tsx
@@ -53,6 +53,10 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
       <Popper
         options={{
           placement: this.props.position || "auto",
+          modifiers: [{
+            name: "eventListeners",
+            enabled: false,
+          }],
         }}
         popperContent={
           <div


### PR DESCRIPTION
## About The Pull Request

Ports the following PR:
- https://github.com/tgstation/tgstation/pull/61343

While poppper tooltips are great, they seem to have been an issue with performance when you had a lot of tooltips. While I believe we currently didn't have anything with this issue, it would be problematic, for example, for the protolathe or autolathe to have a tooltip on every design printable.

The folks over on tgstation figured out how to fix the performance issues by disabling an event listener in popper that doesn't seem to be needed in tgui at all, in their case allowing them to slap a tooltip on every item in every research in the tech tree.

I have tested this PR with my WIP tgui protolathe and saw no noticable lag with tooltips enabled, which was a very choppy experience without this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows us to have many things with tooltips without performance issues while keeping popper's benefits

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: KubeRoot, Mothblocks
code: Tooltips in tgui are now very fast, even with a lot of them on one interface.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
