### PR TITLE
Heretics no longer gib their sacrifice targets, instead spilling out their internal organs.

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -265,7 +265,10 @@
 		if(LH.target && LH.target.stat == DEAD)
 			to_chat(carbon_user,"<span class='danger'>Your patrons accepts your offer..</span>")
 			var/mob/living/carbon/human/H = LH.target
-			H.gib()
+			var/obj/item/bodypart/chest/chest = H.get_bodypart(BODY_ZONE_CHEST)
+			chest.dismember()
+			H.visible_message("<span class='danger'>[H.name] Is quickly surrounded by invisible claws; lacerating their chest open, spilling their organs out!</span>", \
+								"<span class='danger'>You feel claws tear your chest open; spilling your organs out onto the floor!</span>", ignored_mobs=H)
 			LH.target = null
 			var/datum/antagonist/heretic/EC = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports Skyrat-SS13/Skyrat-tg#4322, heretics no longer gib their living heart targets, instead spilling out their target's chest organs.

## Why It's Good For The Game

Heretics can be pretty hard to RP and play without feeling like it's murderboning, since they are required to gib targets to keep progressing. Also, it makes heretics actually have to put effort into hiding bodies, instead of just shoving the head into disposals and moving on.

Disclaimer: This PR was meant for a downstream but Kapu asked me to punt it upstream so I'm PRing it here.

## Changelog
:cl:
balance: Heretics no longer gib their sacrifice targets, instead spilling out their internal organs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
