### PR TITLE
Remove delay from say verb caused by typing indicators

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1792,6 +1792,7 @@
 #include "code\modules\client\loadout\loadout_suit.dm"
 #include "code\modules\client\loadout\loadout_uniform.dm"
 #include "code\modules\client\verbs\etips.dm"
+#include "code\modules\client\verbs\input_box.dm"
 #include "code\modules\client\verbs\looc.dm"
 #include "code\modules\client\verbs\medals.dm"
 #include "code\modules\client\verbs\ooc.dm"

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(input)
 		"default" = list(
 			"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = ".say",
+			"T" = "\".winset \\\"command=.start_typing;command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
 			"M" = ".me",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
@@ -40,13 +40,13 @@ SUBSYSTEM_DEF(input)
 			),
 		"old_default" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
-			"Ctrl+T" = ".say",
+			"Ctrl+T" = "\".winset \\\"command=.start_typing;command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
 			"Ctrl+O" = "ooc",
 			),
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = ".say",
+			"T" = "\".winset \\\"command=.start_typing;command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
 			"M" = ".me",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -32,22 +32,22 @@ SUBSYSTEM_DEF(input)
 		"default" = list(
 			"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = "\".winset \\\"command=.start_typing;command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
-			"M" = ".me",
+			"T" = "\".winset \\\"command=\\\".start_typing say\\\";command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
+			"M" = "\".winset \\\"command=\\\".start_typing me\\\";command=.init_me;mewindow.is-visible=true;mewindow.input.focus=true;mewindow.input.text=\\\"\\\"\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 			),
 		"old_default" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
-			"Ctrl+T" = "\".winset \\\"command=.start_typing;command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
+			"Ctrl+T" = "\".winset \\\"command=\\\".start_typing say\\\";command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
 			"Ctrl+O" = "ooc",
 			),
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = "\".winset \\\"command=.start_typing;command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
-			"M" = ".me",
+			"T" = "\".winset \\\"command=\\\".start_typing say\\\";command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
+			"M" = "\".winset \\\"command=\\\".start_typing me\\\";command=.init_me;mewindow.is-visible=true;mewindow.input.focus=true;mewindow.input.text=\\\"\\\"\\\"\"",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",

--- a/code/modules/client/verbs/input_box.dm
+++ b/code/modules/client/verbs/input_box.dm
@@ -25,15 +25,58 @@
 		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"[id].is-visible=false\\\"\"")
 		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"[id].is-visible=false\\\"\"")
 
+	//Window scaling!
+	//The window isn't scaled by DPI scaling, so it'll appear too big/too small with DPI scaling other than the one it was based on
+	//This code uses the title bar to figure out what DPI scaling is being used and resize the window based on that
+	//Figure out the DPI scaling based on the titlebar size of the window, based on outer-inner height
+	var/window_data = params2list(winget(src, id, "outer-size;inner-size"))
+	var/window_innersize = splittext(window_data["inner-size"], "x")
+	var/window_outersize = splittext(window_data["outer-size"], "x")
+
+	var/titlebarHeight = text2num(window_outersize[2])-text2num(window_innersize[2])
+
+	//Known titlebar heights for DPI scaling:
+	//win7:  100%-28, 125%-33, 150%-39
+	//win10: 100%-29, 125%-35, 150%-40
+
+	//Known window sizes for DPI scaling: (Win7)
+	//100%: 302x86,  font 7
+	//125%: 402x106, font 8
+	//150%: 503x133, font 8
+
+	var/scaling = FALSE
+
+	//Those are the default values for the window
+	var/window_width  = 302
+	var/window_height = 86
+	var/font_size = 7
+
+	//The values used here were sampled from BYOND in practice, I couldn't find a formula that would describe them
+	switch(titlebarHeight)
+		if(30 to 37)
+			scaling = 1.25
+			window_width  = 402
+			window_height = 106
+			font_size = 8
+		if(37 to 42)
+			scaling = 1.50
+			window_width  = 503
+			window_height = 133
+			font_size = 8
+
+	if(scaling)
+		winset(src, null, "[id].size=[window_width]x[window_height];[id].input.font-size=[font_size];[id].accept.font-size=[font_size];[id].cancel.font-size=[font_size]")
+	//End window scaling
+
 	//Center the window on the main window
 	//The window size is hardcoded to be 410x133, taken from skin.dmf
