### PR TITLE
Makes RCDs rare-ish again.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -35,7 +35,9 @@
 	new /obj/item/storage/photo_album/CE(src)
 	new /obj/item/card/id/departmental_budget/eng(src)
 	new /obj/item/storage/bag/construction(src)
-	
+	new /obj/item/construction/rcd(src)
+	new /obj/item/rcd_ammo/large(src)
+
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"
 	req_access = list(ACCESS_ENGINE_EQUIP)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -35,7 +35,7 @@
 	new /obj/item/storage/photo_album/CE(src)
 	new /obj/item/card/id/departmental_budget/eng(src)
 	new /obj/item/storage/bag/construction(src)
-	new /obj/item/construction/rcd(src)
+	new /obj/item/construction/rcd/loaded(src)
 	new /obj/item/rcd_ammo/large(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -70,7 +70,7 @@
 	materials = list(/datum/material/iron = 60000, /datum/material/glass = 5000)  // costs more than what it did in the autolathe, this one comes loaded.
 	build_path = /obj/item/construction/rcd/loaded
 	category = list("Tool Designs")
-	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+	departmental_flags =  DEPARTMENTAL_FLAG_ENGINEERING
 
 
 /datum/design/rcd_upgrade/frames

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -8,7 +8,6 @@
 	products = list(/obj/item/clothing/glasses/meson/engine = 2,
 					/obj/item/clothing/glasses/welding = 3,
 					/obj/item/multitool = 4,
-					/obj/item/construction/rcd/loaded = 3,
 					/obj/item/grenade/chem_grenade/smart_metal_foam = 10,
 					/obj/item/geiger_counter = 5,
 					/obj/item/stock_parts/cell/high = 10,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the 3 RCDs from the Engivend.
Adds an RCD to the Chief Engineer's locker.

Removes the RCD from Cargo's protolathe.

**RCDs are still available in engineering protolathe**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. The reason for the addition to the Engivend was a MASSIVE cope. "Engineers need to carry around materials". Yeah, no fucking shit. Construction is a mechanic for a reason.

2. RCDs are EXTREMELY powerful, being able to space tiles or create walls in seconds. Having 5 of these fuckers roundstart trivializes engineer gameplay.

3. Why the hell can Cargo print these things? Ask engineering for one.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Engivend no longer stocks RCDs.
del: Cargo can no longer print RCDs (Engineering still can)
add: Chief Engineer starts with an RCD in their locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
