### PR TITLE
casting_clothing is now a var editable at runtime instead of defined in the proc

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -154,8 +154,12 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/centcom_cancast = TRUE //Whether or not the spell should be allowed on z2
 
 
-	var/list/casting_clothes //used in the actuel checks
-	var/static/list/casting_clothes_base //to modify clothing list, overwrite the init call to re-assign casting_clothes
+	/// Typecache of clothing needed to cast the spell. Used in actual checks. Override in Initialize if your spell requires different clothing.
+	/// !!Shared between instances, make a copy to modify.
+	var/list/casting_clothes
+
+	/// Base typecache of clothing needed to cast spells. Do not modify, make a separate static var in subtypes if necessary.
+	var/static/list/casting_clothes_base
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -155,7 +155,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 
 	var/list/casting_clothes //used in the actuel checks
-	var/static/list/casting_clothes_override //if you want your spell to require different clothing, use this
+	var/static/list/casting_clothes_override //if you want your spell to require different clothing, use this. besure to do typecacheof(list(stuff))!!!!
 	var/static/list/casting_clothes_base = typecacheof(list(/obj/item/clothing/suit/wizrobe,
 			/obj/item/clothing/suit/space/hardsuit/wizard,
 			/obj/item/clothing/head/wizard,

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -153,12 +153,13 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 	var/centcom_cancast = TRUE //Whether or not the spell should be allowed on z2
 
-	var/list/casting_clothes = typecacheof(list(/obj/item/clothing/suit/wizrobe, //The clothing required when clothes_req = TRUE
+	//The clothing required when clothes_req = TRUE
+	var/list/casting_clothes = list(/obj/item/clothing/suit/wizrobe,
 		/obj/item/clothing/suit/space/hardsuit/wizard,
 		/obj/item/clothing/head/wizard,
 		/obj/item/clothing/head/helmet/space/hardsuit/wizard,
 		/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
-		/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard))
+		/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard)
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"
@@ -282,6 +283,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/Initialize()
 	. = ..()
 
+	casting_clothes = typecacheof(casting_clothes)
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -153,6 +153,13 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 	var/centcom_cancast = TRUE //Whether or not the spell should be allowed on z2
 
+	var/list/casting_clothes = typecacheof(list(/obj/item/clothing/suit/wizrobe, //The clothing required when clothes_req = TRUE
+		/obj/item/clothing/suit/space/hardsuit/wizard,
+		/obj/item/clothing/head/wizard,
+		/obj/item/clothing/head/helmet/space/hardsuit/wizard,
+		/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
+		/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard))
+
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"
 	action_background_icon_state = "bg_spell"
@@ -204,13 +211,6 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 		if((invocation_type == "whisper" || invocation_type == "shout") && !H.can_speak_vocal())
 			to_chat(user, "<span class='notice'>You can't get the words out!</span>")
 			return FALSE
-
-		var/list/casting_clothes = typecacheof(list(/obj/item/clothing/suit/wizrobe,
-		/obj/item/clothing/suit/space/hardsuit/wizard,
-		/obj/item/clothing/head/wizard,
-		/obj/item/clothing/head/helmet/space/hardsuit/wizard,
-		/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
-		/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard))
 
 		if(clothes_req) //clothes check
 			if(!is_type_in_typecache(H.wear_suit, casting_clothes))

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -155,13 +155,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 
 	var/list/casting_clothes //used in the actuel checks
-	var/static/list/casting_clothes_override //if you want your spell to require different clothing, use this. besure to do typecacheof(list(stuff))!!!!
-	var/static/list/casting_clothes_base = typecacheof(list(/obj/item/clothing/suit/wizrobe,
-			/obj/item/clothing/suit/space/hardsuit/wizard,
-			/obj/item/clothing/head/wizard,
-			/obj/item/clothing/head/helmet/space/hardsuit/wizard,
-			/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
-			/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard))//base clothing list, do not modify
+	var/static/list/casting_clothes_base //to modify clothing list, overwrite the init call to re-assign casting_clothes
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"
@@ -285,10 +279,15 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/Initialize()
 	. = ..()
 
-	if(casting_clothes_override)
-		casting_clothes = casting_clothes_override
-	else
-		casting_clothes = casting_clothes_base
+	if(!casting_clothes_base)
+		casting_clothes_base = typecacheof(list(/obj/item/clothing/suit/wizrobe,
+			/obj/item/clothing/suit/space/hardsuit/wizard,
+			/obj/item/clothing/head/wizard,
+			/obj/item/clothing/head/helmet/space/hardsuit/wizard,
+			/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
+			/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard))
+
+	casting_clothes = casting_clothes_base
 
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -153,13 +153,15 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 
 	var/centcom_cancast = TRUE //Whether or not the spell should be allowed on z2
 
-	//The clothing required when clothes_req = TRUE
-	var/list/casting_clothes = list(/obj/item/clothing/suit/wizrobe,
-		/obj/item/clothing/suit/space/hardsuit/wizard,
-		/obj/item/clothing/head/wizard,
-		/obj/item/clothing/head/helmet/space/hardsuit/wizard,
-		/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
-		/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard)
+
+	var/list/casting_clothes //used in the actuel checks
+	var/static/list/casting_clothes_override //if you want your spell to require different clothing, use this
+	var/static/list/casting_clothes_base = typecacheof(list(/obj/item/clothing/suit/wizrobe,
+			/obj/item/clothing/suit/space/hardsuit/wizard,
+			/obj/item/clothing/head/wizard,
+			/obj/item/clothing/head/helmet/space/hardsuit/wizard,
+			/obj/item/clothing/suit/space/hardsuit/shielded/wizard,
+			/obj/item/clothing/head/helmet/space/hardsuit/shielded/wizard))//base clothing list, do not modify
 
 	action_icon = 'icons/mob/actions/actions_spells.dmi'
 	action_icon_state = "spell_default"
@@ -283,7 +285,11 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/Initialize()
 	. = ..()
 
-	casting_clothes = typecacheof(casting_clothes)
+	if(casting_clothes_override)
+		casting_clothes = casting_clothes_override
+	else
+		casting_clothes = casting_clothes_base
+
 	still_recharging_msg = "<span class='notice'>[name] is still recharging.</span>"
 	charge_counter = charge_max
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

moves the casting_clothes into var of the datum instead of the proc

## Why It's Good For The Game

Makes it so you could assign different clothing to cast the spell. instead of being locked to the wizard robes specificly. magic crown maby? also should allow admins to VV spell to use custom clothing :)

If desired, I could extent the system to check all user clothing for example magic gloves. or clowns requiring clown masks to cast certain spells(example)
## Changelog
:cl:
tweak: Clothing req is now a variable of spell instead of hard coded in the proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
