### PR TITLE
Port keybind improvements from tg, use them to fix arm augment issues

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -66,6 +66,7 @@
 #include "code\__DEFINES\inventory.dm"
 #include "code\__DEFINES\is_helpers.dm"
 #include "code\__DEFINES\jobs.dm"
+#include "code\__DEFINES\keybinding.dm"
 #include "code\__DEFINES\language.dm"
 #include "code\__DEFINES\layers.dm"
 #include "code\__DEFINES\lighting.dm"

--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -1,0 +1,68 @@
+//Signals
+
+//General
+#define COMSIG_KB_ACTIVATED (1<<0)
+
+//Admin
+#define COMSIG_KB_ADMIN_ASAY_DOWN "keybinding_admin_asay_down"
+#define COMSIG_KB_ADMIN_MSAY_DOWN "keybinding_admin_msay_down"
+#define COMSIG_KB_ADMIN_DSAY_DOWN "keybinding_admin_dsay_down"
+#define COMSIG_KB_ADMIN_TOGGLEBUILDMODE_DOWN "keybinding_admin_togglebuildmode_down"
+#define COMSIG_KB_ADMIN_AGHOST_DOWN "keybinding_admin_aghost_down"
+#define COMSIG_KB_ADMIN_PLAYERPANEL_DOWN "keybinding_admin_playerpanelnew_down"
+#define COMSIG_KB_ADMIN_INVISIMINTOGGLE_DOWN "keybinding_admin_invisimintoggle_down"
+
+//Carbon
+#define COMSIG_KB_CARBON_TOGGLETHROWMODE_DOWN "keybinding_carbon_togglethrowmode_down"
+#define COMSIG_KB_CARBON_SELECTHELPINTENT_DOWN "keybinding_carbon_selecthelpintent_down"
+#define COMSIG_KB_CARBON_SELECTDISARMINTENT_DOWN "keybinding_carbon_selectdisarmintent_down"
+#define COMSIG_KB_CARBON_SELECTGRABINTENT_DOWN "keybinding_carbon_selectgrabintent_down"
+#define COMSIG_KB_CARBON_SELECTHARMINTENT_DOWN "keybinding_carbon_selectharmintent_down"
+#define COMSIG_KB_CARBON_GIVEITEM_DOWN "keybinding_carbon_giveitem_down"
+
+//Client
+#define COMSIG_KB_CLIENT_GETHELP_DOWN "keybinding_client_gethelp_down"
+#define COMSIG_KB_CLIENT_SCREENSHOT_DOWN "keybinding_client_screenshot_down"
+#define COMSIG_KB_CLIENT_MINIMALHUD_DOWN "keybinding_client_minimalhud_down"
+#define COMSIG_KB_CLIENT_ZOOMIN_DOWN "keybinding_client_zoomin_down"
+
+//Human
+#define COMSIG_KB_HUMAN_QUICKEQUIP_DOWN "keybinding_human_quickequip_down"
+#define COMSIG_KB_HUMAN_QUICKEQUIPBELT_DOWN "keybinding_human_quickequipbelt_down"
+#define COMSIG_KB_HUMAN_BAGEQUIP_DOWN "keybinding_human_bagequip_down"
+#define COMSIG_KB_HUMAN_SUITEQUIP_DOWN "keybinding_human_suitequip_down"
+
+//Living
+#define COMSIG_KB_LIVING_RESIST_DOWN "keybinding_living_resist_down"
+#define COMSIG_KB_LIVING_REST_DOWN "keybinding_living_rest_down"
+#define COMSIG_KB_LIVING_LOOKUP_DOWN "keybinding_living_lookup_down"
+#define COMSIG_KB_LIVING_LOOKDOWN_DOWN "keybinding_living_lookdown_down"
+
+//Mob
+#define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"
+#define COMSIG_KB_MOB_FACEEAST_DOWN "keybinding_mob_faceeast_down"
+#define COMSIG_KB_MOB_FACESOUTH_DOWN "keybinding_mob_facesouth_down"
+#define COMSIG_KB_MOB_FACEWEST_DOWN "keybinding_mob_facewest_down"
+#define COMSIG_KB_MOB_STOPPULLING_DOWN "keybinding_mob_stoppulling_down"
+#define COMSIG_KB_MOB_CYCLEINTENTRIGHT_DOWN "keybinding_mob_cycleintentright_down"
+#define COMSIG_KB_MOB_CYCLEINTENTLEFT_DOWN "keybinding_mob_cycleintentleft_down"
+#define COMSIG_KB_MOB_SWAPHANDS_DOWN "keybinding_mob_swaphands_down"
+#define COMSIG_KB_MOB_ACTIVATEINHAND_DOWN "keybinding_mob_activateinhand_down"
+#define COMSIG_KB_MOB_DROPITEM_DOWN "keybinding_mob_dropitem_down"
+#define COMSIG_KB_MOB_TOGGLEMOVEINTENT_DOWN "keybinding_mob_togglemoveintent_down"
+#define COMSIG_KB_MOB_TOGGLEMOVEINTENTALT_DOWN "keybinding_mob_togglemoveintentalt_down"
+#define COMSIG_KB_MOB_TARGETCYCLEHEAD_DOWN "keybinding_mob_targetcyclehead_down"
+#define COMSIG_KB_MOB_TARGETRIGHTARM_DOWN "keybinding_mob_targetrightarm_down"
+#define COMSIG_KB_MOB_TARGETBODYCHEST_DOWN "keybinding_mob_targetbodychest_down"
+#define COMSIG_KB_MOB_TARGETLEFTARM_DOWN "keybinding_mob_targetleftarm_down"
+#define COMSIG_KB_MOB_TARGETRIGHTLEG_DOWN "keybinding_mob_targetrightleg_down"
+#define COMSIG_KB_MOB_TARGETBODYGROIN_DOWN "keybinding_mob_targetbodygroin_down"
+#define COMSIG_KB_MOB_TARGETLEFTLEG_DOWN "keybinding_mob_targetleftleg_down"
+#define COMSIG_KB_MOB_PREVENTMOVEMENT_DOWN "keybinding_mob_preventmovement_down"
+
+//Robot
+#define COMSIG_KB_SILICON_TOGGLEMODULEONE_DOWN "keybinding_silicon_togglemoduleone_down"
+#define COMSIG_KB_SILICON_TOGGLEMODULETWO_DOWN "keybinding_silicon_togglemoduletwo_down"
+#define COMSIG_KB_SILICON_TOGGLEMODULETHREE_DOWN "keybinding_silicon_togglemodulethree_down"
+#define COMSIG_KB_SILICON_CYCLEINTENT_DOWN "keybinding_silicon_cycleintent_down"
+#define COMSIG_KB_SILICON_UNEQUIPMODULE_DOWN "keybinding_silicon_unequipmodule_down"

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -54,7 +54,7 @@
 	// Keybindings
 	for(var/KB in subtypesof(/datum/keybinding))
 		var/datum/keybinding/keybinding = KB
