### PR TITLE
Traumas On Death

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -104,7 +104,12 @@
 
 /mob/living/carbon/death(gibbed)
 	. = ..()
-
+	//Death trauma
+	var/obj/item/organ/brain/B = getorgan(/obj/item/organ/brain)
+	if(istype(B) && B.organ_flags & ORGAN_VITAL)
+		var/trauma_type = pick(BRAIN_TRAUMA_MILD, BRAIN_TRAUMA_SEVERE)
+		gain_trauma_type(trauma_type, TRAUMA_RESILIENCE_MAGIC)
+	
 	set_drugginess(0)
 	set_disgust(0)
 	update_damage_hud()


### PR DESCRIPTION
## About The Pull Request

Adds very simple yet powerfull new game mechanic - dying will now apply random permanent brain trauma

## Why It's Good For The Game
I think everybody can agree dying in the game has very little consequences. You can always get quickly patched up and usually be back up within few minutes going about your bussines as if nothing happend. Dying only truly matters if your corpse is intentionally prevented from being revived and very much feels like just another way to incapiciate somebody rather than something significant. 

My PR attempts to make death more impactfull by adding a permanent consequence to dying - unremovable brain trauma player has to deal with. It makes for an interesting gameplay and a challenge where player has to go on with some sort of burden. Players will value their lives more and will likely respond differently to various threats. For example rushing a traitor to shove him and steal his energy sword - in current situation you only risk waiting 3 minutes to get revived and get back to validhunting. With the proposed change this can result in person being forced to use a wheelchair for rest of the round if they fail and die in the process- do they really want to take the risk ?  Another example would be security officers having to consider whether they really need to use lethal force for the situation - is the impact it might have worth it ?
## Changelog
:cl:
balance: Dying will cause a random permanent brain trauma to make death more significant event
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
