### PR TITLE
Adds living hour requirement for antags

### DIFF
--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -34,6 +34,7 @@ GLOBAL_VAR(clockcult_eminence)
 	recommended_enemies = 4
 	antag_flag = ROLE_SERVANT_OF_RATVAR
 	enemy_minimum_age = 14
+	min_antag_hours = 100
 
 	title_icon = "clockcult"
 	announce_span = "danger"

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -44,6 +44,7 @@
 	required_enemies = 4
 	recommended_enemies = 4
 	enemy_minimum_age = 14
+	min_antag_hours = 100
 
 	announce_span = "cult"
 	announce_text = "Some crew members are trying to start a cult to Nar'Sie!\n\

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -37,6 +37,7 @@
 	var/enemy_minimum_age = 7 //How many days must players have been playing before they can play this antagonist
 	var/list/allowed_special = list()	//Special roles that can spawn (Add things like /datum/antagonist/special/undercover for them to be able to spawn during this gamemode)
 	var/list/active_specials = list()	//Special roles that have spawned, and can now spawn late
+	var/min_antag_hours = 10 //Minimum living hours required to be a roundstart antagonist
 
 	var/announce_span = "warning" //The gamemode's name will be in this span during announcement.
 	var/announce_text = "This gamemode forgot to set a descriptive text! Uh oh!" //Used to describe a gamemode when it's announced.
@@ -482,7 +483,7 @@
 		if(player.client && player.ready == PLAYER_READY_TO_PLAY)
 			if(role in player.client.prefs.be_special)
 				if(!is_banned_from(player.ckey, list(role, ROLE_SYNDICATE)) && !QDELETED(player))
-					if(age_check(player.client)) //Must be older than the minimum age
+					if(age_check(player.client) && time_check(player.client)) //Must be older than the minimum age
 						candidates += player.mind				// Get a list of all the people who want to be the antagonist for this round
 
 	if(restricted_jobs)
@@ -714,6 +715,10 @@
 		return 1	//Available in 0 days = available right now = player is old enough to play.
 	return 0
 
+/datum/game_mode/proc/time_check(client/C)
+	if((C.get_exp_living(TRUE)/60) >= min_antag_hours)
+		return TRUE	//Player has enough hours to be the antag.
+	return FALSE
 
 /datum/game_mode/proc/get_remaining_days(client/C)
 	if(!C)

--- a/code/game/gamemodes/incursion/incursion.dm
+++ b/code/game/gamemodes/incursion/incursion.dm
@@ -10,6 +10,7 @@
 	antag_flag = ROLE_INCURSION
 	false_report_weight = 10
 	enemy_minimum_age = 0
+	min_antag_hours = 100
 
 	announce_span = "danger"
 	announce_text = "A large force of syndicate operatives have infiltrated the ranks of the station and wish to take it by force!\n\

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -10,6 +10,7 @@
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14
+	min_antag_hours = 200
 
 	announce_span = "danger"
 	announce_text = "Syndicate forces are approaching the station in an attempt to destroy it!\n\

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -20,6 +20,7 @@
 	recommended_enemies = 3
 	enemy_minimum_age = 14
 	title_icon = "revolution"
+	min_antag_hours = 100
 
 	announce_span = "danger"
 	announce_text = "Some crewmembers are attempting a coup!\n\

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -18,6 +18,7 @@
 	<span class='danger'>Wizard</span>: Accomplish your objectives and cause mayhem on the station.\n\
 	<span class='notice'>Crew</span>: Eliminate the wizard before they can succeed!"
 	var/finished = 0
+	min_antag_hours = 200
 
 	title_icon = "wizard"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All roundstart antags now require a certain number of living hours. These have been classed into one of three categories:

Showrunner (Wizard, Nuclear Operative): 200 hours
Team (Head Revolutionary, Clockwork Cultist, Cultist, Incursionist (Roundstart Only)): 100 hours
All Other Roundstart Antags: 10 hours
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nukies that don't know which end of the C20-R points away from you are kinda dumb. Especially on a server where the primary round driver is antagonists.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Antags now have living hour restrictions on rolling them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
