### PR TITLE
Janitor ERT gets a Janicart

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -390,7 +390,7 @@
 	var/static/list/cart_spaghetti_list
 	if(!cart_spaghetti_list)
 		cart_spaghetti_list = list()
-		var/list/templist = list(/obj/vehicle/ridden/janicart/upgraded)
+		var/list/templist = list(/obj/vehicle/ridden/janicart/upgraded/keyless)
 		for(var/V in templist)
 			var/atom/A = V
 			cart_spaghetti_list[initial(A.name)] = A

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -387,11 +387,4 @@
 	desc = "Summons a pod containing one (1) pimpin ride."
 
 /obj/item/choice_beacon/janicart/generate_display_names()
-	var/static/list/cart_spaghetti_list
-	if(!cart_spaghetti_list)
-		cart_spaghetti_list = list()
-		var/list/templist = list(/obj/vehicle/ridden/janicart/upgraded/keyless)
-		for(var/V in templist)
-			var/atom/A = V
-			cart_spaghetti_list[initial(A.name)] = A
-	return cart_spaghetti_list
+	return list("janitor cart" = /obj/vehicle/ridden/janicart/upgraded/keyless)

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -381,3 +381,17 @@
 	name = "goat delivery beacon"
 	default_name = "Billy"
 	mob_choice = /mob/living/simple_animal/hostile/retaliate/goat
+
+/obj/item/choice_beacon/janicart
+	name = "janicart delivery beacon"
+	desc = "Summons a pod containing one (1) pimpin ride."
+
+/obj/item/choice_beacon/janicart/generate_display_names()
+	var/static/list/cart_spaghetti_list
+	if(!cart_spaghetti_list)
+		cart_spaghetti_list = list()
+		var/list/templist = list(/obj/vehicle/ridden/janicart/upgraded)
+		for(var/V in templist)
+			var/atom/A = V
+			cart_spaghetti_list[initial(A.name)] = A
+	return cart_spaghetti_list

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -273,7 +273,8 @@
 		/obj/item/melee/baton/loaded=1,
 		/obj/item/mop/advanced=1,
 		/obj/item/reagent_containers/glass/bucket=1,
-		/obj/item/grenade/clusterbuster/cleaner=1)
+		/obj/item/grenade/clusterbuster/cleaner=1,
+		/obj/item/choice_beacon/janicart)
 
 /datum/outfit/ert/janitor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
@@ -291,7 +292,8 @@
 		/obj/item/storage/box/lights/mixed=1,
 		/obj/item/melee/baton/loaded=1,
 		/obj/item/grenade/clusterbuster/cleaner=3,
-		/obj/item/reagent_containers/spray/chemsprayer/janitor=1)
+		/obj/item/reagent_containers/spray/chemsprayer/janitor=1,
+		/obj/item/choice_beacon/janicart)
 
 /datum/outfit/ert/kudzu
 	name = "ERT Weed Whacker"

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -74,3 +74,7 @@
 
 /obj/vehicle/ridden/janicart/upgraded
 	floorbuffer = TRUE
+
+/obj/vehicle/ridden/janicart/upgraded/keyless
+	floorbuffer = TRUE
+	key_type = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Janitor ERT members now get a choice beacon that allows them to summon a janicart with floor buffer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, the Janitor and Heavy Duty Janitor ERTs are entirely outmatched by either a single janiborg or janitor with floor buffer. This puts them more on par.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Janitor ERT now gets a Janicart Beacon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
