### PR TITLE
Expands the Ethereal colour list

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -41,7 +41,26 @@ GLOBAL_LIST_EMPTY(ipc_antennas_list)
 GLOBAL_LIST_EMPTY(ipc_chassis_list)
 GLOBAL_LIST_EMPTY(insect_type_list)
 
-GLOBAL_LIST_INIT(color_list_ethereal, list("F Class(Green)" = "97ee63", "F2 Class (Light Green)" = "00fa9a", "F3 Class (Dark Green)" = "37835b", "M Class (Red)" = "9c3030", "M1 Class (Purple)" = "ee82ee", "G Class (Yellow)" = "fbdf56", "O Class (Blue)" = "3399ff", "A Class (Cyan)" = "00ffff"))
+GLOBAL_LIST_INIT(color_list_ethereal, list(
+	"Red" = "ff3131",
+	"Maroon" = "9c3030",
+	"Orange" = "f69c28",
+	"Sandy Yellow" = "ffefa5",
+	"Yellow" = "fbdf56",
+	"Green" = "97ee63",
+	"Dark Green" = "0ab432",
+	"Spring Green" = "00fa9a",
+	"Sea Green" = "37835b",
+	"Cyan" = "00ffff",
+	"Dark Teal" = "5ea699",
+	"Powder Blue" = "95e5ff",
+	"Denim Blue" = "3399ff",
+	"Royal Blue" = "5860f5",
+	"Lavender" = "d1acff",
+	"Purple" = "a42df7",
+	"Orchid Purple" = "ee82ee",
+	"Rose" = "ff92b6",
+	"Gray" = "979497"))
 
 GLOBAL_LIST_INIT(ghost_forms_with_directions_list, list("ghost")) //stores the ghost forms that support directional sprites
 GLOBAL_LIST_INIT(ghost_forms_with_accessories_list, list("ghost")) //stores the ghost forms that support hair and other such things

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -1,6 +1,4 @@
 
-#define ETHEREAL_COLORS list("#00ffff", "#ffc0cb", "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FFFF00", "#FF7F00", "#FF0000")
-
 /datum/species/ethereal
 	name = "Ethereal"
 	id = "ethereal"
@@ -100,22 +98,19 @@
 	handle_emag(H)
 	addtimer(CALLBACK(src, .proc/stop_emag, H), 30 SECONDS) //Disco mode for 30 seconds! This doesn't affect the ethereal at all besides either annoying some players, or making someone look badass.
 
-
 /datum/species/ethereal/spec_life(mob/living/carbon/human/H)
 	.=..()
 	handle_charge(H)
-
 
 /datum/species/ethereal/proc/stop_emp(mob/living/carbon/human/H)
 	EMPeffect = FALSE
 	spec_updatehealth(H)
 	to_chat(H, "<span class='notice'>You feel more energized as your shine comes back.</span>")
 
-
 /datum/species/ethereal/proc/handle_emag(mob/living/carbon/human/H)
 	if(!emageffect)
 		return
-	current_color = pick(ETHEREAL_COLORS)
+	current_color = "#[GLOB.color_list_ethereal[pick(GLOB.color_list_ethereal)]]"	//Picks a random colour from the Ethereal colour list
 	spec_updatehealth(H)
 	addtimer(CALLBACK(src, .proc/handle_emag, H), 5) //Call ourselves every 0.5 seconds to change color
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames the existing Ethereal colours and adds a whole bunch of new ones! The old colours are marked out in the preview below:

![image](https://user-images.githubusercontent.com/29107291/136633640-bcc65a7d-ee64-4e43-9c52-f80c6e46a8bf.png)

> "So why not a colour picker?"

Aside from the code being enough of a mess that I couldn't get it to work after quite a few attempts, it introduces two more issues: First, due to the brightness restriction on character colours a few of the existing Ethereal colours wouldn't be possible and second, white and light brown are used to indicate an Ethereal's health at a glance and restricting those areas of colour would require even more messy code and exceptions. If someone wishes to tackle that in the future or standardize Ethereals to use the mutation colour instead they're more than welcome to.

[Auth by Francinium](https://discord.com/channels/427337870844362753/801432004058939422/896042201111474207)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More customisation for a race that has next to no customisation as is.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds eleven more possible Ethereal colours and renames the existing ones to match
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
