### PR TITLE
Expands the meta exploration dock

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3804,6 +3804,7 @@
 	desc = "A fierce companion for any person of power, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine.";
 	emote_hear = list("chitters");
 	faction = list("spiders");
+	harm_intent_damage = 3;
 	health = 200;
 	icon_dead = "guard_dead";
 	icon_gib = "guard_dead";
@@ -9791,6 +9792,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"asA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "asB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
@@ -10965,11 +10976,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "avb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/item/toy/plush/beeplushie{
+	name = "Mister Buzz"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/light/colour_cycle/dancefloor_a,
+/area/science/misc_lab/range)
 "avc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11152,7 +11163,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "avy" = (
@@ -11248,14 +11261,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avK" = (
-/obj/effect/spawner/room/threexthree,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "avL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
 	},
-/obj/effect/spawner/room/threexthree,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "avM" = (
@@ -11334,38 +11348,25 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"avV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"avW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
 	req_one_access_txt = "12;47"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"avW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "avX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room";
-	req_one_access_txt = "12;47"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel,
+/area/science/misc_lab/range)
 "avY" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -11658,16 +11659,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "awB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "awC" = (
@@ -12228,6 +12228,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"axN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms,
+/area/space/nearstation)
 "axO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15502,6 +15510,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"aEu" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "aEv" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -21676,9 +21691,15 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "aRy" = (
 /turf/closed/wall/r_wall,
@@ -30776,6 +30797,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -36249,6 +36273,11 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
+"btA" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil,
+/turf/open/space,
+/area/solar/starboard/aft)
 "btB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -36922,19 +36951,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard)
-"buW" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/research/glass{
-	name = "science shuttle dock";
-	req_one_access_txt = "49"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
 "buX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -36994,8 +37010,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot,
-/obj/machinery/rnd/production/circuit_imprinter/department/engineering,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
 "bvf" = (
@@ -37411,15 +37427,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"bvT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "bvU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -43267,17 +43274,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "bIv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel,
+/area/science/shuttledock)
 "bIx" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/suit/hooded/wintercoat,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/science/misc_lab/range)
 "bIy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -60718,10 +60727,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "cud" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "cue" = (
 /obj/structure/cable{
@@ -61284,15 +61292,15 @@
 /turf/open/space,
 /area/solar/port/aft)
 "cvj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/effect/landmark/start/exploration,
+/turf/open/floor/plasteel,
+/area/science/misc_lab/range)
 "cvl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -61777,6 +61785,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cwc" = (
@@ -61785,21 +61794,8 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "cwd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/gun/energy/laser/practice{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/gun/energy/laser/practice{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/carpet,
 /area/science/misc_lab/range)
 "cwe" = (
 /obj/structure/cable,
@@ -62329,8 +62325,7 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "cwZ" = (
-/obj/structure/target_stake,
-/obj/item/target/syndicate,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "cxa" = (
@@ -62714,14 +62709,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cxP" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "cxU" = (
 /turf/closed/wall,
@@ -63178,13 +63173,6 @@
 "cyK" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"cyM" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
 "cyN" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -63568,37 +63556,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"czF" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel{
-	dir = 1
-	},
-/area/science/mixing)
 "czG" = (
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/target,
-/obj/item/target/syndicate,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/structure/closet/crate/secure{
-	desc = "A secure crate containing various materials for building a customised test-site.";
-	name = "Test Site Materials Crate";
-	req_access_txt = "8"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/obj/machinery/suit_storage_unit/exploration,
+/turf/open/floor/plasteel/techmaint,
 /area/science/mixing)
 "czH" = (
 /obj/machinery/airalarm/all_access{
@@ -63613,15 +63576,9 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "czI" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
-	},
-/turf/closed/wall,
-/area/science/mixing)
-"czJ" = (
-/turf/closed/wall,
-/area/science/test_area)
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/science/shuttledock)
 "czK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -64191,40 +64148,29 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cAN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cAO" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/camera{
+	c_tag = "exploration Prep Room";
+	dir = 9;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cAP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/mixing)
-"cAQ" = (
-/obj/structure/window/reinforced,
-/obj/item/target,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 3
 	},
-/turf/open/floor/plating,
-/area/science/test_area)
+/obj/item/pen,
+/obj/item/folder/white{
+	pixel_x = -6;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "cAS" = (
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
@@ -64521,89 +64467,45 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "cBH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/table,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBJ" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cBK" = (
-/obj/machinery/light/small,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer/almost_empty,
+/obj/item/reagent_containers/food/drinks/beer/almost_empty{
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/carpet/cyan,
 /area/science/mixing)
 "cBL" = (
-/obj/structure/chair{
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/obj/effect/landmark/start/exploration,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/button/massdriver{
-	id = "toxinsdriver";
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/cyan,
 /area/science/mixing)
-"cBM" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'BOMB RANGE";
-	name = "BOMB RANGE"
-	},
-/turf/closed/wall,
-/area/science/test_area)
-"cBN" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cBO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cBP" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
 "cBQ" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable,
@@ -65009,34 +64911,15 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "cCG" = (
-/obj/machinery/door/window/southleft{
-	name = "Mass Driver Door";
-	req_access_txt = "7"
-	},
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"cCH" = (
-/obj/structure/chair{
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/landmark/start/exploration,
+/obj/item/radio/intercom{
+	pixel_y = -29
 	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cCI" = (
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cCJ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "cCK" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/freezer,
@@ -65345,73 +65228,57 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cDq" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "toxinsdriver"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/science/mixing)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cDr" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cDs" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/science/mixing)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/science/misc_lab/range)
 "cDt" = (
-/obj/machinery/door/poddoor{
-	id = "toxinsdriver";
-	name = "Toxins Launcher Bay Door"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/science/mixing)
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel,
+/area/science/shuttledock)
 "cDu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cDv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cDw" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cDx" = (
-/obj/item/beacon,
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cDy" = (
-/obj/item/target/alien/anchored,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/camera/preset/toxins{
-	dir = 8
-	},
-/turf/open/floor/plating/airless{
-	luminosity = 2
-	},
-/area/science/test_area)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cDz" = (
-/turf/closed/indestructible{
-	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
-	icon_state = "riveted";
-	name = "hyper-reinforced wall"
-	},
+/turf/open/space/basic,
 /area/science/test_area)
 "cDA" = (
 /obj/structure/bed/roller,
@@ -66020,26 +65887,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cEA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/lattice,
+/turf/closed/wall,
 /area/space/nearstation)
-"cEB" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
 "cEC" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice,
+/turf/open/space,
 /area/science/test_area)
 "cED" = (
 /obj/structure/cable{
@@ -66433,27 +66286,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cFv" = (
-/obj/structure/chair{
+"cFw" = (
+/obj/structure/window/reinforced,
+/obj/item/target,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/science/test_area)
-"cFw" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/science/test_area)
 "cFx" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
+/turf/closed/wall,
 /area/science/test_area)
 "cFy" = (
 /obj/item/radio/intercom{
@@ -66903,13 +66745,10 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cGp" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/target,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/science/test_area)
 "cGq" = (
 /obj/structure/table/glass,
@@ -68560,29 +68399,30 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cJe" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "cJf" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/machinery/button/massdriver{
+	id = "toxinsdriver";
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 8;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("toxins");
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/space/nearstation)
 "cJg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -69355,23 +69195,28 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "cKP" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/aft)
-"cKQ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Quarter Solar Access";
-	req_access_txt = "10"
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "toxinsdriver"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"cKR" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/starboard/aft)
+"cKQ" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "science shuttle dock";
+	req_one_access_txt = "49"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cKS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -69790,12 +69635,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "cLE" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 1;
-	name = "euthanization chamber freezer"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cLF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -69808,37 +69657,26 @@
 	},
 /area/maintenance/starboard/aft)
 "cLK" = (
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage Room";
+	req_one_access_txt = "12;47"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cLL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cLM" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/starboard/aft";
-	dir = 1;
-	name = "Starboard Quarter Solar APC";
-	pixel_y = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cLN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -70090,35 +69928,7 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cMq" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Aft Starboard Solar Maintenance";
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
-"cMr" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/solars/starboard/aft)
 "cMs" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cMt" = (
@@ -70681,30 +70491,35 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cNo" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cNp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/structure/chair/stool,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cNq" = (
-/obj/machinery/power/solar_control{
-	dir = 8;
-	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -71958,17 +71773,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cQv" = (
-/obj/machinery/camera{
-	c_tag = "Toxins - Launch Area";
-	network = list("ss13","rd")
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/suit_storage_unit/rd,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/obj/machinery/suit_storage_unit/exploration,
+/turf/open/floor/plasteel/techmaint,
 /area/science/mixing)
 "cQx" = (
 /obj/structure/chair{
@@ -71987,25 +71796,13 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cQB" = (
-/obj/machinery/doppler_array/research/science{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
+/obj/machinery/suit_storage_unit/exploration,
+/turf/open/floor/plasteel/techmaint,
 /area/science/mixing)
 "cQC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -72178,8 +71975,13 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cRa" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRb" = (
 /obj/structure/sign/warning/securearea,
@@ -72241,26 +72043,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cRh" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "cRi" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -72271,17 +72053,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cRk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cRl" = (
 /obj/machinery/door/window{
 	dir = 4;
@@ -72373,117 +72153,44 @@
 	dir = 1
 	},
 /area/chapel/main)
-"cRu" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
-"cRv" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "xeno_airlock_exterior";
-	idSelf = "xeno_airlock_control";
-	name = "Access Button";
-	pixel_x = -24;
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "xeno_airlock_exterior";
-	name = "Xenobiology Lab External Airlock";
-	req_access_txt = "55"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+"cRA" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cRw" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
-"cRx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
-"cRy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cRz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cRA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cRB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
+"cRC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cRC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/sand,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cRD" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
 	},
+/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/science/misc_lab/range)
 "cRE" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -72598,11 +72305,111 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "cRM" = (
-/obj/machinery/processor/slime,
-/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cRN" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"cRP" = (
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/chapel/main)
+"cRR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/computer/camera_advanced/xenobio,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"cRT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	pixel_x = 25
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"cRU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"cRV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"cRW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"cRX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"cRY" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/science/shuttledock)
+"cRZ" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -72615,110 +72422,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cRO" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/starboard/aft)
-"cRP" = (
-/obj/machinery/door/poddoor{
-	id = "chapelgun";
-	name = "Chapel Launcher Door"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/chapel/main)
-"cRR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"cRS" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cRT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"cRU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/xenobiology)
-"cRV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cRW" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio8";
-	name = "containment blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/xenobiology)
-"cRX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cRY" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "test chamber blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/xenobiology)
-"cRZ" = (
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "cSa" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSb" = (
@@ -72730,36 +72441,49 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = -32
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio8";
-	name = "containment blast door"
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSd" = (
 /turf/closed/wall,
 /area/science/xenobiology)
 "cSe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/camera_advanced/xenobio,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSf" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/smartfridge/extract/preloaded,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSg" = (
@@ -72776,11 +72500,16 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cSi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSj" = (
 /obj/machinery/disposal/bin,
@@ -72794,137 +72523,91 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSk" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/disposal/bin{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cSl" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSm" = (
-/obj/structure/window/reinforced,
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio8";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSn" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cSp" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #1";
-	dir = 4;
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "cSq" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "containment blast door"
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSs" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #1";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"cSt" = (
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSv" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio8";
-	name = "containment blast door"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSw" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSx" = (
-/obj/machinery/light/small{
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #2";
-	dir = 8;
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSy" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"cSz" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/space,
-/area/solar/starboard/aft)
 "cSA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -72936,38 +72619,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio3";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/processor/slime,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cSC" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/space,
-/area/solar/starboard/aft)
 "cSD" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
+	id = "xenobio3";
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -73000,13 +72662,9 @@
 /area/science/xenobiology)
 "cSG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSI" = (
 /obj/structure/sign/warning/electricshock,
@@ -73027,22 +72685,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSL" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cSM" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	id = "xenobio7";
+	id = "xenobio8";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
 	req_access_txt = "55"
@@ -73057,11 +72709,11 @@
 	base_state = "right";
 	dir = 8;
 	icon_state = "right";
-	name = "Containment Pen #3";
+	name = "Containment Pen #1";
 	req_access_txt = "55"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
+	id = "xenobio3";
 	name = "containment blast door"
 	},
 /obj/structure/cable/yellow{
@@ -73072,7 +72724,7 @@
 "cSO" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	name = "Containment Pen #3";
+	name = "Containment Pen #1";
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -73090,11 +72742,11 @@
 "cSQ" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	name = "Containment Pen #4";
+	name = "Containment Pen #2";
 	req_access_txt = "55"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio7";
+	id = "xenobio8";
 	name = "containment blast door"
 	},
 /obj/structure/cable/yellow{
@@ -73107,7 +72759,7 @@
 	base_state = "right";
 	dir = 8;
 	icon_state = "right";
-	name = "Containment Pen #4";
+	name = "Containment Pen #2";
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -73116,6 +72768,25 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cSS" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio3";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"cST" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
 	id = "xenobio2";
@@ -73134,60 +72805,42 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"cST" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xenobio1";
-	name = "Containment Blast Doors";
-	pixel_y = 4;
-	req_access_txt = "55"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "cSV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSW" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
 "cSY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -73197,30 +72850,27 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "cSZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+/obj/structure/window/reinforced,
+/obj/machinery/button/door{
+	id = "xenobio6";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 10
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTa" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
+/area/science/misc_lab/range)
 "cTb" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	name = "Containment Pen #5";
+	name = "Containment Pen #3";
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -73233,11 +72883,11 @@
 	base_state = "right";
 	dir = 8;
 	icon_state = "right";
-	name = "Containment Pen #5";
+	name = "Containment Pen #3";
 	req_access_txt = "55"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
+	id = "xenobio2";
 	name = "containment blast door"
 	},
 /obj/structure/cable/yellow{
@@ -73250,7 +72900,7 @@
 	base_state = "right";
 	dir = 8;
 	icon_state = "right";
-	name = "Containment Pen #6";
+	name = "Containment Pen #4";
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -73271,11 +72921,11 @@
 "cTg" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	name = "Containment Pen #6";
+	name = "Containment Pen #4";
 	req_access_txt = "55"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio6";
+	id = "xenobio7";
 	name = "containment blast door"
 	},
 /obj/structure/cable/yellow{
@@ -73284,117 +72934,94 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "cTj" = (
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"cTk" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/button/ignition{
-	id = "Xenobio";
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/machinery/button/door{
-	id = "Xenolab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 4;
-	pixel_y = -3;
-	req_access_txt = "55"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"cTm" = (
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/cable/yellow,
 /obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "test chamber blast door"
+	id = "xenobio1";
+	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"cTn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+"cTk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"cTm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "cTo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/chapel/main)
-"cTp" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "cTq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/research/glass{
+	name = "science shuttle dock";
+	req_one_access_txt = "49"
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "Test Chamber Maintenance";
-	req_access_txt = "47"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "cTr" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Test Chamber Monitor";
-	network = list("xeno");
-	pixel_y = 2
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door{
+	id = "xenobio1";
+	name = "Containment Blast Doors";
+	pixel_y = 4;
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTs" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cTt" = (
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Maximum Security Test Chamber";
-	req_access_txt = "55"
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cTw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -73413,38 +73040,50 @@
 	},
 /area/chapel/main)
 "cTz" = (
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"cTA" = (
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "cTB" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/maintenance/department/science/xenobiology)
 "cTC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cTD" = (
-/obj/structure/cable/yellow,
-/obj/machinery/shieldwallgen/xenobiologyaccess,
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/science/shuttledock)
 "cTR" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "cTT" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cUA" = (
 /obj/structure/toilet{
@@ -73478,13 +73117,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "cUM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cUN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -73496,7 +73131,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cUR" = (
@@ -73536,14 +73170,15 @@
 /turf/open/space/basic,
 /area/space)
 "cVa" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cVb" = (
 /obj/structure/table/wood,
@@ -73843,12 +73478,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cZa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "cZc" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -73885,7 +73514,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cZv" = (
-/turf/open/floor/circuit/telecomms,
+/obj/item/radio/intercom{
+	pixel_y = -25
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "cZR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -73917,6 +73549,128 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "daA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"daB" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"daC" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"daD" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"daE" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"daF" = (
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"daG" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/button/ignition{
+	id = "Xenobio";
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/machinery/button/door{
+	id = "Xenolab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 4;
+	pixel_y = -3;
+	req_access_txt = "55"
+	},
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"daH" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"daI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"daK" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "test chamber blast door"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"daL" = (
 /obj/machinery/door/window/southleft{
 	name = "Maximum Security Test Chamber";
 	req_access_txt = "55"
@@ -73930,140 +73684,52 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"daB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daC" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
-"daD" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daE" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron{
-	amount = 10
-	},
-/obj/item/electropack,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daF" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daG" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daH" = (
-/obj/item/beacon,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daI" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daJ" = (
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daK" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Test Chamber";
-	dir = 1;
-	network = list("ss13","rd","xeno")
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"daL" = (
-/obj/machinery/light,
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "daM" = (
-/obj/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = 2;
-	pixel_y = -1
-	},
-/turf/open/floor/engine,
+/obj/structure/cable/yellow,
+/obj/machinery/shieldwallgen/xenobiologyaccess,
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "daN" = (
-/obj/item/radio/intercom{
-	pixel_y = -25
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "test chamber blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "daO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "daP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/machinery/light/small{
+/obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/effect/landmark/start/exploration,
+/turf/open/floor/carpet/cyan,
+/area/science/mixing)
 "daQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/obj/effect/landmark/start/exploration,
+/turf/open/floor/carpet/cyan,
+/area/space/nearstation)
 "daR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "daS" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/circuit/telecomms,
+/obj/machinery/light,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "daW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -74157,7 +73823,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #3";
+	c_tag = "Xenobiology Lab - Pen #1";
 	dir = 4;
 	network = list("ss13","rd","xeno")
 	},
@@ -74168,7 +73834,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #4";
+	c_tag = "Xenobiology Lab - Pen #2";
 	dir = 8;
 	network = list("ss13","rd","xeno")
 	},
@@ -74189,7 +73855,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #5";
+	c_tag = "Xenobiology Lab - Pen #3";
 	dir = 4;
 	network = list("ss13","rd","xeno")
 	},
@@ -74200,26 +73866,31 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Pen #6";
+	c_tag = "Xenobiology Lab - Pen #4";
 	dir = 8;
 	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "dbv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small,
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
-"dbw" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Kill Chamber";
-	dir = 1;
-	network = list("ss13","rd","xeno");
-	start_active = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/starboard/aft";
+	name = "Starboard Quarter Maintenance APC";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"dbw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dbE" = (
 /obj/machinery/plantgenes{
 	pixel_y = 6
@@ -74287,16 +73958,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
-"dbK" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/space,
-/area/solar/starboard/aft)
 "dbL" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -74308,6 +73969,79 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
 "dbM" = (
+/turf/open/space/basic,
+/area/solar/starboard/aft)
+"dbN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
+"dbO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/space,
+/area/solar/starboard/aft)
+"dbP" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room";
+	req_access_txt = "8"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/aft)
+"dbQ" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/aft)
+"dbR" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/starboard/aft)
+"dbS" = (
+/obj/machinery/camera{
+	c_tag = "Toxins - Launch Area";
+	network = list("ss13","rd")
+	},
+/obj/machinery/suit_storage_unit/rd,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/starboard/aft)
+"dbT" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/starboard/aft)
+"dbU" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/solar/starboard/aft)
+"dbV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -74320,96 +74054,187 @@
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
-"dbN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
-"dbO" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/solar/starboard/aft)
-"dbP" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
-"dbQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
-"dbR" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space,
-/area/solar/starboard/aft)
-"dbS" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil,
-/turf/open/space,
-/area/solar/starboard/aft)
-"dbT" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/space,
-/area/solar/starboard/aft)
-"dbU" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/solar/starboard/aft)
-"dbV" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space,
-/area/solar/starboard/aft)
 "dbW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "0-2"
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
 "dbX" = (
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/target,
+/obj/item/target/syndicate,
+/obj/item/target/alien,
+/obj/item/target/clown,
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Test Site Materials Crate";
+	req_access_txt = "8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/maintenance/starboard/aft)
+"dbY" = (
+/obj/machinery/doppler_array/research/science{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 22
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/space/nearstation)
+"dbZ" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/space/nearstation)
+"dcg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"dch" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"dci" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"dcs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"dct" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/starboard/aft)
+"dcu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/aft)
+"dcx" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/science/xenobiology)
+"dcz" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "xeno_airlock_exterior";
+	idSelf = "xeno_airlock_control";
+	name = "Access Button";
+	pixel_x = -24;
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "xeno_airlock_exterior";
+	name = "Xenobiology Lab External Airlock";
+	req_access_txt = "55"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"dcA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/aft)
+"dcB" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 8;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("toxins");
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/space/nearstation)
+"dcC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"dcD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
+"dcE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/sink{
 	dir = 8;
@@ -74421,41 +74246,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dbY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dbZ" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "xeno_airlock_interior";
-	idSelf = "xeno_airlock_control";
-	name = "Access Button";
-	pixel_x = 29;
-	pixel_y = -8;
-	req_access_txt = "55"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dca" = (
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
+"dcI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -74464,7 +74255,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dcb" = (
+"dcJ" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
@@ -74480,7 +74271,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dcc" = (
+"dcK" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 4
@@ -74521,7 +74312,7 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dcd" = (
+"dcL" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
 	pixel_y = 4
@@ -74551,7 +74342,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dce" = (
+"dcM" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 2;
@@ -74566,7 +74357,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dcf" = (
+"dcN" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
@@ -74577,406 +74368,14 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dch" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dci" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcj" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "xeno_airlock_interior";
-	name = "Xenobiology Lab Internal Airlock";
-	req_access_txt = "55"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dck" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "xeno_airlock_exterior";
-	idInterior = "xeno_airlock_interior";
-	idSelf = "xeno_airlock_control";
-	name = "Access Console";
-	pixel_x = -25;
-	pixel_y = -25;
-	req_access_txt = "55"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/camera_advanced/xenobio,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"dcn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/smartfridge/extract/preloaded,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"dco" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/machinery/computer/camera_advanced/xenobio,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"dcp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcq" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcr" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcs" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Airlock";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dct" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcu" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"dcw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"dcx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"dcy" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
-"dcA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcC" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcD" = (
-/obj/machinery/reagentgrinder{
-	pixel_x = -1;
-	pixel_y = 8
-	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcE" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/science/xenobiology)
-"dcG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcJ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/extinguisher,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcK" = (
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcL" = (
-/obj/machinery/light,
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcM" = (
-/obj/machinery/chem_master,
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcN" = (
-/obj/machinery/chem_heater,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dcO" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Central";
-	dir = 8;
-	network = list("ss13","rd")
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "dcP" = (
 /obj/structure/disposalpipe/segment{
@@ -74986,7 +74385,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
+	id = "xenobio3";
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -75004,7 +74403,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio7";
+	id = "xenobio8";
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -75019,13 +74418,22 @@
 	},
 /obj/structure/cable/yellow,
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio7";
+	id = "xenobio8";
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcT" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Central";
+	dir = 8;
+	network = list("ss13","rd")
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -75040,7 +74448,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
+	id = "xenobio2";
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -75048,13 +74456,13 @@
 /area/science/xenobiology)
 "dcV" = (
 /obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
 /obj/machinery/button/door{
-	id = "xenobio6";
+	id = "xenobio7";
 	name = "Containment Blast Doors";
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -75065,17 +74473,85 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "xenobio6";
+	id = "xenobio7";
 	name = "containment blast door"
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dcX" = (
+/obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio2";
+	name = "containment blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"dcY" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/solar/starboard/aft)
+"dcZ" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/solar/starboard/aft)
+"dda" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
+"ddb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio7";
+	name = "containment blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"ddc" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"ddd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"dde" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet,
+/turf/open/floor/engine,
+/area/maintenance/department/science/xenobiology)
+"ddf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
 	name = "containment blast door"
@@ -75083,41 +74559,112 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"dcY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"ddg" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio6";
+	name = "containment blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"ddj" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"dcZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #5";
+	dir = 4;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/maintenance/department/science/xenobiology)
+"ddk" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio1";
+	name = "containment blast door"
+	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/engine,
 /area/science/xenobiology)
-"dda" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+"ddl" = (
+/obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
+"ddm" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/science/test_area)
+"ddn" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"ddb" = (
+"ddo" = (
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio6";
+	name = "containment blast door"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"ddp" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage Room";
+	req_one_access_txt = "12;47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"ddq" = (
+/turf/open/floor/engine,
+/area/maintenance/department/science/xenobiology)
+"ddr" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #6";
+	dir = 8;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/maintenance/department/science/xenobiology)
+"dds" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -75132,19 +74679,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"ddc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+"ddt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"ddd" = (
+/turf/open/floor/engine,
+/area/maintenance/department/science/xenobiology)
+"ddu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -75156,209 +74697,42 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dde" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"ddf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Aft-Port";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/bz,
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"ddg" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Aft-Starboard";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"ddh" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/department/science/xenobiology)
-"ddi" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"ddj" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/department/science/xenobiology)
-"ddk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"ddl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/item/radio/intercom{
-	pixel_y = -29
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"ddm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"ddn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"ddo" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"ddp" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Test Chamber Maintenance";
-	req_access_txt = "47"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
-"ddq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"ddr" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"dds" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
-"ddt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"ddu" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "test chamber blast door"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "ddv" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/door/window/southleft{
+	name = "Mass Driver Door";
+	req_access_txt = "7"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Xenolab";
-	name = "test chamber blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/xenobiology)
-"ddw" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/science/xenobiology";
-	dir = 4;
-	name = "Test Chamber Maintenance APC";
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/aft)
 "ddx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/chair,
-/obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "ddy" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ddz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "ddA" = (
+/turf/closed/wall,
+/area/space)
+"ddB" = (
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Test Chamber";
+	dir = 1;
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"ddC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
 	glass = 1;
@@ -75367,21 +74741,6 @@
 	req_access_txt = "55"
 	},
 /turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"ddB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 1;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
-"ddC" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/disposaloutlet,
-/turf/open/floor/plating/airless,
 /area/science/xenobiology)
 "ddE" = (
 /obj/effect/landmark/start/cook,
@@ -77103,9 +76462,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "diQ" = (
@@ -77172,23 +76528,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "djg" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"djh" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -77218,11 +76563,14 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "djs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "djt" = (
 /obj/structure/cable{
@@ -77274,6 +76622,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"djG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "djM" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -77322,35 +76676,17 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/xenobiology)
 "dmq" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/machinery/door/airlock/research{
-	glass = 1;
-	name = "Slime Euthanization Chamber";
-	opacity = 0;
-	req_access_txt = "55"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dmr" = (
-/obj/machinery/door/airlock/research{
-	glass = 1;
-	name = "Slime Euthanization Chamber";
-	opacity = 0;
-	req_access_txt = "55"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+/turf/open/floor/plating/airless,
+/area/science/test_area)
 "dmD" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
@@ -77422,9 +76758,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dnJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dnO" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/cobweb,
@@ -77483,16 +76824,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"dpI" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dpL" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -77510,22 +76841,27 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
 "drM" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 5;
-	height = 7;
-	id = "exploration_home";
-	name = "Exploration Dock";
-	roundstart_template = /datum/map_template/shuttle/exploration;
-	width = 13
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/spawner/room/threexthree,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "drQ" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
+"dsf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space,
+/area/space/nearstation)
 "dsg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -77765,10 +77101,7 @@
 /area/maintenance/port/aft)
 "dyp" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
@@ -77832,6 +77165,12 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"dAQ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/science/xenobiology)
 "dAW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -77845,11 +77184,11 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "dAZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/space)
 "dBu" = (
 /turf/closed/wall,
 /area/engine/gravity_generator)
@@ -78577,13 +77916,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"dDI" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dDJ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow{
@@ -78634,13 +77966,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "dGH" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/camera{
+	c_tag = "Science Shuttle Dock";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "dHC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78691,6 +78029,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"dIO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "dKe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78704,6 +78051,22 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
+"dLy" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "dLG" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/stripes/line{
@@ -78726,6 +78089,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dML" = (
+/turf/open/floor/circuit/telecomms,
+/area/space/nearstation)
 "dNO" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -78748,15 +78114,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"dQI" = (
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
 "dUj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/door/poddoor{
+	id = "toxinsdriver";
+	name = "Toxins Launcher Bay Door"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/space)
 "dUZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -78797,6 +78162,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"ecn" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ecs" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -78920,6 +78298,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/target_stake,
+/obj/item/target/syndicate,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "esP" = (
@@ -78945,6 +78328,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"etu" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1;
+	name = "euthanization chamber freezer"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "evh" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -78958,12 +78348,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ext" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/turf/open/floor/plating/airless,
+/area/space)
 "exJ" = (
 /obj/structure/table/glass,
 /obj/item/folder,
@@ -79008,6 +78397,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"eHg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms,
+/area/space)
 "eId" = (
 /obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79016,6 +78414,10 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"eJv" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall,
+/area/science/xenobiology)
 "eLn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -79042,6 +78444,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"eSo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "eTL" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/barman_recipes{
@@ -79070,15 +78479,8 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "eXl" = (
-/obj/machinery/power/apc/auto_name/south{
-	pixel_y = -24
-	},
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/turf/open/floor/plating/airless,
+/area/space)
 "eXp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79092,17 +78494,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fbK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+"eZt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "xeno_airlock_exterior";
+	idInterior = "xeno_airlock_interior";
+	idSelf = "xeno_airlock_control";
+	name = "Access Console";
+	pixel_x = -25;
+	pixel_y = -25;
+	req_access_txt = "55"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"fbK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/starboard/aft)
 "fcn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79120,6 +78543,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
+"fdf" = (
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "fdr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -79148,6 +78581,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"fiB" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "fki" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -79220,6 +78663,16 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"fzi" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/space)
 "fBq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79243,6 +78696,10 @@
 /obj/item/bedsheet/syndie,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"fDE" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "fEL" = (
 /obj/machinery/telecomms/relay/preset/exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -79251,13 +78708,8 @@
 /turf/closed/wall,
 /area/science/nanite)
 "fFM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/item/toy/plush/beeplushie,
+/turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/science/misc_lab/range)
 "fGw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79324,6 +78776,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"fKZ" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Aft-Starboard";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "fLl" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 25
@@ -79331,6 +78798,22 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
+"fLN" = (
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "test chamber blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "fMv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -79398,6 +78881,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fUS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "fXe" = (
 /obj/structure/mirror{
 	pixel_x = 28
@@ -79407,6 +78899,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"fYB" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/circuit/telecomms,
+/area/space/nearstation)
 "fZP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -79433,6 +78929,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"geC" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/extinguisher{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/extinguisher,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ggI" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -79527,11 +79038,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gqd" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/space)
 "gra" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -79563,6 +79073,28 @@
 	},
 /turf/open/floor/plating,
 /area/science/nanite)
+"gtD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/chair,
+/obj/item/cigbutt,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"gxM" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Xenolab";
+	name = "test chamber blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "gyr" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -79574,28 +79106,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"gzP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "gzS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/aisat)
 "gAP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "gCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -79609,6 +79131,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gED" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/space,
+/area/space)
 "gHQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -79654,6 +79181,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/cryopods)
+"gLo" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron{
+	amount = 10
+	},
+/obj/item/electropack,
+/turf/open/floor/engine,
+/area/maintenance/department/science/xenobiology)
 "gLC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -79676,6 +79211,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"gNG" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/space,
+/area/space)
 "gQZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -79687,11 +79229,24 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "gRW" = (
-/obj/machinery/computer/objective{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"gTA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/space)
+"gVg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/space)
 "gXp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -79807,20 +79362,19 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "hrp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "hry" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "htz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/science/shuttledock)
+/obj/item/beacon,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "huT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -79854,13 +79408,13 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "hyY" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/exploration,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "hzK" = (
@@ -79890,6 +79444,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"hCC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "hCF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -79897,15 +79456,11 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/dorms)
 "hFV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/airalarm/directional/west,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Testing Range"
-	},
+/obj/machinery/vendor/exploration,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "hGe" = (
@@ -79916,10 +79471,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "hIy" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plating,
 /area/science/shuttledock)
 "hJU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -79948,6 +79504,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"hKL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"hNG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "hPc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -80014,9 +79593,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "hZi" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/science/shuttledock)
+/obj/item/target/alien/anchored,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera/preset/toxins{
+	dir = 8
+	},
+/turf/open/floor/plating/airless{
+	luminosity = 2
+	},
+/area/space/nearstation)
 "iaj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -80042,6 +79629,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
+"ifc" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
 "ifN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -80052,10 +79648,28 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "iia" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/indestructible{
+	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
+	icon_state = "riveted";
+	name = "hyper-reinforced wall"
+	},
+/area/space)
+"ikw" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"iky" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/department/science/xenobiology)
 "iof" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -80126,17 +79740,39 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "iuF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/power/solar{
+	id = "aftstarboard";
+	name = "Aft-Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space/nearstation)
+"ivA" = (
+/obj/machinery/door/airlock/research{
+	glass = 1;
+	name = "Slime Euthanization Chamber";
+	opacity = 0;
+	req_access_txt = "55"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"ixK" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "49;47"
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
+/area/space)
 "ixU" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -80203,8 +79839,18 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "iBo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "iBp" = (
@@ -80223,6 +79869,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iGM" = (
+/obj/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = 2;
+	pixel_y = -1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "iGZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80248,12 +79914,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "iHM" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/obj/machinery/power/solar{
+	id = "aftstarboard";
+	name = "Aft-Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space/nearstation)
+"iIv" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "iKA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -80308,11 +79983,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "iPi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
-/area/science/shuttledock)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/space)
 "iPk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80348,14 +80022,9 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "iUx" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iWm" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -80393,9 +80062,34 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jdF" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "jdU" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"jdW" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/white,
 /area/space)
 "jeD" = (
 /obj/structure/cable/yellow{
@@ -80443,6 +80137,15 @@
 	},
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
+"jje" = (
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Kill Chamber";
+	dir = 1;
+	network = list("ss13","rd","xeno");
+	start_active = 1
+	},
+/turf/open/floor/circuit/telecomms,
+/area/space)
 "jmO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80493,6 +80196,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
+"jra" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -80522,14 +80230,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "juU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/turf/open/floor/plating/airless,
+/area/space)
 "jwU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -80628,6 +80336,16 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"jHo" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/space)