-		if(!initial(keybinding.key))
+		if(!initial(keybinding.key) || !initial(keybinding.keybind_signal))
 			continue
 		var/datum/keybinding/instance = new keybinding
 		GLOB.keybindings_by_name[initial(instance.name)] = instance

--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -10,8 +10,12 @@
 	name = "admin_say"
 	full_name = "Admin say"
 	description = "Talk with other admins."
+	keybind_signal = COMSIG_KB_ADMIN_ASAY_DOWN
 
 /datum/keybinding/admin/admin_say/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.get_admin_say()
 	return TRUE
 
@@ -21,11 +25,16 @@
 	name = "mentor_say"
 	full_name = "Mentor say"
 	description = "Speak with other mentors."
+	keybind_signal = COMSIG_KB_ADMIN_MSAY_DOWN
 
 /datum/keybinding/admin/mentor_say/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.get_mentor_say()
 	return TRUE
 
+//Snowflakey fix for mentors not being able to use the hotkey, without moving the hotkey to a new category
 /datum/keybinding/admin/mentor_say/can_use(client/user)
 	return user.mentor_datum ? TRUE : FALSE
 
@@ -35,8 +44,12 @@
 	name = "admin_ghost"
 	full_name = "Admin Ghost"
 	description = "Toggle your admin ghost status."
+	keybind_signal = COMSIG_KB_ADMIN_AGHOST_DOWN
 
 /datum/keybinding/admin/admin_ghost/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.admin_ghost()
 	return TRUE
 
@@ -46,8 +59,12 @@
 	name = "player_panel"
 	full_name = "Player Panel"
 	description = "View the player panel list."
+	keybind_signal = COMSIG_KB_ADMIN_PLAYERPANEL_DOWN
 
 /datum/keybinding/admin/player_panel/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.holder.player_panel_new()
 	return TRUE
 
@@ -57,8 +74,12 @@
 	name = "toggle_build_mode"
 	full_name = "Toggle Build Mode"
 	description = "Toggle admin build mode on or off."
+	keybind_signal = COMSIG_KB_ADMIN_TOGGLEBUILDMODE_DOWN
 
 /datum/keybinding/admin/build_mode/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.togglebuildmodeself()
 	return TRUE
 
@@ -68,8 +89,12 @@
 	name = "invismin"
 	full_name = "Toggle Invismin"
 	description = "Toggle your admin invisibility."
+	keybind_signal = COMSIG_KB_ADMIN_INVISIMINTOGGLE_DOWN
 
 /datum/keybinding/admin/invismin/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.invisimin()
 	return TRUE
 
@@ -79,7 +104,11 @@
 	name = "dead_say"
 	full_name = "Dead Say"
 	description = "Speak in deadchat as an admin."
+	keybind_signal = COMSIG_KB_ADMIN_DSAY_DOWN
 
 /datum/keybinding/admin/dead_say/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.get_dead_say()
 	return TRUE

--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -2,6 +2,8 @@
 	category = CATEGORY_ADMIN
 	weight = WEIGHT_ADMIN
 
+/datum/keybinding/admin/can_use(client/user)
+	return user.holder ? TRUE : FALSE
 
 /datum/keybinding/admin/admin_say
 	key = "F3"
@@ -10,7 +12,6 @@
 	description = "Talk with other admins."
 
 /datum/keybinding/admin/admin_say/down(client/user)
-	if (!user.holder) return
 	user.get_admin_say()
 	return TRUE
 
@@ -22,9 +23,11 @@
 	description = "Speak with other mentors."
 
 /datum/keybinding/admin/mentor_say/down(client/user)
-	if (!user.holder) return
 	user.get_mentor_say()
 	return TRUE
+
+/datum/keybinding/admin/mentor_say/can_use(client/user)
+	return user.mentor_datum ? TRUE : FALSE
 
 
 /datum/keybinding/admin/admin_ghost
@@ -34,7 +37,6 @@
 	description = "Toggle your admin ghost status."
 
 /datum/keybinding/admin/admin_ghost/down(client/user)
-	if (!user.holder) return
 	user.admin_ghost()
 	return TRUE
 
@@ -46,7 +48,6 @@
 	description = "View the player panel list."
 
 /datum/keybinding/admin/player_panel/down(client/user)
-	if (!user.holder) return
 	user.holder.player_panel_new()
 	return TRUE
 
@@ -58,7 +59,6 @@
 	description = "Toggle admin build mode on or off."
 
 /datum/keybinding/admin/build_mode/down(client/user)
-	if (!user.holder) return
 	user.togglebuildmodeself()
 	return TRUE
 
@@ -70,7 +70,6 @@
 	description = "Toggle your admin invisibility."
 
 /datum/keybinding/admin/invismin/down(client/user)
-	if (!user.holder) return
 	user.invisimin()
 	return TRUE
 

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -11,8 +11,12 @@
 	full_name = "Toggle throw mode"
 	description = "Toggle throwing the current item or not."
 	category = CATEGORY_CARBON
+	keybind_signal = COMSIG_KB_CARBON_TOGGLETHROWMODE_DOWN
 
 /datum/keybinding/carbon/toggle_throw_mode/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/carbon/C = user.mob
 	C.toggle_throw_mode()
 	return TRUE
@@ -24,8 +28,12 @@
 	full_name = "Select help intent"
 	description = ""
 	category = CATEGORY_CARBON
+	keybind_signal = COMSIG_KB_CARBON_SELECTHELPINTENT_DOWN
 
 /datum/keybinding/carbon/select_help_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.mob?.a_intent_change(INTENT_HELP)
 	return TRUE
 
@@ -36,8 +44,12 @@
 	full_name = "Select disarm intent"
 	description = ""
 	category = CATEGORY_CARBON
+	keybind_signal = COMSIG_KB_CARBON_SELECTDISARMINTENT_DOWN
 
 /datum/keybinding/carbon/select_disarm_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if (!iscarbon(user.mob)) return
 	var/mob/living/carbon/C = user.mob
 	C.a_intent_change(INTENT_DISARM)
@@ -50,8 +62,12 @@
 	full_name = "Select grab intent"
 	description = ""
 	category = CATEGORY_CARBON
+	keybind_signal = COMSIG_KB_CARBON_SELECTGRABINTENT_DOWN
 
 /datum/keybinding/carbon/select_grab_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if (!iscarbon(user.mob)) return
 	var/mob/living/carbon/C = user.mob
 	C.a_intent_change(INTENT_GRAB)
@@ -64,8 +80,12 @@
 	full_name = "Select harm intent"
 	description = ""
 	category = CATEGORY_CARBON
+	keybind_signal = COMSIG_KB_CARBON_SELECTHARMINTENT_DOWN
 
 /datum/keybinding/carbon/select_harm_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
 	user.mob?.a_intent_change(INTENT_HARM)
 	return TRUE
 
@@ -75,8 +95,12 @@
 	full_name = "Give item"
 	description = "Give the item you're currently holding"
 	category = CATEGORY_CARBON
+	keybind_signal = COMSIG_KB_CARBON_GIVEITEM_DOWN
 
 /datum/keybinding/carbon/give/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/carbon/C = user.mob
 	C.give()
 	return TRUE

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -2,6 +2,8 @@
 	category = CATEGORY_CARBON
 	weight = WEIGHT_MOB
 
+/datum/keybinding/carbon/can_use(client/user)
+	return iscarbon(user.mob)
 
 /datum/keybinding/carbon/toggle_throw_mode
 	key = "R"
@@ -11,7 +13,6 @@
 	category = CATEGORY_CARBON
 
 /datum/keybinding/carbon/toggle_throw_mode/down(client/user)
-	if (!iscarbon(user.mob)) return
 	var/mob/living/carbon/C = user.mob
 	C.toggle_throw_mode()
 	return TRUE
@@ -25,9 +26,7 @@
 	category = CATEGORY_CARBON
 
 /datum/keybinding/carbon/select_help_intent/down(client/user)
-	if (!iscarbon(user.mob)) return
-	var/mob/living/carbon/C = user.mob
-	C.a_intent_change(INTENT_HELP)
+	user.mob?.a_intent_change(INTENT_HELP)
 	return TRUE
 
 
@@ -67,9 +66,7 @@
 	category = CATEGORY_CARBON
 
 /datum/keybinding/carbon/select_harm_intent/down(client/user)
-	if (!iscarbon(user.mob)) return
-	var/mob/living/carbon/C = user.mob
-	C.a_intent_change(INTENT_HARM)
+	user.mob?.a_intent_change(INTENT_HARM)
 	return TRUE
 
 /datum/keybinding/carbon/give
@@ -80,8 +77,6 @@
 	category = CATEGORY_CARBON
 
 /datum/keybinding/carbon/give/down(client/user)
-	if(!iscarbon(user.mob))
-		return
 	var/mob/living/carbon/C = user.mob
 	C.give()
 	return TRUE

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -1,39 +1,51 @@
 /datum/keybinding/client
-    category = CATEGORY_CLIENT
-    weight = WEIGHT_HIGHEST
+	category = CATEGORY_CLIENT
+	weight = WEIGHT_HIGHEST
 
 
 /datum/keybinding/client/get_help
-    key = "F1"
-    name = "get_help"
-    full_name = "Get Help"
-    description = "Ask an admin or mentor for help."
+	key = "F1"
+	name = "get_help"
+	full_name = "Get Help"
+	description = "Ask an admin or mentor for help."
+	keybind_signal = COMSIG_KB_CLIENT_GETHELP_DOWN
 
 /datum/keybinding/client/get_help/down(client/user)
-    user.get_adminhelp()
-    return TRUE
+	. = ..()
+	if(.)
+		return
+	user.get_adminhelp()
+	return TRUE
 
 
 /datum/keybinding/client/screenshot
-    key = "F2"
-    name = "screenshot"
-    full_name = "Screenshot"
-    description = "Take a screenshot."
+	key = "F2"
+	name = "screenshot"
+	full_name = "Screenshot"
+	description = "Take a screenshot."
+	keybind_signal = COMSIG_KB_CLIENT_SCREENSHOT_DOWN
 
 /datum/keybinding/client/screenshot/down(client/user)
-    winset(user, null, "command=.screenshot [!user.keys_held["shift"] ? "auto" : ""]")
-    return TRUE
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=.screenshot [!user.keys_held["shift"] ? "auto" : ""]")
+	return TRUE
 
 
 /datum/keybinding/client/toggleminimalhud
-    key = "F12"
-    name = "toggleminimalhud"
-    full_name = "Toggle Minimal HUD"
-    description = "Toggle the minimalized state of your hud."
+	key = "F12"
+	name = "toggleminimalhud"
+	full_name = "Toggle Minimal HUD"
+	description = "Toggle the minimalized state of your hud."
+	keybind_signal = COMSIG_KB_CLIENT_MINIMALHUD_DOWN
 
 /datum/keybinding/client/toggleminimalhud/down(client/user)
-    user.mob.button_pressed_F12()
-    return TRUE
+	. = ..()
+	if(.)
+		return
+	user.mob.button_pressed_F12()
+	return TRUE
 
 
 /datum/keybinding/client/zoomin
@@ -41,8 +53,12 @@
 	name = "zoomin"
 	full_name = "Zoom In"
 	description = "Temporary switch icon scaling mode to 4x until unpressed"
+	keybind_signal = COMSIG_KB_CLIENT_ZOOMIN_DOWN
 
 /datum/keybinding/client/zoomin/down(client/user)
+	. = ..()
+	if(.)
+		return
 	winset(user, "mapwindow.map", "zoom=[PIXEL_SCALING_4X]")
 
 /datum/keybinding/client/zoomin/up(client/user)

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -2,6 +2,8 @@
 	category = CATEGORY_HUMAN
 	weight = WEIGHT_MOB
 
+/datum/keybinding/human/can_use(client/user)
+	return ishuman(user.mob) && !user.mob.incapacitated()
 
 /datum/keybinding/human/quick_equip
 	key = "E"
@@ -10,8 +12,6 @@
 	description = ""
 
 /datum/keybinding/human/quick_equip/down(client/user)
-	if(!ishuman(user.mob) || user.mob.incapacitated())
-		return
 	var/mob/living/carbon/human/H = user.mob
 	H.quick_equip()
 	return TRUE
@@ -24,8 +24,6 @@
 	description = ""
 
 /datum/keybinding/human/quick_equip_belt/down(client/user)
-	if(!ishuman(user.mob) || user.mob.incapacitated())
-		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_belt = H.get_item_by_slot(ITEM_SLOT_BELT)
@@ -63,8 +61,6 @@
 	description = ""
 
 /datum/keybinding/human/quick_equip_backpack/down(client/user)
-	if(!ishuman(user.mob) || user.mob.incapacitated())
-		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_back = H.get_item_by_slot(ITEM_SLOT_BACK)
@@ -101,8 +97,6 @@
 	description = ""
 
 /datum/keybinding/human/quick_equip_suit_storage/down(client/user)
-	if(!ishuman(user.mob) || user.mob.incapacitated())
-		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/stored = H.get_item_by_slot(ITEM_SLOT_SUITSTORE)

--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -5,13 +5,18 @@
 /datum/keybinding/human/can_use(client/user)
 	return ishuman(user.mob) && !user.mob.incapacitated()
 
+
 /datum/keybinding/human/quick_equip
 	key = "E"
 	name = "quick_equip"
 	full_name = "Quick equip"
 	description = ""
+	keybind_signal = COMSIG_KB_HUMAN_QUICKEQUIP_DOWN
 
 /datum/keybinding/human/quick_equip/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/carbon/human/H = user.mob
 	H.quick_equip()
 	return TRUE
