### PR TITLE
fixes ai beeing able to see overhead chat trough static

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -309,7 +309,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		//Dont create the overhead radio chat if we heard the speaker speak
 		if(get_dist(get_turf(v.source), get_turf(src)) <= 1)
 			return CHATMESSAGE_CANNOT_HEAR
-		//The AI shouldn't be able to see the overhead chat trough  the static
+		//The AI shouldn't be able to see the overhead chat trough the static
 		if(isAI(src) && !GLOB.cameranet.checkCameraVis(v.source))
 			return CHATMESSAGE_CANNOT_HEAR
 	var/datum/language/language_instance = GLOB.language_datum_instances[message_language]

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -309,6 +309,9 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		//Dont create the overhead radio chat if we heard the speaker speak
 		if(get_dist(get_turf(v.source), get_turf(src)) <= 1)
 			return CHATMESSAGE_CANNOT_HEAR
+		//The AI shouldn't be able to see the overhead chat trough  the static
+		if(isAI(src) && !GLOB.cameranet.checkCameraVis(v.source))
+			return CHATMESSAGE_CANNOT_HEAR
 	var/datum/language/language_instance = GLOB.language_datum_instances[message_language]
 	if(language_instance?.display_icon(src))
 		return CHATMESSAGE_SHOW_LANGUAGE_ICON


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For quite some time the ai could see the location of a speaker even if said speaker was in a area without cameras if they said something over coms cause then the AI would see their overhead chat suddenly popping up in said area even trough the ai should not be able to get any information from said area cause it is in static. This PR adds an extra check that will check if the ai can actually see the speaker in question trough its cameras if not the overhead  chat will not appear.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes ai beeing able to see overhead chat trough static

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
