### PR TITLE
Removes the funny word from owospeak

### DIFF
--- a/strings/owo_talk.json
+++ b/strings/owo_talk.json
@@ -59,7 +59,6 @@
         "sci":"smart kitties",
         "rd":"smartest cat",
         "head of":"head kitty of",
-        "nyagger":"best kitten",
         "catbeast":"kitten",
         "catbeasts":"kittens",
         "i":"cat",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the funny word.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Funny word is bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: owospeak doesn't have the funny word in it anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