+"jIQ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "jKK" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -80638,16 +80356,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "jLY" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/jukebox/disco,
+/obj/item/paper/crumpled/bloody{
+	info = "atleast i still have you, mister Buzz :)"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/vaporwave,
 /area/science/misc_lab/range)
 "jMe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80668,6 +80381,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"jOx" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "jPO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -80675,11 +80395,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "jQw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space,
+/area/solar/starboard/aft)
 "jSj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -80699,6 +80418,19 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"jVm" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "jWT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -80747,6 +80479,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"jYL" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jZN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
@@ -80779,8 +80517,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kfu" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Exploration Control";
+	req_one_access_txt = "49"
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "kgI" = (
 /obj/effect/turf_decal/stripes/line,
@@ -80789,6 +80534,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"kgP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small,
+/turf/open/floor/circuit/telecomms,
+/area/space)
 "kie" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster{
@@ -80876,7 +80626,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "krD" = (
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "krL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -80885,9 +80638,12 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
 "kss" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/space)
 "ksx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -80903,14 +80659,28 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "kuN" = (
-/obj/machinery/computer/shuttle_flight/custom_shuttle/exploration{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"kuO" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Test Chamber Maintenance";
+	req_access_txt = "47"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"kwj" = (
+/obj/effect/spawner/room/fivexthree,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "kwI" = (
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_y = 3
@@ -80936,14 +80706,10 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "kxk" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/machinery/computer/objective{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
-	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/carpet,
 /area/science/misc_lab/range)
 "kxo" = (
 /turf/open/floor/carpet/orange,
@@ -81044,19 +80810,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "kDM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/light/small,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "kGe" = (
 /obj/structure/cable{
@@ -81066,6 +80826,13 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"kIE" = (
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "kKW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -81073,17 +80840,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "kMb" = (
-/obj/machinery/camera{
-	c_tag = "Research Division Testing Range";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/exploration,
-/turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "kMV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -81110,21 +80874,30 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "kOt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
-"kOW" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "science shuttle dock";
-	req_one_access_txt = "49"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"kPo" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
+"kQE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "kSB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk,
@@ -81155,6 +80928,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"kWO" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/space,
+/area/space)
+"kXu" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "kZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -81205,6 +80999,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"lrr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/research{
+	glass = 1;
+	name = "Slime Euthanization Chamber";
+	opacity = 0;
+	req_access_txt = "55"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "lrF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -81212,6 +81024,34 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"ltd" = (
+/obj/machinery/chem_heater,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"lvF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "lvJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -81248,8 +81088,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "lwJ" = (
-/obj/effect/landmark/start/exploration,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "lxh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -81269,12 +81108,23 @@
 /turf/open/space,
 /area/space/nearstation)
 "lzk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"lAC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plating,
+/area/space)
+"lBG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/space,
+/area/space)
 "lCX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -81283,14 +81133,22 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "lDp" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/maintenance/starboard/aft";
-	name = "Starboard Quarter Maintenance APC";
-	pixel_y = -24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lEv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -81333,9 +81191,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage Room";
+	req_one_access_txt = "12;47"
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lMJ" = (
@@ -81369,10 +81229,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "49;47"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;47"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "lTL" = (
@@ -81419,11 +81279,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
 "lWA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
+/area/science/shuttledock)
+"lWH" = (
+/obj/structure/closet/l3closet/scientist,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/area/science/xenobiology)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -81457,11 +81326,13 @@
 /area/science/nanite)
 "lZW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/door/airlock/external,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/science/shuttledock)
+/area/maintenance/starboard/aft)
 "mco" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -81478,11 +81349,29 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mgO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"mgP" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/area/science/xenobiology)
 "mgY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -81586,6 +81475,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mFD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = -29
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mGI" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -81613,18 +81515,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "mGY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Science Shuttle Dock";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/science/shuttledock)
 "mHF" = (
 /obj/structure/cable/yellow{
@@ -81636,12 +81532,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "mIf" = (
-/obj/machinery/light/small{
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage Room";
+	req_one_access_txt = "12;47"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/vendor/exploration,
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "mKD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -81655,13 +81557,35 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"mLA" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mLO" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/space/basic,
+/area/space/nearstation)
+"mMv" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
+"mMS" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/space)
 "mNe" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -81683,6 +81607,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"mOI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "mRq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -81720,8 +81649,13 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;47"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"mXQ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "mYd" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -81816,8 +81750,17 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "ney" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "nhp" = (
 /obj/effect/turf_decal/delivery,
@@ -81834,7 +81777,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "npK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -81851,17 +81800,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"nrT" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "ntl" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/suit_storage_unit/exploration,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"nuV" = (
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "nwf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/status_display/evac{
@@ -81897,6 +81849,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
+"nwN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "nwW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -81920,6 +81887,15 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"nyf" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/space)
 "nyo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -81929,6 +81905,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"nzV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "nAG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -81943,6 +81926,7 @@
 /area/maintenance/starboard)
 "nAO" = (
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nBD" = (
@@ -81990,9 +81974,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
@@ -82028,9 +82017,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nKN" = (
@@ -82064,13 +82050,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "nLK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "nRS" = (
 /obj/structure/musician/piano,
@@ -82101,6 +82082,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"nWU" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "nXA" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -82111,9 +82097,23 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "obb" = (
-/obj/structure/target_stake,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "obX" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -82157,12 +82157,39 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"ogK" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ohA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall,
 /area/security/prison)
+"ohH" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "xeno_airlock_interior";
+	idSelf = "xeno_airlock_control";
+	name = "Access Button";
+	pixel_x = 29;
+	pixel_y = -8;
+	req_access_txt = "55"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ojf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82172,18 +82199,26 @@
 "ojg" = (
 /turf/closed/wall,
 /area/science/misc_lab/range)
-"ojw" = (
-/obj/effect/turf_decal/stripes/line{
+"oji" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
-/obj/structure/rack,
-/obj/item/hand_labeler,
-/obj/item/wrench,
-/obj/item/crowbar,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"ojo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Test Chamber Maintenance";
+	req_access_txt = "47"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "ojC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -82223,6 +82258,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"ooZ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/space/basic,
+/area/space)
 "opl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -82230,13 +82270,49 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"oqf" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "xeno_airlock_interior";
+	name = "Xenobiology Lab Internal Airlock";
+	req_access_txt = "55"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "oqs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
@@ -82264,6 +82340,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"otH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
 "oub" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
@@ -82271,6 +82354,12 @@
 "ovj" = (
 /turf/closed/wall,
 /area/maintenance/starboard/secondary)
+"ovB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ovD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/sign/map/left{
@@ -82286,6 +82375,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ovE" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ovP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82373,11 +82471,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "oHw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/science/xenobiology)
 "oJW" = (
 /obj/machinery/camera{
@@ -82399,6 +82495,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/port/aft)
+"oQZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/space)
 "oRL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -82436,12 +82539,20 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"oZK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+"oVc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/turf/open/floor/plating,
+/area/science/xenobiology)
+"oZK" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "pcc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82449,6 +82560,9 @@
 /turf/closed/wall,
 /area/quartermaster/miningoffice)
 "pcn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "pco" = (
@@ -82490,6 +82604,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"pfz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "pfL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82543,6 +82665,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"pkY" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/turf/open/floor/plating/airless,
+/area/space)
 "pok" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82597,6 +82726,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pDk" = (
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Test Chamber Monitor";
+	network = list("xeno");
+	pixel_y = 2
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "pEJ" = (
 /obj/item/cigbutt,
 /obj/item/rack_parts,
@@ -82638,6 +82778,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pNU" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "pOm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -82649,19 +82794,22 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "pPc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room";
-	req_one_access_txt = "12;47"
+/obj/machinery/power/solar{
+	id = "aftstarboard";
+	name = "Aft-Starboard Solar Array"
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space)
+"pPp" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/space)
 "pPs" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -82754,6 +82902,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
+"pYR" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "qak" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
@@ -82771,16 +82922,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "qcZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/landmark/start/exploration,
+/obj/structure/chair/office/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/carpet,
 /area/science/misc_lab/range)
 "qdE" = (
 /turf/open/floor/carpet/purple,
@@ -82830,13 +82976,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "qjB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "qjJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -82871,6 +83016,12 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -82973,11 +83124,32 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"qIP" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "qLf" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
 /turf/open/floor/engine/cult,
 /area/library)
+"qNz" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "qNF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83044,6 +83216,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"rev" = (
+/obj/machinery/door/window/southleft{
+	dir = 1;
+	name = "Maximum Security Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "rhR" = (
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
 	pixel_y = -32
@@ -83081,16 +83262,9 @@
 /turf/closed/wall,
 /area/vacant_room/commissary)
 "rvY" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/window,
+/turf/open/floor/plating,
 /area/science/shuttledock)
 "rwk" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -83152,12 +83326,21 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "rDf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
-/obj/machinery/door/airlock/external,
+/obj/item/target,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/science/shuttledock)
+/area/space)
+"rEY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/space)
 "rFZ" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -83166,6 +83349,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/security/brig)
+"rIl" = (
+/obj/item/beacon,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "rIo" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
@@ -83198,13 +83385,19 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "rIW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"rNJ" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "rPH" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -83235,6 +83428,22 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"rWT" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
+"rZz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "sao" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/bot,
@@ -83257,25 +83466,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "scW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "sdi" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/machinery/camera{
+	c_tag = "Science Shuttle Dock";
+	dir = 4;
+	network = list("ss13","rd")
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "sdF" = (
 /obj/structure/disposalpipe/segment,
@@ -83287,6 +83489,11 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
+"seE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/solar/starboard/aft)
 "seK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -83333,7 +83540,13 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "siX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83342,37 +83555,55 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
 "sjV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/science/shuttledock)
+/area/maintenance/starboard/aft)
 "slE" = (
 /obj/machinery/telecomms/receiver/preset_exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "sql" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/computer/cryopod{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
+"srO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/space)
+"ssD" = (
+/obj/machinery/sparker{
+	id = "Xenobio";
+	pixel_x = -25
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "svg" = (
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
-"syh" = (
+"sxH" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/area/science/xenobiology)
+"syh" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/spawner/room/threexthree,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "szz" = (
 /obj/machinery/light{
 	dir = 4
@@ -83384,13 +83615,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "szA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/light_switch{
+	pixel_x = -25;
+	pixel_y = -4
 	},
-/obj/structure/window/reinforced{
+/obj/machinery/computer/shuttle_flight/custom_shuttle/exploration{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/science/misc_lab/range)
 "sAD" = (
 /obj/structure/cable/white{
@@ -83552,6 +83784,23 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"sSa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
+"sTZ" = (
+/obj/machinery/chem_master,
+/obj/item/radio/intercom{
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "sYk" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "space-bridge access"
@@ -83574,6 +83823,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/port/aft)
+"tab" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"tfH" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -83592,30 +83856,46 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tqy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
-"tqR" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
+"tpN" = (
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "aftstarboard";
+	name = "Starboard Quarter Solar Control"
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
-"tqW" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room";
-	req_one_access_txt = "12;47"
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/space)
+"tqy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
+"tqR" = (
+/obj/machinery/power/apc/auto_name/south{
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/misc_lab/range)
+"tqW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/maintenance/solars/starboard/aft)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83655,6 +83935,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tvp" = (
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "twg" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -83671,12 +83954,10 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"txx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
+"twJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "tzs" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -83697,6 +83978,25 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"tBi" = (
+/obj/machinery/light,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"tBs" = (
+/turf/open/floor/circuit/telecomms,
+/area/space)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -83745,7 +84045,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/suit_storage_unit/exploration,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "tLf" = (
@@ -83788,11 +84087,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "tRl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/maintenance/starboard/aft)
+/area/space/nearstation)
 "tRF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -83825,17 +84122,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "tVY" = (
-/obj/structure/closet/crate,
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target/syndicate,
-/obj/item/target/syndicate,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/plasteel/white,
-/area/science/misc_lab/range)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "tWv" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
@@ -83861,14 +84150,23 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"uaC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"ubc" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Airlock";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"ueg" = (
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "uej" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -83901,6 +84199,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ugm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "uhY" = (
 /obj/machinery/computer/warrant{
 	dir = 1
@@ -83940,20 +84250,13 @@
 /turf/open/floor/wood,
 /area/library)
 "ulC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -4
-	},
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage Room";
+	req_one_access_txt = "12;47"
+	},
+/turf/open/floor/plating,
+/area/space)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -84002,9 +84305,8 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
 "uuw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
+/turf/closed/wall/r_wall,
+/area/space)
 "uuJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -84017,6 +84319,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/secondary)
+"uuU" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Aft-Port";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/bz,
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "uvc" = (
 /obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_x = 32
@@ -84061,15 +84378,9 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "uEU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/exploration,
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/space)
 "uGa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -84097,6 +84408,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"uNd" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/science/xenobiology";
+	dir = 4;
+	name = "Test Chamber Maintenance APC";
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
+"uPm" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "uPU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters";
@@ -84160,6 +84487,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/cryopods)
+"vdm" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "vfy" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -84181,6 +84512,11 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
+"vhr" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/science/xenobiology)
 "vhG" = (
 /obj/structure/table/glass,
 /obj/machinery/camera/autoname{
@@ -84209,11 +84545,16 @@
 /turf/open/floor/wood,
 /area/library)
 "vjL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Quarter Solar Access";
+	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "vjS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/closed/wall,
@@ -84226,14 +84567,27 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "vlO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
+"vmF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/science/xenobiology)
+"vmW" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space,
+/area/space)
+"vnk" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "vnp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -84246,6 +84600,11 @@
 "vox" = (
 /turf/open/floor/engine/vacuum,
 /area/maintenance/starboard)
+"voQ" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/department/science/xenobiology)
 "vpJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -84256,8 +84615,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "vvZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "vzO" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -84276,13 +84638,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "vCj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 5;
+	height = 7;
+	id = "exploration_home";
+	name = "Exploration Dock";
+	roundstart_template = /datum/map_template/shuttle/exploration;
+	width = 13
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/space/basic,
 /area/science/shuttledock)
 "vDo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -84345,6 +84710,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"vMT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
 "vNr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84361,13 +84732,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vRq" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/shuttledock)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vRM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -84380,6 +84748,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
+"vVw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space,
+/area/solar/starboard/aft)
 "vWK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -84393,6 +84768,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"vXe" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/camera{
+	c_tag = "Aft Starboard Solar Maintenance";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
 "vYe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -84425,8 +84813,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -84509,6 +84900,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"wni" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	id = "aftstarboard";
+	name = "Aft-Starboard Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space)
 "wnQ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -84541,6 +84942,13 @@
 "wtq" = (
 /turf/closed/wall,
 /area/maintenance/aft/secondary)
+"wvo" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "wvF" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner,
@@ -84576,11 +84984,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "wyv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/science/mixing)
+/turf/open/floor/plating,
+/area/space)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -84598,14 +85003,20 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "wCO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"wDY" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "wFH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84731,11 +85142,17 @@
 	dir = 8
 	},
 /area/medical/surgery)
+"wUO" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/space)
 "wVi" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "wVw" = (
 /obj/structure/cable/yellow{
@@ -84920,26 +85337,21 @@
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
 "xse" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/space)
 "xsr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/anesthetic_machine,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"xsZ" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "xvg" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -84956,14 +85368,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xwI" = (
+/obj/machinery/power/smes,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/turf/open/floor/plating,
+/area/space)
 "xwS" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -85068,41 +85478,36 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "xFP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
-	req_access_txt = "8"
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"xHp" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/shuttledock)
-"xIt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/space)
+"xHp" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/solars/starboard/aft";
+	dir = 1;
+	name = "Starboard Quarter Solar APC";
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/space)
+"xIt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
 "xJp" = (
 /obj/item/kirbyplants/random,
@@ -85119,9 +85524,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "xQQ" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plasteel/white,
-/area/science/shuttledock)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/space/nearstation)
+"xSq" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/space)
 "xTv" = (
 /obj/structure/pool_ladder,
 /turf/open/indestructible/sound/pool/end,
@@ -85179,6 +85592,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/misc_lab/range)
 "yic" = (
@@ -85201,9 +85615,7 @@
 /turf/closed/wall,
 /area/maintenance/port)
 "ykS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/science/xenobiology)
 "ylE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -114088,7 +114500,7 @@ ahB
 aoA
 ahB
 ark
-aoA
+asA
 ahB
 ave
 awl
@@ -115732,10 +116144,10 @@ cRe
 cRe
 cRe
 cRe
-aaa
-aaa
-aaa
-aaa
+dcC
+dcC
+dcC
+dcC
 aaa
 aaa
 aaa
@@ -115986,13 +116398,13 @@ cRf
 cYT
 cRg
 cYT
-cYT
+cSJ
 djg
-cRe
-aaa
-aaa
-aaa
-aaa
+cSJ
+pPp
+oQZ
+jdW
+dcC
 aaa
 aaa
 aaa
@@ -116244,12 +116656,12 @@ cRe
 cRe
 cRe
 cRe
-uaC
 cRe
-aaa
-aaa
-aaa
-aaa
+cRe
+dcC
+dcC
+rWT
+dcC
 aaa
 aaa
 aaa
@@ -116500,23 +116912,19 @@ aaa
 aaf
 aaa
 aaa
-cRe
-uaC
-cRe
+ykS
+ykS
+dcx
 aaa
+dcC
+rWT
+dcD
 aaa
+dda
 aaa
-aaf
+auv
 aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -116526,9 +116934,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
 aaa
 aaa
+aaa
+aaa
+auv
+aaa
+dda
 aaa
 aaa
 aaa
@@ -116757,35 +117169,35 @@ aaa
 aaf
 aaa
 aaa
-cRe
-uaC
-cRe
-aaf
+ykS
+dcx
+dcx
+lMJ
+dcC
+rWT
+dcD
+auv
+dda
+dda
+auv
 aaa
-aaa
-aaf
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+dda
 aaa
 aaa
 aaa
+auv
+aaa
+dda
 aaa
 aaa
 aaa
-aaf
 aaa
+auv
 aaa
-aaf
+dda
+auv
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -117014,46 +117426,46 @@ aaf
 aaf
 aaf
 aaa
+dcx
+dcx
+ykS
+dcx
 cRe
-uaC
+dcg
 cRe
-cRu
-cRi
-cRi
-cRi
-cRi
-aaf
+nrT
+beq
+uuw
+beq
+beq
+dda
 aaa
 aaf
 aaf
-aaa
-aaa
-aaf
-aaf
-aaf
+auv
 aaa
 aaf
 aaf
 aaf
 aaa
-aaa
+dda
 aaf
 aaf
+auv
+auv
+aaf
+dda
 aaf
 aaf
-aaf
-aaa
-aaf
-aaf
-aaa
+dda
+auv
 aaf
 aaf
-aai
-aag
-aaa
-aaa
-aaa
-aaa
+auv
+dda
+dda
+qIP
+wDY
 aaa
 aaa
 aaa
@@ -117271,19 +117683,19 @@ aaa
 aaa
 aaf
 aaf
+dcx
+ykS
+ykS
+ykS
 cRe
-uaC
-cRe
-cRi
-dbX
 dcg
-dcs
+cRe
 cRi
 dcE
+mFD
+ubc
 cRi
-cRi
-cRi
-cRi
+dAQ
 cRi
 cRi
 cRi
@@ -117297,21 +117709,21 @@ dlV
 dlV
 dlV
 dlV
+beq
+uuw
+uuw
+beq
+dda
+aaa
+aaa
 aaf
 aaa
+auv
+auv
+dda
 aaa
-aaf
-aaa
-aaa
-aaa
-aaf
-aaa
-aag
-aag
-aaa
-aaa
-aaa
-aaa
+wDY
+wDY
 aaa
 aaa
 aaa
@@ -117528,47 +117940,47 @@ dvY
 dvY
 dvY
 dvY
+dcx
+ykS
+ykS
+ykS
 cRe
-djh
-cYT
-cRv
-dbY
 dch
-dct
+cYT
 dcz
 djs
-cRi
-cSh
+mgP
+lWH
 cSp
-cSy
-cSd
+vmF
+cRi
 cSh
 dbo
 cSy
 cSd
 cSh
 dbs
-cSn
-cRi
+cSy
+cSd
 dde
 ddj
-cTp
+ddq
+dlV
+mXQ
+voQ
+nWU
 dlV
 dlV
 dlV
 dlV
 dlV
-dlV
-dlV
-dlV
-dlV
+uuw
+uuw
+beq
+uuw
 aaa
 aaa
-aai
-aaa
-aaa
-aaa
-aaa
+qIP
 aaa
 aaa
 aaa
@@ -117785,13 +118197,17 @@ auT
 auT
 awI
 dvY
+dcx
+ykS
+ykS
+ykS
 cRe
 cRe
 cRe
 cRi
-dbZ
-dci
-dcu
+ohH
+ecn
+kXu
 cRi
 cRe
 cRi
@@ -117803,29 +118219,25 @@ cSg
 cSn
 cSn
 cSd
-cSg
-cSn
-cSn
-cRi
-cTA
-cTn
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-cTC
-daO
-bIx
+ddt
+ddq
+ddq
 dlV
-aaf
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
+tvp
+ovB
+cTC
+cTC
+cTC
+cTC
+cTC
+cTC
+twJ
+djG
+iIv
+uuw
+dda
+dda
+wDY
 aaa
 aaa
 aaa
@@ -118042,15 +118454,19 @@ auT
 auT
 auT
 dvY
+vLD
 aaa
 aaa
-aaa
-cRw
+ykS
+ykS
+dcx
+ykS
+vdm
 cRi
-dcj
-cRx
+oqf
+sSa
 cRi
-cRD
+jYL
 cSd
 cSg
 cSn
@@ -118065,25 +118481,21 @@ cSn
 cSn
 cRi
 cRi
-cTq
+ojo
 cRi
 cRi
 cRi
-cRi
-cRi
-cRi
-cRi
-daP
-cLE
 dlV
+cRi
+dlV
+uuw
+ixK
+etu
+beq
 aaa
 aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
+dda
+wDY
 aaa
 aaa
 aaa
@@ -118299,16 +118711,16 @@ auT
 auT
 auT
 dvY
-aaa
-aaa
-aaf
+vLD
+vLD
+lMJ
+dcx
+dcx
+dcx
+dcx
 cRi
-cRh
-dck
-cRz
-cRB
 cRN
-cSd
+eZt
 cRU
 cSq
 cRZ
@@ -118324,23 +118736,23 @@ cSd
 ddf
 ddk
 cTj
-cTD
-cRi
-cSn
+cSd
+uuU
+kPo
 daF
-daJ
+daM
 cRi
-bvT
+ddq
+ssD
+nuV
 cRi
-cRi
-cRi
-cRi
+fUS
+uuw
+beq
+uuw
+uuw
 aaa
-aai
-aaa
-aaa
-aaa
-aaa
+qIP
 aaa
 aaa
 aaa
@@ -118552,24 +118964,24 @@ dyc
 dxQ
 dvY
 auT
-avb
-awB
 auT
+awB
+rIW
 dvY
-aaa
-aaa
-aaa
+ddA
+ddA
+ddA
+cSd
+ykS
+ykS
+dcx
 cRi
-dca
-dcl
-cRy
-cRA
 cRM
 cRa
-cSj
+eSo
 cSs
 cSB
-cSI
+eJv
 cSj
 cSO
 cSS
@@ -118577,27 +118989,27 @@ cSI
 cSj
 cTb
 cST
-cSd
-cSL
+cSI
+cSj
 cVa
 cTr
-cRY
+cSd
 daC
+oji
+pDk
+gxM
+xsZ
 cSn
 cSn
 cSn
 cRi
-dmq
-cRi
-cZv
-cZv
-cRi
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
+lrr
+beq
+dML
+tBs
+uuw
+dda
+wDY
 aaa
 aaa
 aaa
@@ -118809,50 +119221,50 @@ nKr
 cxM
 dvY
 auT
-dAZ
 auT
+lzk
 auT
 dvY
-aaa
-aaa
-aaf
-cRe
-cRS
-dcm
-dcv
-cRC
-dcG
+wyv
+rEY
+kwj
+cSd
+dcx
+ykS
+dcx
+cRi
+dcI
 cSe
 cSi
-cSr
-cSA
+ovE
+hCC
 cSG
-cSK
+tab
 cSr
 cSA
 cSW
 cSK
 cSr
-dcY
+cSA
 ddc
-cSk
-ddl
+cSK
+cSr
 cTk
 cTm
 daB
-daB
+lvF
 daG
-cSn
-cRi
+fLN
+ddx
 ddx
 ddz
-daR
-cZv
-cRe
-aaa
-aaa
-aaa
-aaa
+cSn
+cRi
+gtD
+lAC
+eHg
+tBs
+dcC
 aaa
 aaa
 aaa
@@ -119060,58 +119472,58 @@ cFs
 cGn
 cHi
 ehL
+auT
 dvY
 dvY
-pPc
-dvY
-dvY
-dvY
-avX
+ddp
 dvY
 dvY
 dvY
-aaa
-aaa
-aaf
-cRe
-cRS
-dcn
-dcw
-cRk
-dcH
+lLE
+dvY
+dvY
+wyv
+vMT
+pYR
+cSd
+dcx
+dcx
+dcx
+cRi
+dcI
 cSf
 cSl
-cSJ
+ugm
 cSa
+dIO
+fiB
 cSJ
-cSJ
-cUM
 cUN
 cSJ
 cSJ
-cSJ
+tfH
 cSV
 cSJ
-cSX
-ddm
+cSJ
+cSJ
 cTt
-daA
-cSn
-cSn
-cSn
+cSJ
+lEv
+hKL
+rev
 daL
-cRi
-daQ
-ddA
+cSn
+cSn
+cSn
 daS
-dbv
+cRi
 cTT
 ddC
-aaf
-aaa
-aaa
-aaa
-aaa
+fYB
+kgP
+jHo
+pkY
+dda
 aaa
 aaa
 aaa
@@ -119317,58 +119729,58 @@ cyK
 cyK
 cyK
 cPe
+daR
 dvY
 auT
-lLE
 avK
+drM
 dvY
 auT
-dAZ
-avK
-dvY
-aaa
-aaa
-aaa
-aaf
-cRe
-cRS
-dco
+lZW
+drM
+ddA
+wyv
+vMT
+pYR
+cSd
+ykS
+ykS
 dcx
-dcA
+cRi
 dcI
 cRR
 cRV
-cRX
-cSb
+hNG
+pfz
 dcO
-dcQ
+rZz
 cRX
 cSb
 dcT
 dcQ
 cRX
-dcZ
+cSb
 ddd
-cTa
-ddn
+dcQ
+cRX
 cTs
 ddu
 daD
-cSn
+aEu
 daH
 daK
-cRi
-bIv
-ddz
+kIE
+cSn
+rIl
 ddB
-cZv
-cRe
+cRi
+jIQ
+lAC
+axN
+tBs
+dcC
 aaa
-aaf
-aaa
-aaa
-aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -119574,58 +119986,58 @@ cyK
 dvY
 cub
 diP
+auT
 dvY
 auT
-scW
 avx
-avV
+awA
 avW
 awA
-auT
-dvY
-aaa
-aaa
-aaa
-aaa
+mgO
+sjV
+ulC
+xse
+gTA
+wyv
+cSd
+ykS
+ykS
+ykS
 cRi
-dcb
-cZa
-dDI
-dcB
 dcJ
-cRa
+ogK
 cSm
 cSw
-cSE
-cSI
+geC
+eJv
 cSM
 cSR
 cSE
 cSI
 dcV
 cTe
-dda
-cSd
+cSE
+cSI
 cSZ
 ddn
 cTz
-ddv
-daC
-cSn
-cSn
+cSd
+ikw
+aEu
+fdf
 daN
-cRi
-dmr
-cRi
+xsZ
+cSn
+cSn
 cZv
-dbw
 cRi
+ivA
+uuw
+dML
+jje
+uuw
 aaa
-aag
-aaa
-aaa
-aaa
-aaa
+wDY
 aaa
 aaa
 aaa
@@ -119831,26 +120243,26 @@ jGE
 dvY
 dxQ
 dyc
-dvY
-auT
-lLE
-auT
+dyc
 dvY
 auT
 auT
 auT
-dxk
-aaa
-aaa
-aaa
-aaa
-cRi
-dcc
-dcp
-txx
-cSt
-dcK
+dvY
+auT
+lZW
+auT
+ddA
+wyv
+wyv
+wyv
 cSd
+dcx
+ykS
+ykS
+cRi
+dcK
+sxH
 cRW
 cSv
 cSc
@@ -119866,23 +120278,23 @@ cSd
 ddg
 ddo
 dds
-cTD
-cRi
+cSd
+fKZ
 daE
 daI
 daM
 cRi
-cTA
+gLo
+jVm
+iGM
 cRi
-cRi
-cRi
-cRi
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
+ueg
+beq
+beq
+uuw
+uuw
+dda
+wDY
 aaa
 aaa
 aaa
@@ -120088,25 +120500,29 @@ wCO
 mWS
 vZt
 lDp
+dbv
 dvY
 dvY
-tqW
 dvY
-cKP
-cKP
-cKP
-cKP
-cKP
-aaa
-aaa
-aaa
-aaa
+pwA
+pwA
+pwA
+mIf
+pwA
+uuw
+uuw
+uuw
+uuw
 cRi
-dcd
-dcq
-dcy
-cSt
+dcx
+ykS
+ykS
+cRi
 dcL
+uPm
+rNJ
+cSv
+tBi
 cSd
 cSn
 cSn
@@ -120121,25 +120537,21 @@ cSn
 cSg
 cRi
 cRi
-ddp
+kuO
 cRi
 cRi
 cRi
-cRi
-cRi
-cRi
-cRi
-cTA
 dlV
+dlV
+beq
+uuw
+wyv
+beq
 aaf
 aaa
 aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
+dda
+wDY
 aaa
 aaa
 aaa
@@ -120342,28 +120754,32 @@ xTC
 iqU
 klP
 oqs
-tRl
-auT
-nAO
 dvY
-auT
+daA
+nAO
+dbw
+dcs
 scW
 avL
-cKR
+cMs
 cLK
-cMq
+cMs
 cNo
-cKP
-aaa
-aaa
-aaa
-aaa
+syh
+uEU
+xwI
+vXe
+mMS
 cRi
-dce
-cSt
-txx
-dcC
+dcx
+dcx
+dcx
+cRi
 dcM
+cSv
+cRW
+mLA
+sTZ
 cSd
 cSn
 cSn
@@ -120373,29 +120789,25 @@ cSn
 cSn
 cSg
 cSd
-cSn
-cSn
-cSg
-cRi
-ddh
+ddq
 ddq
 ddt
-ddt
-ddt
-ddt
-ddw
-cTA
-cTA
-ddy
 dlV
-aaf
-aaf
+vhr
+vnk
+ddy
+ddy
+ddy
+ddy
+uNd
+pYR
+pYR
+wUO
+beq
+dda
+dda
 aaa
-aai
-aaa
-aaa
-aaa
-aaa
+qIP
 aaa
 aaa
 aaa
@@ -120597,62 +121009,62 @@ ojg
 ojg
 ojg
 czD
+czD
+czD
+czD
+czD
 cyy
-xFP
-wyv
-czD
-czD
-dvY
-auT
+dbP
+dct
 fbK
-avU
-cKQ
-cLL
-cMr
+dvY
+pwA
+pwA
+cMs
 cNp
-cKP
-aaf
-aaa
-aaa
-aaa
+tqy
+vjL
+xFP
+nyf
+gVg
 cRi
-dcf
-dcr
-dpI
-dcD
+dcx
+ykS
+ykS
+cRi
 dcN
+jOx
+jdF
+cSx
+ltd
 cSd
 cSn
-cSx
-cSF
-cSd
-cSy
 dbp
 cSF
 cSd
-cSn
+cSy
 dbt
 cSF
-cRi
-ddi
+cSd
+ddq
 ddr
 cTB
 dlV
+pNU
+iky
+fDE
 dlV
 dlV
 dlV
 dlV
-dlV
-dlV
-dlV
-aaf
+beq
+uuw
+uuw
+beq
+dda
 aaa
 aaa
-aag
-aaa
-aaa
-aaa
-aaa
+wDY
 aaa
 aaa
 aaa
@@ -120850,36 +121262,36 @@ lal
 ygk
 sdi
 aRw
-krD
-krD
+cLM
+cSk
 wVi
 czD
-czD
+cQB
 cQC
 cBH
 cCG
-cDq
-dvY
-auT
+czD
+dbQ
+dcu
 gAP
-auT
+ddv
 cKP
-cLM
+pwA
 cMs
 cNq
-cKP
-aaa
-aav
-aaa
-aaa
+cMs
+uuw
+xHp
+ifc
+tpN
 cRi
 oHw
 ykS
-gzP
+ykS
 cRi
-cRi
-cRi
-cRi
+oVc
+mOI
+nzV
 cRi
 cRi
 cRi
@@ -120895,22 +121307,22 @@ dlV
 dlV
 dlV
 dlV
-aaa
+uuw
+beq
+beq
+beq
+auv
+aaf
+dda
 aaf
 aaf
 aaf
+auv
 aaf
-aaf
-aaa
-aaf
-aaf
-aag
-aag
-aaf
-aaa
-aaa
-aaa
-aaa
+dda
+wDY
+wDY
+dda
 aaa
 aaa
 aaa
@@ -121105,9 +121517,9 @@ cuZ
 eqG
 cwZ
 vVq
-cyM
+lwJ
 nli
-krD
+cxP
 lwJ
 tJT
 czD
@@ -121115,57 +121527,57 @@ cQv
 cAN
 cBI
 cAP
-cDr
-dvY
-dvY
+czD
+dbS
+dcA
 xIt
-uuw
+dxk
 vvZ
-iia
-dbP
+pwA
+pwA
 dbN
-cKP
+tqW
+vlO
+xQQ
+qNz
+dcC
+uuw
+lMJ
+auv
+auv
+auv
+dda
+dda
 aaf
-aaf
-aaf
-aaa
-aaa
-viG
-aaf
-aaf
-aaf
-aaa
-aaa
-aaf
-aaf
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
-aaf
-aaa
-aaf
-aaf
-aaa
+auv
+auv
+kWO
+dda
 aaf
 aaa
 aaa
 aaa
 aaf
+auv
+aaa
+auv
+aaf
+dda
+auv
+dda
+dda
+aaa
+aaf
 aaa
 aaa
 aaa
+dda
+aaa
+auv
 aaa
 aaa
-aai
 aaa
-aaa
-aaa
-aaa
+qIP
 aaa
 aaa
 aaa
@@ -121361,33 +121773,42 @@ cuc
 cuZ
 dyp
 pcn
