### PR TITLE
Show "important" messages in created chat tabs

### DIFF
--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -11,14 +11,25 @@ export const canPageAcceptType = (page, type) => (
   type.startsWith(MESSAGE_TYPE_INTERNAL) || page.acceptedTypes[type]
 );
 
-export const createPage = obj => ({
-  id: createUuid(),
-  name: 'New Tab',
-  acceptedTypes: {},
-  unreadCount: 0,
-  createdAt: Date.now(),
-  ...obj,
-});
+export const createPage = obj => {
+  let acceptedTypes = {}
+
+  for (let typeDef of MESSAGE_TYPES) {
+    if(typeDef.important)
+    {
+      acceptedTypes[typeDef.type] = true;
+    }
+  }
+
+  return {
+    id: createUuid(),
+    name: 'New Tab',
+    acceptedTypes: acceptedTypes,
+    unreadCount: 0,
+    createdAt: Date.now(),
+    ...obj,
+  };
+};
 
 export const createMainPage = () => {
   const acceptedTypes = {};

--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -12,11 +12,10 @@ export const canPageAcceptType = (page, type) => (
 );
 
 export const createPage = obj => {
-  let acceptedTypes = {}
+  let acceptedTypes = {};
 
   for (let typeDef of MESSAGE_TYPES) {
-    if(typeDef.important)
-    {
+    if (typeDef.important) {
       acceptedTypes[typeDef.type] = true;
     }
   }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/5499

TGUI chat allows you to create chat tabs where you can switch which types of messages show up in which tabs. There is, however, a type of messages that is always enabled and doesn't show up in the settings: `MESSAGE_TYPE_SYSTEM`, which is supposed to always be enabled.

However, presumably due to an oversight, when creating a new chat tab the message type isn't enabled and cannot be enabled by the user. This type of message also happens to include chemical scan results from the health analyzer when overdosing, presumably due to another oversight. What this means is, if somebody uses a custom-created chat tab as their main tab, they have no way to see the chemical scan results when overdosing, especially if they deleted the main tab at some point.

This PR makes newly created tabs in tgui chat have all message types marked as `important` enabled by default. This does not apply to previously created chat tabs, if you've been affected by the issue you'll need to recreate them. This also means users have no way to hide messages wrongly showing up as important despite being rather mundane, but I believe that should be fixed separately.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Important messages that are so important they **cannot** be hidden should *not* be hidden when creating your own chat tabs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Newly created chat tabs will now show important messages. If you're using custom-created chat tabs, you'll need to delete and recreate them to be able to see them. This fixes being unable to see if somebody is overdosing when doing chemical scans with the health analyzer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
