### PR TITLE
Fixes fairygrass shuttle floor issue

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -85,6 +85,9 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(requires_activation)
 		CALCULATE_ADJACENT_TURFS(src)
 
+	if(color)
+		add_atom_colour(color, FIXED_COLOUR_PRIORITY)
+		
 	if (light_power && light_range)
 		update_light()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Short version: Fixes the issue where fairygrass destroyed the floor when shuttles took off.

Long version: `/turf/Initialize()` didn't include a check for adding the `color` variable to `atom_colors` unlike `atom/Initialize()`. When shuttles took off and tried to copy the turfs involved, it would runtime as the `color` variable was set but `atom_colors` was null, this should hopefully fix that and not break anything else. Probably. I hope.

Also thanks to @ivanmixo for the guiding hand.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Floors breaking is bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

closes #5637

## Changelog
:cl:
fix: Fixes fairygrass shuttle flight runtime
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
