### PR TITLE
Fixes oozelings going below 0% blood volume from fire extinguishers.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -233,8 +233,7 @@
 	if(!istype(M))
 		return
 	if(isoozeling(M))
-		M.blood_volume -= 30
-		M.blood_volume = max(M.blood_volume, 0)
+		M.blood_volume = max(M.blood_volume - 30, 0)
 		to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
 		return
 	if(method == TOUCH)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -233,6 +233,9 @@
 	if(!istype(M))
 		return
 	if(isoozeling(M))
+		if(M.blood_volume <= 0)
+			M.blood_volume = 0
+			return
 		M.blood_volume -= 30
 		to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
 		return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -233,10 +233,8 @@
 	if(!istype(M))
 		return
 	if(isoozeling(M))
-		if(M.blood_volume <= 0)
-			M.blood_volume = 0
-			return
 		M.blood_volume -= 30
+		M.blood_volume = max(M.blood_volume, 0)
 		to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
 		return
 	if(method == TOUCH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
All carbons have a check to never go below 0, however this was hardcoded to remove 30 blood and blatently ignored the check. It's really annoying to see unrevivable oozelings with -23330% blood.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: mc_meiler
fix: fixed oozelings going below 0% blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
