### PR TITLE
Fix armory spelling

### DIFF
--- a/_maps/RuinGeneration/13x13_corgarmory.dmm
+++ b/_maps/RuinGeneration/13x13_corgarmory.dmm
@@ -5,7 +5,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/ruinloot/armoury,
+/obj/effect/spawner/lootdrop/ruinloot/armory,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "b" = (
@@ -14,7 +14,7 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Blast Doors"
 	},
 /obj/effect/abstract/doorway_marker,
@@ -58,7 +58,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/ruinloot/armoury,
+/obj/effect/spawner/lootdrop/ruinloot/armory,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "j" = (
@@ -78,7 +78,7 @@
 "l" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet,
-/obj/effect/spawner/lootdrop/ruinloot/armoury,
+/obj/effect/spawner/lootdrop/ruinloot/armory,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "m" = (
@@ -159,7 +159,7 @@
 	req_access_txt = "3"
 	},
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/ruinloot/armoury,
+/obj/effect/spawner/lootdrop/ruinloot/armory,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "A" = (
@@ -172,7 +172,7 @@
 "B" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/lootdrop/ruinloot/armoury,
+/obj/effect/spawner/lootdrop/ruinloot/armory,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "E" = (
@@ -287,7 +287,7 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Blast Doors"
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1196,11 +1196,11 @@
 /area/crew_quarters/heads/hos)
 "acT" = (
 /obj/machinery/door/window/eastleft{
-	name = "armoury desk";
+	name = "armory desk";
 	req_access_txt = "1"
 	},
 /obj/machinery/door/window/westleft{
-	name = "armoury desk";
+	name = "armory desk";
 	req_access_txt = "3"
 	},
 /obj/structure/table/reinforced,
@@ -1384,7 +1384,7 @@
 "adl" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory";
-	name = "Armoury Shutter"
+	name = "Armory Shutter"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -15078,7 +15078,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/button/door{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Xenobiology Containment Cell Lockdown";
 	pixel_x = -28;
 	pixel_y = 28;
@@ -26156,7 +26156,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/button/door{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Armory Blast Doors";
 	pixel_x = -28;
 	pixel_y = 28;
@@ -36238,7 +36238,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/poddoor/preopen{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Blast Doors"
 	},
 /obj/machinery/door/firedoor,
@@ -43240,7 +43240,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/button/door{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Armory Blast Doors";
 	pixel_x = 26;
 	pixel_y = -26;
@@ -55923,7 +55923,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/poddoor/preopen{
-	id = "armourydoors";
+	id = "armorydoors";
 	name = "Blast Doors"
 	},
 /obj/machinery/door/firedoor,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -56782,7 +56782,7 @@
 /area/ai_monitored/security/armory)
 "bTl" = (
 /obj/machinery/camera/motion{
-	c_tag = "Armoury - Exterior";
+	c_tag = "Armory - Exterior";
 	dir = 4
 	},
 /turf/open/space,
@@ -58245,7 +58245,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security{
-	name = "Armoury";
+	name = "Armory";
 	req_access_txt = "3";
 	security_level = 6
 	},
@@ -60130,7 +60130,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/security{
-	name = "Armoury";
+	name = "Armory";
 	req_access_txt = "3";
 	security_level = 6
 	},
@@ -61544,7 +61544,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/security/armory";
 	dir = 2;
-	name = "Armoury APC";
+	name = "Armory APC";
 	pixel_y = -24
 	},
 /obj/machinery/camera{
@@ -62558,8 +62558,8 @@
 /area/ai_monitored/security/armory)
 "cbI" = (
 /obj/machinery/door/poddoor{
-	id = "armouryaccess";
-	name = "Armoury Access"
+	id = "armoryaccess";
+	name = "Armory Access"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -62572,13 +62572,13 @@
 "cbJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/northright{
-	name = "Armoury Desk";
+	name = "Armory Desk";
 	req_access_txt = "3"
 	},
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/southright{
-	name = "Armoury Desk"
+	name = "Armory Desk"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -62595,8 +62595,8 @@
 /area/ai_monitored/security/armory)
 "cbL" = (
 /obj/machinery/button/door{
-	id = "armouryaccess";
-	name = "Armoury Access";
+	id = "armoryaccess";
+	name = "Armory Access";
 	pixel_x = -26;
 	pixel_y = -26;
 	req_access_txt = "3"

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6022,7 +6022,7 @@
 	},
 /obj/machinery/button/door{
 	id = "sidearmory";
-	name = "Armoury Shutter Toggle";
+	name = "Armory Shutter Toggle";
 	pixel_x = -8;
 	pixel_y = 24;
 	req_access_txt = "3"
@@ -8846,7 +8846,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/camera/motion{
-	c_tag = "Armoury Internal";
+	c_tag = "Armory Internal";
 	dir = 8
 	},
 /obj/effect/turf_decal/box,
@@ -33342,7 +33342,7 @@
 /obj/item/folder/red,
 /obj/item/pen,
 /obj/machinery/door/window/brigdoor/westright{
-	name = "Armoury Desk";
+	name = "Armory Desk";
 	req_access_txt = "3"
 	},
 /turf/open/floor/plating,
@@ -77807,11 +77807,11 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
 	id = "sidearmory";
-	name = "Side Armoury Shutter"
+	name = "Side Armory Shutter"
 	},
 /obj/machinery/button/door{
 	id = "sidearmory";
-	name = "Armoury Shutter Toggle";
+	name = "Armory Shutter Toggle";
 	pixel_y = -24;
 	req_access_txt = "3"
 	},
@@ -79183,16 +79183,16 @@
 "ckl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
-	name = "Armoury";
+	name = "Armory";
 	req_access_txt = "58"
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "frontarmory";
-	name = "Front Armoury Shutter"
+	name = "Front Armory Shutter"
 	},
 /obj/machinery/button/door{
 	id = "frontarmory";
-	name = "Armoury Shutter Toggle";
+	name = "Armory Shutter Toggle";
 	pixel_y = 24;
 	req_access_txt = "58"
 	},
@@ -82139,7 +82139,7 @@
 "coR" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/security{
-	name = "Armoury";
+	name = "Armory";
 	req_access_txt = "3";
 	security_level = 6
 	},
@@ -86270,7 +86270,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/security/armory";
 	dir = 2;
-	name = "Armoury APC";
+	name = "Armory APC";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
@@ -88195,7 +88195,7 @@
 /area/maintenance/port/fore)
 "cxE" = (
 /obj/machinery/camera/motion{
-	c_tag = "Armoury External";
+	c_tag = "Armory External";
 	dir = 2
 	},
 /obj/structure/lattice/catwalk,
@@ -99123,7 +99123,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/security{
-	name = "Armoury";
+	name = "Armory";
 	req_access_txt = "3";
 	security_level = 6
 	},

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/mapping.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/mapping.dm
@@ -148,8 +148,8 @@
 		/obj/item/grenade/exploration = 1,
 	)
 
-//Armoury stuff
-/obj/effect/spawner/lootdrop/ruinloot/armoury
+//Armory stuff
+/obj/effect/spawner/lootdrop/ruinloot/armory
 	loot = list(
 		"" = 30,
 		/obj/item/gun/energy/disabler = 5,

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_part_types.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_part_types.dm
@@ -96,8 +96,8 @@
 	file_name = "9x9_checkpoint"
 	weight = 5
 
-/datum/map_template/ruin_part/corgarmoury
-	file_name = "13x13_corgarmoury"
+/datum/map_template/ruin_part/corgarmory
+	file_name = "13x13_corgarmory"
 	weight = 5
 	loot_room = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/5757

Renames all cases of "armoury" to "armory", with the exception of references to canada

<details>

<summary>nothing important here</summary>

I **DID NOT** test any of this, in case somebody decides to merge it as a joke, this touched some IDs on remote controlled devices, as well as area typepaths, and might've broken stuff through that.

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Corrupting our glorious language is a crime. Our language shall remain pure, with the exception of mocking canada.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed armory spelling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