-vVq
-cyM
-nli
-krD
+bIx
 lwJ
+cDu
+cRk
+cSL
 hyY
-czD
-czF
-cAN
+cTq
 cBJ
-cAP
-cDs
-dvY
-dvY
+cBJ
+cBJ
+daO
+czD
+dbT
+dcA
 cJe
-dvY
-aaa
+dxk
+dAZ
 pwA
-dbQ
-dbN
+pwA
+obb
+ddA
+aaa
+ddA
+nwN
+dcC
+aaa
+vLD
+aaa
+auv
 aaa
 aaa
 aaa
 aaf
 aaa
 aaa
-gqd
+kQE
 aaa
 aaf
 aaa
@@ -121397,16 +121818,7 @@ aaf
 aaa
 aaa
 aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -121613,47 +122025,47 @@ ovj
 ovj
 ovj
 cuZ
-iuF
+ovj
+ojg
 cuZ
 cuZ
-eqG
-pcn
-vVq
-cyM
-nli
-krD
-lwJ
-kMb
+cuZ
+cuZ
+ojg
+cKQ
+ojg
+ojg
+ojg
 czD
 czG
 cAN
 cBK
+daP
 czD
-cDt
-dvY
-dvY
+dbX
+dcA
 kDM
-dnJ
-osW
+dvY
+dUj
+pwA
+pwA
 iBo
-xse
-iBo
-eUG
-eUG
-eUG
-eUG
-osW
-osW
+tRl
+vRq
+jra
+dLy
+srO
+gED
 mLO
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ooZ
+ooZ
+ooZ
+gED
+gED
+gED
+osW
+osW
+gNG
 aaa
 aaa
 aaa
@@ -121871,42 +122283,42 @@ cpH
 cqX
 cuZ
 fFM
-cud
+ojg
 kxk
 szA
 hFV
 qjB
 dGH
 ney
-krD
-lwJ
+cRA
+ntl
 ntl
 czD
 cQB
 cAO
 cBL
-cEA
-cDu
-cEA
-ack
+daQ
+blx
+dbY
+dcB
 cJf
-ack
-aaa
-aaf
+dcD
+ext
+dcD
 dbR
+oZK
+tVY
+aaa
+dda
+otH
 aaa
 aaa
+auv
+aaa
+dda
 aaa
 aaa
-aaf
-aaa
-aaa
-aqB
-aaa
-aaa
-aaa
-aaa
-aaa
+vmW
 aaa
 aaa
 aaa
@@ -122128,42 +122540,42 @@ dwX
 nbv
 cuZ
 jLY
-lzk
+ojg
 qcZ
 cwd
 kfu
 cxP
-krD
-nli
-krD
-krD
+cDq
+cLE
+cRB
+cSX
 tqR
 czD
-czI
-cAP
-cAP
+czD
+czD
+czD
 blx
-anS
 blx
+dbZ
+dcC
+dcD
+ddA
+eXl
+blx
+dbM
+dda
+auv
+aaa
+dda
+otH
 aaa
 aaf
+auv
 aaa
+dda
 aaa
-aaf
-dbR
-aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaf
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+dda
+iPi
 aaa
 aaa
 aaa
@@ -122384,43 +122796,43 @@ ovj
 ovj
 atd
 cuZ
-cuZ
-obb
+avb
+ojg
 sql
 kOt
 krD
-krD
-krD
-nli
-krD
-krD
-krD
+cud
+cDr
+cLL
+cRC
+cTa
+ntl
 cEA
+auv
+auv
+auv
+auv
+auv
 aaf
 aaf
 aaf
 anS
 anS
 anS
-lMJ
+dcY
 anT
 anT
 anT
 aaf
-dbR
+otH
 aqB
 anT
 aqB
-anT
-anT
-anT
-aaf
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+iPi
+iPi
+iPi
+dda
+iPi
 aaa
 aaa
 aaa
@@ -122641,43 +123053,43 @@ ovj
 nbv
 nbv
 auc
-cuZ
-tVY
+ojg
+ojg
 nLK
 hrp
-krD
-krD
-krD
-nli
-krD
-krD
-kss
-cEA
+avX
+cvj
+cDs
+ojg
+cRD
+ojg
+ojg
+blx
+auv
+auv
+auv
+auv
+auv
 aaf
 aaf
-lMJ
-aaf
-aaf
-aaf
-aaf
+vLD
+dda
+dda
+dda
+dbU
 aaa
 aaa
+auv
 aaa
-aaa
-cSz
-aaa
-aaa
-aaf
-aaa
+lBG
+auv
 aaa
 aaf
 aaa
-anT
 aaa
+dda
 aaa
-aaa
-aaa
-aaa
+iPi
 aaa
 aaa
 aaa
@@ -122898,44 +123310,44 @@ ovj
 nbv
 nbv
 nbv
-cuZ
+ojg
 mjJ
-buW
+rvY
 mjJ
+bIv
+czI
+cDt
+rvY
+cRY
 mjJ
-mjJ
-mjJ
-kOW
-mjJ
-mjJ
-mjJ
-mjJ
+qOT
+cTD
 aaa
 aaa
 aaa
 aaa
-aaf
+auv
+dbM
+dbM
+dbM
+dbM
+dbU
+iuF
+dbJ
+pPc
 dbJ
 dbJ
-dbJ
-dbJ
-dbJ
-aaf
-cRO
+dbU
+dbR
+dbM
+pPc
+iuF
+iuF
+pPc
+pPc
 aaa
-dbJ
-dbJ
-dbJ
-dbJ
-dbJ
-aaa
-aqB
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+vmW
+dda
 aaa
 aaa
 aaa
@@ -123156,43 +123568,43 @@ nbv
 nbv
 nbv
 ovj
+qOT
+qOT
 mjJ
-juU
-ulC
-ojw
+rvY
 rvY
 mGY
 lWA
 hIy
-dQI
-vRq
-mjJ
+rvY
+qOT
+cTD
 aaa
 aaa
 aaa
 aaa
-aaf
-dbK
+auv
 dbM
 dbM
 dbM
 dbM
+dbU
 dbO
-cRO
-cSC
 dbV
 dbV
 dbV
 dbV
+seE
+dbR
 dbW
-aaf
-anT
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dsf
+dsf
+dsf
+mMv
+fzi
+dda
+iPi
+dda
 aaa
 aaa
 aaa
@@ -123413,42 +123825,42 @@ nbv
 nbv
 nbv
 ovj
-mjJ
-syh
-iUx
-dUj
-dUj
-xwI
-cvj
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
 vCj
-dUj
-eXl
-mjJ
+qOT
+qOT
+qOT
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
+dbM
+dbM
+dbM
+dbU
+dbU
+iHM
+dbL
+iHM
 dbL
 dbL
-dbL
-dbL
-dbL
-aaf
-dbS
-aaf
-dbL
-dbL
-dbL
-dbL
-dbL
+dbU
+btA
+dbU
+wni
+iHM
+wni
+wni
+wni
 aaa
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+iPi
 aaa
 aaa
 aaa
@@ -123670,42 +124082,42 @@ nbv
 nbv
 nbv
 ovj
-mjJ
-dQI
-vjL
-tqy
-tqy
-ext
-mgO
-jQw
-dQI
-iHM
-hZi
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
 aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
+auv
+auv
+auv
+auv
+vLD
+dda
+dda
+dbU
+dda
+auv
 aaa
 aaa
+ack
 aaa
-cRO
+dda
+auv
 aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-anT
+dda
 aaa
 aaa
-aaa
-aaa
-aaa
+iPi
 aaa
 aaa
 aaa
@@ -123927,42 +124339,42 @@ jah
 jah
 jah
 ovj
-mjJ
-xQQ
-mIf
-oZK
-uEU
-vlO
-mjJ
-rDf
-mjJ
-mjJ
-mjJ
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
 aaa
 aaa
 aaa
 aaa
-aaf
+auv
+dbM
+dbM
+dbM
+dbM
+dbU
+iuF
+dbJ
+pPc
 dbJ
 dbJ
-dbJ
-dbJ
-dbJ
-aaf
-cRO
-aaa
-dbJ
-dbJ
-dbJ
-dbJ
-dbJ
-aaf
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+dbU
+dbR
+dbM
+iuF
+iuF
+pPc
+pPc
+pPc
+dda
+iPi
 aaa
 aaa
 aaa
@@ -124184,42 +124596,42 @@ osW
 osW
 osW
 ctl
-mjJ
-htz
-mjJ
-kuN
-gRW
-rIW
-htz
-xHp
-mjJ
 qOT
-lMJ
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+auv
 aaa
 aaa
 aaa
-aaf
-aaf
-dbK
+auv
+auv
 dbM
 dbM
 dbM
-dbM
+dbU
+dbU
 dbO
-cRO
-cSC
 dbV
 dbV
 dbV
 dbV
+seE
+dbR
 dbW
-aaf
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+dsf
+dsf
+mMv
+mMv
+fzi
+dda
+iPi
 aaa
 aaa
 aaa
@@ -124443,40 +124855,40 @@ aaf
 lrF
 aaa
 aaa
-mjJ
-htz
-htz
-sjV
-iPi
-lZW
-htz
 qOT
-lMJ
-lMJ
-lMJ
-lMJ
-aaf
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+qOT
+auv
+auv
+auv
+auv
+auv
 aaa
+dbM
+dbM
+dcY
+dbU
+dcY
+iHM
+dbL
+iHM
 dbL
 dbL
-dbL
-dbL
-dbL
-aaf
-cRO
-aaf
-dbL
-dbL
-dbL
-dbL
-dbL
+dbU
+dbR
+dbU
+wni
+iHM
+wni
+wni
+wni
 aaa
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+iPi
 aaa
 aaa
 aaa
@@ -124705,36 +125117,36 @@ aaa
 aaa
 aaa
 aaa
-drM
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+auv
+auv
+aaa
+auv
+cUM
+aaf
+dda
+aaa
+dbU
+dda
+dda
+auv
+auv
+ack
+auv
 aaa
 aaf
 aaf
+dda
+dda
 aaa
-aaf
-aaf
-aaf
-aaa
-aaa
-cRO
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
-aaa
-aqB
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+vmW
+dda
 aaa
 aaa
 aaa
@@ -124968,29 +125380,29 @@ aaa
 aaa
 aaa
 aaa
-fwb
-fwb
-aaf
+auv
+auv
+auv
+dbM
+dbM
+dcZ
+dcZ
+dbU
+iuF
+dbJ
+pPc
 dbJ
 dbJ
-dbJ
-dbJ
-dbJ
-aaf
-cRO
-aaa
-dbJ
-dbJ
-dbJ
-dbJ
-dbJ
-aaf
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+dbU
+dbR
+dbM
+iuF
+iuF
+pPc
+pPc
+pPc
+dda
+iPi
 aaa
 aaa
 aaa
@@ -125227,27 +125639,27 @@ aaa
 aaa
 aaa
 aaa
-aaf
-dbK
+auv
 dbM
 dbM
 dbM
 dbM
+dbU
 dbO
-cRO
-cSC
 dbV
 dbV
 dbV
 dbV
+seE
+dbR
 dbW
+mMv
+dsf
+mMv
+mMv
+fzi
 aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -125484,25 +125896,25 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
+dbM
+dbM
+dbM
+dbM
+dbU
+iHM
+dbL
+iHM
 dbL
 dbL
-dbL
-dbL
-dbL
-aaf
-dbT
-aaf
-dbL
-dbL
-dbL
-dbL
-dbL
-aaa
-aaa
-aaa
-aaa
-aaa
+dbU
+vVw
+dbU
+wni
+wni
+wni
+wni
+wni
 aaa
 aaa
 aaa
@@ -125741,26 +126153,26 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
+aaa
+auv
+auv
+aaa
+dda
+aaa
+dbU
+dda
+auv
+aaa
+auv
+xSq
 aaa
 aaf
-aaf
+aaa
+dda
 aaa
 aaa
-aaa
-dbR
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -125998,26 +126410,26 @@ aaa
 aaa
 aaa
 aaa
-aaf
-anT
-anT
-anT
+auv
+auv
+auv
+auv
 aaa
 aaf
+iPi
+jQw
+iPi
 aaa
-dbR
+dda
+auv
+otH
+auv
+auv
 aaa
-aaa
-aaa
-aaf
-aaf
-anT
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+dda
+dda
+iPi
+iPi
 aaa
 aaa
 aaa
@@ -126254,23 +126666,23 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
 aaa
-aaf
+auv
 aaa
-aaa
-anT
+dda
 aaf
+auv
 dbU
-aaf
-aqB
+auv
+auv
+iPi
+dda
+wvo
+dda
+vmW
 aac
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -126509,26 +126921,26 @@ aaa
 aaa
 aaa
 aaa
+vLD
 aaa
 aaa
+auv
+aaa
+auv
+auv
 aaa
 aaf
 aaa
-aaf
-aaf
-aaa
+dda
+dda
+auv
 aqB
+auv
 aaa
 aaa
-aaa
-anT
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+iPi
+dda
+dda
 aaa
 aaa
 aaa
@@ -126768,22 +127180,22 @@ lMJ
 lMJ
 lMJ
 lMJ
+lMJ
+lMJ
+vLD
+vLD
+vLD
+dda
 aaf
-aaf
-jdU
-aaa
-aaa
-aaa
-anT
-anT
-anT
-anT
-anT
-aaa
-aaa
-aaa
-aaa
-aaa
+iUx
+auv
+auv
+auv
+iPi
+iPi
+iPi
+iPi
+iPi
 aaa
 aaa
 aaa
@@ -127010,36 +127422,36 @@ aaa
 bzi
 aaa
 uYt
-aaa
-aaa
-aaa
+avU
+avU
+avU
 aac
 aaf
 aaf
 aaf
 aaf
 aaf
-aaa
+avU
 aaa
 fwb
-fwb
-fwb
-fwb
-fwb
-aaf
+cUM
+cUM
+cUM
+cUM
+cUM
+dci
+dci
+dci
+dci
+dda
+auv
+aaa
+auv
 aaa
 aaa
+dda
 aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -127271,24 +127683,24 @@ aaf
 aaa
 aaa
 aaa
+avU
+avU
+aaa
+avU
+avU
+avU
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -127540,13 +127952,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
 aaa
 aaa
 aaa
-aaa
-aaa
+dda
+dda
 aaa
 aaa
 aaa
@@ -127797,12 +128209,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -128054,12 +128466,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -128311,12 +128723,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -128568,12 +128980,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -128825,12 +129237,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -129081,13 +129493,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -129326,11 +129738,11 @@ uYt
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
+auv
+auv
+auv
+auv
+auv
 aaa
 aaa
 aaa
@@ -129339,12 +129751,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -129580,28 +129992,28 @@ eUG
 ggI
 ggI
 dkZ
-aaf
-aaf
-aaf
-aaf
+auv
+auv
+auv
+auv
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-lMJ
-lMJ
-lMJ
-lMJ
-lMJ
-aaf
-aaf
+auv
+auv
+auv
+auv
+auv
+auv
+auv
+auv
+auv
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -129853,12 +130265,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -130110,12 +130522,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -130367,13 +130779,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
 aaa
 aaa
 aaa
-aaa
-aaa
+dda
+dda
 aaa
 aaa
 aaa
@@ -130624,12 +131036,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -130881,12 +131293,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -131138,12 +131550,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -131395,12 +131807,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -131652,12 +132064,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -131908,13 +132320,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
 aaa
 aaa
 aaa
-aaa
-aaa
+dda
+dda
 aaa
 aaa
 aaa
@@ -132166,12 +132578,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -132423,12 +132835,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -132680,12 +133092,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -132937,12 +133349,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -133194,13 +133606,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
 aaa
 aaa
 aaa
-aaa
-aaa
+dda
+dda
 aaa
 aaa
 aaa
@@ -133451,12 +133863,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -133708,12 +134120,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -133965,12 +134377,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -134222,12 +134634,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -134478,13 +134890,13 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
 aaa
 aaa
 aaa
-aaa
-aaa
+dda
+dda
 aaa
 aaa
 aaa
@@ -134736,12 +135148,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa
@@ -134992,14 +135404,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+auv
+auv
+auv
 aaa
 aaa
-aaa
-aaa
-aaa
+dda
+dda
+dda
 aaa
 aaa
 aaa
@@ -135248,16 +135660,16 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+auv
+auv
+auv
+auv
+auv
+dda
+dda
+dda
+dda
+dda
 aaa
 aaa
 aaa
@@ -135504,18 +135916,18 @@ aaa
 aaa
 aaa
 aaa
+auv
+auv
+cDz
+cDz
+cDz
 aaf
 aaf
-czK
-cDv
-czK
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dcC
+ext
+dcC
+dda
+dda
 aaa
 aaa
 aaa
@@ -135760,20 +136172,20 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-cBM
-czK
-cDw
-czK
-cBM
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+auv
+auv
+cDz
+cDz
+cDz
+cEC
+cEC
+dbZ
+dcD
+gqd
+dcC
+kss
+dda
+dda
 aaa
 aaa
 aaa
@@ -136016,22 +136428,22 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
+auv
+auv
+cDz
+cDz
+cDz
+cEC
+cEC
 czK
 czK
-cCH
-cDv
-cEB
-czK
-czK
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dmq
+gRW
+jdU
+dcC
+dcC
+dda
+dda
 aaa
 aaa
 aaa
@@ -136273,22 +136685,22 @@ aaa
 aaa
 aaa
 aaa
-aaf
-czJ
-czJ
-cBN
-cCI
-cCI
-cCI
-cFv
-czJ
-czJ
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+auv
+cDz
+cDz
+cDz
+cDz
+cEC
+cFx
+cFx
+ddl
+dmr
+anS
+eXl
+kuN
+ddA
+ddA
+dda
 aaa
 aaa
 aaa
@@ -136528,26 +136940,26 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+auv
+auv
+auv
+cDz
+cDz
+cEC
+cEC
+cEC
 czK
-cAQ
-cBO
-cCI
-cDx
-cCI
 cFw
 cGp
-czK
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dmr
+htz
+anS
+qkj
+rDf
+dcC
+dda
+dda
+dda
 aaa
 aaa
 aaa
@@ -136787,22 +137199,22 @@ aaa
 aaa
 aaa
 aaa
-aaf
-czJ
-czJ
-cBP
-cCI
-cCI
-cCI
+auv
+cDz
+cDz
+cDz
+cDz
+cEC
 cFx
-czJ
-czJ
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+cFx
+ddm
+dmr
+anS
+eXl
+kMb
+ddA
+ddA
+dda
 aaa
 aaa
 aaa
@@ -137044,22 +137456,22 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-czK
-czK
-cCJ
-cDy
+auv
+auv
+cDz
+cDz
+cDz
+cEC
 cEC
 czK
 czK
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dnJ
+hZi
+juU
+dcC
+dcC
+dda
+dda
 aaa
 aaa
 aaa
@@ -137302,20 +137714,20 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-cBM
-czK
+auv
+auv
 cDz
-czK
-cBM
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+cDz
+cDz
+cEC
+cEC
+dbZ
+dcD
+iia
+dcC
+kss
+dda
+dda
 aaa
 aaa
 aaa
@@ -137560,18 +137972,18 @@ aaa
 aaa
 aaa
 aaa
+auv
+auv
+cDz
+cDz
+cDz
 aaf
 aaf
-czK
-czJ
-czK
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+dcC
+ddA
+dcC
+dda
+dda
 aaa
 aaa
 aaa
@@ -137818,16 +138230,16 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+auv
+auv
+auv
+auv
+auv
+dda
+dda
+dda
+dda
+dda
 aaa
 aaa
 aaa
@@ -138076,14 +138488,14 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaf
+auv
+auv
+auv
 aaa
 aaa
-aaa
-aaa
-aaa
+dda
+dda
+dda
 aaa
 aaa
 aaa
@@ -138334,12 +138746,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+auv
 aaa
 aaa
 aaa
 aaa
-aaa
+dda
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10980,7 +10980,7 @@
 	name = "Mister Buzz"
 	},
 /turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/science/misc_lab/range)
+/area/maintenance/starboard/secondary)
 "avc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11348,9 +11348,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "avU" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/science/shuttledock)
 "avW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage Room";
@@ -11366,7 +11365,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "avY" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -12235,7 +12234,7 @@
 	name = "server vent"
 	},
 /turf/open/floor/circuit/telecomms,
-/area/space/nearstation)
+/area/science/xenobiology)
 "axO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32105,8 +32104,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "blx" = (
-/turf/closed/wall,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/science/shuttledock)
 "bly" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -60730,7 +60730,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cue" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -61300,7 +61300,7 @@
 	},
 /obj/effect/landmark/start/exploration,
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cvl" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -61796,7 +61796,7 @@
 "cwd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/carpet,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cwe" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -63562,7 +63562,7 @@
 	},
 /obj/machinery/suit_storage_unit/exploration,
 /turf/open/floor/plasteel/techmaint,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "czH" = (
 /obj/machinery/airalarm/all_access{
 	dir = 8;
@@ -64149,7 +64149,7 @@
 /area/science/research)
 "cAN" = (
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cAO" = (
 /obj/machinery/camera{
 	c_tag = "exploration Prep Room";
@@ -64157,7 +64157,7 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cAP" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -64170,7 +64170,7 @@
 	pixel_y = -4
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cAS" = (
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
@@ -64471,7 +64471,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cBI" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green{
@@ -64479,13 +64479,13 @@
 	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cBJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cBK" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer/almost_empty,
@@ -64495,7 +64495,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/cyan,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cBL" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -64505,7 +64505,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/cyan,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cBQ" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable,
@@ -64919,7 +64919,7 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cCK" = (
 /mob/living/carbon/monkey,
 /turf/open/floor/plasteel/freezer,
@@ -65233,14 +65233,14 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cDr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cDs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65252,7 +65252,7 @@
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cDt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -65278,8 +65278,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/misc_lab/range)
 "cDz" = (
-/turf/open/space/basic,
-/area/science/test_area)
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "cDA" = (
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/freezer,
@@ -65889,10 +65890,10 @@
 "cEA" = (
 /obj/structure/lattice,
 /turf/closed/wall,
-/area/space/nearstation)
+/area/science/shuttledock)
 "cEC" = (
-/obj/structure/lattice,
-/turf/open/space,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/science/test_area)
 "cED" = (
 /obj/structure/cable{
@@ -68401,7 +68402,7 @@
 "cJe" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "cJf" = (
 /obj/structure/chair{
 	dir = 4
@@ -68423,7 +68424,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/space/nearstation)
+/area/science/mixing)
 "cJg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/bedsheet/medical,
@@ -69200,7 +69201,7 @@
 	id = "toxinsdriver"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/science/mixing)
 "cKQ" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "science shuttle dock";
@@ -69216,7 +69217,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cKS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -69644,7 +69645,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cLF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -69662,7 +69663,7 @@
 	req_one_access_txt = "12;47"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "cLL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -69672,7 +69673,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cLM" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
@@ -69929,7 +69930,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cMs" = (
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "cMt" = (
 /obj/structure/disposalpipe/segment{
@@ -70498,7 +70499,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "cNp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -70510,7 +70511,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "cNq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70522,7 +70523,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "cNr" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -71778,7 +71779,7 @@
 	},
 /obj/machinery/suit_storage_unit/exploration,
 /turf/open/floor/plasteel/techmaint,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cQx" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -71798,14 +71799,14 @@
 "cQB" = (
 /obj/machinery/suit_storage_unit/exploration,
 /turf/open/floor/plasteel/techmaint,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cQC" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cQD" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -72160,7 +72161,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cRB" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72174,7 +72175,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cRC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -72183,14 +72184,14 @@
 /obj/effect/turf_decal/sand,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cRD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cRE" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -72840,7 +72841,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cSY" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/wood,
@@ -72866,7 +72867,7 @@
 "cTa" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "cTb" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -72982,7 +72983,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "cTr" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -73056,22 +73057,13 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cTB" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/maintenance/department/science/xenobiology)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "cTC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"cTD" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/science/shuttledock)
 "cTR" = (
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
@@ -73706,21 +73698,21 @@
 	},
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "daP" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /obj/effect/landmark/start/exploration,
 /turf/open/floor/carpet/cyan,
-/area/science/mixing)
+/area/science/misc_lab/range)
 "daQ" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
 	},
 /obj/effect/landmark/start/exploration,
 /turf/open/floor/carpet/cyan,
-/area/space/nearstation)
+/area/science/misc_lab/range)
 "daR" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -73985,7 +73977,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "dbO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -74004,13 +73996,13 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "dbQ" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "dbR" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -74027,7 +74019,7 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "dbT" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -74036,7 +74028,7 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "dbU" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -74083,7 +74075,7 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "dbY" = (
 /obj/machinery/doppler_array/research/science{
 	dir = 4
@@ -74097,14 +74089,14 @@
 /turf/open/floor/plasteel{
 	dir = 1
 	},
-/area/space/nearstation)
+/area/science/mixing)
 "dbZ" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
 	name = "BOMB RANGE"
 	},
 /turf/closed/wall,
-/area/space/nearstation)
+/area/science/mixing)
 "dcg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -74126,11 +74118,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dci" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "dcs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -74143,7 +74130,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "dcu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -74161,11 +74148,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
-"dcx" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/science/xenobiology)
+/area/science/mixing)
 "dcz" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "xeno_airlock_exterior";
@@ -74208,7 +74191,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "dcB" = (
 /obj/structure/chair{
 	dir = 4
@@ -74225,15 +74208,11 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel,
-/area/space/nearstation)
-"dcC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/area/science/mixing)
 "dcD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/science/mixing)
 "dcE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/sink{
@@ -74491,19 +74470,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"dcY" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/solar/starboard/aft)
-"dcZ" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/solar/starboard/aft)
-"dda" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "ddb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74538,13 +74504,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"dde" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet,
-/turf/open/floor/engine,
-/area/maintenance/department/science/xenobiology)
 "ddf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74580,7 +74539,7 @@
 	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
-/area/maintenance/department/science/xenobiology)
+/area/science/xenobiology)
 "ddk" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -74663,7 +74622,7 @@
 	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
-/area/maintenance/department/science/xenobiology)
+/area/science/xenobiology)
 "dds" = (
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
@@ -74679,12 +74638,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"ddt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/maintenance/department/science/xenobiology)
 "ddu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -74704,7 +74657,7 @@
 	},
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "ddx" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
@@ -74723,7 +74676,7 @@
 /area/science/xenobiology)
 "ddA" = (
 /turf/closed/wall,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "ddB" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Test Chamber";
@@ -76627,7 +76580,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/department/science/xenobiology)
 "djM" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -76683,7 +76636,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/science/test_area)
 "dmr" = (
 /turf/open/floor/plating/airless,
 /area/science/test_area)
@@ -76765,7 +76718,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/science/test_area)
 "dnO" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/cobweb,
@@ -76849,19 +76802,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
-"dsf" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space,
-/area/space/nearstation)
 "dsg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -77188,7 +77128,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/science/mixing)
 "dBu" = (
 /turf/closed/wall,
 /area/engine/gravity_generator)
@@ -77979,7 +77919,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "dHC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -78066,7 +78006,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/solars/starboard/aft)
 "dLG" = (
 /obj/machinery/cryopod,
 /obj/effect/turf_decal/stripes/line{
@@ -78089,9 +78029,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dML" = (
-/turf/open/floor/circuit/telecomms,
-/area/space/nearstation)
 "dNO" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -78121,7 +78058,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/space)
+/area/science/mixing)
 "dUZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -78334,7 +78271,7 @@
 	name = "euthanization chamber freezer"
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/department/science/xenobiology)
 "evh" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -78352,7 +78289,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/mixing)
 "exJ" = (
 /obj/structure/table/glass,
 /obj/item/folder,
@@ -78405,7 +78342,7 @@
 	pressure_checks = 0
 	},
 /turf/open/floor/circuit/telecomms,
-/area/space)
+/area/science/xenobiology)
 "eId" = (
 /obj/machinery/telecomms/broadcaster/preset_exploration,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -78480,7 +78417,7 @@
 /area/maintenance/starboard/fore)
 "eXl" = (
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/mixing)
 "eXp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -78526,7 +78463,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "fcn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -78672,7 +78609,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/space,
-/area/space)
+/area/solar/starboard/aft)
 "fBq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -78710,7 +78647,7 @@
 "fFM" = (
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
-/area/science/misc_lab/range)
+/area/maintenance/starboard/secondary)
 "fGw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -78902,7 +78839,7 @@
 "fYB" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/circuit/telecomms,
-/area/space/nearstation)
+/area/science/xenobiology)
 "fZP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -79042,7 +78979,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "gra" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -79118,7 +79055,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "gCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
@@ -79131,11 +79068,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"gED" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/space,
-/area/space)
 "gHQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -79217,7 +79149,7 @@
 	dir = 9
 	},
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "gQZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -79233,20 +79165,20 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/science/test_area)
 "gTA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "gVg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "gXp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -79366,7 +79298,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "hry" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -79374,7 +79306,7 @@
 "htz" = (
 /obj/item/beacon,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/science/test_area)
 "huT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -79462,7 +79394,7 @@
 	},
 /obj/machinery/vendor/exploration,
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "hGe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -79603,7 +79535,7 @@
 /turf/open/floor/plating/airless{
 	luminosity = 2
 	},
-/area/space/nearstation)
+/area/science/test_area)
 "iaj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -79637,7 +79569,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "ifN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -79653,7 +79585,7 @@
 	icon_state = "riveted";
 	name = "hyper-reinforced wall"
 	},
-/area/space)
+/area/science/test_area)
 "ikw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -79772,7 +79704,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/department/science/xenobiology)
 "ixU" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -79852,7 +79784,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "iBp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -79928,7 +79860,7 @@
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/suit/hooded/wintercoat,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/department/science/xenobiology)
 "iKA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -79982,11 +79914,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"iPi" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
-/area/space)
 "iPk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80024,7 +79951,7 @@
 "iUx" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "iWm" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -80080,7 +80007,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "jdW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -80090,7 +80017,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/white,
-/area/space)
+/area/science/xenobiology)
 "jeD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -80145,7 +80072,7 @@
 	start_active = 1
 	},
 /turf/open/floor/circuit/telecomms,
-/area/space)
+/area/science/xenobiology)
 "jmO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80196,11 +80123,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
-"jra" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -80237,7 +80159,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "jwU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -80339,7 +80261,7 @@
 "jHo" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/science/xenobiology)
 "jIQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -80361,7 +80283,7 @@
 	info = "atleast i still have you, mister Buzz :)"
 	},
 /turf/open/floor/plasteel/vaporwave,
-/area/science/misc_lab/range)
+/area/maintenance/starboard/secondary)
 "jMe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -80394,11 +80316,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"jQw" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
-/area/solar/starboard/aft)
 "jSj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -80526,7 +80443,7 @@
 	req_one_access_txt = "49"
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "kgI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -80538,7 +80455,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small,
 /turf/open/floor/circuit/telecomms,
-/area/space)
+/area/science/xenobiology)
 "kie" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster{
@@ -80630,7 +80547,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "krL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -80643,7 +80560,7 @@
 	name = "BOMB RANGE"
 	},
 /turf/closed/wall,
-/area/space)
+/area/science/test_area)
 "ksx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -80666,7 +80583,7 @@
 	dir = 10
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "kuO" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Test Chamber Maintenance";
@@ -80680,7 +80597,7 @@
 "kwj" = (
 /obj/effect/spawner/room/fivexthree,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/starboard/aft)
 "kwI" = (
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_y = 3
@@ -80710,7 +80627,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "kxo" = (
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/dorms)
@@ -80817,7 +80734,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "kGe" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -80847,7 +80764,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/science/test_area)
 "kMV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -80878,7 +80795,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "kPo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80897,7 +80814,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "kSB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk,
@@ -80928,13 +80845,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
-"kWO" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/space,
-/area/space)
 "kXu" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/airalarm{
@@ -81023,7 +80933,7 @@
 	},
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "ltd" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/tile/purple,
@@ -81117,14 +81027,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
-/area/space)
+/area/science/xenobiology)
 "lBG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/open/space,
-/area/space)
+/area/solar/starboard/aft)
 "lCX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -81234,7 +81144,7 @@
 	req_one_access_txt = "12;47"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/starboard/secondary)
 "lTL" = (
 /obj/structure/sink{
 	dir = 8;
@@ -81543,7 +81453,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "mKD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -81579,13 +81489,13 @@
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space)
+/area/solar/starboard/aft)
 "mMS" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "mNe" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -81761,7 +81671,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "nhp" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
@@ -81809,7 +81719,7 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "nuV" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -81863,7 +81773,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/solars/starboard/aft)
 "nwW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -81895,7 +81805,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "nyo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -82052,7 +81962,7 @@
 "nLK" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "nRS" = (
 /obj/structure/musician/piano,
 /obj/structure/window/reinforced{
@@ -82113,7 +82023,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "obX" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -82258,11 +82168,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"ooZ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/space/basic,
-/area/space)
 "opl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -82322,11 +82227,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port)
-"osW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "otD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82340,13 +82240,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"otH" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space,
-/area/space/nearstation)
 "oub" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
@@ -82474,7 +82367,7 @@
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space/basic,
-/area/science/xenobiology)
+/area/space/nearstation)
 "oJW" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Shared Storage";
@@ -82495,13 +82388,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/port/aft)
-"oQZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/space)
 "oRL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -82552,7 +82438,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "pcc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82671,7 +82557,7 @@
 	},
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "pok" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -82699,9 +82585,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pwA" = (
-/turf/closed/wall,
-/area/maintenance/solars/starboard/aft)
 "pAS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -82803,13 +82686,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space)
-"pPp" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "pPs" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -82902,9 +82778,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"pYR" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "qak" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
@@ -82927,7 +82800,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "qdE" = (
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
@@ -82982,7 +82855,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "qjJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -83124,11 +82997,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
-"qIP" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "qLf" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -83149,7 +83017,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/solars/starboard/aft)
 "qNF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83160,9 +83028,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qOT" = (
-/turf/open/space/basic,
-/area/science/shuttledock)
 "qPZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83333,14 +83198,14 @@
 /obj/item/target,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/space)
