### PR TITLE
Great (temp?) Snowcone fix and rework

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_frozen.dm
+++ b/code/modules/food_and_drinks/food/snacks_frozen.dm
@@ -62,16 +62,21 @@
 /////////////
 
 /obj/item/reagent_containers/food/snacks/snowcones //We use this as a base for all other snowcones (I feel that this is extremely outdated as it forced all snowcones to have no contents other than water)
-	name = "flavorless snowcone"
-	desc = "It's just shaved ice. Still fun to chew on."
 	icon = 'icons/obj/food/frozen_treats.dmi'
-	icon_state = "flavorless_sc"
 	trash = /obj/item/reagent_containers/food/drinks/sillycup //We dont eat paper cups
 	bonus_reagents = list(/datum/reagent/water = 10) //~~Base line will allways give water~~ This line seems to break everything, added "redundant" code to force and override flavorings, appologies
 	list_reagents = list(/datum/reagent/water = 10) // We dont get food for water/juices.
 	filling_color = "#FFFFFF" //Ice is white
 	tastes = list("ice" = 1, "water" = 1)
 	foodtype = SUGAR //We use SUGAR as a base line to act in as junkfood, other wise we use fruit
+
+/obj/item/reagent_containers/food/snacks/snowcones/flavourless
+	name = "flavorless snowcone"
+	desc = "It's just shaved ice. Still fun to chew on."
+	icon_state = "flavorless_sc"
+	bonus_reagents = list(/datum/reagent/consumable/ice = 10)
+	list_reagents = list(/datum/reagent/consumable/ice = 10)
+	tastes = list("ice" = 1)
 
 /obj/item/reagent_containers/food/snacks/snowcones/lime
 	name = "lime snowcone"

--- a/code/modules/food_and_drinks/food/snacks_frozen.dm
+++ b/code/modules/food_and_drinks/food/snacks_frozen.dm
@@ -61,14 +61,14 @@
 //SNOWCONES//
 /////////////
 
-/obj/item/reagent_containers/food/snacks/snowcones //We use this as a base for all other snowcones
+/obj/item/reagent_containers/food/snacks/snowcones //We use this as a base for all other snowcones (I feel that this is extremely outdated as it forced all snowcones to have no contents other than water)
 	name = "flavorless snowcone"
 	desc = "It's just shaved ice. Still fun to chew on."
 	icon = 'icons/obj/food/frozen_treats.dmi'
 	icon_state = "flavorless_sc"
 	trash = /obj/item/reagent_containers/food/drinks/sillycup //We dont eat paper cups
-	bonus_reagents = list(/datum/reagent/water = 10) //Base line will allways give water
-	list_reagents = list(/datum/reagent/water = 1) // We dont get food for water/juices
+	bonus_reagents = list(/datum/reagent/water = 10) //~~Base line will allways give water~~ This line seems to break everything, added "redundant" code to force and override flavorings, appologies
+	list_reagents = list(/datum/reagent/water = 10) // We dont get food for water/juices.
 	filling_color = "#FFFFFF" //Ice is white
 	tastes = list("ice" = 1, "water" = 1)
 	foodtype = SUGAR //We use SUGAR as a base line to act in as junkfood, other wise we use fruit
@@ -77,7 +77,8 @@
 	name = "lime snowcone"
 	desc = "Lime syrup drizzled over a snowball in a paper cup."
 	icon_state = "lime_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/limejuice = 5)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/limejuice = 5, /datum/reagent/consumable/ice = 10) // bonus reagents is used when crafting menu makes it//
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/limejuice = 5, /datum/reagent/consumable/ice = 10) // list reagents is used when spawned via admin menus, both seems mutually exclusive due to how this is set up//
 	tastes = list("ice" = 1, "water" = 1, "limes" = 5)
 	foodtype = FRUIT
 
