### PR TITLE
Disables Fly & Squid characters

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -505,7 +505,6 @@ ROUNDSTART_RACES plasmaman
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES agent
-#ROUNDSTART_RACES military_synth
 #ROUNDSTART_RACES pod
 #ROUNDSTART_RACES skeleton
 #ROUNDSTART_RACES slime

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -500,7 +500,6 @@ ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES plasma_golem
 #ROUNDSTART_RACES shadow
 #ROUNDSTART_RACES silver_golem
-#ROUNDSTART_RACES synth
 #ROUNDSTART_RACES uranium_golem
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -511,6 +511,12 @@ ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES military_synth
 #ROUNDSTART_RACES agent
 
+## Roundstart no-reset races
+##-------------------------------------------------------------------------------------------
+## Races defined here will not cause existing characters to be reset to human if they currently have a non-roundstart species defined.
+ROUNDSTART_NO_HARD_CHECK squid
+ROUNDSTART_NO_HARD_CHECK fly
+
 ## Paywall Races
 ##-------------------------------------------------------------------------------------------
 ## Uncommenting races will restrict them behind the patreon paywall

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -509,12 +509,6 @@ ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES slime
 #ROUNDSTART_RACES zombie
 
-## Roundstart no-reset races
-##-------------------------------------------------------------------------------------------
-## Races defined here will not cause existing characters to be reset to human if they currently have a non-roundstart species defined.
-ROUNDSTART_NO_HARD_CHECK squid
-ROUNDSTART_NO_HARD_CHECK fly
-
 ## Paywall Races
 ##-------------------------------------------------------------------------------------------
 ## Uncommenting races will restrict them behind the patreon paywall

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -491,25 +491,25 @@ ROUNDSTART_RACES ethereal
 ROUNDSTART_RACES ipc
 ROUNDSTART_RACES oozeling
 ROUNDSTART_RACES plasmaman
-#ROUNDSTART_RACES jelly
-#ROUNDSTART_RACES shadow
-#ROUNDSTART_RACES iron_golem
+#ROUNDSTART_RACES abductor
 #ROUNDSTART_RACES adamantine_golem
-#ROUNDSTART_RACES plasma_golem
 #ROUNDSTART_RACES diamond_golem
 #ROUNDSTART_RACES gold_golem
+#ROUNDSTART_RACES iron_golem
+#ROUNDSTART_RACES jelly
+#ROUNDSTART_RACES plasma_golem
+#ROUNDSTART_RACES shadow
 #ROUNDSTART_RACES silver_golem
-#ROUNDSTART_RACES uranium_golem
-#ROUNDSTART_RACES abductor
 #ROUNDSTART_RACES synth
+#ROUNDSTART_RACES uranium_golem
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
-#ROUNDSTART_RACES skeleton
-#ROUNDSTART_RACES zombie
-#ROUNDSTART_RACES slime
-#ROUNDSTART_RACES pod
-#ROUNDSTART_RACES military_synth
 #ROUNDSTART_RACES agent
+#ROUNDSTART_RACES military_synth
+#ROUNDSTART_RACES pod
+#ROUNDSTART_RACES skeleton
+#ROUNDSTART_RACES slime
+#ROUNDSTART_RACES zombie
 
 ## Roundstart no-reset races
 ##-------------------------------------------------------------------------------------------

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -478,20 +478,21 @@ SILICON_MAX_LAW_AMOUNT 12
 ROUNDSTART_RACES human
 
 ## Races that are strictly worse than humans that could probably be turned on without balance concerns
-ROUNDSTART_RACES lizard
-ROUNDSTART_RACES fly
-ROUNDSTART_RACES moth
 ROUNDSTART_RACES felinid
-ROUNDSTART_RACES squid
+ROUNDSTART_RACES lizard
+ROUNDSTART_RACES moth
+#ROUNDSTART_RACES fly
+#ROUNDSTART_RACES squid
 
 
 ## Races that are better than humans in some ways, but worse in others
-ROUNDSTART_RACES ethereal
 ROUNDSTART_RACES apid
+ROUNDSTART_RACES ethereal
+ROUNDSTART_RACES ipc
 ROUNDSTART_RACES oozeling
+ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES jelly
 #ROUNDSTART_RACES shadow
-ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES iron_golem
 #ROUNDSTART_RACES adamantine_golem
 #ROUNDSTART_RACES plasma_golem
@@ -501,7 +502,6 @@ ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES uranium_golem
 #ROUNDSTART_RACES abductor
 #ROUNDSTART_RACES synth
-ROUNDSTART_RACES ipc
 
 ## Races that are straight upgrades. If these are on expect powergamers to always pick them
 #ROUNDSTART_RACES skeleton


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fly/squid characters will no longer be selectable races for new characters. ~~Pre-existing characters can still be played like normal~~

I also sorted the species alphabetically and grouped them based on their state. 

(Note: Removed (mil) synths since Kapu forgot to do so in their pr #5623)

## Why It's Good For The Game

Both Flies and Squids are severely underutilized and have been lacking in updates. This prevents them from bloating the current species list while still allowing people who primarily play as either species to continue doing so for the time being.

## Changelog
:cl:
config: Squid & fly have been removed as selectable species
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
