### PR TITLE
Fix research tier calculation

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -31,8 +31,8 @@
 	var/list/scanned_atoms = list()
 	//Discovery cost tiers
 	var/current_tier = 1
-	var/list/items_per_tier = list()			//Assoc list, Key = "[tier level]", Value = Amount of items in tier
-	var/list/unlocked_in_tier = list()			//Assoc list, Key = "[tier level]", Value = Amount of items unlocked in tier
+	var/list/items_per_tier = list()			//Assoc list, Key = "[tier level]", Value = Amount of nodes in tier
+	var/list/unlocked_in_tier = list()			//Assoc list, Key = "[tier level]", Value = Amount of nodes unlocked in tier
 
 /datum/techweb/New()
 	SSresearch.techwebs += src

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -43,7 +43,7 @@
 	items_per_tier = list()
 	for(var/id in SSresearch.techweb_nodes)
 		var/datum/techweb_node/node = SSresearch.techweb_node_by_id(id)
-		if(islist(items_per_tier["[node.tech_tier]"]))
+		if(items_per_tier["[node.tech_tier]"])
 			items_per_tier["[node.tech_tier]"] += 1
 		else
 			items_per_tier["[node.tech_tier]"] = 1
@@ -93,7 +93,7 @@
 	for(var/id in processing)
 		var/datum/techweb_node/node = SSresearch.techweb_node_by_id(id)
 		update_node_status(node, FALSE)
-		if(islist(items_per_tier["[node.tech_tier]"]))
+		if(items_per_tier["[node.tech_tier]"])
 			items_per_tier["[node.tech_tier]"] += 1
 		else
 			items_per_tier["[node.tech_tier]"] = 1
@@ -104,9 +104,10 @@
 		V.updateUsrDialog()
 
 /datum/techweb/proc/recalculate_tiers()
+	unlocked_in_tier = list()
 	for(var/id in researched_nodes)
 		var/datum/techweb_node/node = SSresearch.techweb_node_by_id(id)
-		if(islist(unlocked_in_tier["[node.tech_tier]"]))
+		if(unlocked_in_tier["[node.tech_tier]"])
 			unlocked_in_tier["[node.tech_tier]"] += 1
 		else
 			unlocked_in_tier["[node.tech_tier]"] = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

```dm
//Unlock 20% of a tier and the tier will progress to that one.
#define TIER_PROPORTATION_TO_UNLOCK 0.2
```

As it turns out, research tier calculation was completely broken. It thought every tier only has a single node, and only counted up to one researched node, making each tier unlocked with just one research.

This was due to a wrong check, presumably due to an incomplete refactor of the code. The `items_per_tier` and `unlocked_in_tier` vars on techwebs store how many research nodes are available, and how many have been researched so far. It is an associative list of stringified research to node count.

However...

```dm
	for(var/id in researched_nodes)
		var/datum/techweb_node/node = SSresearch.techweb_node_by_id(id)
		if(islist(unlocked_in_tier["[node.tech_tier]"]))
			unlocked_in_tier["[node.tech_tier]"] += 1
		else
			unlocked_in_tier["[node.tech_tier]"] = 1
```

The code thought they held a list, not a count. Because of this, the check always failed, and the value was always set to `1`.

This PR fixes the bad check, as well as `unlocked_in_tier` not being reset in `recalculate_tiers`. Also updated comments describing the vars to be more accurate.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is what was intended for supercruise; it might not be well-balanced, but it seems like discovery research barely matters in the current state.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Research tiers are now calculated correctly. This means you now correctly need 20% of a tier's nodes researched before the global research tier advances to it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
