### PR TITLE
[PORT] Anonymizes chapel intercom, so chaplain doesn't know who's talking.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14717,11 +14717,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aNX" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
-	pixel_x = 25
+/obj/item/radio/intercom/chapel{
+	pixel_x = 26
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -15470,11 +15467,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQz" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
-	pixel_x = 25
+/obj/item/radio/intercom/chapel{
+	pixel_x = 26
 	},
 /obj/structure/chair{
 	dir = 1

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -54783,6 +54783,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/radio/intercom/chapel{
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "mJJ" = (
@@ -72523,6 +72526,9 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/item/radio/intercom/chapel{
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -97960,7 +97966,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/upper/primary/fore)
 "wWV" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/grille,
+/obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "wXa" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -116690,10 +116690,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
+/obj/item/radio/intercom/chapel{
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -116716,10 +116713,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
+/obj/item/radio/intercom/chapel{
 	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -72545,11 +72545,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "cNz" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
-	pixel_x = -25
+/obj/item/radio/intercom/chapel{
+	pixel_x = -26
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -73074,11 +73071,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cOL" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
-	pixel_x = 25
+/obj/item/radio/intercom/chapel{
+	pixel_x = 26
 	},
 /obj/structure/chair{
 	dir = 1

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -63696,10 +63696,7 @@
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
+/obj/item/radio/intercom/chapel{
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -63987,10 +63984,7 @@
 /area/science/xenobiology)
 "whH" = (
 /obj/structure/chair/wood/normal,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1481;
-	name = "Confessional Intercom";
+/obj/item/radio/intercom/chapel{
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -145,3 +145,9 @@
 	pixel_shift = 29
 	inverse = TRUE
 	materials = list(/datum/material/iron = 75, /datum/material/glass = 25)
+
+/obj/item/radio/intercom/chapel
+	name = "Confessional intercom"
+	anonymize = TRUE
+	frequency = 1481
+	broadcasting = TRUE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -33,6 +33,9 @@
 	var/use_command = FALSE  // If true, broadcasts will be large and BOLD.
 	var/command = FALSE  // If true, use_command can be toggled at will.
 
+	///makes anyone who is talking through this anonymous.
+	var/anonymize = FALSE
+
 	// Encryption key handling
 	var/obj/item/encryptionkey/keyslot
 	var/translate_binary = FALSE  // If true, can hear the special binary channel.

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -195,12 +195,12 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/obj/item/radio/radio
 
 INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
-/atom/movable/virtualspeaker/Initialize(mapload, atom/movable/M, radio)
+/atom/movable/virtualspeaker/Initialize(mapload, atom/movable/M, _radio)
 	. = ..()
-	radio = radio
+	radio = _radio
 	source = M
-	if (istype(M))
-		name = M.GetVoice()
+	if(istype(M))
+		name = radio.anonymize ? "Unknown" : M.GetVoice()
 		verb_say = M.verb_say
 		verb_ask = M.verb_ask
 		verb_exclaim = M.verb_exclaim


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PR:
- https://github.com/tgstation/tgstation/pull/54476

When using the confessional intercom, your name now shows up as "Unknown". Note that you can still change the frequency of the intercom to talk on other non-encrypted channels anonymously.

Replaces the intercoms on maps with a new subtype that doesn't require varedits on the map level. Adds intercoms and a grille to corg's confessional, which didn't have either unlike other maps.

I could also integrate this with wires, to let you, for example, enable anonymization by cutting a specific wire or temporarily enable it by pulsing it. This PR doesn't do that (right now) though, because I'm not sure how to integrate that with mapped anonymization and if the maintainers would want it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mostly roleplay fluff for the rare case somebody uses the confessional, with potential miscellaneous use-cases.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: KubeRoot, EdgeLordExe
add: Radios now have code support for anonymization
tweak: The intercoms in chapel confessionals will now hide your name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