@@ -85,7 +86,8 @@
 	name = "lemon snowcone"
 	desc = "Lemon syrup drizzled over a snowball in a paper cup."
 	icon_state = "lemon_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/lemonjuice = 5)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/lemonjuice = 5, /datum/reagent/consumable/ice = 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/lemonjuice = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "lemons" = 5)
 	foodtype = FRUIT
 
@@ -93,7 +95,8 @@
 	name = "apple snowcone"
 	desc = "Apple syrup drizzled over a snowball in a paper cup."
 	icon_state = "amber_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/applejuice = 5)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/applejuice = 5, /datum/reagent/consumable/ice = 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/applejuice = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "apples" = 5)
 	foodtype = FRUIT
 
@@ -101,7 +104,8 @@
 	name = "grape snowcone"
 	desc = "Grape syrup drizzled over a snowball in a paper cup."
 	icon_state = "grape_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/grapejuice = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/grapejuice = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/grapejuice = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "grape" = 5)
 	foodtype = FRUIT
 
@@ -109,7 +113,8 @@
 	name = "orange snowcone"
 	desc = "Orange syrup drizzled over a snowball in a paper cup."
 	icon_state = "orange_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/orangejuice = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/orangejuice = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/orangejuice = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "orange" = 5)
 	foodtype = FRUIT
 
@@ -117,7 +122,8 @@
 	name = "bluecherry snowcone"
 	desc = "Bluecherry syrup drizzled over a snowball in a paper cup, how rare!"
 	icon_state = "blue_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/bluecherryjelly = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/bluecherryjelly = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/bluecherryjelly = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "blue" = 5, "cherries" = 5)
 	foodtype = FRUIT
 
@@ -125,7 +131,8 @@
 	name = "cherry snowcone"
 	desc = "Cherry syrup drizzled over a snowball in a paper cup."
 	icon_state = "red_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/cherryjelly = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/cherryjelly = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents =  list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/cherryjelly = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "red" = 5, "cherries" = 5)
 	foodtype = FRUIT
 
@@ -133,7 +140,8 @@
 	name = "berry snowcone"
 	desc = "Berry syrup drizzled over a snowball in a paper cup."
 	icon_state = "berry_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/berryjuice = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/berryjuice = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/berryjuice = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "berries" = 5)
 	foodtype = FRUIT
 
@@ -141,7 +149,8 @@
 	name = "fruit salad snowcone"
 	desc = "A delightful mix of citrus syrups drizzled over a snowball in a paper cup."
 	icon_state = "fruitsalad_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/lemonjuice = 5, /datum/reagent/consumable/limejuice = 5, /datum/reagent/consumable/orangejuice = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/lemonjuice = 5, /datum/reagent/consumable/limejuice = 5, /datum/reagent/consumable/orangejuice = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/lemonjuice = 5, /datum/reagent/consumable/limejuice = 5, /datum/reagent/consumable/orangejuice = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "oranges" = 5, "limes" = 5, "lemons" = 5, "citrus" = 5, "salad" = 5)
 	foodtype = FRUIT
 
@@ -149,7 +158,8 @@
 	name = "pineapple snowcone"
 	desc = "Pineapple syrup drizzled over a snowball in a paper cup."
 	icon_state = "pineapple_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/water = 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "pineapples" = 5)
 	foodtype = PINEAPPLE //Pineapple to allow all that like pineapple to enjoy
 
@@ -157,28 +167,32 @@
 	name = "mime snowcone"
 	desc = "..."
 	icon_state = "mime_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nothing = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nothing = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nothing = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "nothing" = 5)
 
 /obj/item/reagent_containers/food/snacks/snowcones/clown
 	name = "clown snowcone"
 	desc = "Laughter drizzled over a snowball in a paper cup."
 	icon_state = "clown_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/laughter = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/laughter = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/laughter = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "jokes" = 5, "brainfreeze" = 5, "joy" = 5)
 
 /obj/item/reagent_containers/food/snacks/snowcones/soda
 	name = "space cola snowcone"
 	desc = "Space Cola drizzled over a snowball in a paper cup."
 	icon_state = "soda_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/space_cola = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/space_cola = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/space_cola = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "cola" = 5)
 
 /obj/item/reagent_containers/food/snacks/snowcones/spacemountainwind
 	name = "Space Mountain Wind snowcone"
 	desc = "Space Mountain Wind drizzled over a snowball in a paper cup."
 	icon_state = "mountainwind_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/spacemountainwind = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/spacemountainwind = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/spacemountainwind = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "mountain wind" = 5)
 
 
