### PR TITLE
Adds wooden bow crafting recipe

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -269,6 +269,16 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/woodenbow
+	name = "Wooden Bow"
+	result = /obj/item/gun/ballistic/bow
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 8,
+				/obj/item/stack/sheet/iron = 2,
+				/obj/item/weaponcrafting/silkstring = 4)
+	time = 120
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/meteorslug
 	name = "Meteorslug Shell"
 	result = /obj/item/ammo_casing/shotgun/meteorslug


### PR DESCRIPTION
## About The Pull Request

A new crafting recipe is added for the wooden bow, under the weapons tab, requiring eight wooden planks, four silkstring, and two iron sheets to craft.

## Why It's Good For The Game

As it currently stands, bows are rarely ever crafted, it's more laborious to make a bow than an improvised shotgun. The wooden bow's crafting recipe streamlines the process a bit, as Iron, Wood, and Silk are materials that you'll already need if you plan on making and using a bow as they're required to craft arrows.

## Changelog
:cl:
add: Added a crafting recipe for the wooden bow
/:cl: