### PR TITLE
Adds a small playtime/age requirement to explorers

### DIFF
--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -7,6 +7,9 @@
 	total_positions = 3
 	spawn_positions = 3
 	supervisors = "the research director"
+	minimal_player_age = 3
+	exp_requirements = 900
+	exp_type = EXP_TYPE_CREW
 	selection_color = "#ffeeff"
 	chat_color = "#85d8b8"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds a relatively small playtime requirement to the Explorers role:

- 3-days on the server
- 5-hours as crew

## Why It's Good For The Game

The explorer role is a fairly experience heavy/involved position that can very easily round-remove the player if they aren't careful (even more-so than mining). Adding a slight requirement should help prevent newer players from being frustrated at its added complexity.

## Changelog
:cl:
add: Explorers now require 3-days on the server and 5-hours of Crew experience before they can be selected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
