### PR TITLE
World reboots will now always call SSdbcore.Disconnect()

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -246,6 +246,7 @@ GLOBAL_VAR(restart_counter)
 
 /world/Reboot(reason = 0, fast_track = FALSE)
 	if (reason || fast_track) //special reboot, do none of the normal stuff
+		SSdbcore.Disconnect()
 		if (usr)
 			log_admin("[key_name(usr)] Has requested an immediate world restart via client side debugging tools")
 			message_admins("[key_name_admin(usr)] Has requested an immediate world restart via client side debugging tools")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If someone used Hardest Restart or the server OOMed, then the DB subsystem would not shutdown, meaning Disconnect() would not be called and the thread(s) won't be cleaned up.

Credit to affected for triggering my paranoia.

## Changelog
:cl:
server: The DB subsystem will now always disconnect properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
