### PR TITLE
Minor Config reorganization, Brig Door Timer Config

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -259,6 +259,7 @@
 #include "code\controllers\configuration\entries\comms.dm"
 #include "code\controllers\configuration\entries\dbconfig.dm"
 #include "code\controllers\configuration\entries\game_options.dm"
+#include "code\controllers\configuration\entries\game_tweaks.dm"
 #include "code\controllers\configuration\entries\general.dm"
 #include "code\controllers\configuration\entries\resources.dm"
 #include "code\controllers\subsystem\acid.dm"

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -70,8 +70,6 @@
 
 /datum/config_entry/flag/disable_peaceborg
 
-/datum/config_entry/flag/economy	//money money money money money money money money money money money money
-
 /datum/config_entry/flag/donator_items 	// do you need to be a donator to use donator items
 
 /datum/config_entry/number/traitor_scaling_coeff	//how much does the amount of players get divided by to determine traitors
@@ -439,11 +437,6 @@
 	config_entry_value = 100
 /datum/config_entry/number/max_slimeperson_bodies
 	config_entry_value = 10
-
-//Maximum citation fine
-/datum/config_entry/number/maxfine
-	config_entry_value = 1000
-	min_val = 0
 
 
 //Shuttle size limiter

--- a/code/controllers/configuration/entries/game_tweaks.dm
+++ b/code/controllers/configuration/entries/game_tweaks.dm
@@ -1,0 +1,20 @@
+//Maximum citation fine
+/datum/config_entry/number/maxfine
+	config_entry_value = 1000
+	min_val = 0
+
+/datum/config_entry/number/brig_timer_max
+	config_entry_value = 15
+	min_val = 1
+
+/datum/config_entry/number/brig_timer_preset_short
+	config_entry_value = 2
+	min_val = 1
+
+/datum/config_entry/number/brig_timer_preset_med
+	config_entry_value = 3
+	min_val = 1
+
+/datum/config_entry/number/brig_timer_preset_long
+	config_entry_value = 5
+	min_val = 1

--- a/code/controllers/configuration/entries/game_tweaks.dm
+++ b/code/controllers/configuration/entries/game_tweaks.dm
@@ -3,6 +3,7 @@
 	config_entry_value = 1000
 	min_val = 0
 
+//Brig timer limits and presets, in minutes
 /datum/config_entry/number/brig_timer_max
 	config_entry_value = 15
 	min_val = 1

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -2,11 +2,8 @@
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
 #define FONT_STYLE "Small Fonts"
-#define MAX_TIMER 15 MINUTES
 
-#define PRESET_SHORT 2 MINUTES
-#define PRESET_MEDIUM 3 MINUTES
-#define PRESET_LONG 5 MINUTES
+
 
 
 
@@ -167,7 +164,7 @@
 		. /= 10
 
 /obj/machinery/door_timer/proc/set_timer(value)
-	var/new_time = clamp(value,0,MAX_TIMER)
+	var/new_time = clamp(value,0,CONFIG_GET(number/brig_timer_max) MINUTES)
 	. = new_time == timer_duration //return 1 on no change
 	timer_duration = new_time
 
@@ -287,11 +284,11 @@
 			var/preset_time = time_left()
 			switch(preset)
 				if("short")
-					preset_time = PRESET_SHORT
+					preset_time = CONFIG_GET(number/brig_timer_preset_short) MINUTES
 				if("medium")
-					preset_time = PRESET_MEDIUM
+					preset_time = CONFIG_GET(number/brig_timer_preset_med) MINUTES
 				if("long")
-					preset_time = PRESET_LONG
+					preset_time = CONFIG_GET(number/brig_timer_preset_long) MINUTES
 			. = !set_timer(preset_time)
 			investigate_log("[key_name(usr)] set cell [id]'s timer to [preset_time/10] seconds", INVESTIGATE_RECORDS)
 			user.log_message("set cell [id]'s timer to [preset_time/10] seconds", LOG_ATTACK)
@@ -302,11 +299,7 @@
 
 
 
-#undef PRESET_SHORT
-#undef PRESET_MEDIUM
-#undef PRESET_LONG
 
-#undef MAX_TIMER
 #undef FONT_SIZE
 #undef FONT_COLOR
 #undef FONT_STYLE

--- a/config/config.txt
+++ b/config/config.txt
@@ -1,9 +1,19 @@
+# This file controls basic or highly important, but not strictly gameplay related options.
+
+
 # You can use the "$include" directive to split your configs however you want
 
+# Core gameplay options
 $include game_options.txt
+# More opinionated gameplay tweaks
+$include gameplay_tweaks.txt
+# Database (SQL), Sensitive stuff
 $include dbconfig.txt
+# Cross-Server Communications
 $include comms.txt
+# Antag Reputation (Alternative weighting)
 $include antag_rep.txt
+# Asset Transport (TGUI)
 $include resources.txt
 
 # You can use the @ character at the beginning of a config option to lock it from being edited in-game

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -613,12 +613,6 @@ RANDOMIZE_SHIFT_TIME
 ## Sets shift time to server time at roundstart. Overridden by RANDOMIZE_SHIFT_TIME ##
 #SHIFT_TIME_REALTIME
 
-## Maximum fine for a citation
-MAXFINE 2000
-
-## Enable the capitalist agenda on your server.
-ECONOMY
-
 ## Crew objectives
 ALLOW_CREW_OBJECTIVES
 

--- a/config/gameplay_tweaks.txt
+++ b/config/gameplay_tweaks.txt
@@ -1,0 +1,11 @@
+#Heavily opinionated or otherwise tweakable configs related to gameplay.
+
+## Maximum fine for a citation
+MAXFINE 2000
+
+## Brig timers, In minutes.
+
+BRIG_TIMER_MAX 20
+BRIG_TIMER_PRESET_SHORT 5
+BRIG_TIMER_PRESET_MED 10
+BRIG_TIMER_PRESET_LONG 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: Brig timer presets and max durations can be modified in the config
config: The economy flag hasn't done anything for over a year, and has been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
