### PR TITLE
Disable TGUI's hotkey passthrough when on non-hotkey mode with input box focused

### DIFF
--- a/tgui/packages/tgui/hotkeys.js
+++ b/tgui/packages/tgui/hotkeys.js
@@ -30,6 +30,9 @@ const hotKeysAcquired = [
 // State of passed-through keys.
 const keyState = {};
 
+// Is hotkey mode on?
+let hotkeyMode;
+
 /**
  * Converts a browser keycode to BYOND keycode.
  */
@@ -73,6 +76,10 @@ const handlePassthrough = key => {
   }
   // Prevent passthrough on Ctrl+F
   if (key.ctrl && key.code === KEY_F) {
+    return;
+  }
+  // Prevent passthrough on old non-hotkey mode
+  if (!hotkeyMode) {
     return;
   }
   // NOTE: Alt modifier is pretty bad and sticky in IE11.
@@ -135,6 +142,12 @@ export const releaseHeldKeys = () => {
   }
 };
 
+export const updateHotkeyMode = () => 
+  Byond.winget("mainwindow", "macro")
+    .then(macro => {
+      hotkeyMode = macro !== "old_default";
+    });
+
 export const setupHotKeys = () => {
   // Read macros
   Byond.winget('default.*').then(data => {
@@ -162,6 +175,10 @@ export const setupHotKeys = () => {
       byondMacros[byondKeyName] = unescape(macro.command);
     }
     logger.debug('loaded macros', byondMacros);
+  });
+  updateHotkeyMode();
+  globalEvents.on('window-focus', () => {
+    updateHotkeyMode();
   });
   // Setup event handlers
   globalEvents.on('window-blur', () => {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TGUI has a neat passthrough system, so that if you have a window opened, you can still press hotkeys to walk around, talk, etc. However, this still runs even if you had the input box focused, where normally pressing keys would type into it, with this instead they will run hotkeys like you were focused on the map. This can be problematic in some cases.

With this change, when your input box is focused and **your hotkey preference is set to "Default" in preferences**, tgui will no longer do that.

This change was implemented by comparing your `mainwindow.macro` with `"old_default"`, using winget from JS, to tell if you are on hotkey mode. This check is done every time a tgui window is focused and applies to that window only. Assuming this never fails, it should work perfectly, since there should be no way to change focus/hotkey mode without unfocusing the window.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/6917698/141661552-a86bbab4-ca9e-4c1f-97c0-fce4d10ba82a.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: TGUI will no longer passthrough inputs when on non-hotkey mode focused on the chatbox. This does not affect most players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
