### PR TITLE
Synchronizer chromosome rework

### DIFF
--- a/code/__HELPERS/dna.dm
+++ b/code/__HELPERS/dna.dm
@@ -8,6 +8,6 @@
 #define GET_MUTATION_TYPE_FROM_ALIAS(A) (GLOB.alias_mutations[A])
 
 #define GET_MUTATION_STABILIZER(A) ((A.stabilizer_coeff < 0) ? 1 : A.stabilizer_coeff)
-#define GET_MUTATION_SYNCHRONIZER(A) ((A.synchronizer_coeff < 0) ? 1 : A.synchronizer_coeff)
+#define GET_MUTATION_SYNCHRONIZER(A) ((A.synchronizer < 0) ? 0 : A.synchronizer)
 #define GET_MUTATION_POWER(A) ((A.power_coeff < 0) ? 1 : A.power_coeff)
 #define GET_MUTATION_ENERGY(A) ((A.energy_coeff < 0) ? 1 : A.energy_coeff)

--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -150,12 +150,11 @@
 	power_dormant = !GET_MUTATION_SYNCHRONIZER(src) //Granting dormant powers is only by synchronizer chromosome so far
 	if(power)
 		var/power_given = FALSE
-		for(var/spell in owner.mind.spell_list)
-			if(spell == power)
-				power_given = TRUE
+		if(locate(power) in owner.mind.spell_list)
+			power_given = TRUE
 		if(power_given && power_dormant) //Power going back into dormancy
 			owner.RemoveSpell(power)
-		if(!power_given && !power_dormant)
+		else if(!power_given && !power_dormant)
 			grant_spell()
 		if(istype(power))
 			power.charge_max *= GET_MUTATION_ENERGY(src)

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -19,17 +19,19 @@
 	text_lose_indication = "<span class='notice'>Your sense of smell goes back to normal.</span>"
 	power = /obj/effect/proc_holder/spell/targeted/olfaction
 	instability = 30
-	synchronizer_coeff = 1
+	synchronizer = FALSE
 	var/reek = 200
 
 /datum/mutation/human/olfaction/on_life()
+	if(GET_MUTATION_SYNCHRONIZER(src))
+		return //If we've synchronized, we have enough control to filter out our stench
 	var/hygiene_now = owner.hygiene
 
 	if(hygiene_now < 100 && prob(3))
-		owner.adjust_disgust(GET_MUTATION_SYNCHRONIZER(src) * (rand(3,5)))
+		owner.adjust_disgust(rand(3,5))
 	if(hygiene_now < HYGIENE_LEVEL_DIRTY && prob(15))
 		to_chat(owner,"<span class='danger'>You get a whiff of your stench and feel sick!</span>")
-		owner.adjust_disgust(GET_MUTATION_SYNCHRONIZER(src) * rand(5,10))
+		owner.adjust_disgust(rand(5,10))
 
 	if(hygiene_now < HYGIENE_LEVEL_NORMAL && reek >= HYGIENE_LEVEL_NORMAL)
 		to_chat(owner,"<span class='warning'>Your inhumanly strong nose picks up a faint odor. Maybe you should shower soon.</span>")
@@ -168,12 +170,12 @@
 	instability = 30
 	power = /obj/effect/proc_holder/spell/self/void
 	energy_coeff = 1
-	synchronizer_coeff = 1
+	synchronizer = FALSE
 
 /datum/mutation/human/void/on_life()
-	if(!isturf(owner.loc))
+	if(!isturf(owner.loc) || GET_MUTATION_SYNCHRONIZER(src))
 		return
-	if(prob((0.5+((100-dna.stability)/20))) * GET_MUTATION_SYNCHRONIZER(src)) //very rare, but enough to annoy you hopefully. +0.5 probability for every 10 points lost in stability
+	if(prob((0.5+((100-dna.stability)/20)))) //very rare, but enough to annoy you hopefully. +0.5 probability for every 10 points lost in stability
 		new /obj/effect/immortality_talisman/void(get_turf(owner), owner)
 
 /obj/effect/proc_holder/spell/self/void
@@ -204,7 +206,7 @@
 	power = /obj/effect/proc_holder/spell/self/self_amputation
 
 	energy_coeff = 1
-	synchronizer_coeff = 1
+	synchronizer = FALSE
 
 /obj/effect/proc_holder/spell/self/self_amputation
 	name = "Drop a limb"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -330,7 +330,7 @@
 		warpchance += 0.25 * GET_MUTATION_ENERGY(src)
 
 /datum/mutation/human/badblink/trigger_mutation()
-	var/warpmessage = pick(
+	var/static/warpmessage = pick(
 		"<span class='warning'>With a sickening 720 degree twist of their back, [owner] vanishes into thin air.</span>",
 		"<span class='warning'>[owner] does some sort of strange backflip into another dimension. It looks pretty painful.</span>",
 		"<span class='warning'>[owner] does a jump to the left, a step to the right, and warps out of reality.</span>",

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -5,7 +5,6 @@
 	text_gain_indication = "<span class='notice'>Your hand feels cold.</span>"
 	instability = 10
 	difficulty = 10
-	synchronizer_coeff = 1
 	power = /obj/effect/proc_holder/spell/targeted/conjure_item/snow
 
 /obj/effect/proc_holder/spell/targeted/conjure_item/snow
@@ -23,7 +22,6 @@
 	text_gain_indication = "<span class='notice'>Your mouth feels waxy.</span>"
 	instability = 10
 	difficulty = 10
-	synchronizer_coeff = 1
 	locked = TRUE
 	power = /obj/effect/proc_holder/spell/targeted/conjure_item/wax
 
@@ -42,7 +40,6 @@
 	text_gain_indication = "<span class='notice'>Your hand feels cold.</span>"
 	instability = 20
 	difficulty = 12
-	synchronizer_coeff = 1
 	power = /obj/effect/proc_holder/spell/aimed/cryo
 
 /obj/effect/proc_holder/spell/aimed/cryo

--- a/code/game/objects/items/chromosome.dm
+++ b/code/game/objects/items/chromosome.dm
@@ -7,7 +7,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 
 	var/stabilizer_coeff = 1 //lower is better, affects genetic stability
-	var/synchronizer_coeff = 1 //lower is better, affects chance to backfire
+	var/synchronizer = FALSE //whether or not the mutation can be controlled more precisely
 	var/power_coeff = 1 //higher is better, affects "strength"
 	var/energy_coeff = 1 //lower is better. affects recharge time
 
@@ -18,7 +18,7 @@
 		return FALSE
 	if((stabilizer_coeff != 1) && (HM.stabilizer_coeff != -1)) //if the chromosome is 1, we dont change anything. If the mutation is -1, we cant change it. sorry
 		return TRUE
-	if((synchronizer_coeff != 1) && (HM.synchronizer_coeff != -1))
+	if((synchronizer = TRUE) && (HM.synchronizer != -1))
 		return TRUE
 	if((power_coeff != 1) && (HM.power_coeff != -1))
 		return TRUE
@@ -28,8 +28,8 @@
 /obj/item/chromosome/proc/apply(datum/mutation/human/HM)
 	if(HM.stabilizer_coeff != -1)
 		HM.stabilizer_coeff = stabilizer_coeff
-	if(HM.synchronizer_coeff != -1)
-		HM.synchronizer_coeff = synchronizer_coeff
+	if(HM.synchronizer != -1)
+		HM.synchronizer = synchronizer
 	if(HM.power_coeff != -1)
 		HM.power_coeff = power_coeff
 	if(HM.energy_coeff != -1)
@@ -60,9 +60,9 @@
 
 /obj/item/chromosome/synchronizer
 	name = "synchronizer chromosome"
-	desc = "A chromosome that reduces mutation knockback and downsides by 50%."
+	desc = "A chromosome that allows for more precise control and less drawbacks of some mutations."
 	icon_state = "synchronizer"
-	synchronizer_coeff = 0.5
+	synchronizer = TRUE
 
 /obj/item/chromosome/power
 	name = "power chromosome"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the synchronizer chromosome to allow for controlled activations of mutations with randomly occurring phenomena. This includes stuff like spatial instability and acidic flesh. It also makes the reduction of negative effects in some mutations (e.g. transient olfaction) stronger. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The synchronizer chromosome in its current state is worthless. Why would anyone put a negative mutation within themselves, and slighty alter the bad effects? This also opens more options for geneticists to experiment with negative mutations.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: the synchronizer chromosome has been reworked, allowing for controlled activation of negative mutations. Only YOU can choose to be on fire!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