@@ -22,8 +27,12 @@
 	name = "quick_equip_belt"
 	full_name = "Put Item In Belt"
 	description = ""
+	keybind_signal = COMSIG_KB_HUMAN_QUICKEQUIPBELT_DOWN
 
 /datum/keybinding/human/quick_equip_belt/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_belt = H.get_item_by_slot(ITEM_SLOT_BELT)
@@ -59,8 +68,12 @@
 	name = "quick_equip_backpack"
 	full_name = "Put Item In Backpack"
 	description = ""
+	keybind_signal = COMSIG_KB_HUMAN_BAGEQUIP_DOWN
 
 /datum/keybinding/human/quick_equip_backpack/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/equipped_back = H.get_item_by_slot(ITEM_SLOT_BACK)
@@ -90,13 +103,18 @@
 	stored.attack_hand(H) // take out thing from backpack
 	return
 
+
 /datum/keybinding/human/quick_equip_suit_storage
 	key = "Shift-Q"
 	name = "quick_equip_suit_storage"
 	full_name = "Put Item In Suit Storage"
 	description = ""
+	keybind_signal = COMSIG_KB_HUMAN_SUITEQUIP_DOWN
 
 /datum/keybinding/human/quick_equip_suit_storage/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/carbon/human/H = user.mob
 	var/obj/item/thing = H.get_active_held_item()
 	var/obj/item/stored = H.get_item_by_slot(ITEM_SLOT_SUITSTORE)

--- a/code/datums/keybinding/keybinding.dm
+++ b/code/datums/keybinding/keybinding.dm
@@ -1,13 +1,16 @@
 /datum/keybinding
-    var/key
-    var/name
-    var/full_name
-    var/description = ""
-    var/category = CATEGORY_MISC
-    var/weight = WEIGHT_LOWEST
+	var/key
+	var/name
+	var/full_name
+	var/description = ""
+	var/category = CATEGORY_MISC
+	var/weight = WEIGHT_LOWEST
 
 /datum/keybinding/proc/down(client/user)
-    return FALSE
-    
+	return FALSE
+	
 /datum/keybinding/proc/up(client/user)
-    return FALSE
+	return FALSE
+
+/datum/keybinding/proc/can_use(client/user)
+	return TRUE

--- a/code/datums/keybinding/keybinding.dm
+++ b/code/datums/keybinding/keybinding.dm
@@ -5,9 +5,16 @@
 	var/description = ""
 	var/category = CATEGORY_MISC
 	var/weight = WEIGHT_LOWEST
+	var/keybind_signal
+
+//I don't know why this is done in New() and not down() when it says down(), but that's how it's currently on tg
+/datum/keybinding/New()
+	if(!keybind_signal)
+		CRASH("Keybind [src] called unredefined down() without a keybind_signal.")
 
 /datum/keybinding/proc/down(client/user)
-	return FALSE
+	SHOULD_CALL_PARENT(TRUE)
+	return SEND_SIGNAL(user.mob, keybind_signal) & COMSIG_KB_ACTIVATED
 	
 /datum/keybinding/proc/up(client/user)
 	return FALSE

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -5,25 +5,35 @@
 /datum/keybinding/living/can_use(client/user)
 	return isliving(user.mob)
 
+
 /datum/keybinding/living/resist
 	key = "B"
 	name = "resist"
 	full_name = "Resist"
 	description = "Break free of your current state. Handcuffs, on fire, being trapped in an alien nest? Resist!"
+	keybind_signal = COMSIG_KB_LIVING_RESIST_DOWN
 
 /datum/keybinding/living/resist/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if (!isliving(user.mob)) return
 	var/mob/living/L = user.mob
 	L.resist()
 	return TRUE
+
 
 /datum/keybinding/living/rest
 	key = "V"
 	name = "rest"
 	full_name = "Rest"
 	description = "Lay down, or get up."
+	keybind_signal = COMSIG_KB_LIVING_REST_DOWN
 
 /datum/keybinding/living/rest/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!isliving(user.mob))
 		return
 	var/mob/living/L = user.mob

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -2,6 +2,8 @@
 	category = CATEGORY_HUMAN
 	weight = WEIGHT_MOB
 
+/datum/keybinding/living/can_use(client/user)
+	return isliving(user.mob)
 
 /datum/keybinding/living/resist
 	key = "B"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -204,9 +204,6 @@
 	. = ..()
 	if(.)
 		return
-	. = ..()
-	if(.)
-		return
 	var/mob/M = user.mob
 	M.toggle_move_intent()
 	return TRUE
@@ -324,9 +321,6 @@
 	keybind_signal = COMSIG_KB_MOB_PREVENTMOVEMENT_DOWN
 
 /datum/keybinding/mob/prevent_movement/down(client/user)
-	. = ..()
-	if(.)
-		return
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -8,8 +8,12 @@
 	name = "face_north"
 	full_name = "Face North"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_FACENORTH_DOWN
 
 /datum/keybinding/mob/face_north/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.northface()
@@ -21,8 +25,12 @@
 	name = "face_east"
 	full_name = "Face East"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_FACEEAST_DOWN
 
 /datum/keybinding/mob/face_east/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.eastface()
