### PR TITLE
Shows legcuffs in examine and lets you see what type of cuffs and bola a mob is restrained with

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -9,9 +9,11 @@
 	. = list("<span class='info'>*---------*\nThis is [icon2html(src, user)] \a <EM>[src]</EM>!")
 	var/list/obscured = check_obscured_slots()
 
-	if (handcuffed)
-		. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] handcuffed!</span>"
-	if (head)
+	if(handcuffed)
+		. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] handcuffed with [handcuffed]!</span>"
+	if(legcuffed)
+		. += "<span class='warning'>[t_He] [t_is] [icon2html(legcuffed, user)] legcuffed with [legcuffed]!</span>"
+	if(head)
 		. += "[t_He] [t_is] wearing [head.get_examine_string(user)] on [t_his] head. "
 	if(wear_mask && !(ITEM_SLOT_MASK in obscured))
 		. += "[t_He] [t_is] wearing [wear_mask.get_examine_string(user)] on [t_his] face."
@@ -22,10 +24,10 @@
 		if(!(I.item_flags & ABSTRACT))
 			. += "[t_He] [t_is] holding [I.get_examine_string(user)] in [t_his] [get_held_index_name(get_held_index_of_item(I))]."
 
-	if (back)
+	if(back)
 		. += "[t_He] [t_has] [back.get_examine_string(user)] on [t_his] back."
 	var/appears_dead = 0
-	if (stat == DEAD)
+	if(stat == DEAD)
 		appears_dead = 1
 		if(getorgan(/obj/item/organ/brain))
 			. += "<span class='deadsay'>[t_He] [t_is] limp and unresponsive, with no signs of life.</span>"
@@ -85,7 +87,7 @@
 		if(temp)
 			if(temp < 25)
 				msg += "[t_He] [t_is] slightly deformed.\n"
-			else if (temp < 50)
+			else if(temp < 50)
 				msg += "[t_He] [t_is] <b>moderately</b> deformed!\n"
 			else
 				msg += "<b>[t_He] [t_is] severely deformed!</b>\n"
@@ -115,7 +117,7 @@
 			. += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly unsimian manner."
 
 	var/trait_exam = common_trait_examine()
-	if (!isnull(trait_exam))
+	if(!isnull(trait_exam))
 		. += trait_exam
 
 	var/datum/component/mood/mood = src.GetComponent(/datum/component/mood)

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -10,9 +10,9 @@
 	var/list/obscured = check_obscured_slots()
 
 	if(handcuffed)
-		. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] handcuffed with [handcuffed]!</span>"
+		. += "<span class='warning'>[t_He] [t_is] handcuffed with [handcuffed]!</span>"
 	if(legcuffed)
-		. += "<span class='warning'>[t_He] [t_is] [icon2html(legcuffed, user)] legcuffed with [legcuffed]!</span>"
+		. += "<span class='warning'>[t_He] [t_is] legcuffed with [legcuffed]!</span>"
 	if(head)
 		. += "[t_He] [t_is] wearing [head.get_examine_string(user)] on [t_his] head. "
 	if(wear_mask && !(ITEM_SLOT_MASK in obscured))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -304,13 +304,13 @@
 	//handcuffed?
 	if(handcuffed)
 		if(istype(handcuffed, /obj/item/restraints/handcuffs/cable))
-			. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] restrained with cable!</span>"
+			. += "<span class='warning'>[t_He] [t_is] restrained with cable!</span>"
 		else
-			. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] handcuffed with [handcuffed]!</span>"
+			. += "<span class='warning'>[t_He] [t_is] handcuffed with [handcuffed]!</span>"
 
 	//legcuffed?
 	if(legcuffed)
-		. += "<span class='warning'>[t_He] [t_is] [icon2html(legcuffed, user)] legcuffed with [legcuffed]!</span>"
+		. += "<span class='warning'>[t_He] [t_is] legcuffed with [legcuffed]!</span>"
 
 	if (length(msg))
 		. += "<span class='warning'>[msg.Join("")]</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -56,15 +56,6 @@
 		if(hand_number)
 			. += "<span class='warning'>[t_He] [t_has] [hand_number > 1 ? "" : "a"] blood-stained hand[hand_number > 1 ? "s" : ""]!</span>"
 
-	//handcuffed?
-
-	//handcuffed?
-	if(handcuffed)
-		if(istype(handcuffed, /obj/item/restraints/handcuffs/cable))
-			. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] restrained with cable!</span>"
-		else
-			. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] handcuffed!</span>"
-
 	//belt
 	if(belt)
 		. += "[t_He] [t_has] [belt.get_examine_string(user)] about [t_his] waist."
@@ -310,6 +301,17 @@
 		if(HAS_TRAIT(src, TRAIT_DIGICAMO))
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.\n"
 
+	//handcuffed?
+	if(handcuffed)
+		if(istype(handcuffed, /obj/item/restraints/handcuffs/cable))
+			. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] restrained with cable!</span>"
+		else
+			. += "<span class='warning'>[t_He] [t_is] [icon2html(handcuffed, user)] handcuffed with [handcuffed]!</span>"
+
+	//legcuffed?
+	if(legcuffed)
+		. += "<span class='warning'>[t_He] [t_is] [icon2html(legcuffed, user)] legcuffed with [legcuffed]!</span>"
+
 	if (length(msg))
 		. += "<span class='warning'>[msg.Join("")]</span>"
 
@@ -373,3 +375,4 @@
 			dat += "[new_text]\n" //dat.Join("\n") doesn't work here, for some reason
 	if(dat.len)
 		return dat.Join()
+a

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -375,4 +375,3 @@
 			dat += "[new_text]\n" //dat.Join("\n") doesn't work here, for some reason
 	if(dat.len)
 		return dat.Join()
-a


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes legcuffs show up on examine, makes it show what type of hand/legcuff it is. Removes the icon in the examine, it looked bad anyways.

![image](https://user-images.githubusercontent.com/22431091/141801834-c6bcd1e6-f614-433f-94f7-3ea4ea4ddffa.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to tell if someone's legcuffed from examine is neat. Being able to see what they're restrained with is also neat.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Legcuffs now show up in examine
add: You can now see what type of restraint the mob is restrained with
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
