### PR TITLE
virology gameplay tweaks and rebalances (again)

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -48,26 +48,7 @@
 
 //add the disease with no checks
 /datum/disease/proc/infect(var/mob/living/infectee, make_copy = TRUE)
-	var/datum/disease/D = make_copy ? Copy() : src
-	if(istype(D, /datum/disease/advance))
-		var/datum/disease/advance/A = D
-		if(!initial && A.mutable && (spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS))
-			var/minimum = 1
-			if(prob(CLAMP(35-(A.resistance + A.stealth), 0, 50) * (A.mutability)))//stealthy/resistant diseases are less likely to mutate. this means diseases used to farm mutations should be easier to cure. hypothetically.
-				if(infectee.job == "clown" || infectee.job == "mime" || prob(1))//infecting a clown or mime can evolve l0 symptoms/. they can also appear very rarely
-					minimum = 0
-				else
-					minimum = CLAMP(A.severity - 3, 1, 6)
-				A.Evolve(minimum, CLAMP(A.severity + 4, minimum, 9))
-				A.id = GetDiseaseID()
-				A.keepid = TRUE//this is really janky, but basically mutated diseases count as the original disease
-				//if you want to evolve a higher level symptom you need to test and spread a deadly virus among test subjects. 
-				//this is to give monkey testing a use, and add a bit more of a roleplay element to virology- testing deadly diseases on and curing/vaccinating monkeys
-				//this also adds the risk of disease escape if strict biohazard protocol is not followed, however
-				//the immutability of resistant diseases discourages this with hard-to-cure diseases.
-				//if players intentionally grief/cant seem to get biohazard protocol down, this can be changed to not use severity. 
-		else
-			A.initial = FALSE //diseases *only* mutate when spreading. they wont mutate from any other kind of injection	*/	
+	var/datum/disease/D = make_copy ? Copy() : src	
 	infectee.diseases += D
 	D.affected_mob = infectee
 	SSdisease.active_diseases += D //Add it to the active diseases list, now that it's actually in a mob and being processed.

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -43,7 +43,19 @@
 	var/dormant = FALSE //this prevents a disease from having any effects or spreading
 	var/keepid = FALSE
 	var/archivecure
