### PR TITLE
Toxins Bomb to grant 50% of General Research Points as Discovery Research Points

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -243,7 +243,7 @@
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		if(D)
 			D.adjust_money(general_point_gain)
-			discovery_point_gain = general_point_gain * 0.1
+			discovery_point_gain = general_point_gain * 0.5
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, general_point_gain)
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, discovery_point_gain)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After discussing it with Bacon, 10% was a bit too low, considering the effort and resources needed for a toxins research bomb, so we decided to up it to 50%

## Why It's Good For The Game

Toxins Bombs are now even more worth it to do for Discovery Research

## Changelog
:cl:
tweak: Toxins Bombs now grant 50% of General Research Points as Discovery Research Points
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