@@ -186,19 +200,22 @@
 	name = "pwrgame snowcone"
 	desc = "Pwrgame soda drizzled over a snowball in a paper cup."
 	icon_state = "pwrgame_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/pwr_game = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/pwr_game = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/pwr_game = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "valid" = 5, "salt" = 5, "wats" = 5)
 
 /obj/item/reagent_containers/food/snacks/snowcones/honey
 	name = "honey snowcone"
 	desc = "Honey drizzled over a snowball in a paper cup."
 	icon_state = "amber_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/honey = 5)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/honey = 5, /datum/reagent/consumable/ice = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/honey = 5, /datum/reagent/consumable/ice = 10)
 	tastes = list("ice" = 1, "water" = 1, "flowers" = 5, "sweetness" = 5, "wax" = 1)
 
 /obj/item/reagent_containers/food/snacks/snowcones/rainbow
 	name = "rainbow snowcone"
 	desc = "A very colorful snowball in a paper cup."
 	icon_state = "rainbow_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/laughter = 25)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/laughter = 25, /datum/reagent/consumable/ice = 10, /datum/reagent/colorful_reagent = 10)
+	bonus_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/laughter = 25, /datum/reagent/consumable/ice = 10, /datum/reagent/colorful_reagent = 10)
 	tastes = list("ice" = 1, "water" = 1, "sunlight" = 5, "light" = 5, "slime" = 5, "paint" = 3, "clouds" = 3)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
@@ -112,7 +112,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/consumable/berryjuice = 5
+		/datum/reagent/consumable/grapejuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/grape
 	subcategory = CAT_ICE
@@ -209,13 +209,13 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/spacemountainwind
 	subcategory = CAT_ICE
-	
+
 /datum/crafting_recipe/food/pwrgame_sc
 	name = "Pwrgame snowcone"
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/consumable/pwr_game = 15
+		/datum/reagent/consumable/pwr_game = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/pwrgame
 	subcategory = CAT_ICE
@@ -235,7 +235,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/colorful_reagent = 1 //Harder to make
+		/datum/reagent/colorful_reagent = 10 //Harder to make
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/rainbow
 	subcategory = CAT_ICE

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
@@ -64,7 +64,7 @@
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15
 	)
-	result = /obj/item/reagent_containers/food/snacks/snowcones
+	result = /obj/item/reagent_containers/food/snacks/snowcones/flavourless
 	subcategory = CAT_ICE
 
 /datum/crafting_recipe/food/pineapple_sc


### PR DESCRIPTION
## About The Pull Request

Enables snow cone reagents being as intended via some minor brute forcing of bonus_reagents and list_reagents (both are mutually exclusive depending on method of creation, Menu and admin respectfully)

Changed contents from water to ice to better reflect the item

Grape snowcones no longer use berry juice for crafting

Rainbow snow cones now require 10 colorful reagent but contain as much when created

SM wind recipe brought into line with the other recipes (15 ice 5 flavor)







## Why It's Good For The Game

Snowcones used to only have 10u water, no matter what one was crafted
Spawned snowcones would also have only the intended flavor with no water

This Fixes both issues and effectivly re-enables snowcones and tweaks minor oddities (as well as a fun addition to rainbow cones)

## Changelog
:cl:
fix: Snowcone reagent contents are now as intented
fix: Grape snowcones now use Grape instead of Berry
tweak: Changed SMwind recipe and Rainbow Snowcone contents to bring them in line with all others



/:cl:

