### PR TITLE
Nerfs firebreath interaction with power chromosomes

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -146,11 +146,7 @@
 	if(!istype(P, /obj/item/projectile/magic/aoe/fireball))
 		return
 	var/obj/item/projectile/magic/aoe/fireball/F = P
-	switch(strength)
-		if(1 to 3)
-			F.exp_light = strength-1
-		if(4 to INFINITY)
-			F.exp_heavy = strength-3
+	F.exp_light = strength-1
 	F.exp_fire += strength
 
 /obj/item/projectile/magic/aoe/fireball/firebreath


### PR DESCRIPTION
## About The Pull Request
Stacking more than three power chromosomes with a firebreath mutation no longer gives the fireball a heavy radius. Instead, it just extends the fireball's light radius

## Why It's Good For The Game
heavy explosions can instantly kill or crit players. giving someone a fireball that has that sort of capability is generally a bad idea. However, this does not make firebreath useless, instead giving it a wide and powerful radius as it gains power instead

## Changelog
:cl:
balance: the fire breath mutation no longer gets a heavy explosion radius when upgraded with power chromosomes
/:cl:
 
