### PR TITLE
Fixes traitor shuttle not beeing deployable on generated asteroid zlevel

### DIFF
--- a/code/modules/shuttle/bluespace_shuttle_pod/shuttle_capsule.dm
+++ b/code/modules/shuttle/bluespace_shuttle_pod/shuttle_capsule.dm
@@ -13,7 +13,8 @@
 	if(!blacklisted_turfs)
 		whitelisted_areas = typecacheof(list(
 			/area/space,
-			/area/lavaland
+			/area/lavaland,
+			/area/asteroid
 		))
 		whitelisted_turfs = typecacheof(list(
 			/turf/open/space,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because generated asteroids have the asteroid/generated area applied for the whole zlevel it was impossible to  spawn the traitor shuttle using the bluespace capsule on that zlevel hench a traitor could get stuck even trough they should have a methode to escape (if they got enough TC at least).
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: traitor bluespace shuttle capsule can now be used on supercruise asteroid zlevel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
