### PR TITLE
Report round id as int in ?status

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -228,7 +228,7 @@
 	data["vote"] = CONFIG_GET(flag/allow_vote_mode)
 	data["ai"] = CONFIG_GET(flag/allow_ai)
 	data["host"] = world.host ? world.host : null
-	data["round_id"] = GLOB.round_id
+	data["round_id"] = text2num(GLOB.round_id) // I don't know who's fault it is that round id is loaded as a string but screw you
 	data["players"] = GLOB.clients.len
 	data["revision"] = GLOB.revdata.commit
 	data["revision_date"] = GLOB.revdata.date


### PR DESCRIPTION
## About The Pull Request

For some unknown and arcane reason, round ID is loaded from the database (where it is an int) into a string in byond. I don't think someone would just do this just because (though I could believe it), so there might be some reason for this that I don't want to break. However, this is causing ?status to report it as a string which causes our API to report it as a string on the status endpoint while it reports it as an int everywhere else. I'd like the API to be consistent and use the same format as the database so this makes sure the API receives the round id in the right format.

## Why It's Good For The Game

Consistency good, also it was breaking some site stuff

## Changelog
:cl:
server: Report round id as int on ?status
/:cl:
