### PR TITLE
Fixes Runtime in CI

### DIFF
--- a/_maps/RandomRooms/5x4/sk_rdm032_deltaEVA.dmm
+++ b/_maps/RandomRooms/5x4/sk_rdm032_deltaEVA.dmm
@@ -106,7 +106,6 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -120,6 +119,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel,
 /area/template_noop)
 "f" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a runtime that occurred in CI because of a decal initializing inside a crate. This PR moves the decals in question below said crate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Random runtimes in CI bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Random Room #032 will no longer cause a runtime during mapload by initializing a decal inside a crate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
