### PR TITLE
Adds BANNED message to antag panel

### DIFF
--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -169,7 +169,7 @@ GLOBAL_VAR(antag_prototypes)
 			if(!is_banned_from(src.key, pref_source.job_rank))
 				antag_header_parts += pref_source.enabled_in_preferences(src) ? "Enabled in Prefs" : "Disabled in Prefs"
 			else
-				antag_header_parts += "<span class='bad'><b>[BANNED]</b></span>"
+				antag_header_parts += "<span class='bad'><b>\[BANNED\]</b></span>"
 
 		//Traitor : None | Traitor | IAA
 		//	Command1 | Command2 | Command3

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -166,7 +166,10 @@ GLOBAL_VAR(antag_prototypes)
 				pref_source = prototype
 				break
 		if(pref_source.job_rank)
-			antag_header_parts += pref_source.enabled_in_preferences(src) ? "Enabled in Prefs" : "Disabled in Prefs"
+			if(!is_banned_from(src.key, pref_source.job_rank))
+				antag_header_parts += pref_source.enabled_in_preferences(src) ? "Enabled in Prefs" : "Disabled in Prefs"
+			else
+				antag_header_parts += "BANNED from Role"
 
 		//Traitor : None | Traitor | IAA
 		//	Command1 | Command2 | Command3

--- a/code/modules/admin/antag_panel.dm
+++ b/code/modules/admin/antag_panel.dm
@@ -169,7 +169,7 @@ GLOBAL_VAR(antag_prototypes)
 			if(!is_banned_from(src.key, pref_source.job_rank))
 				antag_header_parts += pref_source.enabled_in_preferences(src) ? "Enabled in Prefs" : "Disabled in Prefs"
 			else
-				antag_header_parts += "BANNED from Role"
+				antag_header_parts += "<span class='bad'><b>[BANNED]</b></span>"
 
 		//Traitor : None | Traitor | IAA
 		//	Command1 | Command2 | Command3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Enabled in Prefs/Disabled in Prefs message will now show a different message if the person in question is banned from the antagonist in question.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
>be me
>admin
>ahelp incoming "I don't want to be changeling, please give it to someone else"
>remove their ling
>look through like ten people before I find someone that shows enabled in prefs
>give them ling
>ghost poll "Would you like to be Changeling?"

oops.jpg
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Traitor panel will now show if the person in question is banned from a specific antagonist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
