### PR TITLE
Fix R&D Console's destructive analyzer interface

### DIFF
--- a/tgui/packages/tgui/interfaces/Techweb.js
+++ b/tgui/packages/tgui/interfaces/Techweb.js
@@ -514,16 +514,18 @@ const TechwebItemmaterials = (props, context) => {
           <Divider />
         </>
       )}
-      <Flex direction="column">
-        Reclaimable materials:
-        {itemmats.map(mats => {
-          return (
-            <Flex.Item key={mats}>
-              {mats}
-            </Flex.Item>
-          );
-        })}
-      </Flex>
+      {!!itemmats && (
+        <Flex direction="column">
+          Reclaimable materials:
+          {itemmats.map(mats => {
+            return (
+              <Flex.Item key={mats}>
+                {mats}
+              </Flex.Item>
+            );
+          })}
+        </Flex>
+      )}
     </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/Techweb.js
+++ b/tgui/packages/tgui/interfaces/Techweb.js
@@ -498,7 +498,7 @@ const TechwebItemmaterials = (props, context) => {
   const { act, data } = useRemappedBackend(context);
   const { itemmats, itempoints } = data;
 
-  return (
+  return (itempoints || itemmats) && (
     <Section mt={1} className="Techweb__NodeContainer">
       {!!itempoints && (
         <>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When interfacing with a destructive analyzer, the console can find any combination of the following three things:
- Reclaimable research points
- Reclaimable materials
- Boostable researches

When any of these is not present, a null is passed instead. The console was correctly handling this case for reclaimable research points and boostable researches, but not for reclaimable materials.

Because of this, if you tried to access the destructive analyzer interface when it had an item without any reclaimable materials inserted (for example a dead mouse), it would bluescreen.

This PR adds the missing check for that, and additionally hides the whole section containing reclaimable things if there are none to display.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The R&D Console no longer crashes when trying to analyze an item with no reclaimable materials.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
