### PR TITLE
Removes confusion from *spin and *flip

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -32,9 +32,6 @@
 	. = ..()
 	if(.)
 		user.SpinAnimation(7,1)
-		if(isliving(user) && !intentional)
-			var/mob/living/L = user
-			L.confused += 2
 
 /datum/emote/spin
 	key = "spin"
@@ -47,9 +44,6 @@
 	. = ..()
 	if(.)
 		user.spin(20, 1)
-		if(isliving(user) && !intentional)
-			var/mob/living/L = user
-			L.confused += 2
 		if(iscyborg(user) && user.has_buckled_mobs())
 			var/mob/living/silicon/robot/R = user
 			var/datum/component/riding/riding_datum = R.GetComponent(/datum/component/riding)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Whoops didn't mean to make a branch on the main repo, remind me to delete it after.

## About The Pull Request

This is pretty stupid considering things like the de-sword and other weapons cause you to spin and this hasn't been properly coded to account for that.
There's no worth in keeping it around either since we don't allow macros anyway so we don't have the *spin *flip spam that TG has.

## Why It's Good For The Game

Using stuff like the de-sword, pool noodles, wrestling, dancing will no longer give you confusion all the time. *spin and *flip no longer add confusion to you when using them.

## Changelog
:cl:
del: Removed confusion from the *spin and *flip emotes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
