### PR TITLE
nerfs reproductive extracts

### DIFF
--- a/code/datums/components/storage/concrete/extract_inventory.dm
+++ b/code/datums/components/storage/concrete/extract_inventory.dm
@@ -24,6 +24,9 @@
 
 	if(length(parent_slime_extract.contents) >= max_items)
 		QDEL_LIST(parent_slime_extract.contents)
+		if(GLOB.total_slimes >= CONFIG_GET(number/max_slimes))
+			to_chat(user, "<i>The extract jiggles, and fails to produce a slime...</i>")
+			return
 		create_extracts(parent_slime_extract,user)
 
 /datum/component/storage/concrete/extract_inventory/proc/create_extracts(obj/item/slimecross/reproductive/parent_slime_extract, mob/user)

--- a/code/datums/components/storage/concrete/extract_inventory.dm
+++ b/code/datums/components/storage/concrete/extract_inventory.dm
@@ -25,7 +25,7 @@
 	if(length(parent_slime_extract.contents) >= max_items)
 		QDEL_LIST(parent_slime_extract.contents)
 		if(GLOB.total_slimes >= CONFIG_GET(number/max_slimes))
-			to_chat(user, "<i>The extract jiggles, and fails to produce a slime...</i>")
+			to_chat(user, "<span class='warning'>The extract jiggles, and fails to produce a slime...</span>")
 			return
 		create_extracts(parent_slime_extract,user)
 

--- a/code/datums/components/storage/concrete/extract_inventory.dm
+++ b/code/datums/components/storage/concrete/extract_inventory.dm
@@ -27,9 +27,7 @@
 		create_extracts(parent_slime_extract,user)
 
 /datum/component/storage/concrete/extract_inventory/proc/create_extracts(obj/item/slimecross/reproductive/parent_slime_extract, mob/user)
-	var/cores = rand(1,4)
 	playsound(parent_slime_extract, 'sound/effects/splat.ogg', 40, TRUE)
 	parent_slime_extract.last_produce = world.time
-	to_chat(user, "<span class='notice'>[parent_slime_extract] briefly swells to a massive size, and expels [cores] extract[cores > 1 ? "s":""]!</span>")
-	for(var/i in 1 to cores)
-		new parent_slime_extract.extract_type(parent_slime_extract.drop_location())
+	to_chat(user, "<span class='notice'>[parent_slime_extract] briefly swells to a massive size, and expels a baby slime!</span>")
+	new /mob/living/simple_animal/slime(parent_slime_extract.drop_location(), parent_slime_extract.colour)

--- a/code/modules/research/xenobiology/crossbreeding/reproductive.dm
+++ b/code/modules/research/xenobiology/crossbreeding/reproductive.dm
@@ -8,7 +8,7 @@ Reproductive extracts:
 	desc = "It pulses with a strange hunger."
 	icon_state = "reproductive"
 	effect = "reproductive"
-	effect_desc = "When fed monkey cubes it produces more extracts. Bio bag compatible as well."
+	effect_desc = "When fed monkey cubes it produces a baby slime. Bio bag compatible as well."
 	layer = LOW_ITEM_LAYER
 	var/last_produce = 0
 	var/cooldown = 60 SECONDS

--- a/code/modules/research/xenobiology/crossbreeding/reproductive.dm
+++ b/code/modules/research/xenobiology/crossbreeding/reproductive.dm
@@ -11,7 +11,7 @@ Reproductive extracts:
 	effect_desc = "When fed monkey cubes it produces a baby slime. Bio bag compatible as well."
 	layer = LOW_ITEM_LAYER
 	var/last_produce = 0
-	var/cooldown = 60 SECONDS
+	var/cooldown = 30 SECONDS
 	var/feed_amount = 3
 	var/datum/component/storage/concrete/extract_inventory/slime_storage
 	var/static/list/typecache_to_take

--- a/code/modules/research/xenobiology/crossbreeding/reproductive.dm
+++ b/code/modules/research/xenobiology/crossbreeding/reproductive.dm
@@ -10,9 +10,8 @@ Reproductive extracts:
 	effect = "reproductive"
 	effect_desc = "When fed monkey cubes it produces more extracts. Bio bag compatible as well."
 	layer = LOW_ITEM_LAYER
-	var/extract_type = /obj/item/slime_extract/
 	var/last_produce = 0
-	var/cooldown = 3 SECONDS
+	var/cooldown = 60 SECONDS
 	var/feed_amount = 3
 	var/datum/component/storage/concrete/extract_inventory/slime_storage
 	var/static/list/typecache_to_take
@@ -65,89 +64,67 @@ Reproductive extracts:
 	QDEL_NULL(slime_storage)
 
 /obj/item/slimecross/reproductive/grey
-	extract_type = /obj/item/slime_extract/grey
 	colour = "grey"
 
 /obj/item/slimecross/reproductive/orange
-	extract_type = /obj/item/slime_extract/orange
 	colour = "orange"
 
 /obj/item/slimecross/reproductive/purple
-	extract_type = /obj/item/slime_extract/purple
 	colour = "purple"
 
 /obj/item/slimecross/reproductive/blue
-	extract_type = /obj/item/slime_extract/blue
 	colour = "blue"
 
 /obj/item/slimecross/reproductive/metal
-	extract_type = /obj/item/slime_extract/metal
 	colour = "metal"
 
 /obj/item/slimecross/reproductive/yellow
-	extract_type = /obj/item/slime_extract/yellow
 	colour = "yellow"
 
 /obj/item/slimecross/reproductive/darkpurple
-	extract_type = /obj/item/slime_extract/darkpurple
 	colour = "dark purple"
 
 /obj/item/slimecross/reproductive/darkblue
-	extract_type = /obj/item/slime_extract/darkblue
 	colour = "dark blue"
 
 /obj/item/slimecross/reproductive/silver
-	extract_type = /obj/item/slime_extract/silver
 	colour = "silver"
 
 /obj/item/slimecross/reproductive/bluespace
-	extract_type = /obj/item/slime_extract/bluespace
 	colour = "bluespace"
 
 /obj/item/slimecross/reproductive/sepia
-	extract_type = /obj/item/slime_extract/sepia
 	colour = "sepia"
 
 /obj/item/slimecross/reproductive/cerulean
-	extract_type = /obj/item/slime_extract/cerulean
 	colour = "cerulean"
 
 /obj/item/slimecross/reproductive/pyrite
-	extract_type = /obj/item/slime_extract/pyrite
 	colour = "pyrite"
 
 /obj/item/slimecross/reproductive/red
-	extract_type = /obj/item/slime_extract/red
 	colour = "red"
 
 /obj/item/slimecross/reproductive/green
-	extract_type = /obj/item/slime_extract/green
 	colour = "green"
 
 /obj/item/slimecross/reproductive/pink
-	extract_type = /obj/item/slime_extract/pink
 	colour = "pink"
 
 /obj/item/slimecross/reproductive/gold
-	extract_type = /obj/item/slime_extract/gold
 	colour = "gold"
 
 /obj/item/slimecross/reproductive/oil
-	extract_type = /obj/item/slime_extract/oil
 	colour = "oil"
 
 /obj/item/slimecross/reproductive/black
-	extract_type = /obj/item/slime_extract/black
 	colour = "black"
 
 /obj/item/slimecross/reproductive/lightpink
-	extract_type = /obj/item/slime_extract/lightpink
 	colour = "light pink"
 
 /obj/item/slimecross/reproductive/adamantine
-	extract_type = /obj/item/slime_extract/adamantine
 	colour = "adamantine"
 
 /obj/item/slimecross/reproductive/rainbow
-	extract_type = /obj/item/slime_extract/rainbow
 	colour = "rainbow"


### PR DESCRIPTION
## About The Pull Request
Reproductive extracts now act on a one minute cooldown, and spawn a single baby slime, instead of 1-4 cores

## Why It's Good For The Game
Reproductive extracts make obsolete the entire slime breeding process, outside of crossbreeds. This PR gives reproductives a more niche use that, while still usable to bypass slime farming, requires a more personal touch, and an upgraded slime harvester, as well as still taking time

## Changelog
:cl:
balance: Reproductive extracts now have a 30 second cooldown, and spawn a single baby slime instead of extracts
/:cl:
