### PR TITLE
Fix a maintenance airlock on metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7472,7 +7472,7 @@
 	dir = 6
 	},
 /turf/closed/wall,
-/area/crew_quarters/fitness/recreation)
+/area/maintenance/starboard/fore)
 "anO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -78216,7 +78216,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/area/maintenance/starboard/fore)
 "dhu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/sign/poster/contraband/random{
@@ -80933,6 +80933,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"eWJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "eXl" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -82075,6 +82079,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"jgD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "jhA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -85908,7 +85918,7 @@
 "xCu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/area/maintenance/starboard/fore)
 "xHp" = (
 /obj/machinery/advanced_airlock_controller{
 	dir = 1;
@@ -127248,10 +127258,10 @@ aav
 aaa
 acP
 acQ
-acP
+dnh
 anN
-amH
-vgU
+eWJ
+jgD
 dnS
 dnS
 dnS
@@ -127762,7 +127772,7 @@ aaa
 aaa
 aie
 aie
-ajb
+dqT
 dht
 xCu
 qHy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Metastation has an external airlock in maintenance between holodeck and gravity generator, where the AAC starts unlinked. The reason for this is, AACs set themselves up on mapload using areas to guess which airlocks are internal and which are external.

The AAC airlock is sandwiched between holodeck and gravity generator, meaning both of its airlocks are detected as external, because they have different areas on the sides.

This PR changes the areas of the walls next to the AAC airlock to be the same as the AAC, which allows it to recognize the internal airlock correctly.

![image](https://user-images.githubusercontent.com/6917698/134781922-af875cc6-c193-467b-bbf4-97311f28d3e3.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is the only mapped on-station external airlock I've seen that's non-functional and needs an atmos technician to set it up before it can be used.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The metastation external airlock in holodeck maintenance now sets up correctly roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
