### PR TITLE
Squidpeople don't wear socks anymore.

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -126,6 +126,7 @@
 #define NOHUSK			22 // Can't be husked.
 #define ROBOTIC_LIMBS	23 //limbs start out as robotic; but also use organic icons. If you want to use the default ones, you'll have to use on_species_gain
 #define NOMOUTH			24
+#define SQUIDLEGS       25 // Like the lizard's digitigrade feet, but for squids. Currently is only relevant for wearing socks
 
 //organ slots
 #define ORGAN_SLOT_BRAIN "brain"

--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -126,7 +126,7 @@
 #define NOHUSK			22 // Can't be husked.
 #define ROBOTIC_LIMBS	23 //limbs start out as robotic; but also use organic icons. If you want to use the default ones, you'll have to use on_species_gain
 #define NOMOUTH			24
-#define SQUIDLEGS       25 // Like the lizard's digitigrade feet, but for squids. Currently is only relevant for wearing socks
+#define NOSOCKS       25 // You cannot wear socks.
 
 //organ slots
 #define ORGAN_SLOT_BRAIN "brain"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -583,7 +583,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				else
 					standing += mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
 
-		if(H.socks && H.get_num_legs(FALSE) >= 2 && !(DIGITIGRADE in species_traits) && (!NOSOCKS in species_traits))
+		if(H.socks && H.get_num_legs(FALSE) >= 2 && !(DIGITIGRADE in species_traits) && !(NOSOCKS in species_traits))
 			var/datum/sprite_accessory/socks/socks = GLOB.socks_list[H.socks]
 			if(socks)
 				standing += mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -583,7 +583,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				else
 					standing += mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
 
-		if(H.socks && H.get_num_legs(FALSE) >= 2 && !(DIGITIGRADE in species_traits) && (!SQUIDLEGS in species_traits))
+		if(H.socks && H.get_num_legs(FALSE) >= 2 && !(DIGITIGRADE in species_traits) && (!NOSOCKS in species_traits))
 			var/datum/sprite_accessory/socks/socks = GLOB.socks_list[H.socks]
 			if(socks)
 				standing += mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -583,7 +583,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				else
 					standing += mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
 
-		if(H.socks && H.get_num_legs(FALSE) >= 2 && !(DIGITIGRADE in species_traits))
+		if(H.socks && H.get_num_legs(FALSE) >= 2 && !(DIGITIGRADE in species_traits) && (!SQUIDLEGS in species_traits))
 			var/datum/sprite_accessory/socks/socks = GLOB.socks_list[H.socks]
 			if(socks)
 				standing += mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)

--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -2,7 +2,7 @@
 	name = "Squidperson"
 	id = "squid"
 	default_color = "b8dfda"
-	species_traits = list(MUTCOLORS,EYECOLOR,SQUIDLEGS)
+	species_traits = list(MUTCOLORS,EYECOLOR,NOSOCKS)
 	inherent_traits = list(TRAIT_NOSLIPALL,TRAIT_EASYDISMEMBER)
 	default_features = list("mcolor" = "FFF") // bald
 	speedmod = 0.5

--- a/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/squidpeople.dm
@@ -2,7 +2,7 @@
 	name = "Squidperson"
 	id = "squid"
 	default_color = "b8dfda"
-	species_traits = list(MUTCOLORS,EYECOLOR)
+	species_traits = list(MUTCOLORS,EYECOLOR,SQUIDLEGS)
 	inherent_traits = list(TRAIT_NOSLIPALL,TRAIT_EASYDISMEMBER)
 	default_features = list("mcolor" = "FFF") // bald
 	speedmod = 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As requested by the [lovely people](https://forums.beestation13.com/t/someone-please-make-a-pr-to-disable-squidpeople-socks/14833) over on the forums, I've made the most 5/10 effort possible to fix the glaring error that has plagued squidpeople since launch. This pull gives squidpeople a new trait 'NOSOCKS', which is checked for when rendering socks onto spacemen. The only error I've found is that it still lets you pick what socks you want to wear, despite them not being visible. I'll fix it if anyone actually cares.

## Why It's Good For The Game

- Fixes a horrific, immersion-breaking glitch.

## Changelog
:cl:
add: Adds the 'NOSOCKS' trait.
tweak: Species with NOSOCKS can't wear socks.
tweak: Squids now have the 'NOSOCKS' trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
