### PR TITLE
fixes isinf macro for windows hosts

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -281,7 +281,7 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 /// isnum() returns TRUE for NaN. Also, NaN != NaN. Checkmate, BYOND.
 #define isnan(x) ( (x) != (x) )
 
-#define isinf(x) (isnum((x)) && (((x) == system_type_infinity) || ((x) == -system_type_infinity)))
+#define isinf(x) (isnum((x)) && (((x) == SYSTEM_TYPE_INFINITY) || ((x) == -SYSTEM_TYPE_INFINITY)))
 
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -281,7 +281,7 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 /// isnum() returns TRUE for NaN. Also, NaN != NaN. Checkmate, BYOND.
 #define isnan(x) ( (x) != (x) )
 
-#define isinf(x) (isnum((x)) && ((num2text(x) == "inf") || (num2text(x) == "-inf") || (num2text(x) == "-1.#INF") || (num2text(x) == "1.#INF")))
+#define isinf(x) (isnum((x)) && (((x) == -inf_win_lin) || ((x) == inf_win_lin)))
 
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -281,7 +281,7 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 /// isnum() returns TRUE for NaN. Also, NaN != NaN. Checkmate, BYOND.
 #define isnan(x) ( (x) != (x) )
 
-#define isinf(x) (isnum((x)) && (((x) == -inf_win_lin) || ((x) == inf_win_lin)))
+#define isinf(x) (isnum((x)) && (((x) == inf_win_lin) || ((x) == -inf_win_lin)))
 
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -281,7 +281,7 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 /// isnum() returns TRUE for NaN. Also, NaN != NaN. Checkmate, BYOND.
 #define isnan(x) ( (x) != (x) )
 
-#define isinf(x) (isnum((x)) && (((x) == text2num("inf")) || ((x) == text2num("-inf"))))
+#define isinf(x) (isnum((x)) && ((num2text(x) == "inf") || (num2text(x) == "-inf") || (num2text(x) == "-1.#INF") || (num2text(x) == "1.#INF")))
 
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -281,7 +281,7 @@ GLOBAL_LIST_INIT(glass_sheet_types, typecacheof(list(
 /// isnum() returns TRUE for NaN. Also, NaN != NaN. Checkmate, BYOND.
 #define isnan(x) ( (x) != (x) )
 
-#define isinf(x) (isnum((x)) && (((x) == inf_win_lin) || ((x) == -inf_win_lin)))
+#define isinf(x) (isnum((x)) && (((x) == system_type_infinity) || ((x) == -system_type_infinity)))
 
 #define isProbablyWallMounted(O) (O.pixel_x > 20 || O.pixel_x < -20 || O.pixel_y > 20 || O.pixel_y < -20)
 

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -6,7 +6,7 @@
 
 #define PI						3.1416
 #define INFINITY				1e31	//closer then enough
-#define inf_win_lin					1.#INF //only for isinf test
+#define system_type_infinity					1.#INF //only for isinf check
 
 #define SHORT_REAL_LIMIT 16777216
 

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -6,7 +6,7 @@
 
 #define PI						3.1416
 #define INFINITY				1e31	//closer then enough
-#define system_type_infinity					1.#INF //only for isinf check
+#define SYSTEM_TYPE_INFINITY					1.#INF //only for isinf check
 
 #define SHORT_REAL_LIMIT 16777216
 

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -6,6 +6,7 @@
 
 #define PI						3.1416
 #define INFINITY				1e31	//closer then enough
+#define inf_win_lin					1.#INF //only for isinf test
 
 #define SHORT_REAL_LIMIT 16777216
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Original behavior for isinf did only account for the behavior of linux hosts and was unable to detect infinities on windows this PR fixes this by changing the check ~~and implementing additional checks for windows hosts~~ so it reliably works for windows and linux.
This is only a temporary fix as there seems to be already a native solution for the next major beyond version in work.
Closes https://github.com/BeeStation/BeeStation-Hornet/issues/5812

Thanks to kuberoot for helping to profile it:
~~while this does fix the problem turns out it also is slower than the original approach(that currently doesn't work on windows)
the difference is in around 1000000 loops the difference is 2.4 seconds for the new methode to 0.5 of the original methode so there is a considerable performance loss here.~~
After changing the approach of the isinf macro the performance loose should be fixed actually should be even faster because now it involves no datatype conversions
## Why It's Good For The Game
infinite values are bad

## Changelog
:cl:
refactor: refactors isinf macro
fix: fixes isinf for windows hosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
