### PR TITLE
Status bar is no longer full-width - implemented clientside

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -58,6 +58,8 @@ window "mainwindow"
 		anchor2 = none
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
+		statusbar = false
+		on-status = ".winset \"[[*]] = \"\" ? status_bar.text = [[*]] status_bar.is-visible = true : status_bar.is-visible = false\""
 		icon = 'icons\\ss13_64.png'
 		macro = "default"
 		menu = "menu"
@@ -109,6 +111,17 @@ window "mapwindow"
 		is-default = true
 		saved-params = "zoom;letterbox;zoom-mode"
 		style=".center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clowntext { color: #FF69Bf !important; font-size: 9px;  font-weight: bold; } .megaphone { font-size: 9px; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; } .emote { font-size: 6px; }"
+	elem "status_bar"
+		type = LABEL
+		pos = 0,464
+		size = 280x16
+		anchor1 = 0,100
+		is-visible = false
+		text = ""
+		align = left
+		background-color = #222222
+		text-color = #ffffff
+		border = line
 
 window "infowindow"
 	elem "infowindow"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alternative implementation of https://github.com/BeeStation/BeeStation-Hornet/pull/5970
Modified port of https://github.com/tgstation/tgstation/pull/57531

When I saw the original code, I realised it could probably work without adding any code serverside. This should mitigate performance issues that were the main reason cited for closing the original PR.

The corner statusbar looks identically to the original PR's, using the same skin code for its element. However, instead of sending the text from the server, I use the `on-status` command on the window to update the `status_bar` element's text and visibility.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Same reasons as original PR - less screen space taken up, more customizable looks. In the end this is a subjective stylistic choice, and I'm ambivalent in regards to what's "better".
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: KubeRoot, Victor239, stylemistake
tweak: Status bar is no longer full-width, hides when unused and looks nicer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
