### PR TITLE
Fixes light eater

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -180,47 +180,49 @@
 	. = ..()
 	if(!proximity)
 		return
+	if(isliving(AM))
+		var/mob/living/L = AM
+		if(isethereal(AM))
+			AM.emp_act(EMP_LIGHT)
 
-/mob/living/lighteater_act(obj/item/light_eater/light_eater)
-	if(on_fire)
-		ExtinguishMob()
-		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
-	for(var/obj/item/O in src)
-		if(O.light_range && O.light_power)
-			O.lighteater_act(light_eater)
-	if(pulling && pulling.light_range)
-		pulling.lighteater_act(light_eater)
+		if(iscyborg(AM))
+			var/mob/living/silicon/robot/borg = AM
+			if(!borg.lamp_cooldown)
+				borg.update_headlamp(TRUE, INFINITY)
+				to_chat(borg, "<span class='danger'>Your headlamp is fried! You'll need a human to help replace it.</span>")
 
-/mob/living/carbon/human/lighteater_act(obj/item/light_eater/light_eater)
-	..()
-	if(isethereal(src))
-		emp_act(EMP_LIGHT)
+		if(L.on_fire)
+			L.ExtinguishMob()
+			playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
 
-/mob/living/silicon/robot/lighteater_act(obj/item/light_eater/light_eater)
-	..()
-	if(!lamp_cooldown)
-		update_headlamp(TRUE, INFINITY)
-		to_chat(src, "<span class='danger'>Your headlamp is fried! You'll need a human to help replace it.</span>")
+		else
+			for(var/obj/item/O in AM)
+				if(O.light_range && O.light_power)
+					disintegrate(O)
+		if(L.pulling && L.pulling.light_range && isitem(L.pulling))
+			disintegrate(L.pulling)
+	else if(isitem(AM))
+		var/obj/item/I = AM
+		if(I.light_range && I.light_power)
+			disintegrate(I)
 
-/obj/structure/bonfire/lighteater_act(obj/item/light_eater/light_eater)
-	if(burning)
-		extinguish()
-		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
+	else if(istype(AM, /obj/structure/bonfire))
+		var/obj/structure/bonfire/F = AM
+		if(F.burning)
+			F.extinguish()
+			playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
 
-/obj/item/pda/lighteater_act(obj/item/light_eater/light_eater)
-	if(!light_range || !light_power)
-		return
-	set_light(0)
-	light_power = 0
-	update_icon()
-	visible_message("<span class='danger'>The light in [src] shorts out!</span>")
-
-/obj/item/lighteater_act(obj/item/light_eater/light_eater)
-	if(!light_range || !light_power)
-		return
-	if(light_eater)
-		visible_message("<span class='danger'>[src] is disintegrated by [light_eater]!</span>")
-	burn()
+/obj/item/light_eater/proc/disintegrate(obj/item/O)
+	if(istype(O, /obj/item/pda))
+		var/obj/item/pda/PDA = O
+		PDA.set_light(0)
+		PDA.fon = FALSE
+		PDA.f_lum = 0
+		PDA.update_icon()
+		visible_message("<span class='danger'>The light in [PDA] shorts out!</span>")
+	else
+		visible_message("<span class='danger'>[O] is disintegrated by [src]!</span>")
+		O.burn()
 	playsound(src, 'sound/items/welder.ogg', 50, 1)
 
 #undef HEART_SPECIAL_SHADOWIFY


### PR DESCRIPTION
No more night lights for the station.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #5276

Light eater now appropriately destroys sources of light again. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Nightmares may as well not exist when they can't eliminate light sources. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Light Eater works again. Fear Nightmares. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
