### PR TITLE
deep frying nonfoods is no longer a qdel v2

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -245,20 +245,21 @@
 	item_flags = fried.item_flags
 	obj_flags = fried.obj_flags
 
+	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_batter)
+
 	if(istype(fried, /obj/item/reagent_containers/food/snacks))
 		fried.reagents.trans_to(src, fried.reagents.total_volume)
 		qdel(fried)
 	else
 		fried.forceMove(src)
 
-/obj/item/reagent_containers/food/snacks/deepfryholder/Destroy()
-	if(contents)
-		QDEL_LIST(contents)
-	. = ..()
+/obj/item/reagent_containers/food/snacks/deepfryholder/proc/clean_batter()
+	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
 	if(contents)
-		QDEL_LIST(contents)
+		for(var/atom/movable/A in contents)
+			A.forceMove(eater.loc)
 	..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -256,6 +256,10 @@
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/clean_batter()
 	qdel(src)
 
+/obj/item/reagent_containers/food/snacks/deepfryholder/Destroy()
+	UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
+	. = ..()
+
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
 	if(contents)
 		for(var/atom/movable/A in contents)


### PR DESCRIPTION

## About The Pull Request
this pr was denied through a qwerty moment about a year ago, even though most devs were in agreeance on it
https://github.com/BeeStation/BeeStation-Hornet/pull/2624
lets try it again

## Why It's Good For The Game
deepfrying is a wayyyy to easily done way to qdel an item, and doesn't even check resistance flags

## Changelog
:cl:
del: removes deepfrying items to destroy them. you can now eat them out of the crust, or just clean them off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
