### PR TITLE
Assembly fixes and cleanups from tg

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -38,14 +38,16 @@
 
 /obj/item/assembly/proc/on_attach()
 
-/obj/item/assembly/proc/on_detach() //call this when detaching it from a device. handles any special functions that need to be updated ex post facto
+//Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
+/obj/item/assembly/proc/on_detach()
 	if(!holder)
 		return FALSE
 	forceMove(holder.drop_location())
 	holder = null
 	return TRUE
 
-/obj/item/assembly/proc/holder_movement()							//Called when the holder is moved
+//Called when the holder is moved
+/obj/item/assembly/proc/holder_movement()
 	if(!holder)
 		return FALSE
 	setDir(holder.dir)
@@ -130,7 +132,7 @@
 /obj/item/assembly/interact(mob/user)
 	return ui_interact(user)
 
-/obj/item/assembly/ui_status(mob/user)
-	. = ..()
-	if(src.can_interact(user) || holder?.can_interact(user))
-		return UI_INTERACTIVE
+/obj/item/assembly/ui_host(mob/user)
+	if(holder)
+		return holder
+	return src

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -154,7 +154,6 @@
 	SSradio.remove_object(src, frequency)
 	frequency = new_frequency
 	radio_connection = SSradio.add_object(src, frequency, RADIO_SIGNALER)
-	return
 
 // Embedded signaller used in grenade construction.
 // It's necessary because the signaler doens't have an off state.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Based on the following commit: https://github.com/tgstation/tgstation/commit/14fd4d745b886f9eb3507cc20242da779ba262e0

Seems like somebody at some point ported parts of these code, but not an important bit that allows major despaghettification of assembly TGUI code. Basically, assemblies bypass the entire ui_status thing allowing interaction in certain cases where TGUI would not permit it. This was done to enable interacting with assemblies when attached to something, either a holder item for two assemblies connected to each other, or something like a TTV.

This replaces the janky code with the appropriate usage of `ui_host` - assemblies will now have their status calculated based on what they are attached to using the correct feature built into TGUI.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good
Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/5961

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: KubeRoot, Arkatos1
fix: Fixed ghosts being able to use remote signallers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
