### PR TITLE
Fixes legacy topic runtime, adds fallback for spacestation13.com

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -168,7 +168,8 @@ GLOBAL_VAR(restart_counter)
 	var/topic_decoded = rustg_url_decode(T)
 	if(!rustg_json_is_valid(topic_decoded))
 		// Fallback check for spacestation13.com requests
-		if(T == "ping")
+		log_topic("(NON-JSON) \"[topic_decoded]\", from:[addr], master:[master], key:[key]")
+		if(topic_decoded == "ping")
 			return length(GLOB.clients)
 		response["statuscode"] = 400
 		response["response"] = "Bad Request - Invalid JSON format"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -155,17 +155,26 @@ GLOBAL_VAR(restart_counter)
 
 	var/list/response[] = list()
 
-	if (length(T) > CONFIG_GET(number/topic_max_size))
+	if(length(T) > CONFIG_GET(number/topic_max_size))
 		response["statuscode"] = 413
 		response["response"] = "Payload too large"
 		return json_encode(response)
 
-	if (SSfail2topic?.IsRateLimited(addr))
+	if(SSfail2topic?.IsRateLimited(addr))
 		response["statuscode"] = 429
 		response["response"] = "Rate limited"
 		return json_encode(response)
 
-	var/list/params[] = json_decode(rustg_url_decode(T))
+	var/topic_decoded = rustg_url_decode(T)
+	if(!rustg_json_is_valid(topic_decoded))
+		// Fallback check for spacestation13.com requests
+		if(T == "ping")
+			return length(GLOB.clients)
+		response["statuscode"] = 400
+		response["response"] = "Bad Request - Invalid JSON format"
+		return json_encode(response)
+
+	var/list/params[] = json_decode(topic_decoded)
 	params["addr"] = addr
 	var/query = params["query"]
 	var/auth = params["auth"]

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -165,10 +165,12 @@ GLOBAL_VAR(restart_counter)
 		response["response"] = "Rate limited"
 		return json_encode(response)
 
+	var/logging = CONFIG_GET(flag/log_world_topic)
 	var/topic_decoded = rustg_url_decode(T)
 	if(!rustg_json_is_valid(topic_decoded))
+		if(logging)
+			log_topic("(NON-JSON) \"[topic_decoded]\", from:[addr], master:[master], key:[key]")
 		// Fallback check for spacestation13.com requests
-		log_topic("(NON-JSON) \"[topic_decoded]\", from:[addr], master:[master], key:[key]")
 		if(topic_decoded == "ping")
 			return length(GLOB.clients)
 		response["statuscode"] = 400
@@ -181,7 +183,7 @@ GLOBAL_VAR(restart_counter)
 	var/auth = params["auth"]
 	var/source = params["source"]
 
-	if(CONFIG_GET(flag/log_world_topic))
+	if(logging)
 		var/list/censored_params = params.Copy()
 		censored_params["auth"] = "***[copytext(params["auth"], -4)]"
 		log_topic("\"[json_encode(censored_params)]\", from:[addr], master:[master], auth:[censored_params["auth"]], key:[key], source:[source]")


### PR DESCRIPTION
## About The Pull Request
Fixes the runtime that's getting spammed a bit due to legacy topic requests. Also adds a simple fallback for the legacy method, ?ping, because let's face it, Wire isn't going to be updating the site to use the fancy web APIs any time soon.

## Why It's Good For The Game
Less log clutter, happy server OPs, happy players browsing the site.

## Changelog
:cl:
server: fixes runtime due to legacy topic requests, adds fallback for spacestation13.com player counts
/:cl:
