### PR TITLE
Notes and messages will not automatically expire

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -300,7 +300,6 @@
 
 /datum/config_entry/flag/manual_note_expiry //Notes can only have expiration times added after creation, not during. Will also prevent automatic notes from expiring.
 
-
 /datum/config_entry/flag/maprotation
 
 /datum/config_entry/flag/automapvote

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -298,6 +298,9 @@
 	min_val = 0
 	integer = FALSE
 
+/datum/config_entry/flag/manual_note_expiry //Notes can only have expiration times added after creation, not during. Will also prevent automatic notes from expiring.
+
+
 /datum/config_entry/flag/maprotation
 
 /datum/config_entry/flag/automapvote

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -56,7 +56,7 @@
 
 	if(CONFIG_GET(flag/manual_note_expiry) && (type in list("note", "message")))
 		expiry = -1
-	if(isnull(expiry))
+	else if(isnull(expiry))
 		if(alert(usr, "Set an expiry time? Expired messages are hidden like deleted ones.", "Expiry time?", "Yes", "No", "Cancel") == "Yes")
 			var/expire_time = input("Set expiry time for [type] as format YYYY-MM-DD HH:MM:SS. All times in server time. HH:MM:SS is optional and 24-hour. Must be later than current time for obvious reasons.", "Set expiry time", SQLtime()) as null|text
 			if(!expire_time)

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -53,6 +53,9 @@
 				secret = 0
 			else
 				return
+
+	if(CONFIG_GET(flag/manual_note_expiry) && type in list("note", "message"))
+		expiry = -1
 	if(isnull(expiry))
 		if(alert(usr, "Set an expiry time? Expired messages are hidden like deleted ones.", "Expiry time?", "Yes", "No", "Cancel") == "Yes")
 			var/expire_time = input("Set expiry time for [type] as format YYYY-MM-DD HH:MM:SS. All times in server time. HH:MM:SS is optional and 24-hour. Must be later than current time for obvious reasons.", "Set expiry time", SQLtime()) as null|text

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -54,7 +54,7 @@
 			else
 				return
 
-	if(CONFIG_GET(flag/manual_note_expiry) && type in list("note", "message"))
+	if(CONFIG_GET(flag/manual_note_expiry) && (type in list("note", "message")))
 		expiry = -1
 	if(isnull(expiry))
 		if(alert(usr, "Set an expiry time? Expired messages are hidden like deleted ones.", "Expiry time?", "Yes", "No", "Cancel") == "Yes")

--- a/config/config.txt
+++ b/config/config.txt
@@ -338,6 +338,9 @@ AUTOMUTE_ON
 ## Uncomment this to let players see their own notes (they can still be set by admins only)
 SEE_OWN_NOTES
 
+## Uncomment this to prevent the game from creating automatically expring notes, and to skip the prompt for admins to enter an expiry time for notes. They can still be added manually.
+MANUAL_NOTE_EXPIRY
+
 ### Comment these two out to prevent notes fading out over time for admins.
 ## Notes older then this will start fading out.
 NOTE_FRESH_DAYS 91.31055


### PR DESCRIPTION

## Why It's Good For The Game
Note expiration is weird because it both is and isn't deletion, and has a very limited usecase.

## Changelog
:cl:
config: A new config has been added to make setting notes to expire a more intentional action.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