@@ -34,8 +42,12 @@
 	name = "face_south"
 	full_name = "Face South"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_FACESOUTH_DOWN
 
 /datum/keybinding/mob/face_south/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.southface()
@@ -46,8 +58,12 @@
 	name = "face_west"
 	full_name = "Face West"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_FACEWEST_DOWN
 
 /datum/keybinding/mob/face_west/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.westface()
@@ -58,8 +74,12 @@
 	name = "stop_pulling"
 	full_name = "Stop pulling"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_STOPPULLING_DOWN
 
 /datum/keybinding/mob/stop_pulling/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	if (!M.pulling)
@@ -73,8 +93,12 @@
 	name = "cycle_intent_right"
 	full_name = "Cycle Intent Right"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_CYCLEINTENTRIGHT_DOWN
 
 /datum/keybinding/mob/cycle_intent_right/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.a_intent_change(INTENT_HOTKEY_RIGHT)
@@ -85,8 +109,12 @@
 	name = "cycle_intent_left"
 	full_name = "Cycle Intent Left"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_CYCLEINTENTLEFT_DOWN
 
 /datum/keybinding/mob/cycle_intent_left/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.a_intent_change(INTENT_HOTKEY_LEFT)
@@ -97,8 +125,12 @@
 	name = "swap_hands"
 	full_name = "Swap hands"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_SWAPHANDS_DOWN
 
 /datum/keybinding/mob/swap_hands/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.mob.swap_hand()
 	return TRUE
@@ -108,8 +140,12 @@
 	name = "activate_inhand"
 	full_name = "Activate in-hand"
 	description = "Uses whatever item you have inhand"
+	keybind_signal = COMSIG_KB_MOB_ACTIVATEINHAND_DOWN
 
 /datum/keybinding/mob/activate_inhand/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.mode()
@@ -120,8 +156,12 @@
 	name = "drop_item"
 	full_name = "Drop Item"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_DROPITEM_DOWN
 
 /datum/keybinding/mob/drop_item/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	var/obj/item/I = M.get_active_held_item()
@@ -136,8 +176,12 @@
 	name = "toggle_move_intent"
 	full_name = "Hold to toggle move intent"
 	description = "Held down to cycle to the other move intent, release to cycle back"
+	keybind_signal = COMSIG_KB_MOB_TOGGLEMOVEINTENT_DOWN
 
 /datum/keybinding/mob/toggle_move_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	var/mob/M = user.mob
 	M.toggle_move_intent()
@@ -154,8 +198,12 @@
 	name = "toggle_move_intent_alt"
 	full_name = "press to cycle move intent"
 	description = "Pressing this cycle to the opposite move intent, does not cycle back"
+	keybind_signal = COMSIG_KB_MOB_TOGGLEMOVEINTENTALT_DOWN
 
 /datum/keybinding/mob/toggle_move_intent_alternative/down(client/user)
+	. = ..()
+	if(.)
+		return
 	. = ..()
 	if(.)
 		return
@@ -168,8 +216,12 @@
 	name = "target_head_cycle"
 	full_name = "Target: Cycle head"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_TARGETCYCLEHEAD_DOWN
 
 /datum/keybinding/mob/target_head_cycle/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.body_toggle_head()
 	return TRUE
@@ -179,8 +231,12 @@
 	name = "target_r_arm"
 	full_name = "Target: right arm"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_TARGETRIGHTARM_DOWN
 
 /datum/keybinding/mob/target_r_arm/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.body_r_arm()
 	return TRUE
@@ -190,8 +246,12 @@
 	name = "target_body_chest"
 	full_name = "Target: Body"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_TARGETBODYCHEST_DOWN
 
 /datum/keybinding/mob/target_body_chest/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.body_chest()
 	return TRUE
@@ -201,8 +261,12 @@
 	name = "target_left_arm"
 	full_name = "Target: left arm"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_TARGETLEFTARM_DOWN
 
 /datum/keybinding/mob/target_left_arm/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.body_l_arm()
 	return TRUE
@@ -212,8 +276,12 @@
 	name = "target_right_leg"
 	full_name = "Target: Right leg"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_TARGETRIGHTLEG_DOWN
 
 /datum/keybinding/mob/target_right_leg/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.body_r_leg()
 	return TRUE
@@ -223,8 +291,12 @@
 	name = "target_body_groin"
 	full_name = "Target: Groin"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_TARGETBODYGROIN_DOWN
 
 /datum/keybinding/mob/target_body_groin/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.body_groin()
 	return TRUE
@@ -234,8 +306,12 @@
 	name = "target_left_leg"
 	full_name = "Target: left leg"
 	description = ""
+	keybind_signal = COMSIG_KB_MOB_TARGETLEFTLEG_DOWN
 
 /datum/keybinding/mob/target_left_leg/down(client/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.mob) return
 	user.body_l_leg()
 	return TRUE
@@ -245,8 +321,12 @@
 	name = "block_movement"
 	full_name = "Block movement"
 	description = "While pressed, prevents movement when pressing directional keys; instead just changes your facing direction"
+	keybind_signal = COMSIG_KB_MOB_PREVENTMOVEMENT_DOWN
 
 /datum/keybinding/mob/prevent_movement/down(client/user)
