### PR TITLE
Overlay Lighting Fixes Part 2

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -30,7 +30,7 @@
 	light_system = MOVABLE_LIGHT
 	light_range = 6
 	light_power = 1
-	light_on = TRUE
+	light_on = FALSE
 	var/twohand_force = 34
 	var/hacked = FALSE
 	var/list/possible_colors = list("red", "blue", "green", "purple")
@@ -73,7 +73,7 @@
 	w_class = w_class_on
 	hitsound = 'sound/weapons/blade1.ogg'
 	START_PROCESSING(SSobj, src)
-	set_light(TRUE)
+	set_light_on(TRUE)
 
 /// Triggered on unwield of two handed item
 /// switch hitsounds
@@ -84,7 +84,7 @@
 	w_class = initial(w_class)
 	hitsound = "swing_hit"
 	STOP_PROCESSING(SSobj, src)
-	set_light(FALSE)
+	set_light_on(FALSE)
 
 /obj/item/dualsaber/update_icon()
 	icon_state = "dualsaber0"

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -679,10 +679,16 @@
 		to_chat(src, "<span class='info'>We successfully repaired ourselves.</span>")
 
 /mob/living/simple_animal/hostile/swarmer/proc/ToggleLight()
-	if(!light_range)
-		set_light_on(TRUE)
-	else
+	if(swarmer_flags & SWARMER_LIGHT_ON)
+		swarmer_flags = ~SWARMER_LIGHT_ON
 		set_light_on(FALSE)
+		if(!mind)
+			return
+		return
+	swarmer_flags |= SWARMER_LIGHT_ON
+	set_light_on(TRUE)
+	if(!mind)
+		return
 
 /mob/living/simple_animal/hostile/swarmer/proc/swarmer_chat(msg)
 	var/rendered = "<B>Swarm communication - [src]</b> [say_quote(msg)]"

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -134,7 +134,7 @@
 		playsound(src.loc, 'sound/weapons/kenetic_reload.ogg', 60, 1)
 
 /obj/item/kinetic_crusher/ui_action_click(mob/user, actiontype)
-	light_on = !light_on
+	set_light_on(!light_on)
 	playsound(user, 'sound/weapons/empty.ogg', 100, TRUE)
 	update_icon()
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -19,6 +19,10 @@
 	head_icon = 'icons/mob/pai_item_head.dmi'
 	var/network = "ss13"
 	var/obj/machinery/camera/current = null
+	light_system = MOVABLE_LIGHT
+	light_power = 1
+	light_range = 5
+	light_on = FALSE
 
 	var/ram = 100	// Used as currency to purchase different abilities
 	var/list/software = list()
@@ -83,7 +87,7 @@
 	var/overload_bulletblock = 0	//Why is this a good idea?
 	var/overload_maxhealth = 0
 	var/silent = FALSE
-	var/brightness_power = 5
+
 
 /mob/living/silicon/pai/can_unbuckle()
 	return FALSE

--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -34,7 +34,7 @@
 	if(client)
 		client.perspective = EYE_PERSPECTIVE
 		client.eye = src
-	set_light(0)
+	set_light_on(FALSE)
 	icon_state = "[chassis]"
 	held_state = "[chassis]"
 	visible_message("<span class='boldnotice'>[src] folds out its holochassis emitter and forms a holoshell around itself!</span>")
@@ -63,7 +63,7 @@
 	forceMove(card)
 	mobility_flags = NONE
 	density = FALSE
-	set_light(0)
+	set_light_on(FALSE)
 	holoform = FALSE
 	set_resting(resting)
 
@@ -93,11 +93,11 @@
 	return FALSE
 
 /mob/living/silicon/pai/proc/toggle_integrated_light()
-	if(!light_range)
-		set_light(brightness_power)
+	if(!light_on)
+		set_light_on(TRUE)
 		to_chat(src, "<span class='notice'>You enable your integrated light.</span>")
 	else
-		set_light(0)
+		set_light_on(FALSE)
 		to_chat(src, "<span class='notice'>You disable your integrated light.</span>")
 
 /mob/living/silicon/pai/mob_try_pickup(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- [x] Fix Kinetic Crusher Light ( #5962  )
- [x] Ghosts can't see in the dark ( #5942  ) [ Explained ]
- [x] Hardsuit helmets glowing ( #5921 ) [ not going to fix that or anything relating hardsuits until #6034 is ported]
- [x] Ability to see in the dark when you have high contrast [ Explained ]
- [x] Fix swarmer light not turning back on
- [x] Fix pAI light not working correctly
- [x] desword glowing 

Fixes #5962 

## Why It's Good For The Game
Bugfixes good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed kinetic Crusher Light not working
fix: Fixed desword glowing even if not wielded
fix: Fixed swarmer lights
fix: Fixed pAI lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
