### PR TITLE
Fix production machines being unusable

### DIFF
--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -20,7 +20,7 @@
 								)
 	production_animation = "circuit_imprinter_ani"
 	allowed_buildtypes = IMPRINTER
-	requires_console = FALSE
+	consoleless_interface = TRUE
 
 /obj/machinery/rnd/production/circuit_imprinter/disconnect_console()
 	linked_console.linked_imprinter = null

--- a/code/modules/research/machinery/departmental_circuit_imprinter.dm
+++ b/code/modules/research/machinery/departmental_circuit_imprinter.dm
@@ -3,7 +3,6 @@
 	desc = "A special circuit imprinter with a built in interface meant for departmental usage, with built in ExoSync receivers allowing it to print designs researched that match its ROM-encoded department type."
 	icon_state = "circuit_imprinter"
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/department
-	consoleless_interface = TRUE
 
 /obj/machinery/rnd/production/circuit_imprinter/department/science
 	name = "department circuit imprinter (Science)"

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -3,7 +3,6 @@
 	desc = "A special protolathe with a built in interface meant for departmental usage, with built in ExoSync receivers allowing it to print designs researched that match its ROM-encoded department type."
 	icon_state = "protolathe"
 	circuit = /obj/item/circuitboard/machine/protolathe/department
-	consoleless_interface = TRUE
 
 /obj/machinery/rnd/production/protolathe/department/engineering
 	name = "department protolathe (Engineering)"

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -20,7 +20,7 @@
 								)
 	production_animation = "protolathe_n"
 	allowed_buildtypes = PROTOLATHE
-	requires_console = FALSE
+	consoleless_interface = TRUE
 
 /obj/machinery/rnd/production/protolathe/disconnect_console()
 	linked_console.linked_lathe = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/BeeStation/BeeStation-Hornet/pull/4843 removes the ability to use production machines (circuit imprinter, protolathe, techfab) via the console. To compensate for this, it's supposed to set those machines as being usable without a console. However, it sets `requires_console = FALSE` instead of `consoleless_interface = TRUE`, which is presumably a coding mistake.

This PR makes circuit imprinters and protolathes usable without a console, by switching out `requires_console` for `consoleless_interface` where needed, and moving up the var override from departmental protolathes up to all protolathes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix for presumed bug. Those machines should be usable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Circuit imprinters and omnilathes are usable without a console, as was presumably intended when to them via consoles was removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
