### PR TITLE
[DNM]Revert "Properly reset view_size when entering a mob"

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -71,10 +71,8 @@
 	update_client_colour()
 	update_mouse_pointer()
 	if(client)
-		if(client.view_size)
-			client.view_size.resetToDefault()	// Sets the defaul view_size because it can be different to what it was on the lobby.
-		else
-			client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
+		client.view_size?.setDefault(getScreenSize(src))	// Sets the defaul view_size because it can be different to what it was on the lobby.
+		client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
 
 		//Reset verb information, give verbs accessible to the mob.
 		if(client.tgui_panel)


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#5504

When you observe, it makes the window 15x15 instead of the intended 17x15.

This should probably be just testmerged instead of fullmerged until the problem is resolved.