### PR TITLE
Station trait command report is now generated independly

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -1,3 +1,6 @@
+#define REPORT_WAIT_TIME_MINIMUM 600
+#define REPORT_WAIT_TIME_MAXIMUM 1500
+
 PROCESSING_SUBSYSTEM_DEF(station)
 	name = "Station"
 	init_order = INIT_ORDER_STATION
@@ -21,6 +24,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	#ifndef UNIT_TESTS
 	if(CONFIG_GET(flag/station_traits))
 		SetupTraits()
+		PrepareReport()
 	#endif
 
 	announcer = new announcer() //Initialize the station's announcer datum
@@ -43,6 +47,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
 	pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
 
+
 ///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them and adds them to the list of traits.
 /datum/controller/subsystem/processing/station/proc/pick_traits(trait_type, amount)
 	if(!amount)
@@ -59,3 +64,21 @@ PROCESSING_SUBSYSTEM_DEF(station)
 		for(var/i in picked_trait.blacklist)
 			var/datum/station_trait/trait_to_remove = i
 			selectable_traits_by_types[initial(trait_to_remove.trait_type)] -= trait_to_remove
+
+/datum/controller/subsystem/processing/station/proc/PrepareReport()
+	if(!station_traits.len)		//no active traits why bother
+		return
+
+	var/report = "<b><i>Central Command Divergency Report</i></b><hr>"
+
+	for(var/datum/station_trait/trait as() in station_traits)
+		if(trait.trait_flags & STATION_TRAIT_ABSTRACT)
+			continue
+		if(!trait.report_message || !trait.show_in_report)
+			continue
+		report += "[trait.get_report()]<BR><hr>"
+
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/print_command_report, report, "Central Command Divergency Report", FALSE), rand(REPORT_WAIT_TIME_MINIMUM, REPORT_WAIT_TIME_MAXIMUM))
+
+#undef REPORT_WAIT_TIME_MINIMUM
+#undef REPORT_WAIT_TIME_MAXIMUM

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -137,7 +137,7 @@
 	. = ..()
 	deathrattle_group = new("[department_name] group")
 	blacklist += subtypesof(/datum/station_trait/deathrattle_department) - type //All but ourselves
-	name = "deathrattled [department_name]"
+	name = "Deathrattled [department_name]"
 	report_message = "All members of [department_name] have received an implant to notify each other if one of them dies. This should help improve job-safety!"
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, .proc/on_job_after_spawn)
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -285,7 +285,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			. += "Good luck."
 
 	. += generate_station_goal_report()
-	. += generate_station_trait_report()
 
 	print_command_report(., "Central Command Status Summary", announce=FALSE)
 	priority_announce("A summary has been copied and printed to all communications consoles.", "Security level elevated.", ANNOUNCER_INTERCEPT)

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -36,7 +36,6 @@
 	var/greenshift_message = "Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!"
 	. += "<b><i>Central Command Status Summary</i></b><hr>"
 	. += greenshift_message
-	. += generate_station_trait_report()
 
 	print_command_report(., "Central Command Status Summary", announce = FALSE)
 	priority_announce(greenshift_message, "Security Report", SSstation.announcer.get_rand_report_sound())

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -388,7 +388,6 @@
 		intercepttext += report
 
 	intercepttext += generate_station_goal_report()
-	intercepttext += generate_station_trait_report()
 
 	print_command_report(intercepttext, "Central Command Status Summary", announce=FALSE)
 	priority_announce("A summary has been copied and printed to all communications consoles.", "Enemy communication intercepted. Security level elevated.", ANNOUNCER_INTERCEPT)
@@ -408,21 +407,6 @@
 	for(var/datum/station_goal/station_goal in station_goals)
 		station_goal.on_report()
 		. += station_goal.get_report()
-	return
-
-/*
- * Generate a list of active station traits to report to the crew.
- *
- * Returns a formatted string of all station traits (that are shown) affecting the station.
- */
-/datum/game_mode/proc/generate_station_trait_report()
-	if(!SSstation.station_traits.len)
-		return
-	. = "<hr><b>Identified shift divergencies:</b><BR>"
-	for(var/datum/station_trait/station_trait as anything in SSstation.station_traits)
-		if(!station_trait.show_in_report)
-			continue
-		. += "[station_trait.get_report()]<BR><hr>"
 	return
 
 // This is a frequency selection system. You may imagine it like a raffle where each player can have some number of tickets. The more tickets you have the more likely you are to


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

even if we have intercept disabled people will see which traits rolled

## Changelog
:cl:
tweak: Station trait command report is now generated independly, that means it will be printed even if intercept isn't enabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
