### PR TITLE
Xenobio Nerfs

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -446,7 +446,7 @@ GLOBAL_LIST_INIT(snow_recipes, list ( \
  * Adamantine
  */
 GLOBAL_LIST_INIT(adamantine_recipes, list(
-	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, req_amount=1, res_amount=1),
+	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, 10),
 	))
 
 /obj/item/stack/sheet/mineral/adamantine

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -471,7 +471,7 @@
 	name = "Slime Potion 2"
 	id = "m_potion2"
 	required_container = /obj/item/slime_extract/lightpink
-	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 5)
 	required_other = TRUE
 
 /datum/chemical_reaction/slime/slimepotion2/on_reaction(datum/reagents/holder)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -965,15 +965,22 @@
 /datum/status_effect/stabilized/rainbow
 	id = "stabilizedrainbow"
 	colour = "rainbow"
+	var/messagefired = FALSE
 
 /datum/status_effect/stabilized/rainbow/tick()
-	if(owner.health <= 0)
+	if(owner.health <= 0 && !messagefired)
 		var/obj/item/slimecross/stabilized/rainbow/X = linked_extract
 		if(istype(X))
 			if(X.regencore)
-				X.regencore.afterattack(owner,owner,TRUE)
-				X.regencore = null
 				owner.visible_message("<span class='warning'>[owner] flashes a rainbow of colors, and [owner.p_their()] skin is coated in a milky regenerative goo!</span>")
-				qdel(src)
-				qdel(linked_extract)
+				addtimer(CALLBACK(src, .proc/activate), 50)
+				messagefired = TRUE
+				
 	return ..()
+
+/datum/status_effect/stabilized/rainbow/proc/activate()
+	var/obj/item/slimecross/stabilized/rainbow/X = linked_extract
+	X.regencore.afterattack(owner,owner,TRUE)
+	X.regencore = null
+	qdel(src)
+	qdel(linked_extract)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -22,7 +22,7 @@ Regenerative extracts:
 	if(H.stat == DEAD)
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
-	if(!do_after(user, 50, target=target))
+	if(!do_after(user, 50, target=target) && !istype(loc, /obj/item/slimecross/stabilized/rainbow))
 		return
 	if(H != user)
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -22,6 +22,8 @@ Regenerative extracts:
 	if(H.stat == DEAD)
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
+	if(!do_after(user, 50, target=target))
+		return
 	if(H != user)
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs the two things that I think are overpowered in Xenobio

1. Regenerative extracts now have a do_after of five seconds
2. Servant golem shells now cost 10 adamantine
3. Sentience potions require Strange Reagent
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instant aheals in combat are not great for balance, this moves them to a more out of combat/medical role. Additionally, this severely nerfs the Regenerative Bluespace instagib strat.

Unfailingly loyal sentient beings are also incredibly powerful, and at the price of one adamantine or light pink plus one unit plasma, bound sentience was able to be spammed. This increases the requirements for creating sentience, so it's not as spammable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Regenerative extracts now take five seconds to apply, instead of instantly.
balance: Servant Golem Shells now cost ten adamantine, instead of one.
balance: Sentience Potions are now created with five units of Strange Reagent in a light pink extract, instead of one unit of Plasma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
