### PR TITLE
Ports Intern Auto-Flags from TG

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -198,6 +198,13 @@
 
 /datum/config_entry/flag/use_exp_restrictions_admin_bypass
 
+/datum/config_entry/flag/use_low_living_hour_intern
+
+/datum/config_entry/number/use_low_living_hour_intern_hours
+	config_entry_value = 0
+	integer = FALSE
+	min_val = 0
+
 /datum/config_entry/string/server
 
 /datum/config_entry/string/banappeals

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -142,7 +142,13 @@ GLOBAL_LIST_EMPTY(PDAs)
 			equipped = TRUE
 
 /obj/item/pda/proc/update_label()
-	name = "PDA-[owner] ([ownjob])" //Name generalisation
+	if(!id)
+		name = "PDA-[owner] ([ownjob])"
+		return
+	if(id.is_intern)
+		name = "PDA-[owner] (Intern [ownjob])" //Name generalisation
+	else
+		name = "PDA-[owner] ([ownjob])"
 
 /obj/item/pda/GetAccess()
 	if(id)

--- a/config/config.txt
+++ b/config/config.txt
@@ -85,6 +85,11 @@ USE_EXP_RESTRICTIONS_HEADS_DEPARTMENT
 USE_EXP_RESTRICTIONS_OTHER
 ## Allows admins to bypass job playtime requirements.
 USE_EXP_RESTRICTIONS_ADMIN_BYPASS
+## Unhash this to have intern tags automatically added to ID cards for station roles depending on the living hours of the player holding them.
+USE_LOW_LIVING_HOUR_INTERN
+## If USE_LOW_LIVING_HOUR_INTERN is unhashed, players under this number of living hours have [Intern] added to their ID card. If this isn't set, uses USE_EXP_RESTRICTIONS_HEADS_HOURS instead. If that isn't set, it finally defaults to a hardcoded fallback of 15 hours.
+USE_LOW_LIVING_HOUR_INTERN_HOURS 20
+
 
 ## log OOC channel
 LOG_OOC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports parts of and the idea of tgstation/tgstation#58236
IDs will now auto flag themselves as belonging to an "Intern Cook" or "Intern Curator" and so on if the player holding them has less than 20 living hours (that's the default, editable in config).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's a lot of players who love teaching new players and showing them the ropes, and this would help them figure out who likely needs that bit of extra attention.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ivniinvi, Timberpoes
add: Players with less than 20 living hours (editable in config) will now have their ID cards display as Intern (job)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
