### PR TITLE
Fixes virus list href exploit

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -260,8 +260,8 @@
 			else if(href_list["vir"])
 				var/href_type = text2path(href_list["vir"])
 				if(ispath(href_type, /datum/disease))
-					  var/datum/disease/type = href_type
-					  src.temp = {"<b>Name:</b> [initial(type.name)]
+					var/datum/disease/type = href_type
+					src.temp = {"<b>Name:</b> [initial(type.name)]
 <BR><b>Number of stages:</b> [initial(type.max_stages)]
 <BR><b>Spread:</b> [initial(type.spread_text)] Transmission
 <BR><b>Possible Cure:</b> [(initial(type.cure_text)||"none")]

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -261,7 +261,7 @@
 				var/href_type = text2path(href_list["vir"])
 				var/datum/disease/type = href_type
 				src.temp = {"<b>Name:</b> [initial(type.name)]
-<BR><b>Number of stages:</b> [type.max_stages)]
+<BR><b>Number of stages:</b> [initial(type.max_stages))]
 <BR><b>Spread:</b> [initial(type.spread_text)] Transmission
 <BR><b>Possible Cure:</b> [(initial(type.cure_text)||"none")]
 <BR>

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -258,7 +258,7 @@
 				src.active2 = null
 
 			else if(href_list["vir"])
-				var/datum/disease/type = href_list["vir"]
+				var/datum/disease/type = text2path(href_list["vir"])
 				var/AfS = ""
 				for(var/mob/M in initial(type.viable_mobtypes))
 					AfS += " [initial(M.name)];"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -260,14 +260,10 @@
 			else if(href_list["vir"])
 				var/href_type = text2path(href_list["vir"])
 				var/datum/disease/type = href_type
-				var/AfS = ""
-				for(var/mob/M as() in initial(type.viable_mobtypes))
-					AfS += " [initial(M.name)];"
 				src.temp = {"<b>Name:</b> [initial(type.name)]
-<BR><b>Number of stages:</b> [initial(type.max_stages)]
+<BR><b>Number of stages:</b> [type.max_stages)]
 <BR><b>Spread:</b> [initial(type.spread_text)] Transmission
 <BR><b>Possible Cure:</b> [(initial(type.cure_text)||"none")]
-<BR><b>Affected Lifeforms:</b>[AfS]
 <BR>
 <BR><b>Notes:</b> [initial(type.desc)]
 <BR>

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -259,8 +259,9 @@
 
 			else if(href_list["vir"])
 				var/href_type = text2path(href_list["vir"])
-				var/datum/disease/type = href_type
-				src.temp = {"<b>Name:</b> [initial(type.name)]
+				if(ispath(href_type, /datum/disease))
+					  var/datum/disease/type = href_type
+					  src.temp = {"<b>Name:</b> [initial(type.name)]
 <BR><b>Number of stages:</b> [initial(type.max_stages)]
 <BR><b>Spread:</b> [initial(type.spread_text)] Transmission
 <BR><b>Possible Cure:</b> [(initial(type.cure_text)||"none")]

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -258,9 +258,10 @@
 				src.active2 = null
 
 			else if(href_list["vir"])
-				var/datum/disease/type = text2path(href_list["vir"])
+				var/href_type = text2path(href_list["vir"])
+				var/datum/disease/type = href_type
 				var/AfS = ""
-				for(var/mob/M in initial(type.viable_mobtypes))
+				for(var/mob/M as() in initial(type.viable_mobtypes))
 					AfS += " [initial(M.name)];"
 				src.temp = {"<b>Name:</b> [initial(type.name)]
 <BR><b>Number of stages:</b> [initial(type.max_stages)]

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -258,20 +258,19 @@
 				src.active2 = null
 
 			else if(href_list["vir"])
-				var/type = href_list["vir"]
-				var/datum/disease/Dis = new type(0)
+				var/datum/disease/type = href_list["vir"]
 				var/AfS = ""
-				for(var/mob/M in Dis.viable_mobtypes)
+				for(var/mob/M in initial(type.viable_mobtypes))
 					AfS += " [initial(M.name)];"
-				src.temp = {"<b>Name:</b> [Dis.name]
-<BR><b>Number of stages:</b> [Dis.max_stages]
-<BR><b>Spread:</b> [Dis.spread_text] Transmission
-<BR><b>Possible Cure:</b> [(Dis.cure_text||"none")]
+				src.temp = {"<b>Name:</b> [initial(type.name)]
+<BR><b>Number of stages:</b> [initial(type.max_stages)]
+<BR><b>Spread:</b> [initial(type.spread_text)] Transmission
+<BR><b>Possible Cure:</b> [(initial(type.cure_text)||"none")]
 <BR><b>Affected Lifeforms:</b>[AfS]
 <BR>
-<BR><b>Notes:</b> [Dis.desc]
+<BR><b>Notes:</b> [initial(type.desc)]
 <BR>
-<BR><b>Danger:</b> [Dis.danger]"}
+<BR><b>Danger:</b> [initial(type.danger)]"}
 
 			else if(href_list["del_all"])
 				src.temp = "Are you sure you wish to delete all records?<br>\n\t<A href='?src=[REF(src)];temp=1;del_all2=1'>Yes</A><br>\n\t<A href='?src=[REF(src)];temp=1'>No</A><br>"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -261,7 +261,7 @@
 				var/href_type = text2path(href_list["vir"])
 				var/datum/disease/type = href_type
 				src.temp = {"<b>Name:</b> [initial(type.name)]
-<BR><b>Number of stages:</b> [initial(type.max_stages))]
+<BR><b>Number of stages:</b> [initial(type.max_stages)]
 <BR><b>Spread:</b> [initial(type.spread_text)] Transmission
 <BR><b>Possible Cure:</b> [(initial(type.cure_text)||"none")]
 <BR>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I can't actually test the code because CBT randomly stopped working and no longer tells me why its failing

Patches a href exploit that allows you to spawn anything in the game in nullspace.
When I say anything, I mean anything (Not just atom types but datums too).

While in theory it should be harmless, many items have behaviours on New() or Initialize() and there are things that teleport themselves out of nullspace (Nuke disks, blob cores, floor cluwnes).

God knows what happens if you make a new /world or master controller

## Why It's Good For The Game

I don't want to be that person that writes 'isn't it obvious' in the why its good for the game box, but seriously isn't it obvious why players shouldn't be able to spawn more than what the admins can spawn.

## Changelog
:cl:
fix: Fixes an exploit allowing you to spawn whatever you want.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