-	var/data = params2list(winget(src, "mainwindow", "pos;outer-size;size;inner-size;is-maximized"))
-	var/mainwindow_pos = splittext(data["pos"], ",")
-	var/mainwindow_size = splittext(data["size"], "x")
-	var/mainwindow_innersize = splittext(data["inner-size"], "x")
-	var/mainwindow_outersize = splittext(data["outer-size"], "x")
+	var/mainwindow_data = params2list(winget(src, "mainwindow", "pos;outer-size;size;inner-size;is-maximized"))
+	var/mainwindow_pos = splittext(mainwindow_data["pos"], ",")
+	var/mainwindow_size = splittext(mainwindow_data["size"], "x")
+	var/mainwindow_innersize = splittext(mainwindow_data["inner-size"], "x")
+	var/mainwindow_outersize = splittext(mainwindow_data["outer-size"], "x")
 
-	var/maximized = (data["is-maximized"] == "true")
+	var/maximized = (mainwindow_data["is-maximized"] == "true")
 
 	if(!maximized)
 		//If the window is anchored (for example win+right), is-maximized is false but pos is no longer reliable
@@ -46,11 +89,11 @@
 
 	// If the window is maximized or anchored, pos is the last position when the window was free-floating
 	if(maximized)
-		target_x = text2num(mainwindow_outersize[1])/2-410/2
-		target_y = text2num(mainwindow_outersize[2])/2-133/2
+		target_x = text2num(mainwindow_outersize[1])/2-window_width/2
+		target_y = text2num(mainwindow_outersize[2])/2-window_height/2
 	else
-		target_x = text2num(mainwindow_pos[1])+text2num(mainwindow_outersize[1])/2-410/2
-		target_y = text2num(mainwindow_pos[2])+text2num(mainwindow_outersize[2])/2-133/2
+		target_x = text2num(mainwindow_pos[1])+text2num(mainwindow_outersize[1])/2-window_width/2
+		target_y = text2num(mainwindow_pos[2])+text2num(mainwindow_outersize[2])/2-window_height/2
 
 	winset(src, id, "pos=[target_x],[target_y]")
 	//End centering
@@ -63,7 +106,7 @@
 	set name = ".init_say"
 	set hidden = TRUE
 
-	create_input_window("saywindow", "Say \\\"text\\\"", ".say", ".cancel_typing say")
+	create_input_window("saywindow", "say \\\"text\\\"", ".say", ".cancel_typing say")
 
 /client/verb/init_me()
 	set name = ".init_me"

--- a/code/modules/client/verbs/input_box.dm
+++ b/code/modules/client/verbs/input_box.dm
@@ -2,27 +2,73 @@
 	if(winexists(src, id))
 		return
 
+	// Create a macro set for handling enter presses
+	winclone(src, "input_box_macro", "persist_[id]_macro")
+	winset(src, "[id]_macro_returnup", "parent=persist_[id]_macro;name=Return+UP;command=\".winset \\\"[id].is-visible=false\\\"\"")
+	// Return+UP allows us to close the window after typing in a command, pressing enter and releasing enter.
+	// Can't use just Return for this, because when there's text in the box Return is handled by BYOND and doesn't run the macro.
+
+	// Create the actual window and set its title and macro set
 	winclone(src, "input_box", id)
-	winset(src, id, "title=[title]")
+	winset(src, id, "title=\"[title]\";macro=persist_[id]_macro")
 
 	if(accept_verb)
 		winset(src, "[id].input", "command=\"[accept_verb] \\\"\"")
-		winset(src, "[id].accept", "command=\".winset \\\"command=\\\"[accept_verb] \[\[[id].input.text as escaped\]\]\\\";[id].is-visible=false\\\"\"")
+		winset(src, "[id].accept", "command=\".winset \\\"command=\\\"[accept_verb] \\\\\\\"\[\[[id].input.text as escaped\]\]\\\";[id].is-visible=false\\\"\"")
 
 	if(cancel_verb)
 		winset(src, "[id].cancel", "command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\"\"")
+		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\"\"")
+		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\"\"")
+		winset(src, id, "on-close=[cancel_verb]")
+	else
+		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"[id].is-visible=false\\\"\"")
+		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"[id].is-visible=false\\\"\"")
 
+	//Center the window on the main window
+	//The window size is hardcoded to be 410x133, taken from skin.dmf
+	var/data = params2list(winget(src, "mainwindow", "pos;outer-size;size;inner-size;is-maximized"))
+	var/mainwindow_pos = splittext(data["pos"], ",")
+	var/mainwindow_size = splittext(data["size"], "x")
+	var/mainwindow_innersize = splittext(data["inner-size"], "x")
+	var/mainwindow_outersize = splittext(data["outer-size"], "x")
+
+	var/maximized = (data["is-maximized"] == "true")
+
+	if(!maximized)
+		//If the window is anchored (for example win+right), is-maximized is false but pos is no longer reliable
+		//In that case, compare inner-size and size to guess if it's actually anchored
+		maximized = text2num(mainwindow_size[1]) != text2num(mainwindow_innersize[1])\
+			|| abs(text2num(mainwindow_size[2]) - text2num(mainwindow_innersize[2])) > 30
+
+	var/target_x
+	var/target_y
+
+	// If the window is maximized or anchored, pos is the last position when the window was free-floating
+	if(maximized)
+		target_x = text2num(mainwindow_outersize[1])/2-410/2
+		target_y = text2num(mainwindow_outersize[2])/2-133/2
+	else
+		target_x = text2num(mainwindow_pos[1])+text2num(mainwindow_outersize[1])/2-410/2
+		target_y = text2num(mainwindow_pos[2])+text2num(mainwindow_outersize[2])/2-133/2
+
+	winset(src, id, "pos=[target_x],[target_y]")
+	//End centering
+
+	//Show the window and focus on the textbox
 	winshow(src, id, TRUE)
 	winset(src, "[id].input", "focus=true")
 
 /client/verb/init_say()
-	set instant = TRUE
 	set name = ".init_say"
+	set hidden = TRUE
 
-	create_input_window("saywindow", "Say \"test\"", ".say", ".cancel_typing")
+	create_input_window("saywindow", "Say \\\"test\\\"", ".say", ".cancel_typing")
 
 /client/verb/init_me() // Currently unused
-	set instant = TRUE
 	set name = ".init_me"
+	set hidden = TRUE
+
+	create_input_window("saywindow", "me (text)", ".me", ".cancel_typing")
 
 	create_input_window("saywindow", "me (text)", ".me", ".cancel_typing")

--- a/code/modules/client/verbs/input_box.dm
+++ b/code/modules/client/verbs/input_box.dm
@@ -1,0 +1,28 @@
+/client/proc/create_input_window(id, title, accept_verb, cancel_verb)
+	if(winexists(src, id))
+		return
+
+	winclone(src, "input_box", id)
+	winset(src, id, "title=[title]")
+
+	if(accept_verb)
+		winset(src, "[id].input", "command=\"[accept_verb] \\\"\"")
+		winset(src, "[id].accept", "command=\".winset \\\"command=\\\"[accept_verb] \[\[[id].input.text as escaped\]\]\\\";[id].is-visible=false\\\"\"")
+
+	if(cancel_verb)
+		winset(src, "[id].cancel", "command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\"\"")
+
+	winshow(src, id, TRUE)
+	winset(src, "[id].input", "focus=true")
+
+/client/verb/init_say()
+	set instant = TRUE
+	set name = ".init_say"
+
+	create_input_window("saywindow", "Say \"test\"", ".say", ".cancel_typing")
+
+/client/verb/init_me() // Currently unused
+	set instant = TRUE
+	set name = ".init_me"
+
+	create_input_window("saywindow", "me (text)", ".me", ".cancel_typing")

--- a/code/modules/client/verbs/input_box.dm
+++ b/code/modules/client/verbs/input_box.dm
@@ -63,12 +63,10 @@
 	set name = ".init_say"
 	set hidden = TRUE
 
-	create_input_window("saywindow", "Say \\\"test\\\"", ".say", ".cancel_typing")
+	create_input_window("saywindow", "Say \\\"test\\\"", ".say", ".cancel_typing say")
 
-/client/verb/init_me() // Currently unused
+/client/verb/init_me()
 	set name = ".init_me"
 	set hidden = TRUE
 
-	create_input_window("saywindow", "me (text)", ".me", ".cancel_typing")
-
-	create_input_window("saywindow", "me (text)", ".me", ".cancel_typing")
+	create_input_window("mewindow", "me (text)", ".me", ".cancel_typing me")