+/area/science/test_area)
 "rEY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "rFZ" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -83428,15 +83293,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"rWT" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "rZz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -83573,12 +83429,12 @@
 	pixel_y = 25
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "srO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "ssD" = (
 /obj/machinery/sparker{
 	id = "Xenobio";
@@ -83603,7 +83459,7 @@
 	},
 /obj/effect/spawner/room/threexthree,
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "szz" = (
 /obj/machinery/light{
 	dir = 4
@@ -83623,7 +83479,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "sAD" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -83870,7 +83726,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "tqy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83878,7 +83734,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "tqR" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -83891,11 +83747,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/misc_lab/range)
+/area/science/shuttledock)
 "tqW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard/aft)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83954,10 +83810,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"twJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "tzs" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -83996,7 +83848,7 @@
 /area/science/xenobiology)
 "tBs" = (
 /turf/open/floor/circuit/telecomms,
-/area/space)
+/area/science/xenobiology)
 "tDM" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -84089,7 +83941,7 @@
 "tRl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/space/nearstation)
+/area/maintenance/starboard/aft)
 "tRF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -84121,10 +83973,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tVY" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space)
 "tWv" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
@@ -84256,7 +84104,7 @@
 	req_one_access_txt = "12;47"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "uoA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -84306,7 +84154,7 @@
 /area/maintenance/department/science)
 "uuw" = (
 /turf/closed/wall/r_wall,
-/area/space)
+/area/maintenance/starboard/aft)
 "uuJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -84380,7 +84228,7 @@
 "uEU" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "uGa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -84554,7 +84402,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/solars/starboard/aft)
 "vjS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/closed/wall,
@@ -84569,7 +84417,7 @@
 "vlO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/maintenance/solars/starboard/aft)
 "vmF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -84577,11 +84425,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/science/xenobiology)
-"vmW" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space,
-/area/space)
 "vnk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -84620,7 +84463,7 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/science/mixing)
 "vzO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -84648,7 +84491,7 @@
 	width = 13
 	},
 /turf/open/space/basic,
-/area/science/shuttledock)
+/area/space)
 "vDo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -84710,12 +84553,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"vMT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
 "vNr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84780,7 +84617,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "vYe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -84900,16 +84737,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"wni" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar{
-	id = "aftstarboard";
-	name = "Aft-Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space)
 "wnQ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -84948,7 +84775,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/solar/starboard/aft)
 "wvF" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner,
@@ -84983,9 +84810,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wyv" = (
-/turf/open/floor/plating,
-/area/space)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 8
@@ -85012,11 +84836,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
-"wDY" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "wFH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -85146,7 +84965,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/space)
+/area/maintenance/department/science/xenobiology)
 "wVi" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -85342,7 +85161,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "xsr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/anesthetic_machine,
@@ -85373,7 +85192,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "xwS" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -85489,7 +85308,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "xHp" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/solars/starboard/aft";
@@ -85501,14 +85320,14 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/solars/starboard/aft)
 "xIt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/maintenance/starboard/aft)
+/area/science/mixing)
 "xJp" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/blue,
@@ -85527,14 +85346,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/solars/starboard/aft)
 "xSq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space)
+/area/solar/starboard/aft)
 "xTv" = (
 /obj/structure/pool_ladder,
 /turf/open/indestructible/sound/pool/end,
@@ -85614,9 +85433,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/port)
-"ykS" = (
-/turf/open/space/basic,
-/area/science/xenobiology)
 "ylE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
@@ -116144,10 +115960,10 @@ cRe
 cRe
 cRe
 cRe
-dcC
-dcC
-dcC
-dcC
+cRe
+cRe
+cRe
+cRe
 aaa
 aaa
 aaa
@@ -116401,10 +116217,10 @@ cYT
 cSJ
 djg
 cSJ
-pPp
-oQZ
+cSJ
+cYT
 jdW
-dcC
+cRe
 aaa
 aaa
 aaa
@@ -116658,10 +116474,10 @@ cRe
 cRe
 cRe
 cRe
-dcC
-dcC
-rWT
-dcC
+cRe
+cRe
+dcg
+cRe
 aaa
 aaa
 aaa
@@ -116912,21 +116728,19 @@ aaa
 aaf
 aaa
 aaa
-ykS
-ykS
-dcx
-aaa
-dcC
-rWT
-dcD
-aaa
-dda
-aaa
-auv
-aaa
-dda
 aaa
 aaa
+lMJ
+aaa
+cRe
+dcg
+cRe
+aaa
+aaf
+aaa
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -116938,9 +116752,11 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
-dda
+aaa
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -117169,35 +116985,35 @@ aaa
 aaf
 aaa
 aaa
-ykS
-dcx
-dcx
+aaa
 lMJ
-dcC
-rWT
-dcD
-auv
-dda
-dda
-auv
+lMJ
+lMJ
+cRe
+dcg
+cRe
 aaa
-dda
-aaa
+aaf
+aaf
 aaa
 aaa
-auv
-aaa
-dda
+aaf
 aaa
 aaa
 aaa
 aaa
-auv
 aaa
-dda
-auv
+aaf
 aaa
-dda
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -117426,46 +117242,46 @@ aaf
 aaf
 aaf
 aaa
-dcx
-dcx
-ykS
-dcx
+lMJ
+lMJ
+aaa
+lMJ
 cRe
 dcg
 cRe
 nrT
-beq
-uuw
-beq
-beq
-dda
+cRi
+cRi
+cRi
+cRi
+aaf
 aaa
-aaf
-aaf
-auv
-aaa
-aaf
 aaf
 aaf
 aaa
-dda
+aaa
 aaf
 aaf
-auv
-auv
 aaf
-dda
+aaa
 aaf
 aaf
-dda
-auv
+aaf
+lMJ
+aaa
 aaf
 aaf
-auv
-dda
-dda
-qIP
-wDY
+aaf
+aaf
+aaf
+aaa
+aaf
+aaf
+aaa
+aaf
+aaf
+aai
+aag
 aaa
 aaa
 aaa
@@ -117683,10 +117499,10 @@ aaa
 aaa
 aaf
 aaf
-dcx
-ykS
-ykS
-ykS
+lMJ
+aaa
+aaa
+aaa
 cRe
 dcg
 cRe
@@ -117705,25 +117521,25 @@ cRi
 cRi
 cRi
 cRi
+cRi
+cRi
+cRi
+cRi
 dlV
 dlV
 dlV
 dlV
-beq
-uuw
-uuw
-beq
-dda
+aaf
 aaa
 aaa
 aaf
 aaa
-auv
-auv
-dda
 aaa
-wDY
-wDY
+aaa
+aaf
+aaa
+aag
+aag
 aaa
 aaa
 aaa
@@ -117940,10 +117756,10 @@ dvY
 dvY
 dvY
 dvY
-dcx
-ykS
-ykS
-ykS
+lMJ
+aaa
+aaa
+aaa
 cRe
 dch
 cYT
@@ -117962,10 +117778,10 @@ cSh
 dbs
 cSy
 cSd
-dde
+cSh
 ddj
-ddq
-dlV
+cSn
+cRi
 mXQ
 voQ
 nWU
@@ -117974,13 +117790,13 @@ dlV
 dlV
 dlV
 dlV
-uuw
-uuw
-beq
-uuw
+dlV
+dlV
+dlV
+dlV
 aaa
 aaa
-qIP
+aai
 aaa
 aaa
 aaa
@@ -118197,10 +118013,10 @@ auT
 auT
 awI
 dvY
-dcx
-ykS
-ykS
-ykS
+lMJ
+aaa
+aaa
+aaa
 cRe
 cRe
 cRe
@@ -118219,10 +118035,10 @@ cSg
 cSn
 cSn
 cSd
-ddt
-ddq
-ddq
-dlV
+cSg
+cSn
+cSn
+cRi
 tvp
 ovB
 cTC
@@ -118231,13 +118047,13 @@ cTC
 cTC
 cTC
 cTC
-twJ
+cTC
 djG
 iIv
-uuw
-dda
-dda
-wDY
+dlV
+aaf
+aaf
+aag
 aaa
 aaa
 aaa
@@ -118454,13 +118270,13 @@ auT
 auT
 auT
 dvY
-vLD
+lMJ
 aaa
 aaa
-ykS
-ykS
-dcx
-ykS
+aaa
+aaa
+lMJ
+aaa
 vdm
 cRi
 oqf
@@ -118488,14 +118304,14 @@ cRi
 dlV
 cRi
 dlV
-uuw
+dlV
 ixK
 etu
-beq
+dlV
 aaa
 aaa
-dda
-wDY
+aaf
+aag
 aaa
 aaa
 aaa
@@ -118711,13 +118527,13 @@ auT
 auT
 auT
 dvY
-vLD
-vLD
 lMJ
-dcx
-dcx
-dcx
-dcx
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
+lMJ
 cRi
 cRN
 eZt
@@ -118747,12 +118563,12 @@ ssD
 nuV
 cRi
 fUS
-uuw
-beq
-uuw
-uuw
+cRi
+cRi
+cRi
+cRi
 aaa
-qIP
+aai
 aaa
 aaa
 aaa
@@ -118968,13 +118784,13 @@ auT
 awB
 rIW
 dvY
-ddA
-ddA
-ddA
-cSd
-ykS
-ykS
-dcx
+dvY
+dvY
+dvY
+dvY
+auv
+aaa
+lMJ
 cRi
 cRM
 cRa
@@ -119004,12 +118820,12 @@ cSn
 cSn
 cRi
 lrr
-beq
-dML
+cRi
 tBs
-uuw
-dda
-wDY
+tBs
+cRi
+aaf
+aag
 aaa
 aaa
 aaa
@@ -119225,13 +119041,13 @@ auT
 lzk
 auT
 dvY
-wyv
+auT
 rEY
 kwj
-cSd
-dcx
-ykS
-dcx
+dvY
+lMJ
+aaa
+lMJ
 cRi
 dcI
 cSe
@@ -119264,7 +119080,7 @@ gtD
 lAC
 eHg
 tBs
-dcC
+cRe
 aaa
 aaa
 aaa
@@ -119482,13 +119298,13 @@ dvY
 lLE
 dvY
 dvY
-wyv
-vMT
-pYR
-cSd
-dcx
-dcx
-dcx
+auT
+lzk
+auT
+dvY
+lMJ
+lMJ
+lMJ
 cRi
 dcI
 cSf
@@ -119523,7 +119339,7 @@ fYB
 kgP
 jHo
 pkY
-dda
+aaf
 aaa
 aaa
 aaa
@@ -119738,14 +119554,14 @@ dvY
 auT
 lZW
 drM
-ddA
-wyv
-vMT
-pYR
-cSd
-ykS
-ykS
-dcx
+dvY
+auT
+lzk
+auT
+dvY
+aaa
+aaa
+lMJ
 cRi
 dcI
 cRR
@@ -119778,9 +119594,9 @@ jIQ
 lAC
 axN
 tBs
-dcC
+cRe
 aaa
-dda
+aaf
 aaa
 aaa
 aaa
@@ -119998,11 +119814,11 @@ sjV
 ulC
 xse
 gTA
-wyv
-cSd
-ykS
-ykS
-ykS
+auT
+dvY
+aaa
+aaa
+aaa
 cRi
 dcJ
 ogK
@@ -120032,12 +119848,12 @@ cSn
 cZv
 cRi
 ivA
-uuw
-dML
+cRi
+tBs
 jje
-uuw
+cRi
 aaa
-wDY
+aag
 aaa
 aaa
 aaa
@@ -120252,14 +120068,14 @@ dvY
 auT
 lZW
 auT
-ddA
-wyv
-wyv
-wyv
-cSd
-dcx
-ykS
-ykS
+dvY
+auT
+auT
+auT
+dvY
+lMJ
+aaa
+aaa
 cRi
 dcK
 sxH
@@ -120289,12 +120105,12 @@ jVm
 iGM
 cRi
 ueg
-beq
-beq
-uuw
-uuw
-dda
-wDY
+cRi
+cRi
+cRi
+cRi
+aaf
+aag
 aaa
 aaa
 aaa
@@ -120504,19 +120320,19 @@ dbv
 dvY
 dvY
 dvY
-pwA
-pwA
-pwA
+dvY
+dvY
+dvY
 mIf
-pwA
+dvY
 uuw
 uuw
 uuw
 uuw
-cRi
-dcx
-ykS
-ykS
+uuw
+lMJ
+aaa
+aaa
 cRi
 dcL
 uPm
@@ -120543,15 +120359,15 @@ cRi
 cRi
 dlV
 dlV
-beq
-uuw
-wyv
-beq
+dlV
+dlV
+tvp
+dlV
 aaf
 aaa
 aaa
-dda
-wDY
+aaf
+aag
 aaa
 aaa
 aaa
@@ -120761,19 +120577,19 @@ dbw
 dcs
 scW
 avL
-cMs
+auT
 cLK
-cMs
+auT
 cNo
 syh
 uEU
 xwI
 vXe
 mMS
-cRi
-dcx
-dcx
-dcx
+cMs
+lMJ
+lMJ
+lMJ
 cRi
 dcM
 cSv
@@ -120789,10 +120605,10 @@ cSn
 cSn
 cSg
 cSd
-ddq
-ddq
-ddt
-dlV
+cSn
+cSn
+cSg
+cRi
 vhr
 vnk
 ddy
@@ -120800,14 +120616,14 @@ ddy
 ddy
 ddy
 uNd
-pYR
-pYR
+tvp
+tvp
 wUO
-beq
-dda
-dda
+dlV
+aaf
+aaf
 aaa
-qIP
+aai
 aaa
 aaa
 aaa
@@ -121008,29 +120824,29 @@ siR
 ojg
 ojg
 ojg
-czD
-czD
-czD
-czD
-czD
+ojg
+ojg
+ojg
+ojg
+ojg
 cyy
 dbP
 dct
 fbK
+czD
+czD
 dvY
-pwA
-pwA
-cMs
+auT
 cNp
 tqy
 vjL
 xFP
 nyf
 gVg
-cRi
-dcx
-ykS
-ykS
+cMs
+lMJ
+aaa
+aaa
 cRi
 dcN
 jOx
@@ -121046,10 +120862,10 @@ cSy
 dbt
 cSF
 cSd
-ddq
+cSn
 ddr
-cTB
-dlV
+cSF
+cRi
 pNU
 iky
 fDE
@@ -121057,14 +120873,14 @@ dlV
 dlV
 dlV
 dlV
-beq
-uuw
-uuw
-beq
-dda
+dlV
+dlV
+dlV
+dlV
+aaf
 aaa
 aaa
-wDY
+aag
 aaa
 aaa
 aaa
@@ -121265,7 +121081,7 @@ aRw
 cLM
 cSk
 wVi
-czD
+ojg
 cQB
 cQC
 cBH
@@ -121276,18 +121092,18 @@ dcu
 gAP
 ddv
 cKP
-pwA
-cMs
+dvY
+auT
 cNq
+auT
 cMs
-uuw
 xHp
 ifc
 tpN
-cRi
+cMs
 oHw
-ykS
-ykS
+aaa
+aaa
 cRi
 oVc
 mOI
@@ -121303,26 +121119,26 @@ cRi
 cRi
 cRi
 cRi
+cRi
+cRi
+cRi
+cRi
 dlV
 dlV
 dlV
 dlV
-uuw
-beq
-beq
-beq
 auv
 aaf
-dda
 aaf
 aaf
 aaf
-auv
 aaf
-dda
-wDY
-wDY
-dda
+aaa
+aaf
+aaf
+aag
+aag
+aaf
 aaa
 aaa
 aaa
@@ -121522,7 +121338,7 @@ nli
 cxP
 lwJ
 tJT
-czD
+ojg
 cQv
 cAN
 cBI
@@ -121531,53 +121347,53 @@ czD
 dbS
 dcA
 xIt
-dxk
+dcD
 vvZ
-pwA
-pwA
+dvY
+dvY
 dbN
 tqW
 vlO
 xQQ
 qNz
-dcC
-uuw
+cTB
+cMs
 lMJ
-auv
-auv
-auv
-dda
-dda
-aaf
-auv
-auv
-kWO
-dda
-aaf
 aaa
 aaa
 aaa
 aaf
-auv
-aaa
-auv
 aaf
-dda
-auv
-dda
-dda
+aaf
+aaa
+aaa
+viG
+aaf
+aaf
+aaa
+aaa
 aaa
 aaf
 aaa
 aaa
 aaa
-dda
+aaf
+aaf
 aaa
-auv
+aaf
+aaf
+aaa
+aaf
 aaa
 aaa
 aaa
-qIP
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aai
 aaa
 aaa
 aaa
@@ -121788,20 +121604,20 @@ czD
 dbT
 dcA
 cJe
-dxk
+dcD
 dAZ
-pwA
-pwA
+dvY
+dvY
 obb
-ddA
+dvY
 aaa
 ddA
 nwN
-dcC
+cTB
 aaa
-vLD
+lMJ
 aaa
-auv
+aaa
 aaa
 aaa
 aaa
@@ -121818,7 +121634,7 @@ aaf
 aaa
 aaa
 aaa
-dda
+aaf
 aaa
 aaa
 aaa
@@ -122024,19 +121840,19 @@ ovj
 ovj
 ovj
 ovj
-cuZ
+dwL
 ovj
-ojg
-cuZ
-cuZ
-cuZ
-cuZ
-ojg
+mjJ
+avU
+avU
+avU
+avU
+mjJ
 cKQ
-ojg
-ojg
-ojg
-czD
+mjJ
+mjJ
+mjJ
+mjJ
 czG
 cAN
 cBK
@@ -122045,26 +121861,26 @@ czD
 dbX
 dcA
 kDM
-dvY
+czD
 dUj
-pwA
-pwA
+dvY
+dvY
 iBo
 tRl
 vRq
-jra
+srO
 dLy
 srO
-gED
+eUG
 mLO
