### PR TITLE
Opens another viro slot

### DIFF
--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -4,8 +4,8 @@
 	department_head = list("Chief Medical Officer")
 	department_flag = MEDSCI
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#d4ebf2"
 	chat_color = "#75AEA3"

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -5,7 +5,7 @@
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2
-	spawn_positions = 2
+	spawn_positions = 2 
 	supervisors = "the chief medical officer"
 	selection_color = "#d4ebf2"
 	chat_color = "#75AEA3"

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -5,7 +5,7 @@
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 2
-	spawn_positions = 2 
+	spawn_positions = 2
 	supervisors = "the chief medical officer"
 	selection_color = "#d4ebf2"
 	chat_color = "#75AEA3"


### PR DESCRIPTION
## About The Pull Request
I had this open, but it went stale with zero response. 
Opens an extra viro slot. Our maps are made with two virologists in mind, anyhow

## Why It's Good For The Game
I didnt go in depth on this in my last PR, so ill sum it up further
Virology is one of the only one slot jobs. Discounting heads, this includes 3 flavor jobs (detective, chaplain, curator) and the Warden. 
Virology is a job with a high entry barrier at the moment. It's a bit intimidating to get into, and I hope having two slots will allow a more experienced virologist to teach a less experienced one.
Having two virology slots also opens up the job to more roleplay after symptom gathering is done. Being able to collaberate and test diseases together, bounce ideas off of each other in character, and show each other tricks is interesting.
Finally, this opens up interesting opportunities for miscommunication, especially as far as virus tests go. And the crew no longer always knows which person exactly is responsible for the deadly plague sweeping the station

## Changelog
:cl:
tweak: adds another viro slot
/:cl:
