### PR TITLE
Code for roundstart_no_hard_check config option

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1969,7 +1969,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/datum/species/chosen_species
 	chosen_species = pref_species.type
-	if(!roundstart_checks || (pref_species.id in GLOB.roundstart_races))
+	if(!roundstart_checks || (pref_species.id in GLOB.roundstart_races) || (pref_species.id in GLOB.roundstart_no_hard_check))
 		chosen_species = pref_species.type
 	else
 		chosen_species = /datum/species/human

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1969,7 +1969,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/datum/species/chosen_species
 	chosen_species = pref_species.type
-	if(!roundstart_checks || (pref_species.id in GLOB.roundstart_races) || (pref_species.id in GLOB.roundstart_no_hard_check))
+	if(!roundstart_checks || (pref_species.id in GLOB.roundstart_races) || pref_species.check_no_hard_check())
 		chosen_species = pref_species.type
 	else
 		chosen_species = /datum/species/human

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1,6 +1,7 @@
 // This code handles different species in the game.
 
 GLOBAL_LIST_EMPTY(roundstart_races)
+GLOBAL_LIST_EMPTY(roundstart_no_hard_check)
 
 /datum/species
 	var/id	// if the game needs to manually check your race to do something not included in a proc here, it will use this
@@ -107,17 +108,29 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	..()
 
 
+/**
+ * Generate list for roundstart selectable races
+ * +
+ * list of races which will not get force set to human on existing characters if not roundstart selectable
+ */
 /proc/generate_selectable_species()
 	for(var/I in subtypesof(/datum/species))
 		var/datum/species/S = new I
 		if(S.check_roundstart_eligible())
 			GLOB.roundstart_races += S.id
-			qdel(S)
+		if(S.check_no_hard_check())
+			GLOB.roundstart_no_hard_check += S.id
+		qdel(S)
 	if(!GLOB.roundstart_races.len)
 		GLOB.roundstart_races += "human"
 
 /datum/species/proc/check_roundstart_eligible()
 	if(id in (CONFIG_GET(keyed_list/roundstart_races)))
+		return TRUE
+	return FALSE
+
+/datum/species/proc/check_no_hard_check()
+	if(id in (CONFIG_GET(keyed_list/roundstart_no_hard_check)))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1,7 +1,6 @@
 // This code handles different species in the game.
 
 GLOBAL_LIST_EMPTY(roundstart_races)
-GLOBAL_LIST_EMPTY(roundstart_no_hard_check)
 
 /datum/species
 	var/id	// if the game needs to manually check your race to do something not included in a proc here, it will use this
@@ -107,20 +106,12 @@ GLOBAL_LIST_EMPTY(roundstart_no_hard_check)
 		limbs_id = id
 	..()
 
-
-/**
- * Generate list for roundstart selectable races
- * +
- * list of races which will not get force set to human on existing characters if not roundstart selectable
- */
 /proc/generate_selectable_species()
 	for(var/I in subtypesof(/datum/species))
 		var/datum/species/S = new I
 		if(S.check_roundstart_eligible())
 			GLOB.roundstart_races += S.id
-		if(S.check_no_hard_check())
-			GLOB.roundstart_no_hard_check += S.id
-		qdel(S)
+			qdel(S)
 	if(!GLOB.roundstart_races.len)
 		GLOB.roundstart_races += "human"
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -509,6 +509,11 @@ ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES slime
 #ROUNDSTART_RACES zombie
 
+## Roundstart no-reset races
+##-------------------------------------------------------------------------------------------
+## Races defined here will not cause existing characters to be reset to human if they currently have a non-roundstart species defined.
+#ROUNDSTART_NO_HARD_CHECK plasmaman
+
 ## Paywall Races
 ##-------------------------------------------------------------------------------------------
 ## Uncommenting races will restrict them behind the patreon paywall


### PR DESCRIPTION
## About The Pull Request

Made a new proc to check if a race is inside the `roundstart_no_hard_check` config list so the config option actually works.

I tested this with my existing plasmamen and lizard characters and it seems to be working.

If i did this as soon as i saw #5690 then maybe existing fly & squid characters could have been saved. Sorry about that.

Atleast this works now if another race gets made not-roundstart selectable but existing characters shall remain untouched.

If there is something missing let me know.

## Why It's Good For The Game

Makes a config option working which did nothing before. See crossedfall comments on #5690 

## Changelog
(Crossedfall is in here because i copied parts of their config stuff from the other pr)
:cl: Sarchutar, Crossedfall
fix: roundstart_no_hard_check config option is working now
config: Commented config option for `roundstart_no_hard_check`
/:cl:
