### PR TITLE
Changes Gaseous Pores to Confuse instead of Sleep

### DIFF
--- a/code/modules/antagonists/changeling/powers/gaseous_pores.dm
+++ b/code/modules/antagonists/changeling/powers/gaseous_pores.dm
@@ -1,27 +1,27 @@
 /datum/action/changeling/gaseous_pores
 	name = "Gaseous Pores"
-	desc = "Our skins bursts, releasing somniferous gases to put opponents to sleep and cover our retreat."
+	desc = "Our skins bursts, releasing gases which bring confusion to our chasers, covering our escape."
 	helptext = "Our kind are immune to the gases internals are not necessary"
 	button_icon_state = "smoke"
-	chemical_cost = 35
+	chemical_cost = 25
 	dna_cost = 2
 	req_stat = UNCONSCIOUS
 	var/range = 4
 
-/obj/effect/particle_effect/smoke/sleeping/changeling
+/obj/effect/particle_effect/smoke/confusing/changeling
 	color = "#9C3636"
 	lifetime = 10
 
-/obj/effect/particle_effect/smoke/sleeping/changeling/smoke_mob(mob/living/carbon/M,datum/antagonist)
+/obj/effect/particle_effect/smoke/confusing/changeling/smoke_mob(mob/living/carbon/M,datum/antagonist)
 	if(is_changeling(M))
 		return FALSE
 	if(..())
-		M.Sleeping(200)
+		M.confused = max(M.confused, 12)
 		INVOKE_ASYNC(M, /mob.proc/emote, "cough")
 		return TRUE
 
-/datum/effect_system/smoke_spread/sleeping/changeling
-	effect_type = /obj/effect/particle_effect/smoke/sleeping/changeling
+/datum/effect_system/smoke_spread/confusing/changeling
+	effect_type = /obj/effect/particle_effect/smoke/confusing/changeling
 
 /datum/action/changeling/gaseous_pores/sting_action(mob/user)
 	..()
@@ -31,7 +31,7 @@
 	var/turf/T = get_turf(user)
 	if(!T)
 		return FALSE
-	var/datum/effect_system/smoke_spread/sleeping/changeling/smoke = new(T)
+	var/datum/effect_system/smoke_spread/confusing/changeling/smoke = new(T)
 	smoke.set_up(range, T)
 	smoke.start()
 	user.visible_message("<span class='warning'>With a guttural screech, [user]'s skin bursts into gas!</span>")

--- a/code/modules/antagonists/changeling/powers/gaseous_pores.dm
+++ b/code/modules/antagonists/changeling/powers/gaseous_pores.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/gaseous_pores
 	name = "Gaseous Pores"
-	desc = "Our skins bursts, releasing gases which bring confusion to our chasers, covering our escape."
+	desc = "Our skins bursts, releasing gases which bring confusion to our pursuers, covering our escape."
 	helptext = "Our kind are immune to the gases internals are not necessary"
 	button_icon_state = "smoke"
 	chemical_cost = 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes gaseous pores confuse instead of sleep, changes chem cost to 25
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gaseous pores was a bit too powerful and was never intended to be used as an offensive ability
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: makes gaseous pores confuse instead of sleep and makes it cheaper  chemicals wise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
