### PR TITLE
Fix for silicon windoor access

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -285,7 +285,7 @@
 	return ..()
 
 /obj/machinery/door/window/interact(mob/user)		//for sillycones
-	try_to_activate_door(user)
+	try_to_activate_door(null, user)
 
 /obj/machinery/door/window/try_to_activate_door(obj/item/I, mob/user)
 	if (..())


### PR DESCRIPTION
## About The Pull Request

Changing one line to add a null so item/I is not the silicon/mob.

Fixes #5721 

## Why It's Good For The Game

Fixing a bug caused by #5638  + silicons have rights too

## Changelog
:cl:
fix: silicons can remotely open windoors again
/:cl:
