### PR TITLE
Fixes people being stuck in limbo if they fall out a transit with no jetpack

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -79,7 +79,7 @@ SUBSYSTEM_DEF(mapping)
 	// and one level with no ruins
 	for (var/i in 1 to config.space_empty_levels)
 		++space_levels_so_far
-		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED), orbital_body_type = /datum/orbital_object/z_linked/beacon/weak)
+		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = SELFLOOPING), orbital_body_type = /datum/orbital_object/z_linked/beacon/weak)
 	// and the transit level
 	transit = add_new_zlevel("Transit/Reserved", list(ZTRAIT_RESERVED = TRUE))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is an empty z-level called "Weak Signal" on the orbit map. There is literally nothing there. Stuff usually falls in there if it falls out of the shuttle. It should have been looping onto other z-levels, but since there are no other z-levels crosslooping, it was trying to loop into nullspace. This is bad, because if you got pinned to a wall, or, God forbid, corner and had no jetpack/fire extinguisher/RCD/materials to make walls to push off, then you were stuck there for good. This PR fixes it by looping the level onto itself.
Tested, works on my machine™.

## Why It's Good For The Game

Being stuck in limbo is bad, lmao

## Changelog
:cl:
fix: People no longer get stuck on walls of an empty z-level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
