### PR TITLE
Bumps BYOND to 514.1572

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM beestation/byond:514.1571 as base
+FROM beestation/byond:514.1572 as base
 
 # Install the tools needed to compile our rust dependencies
 FROM base as rust-build

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -53,9 +53,9 @@
 
 //Update this whenever the byond version is stable so people stop updating to hilariously broken versions
 #define MAX_COMPILER_VERSION 514
-#define MAX_COMPILER_BUILD 1571
+#define MAX_COMPILER_BUILD 1572
 #if DM_VERSION > MAX_COMPILER_VERSION || DM_BUILD > MAX_COMPILER_BUILD
-#warn WARNING: Your BYOND version is over the recommended version (514.1571)! Stability is not guaranteed.
+#warn WARNING: Your BYOND version is over the recommended version (514.1572)! Stability is not guaranteed.
 #endif
 //Log the full sendmaps profile on 514.1556+, any earlier and we get bugs or it not existing
 #if DM_VERSION >= 514 && DM_BUILD >= 1556

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -4,7 +4,7 @@
 
 
 #define UPLOAD_LIMIT		10485760	//Restricts client uploads to the server to 1MB //Could probably do with being lower.
-#define MAX_RECOMMENDED_CLIENT 1571
+#define MAX_RECOMMENDED_CLIENT 1572
 
 GLOBAL_LIST_INIT(blacklisted_builds, list(
 	"1407" = "bug preventing client display overrides from working leads to clients being able to see things/mobs they shouldn't be able to see",

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=514
-export BYOND_MINOR=1571
+export BYOND_MINOR=1572
 
 #rust version
 export RUST_VERSION=1.54.0


### PR DESCRIPTION
## About The Pull Request

1572 adds a security fix and some other minor fixes.

## Changelog
:cl:
server: BYOND bumped to 514.1572
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
