### PR TITLE
fixes a years-old stamcrit bug

### DIFF
--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -15,7 +15,8 @@
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going.</span>")
 	stam_regen_start_time = world.time + STAMINA_CRIT_TIME
 	stam_paralyzed = TRUE
-
+	update_mobility()
+	
 /mob/living/carbon/adjust_drugginess(amount)
 	druggy = max(druggy+amount, 0)
 	if(druggy)


### PR DESCRIPTION
## About The Pull Request
you now fall down instantly upon entering stamcrit, instead of waiting for the next time a life tick calls update_mobility

## Why It's Good For The Game
players now get accurate feedback when they deal enough damage to down a person, instead of stamina damage feeling a lot weaker than it is due to the extra few seconds it takes

## Changelog
:cl:
fix: you now enter stamcrit as soon as you take enough damage to do so
/:cl:
