### PR TITLE
Punch damage is now consistent

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3804,7 +3804,6 @@
 	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
 	emote_hear = list("chitters");
 	faction = list("spiders");
-	harm_intent_damage = 3;
 	health = 200;
 	icon_dead = "guard_dead";
 	icon_gib = "guard_dead";

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -21,7 +21,6 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
-	harm_intent_damage = 0
 	status_flags = 0
 	wander = FALSE
 	density = FALSE

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -37,7 +37,6 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
-	harm_intent_damage = 0
 	friendly = "touches"
 	status_flags = 0
 	wander = FALSE

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -61,6 +61,9 @@ In all, this is a lot like the monkey code. /N
 		if("grab")
 			grabbedby(M)
 		if ("harm")
+			if(HAS_TRAIT(M, TRAIT_PACIFISM))
+				to_chat(M, "<span class='notice'>You don't want to hurt [src]!</span>")
+				return 0
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			return 1
 		if("disarm")

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -19,22 +19,12 @@
 	if(..())
 		switch(M.a_intent)
 			if ("harm")
-				var/damage = rand(1, 9)
-				if (prob(90))
-					playsound(loc, "punch", 25, 1, -1)
-					visible_message("<span class='danger'>[M] punches [src]!</span>", \
-							"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-					if ((stat != DEAD) && (damage > 9 || prob(5)))//Regular humans have a very small chance of knocking an alien down.
-						Unconscious(40)
-						visible_message("<span class='danger'>[M] knocks [src] down!</span>", \
-								"<span class='userdanger'>[M] knocks you down!</span>")
-					var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
-					apply_damage(damage, BRUTE, affecting)
-					log_combat(M, src, "attacked")
-				else
-					playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-					visible_message("<span class='danger'>[M]'s punch misses [src]!</span>", \
-						"<span class='userdanger'>[M]'s punch misses you!</span>", null, COMBAT_MESSAGE_RANGE)
+				playsound(loc, "punch", 25, 1, -1)
+				visible_message("<span class='danger'>[M] punches [src]!</span>", \
+						"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
+				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
+				apply_damage(M.dna.species.punchdamage, BRUTE, affecting)
+				log_combat(M, src, "attacked")
 
 			if ("disarm")
 				if (!(mobility_flags & MOBILITY_STAND))

--- a/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva_defense.dm
@@ -2,21 +2,12 @@
 
 /mob/living/carbon/alien/larva/attack_hand(mob/living/carbon/human/M)
 	if(..())
-		var/damage = rand(1, 9)
-		if (prob(90))
-			playsound(loc, "punch", 25, 1, -1)
-			log_combat(M, src, "attacked")
-			visible_message("<span class='danger'>[M] kicks [src]!</span>", \
-					"<span class='userdanger'>[M] kicks you!</span>", null, COMBAT_MESSAGE_RANGE)
-			if ((stat != DEAD) && (damage > 4.9))
-				Unconscious(rand(100,200))
-
-			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
-			apply_damage(damage, BRUTE, affecting)
-		else
-			playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-			visible_message("<span class='danger'>[M]'s kick misses [src]!</span>", \
-					"<span class='userdanger'>[M]'s kick misses you!</span>", null, COMBAT_MESSAGE_RANGE)
+		playsound(loc, "punch", 25, 1, -1)
+		log_combat(M, src, "attacked")
+		visible_message("<span class='danger'>[M] kicks [src]!</span>", \
+				"<span class='userdanger'>[M] kicks you!</span>", null, COMBAT_MESSAGE_RANGE)
+		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
+		apply_damage(M.dna.species.punchdamage, BRUTE, affecting)
 
 /mob/living/carbon/alien/larva/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
 	if(user.a_intent == INTENT_HARM)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -75,11 +75,21 @@
 							"<span class='notice'>You pet [src].</span>")
 		if("grab")
 			grabbedby(M)
+		if(HAS_TRAIT(M, TRAIT_PACIFISM))
+			to_chat(M, "<span class='notice'>You don't want to hurt [src]!</span>")
+			return
+		else if(M.dna.species.punchdamage >= 10)
+			adjustBruteLoss(M.dna.species.punchdamage)
+			playsound(loc, "punch", 25, 1, -1)
+			visible_message("<span class='danger'>[M] punches [src]!</span>", \
+				"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
+			log_combat(M, src, "attacked")
 		else
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			playsound(src.loc, 'sound/effects/bang.ogg', 10, 1)
 			visible_message("<span class='danger'>[M] punches [src], but doesn't leave a dent!</span>", \
 				"<span class='warning'>[M] punches you, but doesn't leave a dent!</span>", null, COMBAT_MESSAGE_RANGE)
+			log_combat(M, src, "tried to punch")
 
 /mob/living/silicon/attack_drone(mob/living/simple_animal/drone/M)
 	if(M.a_intent == INTENT_HARM)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -75,16 +75,17 @@
 							"<span class='notice'>You pet [src].</span>")
 		if("grab")
 			grabbedby(M)
-		if(HAS_TRAIT(M, TRAIT_PACIFISM))
-			to_chat(M, "<span class='notice'>You don't want to hurt [src]!</span>")
-			return
-		else if(M.dna.species.punchdamage >= 10)
-			adjustBruteLoss(M.dna.species.punchdamage)
-			playsound(loc, "punch", 25, 1, -1)
-			visible_message("<span class='danger'>[M] punches [src]!</span>", \
-				"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-			log_combat(M, src, "attacked")
 		else
+			if(HAS_TRAIT(M, TRAIT_PACIFISM))
+				to_chat(M, "<span class='notice'>You don't want to hurt [src]!</span>")
+				return
+			if(M.dna.species.punchdamage >= 10)
+				adjustBruteLoss(M.dna.species.punchdamage)
+				playsound(loc, "punch", 25, 1, -1)
+				visible_message("<span class='danger'>[M] punches [src]!</span>", \
+					"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
+				log_combat(M, src, "attacked")
+				return
 			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 			playsound(src.loc, 'sound/effects/bang.ogg', 10, 1)
 			visible_message("<span class='danger'>[M] punches [src], but doesn't leave a dent!</span>", \

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -20,7 +20,7 @@
 			visible_message("<span class='danger'>[M] [response_harm] [src]!</span>",\
 				"<span class='userdanger'>[M] [response_harm] you!</span>", null, COMBAT_MESSAGE_RANGE)
 			playsound(loc, attacked_sound, 25, 1, -1)
-			attack_threshold_check(harm_intent_damage)
+			attack_threshold_check(M.dna.species.punchdamage)
 			log_combat(M, src, "attacked")
 			updatehealth()
 			return TRUE

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -137,8 +137,8 @@
 	icon_living = "behemoth"
 	maxHealth = 150
 	health = 150
-	response_harm = "harmlessly punches"
-	harm_intent_damage = 0
+	response_harm = "punches"
+
 	obj_damage = 90
 	melee_damage = 25
 	attacktext = "smashes their armored gauntlet into"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -260,7 +260,6 @@
 	health = 50
 	maxHealth = 50
 	gender = FEMALE
-	harm_intent_damage = 10
 	butcher_results = list(/obj/item/organ/brain = 1, /obj/item/organ/heart = 1, /obj/item/reagent_containers/food/snacks/cakeslice/birthday = 3,  \
 	/obj/item/reagent_containers/food/snacks/meat/slab = 2)
 	response_harm = "takes a bite out of"

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -25,9 +25,8 @@
 	response_help  = "shoos"
 	response_disarm = "swats away"
 	response_harm   = "squashes"
-	harm_intent_damage = 10 //you can swat bees in one hit
-	maxHealth = 10
-	health = 10
+	maxHealth = 6
+	health = 6
 	spacewalk = TRUE
 	faction = list("hostile")
 	move_to_delay = 0

--- a/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
@@ -17,7 +17,6 @@
 	health = 45
 	speak_emote = list("telepathically cries")
 
-	harm_intent_damage = 15
 	obj_damage = 60
 	melee_damage = 20
 	attacktext = "blinks at"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -640,7 +640,6 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 	speak_emote = list("oscillates")
 	maxHealth = 2
 	health = 2
-	harm_intent_damage = 1 //leaving this at 1 so lightgeists don't get beat to death
 	friendly = "mends"
 	density = FALSE
 	movement_type = FLYING

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -15,7 +15,6 @@
 	vision_range = 6
 	aggro_vision_range = 18
 	environment_smash = ENVIRONMENT_SMASH_NONE  //This is to prevent elites smashing up the mining station, we'll make sure they can smash minerals fine below.
-	harm_intent_damage = 0 //Punching elites gets you nowhere
 	stat_attack = UNCONSCIOUS
 	layer = LARGE_MOB_LAYER
 	sentience_type = SENTIENCE_BOSS

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -19,7 +19,6 @@
 	speed = 3
 	maxHealth = 300
 	health = 300
-	harm_intent_damage = 0
 	obj_damage = 100
 	melee_damage = 25
 	attacktext = "pulverizes"

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -82,7 +82,6 @@
 	F.icon_state = "Fugu1"
 	F.obj_damage = 60
 	F.melee_damage = 20
-	F.harm_intent_damage = 0
 	F.throw_message = "is absorbed by the girth of the"
 	F.retreat_distance = null
 	F.minimum_distance = 1
@@ -99,7 +98,6 @@
 		icon_state = "Fugu0"
 		obj_damage = 0
 		melee_damage = 0
-		harm_intent_damage = 6
 		throw_message = "is avoided by the"
 		retreat_distance = 9
 		minimum_distance = 9

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -28,7 +28,6 @@
 	var/response_help   = "pokes"
 	var/response_disarm = "shoves"
 	var/response_harm   = "hits"
-	var/harm_intent_damage = 6 //the damage dealt to a mob when punched. default is default punch damage
 	var/force_threshold = 0 //Minimum force required to deal any damage
 
 	//Temperature effect


### PR DESCRIPTION
## About The Pull Request
living/carbon/humans always deal their punch damage (default is 6) when attacking mobs. there is no knockdown, no extraneous effects. just your damage
pacifists can no longer attack aliens
bees have lower hp, letting you still punch them in one hit (why the FUCK did they have 10 anyways)

## Why It's Good For The Game
the damage you deal with your unarmed strikes is now consistent. This also allows races- or, with kapulimbs becoming a factor- limbs with their own special punchdamage- to deal their damage consistently as a weapon even against non-human mobs.
also, humans having a 10% chance to knock a xenomorph out with a punch is stupid

## Changelog
:cl:
tweak: humans always deal normal punch damage to mobs, instead of having weird damage calcs depending on the mob subtype
tweak: attacking borgs with a punch that deals over 10 damage damages them
balance: bees now have 6 hp
fix: pacifists can no longer attack aliens
/:cl:
