### PR TITLE
Remove dependency on R&D consoles from protolathes and circuit imprinters

### DIFF
--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -21,6 +21,7 @@
 	production_animation = "circuit_imprinter_ani"
 	allowed_buildtypes = IMPRINTER
 	consoleless_interface = TRUE
+	requires_console = FALSE
 
 /obj/machinery/rnd/production/circuit_imprinter/disconnect_console()
 	linked_console.linked_imprinter = null

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -21,6 +21,7 @@
 	production_animation = "protolathe_n"
 	allowed_buildtypes = PROTOLATHE
 	consoleless_interface = TRUE
+	requires_console = FALSE
 
 /obj/machinery/rnd/production/protolathe/disconnect_console()
 	linked_console.linked_lathe = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some protolathes and circuit imprinters currently are unable to print without first being linked from a nearby R&D Console. This PR adds `requires_console = FALSE` to remove that requirement.

The interface can be accessed on those machines, materials can be withdrawn and research can be synchronised(!), only printing is affected. This course of action was chosen after discussion with Archanial:

![image](https://user-images.githubusercontent.com/6917698/140374162-448c5b40-b6d1-43d7-a633-00e7ae90e051.png)

Other options, for example making production machines consistently dependent on consoles, would require significantly more work and could prove problematic with the way stations are currently mapped.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The current behavior is confusing and problematic, while providing no real value in terms of game mechanics in realistic scenarios.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Protolathes and circuit imprinters are no longer dependent on R&D consoles. This addresses issues with people being unable to print with them in some cases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
