### PR TITLE
Spray Tan Fix

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -453,7 +453,6 @@
 	..()
 
 /datum/reagent/spraytan/overdose_start(mob/living/M)
-	. = ..()
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
 	if(!ishuman(M))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -455,33 +455,31 @@
 /datum/reagent/spraytan/overdose_start(mob/living/M)
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
-	if(!ishuman(M))
-		return
-	var/mob/living/carbon/human/N = M
-	N.hair_style = "Spiky"
-	N.facial_hair_style = "Shaved"
-	N.facial_hair_color = "000"
-	N.hair_color = "000"
-	if(!(HAIR in N.dna.species.species_traits)) //No hair? No problem!
-		N.dna.species.species_traits += HAIR
-	if(N.dna.species.use_skintones)
-		N.skin_tone = "orange"
-	else if(MUTCOLORS in N.dna.species.species_traits) //Aliens with custom colors simply get turned orange
-		N.dna.features["mcolor"] = "f80"
-	N.regenerate_icons()
+	if(ishuman(M))
+		var/mob/living/carbon/human/N = M
+		N.hair_style = "Spiky"
+		N.facial_hair_style = "Shaved"
+		N.facial_hair_color = "000"
+		N.hair_color = "000"
+		if(!(HAIR in N.dna.species.species_traits)) //No hair? No problem!
+			N.dna.species.species_traits += HAIR
+		if(N.dna.species.use_skintones)
+			N.skin_tone = "orange"
+		else if(MUTCOLORS in N.dna.species.species_traits) //Aliens with custom colors simply get turned orange
+			N.dna.features["mcolor"] = "f80"
+		N.regenerate_icons()
 	..()
-	return
 
 /datum/reagent/spraytan/overdose_process(mob/living/M)
-	var/mob/living/carbon/human/N = M
-	if(prob(7))
-		if(N.w_uniform)
-			M.visible_message(pick("<b>[M]</b>'s collar pops up without warning.</span>", "<b>[M]</b> flexes [M.p_their()] arms."))
-		else
-			M.visible_message("<b>[M]</b> flexes [M.p_their()] arms.")
-	if(prob(10))
-		M.say(pick("Shit was SO cash.", "You are everything bad in the world.", "What sports do you play, other than 'jack off to naked drawn Japanese people?'", "Don???t be a stranger. Just hit me with your best shot.", "My name is John and I hate every single one of you."), forced = /datum/reagent/spraytan)
-	..()
+	if(ishuman(M))
+		var/mob/living/carbon/human/N = M
+		if(prob(7))
+			if(N.w_uniform)
+				M.visible_message(pick("<b>[M]</b>'s collar pops up without warning.</span>", "<b>[M]</b> flexes [M.p_their()] arms."))
+			else
+				M.visible_message("<b>[M]</b> flexes [M.p_their()] arms.")
+		if(prob(10))
+			M.say(pick("Shit was SO cash.", "You are everything bad in the world.", "What sports do you play, other than 'jack off to naked drawn Japanese people?'", "Don???t be a stranger. Just hit me with your best shot.", "My name is John and I hate every single one of you."), forced = /datum/reagent/spraytan)
 
 #define MUT_MSG_IMMEDIATE 1
 #define MUT_MSG_EXTENDED 2

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -452,32 +452,37 @@
 				to_chat(M, "<span class='notice'>That tasted horrible.</span>")
 	..()
 
-
-/datum/reagent/spraytan/overdose_process(mob/living/M)
+/datum/reagent/spraytan/overdose_start(mob/living/M)
+	. = ..()
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 
-	if(ishuman(M))
-		var/mob/living/carbon/human/N = M
-		N.hair_style = "Spiky"
-		N.facial_hair_style = "Shaved"
-		N.facial_hair_color = "000"
-		N.hair_color = "000"
-		if(!(HAIR in N.dna.species.species_traits)) //No hair? No problem!
-			N.dna.species.species_traits += HAIR
-		if(N.dna.species.use_skintones)
-			N.skin_tone = "orange"
-		else if(MUTCOLORS in N.dna.species.species_traits) //Aliens with custom colors simply get turned orange
-			N.dna.features["mcolor"] = "f80"
-		N.regenerate_icons()
-		if(prob(7))
-			if(N.w_uniform)
-				M.visible_message(pick("<b>[M]</b>'s collar pops up without warning.</span>", "<b>[M]</b> flexes [M.p_their()] arms."))
-			else
-				M.visible_message("<b>[M]</b> flexes [M.p_their()] arms.")
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/N = M
+	N.hair_style = "Spiky"
+	N.facial_hair_style = "Shaved"
+	N.facial_hair_color = "000"
+	N.hair_color = "000"
+	if(!(HAIR in N.dna.species.species_traits)) //No hair? No problem!
+		N.dna.species.species_traits += HAIR
+	if(N.dna.species.use_skintones)
+		N.skin_tone = "orange"
+	else if(MUTCOLORS in N.dna.species.species_traits) //Aliens with custom colors simply get turned orange
+		N.dna.features["mcolor"] = "f80"
+	N.regenerate_icons()
+	..()
+	return
+
+/datum/reagent/spraytan/overdose_process(mob/living/M)
+	var/mob/living/carbon/human/N = M
+	if(prob(7))
+		if(N.w_uniform)
+			M.visible_message(pick("<b>[M]</b>'s collar pops up without warning.</span>", "<b>[M]</b> flexes [M.p_their()] arms."))
+		else
+			M.visible_message("<b>[M]</b> flexes [M.p_their()] arms.")
 	if(prob(10))
 		M.say(pick("Shit was SO cash.", "You are everything bad in the world.", "What sports do you play, other than 'jack off to naked drawn Japanese people?'", "Don???t be a stranger. Just hit me with your best shot.", "My name is John and I hate every single one of you."), forced = /datum/reagent/spraytan)
 	..()
-	return
 
 #define MUT_MSG_IMMEDIATE 1
 #define MUT_MSG_EXTENDED 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes Spray Tan's overdose to no longer do a full appearance transform every tick it is processing, instead it only does it once upon the overdose threshold being met.
I have not touched the actual functionality of the chemical itself.

## Why It's Good For The Game

Should be a very minor performance boost in the event people are using Spray Tan.

## Changelog
:cl:
tweak: Spray Tan processing made more efficient
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
