### PR TITLE
Janitorial Rebalance

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -63,6 +63,7 @@
 	name = "custodial holobarrier projector"
 	desc = "A holographic projector that creates hard light wet floor barriers."
 	holosign_type = /obj/structure/holosign/barrier/wetsign
+	custom_price = 200
 	creation_time = 20
 	max_signs = 12
 

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -570,6 +570,7 @@
 	icon_state = "caution"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
+	custom_price = 10
 	force = 1
 	throwforce = 3
 	throw_speed = 2

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1055,3 +1055,11 @@
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
 	build_path = /obj/item/airlock_painter/decal
 	category = list("initial","Tools","Tool Designs")
+
+/datum/design/cautionsign
+	name = "Wet Floor Sign"
+	id = "wetfloorsign"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 50)
+	build_path = /obj/item/clothing/suit/caution
+	category = list("initial","Misc")

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -334,14 +334,17 @@
 					/obj/item/paint/paint_remover = 2,
 					/obj/item/melee/flyswatter = 2,
 					/obj/item/flashlight = 2,
-					/obj/item/clothing/suit/caution = 6,
-					/obj/item/holosign_creator/janibarrier = 2,
+					/obj/item/clothing/suit/caution = 12, //The modern, good ones.
 					/obj/item/lightreplacer = 2,
 					/obj/item/soap/nanotrasen = 2,
 					/obj/item/storage/bag/trash = 2,
 					/obj/item/clothing/shoes/galoshes = 2,
 					/obj/item/watertank/janitor = 1,
 					/obj/item/storage/belt/janitor = 2)
+	contraband = list(
+					/obj/item/holosign_creator/janibarrier = 1,
+					/obj/item/caution = 3, //The really old crusty ones
+	)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
 	payment_department = ACCOUNT_SRV
 /obj/item/vending_refill/wardrobe/jani_wardrobe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The holosign projector has been moved to the janidrobe's contraband list, the cost of physical wet floor signs has been dumpstered, and the supply substantially increased to act as a supply of spares.

If you lose all of them, you can print more in an autolathe. Or if you just... want one for some reason. I don't judge.

## Why It's Good For The Game

The holosign is now a reward for a 'job well done'
...This is honestly just done to make their job a bit more involved.

## Changelog
:cl:
balance: Janitors are now expected to use their actual wet floor signs. Their supply and cost have been adjusted accordingly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
