### PR TITLE
Spellcheck & store history in memory for VIP extraction POI

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -44,19 +44,22 @@
 	var/antag_elligable = FALSE
 	switch(pickweight(list("centcom_official" = 4, "dictator" = 1, "greytide" = 3)))
 		if("centcom_official")
-			created_human.mind.store_memory("You are a CentCom official onboard a badly damaged station. Making your way back to Space Station 13 to uncover the secrets you hold is \
-				your top priority as far as Nanotrasen is concerned, but surviving just one more day is all you can ask for.")
+			created_human.flavor_text = "You are a CentCom official onboard a badly damaged station. Making your way back to Space Station 13 to uncover the secrets you hold is \
+				your top priority as far as Nanotrasen is concerned, but surviving just one more day is all you can ask for."
+			created_human.mind.store_memory(created_human.flavor_text)
 			created_human.equipOutfit(/datum/outfit/centcom_official_vip)
 			antag_elligable = TRUE
 		if("dictator")
-			created_human.mind.store_memory("It has been months since your regime fell. Once a hero, you're now just someone wishing that they will see the next sunrise. You know those \
+			created_human.flavor_text = "It has been months since your regime fell. Once a hero, you're now just someone wishing that they will see the next sunrise. You know those \
 				Nanotrasen pigs are after you, and will stop at nothing to capture you. All you want at this point is to get out and survive, however it is likely you will never leave \
-				without being captured.")
+				without being captured."
+			created_human.mind.store_memory(created_human.flavor_text)
 			created_human.equipOutfit(/datum/outfit/vip_dictator)
 			created_human.mind.add_antag_datum(/datum/antagonist/vip_dictator)
 		if("greytide")
-			created_human.mind.store_memory("You are just an assistant on a lonely derelict station. You dream of going home, \
-				but it would take another one of the miracles that kept you alive to get you home.")
+			created_human.flavor_text = "You are just an assistant on a lonely derelict station. You dream of going home, \
+				but it would take another one of the miracles that kept you alive to get you home."
+			created_human.mind.store_memory(created_human.flavor_text)
 			created_human.equipOutfit(/datum/outfit/greytide)
 			antag_elligable = TRUE
 	if(antag_elligable)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -44,19 +44,19 @@
 	var/antag_elligable = FALSE
 	switch(pickweight(list("centcom_official" = 4, "dictator" = 1, "greytide" = 3)))
 		if("centcom_official")
-			created_human.flavor_text = "You are centcom official on board a badly damaged station. Making your way back to the station to uncover the secrets you hold is \
-				your top priority as far as Nanotrasen is concerned, but just surviving 1 more day is all you can ask for."
+			created_human.mind.store_memory("You are a CentCom official onboard a badly damaged station. Making your way back to Space Station 13 to uncover the secrets you hold is \
+				your top priority as far as Nanotrasen is concerned, but surviving just one more day is all you can ask for.")
 			created_human.equipOutfit(/datum/outfit/centcom_official_vip)
 			antag_elligable = TRUE
 		if("dictator")
-			created_human.flavor_text = "It has been months since your regime fell. Once a hero, now just someone wishing that they will see the next sunrise. You know those \
+			created_human.mind.store_memory("It has been months since your regime fell. Once a hero, you're now just someone wishing that they will see the next sunrise. You know those \
 				Nanotrasen pigs are after you, and will stop at nothing to capture you. All you want at this point is to get out and survive, however it is likely you will never leave \
-				without being captured."
+				without being captured.")
 			created_human.equipOutfit(/datum/outfit/vip_dictator)
 			created_human.mind.add_antag_datum(/datum/antagonist/vip_dictator)
 		if("greytide")
-			created_human.flavor_text = "You are just a lonely assistant, on a lonely derelict station. You dream of going home, \
-				but it would take another one of the miracles that kept you alive to get you home."
+			created_human.mind.store_memory("You are just an assistant on a lonely derelict station. You dream of going home, \
+				but it would take another one of the miracles that kept you alive to get you home.")
 			created_human.equipOutfit(/datum/outfit/greytide)
 			antag_elligable = TRUE
 	if(antag_elligable)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -46,22 +46,20 @@
 		if("centcom_official")
 			created_human.flavor_text = "You are a CentCom official onboard a badly damaged station. Making your way back to Space Station 13 to uncover the secrets you hold is \
 				your top priority as far as Nanotrasen is concerned, but surviving just one more day is all you can ask for."
-			created_human.mind.store_memory(created_human.flavor_text)
 			created_human.equipOutfit(/datum/outfit/centcom_official_vip)
 			antag_elligable = TRUE
 		if("dictator")
 			created_human.flavor_text = "It has been months since your regime fell. Once a hero, you're now just someone wishing that they will see the next sunrise. You know those \
 				Nanotrasen pigs are after you, and will stop at nothing to capture you. All you want at this point is to get out and survive, however it is likely you will never leave \
 				without being captured."
-			created_human.mind.store_memory(created_human.flavor_text)
 			created_human.equipOutfit(/datum/outfit/vip_dictator)
 			created_human.mind.add_antag_datum(/datum/antagonist/vip_dictator)
 		if("greytide")
 			created_human.flavor_text = "You are just an assistant on a lonely derelict station. You dream of going home, \
 				but it would take another one of the miracles that kept you alive to get you home."
-			created_human.mind.store_memory(created_human.flavor_text)
 			created_human.equipOutfit(/datum/outfit/greytide)
 			antag_elligable = TRUE
+	created_human.mind.store_memory(created_human.flavor_text)
 	if(antag_elligable)
 		if(prob(7))
 			created_human.mind.make_Traitor()


### PR DESCRIPTION
## About The Pull Request

Fixes some small, but annoying issues with the VIP extraction POI. I'm not sure why it was flavor text in the first place, it should've always been a memory in notes.

## Why It's Good For The Game

It should've worked like this in the first place.

## Changelog
:cl:
spellcheck: Changed flavor text to text in Notes for VIPs from the VIP extraction exploration mission.
/:cl:

Note: This is untested. Literally could not get the ghost role to work on a local server. This should, theoretically, work completely fine. I would appreciate someone testing it who knows how.