### PR TITLE
Disease number tweaks

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -550,11 +550,11 @@
 	var/datum/disease/advance/A = make_copy ? Copy() : src
 	if(!initial && A.mutable && (spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS))
 		var/minimum = 1
-		if(prob(CLAMP(35-(A.resistance + A.stealth), 0, 50) * (A.mutability)))//stealthy/resistant diseases are less likely to mutate. this means diseases used to farm mutations should be easier to cure. hypothetically.
+		if(prob(CLAMP(35-(A.resistance + A.stealth - A.speed), 0, 50) * (A.mutability)))//stealthy/resistant diseases are less likely to mutate. this means diseases used to farm mutations should be easier to cure. hypothetically.
 			if(infectee.job == "clown" || infectee.job == "mime" || prob(1))//infecting a clown or mime can evolve l0 symptoms/. they can also appear very rarely
 				minimum = 0
 			else
-				minimum = CLAMP(A.severity - 3, 1, 6)
+				minimum = CLAMP(A.severity - 1, 1, 7)
 			A.Evolve(minimum, CLAMP(A.severity + 4, minimum, 9))
 			A.id = GetDiseaseID()
 			A.keepid = TRUE//this is really janky, but basically mutated diseases count as the original disease

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -26,7 +26,7 @@
 	. = ..()
 	icon_state = "[icon_state]-old" //change from the normal blood icon selected from random_icon_states in the parent's Initialize to the old dried up blood.
 	if(prob(75))
-		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(1, 4), rand(4, 9), 4)
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(1, 4), rand(7, 9), 4)
 		disease += R
 
 /obj/effect/decal/cleanable/blood/old/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -353,9 +353,9 @@
 /datum/job/proc/dormant_disease_check(mob/living/carbon/human/H)
 	var/datum/symptom/guaranteed
 	var/sickrisk = 1
-	var/unfunny = TRUE
+	var/unfunny = 4
 	if((flag == CLOWN) || (flag == MIME))
-		unfunny= FALSE
+		unfunny = 0
 	if(islizard(H) || iscatperson(H))
 		sickrisk += 0.5 //these races like eating diseased mice, ew
 	if(MOB_INORGANIC in H.mob_biotypes)
@@ -370,7 +370,7 @@
 	else if(!(MOB_ORGANIC in H.mob_biotypes))
 		return //this mob cant be given a disease
 	if(prob(biohazard * sickrisk))
-		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(1, 4), rand(1, 9), unfunny, guaranteed, infected = H)
+		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(1, 4), rand(7, 9), unfunny, guaranteed, infected = H)
 		scandisease.dormant = TRUE
 		scandisease.spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 		scandisease.spread_text = "None"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -41,7 +41,7 @@
 	icon_dead = "mouse_[body_color]_dead"
 	held_state = "mouse_[body_color]"
 	if(prob(75))
-		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(1, 6), rand(5, 9), rand(3,4), infected = src)
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(1, 6), 9, 1, infected = src)
 		ratdisease += R
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = .proc/on_entered,

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -230,7 +230,7 @@
 /obj/item/reagent_containers/syringe/used/Initialize()
 	. = ..()
 	if(prob(75))
-		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), rand(6, 9), rand(3,4), infected = src)
+		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(3, 6), rand(7, 9), rand(3,4), infected = src)
 		syringediseases += R
 
 /obj/item/reagent_containers/syringe/epinephrine


### PR DESCRIPTION
## About The Pull Request
Buffs random diseases from all sources, slightly

## Why It's Good For The Game
i toned random viruses down a bit far, and the job seems quite hit-and-miss right now. Especially with #5624 on the horizon, which will make virology more inconsistent by virtue of increasing the pool size

## Changelog
:cl:
tweak: buffs random viruses slightly
/:cl:
