### PR TITLE
nerfs directional blocking

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -593,20 +593,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	owner.apply_damage(attackforce, STAMINA, blockhand, block_power)
 	if((owner.getStaminaLoss() >= 35 && HAS_TRAIT(src, TRAIT_NODROP)) || (HAS_TRAIT(owner, TRAIT_NOLIMBDISABLE) && owner.getStaminaLoss() >= 30))//if you don't drop the item, you can't block for a few seconds
 		owner.blockbreak()
-	if(attackforce)//right here is essentially the same code used for animating a melee attack, but it's inverted and slightly smaller a difference
-		var/pixel_x_diff = 0 
-		var/pixel_y_diff = 0
-		var/direction = get_dir(owner, hitby)
-		if(direction & NORTH)
-			pixel_y_diff = -6
-		else if(direction & SOUTH)
-			pixel_y_diff = 6
-		if(direction & EAST)
-			pixel_x_diff = -6
-		else if(direction & WEST)
-			pixel_x_diff = 6
-		animate(owner, pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, time = 2)
-		animate(owner, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, time = 2)
+	if(attackforce)
 		owner.changeNext_move(CLICK_CD_MELEE) 
 	return TRUE
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -308,7 +308,20 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		if(resistance_flags & FIRE_PROOF)
 			. += "[src] is made of fire-retardant materials."
 	if(block_level || block_upgrade_walk)
-		. += "[src] has blocking capabilities. It blocks in a [45 * ((block_level * 2) - 1)] degree arc, or a [45 * ((block_level + block_upgrade_walk * 2) - 1)] degree arc while walking"
+		if(block_upgrade_walk == 1 && !block_level)
+			. += "While walking, [src] can block attacks in a <b>narrow</b> arc."
+		else 
+			switch(block_upgrade_walk + block_level)
+				if(1)
+					. += "[src] can block attacks in a <b>narrow</b> arc."
+				if(2)
+					. += "[src] can block attacks in a <b>wide</b> arc."
+				if(3)
+					. += "[src] can block attacks in a <b>very wide</b> arc."
+				if(4 to INFINITY)
+					. += "[src] can block attacks in a <b>nearly complete</b> arc."
+			if(block_upgrade_walk)
+				. += "[src] is <b>less</b> effective at blocking while the user is <b>running</b>."
 		switch(block_power)
 			if(-INFINITY to -1)
 				. += "[src] is weighted extremely poorly for blocking"

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -9,7 +9,6 @@
 	flags_1 = CONDUCT_1
 	force = 13
 	block_power = 20
-	block_upgrade_walk = 2
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	attack_weight = 2
 	var/force_on = 24

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -207,7 +207,6 @@
 	force = 9 // Not as good as a stun baton.
 	brightness_on = 5 // A little better than the standard flashlight.
 	hitsound = 'sound/weapons/genhit1.ogg'
-	block_upgrade_walk = 1
 
 // the desk lamps are a bit special
 /obj/item/flashlight/lamp

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -11,7 +11,6 @@
 	throw_speed = 2
 	throw_range = 7
 	force = 10
-	block_upgrade_walk = 1
 	materials = list(/datum/material/iron = 90)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 	dog_fashion = /datum/dog_fashion/back
@@ -41,7 +40,6 @@
 	max_water = 30
 	sprite_name = "miniFE"
 	dog_fashion = null
-	block_upgrade_walk = 0
 
 /obj/item/extinguisher/proc/refill()
 	create_reagents(max_water, AMOUNT_VISIBLE)

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -8,7 +8,6 @@
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
 	attack_weight = 3
-	block_upgrade_walk = 1
 	force = 5
 	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -9,7 +9,6 @@
 	flags_1 = CONDUCT_1
 	force = 3
 	throwforce = 10
-	block_upgrade_walk = 1
 	var/acti_sound = 'sound/items/welderactivate.ogg'
 	var/deac_sound = 'sound/items/welderdeactivate.ogg'
 	throw_speed = 1

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -15,7 +15,6 @@
 	w_class = WEIGHT_CLASS_GIGANTIC
 	force = 12
 	block_upgrade_walk = 1
-	block_level = 1
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
 	var/awakened = FALSE

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -375,7 +375,6 @@
 	attack_verb = list("sawed", "tore", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
-	block_upgrade_walk = 0
 	toolspeed = 1.5 //slower than a real saw
 
 /obj/item/nullrod/claymore/glowing
@@ -579,7 +578,7 @@
 	tool_behaviour = TOOL_SAW
 	toolspeed = 2 //slower than a real saw
 	attack_weight = 2
-	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
+	block_upgrade_walk = 0
 
 
 /obj/item/nullrod/chainsaw/Initialize()

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -375,6 +375,7 @@
 	attack_verb = list("sawed", "tore", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
+	block_upgrade_walk = 0
 	toolspeed = 1.5 //slower than a real saw
 
 /obj/item/nullrod/claymore/glowing

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -79,7 +79,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	block_upgrade_walk = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	throw_speed = 3
 	throw_range = 6

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -38,8 +38,6 @@
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
-	block_upgrade_walk = 1
-	block_level = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 20
 	throwforce = 10
@@ -165,7 +163,6 @@
 	item_state = "classic_baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	block_upgrade_walk = 1
 	slot_flags = ITEM_SLOT_BELT
 	force = 12 //9 hit crit
 	w_class = WEIGHT_CLASS_NORMAL
@@ -732,7 +729,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NONE
 	force = 0
-	block_upgrade_walk = 1
 	attack_verb = list("hit", "poked")
 	var/obj/item/reagent_containers/food/snacks/sausage/held_sausage
 	var/static/list/ovens
@@ -845,7 +841,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 0
 	throwforce = 0
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("repelled")
 	var/cooldown = 0

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -8,8 +8,6 @@
 	force = 8
 	throwforce = 10
 	block_upgrade_walk = 1
-	block_level = 1
-	block_power = 20
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -7,7 +7,6 @@
 	desc = "A gas-powered cannon that can fire any object loaded into it."
 	w_class = WEIGHT_CLASS_BULKY
 	force = 8 //Very heavy
-	block_upgrade_walk = 1
 	attack_verb = list("bludgeoned", "smashed", "beaten")
 	icon = 'icons/obj/pneumaticCannon.dmi'
 	icon_state = "pneumaticCannon"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/obj/shields.dmi'
 	block_level = 1
 	block_upgrade_walk = 1
-	block_flags = null
+	block_flags = BLOCKING_PROJECTILE
 	block_power = 50
 	max_integrity =  75
 	var/transparent = FALSE	// makes beam projectiles pass through the shield
@@ -13,6 +13,7 @@
 	if(transparent && (hitby.pass_flags & PASSGLASS))
 		return FALSE
 	return ..()
+	
 
 /obj/item/shield/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
 	if(durability)
@@ -38,6 +39,8 @@
 			if(block_flags & BLOCKING_NASTY)
 				L.attackby(src, owner)
 				owner.visible_message("<span class='danger'>[L] injures themselves on [owner]'s [src]!</span>")
+		if(attackforce)
+			owner.changeNext_move(CLICK_CD_MELEE) 
 		if (obj_integrity <= attackforce)
 			var/turf/T = get_turf(owner)
 			T.visible_message("<span class='warning'>[hitby] destroys [src]!</span>")
@@ -128,7 +131,6 @@
 
 /obj/item/shield/riot/roman/fake
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>. It appears to be a bit flimsy."
-	block_level = 1
 	block_upgrade_walk = 1
 	block_power = 0
 	max_integrity = 30

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -26,7 +26,6 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	hitsound = 'sound/weapons/grenadelaunch.ogg'
 	embedding = list()
 	novariants = TRUE
-	block_upgrade_walk = 1
 
 /obj/item/stack/rods/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins to stuff \the [src] down [user.p_their()] throat! It looks like [user.p_theyre()] trying to commit suicide!</span>")//it looks like theyre ur mum

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -40,7 +40,6 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 	force_string = "holy"
-	block_upgrade_walk = 1
 
 /obj/item/storage/book/bible/Initialize()
 	. = ..()

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -9,7 +9,6 @@
 	hitsound = "swing_hit"
 	throw_speed = 2
 	throw_range = 4
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	resistance_flags = FLAMMABLE

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -131,7 +131,6 @@
 	throw_range = 4
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
-	block_upgrade_walk = 1
 
 /obj/item/storage/secure/briefcase/PopulateContents()
 	new /obj/item/paper(src)

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -14,7 +14,6 @@
 	materials = list(/datum/material/iron = 500)
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
-	block_upgrade_walk = 1
 	custom_materials = list(/datum/material/iron = 500) //Toolboxes by default use iron as their core, custom material.
 	var/latches = "single_latch"
 	var/has_latches = TRUE

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -10,7 +10,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	throwforce = 7
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_SMALL
 	materials = list(/datum/material/iron=50)
 

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -9,7 +9,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	throwforce = 7
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/ratchet.ogg'
 	materials = list(/datum/material/iron=150)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -244,15 +244,6 @@
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb = list("attacked", "struck", "hit")
 	var/hacked = FALSE
-	block_upgrade_walk = 1
-	block_power = -200
-
-/obj/item/toy/sword/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
-	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-	if(damage)
-		throw_at(throw_target, 5, 1)
-		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
-	return ..()
 
 /obj/item/toy/sword/attack_self(mob/user)
 	active = !( active )
@@ -316,15 +307,6 @@
 	attack_verb = list("pricked", "absorbed", "gored")
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
-	block_upgrade_walk = 1
-	block_power = -200
-
-/obj/item/toy/foamblade/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
-	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-	if(damage)
-		throw_at(throw_target, 5, 1)
-		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
-	return ..()
 
 /obj/item/toy/windupToolbox
 	name = "windup toolbox"
@@ -383,15 +365,8 @@
 	throw_range = 5
 	twohand_force = 0
 	attack_verb = list("attacked", "struck", "hit")
-	block_upgrade_walk = 1
-	block_power = -100
-
-/obj/item/dualsaber/toy/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
-	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-	if(damage)
-		throw_at(throw_target, 5, 1)
-		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
-	return ..()
+	block_upgrade_walk = 0
+	block_level = 0
 
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0
@@ -418,17 +393,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	block_upgrade_walk = 1
-	block_level = 1
-	block_flags = BLOCKING_ACTIVE | BLOCKING_PROJECTILE
-	block_power = -500 //not to be used on anything more effective than nerf darts
-
-/obj/item/toy/katana/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
-	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-	if(damage > 5)// a toy katana can block other toy katanas, that's about it.
-		throw_at(throw_target, 5, 1)
-		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
-	return ..()
+	block_flags = BLOCKING_ACTIVE | BLOCKING_PROJECTILE //if it some how gets block level, katanas block projectiles for the meme
 
 /*
  * Snap pops

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -247,6 +247,13 @@
 	block_upgrade_walk = 1
 	block_power = -200
 
+/obj/item/toy/sword/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+	if(damage)
+		throw_at(throw_target, 5, 1)
+		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
+	return ..()
+
 /obj/item/toy/sword/attack_self(mob/user)
 	active = !( active )
 	if (active)
@@ -312,6 +319,12 @@
 	block_upgrade_walk = 1
 	block_power = -200
 
+/obj/item/toy/foamblade/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+	if(damage)
+		throw_at(throw_target, 5, 1)
+		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
+	return ..()
 
 /obj/item/toy/windupToolbox
 	name = "windup toolbox"
@@ -373,6 +386,13 @@
 	block_upgrade_walk = 1
 	block_power = -100
 
+/obj/item/dualsaber/toy/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+	if(damage)
+		throw_at(throw_target, 5, 1)
+		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
+	return ..()
+
 /obj/item/dualsaber/toy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	return 0
 
@@ -402,6 +422,13 @@
 	block_level = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_PROJECTILE
 	block_power = -500 //not to be used on anything more effective than nerf darts
+
+/obj/item/toy/katana/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+	if(damage > 5)// a toy katana can block other toy katanas, that's about it.
+		throw_at(throw_target, 5, 1)
+		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
+	return ..()
 
 /*
  * Snap pops

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -41,7 +41,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	slot_flags = ITEM_SLOT_BELT
 	force = 2
 	throwforce = 1
-	block_level = 1
 	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -248,7 +247,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	w_class = WEIGHT_CLASS_HUGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")
-	block_power = 50
+	block_power = 20
 	block_level = 1
 	block_upgrade_walk = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY | BLOCKING_PROJECTILE
@@ -272,7 +271,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	flags_1 = CONDUCT_1
 	force = 9
 	throwforce = 10
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(/datum/material/iron=1150, /datum/material/glass=75)
 	attack_verb = list("hit", "bludgeoned", "whacked", "bonked")
@@ -482,7 +480,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_state = "stick"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	block_upgrade_walk = 1
 	force = 3
 	throwforce = 5
 	throw_speed = 2
@@ -621,8 +618,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A skateboard. It can be placed on its wheels and ridden, or used as a strong weapon."
 	icon_state = "skateboard"
 	item_state = "skateboard"
-	block_level = 1
-	block_upgrade_walk = 1 //yes, you can use this to fend off attackers
+	block_upgrade_walk = 1
 	force = 12
 	throwforce = 4
 	w_class = WEIGHT_CLASS_NORMAL
@@ -864,7 +860,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	force = 10
 	throwforce = 5
-	block_upgrade_walk = 1
 	attack_verb = list("clubbed", "bludgeoned")
 	var/breakforce = 30
 	var/stamforce = 15

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -156,9 +156,6 @@
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
-	block_power = 20
-	block_level = 1
-	block_upgrade_walk = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -17,7 +17,6 @@
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
 	w_class = WEIGHT_CLASS_SMALL
-	block_upgrade_walk = 1
 	block_power = 0
 	block_level = 0
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
@@ -44,7 +43,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	block_level = 1
 	block_upgrade_walk = 1
-	block_power = 30
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	force = 30
 	throwforce = 10

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -11,7 +11,6 @@
 	item_state = "knife"
 	lefthand_file = 'icons/mob/inhands/equipment/kitchen_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/kitchen_righthand.dmi'
-	block_upgrade_walk = 1
 	force = 15
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -8,7 +8,6 @@
 	amount_per_transfer_from_this = 10
 	volume = 100
 	throwforce = 15
-	block_upgrade_walk = 1
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
@@ -16,15 +15,6 @@
 	foodtype = ALCOHOL
 	///Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	var/bottle_knockdown_duration = 1.3 SECONDS
-
-/obj/item/reagent_containers/food/drinks/bottle/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
-	if(isliving(hitby))
-		var/mob/living/L = hitby
-		smash(L)
-	else
-		smash()
-	return TRUE
-
 
 /obj/item/reagent_containers/food/drinks/bottle/smash(mob/living/target, mob/thrower, ranged = FALSE)
 	//Creates a shattering noise and replaces the bottle with a broken_bottle

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -36,7 +36,6 @@
 	desc = "It's better than bad, it's good!"
 	icon_state = "logs"
 	force = 5
-	block_upgrade_walk = 1
 	throwforce = 5
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2

--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -13,7 +13,6 @@
 	var/list/allowed_instrument_ids
 	/// How far away our song datum can be heard.
 	var/instrument_range = 15
-	block_upgrade_walk = 1
 
 /obj/item/instrument/Initialize(mapload)
 	. = ..()

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -12,7 +12,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	throwforce = 5
-	block_upgrade_walk = 1
 	throw_speed = 4
 	armour_penetration = 10
 	materials = list(/datum/material/iron=1150, /datum/material/glass=2075)

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -6,7 +6,6 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	attack_weight = 2
-	block_upgrade_walk = 1
 	force = 15
 	throwforce = 10
 	item_state = "pickaxe"
@@ -101,7 +100,6 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 8
-	block_upgrade_walk = 1
 	tool_behaviour = TOOL_SHOVEL
 	toolspeed = 1
 	usesound = 'sound/effects/shovel_dig.ogg'

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -156,11 +156,17 @@
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "asclepius_dormant"
 	block_upgrade_walk = 1
-	block_level = 2
+	block_level = 1
 	block_power = 40 //blocks very well to encourage using it. Just because you're a pacifist doesn't mean you can't defend yourself
 	block_flags = null //not active, so it's null
 	var/activated = FALSE
 	var/usedHand
+
+/obj/item/rod_of_asclepius/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	if(!activated)
+		return FALSE 
+	return ..()
+	
 
 /obj/item/rod_of_asclepius/attack_self(mob/user)
 	if(activated)
@@ -746,7 +752,6 @@
 	attack_verb_on = list("cleaved", "swiped", "slashed", "chopped")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	hitsound_on = 'sound/weapons/bladeslice.ogg'
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = IS_SHARP
 	faction_bonus_force = 45

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -161,8 +161,6 @@
 	icon_state = "arm_blade"
 	item_state = "arm_blade"
 	force = 25
-	block_upgrade_walk = 1
-	block_level = 1
 	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'

--- a/code/modules/pool/pool_items.dm
+++ b/code/modules/pool/pool_items.dm
@@ -6,18 +6,8 @@
 	damtype = STAMINA
 	w_class = WEIGHT_CLASS_BULKY
 	block_sound = 'sound/weapons/tap.ogg'
-	block_level = 1
-	block_upgrade_walk = 1
-	block_power = 0
-	block_flags = BLOCKING_ACTIVE
 	attack_verb = list("wacked")
 
-/obj/item/pool/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
-	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
-	if(damage)
-		throw_at(throw_target, 5, 1)
-		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
-	return ..()
 
 /obj/item/pool/Initialize()
 	. = ..()

--- a/code/modules/pool/pool_items.dm
+++ b/code/modules/pool/pool_items.dm
@@ -7,10 +7,17 @@
 	w_class = WEIGHT_CLASS_BULKY
 	block_sound = 'sound/weapons/tap.ogg'
 	block_level = 1
-	block_upgrade_walk = 0
+	block_upgrade_walk = 1
 	block_power = 0
-	block_flags = BLOCKING_ACTIVE | BLOCKING_NASTY
+	block_flags = BLOCKING_ACTIVE
 	attack_verb = list("wacked")
+
+/obj/item/pool/on_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
+	var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
+	if(damage)
+		throw_at(throw_target, 5, 1)
+		to_chat(owner, "<span class='userdanger'>The [src] is flung away by [attack_text]!</span>")
+	return ..()
 
 /obj/item/pool/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -73,7 +73,6 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/c20r/unrestricted
 	pin = /obj/item/firing_pin
@@ -97,7 +96,6 @@
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
 	fire_rate = 3
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/ballistic/automatic/wt550/rubber_loaded
@@ -128,7 +126,6 @@
 	spread_unwielded = 15
 	mag_display = TRUE
 	empty_indicator = TRUE
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/m90/Initialize()
 	. = ..()
@@ -200,7 +197,6 @@
 	fire_rate = 5
 	can_suppress = FALSE
 	bolt_type = BOLT_TYPE_OPEN
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/ar
 	name = "\improper NT-ARG 'Boarder'"
@@ -237,7 +233,6 @@
 	tac_reloads = FALSE
 	fire_sound = 'sound/weapons/rifleshot.ogg'
 	rack_sound = 'sound/weapons/chunkyrack.ogg'
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/l6_saw/unrestricted
 	pin = /obj/item/firing_pin
@@ -315,7 +310,6 @@
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate
 	name = "syndicate sniper rifle"
@@ -341,7 +335,6 @@
 	mag_display = TRUE
 	automatic = 0
 	fire_rate = 1.5
-	block_upgrade_walk = 1
 
 // Laser rifle (rechargeable magazine) //
 
@@ -356,5 +349,4 @@
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
 	fire_rate = 2
-	block_upgrade_walk = 1
 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -14,7 +14,6 @@
 	bolt_type = BOLT_TYPE_NO_BOLT
 	weapon_weight = WEAPON_MEDIUM
 	fire_rate = 2
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -15,7 +15,6 @@
 	bolt_drop_sound = "sound/weapons/mosinboltin.ogg"
 	tac_reloads = FALSE
 	weapon_weight = WEAPON_MEDIUM
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/rifle/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -26,7 +26,6 @@
 	cartridge_wording = "shell"
 	tac_reloads = FALSE
 	fire_rate = 1 //reee
-	block_upgrade_walk = 1
 	recoil = 1
 	pb_knockback = 2
 

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -13,7 +13,6 @@
 	casing_ejector = FALSE
 	fire_rate = 3
 	weapon_weight = WEAPON_LIGHT
-	block_upgrade_walk = 1
 
 /obj/item/gun/ballistic/automatic/toy/update_icon()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -12,7 +12,6 @@
 	flight_y_offset = 10
 	weapon_weight = WEAPON_MEDIUM
 	dual_wield_spread = 60
-	block_upgrade_walk = 1
 
 /obj/item/gun/energy/e_gun/mini
 	name = "miniature energy gun"

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -19,7 +19,6 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
-	block_upgrade_walk = 1
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -3,7 +3,6 @@
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
 	item_state = "laser"
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 	materials = list(/datum/material/iron=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -5,7 +5,6 @@
 	item_state = null
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
-	block_upgrade_walk = 1
 	modifystate = TRUE
 	flags_1 =  CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -11,7 +11,6 @@
 	ammo_x_offset = 3
 	flight_x_offset = 17
 	flight_y_offset = 9
-	block_upgrade_walk = 1
 
 /obj/item/gun/energy/ionrifle/emp_act(severity)
 	return
@@ -84,7 +83,6 @@
 	desc = "A prototype weapon recovered from the ruins of Research-Station Epsilon."
 	icon_state = "xray"
 	item_state = null
-	block_upgrade_walk = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/mindflayer)
 	ammo_x_offset = 2
 
@@ -139,7 +137,6 @@
 	flags_1 = CONDUCT_1
 	attack_verb = list("attacked", "slashed", "cut", "sliced")
 	force = 12
-	block_upgrade_walk = 1
 	sharpness = IS_SHARP
 	can_charge = FALSE
 	dead_cell = TRUE
@@ -338,7 +335,6 @@
 	automatic = 1
 	fire_rate = 4
 	pin = null
-	block_upgrade_walk = 1
 
 /obj/item/gun/energy/temperature/pin
 	pin = /obj/item/firing_pin
@@ -347,7 +343,6 @@
 	name = "security temperature gun"
 	desc = "A weapon that can only be used to its full potential by the truly robust."
 	pin = /obj/item/firing_pin
-	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/energy/laser/instakill
@@ -357,7 +352,6 @@
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit."
 	ammo_type = list(/obj/item/ammo_casing/energy/instakill)
 	force = 60
-	block_upgrade_walk = 1
 
 /obj/item/gun/energy/laser/instakill/red
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a red design."

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -7,7 +7,6 @@
 	fire_rate = 1.5
 	block_power = 20 //staffs can block shit if you're walking
 	block_upgrade_walk = 1
-	block_level = 1
 
 /obj/item/gun/magic/staff/change
 	name = "staff of change"

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -19,7 +19,6 @@
 	fire_sound = 'sound/weapons/beam_sniper.ogg'
 	slot_flags = ITEM_SLOT_BACK
 	force = 15
-	block_upgrade_walk = 1
 	materials = list()
 	recoil = 4
 	ammo_x_offset = 3

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -6,7 +6,6 @@
 	item_state = "blastcannon_empty"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 10
-	block_upgrade_walk = 1
 	fire_sound = 'sound/weapons/blastcannon.ogg'
 	item_flags = NONE
 	clumsy_check = FALSE

--- a/code/modules/projectiles/guns/misc/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/misc/grenade_launcher.dm
@@ -8,7 +8,6 @@
 	throw_speed = 2
 	throw_range = 7
 	force = 5
-	block_upgrade_walk = 1
 	var/list/grenades = new/list()
 	var/max_grenades = 3
 	materials = list(/datum/material/iron=2000)

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -26,7 +26,6 @@
 	righthand_file = 'icons/mob/inhands/misc/lavaland_righthand.dmi'
 	desc = "Not to be confused with the kind Research hassles you for."
 	force = 12
-	block_level = 1
 	block_upgrade_walk = 1
 	w_class = WEIGHT_CLASS_NORMAL
 	resistance_flags = LAVA_PROOF | FIRE_PROOF


### PR DESCRIPTION
## About The Pull Request
-blocking has been removed and nerfed on many items
-blocking (and force strings) are now properly communicated when examining an item
-blocking now causes minor hitstun- delays your next click about as long as a melee attack would
-shields now block projectiles again

## Why It's Good For The Game
When i made blocking, my true intent was some counterplay to stunbatons and other melee weapons, and slow down combat, but it was poorly balanced and communicated. I've rectified

## Changelog
:cl:
add: examining an item now tells its blocking ability, blocking arc, and the force string you see on a mouse over
balance: shields can now block projectiles again
balance: blocking has been nerfed on many items
balance: blocking itself has had a minor nerf- blocking an attack delays your next action as if you have hit with a melee attack
/:cl:
 
