### PR TITLE
Bans Eris sprites

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,6 +53,9 @@ They are mostly the same as /tg/station's code standards, though we are not quit
 Failure to meet these standards can result in your pull request being closed. The code standards are non-exhaustive and Maintainers have the final say.
 
 ## 5. Codebase-specific Policies
+### CEV-Eris
+Sprites from CEV-Eris and sprites clearly inspired by their art style are generally not permitted unless you recolor them using a tolerable color palette.
+
 ### HippieStation
 HippieStation's code standards are much more lax than BeeStation. Their code typically does not meet our standards. Therefore, you should not attempt to port code from HippieStation unless you have the experience and knowledge necessary to rewrite the code to our standards. Maintainers will not hold your hand for this, instead they will simply close the pull request.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The color palette is awful and having like 20 Eris sprites creates an awful style mishmash on top of our already awful style mishmash.

## Changelog
:cl:
add: Updated the contributing guidelines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
