### PR TITLE
1% chance for Todd-Sie to spawn instead of Nar-Sie when summoned

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -507,7 +507,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 		var/obj/structure/destructible/clockwork/massive/celestial_gateway/gateway = GLOB.celestial_gateway
 		gateway.open_gateway()
 	else
-		new /obj/singularity/narsie/large/cult(T) //Causes Nar'Sie to spawn even if the rune has been removed
+		if(prob(99))
+			new /obj/singularity/narsie/large/cult(T) //Causes Nar'Sie to spawn even if the rune has been removed
+		else
+			new /obj/singularity/narsie/large/cult/toddsie(T)
 
 /obj/effect/rune/narsie/attackby(obj/I, mob/user, params)	//Since the narsie rune takes a long time to make, add logging to removal.
 	if((istype(I, /obj/item/melee/cultblade/dagger) && iscultist(user)))

--- a/code/modules/power/singularity/toddsie.dm
+++ b/code/modules/power/singularity/toddsie.dm
@@ -28,3 +28,25 @@
 		to_chat(target, "<span class ='cult'>TODD'SIE HUNGERS FOR YOUR SOUL.</span>")
 	else
 		to_chat(target, "<span class ='cult'>TODD'SIE HAS CHOSEN YOU TO LEAD HIM TO HIS NEXT MEAL.</span>")
+
+/obj/singularity/narsie/large/cult/toddsie
+	name = "Todd'Sie's Avatar"
+	icon = 'icons/obj/toddsie.dmi'
+	desc = "Your mind begins to bubble and ooze as it tries to comprehend what it sees. You realize for some reason you want to buy Skyrim."
+	pixel_x = -236
+	pixel_y = -256
+	current_size = 12
+	grav_pull = 10
+	consume_range = 12 //How many tiles out do we eat
+
+/obj/singularity/narsie/toddsie/Initialize()
+	. = ..()
+	send_to_playing_players("<span class='narsie'>TODD'SIE HAS RISEN. BUY. SKYRIM.</span>")
+	sound_to_playing_players('sound/creatures/narsie_rises.ogg')
+
+	var/area/A = get_area(src)
+	if(A)
+		var/mutable_appearance/alert_overlay = mutable_appearance('icons/effects/cult_effects.dmi', "ghostalertsie")
+		notify_ghosts("Todd'Sie has risen in \the [A.name]. Reach out to the Geometer to be given a new shell for your soul.", source = src, alert_overlay = alert_overlay, action=NOTIFY_ATTACK)
+	INVOKE_ASYNC(src, .proc/narsie_spawn_animation)
+	UnregisterSignal(src, COMSIG_ATOM_BSA_BEAM)

--- a/code/modules/power/singularity/toddsie.dm
+++ b/code/modules/power/singularity/toddsie.dm
@@ -39,7 +39,7 @@
 	grav_pull = 10
 	consume_range = 12 //How many tiles out do we eat
 
-/obj/singularity/narsie/toddsie/Initialize()
+/obj/singularity/narsie/large/cult/toddsie/Initialize()
 	. = ..()
 	send_to_playing_players("<span class='narsie'>TODD'SIE HAS RISEN. BUY. SKYRIM.</span>")
 	sound_to_playing_players('sound/creatures/narsie_rises.ogg')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's basically what's said in the title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The crew needs to be reminded to sink cash into our favorite person in the whole wide world.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Phil Smith
tweak: 1% chance for Todd-Sie to spawn instead of Nar-Sie when the blood cult completes the summoning ritual.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
