### PR TITLE
Fixes equiping cult or heretics failing

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -92,10 +92,10 @@
 	var/where = mob.equip_in_one_of_slots(T, slots)
 	if(!where)
 		//Our last attempt, we force the item into the backpack
-		if(istype(H.back, /obj/item/storage/backpack))
-			var/obj/item/storage/backpack/B = H.back
+		if(istype(mob.back, /obj/item/storage/backpack))
+			var/obj/item/storage/backpack/B = mob.back
 			SEND_SIGNAL(B, COMSIG_TRY_STORAGE_INSERT, T, null, TRUE, TRUE)
-			to_chat(H, "<span class='danger'>You have a [item_name] in your backpack.</span>")
+			to_chat(mob, "<span class='danger'>You have a [item_name] in your backpack.</span>")
 			return TRUE
 		else
 			message_admins("Heretic couldn't be equipped.")

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -98,7 +98,7 @@
 			to_chat(mob, "<span class='danger'>You have a [item_name] in your backpack.</span>")
 			return TRUE
 		else
-			message_admins("Heretic couldn't be equipped.")
+			message_admins("[ADMIN_FULLMONTY(mob)] the cultist couldn't be equipped.")
 			return FALSE
 	else
 		to_chat(mob, "<span class='danger'>You have a [item_name] in your [where].</span>")

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -91,8 +91,15 @@
 	var/item_name = initial(item_path.name)
 	var/where = mob.equip_in_one_of_slots(T, slots)
 	if(!where)
-		to_chat(mob, "<span class='userdanger'>Unfortunately, you weren't able to get a [item_name]. This is very bad and you should adminhelp immediately (press F1).</span>")
-		return 0
+		//Our last attempt, we force the item into the backpack
+		if(istype(H.back, /obj/item/storage/backpack))
+			var/obj/item/storage/backpack/B = H.back
+			SEND_SIGNAL(B, COMSIG_TRY_STORAGE_INSERT, T, null, TRUE, TRUE)
+			to_chat(H, "<span class='danger'>You have a [item_name] in your backpack.</span>")
+			return TRUE
+		else
+			message_admins("Heretic couldn't be equipped.")
+			return FALSE
 	else
 		to_chat(mob, "<span class='danger'>You have a [item_name] in your [where].</span>")
 		if(where == "backpack")

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -74,10 +74,17 @@
 
 	var/T = new item_path(H)
 	var/item_name = initial(item_path.name)
-	var/where = H.equip_in_one_of_slots(T, slots)
+	var/where = H.equip_in_one_of_slots(T, slots, qdel_on_fail = FALSE)
 	if(!where)
-		to_chat(H, "<span class='userdanger'>Unfortunately, you weren't able to get a [item_name]. This is very bad and you should adminhelp immediately (press F1).</span>")
-		return FALSE
+		//Our last attempt, we force the item into the backpack
+		if(istype(H.back, /obj/item/storage/backpack))
+			var/obj/item/storage/backpack/B = H.back
+			SEND_SIGNAL(B, COMSIG_TRY_STORAGE_INSERT, T, null, TRUE, TRUE)
+			to_chat(H, "<span class='danger'>You have a [item_name] in your backpack.</span>")
+			return TRUE
+		else
+			message_admins("Heretic couldn't be equipped.")
+			return FALSE
 	else
 		to_chat(H, "<span class='danger'>You have a [item_name] in your [where].</span>")
 		if(where == "backpack")

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -83,7 +83,7 @@
 			to_chat(H, "<span class='danger'>You have a [item_name] in your backpack.</span>")
 			return TRUE
 		else
-			message_admins("Heretic couldn't be equipped.")
+			message_admins("[ADMIN_FULLMONTY(H)] the heretic couldn't be equipped.")
 			return FALSE
 	else
 		to_chat(H, "<span class='danger'>You have a [item_name] in your [where].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You could have your backpack full with items from beeshop. This forces items to go into backpack. Fails if someone doesn't have backpack but that would only happen if an admin tries to equip someone.

## Changelog
:cl:
fix: heretics or cult won't fail to equip if you have your backpack already full
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
