### PR TITLE
Add examining and scanning items in smartfridges

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -41,7 +41,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "an" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "ao" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -825,7 +825,7 @@
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ca" = (

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -525,7 +525,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/cabin)
 "bx" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/cabin)
 "by" = (

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -2306,7 +2306,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/kitchen)
 "fk" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/open/floor/plasteel,
 /area/awaymission/snowdin/post/kitchen)
 "fl" = (

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2887,7 +2887,7 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "fL" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "fM" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -15613,7 +15613,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aSP" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aSQ" = (

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -35014,7 +35014,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "idd" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "idt" = (
@@ -48707,7 +48707,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lsq" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "lsv" = (
@@ -50855,7 +50855,7 @@
 /turf/open/floor/plasteel,
 /area/medical/chemistry/upper)
 "lSH" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/hydroponics)
 "lSU" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32251,7 +32251,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bhG" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/hydroponics)
 "bhH" = (
@@ -32294,7 +32294,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "bhK" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "bhL" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -44911,7 +44911,7 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bmA" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "bmB" = (
@@ -45355,7 +45355,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bnj" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/hydroponics)
 "bnk" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -47969,7 +47969,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bSW" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/hydroponics)
 "bSX" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -22745,7 +22745,7 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "aZZ" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "baa" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4220,7 +4220,7 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "py" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
 	icon_state = "wood";

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -2922,7 +2922,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/shuttle/abandoned/bar)
 "dS" = (
-/obj/machinery/smartfridge,
+/obj/machinery/smartfridge/plants,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bar)
 "dT" = (

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -443,9 +443,10 @@
 /obj/item/circuitboard/machine/smartfridge
 	name = "smartfridge (Machine Board)"
 	icon_state = "generic"
-	build_path = /obj/machinery/smartfridge
+	build_path = /obj/machinery/smartfridge/plants
 	req_components = list(/obj/item/stock_parts/matter_bin = 1)
 	var/static/list/fridges_name_paths = list(/obj/machinery/smartfridge = "plant produce",
+	var/static/list/fridges_name_paths = list(/obj/machinery/smartfridge/plants = "plant produce",
 		/obj/machinery/smartfridge/food = "food",
 		/obj/machinery/smartfridge/drinks = "drinks",
 		/obj/machinery/smartfridge/extract = "slimes",

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -444,8 +444,10 @@
 	name = "smartfridge (Machine Board)"
 	icon_state = "generic"
 	build_path = /obj/machinery/smartfridge/plants
-	req_components = list(/obj/item/stock_parts/matter_bin = 1)
-	var/static/list/fridges_name_paths = list(/obj/machinery/smartfridge = "plant produce",
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 1,
+		/obj/item/stock_parts/scanning_module = 1,
+		)
 	var/static/list/fridges_name_paths = list(/obj/machinery/smartfridge/plants = "plant produce",
 		/obj/machinery/smartfridge/food = "food",
 		/obj/machinery/smartfridge/drinks = "drinks",

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -258,6 +258,27 @@
 						break
 			if (visible_contents && .)
 				update_icon()
+		if("examine")
+			var/name = params["name"]
+			var/obj/item/target
+			for(var/obj/item/O in src)
+				if(O.name == name)
+					target = O
+					break
+
+			if(!target)
+				return
+
+			//Code copypasted from /mob/verb/examinate
+			if(is_blind(usr))
+				to_chat(usr, "<span class='warning'>You can't see inside [src]!</span>")
+				return
+
+			usr.face_atom(src)
+			var/list/result = target.examine(usr)
+			to_chat(usr, result.Join("\n"))
+			SEND_SIGNAL(usr, COMSIG_MOB_EXAMINATE, target)
+			return
 
 // -----------------------------
 //  Standard botany smartfridge

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -2,7 +2,7 @@
 //  SmartFridge.  Much todo
 // -------------------------
 /obj/machinery/smartfridge
-	name = "smartfridge"
+	name = "undefined smartfridge"
 	desc = "Keeps cold things cold and hot things cold."
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "smartfridge"
@@ -166,8 +166,6 @@
 
 
 /obj/machinery/smartfridge/proc/accept_check(obj/item/O)
-	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/) || istype(O, /obj/item/seeds/) || istype(O, /obj/item/grown/))
-		return TRUE
 	return FALSE
 
 /obj/machinery/smartfridge/proc/load(obj/item/O)
@@ -261,6 +259,17 @@
 			if (visible_contents && .)
 				update_icon()
 
+// -----------------------------
+//  Standard botany smartfridge
+// -----------------------------
+
+/obj/machinery/smartfridge/plants
+	name = "smartfridge"
+
+/obj/machinery/smartfridge/plants/accept_check(obj/item/O)
+	if(istype(O, /obj/item/reagent_containers/food/snacks/grown/) || istype(O, /obj/item/seeds/) || istype(O, /obj/item/grown/))
+		return TRUE
+	return FALSE
 
 // ----------------------------
 //  Drying Rack 'smartfridge'
@@ -390,6 +399,7 @@
 //  Food smartfridge
 // ----------------------------
 /obj/machinery/smartfridge/food
+	name = "smartfridge"
 	desc = "A refrigerated storage unit for food."
 
 /obj/machinery/smartfridge/food/accept_check(obj/item/O)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -322,8 +322,8 @@
 	scanner = new
 
 /obj/machinery/smartfridge/plants/Destroy()
+	QDEL_NULL(scanner)
 	. = ..()
-	qdel(scanner)
 
 /obj/machinery/smartfridge/plants/scan(obj/item/O, mob/M)
 	O.attackby(scanner, M)

--- a/tgui/packages/tgui/interfaces/SmartVend.js
+++ b/tgui/packages/tgui/interfaces/SmartVend.js
@@ -29,8 +29,10 @@ export const SmartVend = (props, context) => {
           ) || (
             <Table>
               <Table.Row header>
-                <Table.Cell collapsing colspan={canscan ? 2 : 1}>
-                  Actions
+                <Table.Cell
+                  collapsing textAlign="center"
+                  colspan={canscan ? 2 : 1}>
+                  Act
                 </Table.Cell>
                 <Table.Cell>
                   Item
@@ -43,26 +45,26 @@ export const SmartVend = (props, context) => {
               {map((value, key) => (
                 <Table.Row key={key}>
                   {!!canscan && (
-                    <Table.Cell>
+                    <Table.Cell collapsing>
                       <Button
                         icon="search"
                         onClick={() => act('scan', {
-                          name: value.name
+                          name: value.name,
                         })}
                         tooltip="Scan"
                         tooltipPosition="bottom"
-                        />
+                      />
                     </Table.Cell>
                   )}
-                  <Table.Cell>
+                  <Table.Cell collapsing>
                     <Button
-                      icon = "eye"
+                      icon="eye"
                       onClick={() => act('examine', {
-                        name: value.name
+                        name: value.name,
                       })}
                       tooltip="Examine"
                       tooltipPosition="bottom"
-                      />
+                    />
                   </Table.Cell>
                   <Table.Cell>
                     {value.name}

--- a/tgui/packages/tgui/interfaces/SmartVend.js
+++ b/tgui/packages/tgui/interfaces/SmartVend.js
@@ -5,6 +5,9 @@ import { Window } from '../layouts';
 
 export const SmartVend = (props, context) => {
   const { act, data } = useBackend(context);
+  const {
+    canscan,
+  } = data;
   return (
     <Window
       width={440}
@@ -26,6 +29,9 @@ export const SmartVend = (props, context) => {
           ) || (
             <Table>
               <Table.Row header>
+                <Table.Cell collapsing colspan={canscan ? 2 : 1}>
+                  Actions
+                </Table.Cell>
                 <Table.Cell>
                   Item
                 </Table.Cell>
@@ -36,6 +42,28 @@ export const SmartVend = (props, context) => {
               </Table.Row>
               {map((value, key) => (
                 <Table.Row key={key}>
+                  {!!canscan && (
+                    <Table.Cell>
+                      <Button
+                        icon="search"
+                        onClick={() => act('scan', {
+                          name: value.name
+                        })}
+                        tooltip="Scan"
+                        tooltipPosition="bottom"
+                        />
+                    </Table.Cell>
+                  )}
+                  <Table.Cell>
+                    <Button
+                      icon = "eye"
+                      onClick={() => act('examine', {
+                        name: value.name
+                      })}
+                      tooltip="Examine"
+                      tooltipPosition="bottom"
+                      />
+                  </Table.Cell>
                   <Table.Cell>
                     {value.name}
                   </Table.Cell>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now examine the items in smartfridges by pressing the eye button before an item. This does not work for blind people.
In select smartfridges, you can use the looking glass icon to scan the item with a scanner built into the smartfridge:
- Plant smartfridges scan using a plant analyzer
- Virology smartfridges scan using a viral extrapolator
Also note, examining items when wearing science goggles will tell you the reagent contents of bottles like normal.

Additional changes applied to make this possible:
- Plant smartfridges have been repathed. `/obj/machinery/smartfridge` should no longer appear in the game, existing instances have been changed to `/obj/machinery/smartfridge/plants`.
- Smartfridges now need a scanning module. The scanning module is currently only used when scanning with viral extrapolator in a virology smartfridge.
- Smartfridges with scanning capability create the appropriate scanning item in nullspace. This is necessary due to the way scanning is currently done in code, removing this constraint would require significant refactoring to the scanning items.

The code here is somewhat hacky and sub-ideal, but doing this properly would require a lot more work I'm not willing to do right now.

### Screenshots:

<details>

<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/6917698/141817316-b91fd1ba-2b9f-4a7e-9096-af0f35152023.png)

![image](https://user-images.githubusercontent.com/6917698/141817346-b9f8c32c-a19e-456e-a3b1-08b82a16f9b4.png)

![image](https://user-images.githubusercontent.com/6917698/141818022-5329df59-e2df-4932-8b73-6faae0870942.png)
Note: the viral extrapolator being present in the smartfridge was fixed since

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adds some nice potentially useful functionality to smartfridges. Particularly useful for virologists, where you often have to scan a lot of samples to find one with the symptom you need.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now examine items inside smartfridges.
add: Virology and botany smartfridges now come with built-in scanners that can be used on items inside them. To account for this, smartfridges now require a scanning module to build.
code: Botany smartfridges have been repathed to be a `/plants` subtype. The base `/obj/machinery/smartfridge` should no longer be used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
