### PR TITLE
Mutations now use a signal for on_move instead of being placed directly in human/Move()

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -86,6 +86,7 @@
 	grant_spell() //we do checks here so nothing about hulk getting magic
 	if(!modified)
 		addtimer(CALLBACK(src, .proc/modify, 5)) //gonna want children calling ..() to run first
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/on_move)
 
 /datum/mutation/human/proc/get_visual_indicator()
 	return
@@ -97,6 +98,7 @@
 	return
 
 /datum/mutation/human/proc/on_move(new_loc)
+	SIGNAL_HANDLER
 	return
 
 /datum/mutation/human/proc/on_life()
@@ -117,6 +119,7 @@
 		if(power)
 			owner.RemoveSpell(power)
 			qdel(src)
+		UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
 		return 0
 	return 1
 

--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -18,6 +18,7 @@
 	owner.alpha = max(0, owner.alpha - 25)
 
 /datum/mutation/human/chameleon/on_move()
+	SIGNAL_HANDLER
 	owner.alpha = CHAMELEON_MUTATION_DEFAULT_TRANSPARENCY
 
 /datum/mutation/human/chameleon/on_attack_hand(atom/target, proximity)

--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -18,7 +18,6 @@
 	owner.alpha = max(0, owner.alpha - 25)
 
 /datum/mutation/human/chameleon/on_move()
-	SIGNAL_HANDLER
 	owner.alpha = CHAMELEON_MUTATION_DEFAULT_TRANSPARENCY
 
 /datum/mutation/human/chameleon/on_attack_hand(atom/target, proximity)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -43,8 +43,6 @@
 
 /mob/living/carbon/human/Move(NewLoc, direct)
 	. = ..()
-	for(var/datum/mutation/human/HM in dna?.mutations)
-		HM.on_move(NewLoc)
 
 	if(shoes)
 		if(mobility_flags & MOBILITY_STAND)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
COMSIG_MOVABLE_MOVED replaces the abominations that is the mutation loop on human/Move()

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Optimization good. Shitcode bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Mutation code is 1% less shit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
