### PR TITLE
Adds config option to blacklist Exploration Crew from antagonist & antagonist objectives.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -143,6 +143,8 @@
 
 /datum/config_entry/flag/protect_heads_from_antagonist	//If heads can be traitor/cult/other
 
+/datum/config_entry/flag/protect_exploration_from_antagonist //If exploration crew can be antagonists or antagonist targets
+
 /datum/config_entry/flag/enforce_human_authority	//If non-human species are barred from joining as a head of staff
 
 /datum/config_entry/flag/allow_latejoin_antagonists	// If late-joining players can be traitor/changeling

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -89,6 +89,7 @@
 	msg += "Protect Authority Roles From Traitor: [CONFIG_GET(flag/protect_roles_from_antagonist)]"
 	msg += "Protect Assistant Role From Traitor: [CONFIG_GET(flag/protect_assistant_from_antagonist)]"
 	msg += "Protect Command Roles From Traitor: [CONFIG_GET(flag/protect_heads_from_antagonist)]"
+	msg += "Protect Exploration From Traitor: [CONFIG_GET(flag/protect_exploration_from_antagonist)]"
 	msg += "Enforce Human Authority: [CONFIG_GET(flag/enforce_human_authority)]"
 	msg += "Allow Latejoin Antagonists: [CONFIG_GET(flag/allow_latejoin_antagonists)]"
 	msg += "Enforce Continuous Rounds: [length(CONFIG_GET(keyed_list/continuous))] of [config.modes.len] roundtypes"

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -89,7 +89,7 @@
 	msg += "Protect Authority Roles From Traitor: [CONFIG_GET(flag/protect_roles_from_antagonist)]"
 	msg += "Protect Assistant Role From Traitor: [CONFIG_GET(flag/protect_assistant_from_antagonist)]"
 	msg += "Protect Command Roles From Traitor: [CONFIG_GET(flag/protect_heads_from_antagonist)]"
-	msg += "Protect Exploration From Traitor: [CONFIG_GET(flag/protect_exploration_from_antagonist)]"
+	msg += "Protect Exploration From Traitor & Objectives: [CONFIG_GET(flag/protect_exploration_from_antagonist)]"
 	msg += "Enforce Human Authority: [CONFIG_GET(flag/enforce_human_authority)]"
 	msg += "Allow Latejoin Antagonists: [CONFIG_GET(flag/allow_latejoin_antagonists)]"
 	msg += "Enforce Continuous Rounds: [length(CONFIG_GET(keyed_list/continuous))] of [config.modes.len] roundtypes"

--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -26,6 +26,8 @@
 		restricted_jobs += "Assistant"
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
 
 	var/list/datum/mind/possible_brothers = get_players_for_role(ROLE_BROTHER)
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -40,6 +40,9 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
+
 	var/num_changelings = 1
 
 	var/csc = CONFIG_GET(number/changeling_scaling_coeff)

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -37,6 +37,9 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
+
 	var/list/datum/mind/possible_changelings = get_players_for_role(ROLE_CHANGELING)
 
 	var/num_changelings = 1

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -73,6 +73,9 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
+
 	//cult scaling goes here
 	recommended_enemies = 1 + round(num_players()/CULT_SCALING_COEFFICIENT)
 	var/remaining = (num_players() % CULT_SCALING_COEFFICIENT) * 10 //Basically the % of how close the population is toward adding another cultis

--- a/code/game/gamemodes/devil/devil_game_mode.dm
+++ b/code/game/gamemodes/devil/devil_game_mode.dm
@@ -30,6 +30,8 @@
 		restricted_jobs += "Assistant"
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
 
 	var/num_devils = 1
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -738,6 +738,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		ruleset.restricted_roles |= "Assistant"
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		ruleset.restricted_roles |= GLOB.command_positions
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs |= "Exploration Crew"
 
 /// Refund threat, but no more than threat_level.
 /datum/game_mode/dynamic/proc/refund_threat(regain)

--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -34,6 +34,8 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
 
 	var/esc = CONFIG_GET(number/ecult_scaling_coeff)
 	if(esc)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -268,6 +268,8 @@
 		replacementmode.restricted_jobs += "Assistant"
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		replacementmode.restricted_jobs += GLOB.command_positions
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		replacementmode.restricted_jobs += "Exploration Crew"
 
 	message_admins("The roundtype will be converted. If you have other plans for the station or feel the station is too messed up to inhabit <A HREF='?_src_=holder;[HrefToken()];toggle_midround_antag=[REF(usr)]'>stop the creation of antags</A> or <A HREF='?_src_=holder;[HrefToken()];end_round=[REF(usr)]'>end the round now</A>.")
 	log_game("Roundtype converted to [replacementmode.name]")

--- a/code/game/gamemodes/hivemind/hivemind.dm
+++ b/code/game/gamemodes/hivemind/hivemind.dm
@@ -80,6 +80,9 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
+
 	var/num_hosts = max( 1 , rand(0,1) + min(8, round(num_players() / 8) ) ) //1 host for every 8 players up to 64, with a 50% chance of an extra
 
 	for(var/j = 0, j < num_hosts, j++)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -171,7 +171,11 @@ GLOBAL_LIST_EMPTY(objectives)
 	update_explanation_text()
 	return target
 
-/datum/objective/proc/is_valid_target(possible_target)
+/datum/objective/proc/is_valid_target(var/datum/mind/possible_target)
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		if(possible_target.assigned_role == "Exploration Crew")
+			return FALSE
+
 	return TRUE
 
 /datum/objective/proc/find_target_by_role(role, role_type=FALSE,invert=FALSE)//Option sets either to check assigned role or special role. Default to assigned., invert inverts the check, eg: "Don't choose a Ling"
@@ -491,8 +495,12 @@ GLOBAL_LIST_EMPTY(objectives)
 	target = ..()
 	update_explanation_text()
 
-/datum/objective/escape/escape_with_identity/is_valid_target(possible_target)
+/datum/objective/escape/escape_with_identity/is_valid_target(var/datum/mind/possible_target)
 	var/list/datum/mind/owners = get_owners()
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		if(possible_target.assigned_role == "Exploration Crew")
+			return FALSE
+
 	for(var/datum/mind/M in owners)
 		if(!M)
 			continue

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -44,6 +44,9 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
+
 	var/num_traitors = 1
 
 	var/tsc = CONFIG_GET(number/traitor_scaling_coeff)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -55,6 +55,9 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		temp.restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		temp.restricted_jobs += "Exploration Crew"
+
 	var/list/mob/living/carbon/human/candidates = list()
 	var/mob/living/carbon/human/H = null
 
@@ -89,6 +92,9 @@
 
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		temp.restricted_jobs += GLOB.command_positions
+
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		temp.restricted_jobs += "Exploration Crew"
 
 	var/list/mob/living/carbon/human/candidates = list()
 	var/mob/living/carbon/human/H = null
@@ -161,6 +167,9 @@
 
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		temp.restricted_jobs += GLOB.command_positions
+
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		temp.restricted_jobs += "Exploration Crew"
 
 	var/list/mob/living/carbon/human/candidates = list()
 	var/mob/living/carbon/human/H = null

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -358,10 +358,9 @@
 	var/sacced = FALSE
 	var/sac_image
 
-/datum/objective/sacrifice/is_valid_target(possible_target)
+/datum/objective/sacrifice/is_valid_target(var/datum/mind/possible_target)
 	. = ..()
-	var/datum/mind/M = possible_target
-	if(istype(M) && isipc(M.current))
+	if(istype(possible_target) && isipc(possible_target.current))
 		return FALSE
 
 /datum/objective/sacrifice/check_completion()

--- a/code/modules/antagonists/roundstart_special/special_antagonist.dm
+++ b/code/modules/antagonists/roundstart_special/special_antagonist.dm
@@ -37,6 +37,9 @@
 	if(CONFIG_GET(flag/protect_heads_from_antagonist))
 		restricted_jobs += GLOB.command_positions
 
+	if(CONFIG_GET(flag/protect_exploration_from_antagonist))
+		restricted_jobs += "Exploration Crew"
+
 /datum/special_role/proc/add_to_pool()
 	if(spawn_mode == SPAWNTYPE_ROUNDSTART)
 		return

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -263,7 +263,7 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## Uncomment to prohibit head roles from becoming most antagonists.
 PROTECT_HEADS_FROM_ANTAGONIST
 
-## Unciomment to prohibit exploration roles from becoming antagonists or their targets.
+## Uncomment to prohibit exploration roles from becoming antagonists or their targets.
 PROTECT_EXPLORATION_FROM_ANTAGONIST
 
 ## If non-human species are barred from joining as a head of staff

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -263,6 +263,9 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## Uncomment to prohibit head roles from becoming most antagonists.
 PROTECT_HEADS_FROM_ANTAGONIST
 
+## Unciomment to prohibit exploration roles from becoming antagonists or their targets.
+PROTECT_EXPLORATION_FROM_ANTAGONIST
+
 ## If non-human species are barred from joining as a head of staff
 #ENFORCE_HUMAN_AUTHORITY
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exploration is currently basically required for the station to function properly, especially in the funds department. They hardly interact with the actual core game outside of dumping massive amounts of money onto the station, and if people want to go off and play a co-op game instead of SS13, they shouldn't really have the chance to be given antag to murder their co-op buddies who will never have the chance to play again for that round.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: Added configuration option to blacklist Exploration Crew from antagonist status and objectives.
tweak: Exploration Crew can no longer be antagonists or their target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
