### PR TITLE
Xenomorph queen only triggers hostile environment if it's on the station Z level

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -41,7 +41,7 @@
 	var/datum/action/small_sprite/smallsprite = new/datum/action/small_sprite/queen()
 
 /mob/living/carbon/alien/humanoid/royal/queen/Initialize()
-	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/check_hostile)
+	RegisterSignal(src, COMSIG_MOVABLE_Z_CHANGED, .proc/check_hostile)
 	check_hostile() //still need to call this
 	//there should only be one queen
 	for(var/mob/living/carbon/alien/humanoid/royal/queen/Q in GLOB.carbon_list)
@@ -92,6 +92,11 @@
 	UnregisterSignal(src, COMSIG_MOVABLE_Z_CHANGED)
 	SSshuttle.clearHostileEnvironment(src)
 	..()
+
+/mob/living/carbon/alien/humanoid/royal/queen/revive(full_heal = 0, admin_revive = 0)
+	if(..())
+		RegisterSignal(src, COMSIG_MOVABLE_Z_CHANGED, .proc/check_hostile)
+		check_hostile()
 
 /mob/living/carbon/alien/humanoid/royal/queen/Destroy()
 	UnregisterSignal(src, COMSIG_MOVABLE_Z_CHANGED)

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -69,6 +69,7 @@
 	..()
 
 /mob/living/carbon/alien/humanoid/royal/queen/proc/check_hostile()
+	SIGNAL_HANDLER
 	if(is_station_level(src.z)) //we don't want the hostile environment if the xenos aren't actually on station
 		SSshuttle.registerHostileEnvironment(src) //aliens delay shuttle
 		addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES) //time until shuttle is freed/called

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -12,6 +12,7 @@
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 20, /obj/item/stack/sheet/animalhide/xeno = 3)
 
 	var/alt_inhands_file = 'icons/mob/alienqueen.dmi'
+	var/game_end_timer
 
 /mob/living/carbon/alien/humanoid/royal/can_inject()
 	return FALSE
@@ -72,7 +73,9 @@
 	SIGNAL_HANDLER
 	if(is_station_level(src.z)) //we don't want the hostile environment if the xenos aren't actually on station
 		SSshuttle.registerHostileEnvironment(src) //aliens delay shuttle
-		addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES) //time until shuttle is freed/called
+		if(game_end_timer)	//clear the timer if it exists
+			deltimer(game_end_timer)
+		game_end_timer = addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES, TIMER_STOPPABLE) //time until shuttle is freed/called
 		return
 	if(src in SSshuttle.hostileEnvironments)
 		SSshuttle.clearHostileEnvironment(src) //left the z level, no longer matters

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -41,8 +41,8 @@
 	var/datum/action/small_sprite/smallsprite = new/datum/action/small_sprite/queen()
 
 /mob/living/carbon/alien/humanoid/royal/queen/Initialize()
-	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/register_hostile)
-	register_hostile() //still need to call this
+	RegisterSignal(src, list(COMSIG_MOVABLE_Z_CHANGED), .proc/check_hostile)
+	check_hostile() //still need to call this
 	//there should only be one queen
 	for(var/mob/living/carbon/alien/humanoid/royal/queen/Q in GLOB.carbon_list)
 		if(Q == src)
@@ -68,10 +68,13 @@
 	internal_organs += new /obj/item/organ/alien/eggsac
 	..()
 
-/mob/living/carbon/alien/humanoid/royal/queen/proc/register_hostile()
+/mob/living/carbon/alien/humanoid/royal/queen/proc/check_hostile()
 	if(is_station_level(src.z)) //we don't want the hostile environment if the xenos aren't actually on station
 		SSshuttle.registerHostileEnvironment(src) //aliens delay shuttle
 		addtimer(CALLBACK(src, .proc/game_end), 30 MINUTES) //time until shuttle is freed/called
+		return
+	if(src in SSshuttle.hostileEnvironments)
+		SSshuttle.clearHostileEnvironment(src) //left the z level, no longer matters
 
 /mob/living/carbon/alien/humanoid/royal/queen/proc/game_end()
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The xenomorph queen delaying the shuttle just because it's alive on an exploration mission site is bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The xenomorph queen no longer blocks the shuttle if it's not on the station's Z level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