-ooZ
-ooZ
-ooZ
-gED
-gED
-gED
-osW
-osW
+mLO
+mLO
+mLO
+eUG
+eUG
+eUG
+vRq
+vRq
 gNG
 aaa
 aaa
@@ -122281,9 +122097,9 @@ atE
 ovj
 cpH
 cqX
-cuZ
+dwL
 fFM
-ojg
+mjJ
 kxk
 szA
 hFV
@@ -122293,32 +122109,32 @@ ney
 cRA
 ntl
 ntl
-czD
+mjJ
 cQB
 cAO
 cBL
 daQ
-blx
+czD
 dbY
 dcB
 cJf
 dcD
 ext
 dcD
-dbR
+ack
 oZK
-tVY
+ack
 aaa
-dda
-otH
+aaf
+xSq
 aaa
 aaa
 auv
 aaa
-dda
+aaf
 aaa
 aaa
-vmW
+aqB
 aaa
 aaa
 aaa
@@ -122538,44 +122354,44 @@ nbv
 atd
 dwX
 nbv
-cuZ
+dwL
 jLY
-ojg
+mjJ
 qcZ
 cwd
 kfu
-cxP
+blx
 cDq
 cLE
 cRB
 cSX
 tqR
+mjJ
+ojg
+ojg
+ojg
+ojg
 czD
-czD
-czD
-czD
-blx
-blx
 dbZ
-dcC
 dcD
-ddA
+dcD
+czD
 eXl
-blx
-dbM
-dda
+czD
+auv
+aaf
 auv
 aaa
-dda
-otH
+aaf
+xSq
 aaa
 aaf
 auv
 aaa
-dda
+aaf
 aaa
-dda
-iPi
+aaf
+anT
 aaa
 aaa
 aaa
@@ -122795,9 +122611,9 @@ nbv
 ovj
 ovj
 atd
-cuZ
+dwL
 avb
-ojg
+mjJ
 sql
 kOt
 krD
@@ -122808,31 +122624,31 @@ cRC
 cTa
 ntl
 cEA
-auv
-auv
-auv
-auv
-auv
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaf
 aaf
-anS
-anS
-anS
-dcY
+eXl
+eXl
+eXl
+lMJ
 anT
 anT
 anT
 aaf
-otH
+xSq
 aqB
 anT
 aqB
-iPi
-iPi
-iPi
-dda
-iPi
+anT
+anT
+anT
+aaf
+anT
 aaa
 aaa
 aaa
@@ -123053,43 +122869,43 @@ ovj
 nbv
 nbv
 auc
-ojg
-ojg
+ovj
+mjJ
 nLK
 hrp
 avX
 cvj
 cDs
-ojg
+mjJ
 cRD
-ojg
-ojg
-blx
-auv
-auv
-auv
-auv
-auv
+mjJ
+mjJ
+mjJ
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaf
-vLD
-dda
-dda
-dda
-dbU
+lMJ
+aaf
+aaf
+aaf
+aaf
 aaa
 aaa
 auv
 aaa
 lBG
-auv
+aaa
 aaa
 aaf
 aaa
 aaa
-dda
+aaf
 aaa
-iPi
+anT
 aaa
 aaa
 aaa
@@ -123310,7 +123126,7 @@ ovj
 nbv
 nbv
 nbv
-ojg
+ovj
 mjJ
 rvY
 mjJ
@@ -123320,18 +123136,18 @@ cDt
 rvY
 cRY
 mjJ
-qOT
-cTD
+aaa
+lMJ
 aaa
 aaa
 aaa
 aaa
-auv
-dbM
-dbM
-dbM
-dbM
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 iuF
 dbJ
 pPc
@@ -123340,14 +123156,14 @@ dbJ
 dbU
 dbR
 dbM
-pPc
-iuF
-iuF
-pPc
-pPc
+dbJ
+dbJ
+dbJ
+dbJ
+dbJ
 aaa
-vmW
-dda
+aqB
+aaf
 aaa
 aaa
 aaa
@@ -123568,8 +123384,8 @@ nbv
 nbv
 nbv
 ovj
-qOT
-qOT
+aaa
+aaa
 mjJ
 rvY
 rvY
@@ -123577,18 +123393,18 @@ mGY
 lWA
 hIy
 rvY
-qOT
-cTD
+aaa
+lMJ
 aaa
 aaa
 aaa
 aaa
-auv
-dbM
-dbM
-dbM
-dbM
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 dbO
 dbV
 dbV
@@ -123597,14 +123413,14 @@ dbV
 seE
 dbR
 dbW
-dsf
-dsf
-dsf
+mMv
+mMv
+mMv
 mMv
 fzi
-dda
-iPi
-dda
+aaf
+anT
+aaf
 aaa
 aaa
 aaa
@@ -123825,27 +123641,27 @@ nbv
 nbv
 nbv
 ovj
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 vCj
-qOT
-qOT
-qOT
 aaa
 aaa
 aaa
-auv
-auv
-dbM
-dbM
-dbM
-dbU
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
 iHM
 dbL
 iHM
@@ -123854,13 +123670,13 @@ dbL
 dbU
 btA
 dbU
-wni
-iHM
-wni
-wni
-wni
+dbL
+dbL
+dbL
+dbL
+dbL
 aaa
-iPi
+anT
 aaa
 aaa
 aaa
@@ -124082,42 +123898,42 @@ nbv
 nbv
 nbv
 ovj
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
 aaa
 aaa
 aaa
 aaa
-auv
-auv
-auv
-auv
-vLD
-dda
-dda
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
+aaf
+aaf
 dbU
-dda
-auv
+aaf
+aaa
 aaa
 aaa
 ack
 aaa
-dda
-auv
-aaa
-dda
+aaf
 aaa
 aaa
-iPi
+aaf
+aaa
+aaa
+anT
 aaa
 aaa
 aaa
@@ -124339,27 +124155,27 @@ jah
 jah
 jah
 ovj
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
 aaa
 aaa
 aaa
 aaa
-auv
-dbM
-dbM
-dbM
-dbM
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 iuF
 dbJ
 pPc
@@ -124368,13 +124184,13 @@ dbJ
 dbU
 dbR
 dbM
-iuF
-iuF
-pPc
-pPc
-pPc
-dda
-iPi
+dbJ
+dbJ
+dbJ
+dbJ
+dbJ
+aaf
+anT
 aaa
 aaa
 aaa
@@ -124592,31 +124408,31 @@ arF
 vRM
 vRM
 vRM
-osW
-osW
-osW
+vRq
+vRq
+vRq
 ctl
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-auv
 aaa
 aaa
 aaa
-auv
-auv
-dbM
-dbM
-dbM
-dbU
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
 dbO
 dbV
 dbV
@@ -124625,13 +124441,13 @@ dbV
 seE
 dbR
 dbW
-dsf
-dsf
+mMv
+mMv
 mMv
 mMv
 fzi
-dda
-iPi
+aaf
+anT
 aaa
 aaa
 aaa
@@ -124855,25 +124671,25 @@ aaf
 lrF
 aaa
 aaa
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-qOT
-auv
-auv
-auv
-auv
-auv
 aaa
-dbM
-dbM
-dcY
-dbU
-dcY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
+aaf
+lMJ
 iHM
 dbL
 iHM
@@ -124882,13 +124698,13 @@ dbL
 dbU
 dbR
 dbU
-wni
-iHM
-wni
-wni
-wni
+dbL
+dbL
+dbL
+dbL
+dbL
 aaa
-iPi
+anT
 aaa
 aaa
 aaa
@@ -125124,29 +124940,29 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
-auv
+aaa
+aaa
+aaa
 cUM
 aaf
-dda
+aaf
 aaa
 dbU
-dda
-dda
-auv
-auv
+aaf
+aaf
+aaa
+aaa
 ack
-auv
+aaa
 aaa
 aaf
 aaf
-dda
-dda
+aaf
+aaf
 aaa
-vmW
-dda
+aqB
+aaf
 aaa
 aaa
 aaa
@@ -125380,14 +125196,14 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-auv
-dbM
-dbM
-dcZ
-dcZ
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+fwb
+fwb
+aaf
 iuF
 dbJ
 pPc
@@ -125396,13 +125212,13 @@ dbJ
 dbU
 dbR
 dbM
-iuF
-iuF
-pPc
-pPc
-pPc
-dda
-iPi
+dbJ
+dbJ
+dbJ
+dbJ
+dbJ
+aaf
+anT
 aaa
 aaa
 aaa
@@ -125639,12 +125455,12 @@ aaa
 aaa
 aaa
 aaa
-auv
-dbM
-dbM
-dbM
-dbM
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 dbO
 dbV
 dbV
@@ -125654,12 +125470,12 @@ seE
 dbR
 dbW
 mMv
-dsf
+mMv
 mMv
 mMv
 fzi
 aaa
-dda
+aaf
 aaa
 aaa
 aaa
@@ -125896,12 +125712,12 @@ aaa
 aaa
 aaa
 aaa
-auv
-dbM
-dbM
-dbM
-dbM
-dbU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 iHM
 dbL
 iHM
@@ -125910,11 +125726,11 @@ dbL
 dbU
 vVw
 dbU
-wni
-wni
-wni
-wni
-wni
+dbL
+dbL
+dbL
+dbL
+dbL
 aaa
 aaa
 aaa
@@ -126153,26 +125969,26 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
-auv
-auv
 aaa
-dda
 aaa
-dbU
-dda
-auv
 aaa
-auv
+aaa
+aaf
+aaa
+aaf
+aaf
+aaa
+aaa
+aaa
 xSq
 aaa
 aaf
 aaa
-dda
+aaf
 aaa
 aaa
-dda
+aaf
 aaa
 aaa
 aaa
@@ -126410,26 +126226,26 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+anT
+anT
+anT
+aaa
+aaf
+aaa
+xSq
 auv
 auv
 aaa
 aaf
-iPi
-jQw
-iPi
-aaa
-dda
-auv
-otH
-auv
-auv
-aaa
-dda
-dda
-iPi
-iPi
+aaf
+anT
+anT
 aaa
 aaa
 aaa
@@ -126666,22 +126482,22 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
-auv
 aaa
-dda
+aaa
+aaa
+aaa
 aaf
-auv
-dbU
-auv
-auv
-iPi
-dda
+aaf
+aaa
+aaf
+aaa
+aaa
+anT
+aaf
 wvo
-dda
-vmW
+aaf
+aqB
 aac
 aaa
 aaa
@@ -126921,26 +126737,26 @@ aaa
 aaa
 aaa
 aaa
-vLD
+lMJ
 aaa
 aaa
-auv
 aaa
-auv
-auv
+aaa
+aaa
+aaa
 aaa
 aaf
 aaa
-dda
-dda
-auv
+aaf
+aaf
+aaa
 aqB
-auv
 aaa
 aaa
-iPi
-dda
-dda
+aaa
+anT
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -127182,20 +126998,20 @@ lMJ
 lMJ
 lMJ
 lMJ
-vLD
-vLD
-vLD
-dda
+lMJ
+lMJ
+lMJ
+aaf
 aaf
 iUx
-auv
-auv
-auv
-iPi
-iPi
-iPi
-iPi
-iPi
+aaa
+aaa
+aaa
+anT
+anT
+anT
+anT
+anT
 aaa
 aaa
 aaa
@@ -127422,16 +127238,16 @@ aaa
 bzi
 aaa
 uYt
-avU
-avU
-avU
+cUM
+cUM
+cUM
 aac
 aaf
 aaf
 aaf
 aaf
 aaf
-avU
+cUM
 aaa
 fwb
 cUM
@@ -127439,19 +127255,19 @@ cUM
 cUM
 cUM
 cUM
-dci
-dci
-dci
-dci
-dda
-auv
-aaa
-auv
+fwb
+fwb
+fwb
+fwb
+aaf
 aaa
 aaa
-dda
 aaa
-dda
+aaa
+aaa
+aaf
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -127683,24 +127499,24 @@ aaf
 aaa
 aaa
 aaa
-avU
-avU
+cUM
+cUM
 aaa
-avU
-avU
-avU
-aaa
-aaa
+cUM
+cUM
+cUM
 aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -127952,13 +127768,13 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
 aaa
 aaa
-dda
-dda
+aaa
+aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -128209,12 +128025,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-vLD
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -128466,12 +128282,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-vLD
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -128723,12 +128539,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-vLD
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -128980,12 +128796,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-vLD
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -129237,12 +129053,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-vLD
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -129493,13 +129309,13 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
 aaa
 aaa
 aaa
-vLD
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -129738,11 +129554,6 @@ uYt
 aaa
 aaa
 aaa
-auv
-auv
-auv
-auv
-auv
 aaa
 aaa
 aaa
@@ -129751,12 +129562,17 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-vLD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+lMJ
 aaa
 aaa
 aaa
@@ -129992,28 +129808,28 @@ eUG
 ggI
 ggI
 dkZ
-auv
-auv
-auv
-auv
-aaa
-aaa
-aaa
-auv
-auv
-auv
-auv
-auv
-auv
-auv
-auv
-auv
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -130265,12 +130081,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -130522,12 +130338,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -130779,13 +130595,13 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
 aaa
 aaa
-dda
-dda
+aaa
+aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -131036,12 +130852,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -131293,12 +131109,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -131550,12 +131366,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -131807,12 +131623,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -132064,12 +131880,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -132320,13 +132136,13 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
 aaa
 aaa
-dda
-dda
+aaa
+aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -132578,12 +132394,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -132835,12 +132651,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -133092,12 +132908,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -133349,12 +133165,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -133606,13 +133422,13 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
 aaa
 aaa
-dda
-dda
+aaa
+aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -133863,12 +133679,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -134120,12 +133936,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -134377,12 +134193,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -134634,12 +134450,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -134890,13 +134706,13 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
 aaa
 aaa
 aaa
-dda
-dda
+aaa
+aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -135148,12 +134964,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -135404,14 +135220,14 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-auv
 aaa
 aaa
-dda
-dda
-dda
+aaa
+aaa
+aaa
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -135660,16 +135476,16 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-auv
-auv
-auv
-dda
-dda
-dda
-dda
-dda
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -135916,18 +135732,18 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-cDz
-cDz
-cDz
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaf
-dcC
-ext
-dcC
-dda
-dda
+czK
+gRW
+czK
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -136172,20 +135988,20 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-cDz
-cDz
-cDz
-cEC
-cEC
-dbZ
-dcD
-gqd
-dcC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
 kss
-dda
-dda
+czK
+gqd
+czK
+kss
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -136428,22 +136244,22 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-cDz
-cDz
-cDz
-cEC
-cEC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
 czK
 czK
 dmq
 gRW
 jdU
-dcC
-dcC
-dda
-dda
+czK
+czK
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -136685,22 +136501,22 @@ aaa
 aaa
 aaa
 aaa
-auv
-cDz
-cDz
-cDz
-cDz
-cEC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 cFx
 cFx
 ddl
 dmr
-anS
-eXl
+dmr
+dmr
 kuN
-ddA
-ddA
-dda
+cFx
+cFx
+aaf
 aaa
 aaa
 aaa
@@ -136940,26 +136756,26 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-auv
-cDz
-cDz
-cEC
-cEC
-cEC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
+aaf
 czK
 cFw
 cGp
 dmr
 htz
-anS
-qkj
+dmr
+cEC
 rDf
-dcC
-dda
-dda
-dda
+czK
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -137199,22 +137015,22 @@ aaa
 aaa
 aaa
 aaa
-auv
-cDz
-cDz
-cDz
-cDz
-cEC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
 cFx
 cFx
 ddm
 dmr
-anS
-eXl
+dmr
+dmr
 kMb
-ddA
-ddA
-dda
+cFx
+cFx
+aaf
 aaa
 aaa
 aaa
@@ -137456,22 +137272,22 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-cDz
-cDz
-cDz
-cEC
-cEC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
 czK
 czK
 dnJ
 hZi
 juU
-dcC
-dcC
-dda
-dda
+czK
+czK
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -137714,20 +137530,20 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-cDz
-cDz
-cDz
-cEC
-cEC
-dbZ
-dcD
-iia
-dcC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
 kss
-dda
-dda
+czK
+iia
+czK
+kss
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -137972,18 +137788,18 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-cDz
-cDz
-cDz
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaf
-dcC
-ddA
-dcC
-dda
-dda
+czK
+cFx
+czK
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -138230,16 +138046,16 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-auv
-auv
-auv
-dda
-dda
-dda
-dda
-dda
+aaa
+aaa
+aaa
+aaa
+aaa
+aaf
+aaf
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -138488,14 +138304,14 @@ aaa
 aaa
 aaa
 aaa
-auv
-auv
-auv
 aaa
 aaa
-dda
-dda
-dda
+aaa
+aaa
+aaa
+aaf
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -138746,12 +138562,12 @@ aaa
 aaa
 aaa
 aaa
-auv
 aaa
 aaa
 aaa
 aaa
-dda
+aaa
+aaf
 aaa
 aaa
 aaa
@@ -139003,12 +138819,12 @@ aaa
 aaa
 aaa
 aaa
-aaf
+cDz
 aaa
 aaa
 aaa
 aaa
-aaa
+auv
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

This PR is made on behalf of Spockeyeye.

## Why It's Good For The Game

This allows for larger exploration shuttles. It also clears up the toxins bomb launcher's path.

## Changelog
:cl:Spockyeyeye
tweak: Expands the Exploration shuttle dock on Meta
tweak: The toxins bomb launcher no longer blows up the exploration shuttle
/:cl: