### PR TITLE
Corrects the burn chamber's mapping area on Pubby

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -55280,7 +55280,7 @@
 "hrU" = (
 /obj/machinery/igniter/on,
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "hsK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61242,7 +61242,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
+/area/engine/supermatter)
 "rSD" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For some reason the burn chamber's vent was in an isolated area instead of being included in the dedicated supermatter area. This meant that not only did you have to configure it using a different air alarm, but, engineers also lacked access to properly configure it by default. 

![image](https://user-images.githubusercontent.com/26130695/139559281-542f3263-0c5b-4673-b4f6-7f0f7e390f1d.png)


## Why It's Good For The Game

Engineers can actually do their job on Pubby without needing assistance from the HoP, CE, AI, etc.

![image](https://user-images.githubusercontent.com/26130695/139559418-a57d14a8-25b1-4868-8787-e7250116bd5c.png)


## Changelog
:cl:
fix: The burn chamber vent on PubbyStation is no longer mapped into the wrong area and can be configured using the Supermatter Engine Air Alarm.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
