### PR TITLE
fix layer manifold runtime on destroy()

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -7,7 +7,7 @@
 	initialize_directions = NORTH|SOUTH
 	pipe_flags = PIPING_ALL_LAYER | PIPING_DEFAULT_LAYER_ONLY | PIPING_CARDINAL_AUTONORMALIZE
 	piping_layer = PIPING_LAYER_DEFAULT
-	device_type = 8 //260 isn't divisible by 35 bull this is 280L
+	device_type = 0
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "manifoldlayer"
 	FASTDMM_PROP(\
@@ -19,6 +19,7 @@
 	var/list/back_nodes
 
 /obj/machinery/atmospherics/pipe/layer_manifold/Initialize()
+	volume = 280 //260 isn't divisible by 35 bull this is 280L
 	front_nodes = list()
 	back_nodes = list()
 	icon_state = "manifoldlayer_center"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

## Why It's Good For The Game

device_type is 0 because layer manifolds uses a different node system, and there's no actual air nodes. the runtime came from member access of node elements that doesn't exist, indexed by device_type. 

## Changelog
:cl:
fix: fixed layer manifold runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
