### PR TITLE
Makes ash heretic immune to fire

### DIFF
--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -11,7 +11,11 @@
 
 /datum/eldritch_knowledge/base_ash/on_gain(mob/user)
 	. = ..()
-	ADD_TRAIT( user, TRAIT_NOFIRE,MAGIC_TRAIT)
+	ADD_TRAIT( user, TRAIT_NOFIRE, MAGIC_TRAIT)
+
+/datum/eldritch_knowledge/base_ash/on_lose(mob/user)
+	. = ..()
+	REMOVE_TRAIT( user, TRAIT_NOFIRE, MAGIC_TRAIT)
 
 /datum/eldritch_knowledge/spell/ashen_shift
 	name = "Ashen Shift"

--- a/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/ash_lore.dm
@@ -9,6 +9,10 @@
 	cost = 1
 	route = PATH_ASH
 
+/datum/eldritch_knowledge/base_ash/on_gain(mob/user)
+	. = ..()
+	ADD_TRAIT( user, TRAIT_NOFIRE,MAGIC_TRAIT)
+
 /datum/eldritch_knowledge/spell/ashen_shift
 	name = "Ashen Shift"
 	gain_text = "The Nightwatcher was the first of them, his treason started it all."
@@ -108,7 +112,7 @@
 	required_atoms = list(/mob/living/carbon/human)
 	cost = 3
 	route = PATH_ASH
-	var/list/trait_list = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_NOFIRE,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
+	var/list/trait_list = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER)
 
 /datum/eldritch_knowledge/final/ash_final/on_finished_recipe(mob/living/user, list/atoms, loc)
 	priority_announce("$^@&#*$^@(#&$(@&#^$&#^@# Fear the blaze, for the Ashlord, [user.real_name] has ascended! The flames shall consume all! $^@&#*$^@(#&$(@&#^$&#^@#","#$^@&#*$^@(#&$(@&#^$&#^@#", ANNOUNCER_SPANOMALIES)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes ash path heretic immune to being set on fire
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People always bump into you in combat and end up seting you on fire as well which makes ash abilities allowing you to set others on fire a hinderance rather than uselfull ability. This tiny PR fixes it
## Changelog
:cl:
tweak: Ash heretics immune to being set on fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
