### PR TITLE
Revert "Fixes to tgchat sorting, you can now sort Mentor PMs"

### DIFF
--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -29,7 +29,6 @@ export const MESSAGE_TYPE_WARNING = 'warning';
 export const MESSAGE_TYPE_DEADCHAT = 'deadchat';
 export const MESSAGE_TYPE_OOC = 'ooc';
 export const MESSAGE_TYPE_ADMINPM = 'adminpm';
-export const MESSAGE_TYPE_MENTORPM = 'mentorpm';
 export const MESSAGE_TYPE_COMBAT = 'combat';
 export const MESSAGE_TYPE_ADMINCHAT = 'adminchat';
 export const MESSAGE_TYPE_MODCHAT = 'modchat';
@@ -59,13 +58,13 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_RADIO,
     name: 'Radio',
     description: 'All departments of radio messages',
-    selector: '.alert, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .expradio, .entradio, .radio, .deptradio, .newscaster, .redteamradio, .blueteamradio, .sinister, .cult, .shadowling, .changeling',
+    selector: '.alert, .syndradio, .centradio, .airadio, .entradio, .comradio, .secradio, .engradio, .medradio, .sciradio, .supradio, .srvradio, .expradio, .radio, .deptradio, .newscaster',
   },
   {
     type: MESSAGE_TYPE_INFO,
     name: 'Info',
     description: 'Non-urgent messages from the game and items',
-    selector: '.notice:not(.pm), .adminnotice, .info',
+    selector: '.notice:not(.pm), .adminnotice, .info, .sinister, .cult',
   },
   {
     type: MESSAGE_TYPE_WARNING,
@@ -82,20 +81,14 @@ export const MESSAGE_TYPES = [
   {
     type: MESSAGE_TYPE_OOC,
     name: 'OOC',
-    description: 'OOC and LOOC messages',
-    selector: '.ooc, .looc, .adminooc',
+    description: 'The bluewall of global OOC messages',
+    selector: '.ooc, .adminooc',
   },
   {
     type: MESSAGE_TYPE_ADMINPM,
     name: 'Admin PMs',
     description: 'Messages to/from admins (adminhelp)',
     selector: '.pm, .adminhelp',
-  },
-  {
-    type: MESSAGE_TYPE_MENTORPM,
-    name: 'Mentor PMs',
-    description: 'Messages to/from mentors (mentorhelp)',
-    selector: '.mentorhelp, .mentorto, .mentorfrom',
   },
   {
     type: MESSAGE_TYPE_COMBAT,
@@ -106,7 +99,7 @@ export const MESSAGE_TYPES = [
   {
     type: MESSAGE_TYPE_UNKNOWN,
     name: 'Unsorted',
-    description: 'Everything that was not sorted',
+    description: 'Everything we could not sort, always enabled',
   },
   // Admin stuff
   {


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#5780

It's deselected by default, no one can see mentor PMs unless they know to go to settings and reenable it. The overlap between the people that know to do this and the primary audience of people using mhelp is very low.