### PR TITLE
pneumatic cannon nerf

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -168,6 +168,7 @@
 	var/turf/T = get_target(target, get_turf(src))
 	playsound(src, fire_sound, 50, 1)
 	fire_items(T, user)
+	user.changeNext_move(CLICK_CD_MELEE)
 	if(pressureSetting >= 3 && iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.visible_message("<span class='warning'>[C] is thrown down by the force of the cannon!</span>", "<span class='userdanger'>[src] slams into your shoulder, knocking you down!")
@@ -225,6 +226,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	maxWeightClass = 7
 	gasPerThrow = 5
+	fire_mode = PCANNON_FIFO
 
 /obj/item/pneumatic_cannon/proc/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
 	if(removing)


### PR DESCRIPTION

## About The Pull Request
instead of firing all items at once, improvised pneumatic cannons will fire a single item at once. They can still hold multiple items
pneumatic cannons now have limited fire rate (0.8 seconds)

## Why It's Good For The Game
pneumatic cannons have effective instakills. this removes that.

## Changelog
:cl:
balance: pneumatic cannons now fire one item at a time. They still hold multiple items, but their fire rate is also now limited
/:cl:

