### PR TITLE
Adds Antag Hud to Hypnoflash Brainwashes/Hypnosis Trauma

### DIFF
--- a/code/datums/brain_damage/hypnosis.dm
+++ b/code/datums/brain_damage/hypnosis.dm
@@ -33,6 +33,10 @@
 										as long as you act like the words are your highest priority.</span>")
 	var/atom/movable/screen/alert/hypnosis/hypno_alert = owner.throw_alert("hypnosis", /atom/movable/screen/alert/hypnosis)
 	hypno_alert.desc = "\"[hypnotic_phrase]\"... your mind seems to be fixated on this concept."
+	var/datum/atom_hud/antag/traitorhud = GLOB.huds[ANTAG_HUD_BRAINWASHED]
+	traitorhud.join_hud(owner.mind.current)
+	if(!owner.mind.antag_hud_icon_state)
+		set_antag_hud(owner.mind.current, "brainwash")
 	..()
 
 /datum/brain_trauma/hypnosis/on_lose()
@@ -40,6 +44,10 @@
 	log_game("[key_name(owner)] is no longer hypnotized with the phrase '[hypnotic_phrase]'.")
 	to_chat(owner, "<span class='userdanger'>You suddenly snap out of your hypnosis. The phrase '[hypnotic_phrase]' no longer feels important to you.</span>")
 	owner.clear_alert("hypnosis")
+	var/datum/atom_hud/antag/traitorhud = GLOB.huds[ANTAG_HUD_BRAINWASHED]
+	traitorhud.leave_hud(owner.mind.current)
+	if(owner.mind.antag_hud_icon_state == "brainwash")
+		set_antag_hud(owner.mind.current, null)
 	..()
 
 /datum/brain_trauma/hypnosis/on_life()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently admins have to look into VV and either the traumas or alerts section to find out if someone is hypnoflashed. This makes it show up on the combo hud.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Hypnoflash victims now show up on the Combo HUD
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
