### PR TITLE
Adds Anti-Kudzu ERT

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -99,3 +99,13 @@
 	mission = "HONK them into submission"
 	polldesc = "an elite Nanotrasen tactical pranking squad"
 	code = "HOOOOOOOOOONK"
+
+/datum/ert/kudzu
+	roles = list(/datum/antagonist/ert/kudzu)
+	leader_role = /datum/antagonist/ert/kudzu
+	teamsize = 5
+	opendoors = FALSE
+	rename_team = "Weed Whackers"
+	mission = "Eliminate the kudzu with extreme prejudice"
+	polldesc = "an elite gardening team"
+	code = "Vine Green"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -548,6 +548,15 @@ update_label("John Doe", "Clowny")
 	access = get_all_accesses()
 	. = ..()
 
+/obj/item/card/id/ert/kudzu
+	registered_name = "Weed Whacker"
+	assignment = "Weed Whacker"
+	icon_state = "ert"
+
+/obj/item/card/id/ert/kudzu/Initialize()
+	access = get_all_accesses()
+	. = ..()
+
 /obj/item/card/id/prisoner
 	name = "prisoner ID card"
 	desc = "You are a number, you are not a free man."

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -376,3 +376,8 @@
 	name = "living lube delivery beacon"
 	default_name = "Offensive"
 	mob_choice = /mob/living/simple_animal/hostile/retaliate/clown/lube
+
+/obj/item/choice_beacon/pet/goat
+	name = "goat delivery beacon"
+	default_name = "Billy"
+	mob_choice = /mob/living/simple_animal/hostile/retaliate/goat

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -126,6 +126,10 @@
 	role = "Heavy Duty Janitor"
 	outfit = /datum/outfit/ert/janitor/heavy
 
+/datum/antagonist/ert/kudzu
+	role = "Weed Whacker"
+	outfit = /datum/outfit/ert/kudzu
+
 /datum/antagonist/ert/deathsquad/leader
 	name = "Deathsquad Officer"
 	outfit = /datum/outfit/death_commando/officer

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -293,6 +293,33 @@
 		/obj/item/grenade/clusterbuster/cleaner=3,
 		/obj/item/reagent_containers/spray/chemsprayer/janitor=1)
 
+/datum/outfit/ert/kudzu
+	name = "ERT Weed Whacker"
+
+	id = /obj/item/card/id/ert/kudzu
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/jani
+	glasses = /obj/item/clothing/glasses/night
+	back = /obj/item/storage/backpack
+	belt = /obj/item/storage/belt/janitor/full
+	r_pocket = /obj/item/grenade/chem_grenade/antiweed
+	l_pocket = /obj/item/grenade/chem_grenade/antiweed
+	l_hand = /obj/item/scythe
+	backpack_contents = list(/obj/item/storage/box/engineer=1,
+		/obj/item/storage/box/lights/mixed=1,
+		/obj/item/melee/baton/loaded=1,
+		/obj/item/choice_beacon/pet/goat,
+		/obj/item/grenade/clusterbuster/antiweed=2)
+
+/datum/outfit/ert/kudzu/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+
+	if(visualsOnly)
+		return
+
+	var/obj/item/radio/R = H.ears
+	R.keyslot = new /obj/item/encryptionkey/headset_service
+	R.recalculateChannels()
+
 /datum/outfit/centcom_intern
 	name = "CentCom Intern"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have seen multiple occasions of kudzu getting way out of hand, and an ERT sent to fight it, which is generally hastily patched together and ill-equipped. This formalizes the Weed Whacker squad.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Admins can now ICly control extremely out of hand kudzu spread.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Weed Whacker ERT is now available to combat extreme kudzu infestations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
