### PR TITLE
Better borg mesons

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -94,6 +94,9 @@
 /datum/hud/robot/New(mob/owner)
 	..()
 	var/mob/living/silicon/robot/mymobR = mymob
+
+	mymobR.overlay_fullscreen("see_through_darkness", /atom/movable/screen/fullscreen/see_through_darkness)
+
 	var/atom/movable/screen/using
 
 	using = new/atom/movable/screen/language_menu

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -973,7 +973,7 @@
 
 	if(sight_mode & BORGMESON)
 		sight |= SEE_TURFS
-		lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 		see_in_dark = 1
 
 	if(sight_mode & BORGMATERIAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes borg mesons look the same as human mesons instead of removing all the lighting.
Before:
![shit_lighting](https://user-images.githubusercontent.com/43815120/138042586-98b225aa-e9b3-48cd-bf4b-6078ff97afe1.png)
After:
![good_lighting](https://user-images.githubusercontent.com/43815120/138036499-35823420-37d3-4279-85de-35311f979a2d.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes borg mesons look better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Cyborg mesons work similarly to human mesons by showing dark areas
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