-	var/static/list/advance_cures = list(list(/datum/reagent/water, /datum/reagent/consumable/nutriment, /datum/reagent/ash, /datum/reagent/iron),list(/datum/reagent/consumable/ethanol, /datum/reagent/uranium/radium, /datum/reagent/oil, /datum/reagent/potassium, /datum/reagent/lithium), list(/datum/reagent/consumable/sodiumchloride, /datum/reagent/drug/nicotine, /datum/reagent/drug/space_drugs),list(/datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/antihol, /datum/reagent/fuel, /datum/reagent/space_cleaner), list(/datum/reagent/medicine/spaceacillin, /datum/reagent/toxin/mindbreaker, /datum/reagent/toxin/itching_powder, /datum/reagent/medicine/cryoxadone, /datum/reagent/medicine/epinephrine), list(/datum/reagent/medicine/mine_salve, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/atropine), list(/datum/reagent/medicine/leporazine, /datum/reagent/water/holywater, /datum/reagent/medicine/neurine), list(/datum/reagent/concentrated_barbers_aid, /datum/reagent/drug/happiness, /datum/reagent/medicine/pen_acid), list(/datum/reagent/medicine/haloperidol, /datum/reagent/pax, /datum/reagent/blackpowder, /datum/reagent/medicine/diphenhydramine),list(/datum/reagent/toxin/lipolicide, /datum/reagent/drug/ketamine, /datum/reagent/drug/methamphetamine), list(/datum/reagent/drug/krokodil, /datum/reagent/hair_dye, /datum/reagent/medicine/modafinil))
+	var/static/list/advance_cures = list(
+		list(/datum/reagent/water, /datum/reagent/consumable/nutriment, /datum/reagent/ash, /datum/reagent/iron),
+		list(/datum/reagent/consumable/ethanol, /datum/reagent/uranium/radium, /datum/reagent/oil, /datum/reagent/potassium, /datum/reagent/lithium), 
+		list(/datum/reagent/consumable/sodiumchloride, /datum/reagent/drug/nicotine, /datum/reagent/drug/space_drugs),
+		list(/datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/antihol, /datum/reagent/fuel, /datum/reagent/space_cleaner), 
+		list(/datum/reagent/medicine/spaceacillin, /datum/reagent/toxin/mindbreaker, /datum/reagent/toxin/itching_powder, /datum/reagent/medicine/cryoxadone, /datum/reagent/medicine/epinephrine), 
+		list(/datum/reagent/medicine/mine_salve, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/atropine), 
+		list(/datum/reagent/medicine/leporazine, /datum/reagent/water/holywater, /datum/reagent/medicine/neurine), 
+		list(/datum/reagent/concentrated_barbers_aid, /datum/reagent/drug/happiness, /datum/reagent/medicine/pen_acid), 
+		list(/datum/reagent/medicine/haloperidol, /datum/reagent/pax, /datum/reagent/blackpowder, /datum/reagent/medicine/diphenhydramine),
+		list(/datum/reagent/toxin/lipolicide, /datum/reagent/drug/ketamine, /datum/reagent/drug/methamphetamine), 
+		list(/datum/reagent/drug/krokodil, /datum/reagent/hair_dye, /datum/reagent/medicine/modafinil)
+		)
 /*
 
 	OLD PROCS
@@ -75,9 +87,7 @@
 			continue
 		if(dormant || P.dormant)//dormant diseases dont interfere with channels, not even with other dormant diseases if you manage to get two
 			continue
-		if(channel == otherchannel && !P.sentient)
-			advance_diseases += P
-		if(IsSame(P))
+		if((IsSame(P) || channel == otherchannel) && !P.sentient)
 			advance_diseases += P
 	var/replace_num = advance_diseases.len + 1 - DISEASE_LIMIT //amount of diseases that need to be removed to fit this one
 	if(replace_num > 0)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -237,32 +237,32 @@
 	stage_rate = 0
 	transmission = 0
 	severity = 0
+	var/c1sev
+	var/c2sev
+	var/c3sev
 	for(var/datum/symptom/S as() in symptoms) 
 		resistance += S.resistance
 		stealth += S.stealth
 		stage_rate += S.stage_speed
 		transmission += S.transmission
-	for(var/datum/symptom/S as() in symptoms) //YES, THIS LOOPS SEVERAL TIMES. YES, IT HAS TO BE THIS WAY AND THERE ISNT REALLY ANY OTHER WAY TO DO IT
+	for(var/datum/symptom/S as() in symptoms) 
 		S.severityset(src)
-	for(var/datum/symptom/S as() in symptoms)//MAKING IT NOT THIS WAY FUCKS UP THE BALANCE OF DISEASE CHANNELS
-		S.severityset(src)
-		if(!S.neutered && S.severity >= 5) //big severity goes first. This means it can be reduced by beneficials, but won't increase from minor symptoms
-			if(severity >= 5)
-				severity += (S.severity -3)//diminishing returns
-			else 
-				severity += S.severity
-	for(var/datum/symptom/S as() in symptoms)//SO DON'T CHANGE IT UNLESS YOU KEEP THE SAME EXACT ORDER OF SEVERITY ADDITION
-		S.severityset(src)
-		if(!S.neutered)
-			switch(S.severity)//these go in the middle. They won't augment large severity diseases, but they can push low ones up to channel 2
-				if(1 to 2)
-					severity= max(severity, min(3, (S.severity + severity)))
-				if(3 to 4)
-					severity = max(severity, min(4, (S.severity + severity)))
-	for(var/datum/symptom/S as() in symptoms) //benign and beneficial symptoms go last
-		S.severityset(src)
-		if(!S.neutered && S.severity <= 0)
-			severity += S.severity
+		if(S.neutered)
+			continue
+		switch(S.severity)
+			if(-INFINITY to 0)
+				c1sev += S.severity
+			if(1 to 2)
+				c2sev= max(c2sev, min(3, (S.severity + c2sev)))
+			if(3 to 4)
+				c2sev = max(c2sev, min(4, (S.severity + c2sev)))
+			if(5 to INFINITY)
+				if(c3sev >= 5)
+					c3sev += (S.severity -3)//diminishing returns
+				else 
+					c3sev += S.severity
+	severity += (max(c2sev, c3sev) + c1sev)
+
 
 // Assign the properties that are in the list.
 /datum/disease/advance/proc/AssignProperties()

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -39,12 +39,11 @@
 	var/sentient = FALSE //used to classify if a disease is sentient
 	var/faltered = FALSE //used if a disease has been made non-contagious
 	// The order goes from easy to cure to hard to cure.
-	var/static/list/advance_cures = list(
-									/datum/reagent/water, /datum/reagent/consumable/ethanol, /datum/reagent/consumable/sodiumchloride,
-									/datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/mine_salve,
-									/datum/reagent/medicine/leporazine, /datum/reagent/concentrated_barbers_aid, /datum/reagent/toxin/lipolicide,
-									/datum/reagent/medicine/haloperidol, /datum/reagent/drug/krokodil
-								)
+	var/mutability = 1
+	var/dormant = FALSE //this prevents a disease from having any effects or spreading
+	var/keepid = FALSE
+	var/archivecure
+	var/static/list/advance_cures = list(list(/datum/reagent/water, /datum/reagent/consumable/nutriment, /datum/reagent/ash, /datum/reagent/iron),list(/datum/reagent/consumable/ethanol, /datum/reagent/uranium/radium, /datum/reagent/oil, /datum/reagent/potassium, /datum/reagent/lithium), list(/datum/reagent/consumable/sodiumchloride, /datum/reagent/drug/nicotine, /datum/reagent/drug/space_drugs),list(/datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/antihol, /datum/reagent/fuel, /datum/reagent/space_cleaner), list(/datum/reagent/medicine/spaceacillin, /datum/reagent/toxin/mindbreaker, /datum/reagent/toxin/itching_powder, /datum/reagent/medicine/cryoxadone, /datum/reagent/medicine/epinephrine), list(/datum/reagent/medicine/mine_salve, /datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/atropine), list(/datum/reagent/medicine/leporazine, /datum/reagent/water/holywater, /datum/reagent/medicine/neurine), list(/datum/reagent/concentrated_barbers_aid, /datum/reagent/drug/happiness, /datum/reagent/medicine/pen_acid), list(/datum/reagent/medicine/haloperidol, /datum/reagent/pax, /datum/reagent/blackpowder, /datum/reagent/medicine/diphenhydramine),list(/datum/reagent/toxin/lipolicide, /datum/reagent/drug/ketamine, /datum/reagent/drug/methamphetamine), list(/datum/reagent/drug/krokodil, /datum/reagent/hair_dye, /datum/reagent/medicine/modafinil))
 /*
 
 	OLD PROCS
@@ -74,14 +73,18 @@
 			if(P.sentient)
 				advance_diseases += P
 			continue
+		if(dormant || P.dormant)//dormant diseases dont interfere with channels, not even with other dormant diseases if you manage to get two
+			continue
 		if(channel == otherchannel && !P.sentient)
+			advance_diseases += P
+		if(IsSame(P))
 			advance_diseases += P
 	var/replace_num = advance_diseases.len + 1 - DISEASE_LIMIT //amount of diseases that need to be removed to fit this one
 	if(replace_num > 0)
 		sortTim(advance_diseases, /proc/cmp_advdisease_resistance_asc)
 		for(var/i in 1 to replace_num)
 			var/datum/disease/advance/competition = advance_diseases[i]
-			if(transmission > competition.resistance)
+			if(transmission > (competition.resistance * 2))
 				competition.cure(FALSE)
 			else
 				return FALSE //we are not strong enough to bully our way in
@@ -100,6 +103,8 @@
 
 // Randomly pick a symptom to activate.
 /datum/disease/advance/stage_act()
+	if(dormant)
+		return
 	..()
 	if(carrier)
 		return
@@ -135,6 +140,7 @@
 	QDEL_LIST(A.symptoms)
 	for(var/datum/symptom/S in symptoms)
 		A.symptoms += S.Copy()
+	A.dormant = dormant
 	A.resistance = resistance
 	A.stealth = stealth
 	A.stage_rate = stage_rate
@@ -142,6 +148,7 @@
 	A.severity = severity
 	A.speed = speed
 	A.id = id
+	A.keepid = keepid
 	A.mutable = mutable
 	A.faltered = faltered
 	//this is a new disease starting over at stage 1, so processing is not copied
@@ -204,7 +211,8 @@
 /datum/disease/advance/proc/Refresh(new_name = FALSE)
 	GenerateProperties()
 	AssignProperties()
-	id = null
+	if(!keepid)
+		id = null
 	var/the_id = GetDiseaseID()
 	if(!SSdisease.archive_diseases[the_id])
 		SSdisease.archive_diseases[the_id] = src // So we don't infinite loop
@@ -226,16 +234,31 @@
 		stealth += S.stealth
 		stage_rate += S.stage_speed
 		transmission += S.transmission
-
 	for(var/datum/symptom/S as() in symptoms)
 		S.severityset(src)
-		if(S.neutered)
-			continue
-		severity += S.severity
+	for(var/datum/symptom/S as() in symptoms)
+		S.severityset(src)
+		if(!S.neutered && S.severity >= 5) //big severity goes first. This means it can be reduced by beneficials, but won't increase from minor symptoms
+			if(severity >= 5)
+				severity += (S.severity -3)//diminishing returns
+			else 
+				severity += S.severity
+	for(var/datum/symptom/S as() in symptoms)
+		S.severityset(src)
+		if(!S.neutered)
+			switch(S.severity)//these go in the middle. They won't augment large severity diseases, but they can push low ones up to channel 2
+				if(1 to 2)
+					severity= max(severity, min(3, (S.severity + severity)))
+				if(3 to 4)
+					severity = max(severity, min(4, (S.severity + severity)))
+	for(var/datum/symptom/S as() in symptoms) //benign and beneficial symptoms go last
+		S.severityset(src)
+		if(!S.neutered && S.severity <= 0)
+			severity += S.severity
 
 // Assign the properties that are in the list.
 /datum/disease/advance/proc/AssignProperties()
-	if(stealth >= 2)
+	if(dormant || stealth >= 2)//dormant diseases dont need to show up for normal docs
 		visibility_flags |= HIDDEN_SCANNER
 	else
 		visibility_flags &= ~HIDDEN_SCANNER
@@ -255,6 +278,9 @@
 	if(faltered)
 		spread_flags = DISEASE_SPREAD_FALTERED
 		spread_text = "Intentional Injection"
+	else if(dormant)
+		spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+		spread_text = "None"
 	else
 		switch(spread_id)
 			if(DISEASE_SPREAD_NON_CONTAGIOUS)
@@ -325,11 +351,13 @@
 // Will generate a random cure, the less resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/GenerateCure()
 	var/res = CLAMP(resistance - (symptoms.len / 2), 1, advance_cures.len)
-	cures = list(advance_cures[res])
+	if(archivecure != res)
+		cures = list(pick(advance_cures[res]))
+		// Get the cure name from the cure_id
+		var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
+		cure_text = D.name
+	archivecure = res
 
-	// Get the cure name from the cure_id
-	var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
-	cure_text = D.name
 
 // Randomly generate a symptom, has a chance to lose or gain a symptom.
 /datum/disease/advance/proc/Evolve(min_level, max_level, ignore_mutable = FALSE)
@@ -395,7 +423,7 @@
 	if(HasSymptom(S))
 		return
 
-	if(!(symptoms.len < (VIRUS_SYMPTOM_LIMIT - 1) + rand(-1, 1)))
+	if(symptoms.len >= VIRUS_SYMPTOM_LIMIT)
 		RemoveSymptom(pick(symptoms))
 	symptoms += S
 	S.OnAdd(src)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -148,7 +148,7 @@
 /datum/disease/advance/Copy()
 	var/datum/disease/advance/A = ..()
 	QDEL_LIST(A.symptoms)
-	for(var/datum/symptom/S in symptoms)
+	for(var/datum/symptom/S as() in symptoms)
 		A.symptoms += S.Copy()
 	A.dormant = dormant
 	A.resistance = resistance

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -132,7 +132,7 @@
 // Tell symptoms stage changed
 /datum/disease/advance/update_stage(new_stage)
 	..()
-	for(var/datum/symptom/S in symptoms)
+	for(var/datum/symptom/S as() in symptoms)
 		S.on_stage_change(new_stage, src)
 
 // Compares type then ID.
@@ -237,23 +237,21 @@
 	stage_rate = 0
 	transmission = 0
 	severity = 0
-	//Why do we need 2 loops here?
-	//First loop just sets stats and second is purely just to set (and get) symptom severity
-	for(var/datum/symptom/S as() in symptoms)
+	for(var/datum/symptom/S as() in symptoms) 
 		resistance += S.resistance
 		stealth += S.stealth
 		stage_rate += S.stage_speed
 		transmission += S.transmission
-	for(var/datum/symptom/S as() in symptoms)
+	for(var/datum/symptom/S as() in symptoms) //YES, THIS LOOPS SEVERAL TIMES. YES, IT HAS TO BE THIS WAY AND THERE ISNT REALLY ANY OTHER WAY TO DO IT
 		S.severityset(src)
-	for(var/datum/symptom/S as() in symptoms)
+	for(var/datum/symptom/S as() in symptoms)//MAKING IT NOT THIS WAY FUCKS UP THE BALANCE OF DISEASE CHANNELS
 		S.severityset(src)
 		if(!S.neutered && S.severity >= 5) //big severity goes first. This means it can be reduced by beneficials, but won't increase from minor symptoms
 			if(severity >= 5)
 				severity += (S.severity -3)//diminishing returns
 			else 
 				severity += S.severity
-	for(var/datum/symptom/S as() in symptoms)
+	for(var/datum/symptom/S as() in symptoms)//SO DON'T CHANGE IT UNLESS YOU KEEP THE SAME EXACT ORDER OF SEVERITY ADDITION
 		S.severityset(src)
 		if(!S.neutered)
 			switch(S.severity)//these go in the middle. They won't augment large severity diseases, but they can push low ones up to channel 2

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -545,7 +545,34 @@
 		message_admins("[key_name_admin(user)] has triggered a custom virus outbreak of [D.admin_details()]")
 		log_virus("[key_name(user)] has triggered a custom virus outbreak of [D.admin_details()]!")
 
+/datum/disease/advance/infect(var/mob/living/infectee, make_copy = TRUE)
+	var/datum/disease/advance/A = make_copy ? Copy() : src
+	if(!initial && A.mutable && (spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS))
+		var/minimum = 1
+		if(prob(CLAMP(35-(A.resistance + A.stealth), 0, 50) * (A.mutability)))//stealthy/resistant diseases are less likely to mutate. this means diseases used to farm mutations should be easier to cure. hypothetically.
+			if(infectee.job == "clown" || infectee.job == "mime" || prob(1))//infecting a clown or mime can evolve l0 symptoms/. they can also appear very rarely
+				minimum = 0
+			else
+				minimum = CLAMP(A.severity - 3, 1, 6)
+			A.Evolve(minimum, CLAMP(A.severity + 4, minimum, 9))
+			A.id = GetDiseaseID()
+			A.keepid = TRUE//this is really janky, but basically mutated diseases count as the original disease
+				//if you want to evolve a higher level symptom you need to test and spread a deadly virus among test subjects. 
+				//this is to give monkey testing a use, and add a bit more of a roleplay element to virology- testing deadly diseases on and curing/vaccinating monkeys
+				//this also adds the risk of disease escape if strict biohazard protocol is not followed, however
+				//the immutability of resistant diseases discourages this with hard-to-cure diseases.
+				//if players intentionally grief/cant seem to get biohazard protocol down, this can be changed to not use severity. 
+	else
+		A.initial = FALSE //diseases *only* mutate when spreading. they wont mutate from any other kind of injection	*/	
+	infectee.diseases += A
+	A.affected_mob = infectee
+	SSdisease.active_diseases += A //Add it to the active diseases list, now that it's actually in a mob and being processed.
 
