### PR TITLE
Changes the experimental dissection point type from regular research to discovery

### DIFF
--- a/code/modules/surgery/advanced/bioware/experimental_dissection.dm
+++ b/code/modules/surgery/advanced/bioware/experimental_dissection.dm
@@ -48,7 +48,7 @@
 
 /datum/surgery_step/dissection/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] dissects [target]!", "<span class='notice'>You dissect [target], and add your discoveries to the research database!</span>")
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = check_value(target)))
+	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_DISCOVERY = check_value(target)))
 	var/obj/item/bodypart/L = target.get_bodypart(BODY_ZONE_CHEST)
 	target.apply_damage(80, BRUTE, L)
 	ADD_TRAIT(target, TRAIT_DISSECTED, "surgery")
@@ -56,7 +56,7 @@
 
 /datum/surgery_step/dissection/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("[user] dissects [target]!", "<span class='notice'>You dissect [target], but do not find anything particularly interesting.</span>")
-	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = (check_value(target) * 0.2)))
+	SSresearch.science_tech.add_point_list(list(TECHWEB_POINT_TYPE_DISCOVERY = (check_value(target) * 0.2)))
 	var/obj/item/bodypart/L = target.get_bodypart(BODY_ZONE_CHEST)
 	target.apply_damage(80, BRUTE, L)
 	ADD_TRAIT(target, TRAIT_DISSECTED, "surgery")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the already research-locked surgery that gives nearly worthless regular research points, instead give discovery points.

## Why It's Good For The Game

There is a high deficit of discovery point sources in the game. Currently, there are 3 ways to get them: scan animal pets and slimes (this will give ~3000 points in total I guess?), make explorers scan stuff (3k total from each kind of spider, 2k from clockwork stuff, and a bit more from the hell-infested station that people don't scan due to severe danger, and artifacts that give 10k, but are rare), and the current meta - make miners scan megafauna that each gives 10k, which is the easiest due to them having a GPS signal. 
Pets can provide only some points for the starting research, the other sources are not quite reliable due to high death rates of the jobs, so often you just sit in the R&D and listen to people yelling at you for not researching stuff.

## Changelog
:cl:
tweak: Experimental dissection now gives discovery points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
