### PR TITLE
makes ipcs respect nocritdamage, reduces IPC crit damage to be in line with intended amounts (according to a line in the code)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -209,14 +209,15 @@
 	return
 
 /datum/species/ipc/spec_life(mob/living/carbon/human/H)
-	H.setOxyLoss(0)
-	H.losebreath = 0
-	if(H.health <= UNCONSCIOUS && H.stat != DEAD && !HAS_TRAIT(H, TRAIT_NOCRITDAMAGE)) // So they die eventually instead of being stuck in crit limbo.
+	if(HAS_TRAIT(H, TRAIT_NOBREATH)) //this is here because i'm overriding spec_life, and is default spec_life behaviour. 
+		H.setOxyLoss(0)
+		H.losebreath = 0
+	if(H.health <= H.crit_threshold && H.stat != DEAD && !HAS_TRAIT(H, TRAIT_NOCRITDAMAGE)) //this is how ipcs get their snowflake 2 burnloss crit damage
 		H.adjustFireLoss(2)
 		if(prob(5))
 			to_chat(H, "<span class='warning'>Alert: Internal temperature regulation systems offline; thermal damage sustained. Shutdown imminent.</span>")
 			H.visible_message("[H]'s cooling system fans stutter and stall. There is a faint, yet rapid beeping coming from inside their chassis.")
-	if(H.getorgan(/obj/item/organ/wings))
+	if(H.getorgan(/obj/item/organ/wings)) //this is also here due to the spec_life override
 		handle_flight(H)
 
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -5,7 +5,7 @@
 	say_mod = "states"
 	sexes = FALSE
 	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOZOMBIE,MUTCOLORS,REVIVESBYHEALING,NOHUSK,NOMOUTH, MUTCOLORS, NO_UNDERWEAR)
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT,TRAIT_NOCRITDAMAGE,TRAIT_EASYDISMEMBER,TRAIT_POWERHUNGRY,TRAIT_XENO_IMMUNE, TRAIT_TOXIMMUNE)
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_NOBREATH,TRAIT_RADIMMUNE,TRAIT_LIMBATTACHMENT,TRAIT_EASYDISMEMBER,TRAIT_POWERHUNGRY,TRAIT_XENO_IMMUNE, TRAIT_TOXIMMUNE)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	mutant_brain = /obj/item/organ/brain/positron
 	mutanteyes = /obj/item/organ/eyes/robotic
@@ -209,12 +209,15 @@
 	return
 
 /datum/species/ipc/spec_life(mob/living/carbon/human/H)
-	. = ..()
-	if(H.health <= UNCONSCIOUS && H.stat != DEAD) // So they die eventually instead of being stuck in crit limbo.
-		H.adjustFireLoss(6) // After BODYTYPE_ROBOTIC resistance this is ~2/second
+	H.setOxyLoss(0)
+	H.losebreath = 0
+	if(H.health <= UNCONSCIOUS && H.stat != DEAD && !HAS_TRAIT(H, TRAIT_NOCRITDAMAGE)) // So they die eventually instead of being stuck in crit limbo.
+		H.adjustFireLoss(2)
 		if(prob(5))
 			to_chat(H, "<span class='warning'>Alert: Internal temperature regulation systems offline; thermal damage sustained. Shutdown imminent.</span>")
 			H.visible_message("[H]'s cooling system fans stutter and stall. There is a faint, yet rapid beeping coming from inside their chassis.")
+	if(H.getorgan(/obj/item/organ/wings))
+		handle_flight(H)
 
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)
 	H.notify_ghost_cloning("You have been repaired!")

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -208,18 +208,6 @@
 	H.visible_message("<span class='notice'>[H] unplugs from the [target].</span>", "<span class='notice'>You unplug from the [target].</span>")
 	return
 
-/datum/species/ipc/spec_life(mob/living/carbon/human/H)
-	if(HAS_TRAIT(H, TRAIT_NOBREATH)) //this is here because i'm overriding spec_life, and is default spec_life behaviour. 
-		H.setOxyLoss(0)
-		H.losebreath = 0
-	if(H.health <= H.crit_threshold && H.stat != DEAD && !HAS_TRAIT(H, TRAIT_NOCRITDAMAGE)) //this is how ipcs get their snowflake 2 burnloss crit damage
-		H.adjustFireLoss(2)
-		if(prob(5))
-			to_chat(H, "<span class='warning'>Alert: Internal temperature regulation systems offline; thermal damage sustained. Shutdown imminent.</span>")
-			H.visible_message("[H]'s cooling system fans stutter and stall. There is a faint, yet rapid beeping coming from inside their chassis.")
-	if(H.getorgan(/obj/item/organ/wings)) //this is also here due to the spec_life override
-		handle_flight(H)
-
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)
 	H.notify_ghost_cloning("You have been repaired!")
 	H.grab_ghost()


### PR DESCRIPTION
## About The Pull Request
reduces ipc crit damage to 2 burn/tick. This is in line with a code comment, that says their crit damage is 6 due to their oracle versions apparently having robotic limb DR. Auth by archanial
ipcs now check crit damage before taking crit damage

## Why It's Good For The Game
IPCS should have respected nocritdamage, this is janky as hell. Their crit damage is also highly overtuned, leading to them dying in less than a minute of going crit, and being exceptionally difficult to heal out of crit


## Changelog
:cl:
fix: IPC crit damage now checks the nocritdamage trait.
fix: IPC crit damage no longer accounts for robotic limb resilience that they dont have.
tweak: at maintainer request, ipc crit damage works like other species with nobreath (ipcs take 1 brute damage per life tick, as opposed to 6 burn damage.)
/:cl:
