### PR TITLE
Fix rubbery ducky mines

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -131,8 +131,8 @@
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	mineEffect(victim)
 	triggered = 1
+	mineEffect(victim)
 	SEND_SIGNAL(src, COMSIG_MINE_TRIGGERED, victim)
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Make ducky mines set there own triggerd state *before* destroying itself in a explosion

## Why It's Good For The Game

Because this isn't good for the game
![afbeelding](https://user-images.githubusercontent.com/36102060/134567944-b430314a-41d8-4859-8e3e-3fffbf16c189.png)
![afbeelding](https://user-images.githubusercontent.com/36102060/134567977-6e619a32-4c0d-4522-ad32-80a6edfb098c.png)


## Changelog
:cl:
fix: Mines explode once instead of too much
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