+	. = ..()
+	if(.)
+		return
 	. = ..()
 	if(.)
 		return

--- a/code/datums/keybinding/robot.dm
+++ b/code/datums/keybinding/robot.dm
@@ -5,57 +5,82 @@
 /datum/keybinding/robot/can_use(client/user)
 	return iscyborg(user.mob)
 
+
 /datum/keybinding/robot/toggle_module_1
 	key = "1"
 	name = "toggle_module_1"
 	full_name = "Toggle Module 1"
 	description = "Toggle your first module as a robot."
+	keybind_signal = COMSIG_KB_SILICON_TOGGLEMODULEONE_DOWN
 
 /datum/keybinding/robot/toggle_module_1/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/silicon/robot/M = user.mob
 	M.toggle_module(1)
 	return TRUE
+
 
 /datum/keybinding/robot/toggle_module_2
 	key = "2"
 	name = "toggle_module_2"
 	full_name = "Toggle Module 2"
 	description = "Toggle your second module as a robot."
+	keybind_signal = COMSIG_KB_SILICON_TOGGLEMODULETWO_DOWN
 
 /datum/keybinding/robot/toggle_module_2/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/silicon/robot/M = user.mob
 	M.toggle_module(2)
 	return TRUE
+
 
 /datum/keybinding/robot/toggle_module_3
 	key = "3"
 	name = "toggle_module_3"
 	full_name = "Toggle Module 3"
 	description = "Toggle your third module as a robot."
+	keybind_signal = COMSIG_KB_SILICON_TOGGLEMODULETHREE_DOWN
 
 /datum/keybinding/robot/toggle_module_3/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/silicon/robot/M = user.mob
 	M.toggle_module(3)
 	return TRUE
+
 
 /datum/keybinding/robot/change_intent_robot
 	key = "4"
 	name = "change_intent_robot"
 	full_name = "Change Intent"
 	description = "Change your intent as a robot."
+	keybind_signal = COMSIG_KB_SILICON_CYCLEINTENT_DOWN
 
 /datum/keybinding/robot/change_intent_robot/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/silicon/robot/M = user.mob
 	M.a_intent_change(INTENT_HOTKEY_LEFT)
 	return TRUE
+
 
 /datum/keybinding/robot/unequip_module
 	key = "Q"
 	name = "unequip_module"
 	full_name = "Unequip Module"
 	description = "Unequip a robot module."
+	keybind_signal = COMSIG_KB_SILICON_UNEQUIPMODULE_DOWN
 
 /datum/keybinding/robot/unequip_module/down(client/user)
+	. = ..()
+	if(.)
+		return
 	var/mob/living/silicon/robot/M = user.mob
 	M.uneq_active()
 	return TRUE

--- a/code/datums/keybinding/robot.dm
+++ b/code/datums/keybinding/robot.dm
@@ -2,6 +2,8 @@
 	category = CATEGORY_ROBOT
 	weight = WEIGHT_ROBOT
 
+/datum/keybinding/robot/can_use(client/user)
+	return iscyborg(user.mob)
 
 /datum/keybinding/robot/toggle_module_1
 	key = "1"
@@ -10,7 +12,6 @@
 	description = "Toggle your first module as a robot."
 
 /datum/keybinding/robot/toggle_module_1/down(client/user)
-	if(!iscyborg(user.mob)) return
 	var/mob/living/silicon/robot/M = user.mob
 	M.toggle_module(1)
 	return TRUE
@@ -22,11 +23,9 @@
 	description = "Toggle your second module as a robot."
 
 /datum/keybinding/robot/toggle_module_2/down(client/user)
-	if(!iscyborg(user.mob)) return
 	var/mob/living/silicon/robot/M = user.mob
 	M.toggle_module(2)
 	return TRUE
-
 
 /datum/keybinding/robot/toggle_module_3
 	key = "3"
@@ -35,7 +34,6 @@
 	description = "Toggle your third module as a robot."
 
 /datum/keybinding/robot/toggle_module_3/down(client/user)
-	if(!iscyborg(user.mob)) return
 	var/mob/living/silicon/robot/M = user.mob
 	M.toggle_module(3)
 	return TRUE
@@ -47,11 +45,9 @@
 	description = "Change your intent as a robot."
 
 /datum/keybinding/robot/change_intent_robot/down(client/user)
-	if(!iscyborg(user.mob)) return
 	var/mob/living/silicon/robot/M = user.mob
 	M.a_intent_change(INTENT_HOTKEY_LEFT)
 	return TRUE
-
 
 /datum/keybinding/robot/unequip_module
 	key = "Q"
@@ -60,7 +56,6 @@
 	description = "Unequip a robot module."
 
 /datum/keybinding/robot/unequip_module/down(client/user)
