### PR TITLE
Toxins Bombs grant 10% of general research points as discovery research points

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -217,32 +217,37 @@
 		say("Warning: No linked research system!")
 		return
 
-	var/point_gain = 0
+	var/general_point_gain = 0
+	var/discovery_point_gain = 0
+
 	/*****The Point Calculator*****/
 
 	if(orig_light_range < 10)
 		say("Explosion not large enough for research calculations.")
 		return
 	else if(orig_light_range < 4500)
-		point_gain = (83300 * orig_light_range) / (orig_light_range + 3000)
+		general_point_gain = (83300 * orig_light_range) / (orig_light_range + 3000)
 	else
-		point_gain = TECHWEB_BOMB_POINTCAP
+		general_point_gain = TECHWEB_BOMB_POINTCAP
 
 	/*****The Point Capper*****/
-	if(point_gain > linked_techweb.largest_bomb_value)
-		if(point_gain <= TECHWEB_BOMB_POINTCAP || linked_techweb.largest_bomb_value < TECHWEB_BOMB_POINTCAP)
+	if(general_point_gain > linked_techweb.largest_bomb_value)
+		if(general_point_gain <= TECHWEB_BOMB_POINTCAP || linked_techweb.largest_bomb_value < TECHWEB_BOMB_POINTCAP)
 			var/old_tech_largest_bomb_value = linked_techweb.largest_bomb_value //held so we can pull old before we do math
-			linked_techweb.largest_bomb_value = point_gain
-			point_gain -= old_tech_largest_bomb_value
-			point_gain = min(point_gain,TECHWEB_BOMB_POINTCAP)
+			linked_techweb.largest_bomb_value = general_point_gain
+			general_point_gain -= old_tech_largest_bomb_value
+			general_point_gain = min(general_point_gain,TECHWEB_BOMB_POINTCAP)
 		else
 			linked_techweb.largest_bomb_value = TECHWEB_BOMB_POINTCAP
-			point_gain = 1000
+			general_point_gain = 1000
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		if(D)
-			D.adjust_money(point_gain)
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, point_gain)
-			say("Explosion details and mixture analyzed and sold to the highest bidder for $[point_gain], with a reward of [point_gain] points.")
+			D.adjust_money(general_point_gain)
+			discovery_point_gain = general_point_gain * 0.1
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, general_point_gain)
+			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, discovery_point_gain)
+
+			say("Explosion details and mixture analyzed and sold to the highest bidder for $[general_point_gain], with a reward of [general_point_gain] general research points and [discovery_point_gain] discovery research points.")
 
 	else //you've made smaller bombs
 		say("Data already captured. Aborting.")

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -247,7 +247,7 @@
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, general_point_gain)
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, discovery_point_gain)
 
-			say("Explosion details and mixture analyzed and sold to the highest bidder for $[general_point_gain], with a reward of [general_point_gain] general research points and [discovery_point_gain] discovery research points.")
+			say("Explosion details and mixture analyzed and sold to the highest bidder for $[general_point_gain], with a reward of [general_point_gain] General Research points and [discovery_point_gain] Discovery Research points.")
 
 	else //you've made smaller bombs
 		say("Data already captured. Aborting.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds 10% of general research points granted by Toxins bombs as Discovery Research points.

![imagen](https://user-images.githubusercontent.com/90270186/144753353-2f3aa6d7-0999-408f-8372-e09496ffd54b.png)
![imagen](https://user-images.githubusercontent.com/90270186/144753355-c566c1f7-f449-4068-a210-7798ca07f3e1.png)
![imagen](https://user-images.githubusercontent.com/90270186/144757632-c574cb38-9ca8-4be4-a8ec-a93c82b90ac0.png)

## Why It's Good For The Game

After the recent balance fixes due to research code not working as intended by the mantainer, Science is really starved on Discovery Research points, so the idea of this PR is giving them one more way to compensate for it. Also makes Toxins a bit more important to be done, as it's largely ignored by Science.

## Changelog
:cl:
balance: Toxins bombs now also grant 10% of the General Research points as Discovery Research Points.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
