### PR TITLE
Discovery Scanner and DNA probe now check if the mob is holographic

### DIFF
--- a/code/modules/exploration_crew/discovery_research/discoverable_component.dm
+++ b/code/modules/exploration_crew/discovery_research/discoverable_component.dm
@@ -41,6 +41,9 @@
 	if(linked_techweb.scanned_atoms[A.type] && !unique)
 		to_chat(user, "<span class='warning'>Datapoints about [A] already in system.</span>")
 		return
+	if(A.flags_1 & HOLOGRAM_1)
+		to_chat(user, "<span class='warning'>[A] is holographic, no datapoints can be extracted.</span>")
+		return
 	scanned = TRUE
 	linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, point_reward)
 	linked_techweb.scanned_atoms[A.type] = TRUE

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -100,7 +100,7 @@
 	if(isanimal(target) || is_type_in_typecache(target,non_simple_animals))
 		if(isanimal(target))
 			var/mob/living/simple_animal/A = target
-			if(!A.healable)//simple approximation of being animal not a robot or similar
+			if(!A.healable || (A.flags_1 & HOLOGRAM_1))//simple approximation of being animal not a robot or similar
 				to_chat(user, "<span class='warning'>No compatible DNA detected.</span>")
 				return
 		if(animals[target.type])

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -100,7 +100,7 @@
 	if(isanimal(target) || is_type_in_typecache(target,non_simple_animals))
 		if(isanimal(target))
 			var/mob/living/simple_animal/A = target
-			if(!A.healable || (A.flags_1 & HOLOGRAM_1))//simple approximation of being animal not a robot or similar
+			if(!A.healable || (A.flags_1 & HOLOGRAM_1)) //simple approximation of being animal not a robot or similar. Also checking if holographic
 				to_chat(user, "<span class='warning'>No compatible DNA detected.</span>")
 				return
 		if(animals[target.type])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The discovery scanner now checks if the mob is holographic or not before giving discovery points.
DNA Probe no longer getting animal DNA from holographic pets.

Closes #5508

## Why It's Good For The Game

Even if it's something that really helps when there's no exploration crew, it does not make sense that the discovery scanner can extract datapoints from holographic pets. This would also mean that discovery points starved scientists now actually have to interact with cargo/sec/etc to scan their pets.

Also added the same check for the DNA probe.

## Changelog
:cl:
fix: Discovery Scanner is no longer able to scan holographic pets.
fix: DNA Probe no longer gets animal DNA from holographic pets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
