### PR TITLE
I fixed shuttles being overweight!

### DIFF
--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -144,7 +144,8 @@
 	//Calculate all the data
 	var/list/areas = M.shuttle_areas
 	for(var/shuttleArea in areas)
-		calculated_mass += length(get_area_turfs(shuttleArea))
+		for(var/turf/T in shuttleArea)
+			calculated_mass += 1
 	for(var/obj/machinery/shuttle/engine/E in GLOB.custom_shuttle_machines)
 		if(!(get_area(E) in areas))
 			continue


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/SinguloStation13/SinguloStation13/pull/77
This fixes custom shuttles "Insufficient engine power to engage supercruise." which was caused by mass calculation calculating the mass of every custom shuttle in existence. This caused issues only now because the testmerged shuttle persistence (#5367) added a ton of shuttle areas that are placed in the world randomly. 

Thank you @KubeRoot for pointing out the SinguloStation solution in the original issue. This PR closes #5423.

## Why It's Good For The Game

I can finally enjoy custom shuttles.
Bacon will be happy to see more feedback when he returns.

## Changelog
:cl:
fix: Shuttles will no longer refuse to lift off due to counting all other shuttle's weight as their own.
/:cl: