### PR TITLE
 fixes excessive disease mutation

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -87,7 +87,9 @@
 			continue
 		if(dormant || P.dormant)//dormant diseases dont interfere with channels, not even with other dormant diseases if you manage to get two
 			continue
-		if((IsSame(P) || channel == otherchannel) && !P.sentient)
+		if(IsSame(P))
+			continue
+		if(channel == otherchannel && !P.sentient)
 			advance_diseases += P
 	var/replace_num = advance_diseases.len + 1 - DISEASE_LIMIT //amount of diseases that need to be removed to fit this one
 	if(replace_num > 0)


### PR DESCRIPTION

## About The Pull Request
a diseases new strains no longer override each other

## Why It's Good For The Game
having diseases change cure whenever you step on blood or use a used syringe is stupid. technically an oversight on my dumbass part

## Changelog
:cl:
fix: tones down disease mutation. you'll now only get one strain of a virus if it mutates. Remember, even if cures change, vaccines stay the same!
/:cl:
