### PR TITLE
fixes heavy deep fried food dropping their contents early

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -261,7 +261,7 @@
 	. = ..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
-	if(contents && !reagents.total_volume)
+	if(LAZYLEN(contents) && !reagents.total_volume)
 		for(var/atom/movable/A in contents)
 			A.forceMove(eater.loc)
 	..()

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -261,7 +261,7 @@
 	. = ..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
-	if(contents)
+	if(contents && !reagents.total_volume)
 		for(var/atom/movable/A in contents)
 			A.forceMove(eater.loc)
 	..()


### PR DESCRIPTION
## About The Pull Request
deep fried foods now drop their contents upon being fully eaten. I didnt try deep frying for longer when testing the former PR. This isn't game breaking (all the deep fried shells impart nutritiously is cooking oil, which the chef has in abundance), but its odd that you drop items out of their shell on the first bite.

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: deep fried foods only drop contents when fully eaten
/:cl:
