### PR TITLE
Fix view_size again

### DIFF
--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -34,9 +34,11 @@
 /datum/viewData/proc/isZooming()
 	return (width || height)
 
-/datum/viewData/proc/resetToDefault()
+/datum/viewData/proc/resetToDefault(var/new_default)
 	width = 0
 	height = 0
+	if(new_default != null)
+		default = new_default
 	apply()
 
 /datum/viewData/proc/add(toAdd)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1815,8 +1815,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							pixel_size = PIXEL_SCALING_3X
 						if(PIXEL_SCALING_3X)
 							pixel_size = PIXEL_SCALING_AUTO
-					user.client.view_size.setDefault(getScreenSize(user))	//Fix our viewport size so it doesn't reset on change
-					user.client.view_size.apply() //Let's winset() it so it actually works
+					user.client.view_size.resetToDefault(getScreenSize(user))	//Fix our viewport size so it doesn't reset on change
 
 				if("scaling_method")
 					switch(scaling_method)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -346,7 +346,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(mind.current.key && mind.current.key[1] != "@")	//makes sure we don't accidentally kick any clients
 		to_chat(usr, "<span class='warning'>Another consciousness is in your body...It is resisting you.</span>")
 		return
-	client.view_size.setDefault(getScreenSize(src))//Let's reset so people can't become allseeing gods
+	client.view_size.resetToDefault(getScreenSize(src))//Let's reset so people can't become allseeing gods //For real this time
 	SStgui.on_transfer(src, mind.current) // Transfer NanoUIs.
 	mind.current.key = key
 	return TRUE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -72,7 +72,7 @@
 	update_mouse_pointer()
 	if(client)
 		if(client.view_size)
-			client.view_size.resetToDefault()	// Sets the defaul view_size because it can be different to what it was on the lobby.
+			client.view_size.resetToDefault(getScreenSize(src))	// Sets the defaul view_size because it can be different to what it was on the lobby.
 		else
 			client.change_view(getScreenSize(src)) // Resets the client.view in case it was changed.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes issue introduced in my own PR: https://github.com/BeeStation/BeeStation-Hornet/pull/5504
Closes https://github.com/BeeStation/BeeStation-Hornet/pull/5505

Turns out when porting code from tg I overlooked one thing: on tg you have widescreen even on the lobby, even though the image doesn't match, whereas bee specifically overrides your view_size on the lobby to not be widescreen.

This adds a new argument to `resetToDefault` and uses it to set the default when it's likely to have changed. Some other code is also changed where it would setDefault then resetToDefault, since that would update the client screen twice, now it only does it once thanks to combining the two calls.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: View range is now actually fixed, sorry for the trouble.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
