### PR TITLE
Fix supercruise artifacts

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -436,6 +436,7 @@ GLOBAL_LIST_EMPTY(destabliization_exits)
 		var/obj/item/stock_parts/cell/C = thing.get_cell()
 		if(C)
 			C.give(250 * delta_time)
+			thing.update_icon()
 
 //===================
 // Light Breaker

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -295,7 +295,8 @@ GLOBAL_LIST_EMPTY(destabliization_exits)
 
 /datum/artifact_effect/reality_destabilizer/Destroy()
 	for(var/atom/movable/AM as() in contained_things)
-		AM.forceMove(get_turf(source_object))
+		if(istype(get_area(AM), /area/tear_in_reality))
+			AM.forceMove(get_turf(source_object))
 	contained_things.Cut()
 	GLOB.destabliization_exits -= source_object
 	. = ..()

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -151,7 +151,7 @@
 	var/datum/proximity_monitor/monitor
 	var/datum/callback/callback
 
-/atom/movable/proximity_monitor_holder/proc/setup(datum/proximity_monitor/_monitor, datum/callback/_callback)
+/atom/movable/proximity_monitor_holder/Initialize(mapload, datum/proximity_monitor/_monitor, datum/callback/_callback)
 	monitor = _monitor
 	callback = _callback
 
@@ -171,9 +171,10 @@
 
 /datum/artifact_effect/projreflect/Initialize(source)
 	. = ..()
+	if(monitor_holder)
+		QDEL_NULL(monitor_holder)
 	var/datum/proximity_monitor/monitor = new(source, 3, FALSE)
-	monitor_holder = new()
-	monitor_holder.setup(monitor, CALLBACK(src, .proc/HasProximity))
+	monitor_holder = new(null, monitor, CALLBACK(src, .proc/HasProximity))
 
 /datum/artifact_effect/projreflect/Destroy()
 	QDEL_NULL(monitor_holder)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -184,6 +184,7 @@
 	if(istype(AM, /obj/item/projectile))
 		var/obj/item/projectile/P = AM
 		P.setAngle(rand(0, 360))
+		P.ignore_source_check = TRUE //Allow the projectile to hit the shooter after it gets reflected
 
 //===================
 // Air Blocker

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -97,20 +97,20 @@
 //===================
 
 /datum/artifact_effect/throwchaos
-	signal_types = list(COMSIG_MOVABLE_POST_THROW)
+	signal_types = list(COMSIG_MOVABLE_PRE_THROW)
 	effect_act_descs = list("thrown")
 
 /datum/artifact_effect/throwchaos/register_signals(source)
-	RegisterSignal(source, COMSIG_MOVABLE_POST_THROW, .proc/throw_thing_randomly)
+	RegisterSignal(source, COMSIG_MOVABLE_PRE_THROW, .proc/throw_thing_randomly)
 
-/datum/artifact_effect/throwchaos/proc/throw_thing_randomly(datum/source, datum/thrownthing, spin)
-	if(!isitem(thrownthing) || QDELETED(thrownthing))
-		return
+/datum/artifact_effect/throwchaos/proc/throw_thing_randomly(datum/source, list/arguments)
 	if(prob(40))
 		return
-	var/atom/new_throw_target = pick(view(5, thrownthing))
-	var/obj/item/I = thrownthing
-	I.throw_at(new_throw_target, 5, 4)
+	var/atom/new_throw_target = pick(view(5, source))
+	if(ismovable(new_throw_target))
+		arguments[1] = new_throw_target //target
+		arguments[2] = 5 //range
+		arguments[3] = 4 //speed
 
 //===================
 // Laughing
@@ -147,13 +147,41 @@
 // Projectile Reflector
 //===================
 
-/datum/artifact_effect/projreflect
-	requires_processing = TRUE
-	effect_act_descs = list("shot at")
+/atom/movable/proximity_monitor_holder
+	var/datum/proximity_monitor/monitor
+	var/datum/callback/callback
 
-/datum/artifact_effect/projreflect/process(delta_time)
-	for(var/obj/item/projectile/P in range(3, src))
-		//Reflect projectile
+/atom/movable/proximity_monitor_holder/proc/setup(datum/proximity_monitor/_monitor, datum/callback/_callback)
+	monitor = _monitor
+	callback = _callback
+
+	monitor.hasprox_receiver = src
+
+/atom/movable/proximity_monitor_holder/HasProximity(atom/movable/AM)
+	return callback.Invoke(AM)
+
+/atom/movable/proximity_monitor_holder/Destroy()
+	QDEL_NULL(monitor)
+	QDEL_NULL(callback)
+	return ..()
+
+/datum/artifact_effect/projreflect
+	effect_act_descs = list("shot at")
+	var/atom/movable/proximity_monitor_holder/monitor_holder
+
+/datum/artifact_effect/projreflect/Initialize(source)
+	. = ..()
+	var/datum/proximity_monitor/monitor = new(source, 3, FALSE)
+	monitor_holder = new()
+	monitor_holder.setup(monitor, CALLBACK(src, .proc/HasProximity))
+
+/datum/artifact_effect/projreflect/Destroy()
+	QDEL_NULL(monitor_holder)
+	return ..()
+
+/datum/artifact_effect/projreflect/proc/HasProximity(atom/movable/AM)
+	if(istype(AM, /obj/item/projectile))
+		var/obj/item/projectile/P = AM
 		P.setAngle(rand(0, 360))
 
 //===================
@@ -161,11 +189,23 @@
 //===================
 
 /datum/artifact_effect/airfreeze
+	signal_types = list(COMSIG_MOVABLE_MOVED)
 	effect_act_descs = list("depressurised")
 
 /datum/artifact_effect/airfreeze/Initialize(atom/source)
 	. = ..()
 	source.CanAtmosPass = ATMOS_PASS_NO
+
+/datum/artifact_effect/airfreeze/register_signals(source)
+	RegisterSignal(source, COMSIG_MOVABLE_MOVED, .proc/updateAir)
+
+/datum/artifact_effect/airfreeze/proc/updateAir(atom/source, atom/oldLoc)
+	if(isturf(oldLoc))
+		var/turf/oldTurf = oldLoc
+		oldTurf.air_update_turf(TRUE)
+	if(isturf(source.loc))
+		var/turf/newTurf = source.loc
+		newTurf.air_update_turf(TRUE)
 
 //===================
 // Atmos Stabilizer
@@ -198,7 +238,7 @@
 	var/turf/T = get_turf(warper)
 	if(T)
 		goonchem_vortex(T, FALSE, 8)
-		playsound(src, 'sound/magic/repulse.ogg')
+		playsound(source_object, 'sound/magic/repulse.ogg', 60)
 		next_use_world_time = world.time + 150
 
 //===================
@@ -212,11 +252,11 @@
 	var/next_use_time = 0
 
 /datum/artifact_effect/access/process(delta_time)
-	if(next_use_time < world.time)
+	if(world.time < next_use_time)
 		return
 	next_use_time = world.time + rand(30 SECONDS, 5 MINUTES)
 	var/list/idcards = list()
-	var/list/things_in_view = view(5, src)
+	var/list/things_in_view = view(5, source_object)
 	for(var/mob/living/carbon/human/H in things_in_view)
 		if(H.get_idcard())
 			idcards += H.get_idcard()
@@ -255,7 +295,7 @@ GLOBAL_LIST_EMPTY(destabliization_exits)
 
 /datum/artifact_effect/reality_destabilizer/Destroy()
 	for(var/atom/movable/AM as() in contained_things)
-		AM.forceMove(get_turf(src))
+		AM.forceMove(get_turf(source_object))
 	contained_things.Cut()
 	GLOB.destabliization_exits -= source_object
 	. = ..()
@@ -268,7 +308,7 @@ GLOBAL_LIST_EMPTY(destabliization_exits)
 	if(!T)
 		return
 	for(var/atom/movable/AM in view(3, T))
-		if(AM == src)
+		if(AM == source_object)
 			continue
 		if(isobj(AM))
 			var/obj/O = AM
@@ -370,10 +410,12 @@ GLOBAL_LIST_EMPTY(destabliization_exits)
 /datum/artifact_effect/gas_remove/process(delta_time)
 	var/turf/T = get_turf(source_object)
 	var/datum/gas_mixture/air = T.return_air()
-	var/moles = min(air.get_moles(input), 5)
+	var/input_id = initial(input.id)
+	var/output_id = initial(output.id)
+	var/moles = min(air.get_moles(input_id), 5)
 	if(moles)
-		air.adjust_moles(input, -moles)
-		air.adjust_moles(output, moles)
+		air.adjust_moles(input_id, -moles)
+		air.adjust_moles(output_id, moles)
 
 //===================
 // Recharger


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Artifacts in supercruise have various effects, but as it turns out *half of them didn't even work.* I fixed all the effects so they work correctly, at least as far as I can tell the intent from the code. I also added some improvements based on minor issues I noticed when testing.

**Stop reading if you don't want spoilers on the artifacts.**

Below is a breakdown of all the artifact effects, which issues I found with them, changes applied to fix the issues and any additional notes (particularly potentially unwanted behavior)

<details>
<summary>Breakdown of all effects</summary>

Name | Issues | Fixes | Notes
-- | -- | -- | --
throwchaos | Expects wrong arguments in signal | Use prethrow, modifying the args to change the target |  
soundindark |   |   |  
inducespasm |   |   |  
projreflect | Doesn't reflect energy projectiles - checks range around effect datum instead of artifact | Refactor to use proximity monitor. Also made reflected projectiles capable of hitting the shooter. | Projectiles can be reflected multiple times if they're not sent out of the artifact's range immediately.
airfreeze | Doesn't update when moved | Update air on old and new turf after moving |  
atmosfix |   |   | Ineffective at removing toxic gasses
gravity_well | Sound effect doesn't work, called on effect datum instead of artifact and without volume | Pass correct object, pass volume |  
access | Checks view around effect datum instead of artifact, the cooldown check is inverted | Pass correct object | Can give access the ID already has, effectively removing one access
reality_destabilizer | Can destabilize itself due to comparing against effect datum instead of artifact | Check against correct object | Can destabilize a person holding it
warp |   |   | Might bypass teleportation restrictions, could be problematic
curse |   |   |  
gas_remove | Passes wrong type to atmos procs | Use datum's id instead of datum itself |  
recharger | Doesn't update visuals on cells | Call update_icon on the charged atom |  
light_breaker |   |   | Doesn't affect light fixtures, can turn any item with a light on into ash, including explorer hardsuits
insanity_pulse |   |   |  

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Artifacts from supercruise often didn't work, they should be much more interesting now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
