### PR TITLE
Changeling snakes adjustement

### DIFF
--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -87,8 +87,8 @@
 	icon_living = "snake"
 	del_on_death = TRUE
 	speak_emote = list("gargles")
-	health = 40
-	maxHealth = 40
+	health = 35
+	maxHealth = 35
 	melee_damage = 3
 	attacktext = "bites"
 	response_help  = "pokes"

--- a/code/modules/antagonists/changeling/powers/regenerate.dm
+++ b/code/modules/antagonists/changeling/powers/regenerate.dm
@@ -80,15 +80,15 @@
 	snek.faction |= "[REF(C)]"
 	return TRUE
 
-/mob/living/simple_animal/hostile/poison/limbsnake
+/mob/living/simple_animal/hostile/poison/limbsnake //its venom, not poison
 	name = "limb snake"
 	desc = "This is no snake at all! It looks like someone's limb grew fangs out of it's fingers and it's out to bite anyone!"
 	icon_state = "snake"
 	icon_living = "snake"
 	del_on_death = TRUE
 	speak_emote = list("gargles")
-	health = 50
-	maxHealth = 50
+	health = 40
+	maxHealth = 40
 	melee_damage = 3
 	attacktext = "bites"
 	response_help  = "pokes"
@@ -104,6 +104,6 @@
 	chat_color = "#26F55A"
 	mobchatspan = "chaplain"
 	faction = list("hostile","creature")
-	poison_per_bite = 4
+	poison_per_bite = 2
 	poison_type = /datum/reagent/toxin/staminatoxin
 	discovery_points = 1000


### PR DESCRIPTION
## About The Pull Request

goddamn snakes (actually vipers)

## Why It's Good For The Game

50 health snakes with 4 tirizene per bite are overkill, with the new values they're still potent while not a I-WIN button
having 60-100 units of tirizene injected in a very short period of time is a fuckton
quick overview of how much that is.
Tirizene
Deals stamina damage over time, slowing down and causing collapse in large doses, but otherwise harmless. 
This will basically disable you in these doses, but for how long?
Lets calculate that really quickly
0.4 units per tick (every tick is about 2 seconds)
100/0.4=250(ticks)
250 ticks equals 500 seconds (usually more than that depending on time dillation)
500 seconds equals to about 8 and a half minutes of you being hopelessly fucked over for 15 changeling chems.

## Changelog
:cl:
balance: changeling snake venom per bite is now 2 (from 4), health reduced to 35 (from 50)
/:cl:

i ded pls nerf