### PR TITLE
Exosuit Fab Ore Silo Fix

### DIFF
--- a/code/game/machinery/fabricators/exosuit_fab.dm
+++ b/code/game/machinery/fabricators/exosuit_fab.dm
@@ -13,7 +13,6 @@
 	output_direction = SOUTH
 
 	remote_materials = TRUE
-	auto_link = TRUE
 	can_sync = TRUE
 	can_print_category = TRUE
 


### PR DESCRIPTION
Exosuit Fabricators are no longer linked to the default silo on build

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Exosuit fabricators no longer automatically link to the default silo network on build.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
