### PR TITLE
nerfs regenerative extracts

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -30,6 +30,7 @@ Regenerative extracts:
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
 	core_effect_before(H, user)
 	H.heal_overall_damage(50, 50, 50)
+	H.adjustToxLoss(-50, forced = TRUE)
 	core_effect(H, user)
 	playsound(target, 'sound/effects/splat.ogg', 40, 1)
 	qdel(src)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -29,7 +29,7 @@ Regenerative extracts:
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
 	core_effect_before(H, user)
-	H.revive(full_heal = 1)
+	H.heal_overall_damage(50, 50, 50)
 	core_effect(H, user)
 	playsound(target, 'sound/effects/splat.ogg', 40, 1)
 	qdel(src)


### PR DESCRIPTION

## About The Pull Request
Regenerative extracts now heal 50 burn, brute, and stamina, instead of being an aheal

## Why It's Good For The Game
giving players on-demand adminheals, even if they dont work on the dead, is absolutely terrible design

## Changelog
:cl:
balance: regenerative extracts now heal about half a human's health, instead of being an aheal
/:cl:
