### PR TITLE
Properly reset view_size when entering a mob

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -71,8 +71,10 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
-		client.view_size?.setDefault(getScreenSize(src))	// Sets the defaul view_size because it can be different to what it was on the lobby.
-		client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
+		if(client.view_size)
+			client.view_size.resetToDefault()	// Sets the defaul view_size because it can be different to what it was on the lobby.
+		else
+			client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
 
 		//Reset verb information, give verbs accessible to the mob.
 		if(client.tgui_panel)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Based on the following PR:
- https://github.com/tgstation/tgstation/pull/53198

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/4951

In some cases your stored view range wasn't reset after entering a mob after ghosting, and then in some cases the stored view range was applied while playing as a mob, giving you a straight up increased view range.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes an issue that would sometimes lead to increased view range while not ghosted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
