### PR TITLE
Fix disposals deleting contents in rare cases

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -41,8 +41,7 @@
 // pipe is deleted
 // ensure if holder is present, it is expelled
 /obj/structure/disposalpipe/Destroy()
-	var/obj/structure/disposalholder/H = locate() in src
-	if(H)
+	for(var/obj/structure/disposalholder/H in src)
 		H.active = FALSE
 		expel(H, get_turf(src), 0)
 	return ..()
@@ -121,8 +120,7 @@
 
 // pipe affected by explosion
 /obj/structure/disposalpipe/contents_explosion(severity, target)
-	var/obj/structure/disposalholder/H = locate() in src
-	if(H)
+	for(var/obj/structure/disposalholder/H in src)
 		H.contents_explosion(severity, target)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces `locate() in src` calls for `disposalholder` inside disposals code to instead use a loop over `disposalholder in src`.

Take the following code for example:

```dm
/obj/structure/disposalpipe/Destroy()
	var/obj/structure/disposalholder/H = locate() in src
	if(H)
		H.active = FALSE
		expel(H, get_turf(src), 0)
```

The code will find the disposalholder currently inside the pipe being destroyed, and will make the holder eject its contents. However, what if there were to be two holders inside one pipe? In the rare but possible event, this will only eject the contents of one holder - the other will be deleted as usual, deleting all of its contents recursively.

The bug can be tested with a setup such as this:
![image](https://user-images.githubusercontent.com/6917698/146684423-fb3104be-e60d-4aa0-bedc-659f70d97cf8.png)

When you flip the lever, each chute will receive one human, and after a short delay will launch its contents, consisting of one human, into the pipes, each in a separate holder. It's important to either have multiple chutes, or wait until the chute finishes before inserting another object, otherwise multiple humans will end up in a single holder.

If you then wait a couple seconds and unwrench the loop of disposals pipes to the left, if you happen to unwrench a pipe containing multiple holders at once, only one of the humans will emerge. Thus, if you do this experiment, you should most likely find yourself with less humans than you started with. In my initial test, I put 8 meters in, and they presumably happened to all be on the same pipe when I unwrenched it, leaving me with just one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good, unintentional qdel bad.
Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/2672
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Disposals will no longer randomly delete their contents when destroyed in a rare case.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
