### PR TITLE
[BEARAXE] Fight Pit Bears now scale to server population.

### DIFF
--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -316,7 +316,7 @@
 
 /mob/living/simple_animal/hostile/bear/fightpit/Initialize()
 	. = ..()
-	var/multiplier = round(length(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS]) / BASE_BEAR_DIVISOR, 0.1)
+	var/multiplier = max(round(length(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS]) / BASE_BEAR_DIVISOR, 0.1), 1)
 	maxHealth *= multiplier
 	health *= multiplier
 	melee_damage *= multiplier

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -3,6 +3,8 @@
 // Wabbajack statue, a sleeping frog statue that shoots bolts of change if
 // living carbons are put on its altar/tables
 
+#define BASE_BEAR_DIVISOR 20 //the number of players for Fight Pit Bears to scale to, standard stats at this number
+
 /obj/machinery/power/emitter/energycannon/magical
 	name = "wabbajack statue"
 	desc = "Who am I? What is my purpose in life? What do I mean by who am I?"
@@ -314,10 +316,10 @@
 
 /mob/living/simple_animal/hostile/bear/fightpit/Initialize()
 	. = ..()
-	var/M = round(GLOB.player_list.len / 20, 0.1)
-	maxHealth *= M
-	health *= M
-	melee_damage *= M
+	var/multiplier = round(length(SSticker.mode.current_players[CURRENT_LIVING_PLAYERS]) / BASE_BEAR_DIVISOR, 0.1)
+	maxHealth *= multiplier
+	health *= multiplier
+	melee_damage *= multiplier
 
 /obj/effect/decal/hammerandsickle
 	name = "hammer and sickle"
@@ -330,3 +332,5 @@
 
 /obj/effect/decal/hammerandsickle/shuttleRotate(rotation)
 	setDir(angle2dir(rotation+dir2angle(dir))) // No parentcall, rest of the rotate code breaks the pixel offset.
+
+#undef BASE_BEAR_DIVISOR

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -315,9 +315,9 @@
 /mob/living/simple_animal/hostile/bear/fightpit/Initialize()
 	. = ..()
 	var/M = round(GLOB.player_list.len / 20, 0.1)
-	src.maxHealth *= M
-	src.health *= M
-	src.melee_damage *= M
+	maxHealth *= M
+	health *= M
+	melee_damage *= M
 
 /obj/effect/decal/hammerandsickle
 	name = "hammer and sickle"

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -314,7 +314,7 @@
 
 /mob/living/simple_animal/hostile/bear/fightpit/Initialize()
 	. = ..()
-	var/M = round(GLOB.player_list.len / 20, 1)
+	var/M = round(GLOB.player_list.len / 20, 0.1)
 	src.maxHealth *= M
 	src.health *= M
 	src.melee_damage *= M

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -310,6 +310,14 @@
 	name = "fight pit bear"
 	desc = "This bear's trained through ancient Russian secrets to fear the walls of its glass prison."
 	environment_smash = ENVIRONMENT_SMASH_NONE
+	gold_core_spawnable = NO_SPAWN
+
+/mob/living/simple_animal/hostile/bear/fightpit/Initialize()
+	. = ..()
+	var/M = round(GLOB.player_list.len / 20, 1)
+	src.maxHealth *= M
+	src.health *= M
+	src.melee_damage *= M
 
 /obj/effect/decal/hammerandsickle
 	name = "hammer and sickle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fight pit bears (the ones on Mother Russia Bleeds) now scale to player pop, maintaining their current stats at a player count of 20, peaking at 3.5x their current stats at 70 pop. Because of these changes, they are no longer gold core spawnable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The bears will no longer slaughter on lowpop, nor will they be complete pushovers on highpop.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Fight Pit Bears now scale to player population.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. --> 