--- a/code/modules/client/verbs/input_box.dm
+++ b/code/modules/client/verbs/input_box.dm
@@ -20,7 +20,7 @@
 		winset(src, "[id].cancel", "command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\"\"")
 		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\"\"")
 		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"command=\\\"[cancel_verb]\\\";[id].is-visible=false\\\"\"")
-		winset(src, id, "on-close=[cancel_verb]")
+		winset(src, id, "on-close=\"[cancel_verb]\"")
 	else
 		winset(src, "[id]_macro_return", "parent=persist_[id]_macro;name=Return;command=\".winset \\\"[id].is-visible=false\\\"\"")
 		winset(src, "[id]_macro_escape", "parent=persist_[id]_macro;name=Escape;command=\".winset \\\"[id].is-visible=false\\\"\"")
@@ -63,7 +63,7 @@
 	set name = ".init_say"
 	set hidden = TRUE
 
-	create_input_window("saywindow", "Say \\\"test\\\"", ".say", ".cancel_typing say")
+	create_input_window("saywindow", "Say \\\"text\\\"", ".say", ".cancel_typing say")
 
 /client/verb/init_me()
 	set name = ".init_me"

--- a/code/modules/keybindings/setup.dm
+++ b/code/modules/keybindings/setup.dm
@@ -22,6 +22,8 @@
 	var/erase_output = ""
 	for(var/i in 1 to macro_sets.len)
 		var/setname = macro_sets[i]