-	if(!iscyborg(user.mob)) return
 	var/mob/living/silicon/robot/M = user.mob
 	M.uneq_active()
 	return TRUE

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(valid_keys, list(
 		kbs += kb
 	kbs = sortList(kbs, /proc/cmp_keybinding_dsc)
 	for (var/datum/keybinding/kb in kbs)
-		if (kb.down(src))
+		if (kb.can_use(src) && kb.down(src))
 			break
 
 	if(holder)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -76,20 +76,33 @@
 	hand = owner.hand_bodyparts[side]
 	if(hand)
 		RegisterSignal(hand, COMSIG_ITEM_ATTACK_SELF, .proc/on_item_attack_self) //If the limb gets an attack-self, open the menu. Only happens when hand is empty
+		RegisterSignal(M, COMSIG_KB_MOB_DROPITEM_DOWN, .proc/dropkey) //We're nodrop, but we'll watch for the drop hotkey anyway and then stow if possible.
 
 /obj/item/organ/cyberimp/arm/Remove(mob/living/carbon/M, special = 0)
 	Retract()
 	if(hand)
 		UnregisterSignal(hand, COMSIG_ITEM_ATTACK_SELF)
+		UnregisterSignal(M, COMSIG_KB_MOB_DROPITEM_DOWN)
 	..()
 
 /obj/item/organ/cyberimp/arm/proc/on_item_attack_self()
 	SIGNAL_HANDLER
 	INVOKE_ASYNC(src, .proc/ui_action_click)
 
-/obj/item/organ/cyberimp/arm/proc/on_item_drop()
+/**
+  * Called when the mob uses the "drop item" hotkey
+  *
+  * Items inside toolset implants have TRAIT_NODROP, but we can still use the drop item hotkey as a
+  * quick way to store implant items. In this case, we check to make sure the user has the correct arm
+  * selected, and that the item is actually owned by us, and then we'll hand off the rest to Retract()
+**/
+/obj/item/organ/cyberimp/arm/proc/dropkey(mob/living/carbon/host)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, .proc/Retract)
+	if(!host)
+		return //How did we even get here
+	if(hand != host.hand_bodyparts[host.active_hand_index])
+		return //wrong hand
+	Retract()
 
 /obj/item/organ/cyberimp/arm/emp_act(severity)
 	. = ..()
@@ -109,8 +122,7 @@
 		"<span class='italics'>You hear a short mechanical noise.</span>")
 
 	owner.transferItemToLoc(active_item, src, TRUE)
-	UnregisterSignal(active_item, COMSIG_ITEM_DROPPED)
-	REMOVE_TRAIT(active_item, TRAIT_NO_STORAGE_INSERT, HAND_REPLACEMENT_TRAIT)
+	REMOVE_TRAIT(active_item, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 	active_item = null
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, 1)
 
@@ -119,8 +131,7 @@
 		return
 
 	active_item = item
-	RegisterSignal(active_item, COMSIG_ITEM_DROPPED, .proc/on_item_drop) //Drop it to put away.
-	ADD_TRAIT(active_item, TRAIT_NO_STORAGE_INSERT, HAND_REPLACEMENT_TRAIT)
+	ADD_TRAIT(active_item, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 
 	active_item.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	active_item.slot_flags = null

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -38,6 +38,7 @@
 #include "anchored_mobs.dm"
 #include "component_tests.dm"
 #include "dynamic_ruleset_sanity.dm"
+#include "keybinding_init.dm"
 #include "reagent_id_typos.dm"
 #include "reagent_recipe_collisions.dm"
 #include "spawn_humans.dm"

--- a/code/modules/unit_tests/keybinding_init.dm
+++ b/code/modules/unit_tests/keybinding_init.dm
@@ -1,0 +1,6 @@
+/datum/unit_test/keybinding_init/Run()
+	for(var/i in subtypesof(/datum/keybinding))
+		var/datum/keybinding/KB = i
+		if(initial(KB.keybind_signal) || !initial(KB.name))
+			continue
+		Fail("[initial(KB.name)] does not have a keybind signal defined.")


### PR DESCRIPTION
## About The Pull Request

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/49116
- https://github.com/tgstation/tgstation/pull/52219
- https://github.com/tgstation/tgstation/pull/54914

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/5618

**I only did rudimentary testing on this.** As it affects a basic element of the game (keybindings) I would recommend a testmerge.

The first PR adds a `can_use` proc to `keybinding` datums, which is called to check if a keybinding is valid to be used before it's executed. Checks shared between keybindings are moved to this new proc, defined on a base type, to reduce boilerplate and help avoid issues due to people forgetting to include those checks.

The second PR adds signals (`keybind_signal`) for every `keybinding`. The signals are called in the base `/datum/keybinding/down()`, which needs to call parent, and can cancel execution of overriden `down` definitions. The signals are required to be defined on every keybinding.
Also included is a unit test that checks to ensure every keybinding with a `name` defined also has a `keybind_signal` defined.
**NOTE:** This only applies to serverside keybindings. This does not include, for example, `T` for say, `Tab` for hotkey mode, `O` for OOC.

The third PR fixes issues with being able to detach arm augment items from your hand. When I was porting the arm augment rework, keybind signals were a missing dependency, and I went with a suggestion I saw on in a comment on that PR. As it turns out, this caused issues that went unnoticed for a while, allowing you to easily detach your augment items from your hand.  

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfixes are good, keybind signals might be useful in other places.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: KubeRoot, AnturK, Coul, Rohesie, zxaber
fix: Fixed at least two ways of detaching arm augment items from your hand.
code: Added can_use and signals to keybinds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
