### PR TITLE
adds some comments for crates and fixes finally golden spawn mimic crate

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -1,3 +1,7 @@
+/* 	Important Info for anyone that wants to make new crates if the open sprite of the crate has a uniform color then you just
+	have to mirror it once in the x and y axis to get the back sprite but if there are any details like writing icons etc in the sprite (like for example the engineering electricity crate) then you
+	have to do the stuff i mentioned first and then mirror the details yet again by selecting them respectivly independently from the rest of the sprite in the x axis.
+	You may also have to adjust the position of the sprite to match the crate in DM.*/
 /obj/structure/closet/crate
 	name = "crate"
 	desc = "A rectangular steel crate."

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -26,7 +26,7 @@
 
 	faction = list("mimic")
 	move_to_delay = 9
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN
 	del_on_death = TRUE
 	hardattacks = TRUE
 
@@ -39,6 +39,7 @@
 	stop_automated_movement = 1
 	wander = FALSE
 	var/attempt_open = FALSE
+	gold_core_spawnable = HOSTILE_SPAWN
 
 // Pickup loot
 /mob/living/simple_animal/hostile/mimic/crate/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out the base mimic had gold_core_spawnable = HOSTILE_SPAWN because of that mob not having the procs of the child it would not have the crate lid applied and wouldn't behave like it was supposed to (beeing inert until someone tries  to open it).
No CL for the comment change cause it doesn't change anything at all for the player just clarifies stuff for people that want to make new crates.

## Why It's Good For The Game

fixes stuff and adds some clarification i feel like are really needed

## Changelog
:cl:
fix: fixes golden core spawned mimic crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
