### PR TITLE
Minor mapping fixes for Box & Pubby

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -31796,9 +31796,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bOz" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -34219,6 +34219,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
+	req_access_txt = "30";
 	security_level = 6
 	},
 /obj/machinery/door/firedoor,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the extra light switch from Box's research lab
![image](https://user-images.githubusercontent.com/26130695/138555909-699e24eb-a48d-4cb4-83cf-9f91c9c35ca2.png)

Also re-adds the access requirements to Pubby's RD office

## Why It's Good For The Game

Access to the RD's office should be restricted... As for the light switch.. Well, it was bothering me.

## Changelog
:cl:
fix: Removed the extra light switch from Box Station's research lab
fix: Re-added the access requirement to Pubby's RD office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
