### PR TITLE
Fixes auto stale

### DIFF
--- a/.github/workflows/stale_prs.yml
+++ b/.github/workflows/stale_prs.yml
@@ -14,5 +14,5 @@ jobs:
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being closed by a maintainer if it is not updated or reviews are not addressed. If your PR is closed as stale, feel free to open a new one after dealing with the issues. This may also be an indication that the maintainers do not have interest in this change, you can try to convince them otherwise, or persist in the doomed world you have created."
         stale-pr-label: 'Stale'
         exempt-pr-label: 'Needs Review'
-        days-before-stale: -1
+        days-before-stale: 100000
         days-before-close: 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets the action for auto staling PRs to apply after a hundred thousand days (273 years). -1 _should_ have made it never auto apply, but apparently we're on an old version of Actions.

Before someone inevitably asks, deleting the option just sets it to 60 days.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
code: Auto Stale Action no longer marks your PR as stale one day before you make it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
