### PR TITLE
Fix inserting prisoner IDs into prisoner consoles

### DIFF
--- a/code/game/machinery/computer/prisoner/_prisoner.dm
+++ b/code/game/machinery/computer/prisoner/_prisoner.dm
@@ -18,6 +18,11 @@
 	id_eject(user)
 
 /obj/machinery/computer/prisoner/proc/id_insert(mob/user, obj/item/card/id/prisoner/P)
+	if(!P)
+		var/obj/item/held_item = user.get_active_held_item()
+		if(istype(held_item, /obj/item/card/id/prisoner))
+			P = held_item
+
 	if(istype(P))
 		if(contained_id)
 			to_chat(user, "<span class='warning'>There's already an ID card in the console!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Issue seemingly introduced in https://github.com/BeeStation/BeeStation-Hornet/pull/1623

Prisoner consoles have special handling for inserting prisoner IDs, handled via `id_insert(mob/user, obj/item/card/id/prisoner/P)`. In a refactor, some cases were introduced where the second argument was passed - this caused the proc to fail silently.

This PR adds special handling for `id_insert`, where if the second argument is not provided, it will try to assume the user's active item. This fixes both ways of inserting IDs into the prisoner management console, as well as inserting IDs via the UI into the labor camp teleporter console.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good - prisoner management console seems to be entirely unusable.

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/5803
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed inserting IDs into prisoner management and labor camp teleporter consoles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
