### PR TITLE
fixes regen extract nerf

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -37,7 +37,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/grey
 	colour = "grey" //Has no bonus effect.
-	effect_desc = "Fully heals the target and does nothing else."
+	effect_desc = "Heals the target and does nothing else."
 
 /obj/item/slimecross/regenerative/orange
 	colour = "orange"
@@ -57,7 +57,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/blue
 	colour = "blue"
-	effect_desc = "Fully heals the target and makes the floor wet."
+	effect_desc = "Heals the target and makes the floor wet."
 
 /obj/item/slimecross/regenerative/blue/core_effect(mob/living/target, mob/user)
 	if(isturf(target.loc))
@@ -67,7 +67,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/metal
 	colour = "metal"
-	effect_desc = "Fully heals the target and encases the target in a locker."
+	effect_desc = "Heals the target and encases the target in a locker."
 
 /obj/item/slimecross/regenerative/metal/core_effect(mob/living/target, mob/user)
 	target.visible_message("<span class='warning'>The milky goo hardens and reshapes itself, encasing [target]!</span>")
@@ -78,7 +78,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/yellow
 	colour = "yellow"
-	effect_desc = "Fully heals the target and fully recharges a single item on the target."
+	effect_desc = "Heals the target and fully recharges a single item on the target."
 
 /obj/item/slimecross/regenerative/yellow/core_effect(mob/living/target, mob/user)
 	var/list/batteries = list()
@@ -92,7 +92,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/darkpurple
 	colour = "dark purple"
-	effect_desc = "Fully heals the target and gives them purple clothing if they are naked."
+	effect_desc = "Heals the target and gives them purple clothing if they are naked."
 
 /obj/item/slimecross/regenerative/darkpurple/core_effect(mob/living/target, mob/user)
 	var/equipped = 0
@@ -105,7 +105,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/darkblue
 	colour = "dark blue"
-	effect_desc = "Fully heals the target and fireproofs their clothes."
+	effect_desc = "Heals the target and fireproofs their clothes."
 
 /obj/item/slimecross/regenerative/darkblue/core_effect(mob/living/target, mob/user)
 	if(!ishuman(target))
@@ -133,7 +133,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/silver
 	colour = "silver"
-	effect_desc = "Fully heals the target and makes their belly feel round and full."
+	effect_desc = "Heals the target and makes their belly feel round and full."
 
 /obj/item/slimecross/regenerative/silver/core_effect(mob/living/target, mob/user)
 	target.set_nutrition(NUTRITION_LEVEL_FULL - 1)
@@ -141,7 +141,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/bluespace
 	colour = "bluespace"
-	effect_desc = "Fully heals the target and teleports them to where this core was created."
+	effect_desc = "Heals the target and teleports them to where this core was created."
 	var/turf/open/T
 
 /obj/item/slimecross/regenerative/bluespace/core_effect(mob/living/target, mob/user)
@@ -156,7 +156,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/sepia
 	colour = "sepia"
-	effect_desc = "Fully heals the target and stops time."
+	effect_desc = "Heals the target and stops time."
 
 /obj/item/slimecross/regenerative/sepia/core_effect_before(mob/living/target, mob/user)
 	to_chat(target, "<span class=notice>You try to forget how you feel.</span>")
@@ -164,7 +164,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/cerulean
 	colour = "cerulean"
-	effect_desc = "Fully heals the target and makes a second regenerative core with no special effects."
+	effect_desc = "Heals the target and makes a second regenerative core with no special effects."
 
 /obj/item/slimecross/regenerative/cerulean/core_effect(mob/living/target, mob/user)
 	src.forceMove(user.loc)
@@ -176,7 +176,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/pyrite
 	colour = "pyrite"
-	effect_desc = "Fully heals and randomly colors the target."
+	effect_desc = "Heals and randomly colors the target."
 
 /obj/item/slimecross/regenerative/pyrite/core_effect(mob/living/target, mob/user)
 	target.visible_message("<span class='warning'>The milky goo coating [target] leaves [target.p_them()] a different color!</span>")
@@ -184,7 +184,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/red
 	colour = "red"
-	effect_desc = "Fully heals the target and injects them with some ephedrine."
+	effect_desc = "Heals the target and injects them with some ephedrine."
 
 /obj/item/slimecross/regenerative/red/core_effect(mob/living/target, mob/user)
 	to_chat(target, "<span class='notice'>You feel... <i>faster.</i></span>")
@@ -192,7 +192,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/green
 	colour = "green"
-	effect_desc = "Fully heals the target and changes the spieces or color of a slime or jellyperson."
+	effect_desc = "Heals the target and changes the species or color of a slime or jellyperson."
 
 /obj/item/slimecross/regenerative/green/core_effect(mob/living/target, mob/user)
 	if(isslime(target))
@@ -205,7 +205,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/pink
 	colour = "pink"
-	effect_desc = "Fully heals the target and injects them with some krokodil."
+	effect_desc = "Heals the target and injects them with some krokodil."
 
 /obj/item/slimecross/regenerative/pink/core_effect(mob/living/target, mob/user)
 	to_chat(target, "<span class='notice'>You feel more calm.</span>")
@@ -213,7 +213,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/gold
 	colour = "gold"
-	effect_desc = "Fully heals the target and produces a random coin."
+	effect_desc = "Heals the target and produces a random coin."
 
 /obj/item/slimecross/regenerative/gold/core_effect(mob/living/target, mob/user)
 	var/newcoin = pick(/obj/item/coin/silver, /obj/item/coin/iron, /obj/item/coin/gold, /obj/item/coin/diamond, /obj/item/coin/plasma, /obj/item/coin/uranium)
@@ -223,7 +223,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/oil
 	colour = "oil"
-	effect_desc = "Fully heals the target and flashes everyone in sight."
+	effect_desc = "Heals the target and flashes everyone in sight."
 
 /obj/item/slimecross/regenerative/oil/core_effect(mob/living/target, mob/user)
 	playsound(src, 'sound/weapons/flash.ogg', 100, 1)
@@ -232,7 +232,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/black
 	colour = "black"
-	effect_desc = "Fully heals the target and creates a duplicate of them, that drops dead soon after."
+	effect_desc = "Heals the target and creates a duplicate of them, that drops dead soon after."
 
 /obj/item/slimecross/regenerative/black/core_effect_before(mob/living/target, mob/user)
 	var/dummytype = target.type
@@ -253,7 +253,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/lightpink
 	colour = "light pink"
-	effect_desc = "Fully heals the target and also heals the user."
+	effect_desc = "Heals the target and also heals the user."
 
 /obj/item/slimecross/regenerative/lightpink/core_effect(mob/living/target, mob/user)
 	if(!isliving(user))
@@ -261,19 +261,20 @@ Regenerative extracts:
 	if(target == user)
 		return
 	var/mob/living/U = user
-	U.revive(full_heal = 1)
+	U.heal_overall_damage(50, 50, 50)
+	U.adjustToxLoss(-50, forced = TRUE)
 	to_chat(U, "<span class='notice'>Some of the milky goo sprays onto you, as well!</span>")
 
 /obj/item/slimecross/regenerative/adamantine
 	colour = "adamantine"
-	effect_desc = "Fully heals the target and boosts their armor."
+	effect_desc = "Heals the target and boosts their armor."
 
 /obj/item/slimecross/regenerative/adamantine/core_effect(mob/living/target, mob/user) //WIP - Find out why this doesn't work.
 	target.apply_status_effect(STATUS_EFFECT_SLIMESKIN)
 
 /obj/item/slimecross/regenerative/rainbow
 	colour = "rainbow"
-	effect_desc = "Fully heals the target and temporarily makes them immortal, but pacifistic."
+	effect_desc = "Heals the target and temporarily makes them immortal, but pacifistic."
 
 /obj/item/slimecross/regenerative/rainbow/core_effect(mob/living/target, mob/user)
 	target.apply_status_effect(STATUS_EFFECT_RAINBOWPROTECTION)


### PR DESCRIPTION
## About The Pull Request
updates regen core subtype descs, fixes light pink regen core

## Why It's Good For The Game
fixes and consistency

## Changelog
:cl:
fix: regenerative extracts now have correct descriptions
fix: light pink regen core has been nerfed as well
/:cl:
