### PR TITLE
Fixes spin and flip confusion

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -32,7 +32,7 @@
 	. = ..()
 	if(.)
 		user.SpinAnimation(7,1)
-		if(isliving(user) && !intentional)
+		if(isliving(user) && intentional)
 			var/mob/living/L = user
 			L.confused += 2
 
@@ -47,7 +47,7 @@
 	. = ..()
 	if(.)
 		user.spin(20, 1)
-		if(isliving(user) && !intentional)
+		if(isliving(user) && intentional)
 			var/mob/living/L = user
 			L.confused += 2
 		if(iscyborg(user) && user.has_buckled_mobs())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now actually checks if the emote was intentional, it was previously checking if it was unintentional.

Alternative to #5668
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Was I high when I wrote this?
Desword and golden bike horn will no longer cause confusion
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Spin and flip confusion now properly checks for intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
