### PR TITLE
Stage Magician gets their own name

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -216,7 +216,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 				if("mime")
 					newname = pick(GLOB.mime_names)
 				if("stage magician")
-					newname = pick(GLOB.magician_names)
+					newname = "[random_unique_name(gender)] [pick(GLOB.magician_titles)]"
 				if("ai")
 					newname = pick(GLOB.ai_names)
 				else

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -215,6 +215,8 @@ Turf and target are separate in case you want to teleport some distance from a t
 					newname = pick(GLOB.clown_names)
 				if("mime")
 					newname = pick(GLOB.mime_names)
+				if("stage magician")
+					newname = pick(GLOB.magician_names)
 				if("ai")
 					newname = pick(GLOB.ai_names)
 				else

--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -50,6 +50,7 @@ GLOBAL_LIST_INIT(preferences_custom_names, list(
 	"human" = list("pref_name" = "Backup Human", "qdesc" = "backup human name, used in the event you are assigned a command role as another species", "allow_numbers" = FALSE , "group" = "backup_human", "allow_null" = FALSE),
 	"clown" = list("pref_name" = "Clown" , "qdesc" = "clown name", "allow_numbers" = FALSE , "group" = "fun", "allow_null" = FALSE),
 	"mime" = list("pref_name" = "Mime", "qdesc" = "mime name" , "allow_numbers" = FALSE , "group" = "fun", "allow_null" = FALSE),
+	"magician" = list("pref_name" = "Stage Mgician", "qdesc" = "magician name (It's magician name, not wizard name. be careful of your decision.)" , "allow_numbers" = TRUE , "group" = "fun", "allow_null" = FALSE),
 	"cyborg" = list("pref_name" = "Cyborg", "qdesc" = "cyborg name (Leave empty to use default naming scheme)", "allow_numbers" = TRUE , "group" = "silicons", "allow_null" = TRUE),
 	"ai" = list("pref_name" = "AI", "qdesc" = "ai name", "allow_numbers" = TRUE , "group" = "silicons", "allow_null" = FALSE),
 	"religion" = list("pref_name" = "Chaplain religion", "qdesc" = "religion" , "allow_numbers" = TRUE , "group" = "chaplain", "allow_null" = FALSE),

--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_INIT(lizard_names_male, world.file2list("strings/names/lizard_male.t
 GLOBAL_LIST_INIT(lizard_names_female, world.file2list("strings/names/lizard_female.txt"))
 GLOBAL_LIST_INIT(clown_names, world.file2list("strings/names/clown.txt"))
 GLOBAL_LIST_INIT(mime_names, world.file2list("strings/names/mime.txt"))
-GLOBAL_LIST_INIT(magician_names, world.file2list("strings/names/magician.txt"))
+GLOBAL_LIST_INIT(magician_titles, world.file2list("strings/names/magician.txt"))
 GLOBAL_LIST_INIT(carp_names, world.file2list("strings/names/carp.txt"))
 GLOBAL_LIST_INIT(golem_names, world.file2list("strings/names/golem.txt"))
 GLOBAL_LIST_INIT(moth_first, world.file2list("strings/names/moth_first.txt"))

--- a/code/_globalvars/lists/names.dm
+++ b/code/_globalvars/lists/names.dm
@@ -15,6 +15,7 @@ GLOBAL_LIST_INIT(lizard_names_male, world.file2list("strings/names/lizard_male.t
 GLOBAL_LIST_INIT(lizard_names_female, world.file2list("strings/names/lizard_female.txt"))
 GLOBAL_LIST_INIT(clown_names, world.file2list("strings/names/clown.txt"))
 GLOBAL_LIST_INIT(mime_names, world.file2list("strings/names/mime.txt"))
+GLOBAL_LIST_INIT(magician_names, world.file2list("strings/names/magician.txt"))
 GLOBAL_LIST_INIT(carp_names, world.file2list("strings/names/carp.txt"))
 GLOBAL_LIST_INIT(golem_names, world.file2list("strings/names/golem.txt"))
 GLOBAL_LIST_INIT(moth_first, world.file2list("strings/names/moth_first.txt"))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2001,6 +2001,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			return pick(GLOB.clown_names)
 		if("mime")
 			return pick(GLOB.mime_names)
+		if("magician")
+			return pick(GLOB.magician_names)
 		if("religion")
 			return DEFAULT_RELIGION
 		if("deity")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2002,7 +2002,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if("mime")
 			return pick(GLOB.mime_names)
 		if("magician")
-			return pick(GLOB.magician_names)
+			return "[random_unique_name()] [pick(GLOB.magician_titles)]"
 		if("religion")
 			return DEFAULT_RELIGION
 		if("deity")

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -78,6 +78,10 @@
 	backpack_contents = list(/obj/item/choice_beacon/magic=1)
 	can_be_admin_equipped = TRUE
 
+/datum/job/gimmick/magician/after_spawn(mob/living/carbon/human/H, mob/M)
+	. = ..()
+	H.apply_pref_name("magician", M.client)
+
 /datum/job/gimmick/hobo
 	title = "Debtor"
 	flag = HOBO
@@ -87,7 +91,7 @@
 	gimmick = TRUE
 	chat_color = "#929292"
 	departments = NONE		//being hobo is not a real job
-	biohazard = 50 //hobos are very likely to have diseases 
+	biohazard = 50 //hobos are very likely to have diseases
 
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/hobo

--- a/strings/names/magician.txt
+++ b/strings/names/magician.txt
@@ -1,0 +1,12 @@
+Ehrich Weiss the Master Mystery
+Dante the Magician
+Penn of Penn & Teller
+Teller of Penn & Teller
+John Scarne the Invisible hands
+Trixie the Great and Powerful
+Oz the Great and Powerful
+Zanatta the Magician
+Kantalv the Great
+Thurston the Great Magician
+Blackstone the Master Magician
+Alexander the Foreseer

--- a/strings/names/magician.txt
+++ b/strings/names/magician.txt
@@ -1,12 +1,37 @@
-Ehrich Weiss the Master Mystery
-Dante the Magician
-Penn of Penn & Teller
-Teller of Penn & Teller
-John Scarne the Invisible hands
-Trixie the Great and Powerful
-Oz the Great and Powerful
-Zanatta the Magician
-Kantalv the Great
-Thurston the Great Magician
-Blackstone the Master Magician
-Alexander the Foreseer
+The Master Magician
+The Mystical Magician
+The Powerful Magician
+The Great Magician
+The Magician
+The Master Illusionist
+The Illusionist
+The Master Legerdemain
+The Master Legerdemainist
+The Legerdemainist
+The Master Of Prestidigitation
+The Prestidigitator
+The Master Prestidigitator
+The Master Sleight Of Hand
+The Master Trickster
+The Trickster
+The Master Deceiver
+The Deceiver
+The Master Escapist
+The Escapist
+The Master Manipulator
+The Manipulator
+The Master Of Attraction
+The Master Of Magic
+The Master Mystery
+The Invisible Hands
+The Great
+The Great and Powerful
+The Foreseer
+The Creator
+The Wonderful
+The Wonder
+The Mystical Hands
+The Living Magician
+The Silver tongue and Hands
+The Top-hat Master
+The Reality-twister

--- a/strings/names/magician.txt
+++ b/strings/names/magician.txt
@@ -2,9 +2,7 @@ The Master Magician
 The Mystical Magician
 The Powerful Magician
 The Great Magician
-The Magician
 The Master Illusionist
-The Illusionist
 The Master Legerdemain
 The Master Legerdemainist
 The Legerdemainist
@@ -13,23 +11,17 @@ The Prestidigitator
 The Master Prestidigitator
 The Master Sleight Of Hand
 The Master Trickster
-The Trickster
 The Master Deceiver
-The Deceiver
 The Master Escapist
-The Escapist
 The Master Manipulator
-The Manipulator
 The Master Of Attraction
 The Master Of Magic
 The Master Mystery
 The Invisible Hands
-The Great
 The Great and Powerful
-The Foreseer
-The Creator
-The Wonderful
-The Wonder
+The Wonderous Foreseer
+The Wonderous Creator
+The Wonderful and Mystical
 The Mystical Hands
 The Living Magician
 The Silver tongue and Hands


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Magician gets their own name

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Magician's comedian fellows have their own names already. why not Stage Magician?
Their naming policy follows the way of Magician - something like "Alexander The Magnificent", not wizard's way.
This needs to update the naming policy at the wiki however.

Note:
Magician.txt contains only titles and you get a random name as "[human name] [magician title(from magican.txt file)]"
also I am not sure how it would work to appearance-ban accounts since I can't test it on my own server.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Stage Magicians can have their own name now. Their naming policy follows to be 'magician-like', not 'wizard-like', so don't pick names like Gandalf the Necromancer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
