### PR TITLE
Adds Custom Beer Nukes

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -1,3 +1,5 @@
+GLOBAL_VAR(CustomBeerMix) //this is probably a really dumb way to do this but I can't think of a better one
+
 /datum/round_event_control/vent_clog
 	name = "Clogged Vents: Normal"
 	typepath = /datum/round_event/vent_clog
@@ -75,14 +77,32 @@
 	reagentsAmount = 250
 
 /datum/round_event_control/vent_clog/beer
-	name = "Foamy beer stationwide"
+	name = "Foamy Beer Stationwide"
 	typepath = /datum/round_event/vent_clog/beer
+	max_occurrences = 0
+
+/datum/round_event_control/vent_clog/custom
+	name = "Foam-Pocalypse"
+	typepath = /datum/round_event/vent_clog/custom
 	max_occurrences = 0
 
 /datum/round_event_control/vent_clog/plasma_decon
 	name = "Plasma decontamination"
 	typepath = /datum/round_event/vent_clog/plasma_decon
 	max_occurrences = 0
+
+/datum/round_event/vent_clog/custom
+	reagentsAmount = 100
+
+/datum/round_event/vent_clog/custom/announce()
+	priority_announce("The scrubbers network is experiencing an unexpected surge of pressurized chemicals. Some ejection of contents may occur.", "Atmospherics alert", SSstation.announcer.get_rand_alert_sound())
+
+/datum/round_event/vent_clog/custom/start()
+	var/datum/reagents/reagent_holder = GLOB.CustomBeerMix
+	saferChems = list()
+	for(var/datum/reagent/R in reagent_holder.reagent_list)
+		saferChems += R.type
+	..()
 
 /datum/round_event/vent_clog/beer
 	reagentsAmount = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Beer Nuke can now be loaded with custom reagents, and the foam from the subsequent event will contain those reagents.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If you can get your hands on both the nuke disk and the beer stained note, the world deserves some high tier pranking.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Beer Nuke can now be loaded with custom reagents, and the subsequent foam event will contain those reagents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
