### PR TITLE
Fix exploration detonator Z level checks

### DIFF
--- a/code/modules/exploration_crew/exploration_explosives.dm
+++ b/code/modules/exploration_crew/exploration_explosives.dm
@@ -115,7 +115,8 @@
 		return
 	var/explosives_trigged = 0
 	for(var/obj/item/grenade/exploration/exploration in linked_explosives)
-		if(get_dist(exploration.target, user) <= range)
+		var/turf/T2 = get_turf(exploration.target)
+		if(T2.get_virtual_z_level() == T.get_virtual_z_level() && get_dist(exploration.target, user) <= range)
 			addtimer(CALLBACK(exploration, /obj/item/grenade/exploration.proc/prime), 10)
 			explosives_trigged ++
 	to_chat(user, "<span class='notice'>[explosives_trigged] explosives triggered.</span>")

--- a/code/modules/exploration_crew/exploration_explosives.dm
+++ b/code/modules/exploration_crew/exploration_explosives.dm
@@ -110,7 +110,7 @@
 	if(.)
 		return
 	var/turf/T = get_turf(user)
-	if(is_station_level(T) && !(obj_flags & EMAGGED))
+	if(is_station_level(T.z) && !(obj_flags & EMAGGED))
 		to_chat(user, "<span class='warning'>STATION SAFETY ENABLED.</span>")
 		return
 	var/explosives_trigged = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The exploration detonator was incorrectly checking if the user is on the station Z level, where it is supposed to prevent usage unless emagged. This was corrected.

The exploration detonator was checking distance to the explosives to make sure you're in range; it was not, however, checking to make sure you're on the same Z level, and the distance check works across Z levels. This was changed to check your and the explosive's turfs to ensure you are on the same virtual Z level. *This will also prevent you from detonating explosives on a different Z level of a multi-Z map.*

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The exploration detonator now correctly checks if you're on the station Z level for its safety. You can also no longer detonate explosives across Z levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
