### PR TITLE
death nettle nerf

### DIFF
--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -103,7 +103,8 @@
 			to_chat(user, "<span class='userdanger'>You are stunned by [src] as you try picking it up!</span>")
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/M, mob/user)
-	if(M.can_inject(user))
+	if(!M.can_inject(user) && user.a_intent == INTENT_HARM)
+		to_chat(user, "<span class='warning'>The [src] harmlessly bounces off of [M]! They're protected from its needles!</span>")
 		return FALSE
 	else
 		return ..()

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -11,7 +11,7 @@
 	growthstages = 5
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy)
 	mutatelist = list(/obj/item/seeds/nettle/death)
-	reagents_add = list(/datum/reagent/toxin/acid = 0.5)
+	reagents_add = list(/datum/reagent/toxin/acid = 0.25)
 
 /obj/item/seeds/nettle/death
 	name = "pack of death-nettle seeds"
@@ -25,7 +25,7 @@
 	yield = 2
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/stinging)
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.5, /datum/reagent/toxin/acid = 0.5)
+	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.25)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/nettle // "snack"
@@ -88,12 +88,13 @@
 	name = "deathnettle"
 	desc = "The <span class='danger'>glowing</span> nettle incites <span class='boldannounce'>rage</span> in you just from looking at it!"
 	icon_state = "deathnettle"
-	force = 30
-	throwforce = 15
+	force = 25
+	throwforce = 12
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/add_juice()
 	..()
-	force = round((5 + seed.potency / 2.5), 1)
+	force = round((5 + seed.potency / 5), 1)
+	throwforce = round((2 + seed.potency / 10), 1)
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/pickup(mob/living/carbon/user)
 	if(..())
@@ -101,15 +102,8 @@
 			user.Paralyze(100)
 			to_chat(user, "<span class='userdanger'>You are stunned by [src] as you try picking it up!</span>")
 
-/obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/carbon/M, mob/user)
-	if(!..())
-		return
-	if(isliving(M))
-		to_chat(M, "<span class='danger'>You are stunned by the powerful acid of [src]!</span>")
-		log_combat(user, M, "attacked", src)
-
-		M.adjust_blurriness(force/7)
-		if(prob(20))
-			M.Unconscious(force / 0.3)
-			M.Paralyze(force / 0.75)
-		M.drop_all_held_items()
+/obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/M, mob/user)
+	if(M.can_inject(user)
+		return FALSE
+	else
+		return ..()

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -103,7 +103,7 @@
 			to_chat(user, "<span class='userdanger'>You are stunned by [src] as you try picking it up!</span>")
 
 /obj/item/reagent_containers/food/snacks/grown/nettle/death/attack(mob/living/M, mob/user)
-	if(M.can_inject(user)
+	if(M.can_inject(user))
 		return FALSE
 	else
 		return ..()


### PR DESCRIPTION
## About The Pull Request
death nettle has been nerfed to be at a more station-centric power level- at max potency, it is a fireaxe sidegrade with 25 damage and 12 throwforce, one handed, that cannot penetrate thick clothing, and no random stun
both nettles have had their acid levels nerfed by half as well, due to how easy to produce they are

## Why It's Good For The Game
death nettles have up to 45 damage, 20% chance to stun, and 100% chance to drop all items on hit at the moment, as well as being thrown to apply massive amounts (up to around 50) of fluorosulfiric acid, all while being able to be produced in massive numbers by botanists. this brings them down to non-antag station levels. 

if this is too much of a nerf, ill take feedback from maintainers

## Changelog
:cl:
balance: nerfs death nettles. they are now no more powerful than a fire axe
/:cl:
