### PR TITLE
Wizarditis fixes

### DIFF
--- a/code/datums/diseases/advance/symptoms/wizarditis.dm
+++ b/code/datums/diseases/advance/symptoms/wizarditis.dm
@@ -11,8 +11,8 @@
 	symptom_delay_max = 45
 	var/teleport = FALSE
 	var/robes = FALSE
-	threshold_desc = "<b>Transmission 14:</b> The host teleports occasionally.<br>\
-					  <b>Speed 7:</b> The host grows a set of wizard robes."
+	threshold_desc = "<b>Transmission 8:</b> The host teleports occasionally.<br>\
+					  <b>Stage Speed 7:</b> The host grows a set of wizard robes."
 
 /datum/symptom/wizarditis/severityset(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/wizarditis.dm
+++ b/code/datums/diseases/advance/symptoms/wizarditis.dm
@@ -47,7 +47,7 @@
 			if(prob(30) && prob(50))
 				to_chat(M, "<span class='danger'>You feel [pick("the magic bubbling in your veins","that this location gives you a +1 to INT","an urge to summon familiar")].</span>")
 
-		if(4)
+		if(4,5)
 
 			if(prob(50))
 				M.say(pick("NEC CANTIO!","AULIE OXIN FIERA!","STI KALY!","EI NATH!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/4287

Wizarditis has a switch that checks disease stage to decide which effects of the symptom should activate, culminating on stage 4. However, diseases go up to stage 5. This PR changes the switch for the final set of effects to activate on both stages 4 and 5.

Additionally, the in-game text for the thresholds is outdated, citing a threshold on a whopping transmission 14. This has been updated to match code to transmission 8. I have also corrected the text citing "Speed 7" to use the full name - "Stage Speed 7".

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Wizarditis now functions correctly at high stages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