+	A.after_add()
+	infectee.med_hud_set_status()
+
+	var/turf/source_turf = get_turf(infectee)
+	log_virus("[key_name(infectee)] was infected by virus: [src.admin_details()] at [loc_name(source_turf)]")
 
 
 /datum/disease/advance/proc/random_disease_name(var/atom/diseasesource)//generates a name for a disease depending on its symptoms and where it comes from

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -35,7 +35,7 @@
 			continue
 		if(initial(S.level) > max_level || initial(S.level) < min_level)
 			continue
-		if(initial(S.level) <= 0) //unobtainable symptoms
+		if(initial(S.level) <= -1) //unobtainable symptoms
 			continue
 		possible_symptoms += S
 	for(var/i in 1 to max_symptoms)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -496,9 +496,10 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 			power = 3 //should make this symptom actually worth it
 	var/mob/living/carbon/M = A.affected_mob
 	ownermind = M.mind
-	sizemult = CLAMP((0.5 + A.stage_rate / 10), 1.1, 2.5)
-	M.resize = sizemult
-	M.update_transform()
+	if(!A.carrier && !A.dormant)
+		sizemult = CLAMP((0.5 + A.stage_rate / 10), 1.1, 2.5)
+		M.resize = sizemult
+		M.update_transform()
 
 /datum/symptom/growth/Activate(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -24,10 +24,10 @@ BONUS
 	prefixes = list("Chronic ")
 
 /datum/symptom/viraladaptation/OnAdd(datum/disease/advance/A)
-	A.mutability = 0.5
+	A.mutability -= 0.5
 
 /datum/symptom/viraladaptation/OnRemove(datum/disease/advance/A)
-	A.mutability = 1
+	A.mutability += 0.5
 
 /*
 //////////////////////////////////////
@@ -56,10 +56,10 @@ BONUS
 	prefixes = list("Unstable ")
 
 /datum/symptom/viralevolution/OnAdd(datum/disease/advance/A)
-	A.mutability = 2
+	A.mutability += 2
 
 /datum/symptom/viralevolution/OnRemove(datum/disease/advance/A)
-	A.mutability = 1
+	A.mutability -= 1
 
 /*
 //////////////////////////////////////

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -15,13 +15,19 @@ BONUS
 */
 /datum/symptom/viraladaptation
 	name = "Viral self-adaptation"
-	desc = "The virus mimics the function of normal body cells, becoming harder to spot and to eradicate, but reducing its speed."
+	desc = "The virus mimics the function of normal body cells, becoming harder to spot and to eradicate, but reducing its speed. This symptom discourages disease mutation"
 	stealth = 3
 	resistance = 5
 	stage_speed = -3
 	transmission = 0
 	level = 3
 	prefixes = list("Chronic ")
+
+/datum/symptom/viraladaptation/OnAdd(datum/disease/advance/A)
+	A.mutability = 0.5
+
+/datum/symptom/viraladaptation/OnRemove(datum/disease/advance/A)
+	A.mutability = 1
 
 /*
 //////////////////////////////////////
@@ -41,13 +47,19 @@ BONUS
 /datum/symptom/viralevolution
 	name = "Viral evolutionary acceleration"
 	desc = "The virus quickly adapts to spread as fast as possible both outside and inside a host. \
-	This, however, makes the virus easier to spot, and less able to fight off a cure."
+	This, however, makes the virus easier to spot, and less able to fight off a cure. This symptom encourages disease mutation"
 	stealth = -2
 	resistance = -3
 	stage_speed = 5
 	transmission = 3
 	level = 3
 	prefixes = list("Unstable ")
+
+/datum/symptom/viralevolution/OnAdd(datum/disease/advance/A)
+	A.mutability = 2
+
+/datum/symptom/viralevolution/OnRemove(datum/disease/advance/A)
+	A.mutability = 1
 
 /*
 //////////////////////////////////////

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -26,7 +26,7 @@
 	. = ..()
 	icon_state = "[icon_state]-old" //change from the normal blood icon selected from random_icon_states in the parent's Initialize to the old dried up blood.
 	if(prob(75))
-		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), 9, 4)
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(1, 4), rand(4, 9), 4)
 		disease += R
 
 /obj/effect/decal/cleanable/blood/old/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)
@@ -143,7 +143,7 @@
 	icon_state += "-old"
 	add_blood_DNA(list("Non-human DNA" = random_blood_type()))
 	if(prob(80))
-		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), 9, 4)
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), rand(8, 9), 4)
 		disease += R
 
 /obj/effect/decal/cleanable/blood/gibs/old/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -150,7 +150,7 @@
 	. = ..()
 	icon_state += "-old"
 	if(prob(95))//vomit is much more likely to be diseased than blood is
-		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), 9, 4, infected = src)
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(2, 5), rand(7, 9), 4, infected = src)
 		disease += R
 
 /obj/effect/decal/cleanable/vomit/old/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -966,10 +966,16 @@ GENE SCANNER
 			var/datum/disease/advance/A = D
 			if(A.stealth >= (2 + scanner.rating)) //the extrapolator can detect diseases of higher stealth than a normal scanner
 				continue
-			to_chat(user, "<span class='info'><font color='green'><b>[A.name]</b>, stage [A.stage]/5</font></span>")
-			to_chat(user, "<span class='info'><b>[A] has the following symptoms:</b></span>")
-			for(var/datum/symptom/S in A.symptoms)
-				to_chat(user, "<span class='info'>[S.name]</span>")
+			if(A.dormant)
+				to_chat(user, "<span class='info'><font color='A19D9C'><b>[A.name]</b>, dormant virus</font></span>")
+				to_chat(user, "<span class='info'><font color='BAB9B9'><b>[A] has the following symptoms:</b></font></span>")
+				for(var/datum/symptom/S in A.symptoms)
+					to_chat(user, "<span class='info'><font color='BAB9B9'>[S.name]</font></span>")
+			else
+				to_chat(user, "<span class='info'><font color='green'><b>[A.name]</b>, stage [A.stage]/5</font></span>")
+				to_chat(user, "<span class='info'><b>[A] has the following symptoms:</b></span>")
+				for(var/datum/symptom/S in A.symptoms)
+					to_chat(user, "<span class='info'>[S.name]</span>")
 		else
 			to_chat(user, "<span class='info'><font color='green'><b>[D.name]</b>, stage [D.stage]/[D.max_stages].</font></span>")
 

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -992,7 +992,7 @@ GENE SCANNER
 		return
 	var/datum/disease/advance/A = input(user,"What disease do you wish to extract") in null|advancediseases
 	if(isolate)
-		for(var/datum/symptom/S in A.symptoms)
+		for(var/datum/symptom/S as() in A.symptoms)
 			if(S.level <= 6 + scanner.rating)
 				symptoms += S
 			continue

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -992,7 +992,7 @@ GENE SCANNER
 		return
 	var/datum/disease/advance/A = input(user,"What disease do you wish to extract") in null|advancediseases
 	if(isolate)
-		for(var/datum/symptom/S as() in A.symptoms)
+		for(var/datum/symptom/S in A.symptoms)
 			if(S.level <= 6 + scanner.rating)
 				symptoms += S
 			continue

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -17,7 +17,6 @@
 
 	var/gps = null
 	var/obj/effect/light_emitter/tendril/emitted_light
-	var/list/necroseed = list()
 
 
 /obj/structure/spawner/lavaland/goliath
@@ -34,17 +33,6 @@ GLOBAL_LIST_INIT(tendrils, list())
 		M.ScrapeAway(null, CHANGETURF_IGNORE_AIR)
 	AddComponent(/datum/component/gps, "Eerie Signal")
 	GLOB.tendrils += src
-	var/datum/disease/advance/random/necropolis/R = new
-	necroseed += R
-
-/obj/structure/spawner/lavaland/extrapolator_act(mob/user, obj/item/extrapolator/E, scan = TRUE)
-	if(!necroseed.len)
-		return FALSE
-	if(scan)
-		E.scan(src, necroseed, user)
-	else
-		E.extrapolate(src, necroseed, user)
-	return TRUE
 
 /obj/structure/spawner/lavaland/deconstruct(disassembled)
 	new /obj/effect/collapse(loc)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -209,7 +209,7 @@
 
 	if(!visualsOnly && announce)
 		announce(H)
-	dormantdiseasecheck(H)
+	dormant_disease_check(H)
 
 /datum/job/proc/get_access()
 	if(!config)	//Needed for robots.
@@ -350,8 +350,8 @@
 
 //why is this as part of a job? because it's something every human recieves at roundstart after all other initializations and factors job in. it fits best with the equipment proc
 //this gives a dormant disease for the virologist to check for. if this disease actually does something to the mob... call me, or your local coder
-/datum/job/proc/dormantdiseasecheck(mob/living/carbon/human/H)
-	var/datum/symptom/guaranteed = null
+/datum/job/proc/dormant_disease_check(mob/living/carbon/human/H)
+	var/datum/symptom/guaranteed
 	var/sickrisk = 1
 	var/unfunny = TRUE
 	if((flag == CLOWN) || (flag == MIME))

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -73,6 +73,8 @@
 	var/random_spawns_possible = TRUE
 	/// Should this job be allowed to be picked for the bureaucratic error event?
 	var/allow_bureaucratic_error = TRUE
+	///how at risk is this occupation at for being a carrier of a dormant disease
+	var/biohazard = 10
 
 	///A dictionary of species IDs and a path to the outfit.
 	var/list/species_outfits = null
@@ -207,6 +209,7 @@
 
 	if(!visualsOnly && announce)
 		announce(H)
+	dormantdiseasecheck(H)
 
 /datum/job/proc/get_access()
 	if(!config)	//Needed for robots.
@@ -344,3 +347,32 @@
 	if(CONFIG_GET(flag/security_has_maint_access))
 		return list(ACCESS_MAINT_TUNNELS)
 	return list()
+
+//why is this as part of a job? because it's something every human recieves at roundstart after all other initializations and factors job in. it fits best with the equipment proc
+//this gives a dormant disease for the virologist to check for. if this disease actually does something to the mob... call me, or your local coder
+/datum/job/proc/dormantdiseasecheck(mob/living/carbon/human/H)
+	var/datum/symptom/guaranteed = null
+	var/sickrisk = 1
+	var/unfunny = TRUE
+	if((flag == CLOWN) || (flag == MIME))
+		unfunny= FALSE
+	if(islizard(H) || iscatperson(H))
+		sickrisk += 0.5 //these races like eating diseased mice, ew
+	if(MOB_INORGANIC in H.mob_biotypes)
+		sickrisk -= 0.5
+		guaranteed = /datum/symptom/inorganic_adaptation
+	else if(MOB_ROBOTIC in H.mob_biotypes)
+		sickrisk -= 0.75
+		guaranteed = /datum/symptom/robotic_adaptation
+	else if(MOB_UNDEAD in H.mob_biotypes)//this doesnt matter if it's not halloween, but...
+		sickrisk -= 0.25
+		guaranteed = /datum/symptom/undead_adaptation
+	else if(!(MOB_ORGANIC in H.mob_biotypes))
+		return //this mob cant be given a disease
+	if(prob(biohazard * sickrisk))
+		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(1, 4), rand(1, 9), unfunny, guaranteed)
+		scandisease.dormant = TRUE
+		scandisease.spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+		scandisease.spread_text = "None"
+		scandisease.visibility_flags |= HIDDEN_SCANNER
+		H.ForceContractDisease(scandisease)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -370,7 +370,7 @@
 	else if(!(MOB_ORGANIC in H.mob_biotypes))
 		return //this mob cant be given a disease
 	if(prob(biohazard * sickrisk))
-		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(1, 4), rand(1, 9), unfunny, guaranteed)
+		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(1, 4), rand(1, 9), unfunny, guaranteed, infected = H)
 		scandisease.dormant = TRUE
 		scandisease.spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 		scandisease.spread_text = "None"

--- a/code/modules/jobs/job_types/brigphys.dm
+++ b/code/modules/jobs/job_types/brigphys.dm
@@ -26,6 +26,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/secmed
 	)
+	biohazard = 15 //still deals with the sick and injured, just less than a medical doctor
+
 /datum/outfit/job/brig_phys
 	name = "Brig Physician"
 	jobtype = /datum/job/brig_phys

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -23,6 +23,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/cargo
 	)
+	biohazard = 15
+
 /datum/outfit/job/cargo_tech
 	name = "Cargo Technician"
 	jobtype = /datum/job/cargo_tech

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -25,6 +25,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/chemist
 	)
+	biohazard = 15
+
 /datum/outfit/job/chemist
 	name = "Chemist"
 	jobtype = /datum/job/chemist

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -34,6 +34,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/cmo
 	)
+	biohazard = 20
 
 /datum/outfit/job/cmo
 	name = "Chief Medical Officer"

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -23,6 +23,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/curator
 	)
+	biohazard = 5 //he doesnt get out much
+
 /datum/outfit/job/curator
 	name = "Curator"
 	jobtype = /datum/job/curator

--- a/code/modules/jobs/job_types/emt.dm
+++ b/code/modules/jobs/job_types/emt.dm
@@ -27,6 +27,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/emt
 	)
+	biohazard = 25//deal with sick like MDS, but also muck around in maint and get into the thick of it
+
 /datum/outfit/job/emt
 	name = "Paramedic"
 	jobtype = /datum/job/emt

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -23,6 +23,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/exploration
 	)
+	biohazard = 20//who knows what you'll find out there that could have nasties on it...
 
 /datum/job/exploration/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source)
 	if(outfit_override)

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -25,6 +25,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/genetics
 	)
+	biohazard = 15
+
 /datum/outfit/job/geneticist
 	name = "Geneticist"
 	jobtype = /datum/job/geneticist

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -87,6 +87,7 @@
 	gimmick = TRUE
 	chat_color = "#929292"
 	departments = NONE		//being hobo is not a real job
+	biohazard = 50 //hobos are very likely to have diseases 
 
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/hobo

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -19,6 +19,8 @@
 
 	display_order = JOB_DISPLAY_ORDER_JANITOR
 	departments = DEPARTMENT_SERVICE
+	
+	biohazard = 20//cleaning up hazardous messes puts janitors at extra risk
 
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/janitor

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -25,6 +25,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/medical
 	)
+	biohazard = 20
 
 /datum/outfit/job/doctor
 	name = "Medical Doctor"

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -38,6 +38,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/rd
 	)
+	biohazard = 20
+
 /datum/outfit/job/rd
 	name = "Research Director"
 	jobtype = /datum/job/rd

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -27,6 +27,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/science
 	)
+	biohazard = 15
 
 /datum/outfit/job/scientist
 	name = "Scientist"

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -31,6 +31,8 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/security
 	)
+	biohazard = 15 //clean your baton, man
+
 /datum/job/officer/get_access()
 	var/list/L = list()
 	L |= ..() | check_config_for_sec_maint()

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -26,6 +26,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/viro
 	)
+	biohazard = 50 //duh
 
 /datum/outfit/job/virologist
 	name = "Virologist"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -41,7 +41,7 @@
 	icon_dead = "mouse_[body_color]_dead"
 	held_state = "mouse_[body_color]"
 	if(prob(75))
-		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), 9, rand(3,4), infected = src)
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(1, 6), rand(5, 9), rand(3,4), infected = src)
 		ratdisease += R
 
 /mob/living/simple_animal/mouse/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)


### PR DESCRIPTION
## About The Pull Request
changes several core aspects of virology.
-nerfs maint diseases
-some crew now occasionally spawn with dormant diseases the virologist can extract via extrapolator or blood sample. this encourages the virologist to collect blood samples and data from the crew, instead of crawling through maint and then spending the rest of the shift in virology
-diseases now have a chance to mutate when they're transmitted. this scales inversely with stealth and resistance, and the level of the symptom mutated depends on severity- the more severe, the higher the symptom level. the end result of this change is that viro is encouraged to test deadly, contagious, but easy to cure viruses on monkeys. this means there is now a reason to follow biohazard SOP as virologist, or when entering the virology lab. this also adds engagement with science, cargo, genetics, and chemistry, whether to cure your old monkeys or get new ones- mutated viruses count as the same disease, so curing them immunizes them to that virus
Edit: people are freaking out cuz i forgot to add that adding cryostylane to a disease means it wont mutate.   Relax.
-removes the tedium balancing involved in adding the last few symptoms to a disease. all it is is a 2-5 minute time-tax
-adds randomized virus cures
-some misc fixes (see changelog. if dirty syringe disease transfer was removed intentionally, i'll modularize it out into a different pr)

## Why It's Good For The Game
my rationalization was in the above description. this change is primarily geared towards crew engagement.
also has a few fixes, see changelog

## Changelog
:cl:
add: diseases can now mutate new symptoms when transmitted between hosts
add: crew can now spawn with dormant viruses, which a virologist can extract with an extrapolator or blood sample
add: adds randomized virus cures
tweak: nerfs maintenance diseases to compensate for the above disease extraction methods
tweak: removes RNG involved in the fourth, fifth, and sixth symptoms added to a virus
fix: fixes a bug when determining severity of a severity 5 symptom
fix: syringes now properly interact with extrapolators
fix: dirty syringes now transfer diseases again. yay?
fix: fixes disease severity calculations that got stealth removed.
/:cl:

