### PR TITLE
Fixes and minor tweaks to hangover

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -57,6 +57,7 @@
 	var/list/turf/turfs = get_safe_random_station_turfs(typesof(/area/hallway), rand(200, 300))
 	for(var/turf/T as() in turfs)
 		new /obj/effect/spawner/hangover_spawn(T)
+	UnregisterSignal(SSmapping, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 
 
 /datum/station_trait/hangover/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/living_mob, mob/spawned_mob, joined_late)
@@ -84,13 +85,15 @@
 	name = "hangover spawner"
 
 /obj/effect/spawner/hangover_spawn/Initialize()
-	. = ..()
 	if(prob(60))
 		new /obj/effect/decal/cleanable/vomit(get_turf(src))
 	if(prob(70))
 		var/bottle_count = pick(10;1, 5;2, 2;3)
 		for(var/index in 1 to bottle_count)
-			new /obj/item/reagent_containers/food/drinks/beer/almost_empty(get_turf(src))
+			var/obj/item/reagent_containers/food/drinks/beer/almost_empty/B = new(get_turf(src))
+			B.pixel_x += rand(-6, 6)
+			B.pixel_y += rand(-6, 6)
+	return INITIALIZE_HINT_QDEL
 
 /datum/station_trait/blackout
 	name = "Blackout"

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -6,6 +6,7 @@ again.
 
 /obj/effect/spawner/structure
 	name = "map structure spawner"
+	density = TRUE
 	var/list/spawn_list
 
 /obj/effect/spawner/structure/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hangover spawn now delete themselves
Bottles will be moved randomly by -6 to 6 pixels
Additionally structure spawns are made dense so stuff doesn't spawn in windows

closes: #5750

## Changelog
:cl:
fix: hangover spawns now delete themselves
tweak: structure spawners are dense now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
