### PR TITLE
Carp Migration no longer notifies ghosts

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -27,17 +27,8 @@
 
 
 /datum/round_event/carp_migration/start()
-	var/mob/living/simple_animal/hostile/carp/fish
 	for(var/obj/effect/landmark/carpspawn/C in GLOB.landmarks_list)
 		if(prob(95))
-			fish = new (C.loc)
+			new /mob/living/simple_animal/hostile/carp(C.loc)
 		else
-			fish = new /mob/living/simple_animal/hostile/carp/megacarp(C.loc)
-
-			fishannounce(fish) //Prefer to announce the megacarps over the regular fishies
-	fishannounce(fish)
-
-/datum/round_event/carp_migration/proc/fishannounce(atom/fish)
-	if (!hasAnnounced)
-		announce_to_ghosts(fish) //Only anounce the first fish
-		hasAnnounced = TRUE
+			new /mob/living/simple_animal/hostile/carp/megacarp(C.loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ghost notification from the Carp Migration event (the object of interest one)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Did anyone actually click on those?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Carp Migration will no longer generate Points of Interest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
