### PR TITLE
Moves beecoin shop purchases from savefiles to the DB

### DIFF
--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -568,6 +568,14 @@ CREATE TABLE `achievement_metadata` (
 	PRIMARY KEY (`achievement_key`)
 ) ENGINE=InnoDB;
 
+DROP TABLE IF EXISTS `metacoin_item_purchases`;
+CREATE TABLE IF NOT EXISTS `metacoin_item_purchases` (
+	`ckey` varchar(32) NOT NULL,
+	`purchase_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+	`item_id` varchar(50) NOT NULL,
+	`amount` tinyint(4) unsigned NOT NULL,
+	PRIMARY KEY (`ckey`,`item_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
 /*!40014 SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS IS NULL, 1, @OLD_FOREIGN_KEY_CHECKS) */;

--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -569,7 +569,7 @@ CREATE TABLE `achievement_metadata` (
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS `SS13_metacoin_item_purchases`;
-CREATE TABLE IF NOT EXISTS `metacoin_item_purchases` (
+CREATE TABLE IF NOT EXISTS `SS13_metacoin_item_purchases` (
 	`ckey` varchar(32) NOT NULL,
 	`purchase_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
 	`item_id` varchar(50) NOT NULL,

--- a/SQL/beestation_schema.sql
+++ b/SQL/beestation_schema.sql
@@ -568,7 +568,7 @@ CREATE TABLE `achievement_metadata` (
 	PRIMARY KEY (`achievement_key`)
 ) ENGINE=InnoDB;
 
-DROP TABLE IF EXISTS `metacoin_item_purchases`;
+DROP TABLE IF EXISTS `SS13_metacoin_item_purchases`;
 CREATE TABLE IF NOT EXISTS `metacoin_item_purchases` (
 	`ckey` varchar(32) NOT NULL,
 	`purchase_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -12,7 +12,7 @@ In any query remember to add a prefix to the table names if you use one.
 Version 5.10, 13 December 2021 by ike709
 Moved the beecoin shop to the DB. Check tools/DatabaseMigrations for the migration script.
 
-CREATE TABLE IF NOT EXISTS `metacoin_item_purchases` (
+CREATE TABLE IF NOT EXISTS `SS13_metacoin_item_purchases` (
 	`ckey` varchar(32) NOT NULL,
 	`purchase_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
 	`item_id` varchar(50) NOT NULL,

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -16,9 +16,8 @@ CREATE TABLE IF NOT EXISTS `metacoin_item_purchases` (
 	`ckey` varchar(32) NOT NULL,
 	`purchase_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
 	`item_id` varchar(50) NOT NULL,
-	`amount` tinyint(4) NOT NULL,
-	PRIMARY KEY (`ckey`,`item_id`),
-	CONSTRAINT `positive_amounts` CHECK (`amount` >= 0)
+	`amount` tinyint(4) unsigned NOT NULL,
+	PRIMARY KEY (`ckey`,`item_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 Version 5.9, 5 October 2019 by Anturke, ported 1 October 2021 by Ivniinvi

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,14 +1,24 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.9; The query to update the schema revision table is:
+The latest database version is 5.10; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 9);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 10);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 9);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 10);
 
 In any query remember to add a prefix to the table names if you use one.
 
 -----------------------------------------------------
+Version 5.10, 13 December 2021 by ike709
+Moved the beecoin shop to the DB. Check tools/DatabaseMigrations for the migration script.
+
+CREATE TABLE IF NOT EXISTS `metacoin_item_purchases` (
+	`ckey` varchar(32) NOT NULL,
+	`purchase_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+	`item_id` varchar(50) NOT NULL,
+	`amount` tinyint(4) NOT NULL,
+	CONSTRAINT `positive_amounts` CHECK (`amount` >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 Version 5.9, 5 October 2019 by Anturke, ported 1 October 2021 by Ivniinvi
 Added achievements table.

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS `metacoin_item_purchases` (
 	`purchase_date` datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
 	`item_id` varchar(50) NOT NULL,
 	`amount` tinyint(4) NOT NULL,
+	PRIMARY KEY (`ckey`,`item_id`),
 	CONSTRAINT `positive_amounts` CHECK (`amount` >= 0)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
   *
   * make sure you add an update to the schema_version stable in the db changelog
   */
-#define DB_MINOR_VERSION 9
+#define DB_MINOR_VERSION 10
 
 
 //! ## Timing subsystem

--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -63,6 +63,8 @@
 
 ///Unlocks an achievement of a specific type.
 /datum/achievement_data/proc/unlock(achievement_type, mob/user)
+	if(IsAdminAdvancedProcCall())
+		return
 	var/datum/award/A = SSachievements.awards[achievement_type]
 	get_data(achievement_type) //Get the current status first if necessary
 	if(istype(A, /datum/award/achievement) && !data[achievement_type])

--- a/code/modules/client/antag_tokens.dm
+++ b/code/modules/client/antag_tokens.dm
@@ -1,7 +1,9 @@
 /client/proc/get_antag_token_count()
+	if(!SSdbcore.IsConnected())
+		return
 	var/datum/DBQuery/query_get_antag_tokens = SSdbcore.NewQuery(
 		"SELECT antag_tokens FROM [format_table_name("player")] WHERE ckey = :ckey",
-		list("ckey" = ckey)	
+		list("ckey" = ckey)
 	)
 	var/token_count = 0
 	if(!query_get_antag_tokens.warn_execute())
@@ -16,6 +18,8 @@
 	return text2num(token_count)
 
 /client/proc/set_antag_token_count(token_count)
+	if(IsAdminAdvancedProcCall() || !SSdbcore.IsConnected())
+		return
 	var/datum/DBQuery/query_set_antag_tokens = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET antag_tokens = :token_count WHERE ckey = :ckey",
 		list("token_count" = token_count, "ckey" = ckey)
@@ -26,9 +30,11 @@
 	qdel(query_set_antag_tokens)
 
 /client/proc/inc_antag_token_count(token_count)
+	if(IsAdminAdvancedProcCall() || !SSdbcore.IsConnected())
+		return
 	var/datum/DBQuery/query_inc_antag_tokens = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET antag_tokens = antag_tokens + :token_count WHERE ckey = :ckey",
-		list("token_count" = token_count, "ckey" = ckey)	
+		list("token_count" = token_count, "ckey" = ckey)
 	)
 	if(!query_inc_antag_tokens.warn_execute())
 		qdel(query_inc_antag_tokens)

--- a/code/modules/client/antag_tokens.dm
+++ b/code/modules/client/antag_tokens.dm
@@ -18,7 +18,7 @@
 	return text2num(token_count)
 
 /client/proc/set_antag_token_count(token_count)
-	if(IsAdminAdvancedProcCall() || !SSdbcore.IsConnected())
+	if(!SSdbcore.IsConnected())
 		return
 	var/datum/DBQuery/query_set_antag_tokens = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET antag_tokens = :token_count WHERE ckey = :ckey",
@@ -30,7 +30,7 @@
 	qdel(query_set_antag_tokens)
 
 /client/proc/inc_antag_token_count(token_count)
-	if(IsAdminAdvancedProcCall() || !SSdbcore.IsConnected())
+	if(!SSdbcore.IsConnected())
 		return
 	var/datum/DBQuery/query_inc_antag_tokens = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET antag_tokens = antag_tokens + :token_count WHERE ckey = :ckey",

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -119,3 +119,6 @@
 
 	//Tick when ghost roles are useable again
 	var/next_ghost_role_tick = 0
+
+	// Metacoin balance, cached to reduce DB queries. Do not directly read or modify this value.
+	var/metacoin_balance

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -977,6 +977,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if (NAMEOF(src, view))
 			view_size.setDefault(var_value)
 			return TRUE
+		if (NAMEOF(src, metacoin_balance))
+			return FALSE
 	. = ..()
 
 /client/proc/rescale_view(change, min, max)
@@ -1103,4 +1105,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		SSambience.ambience_listening_clients -= src
 
 /client/proc/give_award(achievement_type, mob/user)
+	if(IsAdminAdvancedProcCall())
+		return
 	return	player_details.achievements.unlock(achievement_type, user)

--- a/code/modules/client/loadout/loadout.dm
+++ b/code/modules/client/loadout/loadout.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_EMPTY(gear_datums)
 
 /datum/gear/proc/purchase(var/client/C) //Called when the gear is first purchased
 	SHOULD_CALL_PARENT(TRUE)
-	if(IsAdminAdvancedProcCall() || !SSdbcore.IsConnected())
+	if(!SSdbcore.IsConnected())
 		return
 	if(!C)
 		return

--- a/code/modules/client/loadout/loadout_ooc.dm
+++ b/code/modules/client/loadout/loadout_ooc.dm
@@ -10,6 +10,7 @@
 
 /datum/gear/ooc/char_slot/purchase(var/client/C)
 	C?.prefs?.max_save_slots += 1
+	..()
 
 /datum/gear/ooc/real_antagtoken
 	display_name = "antag token"
@@ -20,3 +21,4 @@
 	C.inc_antag_token_count(1)
 	message_admins("[C.ckey] has purchased a genuine antag token.")
 	log_game("[C.ckey] has purchased a genuine antag token.")
+	..()

--- a/code/modules/client/loadout/loadout_ooc.dm
+++ b/code/modules/client/loadout/loadout_ooc.dm
@@ -9,8 +9,9 @@
 	cost = 10000
 
 /datum/gear/ooc/char_slot/purchase(var/client/C)
-	C?.prefs?.max_save_slots += 1
-	..()
+	. = ..()
+	if(.)
+		C?.prefs?.max_save_slots += 1
 
 /datum/gear/ooc/real_antagtoken
 	display_name = "antag token"
@@ -18,7 +19,8 @@
 	cost = 100000
 
 /datum/gear/ooc/real_antagtoken/purchase(var/client/C)
-	C.inc_antag_token_count(1)
-	message_admins("[C.ckey] has purchased a genuine antag token.")
-	log_game("[C.ckey] has purchased a genuine antag token.")
-	..()
+	. = ..()
+	if(.)
+		C.inc_antag_token_count(1)
+		message_admins("[C.ckey] has purchased a genuine antag token.")
+		log_game("[C.ckey] has purchased a genuine antag token.")

--- a/code/modules/client/loadout/loadout_ooc.dm
+++ b/code/modules/client/loadout/loadout_ooc.dm
@@ -8,7 +8,7 @@
 	description = "An extra charslot. Pretty self-explanatory."
 	cost = 10000
 
-/datum/gear/ooc/char_slot/purchase(var/client/C)
+/datum/gear/ooc/char_slot/purchase(var/client/C, donor = FALSE)
 	. = ..()
 	if(.)
 		C?.prefs?.max_save_slots += 1
@@ -18,7 +18,7 @@
 	description = "If you can afford it, you deserve it."
 	cost = 100000
 
-/datum/gear/ooc/real_antagtoken/purchase(var/client/C)
+/datum/gear/ooc/real_antagtoken/purchase(var/client/C, donor = FALSE)
 	. = ..()
 	if(.)
 		C.inc_antag_token_count(1)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -714,7 +714,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				dat += "<tr style='vertical-align:top;'><td width=15%>[G.display_name]\n"
 				var/donator = G.sort_category == "Donator" // purchase box and cost coloumns doesn't appear on donator items
-				if(G.id in purchased_gear)
+				if(purchased_gear?[G.id] >= 1)
 					if(G.sort_category == "OOC")
 						dat += "<i>Purchased.</i></td>"
 					else
@@ -1228,7 +1228,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(href_list["preference"] == "gear")
 		if(href_list["purchase_gear"])
 			var/datum/gear/TG = GLOB.gear_datums[href_list["purchase_gear"]]
-			if(purchased_gear[TG.id] > TG.max_purchases)
+			if(purchased_gear[TG.id] >= TG.max_purchases)
 				to_chat(user, "<span class='warning'>You can't purchase this gear again!</span>")
 				return
 			if(TG.sort_category == "Donator")
@@ -1253,7 +1253,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							type_blacklist += G.subtype_path
 						if(!(G.slot in slot_blacklist))
 							slot_blacklist += G.slot
-				if((TG.id in purchased_gear))
+				if(purchased_gear?[TG.id] >= 1)
 					if(!(TG.subtype_path in type_blacklist) || !(TG.slot in slot_blacklist))
 						equipped_gear += TG.id
 					else
@@ -2036,14 +2036,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(IS_PATRON(parent.ckey) || (parent in GLOB.admins))
 		for(var/gear_id in DLC.gear)
 			var/datum/gear/AG = DLC.gear[gear_id]
-			if(AG.id in purchased_gear)
+			if(purchased_gear?[AG.id] >= 1)
 				continue
-			purchased_gear += AG.id
+			purchased_gear[AG.id] = 1
 			AG.purchase(parent)
 		save_preferences()
 	else if(purchased_gear.len || equipped_gear.len)
 		for(var/gear_id in DLC.gear)
 			var/datum/gear/RG = DLC.gear[gear_id]
 			equipped_gear -= RG.id
-			purchased_gear -= RG.id
+			purchased_gear[RG.id] -= 1
 		save_preferences()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2040,10 +2040,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				continue
 			purchased_gear[AG.id] = 1
 			AG.purchase(parent)
-		save_preferences()
 	else if(purchased_gear.len || equipped_gear.len)
 		for(var/gear_id in DLC.gear)
 			var/datum/gear/RG = DLC.gear[gear_id]
 			equipped_gear -= RG.id
 			purchased_gear[RG.id] = 0
-		save_preferences()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -141,13 +141,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(istype(C))
 		if(!IsGuestKey(C.key))
 			load_path(C.ckey)
+			load_gear(C.ckey)
 			unlock_content = C.IsByondMember()
 			if(unlock_content)
 				max_save_slots = 8
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
-		if("6030fe461e610e2be3a2c3e75c06067e" in purchased_gear) //MD5 hash of, "extra character slot"
-			max_save_slots += 1
+		if(purchased_gear?["6030fe461e610e2be3a2c3e75c06067e"]) //MD5 hash of, "extra character slot"
+			max_save_slots += purchased_gear["6030fe461e610e2be3a2c3e75c06067e"]
 		if(load_character())
 			return
 	//we couldn't load character data so just randomize the character appearance + name
@@ -1227,14 +1228,15 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(href_list["preference"] == "gear")
 		if(href_list["purchase_gear"])
 			var/datum/gear/TG = GLOB.gear_datums[href_list["purchase_gear"]]
+			if(purchased_gear[TG.id] > TG.max_purchases)
+				to_chat(user, "<span class='warning'>You can't purchase this gear again!</span>")
+				return
 			if(TG.sort_category == "Donator")
 				if(CONFIG_GET(flag/donator_items) && alert(parent, "This item is only accessible to our patrons. Would you like to subscribe?", "Patron Locked", "Yes", "No") == "Yes")
 					parent.donate()
-			else if(TG.cost < user.client.get_metabalance())
-				purchased_gear += TG.id
+			else if(TG.cost <= user.client.get_metabalance())
 				TG.purchase(user.client)
 				user.client.inc_metabalance((TG.cost * -1), TRUE, "Purchased [TG.display_name].")
-				save_preferences()
 			else
 				to_chat(user, "<span class='warning'>You don't have enough [CONFIG_GET(string/metacurrency_name)]s to purchase \the [TG.display_name]!</span>")
 		if(href_list["toggle_gear"])

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1235,8 +1235,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if(CONFIG_GET(flag/donator_items) && alert(parent, "This item is only accessible to our patrons. Would you like to subscribe?", "Patron Locked", "Yes", "No") == "Yes")
 					parent.donate()
 			else if(TG.cost <= user.client.get_metabalance())
-				TG.purchase(user.client)
-				user.client.inc_metabalance((TG.cost * -1), TRUE, "Purchased [TG.display_name].")
+				if(TG.purchase(user.client))
+					user.client.inc_metabalance((TG.cost * -1), TRUE, "Purchased [TG.display_name].")
 			else
 				to_chat(user, "<span class='warning'>You don't have enough [CONFIG_GET(string/metacurrency_name)]s to purchase \the [TG.display_name]!</span>")
 		if(href_list["toggle_gear"])
@@ -2039,7 +2039,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(purchased_gear?[AG.id] >= 1)
 				continue
 			purchased_gear[AG.id] = 1
-			AG.purchase(parent)
+			if(!AG.purchase(parent, donor = TRUE))
+				purchased_gear[AG.id] = 0
 	else if(purchased_gear.len || equipped_gear.len)
 		for(var/gear_id in DLC.gear)
 			var/datum/gear/RG = DLC.gear[gear_id]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2045,5 +2045,5 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		for(var/gear_id in DLC.gear)
 			var/datum/gear/RG = DLC.gear[gear_id]
 			equipped_gear -= RG.id
-			purchased_gear[RG.id] -= 1
+			purchased_gear[RG.id] = 0
 		save_preferences()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	35
+#define SAVEFILE_VERSION_MAX	36
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -55,6 +55,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		S.dir.Remove("overhead_chat")
 	if(current_version < 35)
 		see_balloon_alerts = BALLOON_ALERT_ALWAYS
+	if(current_version < 36)
+		S.dir.Remove("purchased_gear")
 	return
 
 /datum/preferences/proc/update_character(current_version, savefile/S)

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -37,8 +37,6 @@
 	return metacoin_balance
 
 /client/proc/set_metacoin_count(mc_count, ann=TRUE)
-	if(IsAdminAdvancedProcCall())
-		return
 	var/datum/DBQuery/query_set_metacoins = SSdbcore.NewQuery(
 		"UPDATE [format_table_name("player")] SET metacoins = :mc_count WHERE ckey = :ckey",
 		list("mc_count" = mc_count, "ckey" = ckey)
@@ -50,8 +48,6 @@
 		to_chat(src, "<span class='rose bold'>Your new metacoin balance is [mc_count]!</span>")
 
 /client/proc/inc_metabalance(mc_count, ann=TRUE, reason=null)
-	if(IsAdminAdvancedProcCall())
-		return
 	if(mc_count >= 0 && !CONFIG_GET(flag/grant_metacurrency))
 		return
 	var/datum/DBQuery/query_inc_metacoins = SSdbcore.NewQuery(

--- a/tools/DatabaseMigrations/MetacoinShopMigrator.dm
+++ b/tools/DatabaseMigrations/MetacoinShopMigrator.dm
@@ -1,0 +1,64 @@
+
+//Migration script generation
+//Fire to generate shop_migration.sql script to use.
+
+/mob/verb/generate_metacoin_shop_migration_script()
+	set name = "Generate Metacoin Shop Migration Script"
+
+	var/ach = "metacoin_item_purchases" //IMPORTANT : ADD PREFIX HERE IF YOU'RE USING PREFIXED SCHEMA
+
+	var/outfile = file("shop_migration.sql")
+	fdel(outfile)
+	outfile << "BEGIN;"
+
+	var/path = "data/player_saves/"
+	var/list/ckeys = list()
+	var/list/ckey_prefpath = list()
+	var/list/directory flist(path)
+	for(var/subdir in directory)
+		var/list/subdirs = flist("data/player_saves/[subdir]")
+		for(var/player in subdirs)
+			var/key = player.copytext(player, 1, length(player))
+			var/fullpath = "data/player_saves/[subdir][player]preferences.sav"
+			if(!fexists(fullpath))
+				world.log << "Failed to find [fullpath] for [key]"
+				continue
+			ckeys += key
+			ckey_prefpath[key] = fullpath
+
+	var/skipped_keys = 0
+	var/i = 0
+	for(var/key in ckeys)
+		var/savefile/S = new /savefile(ckey_prefpath[key])
+		if(!S)
+			world.log << "Failed to load savefile for [key]"
+			skipped_keys += 1
+			continue
+		S.cd = "/"
+		var/savefile_version
+		S["version"] >> savefile_version
+		if(savefile_version < 32)
+			world.log << "Skipping [key] because savefile version is too old"
+			skipped_keys += 1
+			continue
+		var/list/purchased_gear = list()
+		S["purchased_gear"] >> purchased_gear
+		if(!length(purchased_gear))
+			world.log << "Skipping [key] because no purchased gear"
+			i++
+			continue
+
+		var/list/values = list()
+		for(var/gear in purchased_gear)
+			values += "('[ckey(key)]','[gear]',1)"
+		if(length(values))
+			var/list/keyline = list("INSERT INTO [ach](ckey,item_id,amount) VALUES")
+			keyline += values.Join(",")
+			keyline += ";"
+			outfile << keyline.Join()
+			i++
+		else
+			skipped_ckeys += 1
+	outfile << "END"
+
+	world.log << "Converted [i]/[length(ckeys)] keys successfully, failed to convert [skipped_ckeys] keys"

--- a/tools/DatabaseMigrations/MetacoinShopMigrator.dm
+++ b/tools/DatabaseMigrations/MetacoinShopMigrator.dm
@@ -33,14 +33,14 @@
 		var/savefile/S = new /savefile(ckey_prefpath[key])
 		if(!S)
 			world.log << "Failed to load savefile for [key]"
-			skipped_noload += 1
+			skipped_noload++
 			continue
 		S.cd = "/"
 		var/savefile_version
 		S["version"] >> savefile_version
 		if(savefile_version < 32)
 			world.log << "Skipping [key] because savefile version is too old ([savefile_version], expected 32 or greater)"
-			skipped_nogear += 1
+			skipped_old += 1
 			continue
 		var/list/purchased_gear = list()
 		S["purchased_gear"] >> purchased_gear
@@ -59,7 +59,7 @@
 			outfile << keyline.Join()
 			passed++
 		else
-			skipped_nogear += 1
+			skipped_nogear++
 	outfile << "END"
 
 	world.log << "Converted [passed] of [length(ckeys)] keys successfully, failed to load [skipped_noload] keys, skipped [skipped_old] due to being too old, skipped [skipped_nogear] due to having no gear."

--- a/tools/DatabaseMigrations/MetacoinShopMigrator.dme
+++ b/tools/DatabaseMigrations/MetacoinShopMigrator.dme
@@ -1,0 +1,18 @@
+// DM Environment file for MetacoinShopMigrator.dm.
+// All manual changes should be made outside the BEGIN_ and END_ blocks.
+// New source code should be placed in .dm files: choose File/New --> Code File.
+
+// BEGIN_INTERNALS
+// END_INTERNALS
+
+// BEGIN_FILE_DIR
+#define FILE_DIR .
+// END_FILE_DIR
+
+// BEGIN_PREFERENCES
+#define DEBUG
+// END_PREFERENCES
+
+// BEGIN_INCLUDE
+#include "MetacoinShopMigrator.dm"
+// END_INCLUDE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Step one of nuking savefiles is moving the beecoin shop entirely to the DB. I also sprinkled around a bunch of admin proccall checks in various places and also laid some of the groundwork for items that can be purchased multiple times.

DNM draft PR until this is thoroughly tested. At the moment it's completely untested.

Credit to whoever wrote the achievement migrator because I ripped bits of that for the gear migrator.

## Changelog
:cl:
server: Moved shop purchases from savefiles to the database. Players should notice no difference unless their savefile hasn't been loaded in over a year, in which case their purchases have been reset.
refactor: Laid the groundwork for shop items being purchasable multiple times.
refactor: Reduced DB calls related to beecoins by caching a client's balance.
fix: Fixed not being able to buy gear that you have exactly enough beecoins to purchase.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