+		if(copytext(setname, 1, 9) == "persist_") // Don't remove macro sets not handled by input. Used in input_box.dm by create_input_window
+			continue
 		var/list/macro_set = params2list(winget(src, "[setname].*", "command")) // The third arg doesnt matter here as we're just removing them all
 		for(var/k in 1 to macro_set.len)
 			var/list/split_name = splittext(macro_set[k], ".")

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -31,7 +31,6 @@ GLOBAL_DATUM_INIT(human_typing_indicator, /mutable_appearance, mutable_appearanc
 	set name = ".Say"
 	set hidden = 1
 
-	winshow(usr, "saywindow", FALSE)
 	remove_typing_indicator()
 	if(message)
 		say_verb(message)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -15,17 +15,29 @@ GLOBAL_DATUM_INIT(human_typing_indicator, /mutable_appearance, mutable_appearanc
 	remove_typing_indicator()
 	. = ..()
 
-////Wrappers////
-//Keybindings were updated to change to use these wrappers. If you ever remove this file, revert those keybind changes
-/mob/verb/say_wrapper()
-	set name = ".Say"
+/mob/verb/start_typing()
+	set name = ".start_typing"
 	set hidden = 1
 
 	create_typing_indicator()
-	var/message = input("","say (text)") as text|null
+
+/mob/verb/cancel_typing()
+	set name = ".cancel_typing"
+	set hidden = 1
+
+	remove_typing_indicator()
+
+/mob/verb/say_wrapper(message as text)
+	set name = ".Say"
+	set hidden = 1
+
+	winshow(usr, "saywindow", FALSE)
 	remove_typing_indicator()
 	if(message)
 		say_verb(message)
+
+////Wrappers////
+//Keybindings were updated to change to use these wrappers. If you ever remove this file, revert those keybind changes
 
 /mob/verb/me_wrapper()
 	set name = ".Me"

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -15,17 +15,38 @@ GLOBAL_DATUM_INIT(human_typing_indicator, /mutable_appearance, mutable_appearanc
 	remove_typing_indicator()
 	. = ..()
 
-/mob/verb/start_typing()
+////Typing verbs////
+//Those are used to show the typing indicator for the player without waiting on the client.
+
+/*
+Some information on how these work:
+The keybindings for say and me have been modified to call start_typing and immediately open the textbox clientside.
+Because of this, the client doesn't have to wait for a message from the server before opening the textbox, the server
+knows immediately when the user pressed the hotkey, and the clientside textbox can signal success or failure to the server.
+
+When you press the hotkey, the .start_typing verb is called with the source ("say" or "me") to show the typing indicator.
+When you send a message from the custom window, the appropriate verb is called, .say or .me
+If you close the window without actually sending the message, the .cancel_typing verb is called with the source.
+
+Both the say/me wrappers and cancel_typing remove the typing indicator.
+*/
+
+/// Show the typing indicator. The source signifies what action the user is typing for.
+/mob/verb/start_typing(source as text) // The source argument is currently unused
 	set name = ".start_typing"
 	set hidden = 1
 
 	create_typing_indicator()
 
-/mob/verb/cancel_typing()
+/// Hide the typing indicator. The source signifies what action the user was typing for.
+/mob/verb/cancel_typing(source as text)
 	set name = ".cancel_typing"
 	set hidden = 1
 
 	remove_typing_indicator()
+
+////Wrappers////
+//Keybindings were updated to change to use these wrappers. If you ever remove this file, revert those keybind changes
 
 /mob/verb/say_wrapper(message as text)
 	set name = ".Say"
@@ -35,15 +56,10 @@ GLOBAL_DATUM_INIT(human_typing_indicator, /mutable_appearance, mutable_appearanc
 	if(message)
 		say_verb(message)
 
-////Wrappers////
-//Keybindings were updated to change to use these wrappers. If you ever remove this file, revert those keybind changes
-
-/mob/verb/me_wrapper()
+/mob/verb/me_wrapper(message as text)
 	set name = ".Me"
 	set hidden = 1
 
-	create_typing_indicator()
-	var/message = input("","me (text)") as text|null
 	remove_typing_indicator()
 	if(message)
 		me_verb(message)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,5 +1,7 @@
 macro "default"
 
+macro "input_box_macro"
+
 
 menu "menu"
 	elem
@@ -316,40 +318,18 @@ window "preferences_window"
 window "input_box"
 	elem "input_box"
 		type = MAIN
-		pos = 281,14
+		pos = 759,487
 		size = 402x106
-		anchor1 = none
-		anchor2 = none
+		anchor1 = 50,50
+		anchor2 = 50,50
 		background-color = none
 		is-visible = false
-		saved-params = "macro"
+		saved-params = ""
 		statusbar = false
-		can-close = false
 		can-minimize = false
 		can-resize = false
 		outer-size = 410x133
 		inner-size = 402x106
-		macro = "default"
-	elem "cancel"
-		type = BUTTON
-		pos = 240,64
-		size = 100x28
-		anchor1 = none
-		anchor2 = none
-		font-size = 8
-		background-color = none
-		saved-params = ""
-		text = "Cancel"
-	elem "accept"
-		type = BUTTON
-		pos = 71,64
-		size = 100x28
-		anchor1 = none
-		anchor2 = none
-		font-size = 8
-		background-color = none
-		saved-params = ""
-		text = "OK"
 	elem "input"
 		type = INPUT
 		pos = 14,20
@@ -359,5 +339,26 @@ window "input_box"
 		font-size = 8
 		border = sunken
 		saved-params = ""
-		no-command = false
+	elem "accept"
+		type = BUTTON
+		pos = 71,64
+		size = 100x28
+		anchor1 = 0,100
+		anchor2 = 50,100
+		font-size = 8
+		background-color = none
+		saved-params = ""
+		text = "OK"
+		command = ""
+	elem "cancel"
+		type = BUTTON
+		pos = 240,64
+		size = 100x28
+		anchor1 = 50,100
+		anchor2 = 100,100
+		font-size = 8
+		background-color = none
+		saved-params = ""
+		text = "Cancel"
+		command = ""
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -313,3 +313,51 @@ window "preferences_window"
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"
 
+window "input_box"
+	elem "input_box"
+		type = MAIN
+		pos = 281,14
+		size = 402x106
+		anchor1 = none
+		anchor2 = none
+		background-color = none
+		is-visible = false
+		saved-params = "macro"
+		statusbar = false
+		can-close = false
+		can-minimize = false
+		can-resize = false
+		outer-size = 410x133
+		inner-size = 402x106
+		macro = "default"
+	elem "cancel"
+		type = BUTTON
+		pos = 240,64
+		size = 100x28
+		anchor1 = none
+		anchor2 = none
+		font-size = 8
+		background-color = none
+		saved-params = ""
+		text = "Cancel"
+	elem "accept"
+		type = BUTTON
+		pos = 71,64
+		size = 100x28
+		anchor1 = none
+		anchor2 = none
+		font-size = 8
+		background-color = none
+		saved-params = ""
+		text = "OK"
+	elem "input"
+		type = INPUT
+		pos = 14,20
+		size = 374x28
+		anchor1 = 0,0
+		anchor2 = 100,0
+		font-size = 8
+		border = sunken
+		saved-params = ""
+		no-command = false
+

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -319,7 +319,7 @@ window "input_box"
 	elem "input_box"
 		type = MAIN
 		pos = 759,487
-		size = 402x106
+		size = 302x86
 		anchor1 = 50,50
 		anchor2 = 50,50
 		background-color = none
@@ -328,35 +328,35 @@ window "input_box"
 		statusbar = false
 		can-minimize = false
 		can-resize = false
-		outer-size = 410x133
-		inner-size = 402x106
+		outer-size = 308x114
+		inner-size = 302x86
 	elem "input"
 		type = INPUT
-		pos = 14,20
-		size = 374x28
-		anchor1 = 0,0
-		anchor2 = 100,0
-		font-size = 8
+		pos = 11,17
+		size = 281x23
+		anchor1 = 4,20
+		anchor2 = 96,47
+		font-size = 7
 		border = sunken
 		saved-params = ""
 	elem "accept"
 		type = BUTTON
-		pos = 71,64
-		size = 100x28
-		anchor1 = 0,100
-		anchor2 = 50,100
-		font-size = 8
+		pos = 52,52
+		size = 75x23
+		anchor1 = 17,60
+		anchor2 = 42,87
+		font-size = 7
 		background-color = none
 		saved-params = ""
 		text = "OK"
 		command = ""
 	elem "cancel"
 		type = BUTTON
-		pos = 240,64
-		size = 100x28
-		anchor1 = 50,100
-		anchor2 = 100,100
-		font-size = 8
+		pos = 179,52
+		size = 75x23
+		anchor1 = 59,60
+		anchor2 = 84,87
+		font-size = 7
 		background-color = none
 		saved-params = ""
 		text = "Cancel"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/BeeStation/BeeStation-Hornet/pull/5169 added typing indicators that show up when you're typing something to say or emote from the T and M hotkeys. Because this wraps the original verbs in an argumentless verb and calls input, it delays the window opening until the server replies to the client's message. In case of high ping, and potentially high server load, this can cause a noticable input delay before the window pops up.

To remedy this, the input popup for typing from the hotkeys was replaced with a custom-made window that can be triggered to open completely clientside without server intervention.

I made a beautiful diagram showing the situation before typing indicators, after typing indicators, and after my PR:

![Untitled Diagram](https://user-images.githubusercontent.com/6917698/133673108-24e13ad5-c061-45ee-a998-aeda64bb56d3.png)

I have also made a video in action, with 100ms of latency enabled on my VM, showing how it behaves:

https://streamable.com/6yfgsh

### The bad

Because I'm doing it all clientside and custom, I can't use the builtin window for inputting text. I had to instead create my own window and handle the textbox and buttons. As a downside of limitations of the Input control, used for the textbox, I cannot have the window simply close when you press enter. To work around this, I have made the textbox close when you *release* enter instead, which should be smooth enough.

Also, because it's custom, there will be differences in how it looks. The most notable differences I can think of being:
- There is an orange dream seeker icon on the top bar on the window
- The text in the input is flush with the top edge, instead of being nicely centered with a margin
- The window can be closed - this could be disabled, but I saw some windows of this sort could be closed, others couldn't, so I went with allowing it since I can handle it correctly
- The window doesn't open in quite the right location if the main window is maximized or anchored (win+right)

### The big explanation

Below is the entire previous description of this PR, before I finalised it and set as ready to review. It contains more explanations on how it works and why things are the way they are. It's quite lengthy and chaotic though, so not sure how much use it is:

<details>

<summary>The big description with full explanation</summary>

Previously, without typing indicators, the verb called when you press `T` took a text message as an argument. This displayed a textbox where you could type the message you want to say. This was handled by BYOND, and would happen before the server knew you were using a verb at all, which means there was no delay due to ping.

The typing indicators, however, wrapped the original code in a wrapper verb that doesn't take an argument and instead calls `input`. This was necessary due to needing to create/remove the typing indicator before/after the input is shown.
However, because the textbox was no longer handled by BYOND directly, this added a delay - your client needs to send a message to the server to invoke the verb, then the server needs to send a message to the client to display the textbox, causing a delay of a full roundtrip based on ping.

After some asking around, I found one way to remove the delay, which is implemented in this PR.

Instead of simply using a verb, the `T` keybind now does two things:
1. Calls a `.start_typing` verb to show a typing indicator
2. Uses `.winset` to show a custom-made textbox, directly on the client, avoiding the delay from doing this from a verb.

There are, of course, caveats:
1. Clientside macros are very chaotic. I'd say a lot of how this works makes no sense, but doing it in reasonable ways didn't work. Maintaining this might be painful.
2. The first time you use the hotkey the window has to be created from the server, for this reason the keybind also calls an additional verb every time you press it. Afterwards, however, the window is hid instead of closing, preventing delay.
3. **The big one.** There is instead a delay before the window closes after you press enter. This is because of how textboxes work in BYOND, which I'll explain further at the end.
  - **EDIT:** This was somewhat fixed. Instead of closing when the server tells the window to close, the window now closes only after you release enter.

### For a quick summary of how this all works:

There is a new window defined in `interface/skin.dmf`, containing a generic window with an Input and two Buttons. A new proc on client called `create_input_window` can be used to create a window with a specific ID, title and verbs to call on accept/cancel. This proc creates a copy of the generic window, setting the right title and commands on its controls, then it displays the window.

The three controls on the window have commands set on them - the buttons use `.winset` to both call a proc and hide the window.
The Input, however, is where it gets tricky.
Inputs in BYOND have two modes: command and no-command.
- When in command mode, the Input does input validation, making sure you're inputting a correct verb and running autocompletion when you press space. When you press enter in this mode, it runs the text you typed in as a command, prepending whatever was set as its `command` field.
- When in no-command mode, you can type anything you want into the Input, and space does not have any special behavior. However, the enter button doesn't do anything, and macro sets seem to not work.

For this, the Input is set to command mode, with the `command` field set to `.say \"`.

Finally, the `T` hotkey was changed to this monstrosity:

```
"T" = "\".winset \\\"command=.start_typing;command=.init_say;saywindow.is-visible=true;saywindow.input.focus=true;saywindow.input.text=\\\"\\\"\\\"\"",
```

Which does the following things:
- Invoke `.start_typing` to display the typing indicator
- Invoke `.init_say` to create a Say window if there isn't one already
- set `saywindow.is-visible=true` to display the window if it exists
- set `saywindow.input.focus=true` to focus on the input textbox
- set `saywindow.input.text=\"\"` to clear the input textbox

### The caveat

Now, the big issue: there is a delay before the window closes when you press enter. This is because of how Inputs work - we can't have it accept input when you press enter when in no-command mode, so we have to use command mode. However, while in command mode, we can't have it run convoluted `.winset` commands while being able to type in spaces. This is because for the Input to accept space as a valid character, you have to either be at the end of a valid verb or argument, or inside a string.
Because of this, the command has to be simple, in this case `.say \"` - which means the Input knows it is in the middle of a string argument, allowing you to type spaces, but prevents us from running clientside macros as a result of pressing enter.

What this means is, while the window can open immediately, if submitted by pressing enter, it has to be closed by the server instead.

Because of this, the scourge of the typing indicator input delay isn't fully removed, instead being moved to closing instead of opening.

It **might be** possible to remove this delay, but I haven't managed in a couple hours of trying.

### Partial solution

I have figured out a way to bypass the issue of closing input lag. While you cannot run a macro on pressing enter when you have a message typed in, you can run a macro when the input is empty. And while the input obviously isn't empty when there's something in the textbox, as soon as you press enter, the textbox is cleared. This means... you can run a macro when you *release* enter, after the textbox clears, that will hide the window.

Along with that, I have added macros that cancel when you press escape, or press enter with an empty textbox, enabled the close button that also cancels. I have added centering when the window initially opens, putting it in the middle of the main game window... which only works correctly if your window is not anchored to the side (win+right, for example), because BYOND.

I have also modified the `erase_all_macros` proc on the client, used by the `input` subsystem when resetting all client macrosets - it now ignores macrosets with the name starting with `persist_`. This could certainly be done better, but for now it should hopefully suffice. The reason for this change is that the macro set for the say window could 

### Videos

I recorded a couple videos of it in action. There's nothing particularly interesting to see, but the second video more importantly has 100ms of latency added showing the issue with closing the window with enter.

https://streamable.com/03i7tz
~~https://streamable.com/oe1hs5~~

Here's a new video with latency: https://streamable.com/6yfgsh

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Input delay is bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The "Say" window no longer has input lag when opening it with the hotkey.
tweak: The "Say" window now has input lag when closing it with enter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
