### PR TITLE
Re-adds the gun wield icon, merges the good parts of both PRs

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -192,8 +192,14 @@
 	if(SEND_SIGNAL(parent, COMSIG_TWOHANDED_WIELD, user) & COMPONENT_TWOHANDED_BLOCK_WIELD)
 		return // blocked wield from item
 
+	//If wielder isn't null already, unreference the old wielder
+	if(wielder != null)
+		unreference_wielder()
+
 	wielder = user
 	wielded = TRUE
+
+	RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/unreference_wielder)
 
 	if(!auto_wield)
 		RegisterSignal(user, COMSIG_MOB_SWAP_HANDS, .proc/on_swap_hands)
@@ -230,6 +236,10 @@
 		user.put_in_active_hand(offhand_item)
 	else
 		user.put_in_inactive_hand(offhand_item)
+
+/datum/component/two_handed/proc/unreference_wielder()
+	UnregisterSignal(wielder, COMSIG_PARENT_QDELETING)
+	wielder = null
 
 /**
  * Unwield the two handed item

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -238,6 +238,7 @@
 		user.put_in_inactive_hand(offhand_item)
 
 /datum/component/two_handed/proc/unreference_wielder()
+	SIGNAL_HANDLER
 	UnregisterSignal(wielder, COMSIG_PARENT_QDELETING)
 	wielder = null
 
@@ -299,6 +300,8 @@
 	// Play sound if set
 	if(unwieldsound)
 		playsound(parent_item.loc, unwieldsound, 50, TRUE)
+
+	unreference_wielder()
 
 	// Remove the object in the offhand
 	if(offhand_item)

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -118,7 +118,7 @@
 								COMSIG_ATOM_UPDATE_ICON,
 								COMSIG_MOVABLE_MOVED,
 								COMSIG_ITEM_SHARPEN_ACT,
-								COMSIG_ITEM_CHECK_WIELDED,))
+								COMSIG_ITEM_CHECK_WIELDED))
 
 /// Triggered on equip of the item containing the component
 /datum/component/two_handed/proc/on_equip(datum/source, mob/user, slot)

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -19,6 +19,9 @@
 	var/icon_wielded = FALSE						/// The icon that will be used when wielded
 	var/obj/item/offhand/offhand_item = null		/// Reference to the offhand created for the item
 	var/sharpened_increase = 0						/// The amount of increase recived from sharpening the item
+	var/unwield_on_swap								/// Allow swapping, unwield on swap
+	var/auto_wield									/// If true wielding will be performed when picked up
+	var/ignore_attack_self							/// If true will not unwield when attacking self.
 
 /**
  * Two Handed component
@@ -32,10 +35,13 @@
  * * force_wielded (optional) The force setting when the item is wielded, do not use with force_multiplier
  * * force_unwielded (optional) The force setting when the item is unwielded, do not use with force_multiplier
  * * icon_wielded (optional) The icon to be used when wielded
+ * * unwield_on_swap (optional) Allow swapping, unwield on swap
+ * * auto_wield (optional) If true wielding will be performed when picked up
  */
 /datum/component/two_handed/Initialize(require_twohands=FALSE, wieldsound=FALSE, unwieldsound=FALSE, attacksound=FALSE, \
-										force_multiplier=0, force_wielded=0, force_unwielded=0, block_power_wielded=0, \
-										block_power_unwielded=0, icon_wielded=FALSE)
+		force_multiplier=0, force_wielded=0, force_unwielded=0, block_power_wielded=0, \
+		block_power_unwielded=0, icon_wielded=FALSE, \
+		unwield_on_swap = FALSE, auto_wield = FALSE, ignore_attack_self = FALSE)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -49,6 +55,9 @@
 	src.block_power_wielded = block_power_wielded
 	src.block_power_unwielded = block_power_unwielded
 	src.icon_wielded = icon_wielded
+	src.unwield_on_swap = unwield_on_swap
+	src.auto_wield = auto_wield
+	src.ignore_attack_self = ignore_attack_self
 
 	if(require_twohands)
 		ADD_TRAIT(parent, TRAIT_NEEDS_TWO_HANDS, ABSTRACT_ITEM_TRAIT)
@@ -57,7 +66,8 @@
 #define ISWIELDED(O) (SEND_SIGNAL(O, COMSIG_ITEM_CHECK_WIELDED) & COMPONENT_IS_WIELDED)
 
 /datum/component/two_handed/InheritComponent(datum/component/two_handed/new_comp, original, require_twohands, wieldsound, unwieldsound, \
-											force_multiplier, force_wielded, force_unwielded, block_power_wielded, block_power_unwielded, icon_wielded)
+		force_multiplier, force_wielded, force_unwielded, block_power_wielded, block_power_unwielded, icon_wielded, \
+		unwield_on_swap, auto_wield, ignore_attack_self)
 	if(!original)
 		return
 	if(require_twohands)
@@ -80,6 +90,12 @@
 		src.block_power_unwielded = block_power_unwielded
 	if(icon_wielded)
 		src.icon_wielded = icon_wielded
+	if(unwield_on_swap)
+		src.unwield_on_swap = unwield_on_swap
+	if(auto_wield)
+		src.auto_wield = auto_wield
+	if(ignore_attack_self)
+		src.ignore_attack_self = ignore_attack_self
 
 // register signals withthe parent item
 /datum/component/two_handed/RegisterWithParent()
@@ -101,13 +117,18 @@
 								COMSIG_ATOM_UPDATE_ICON,
 								COMSIG_MOVABLE_MOVED,
 								COMSIG_ITEM_SHARPEN_ACT,
-								COMSIG_ITEM_CHECK_WIELDED))
+								COMSIG_ITEM_CHECK_WIELDED,))
 
 /// Triggered on equip of the item containing the component
 /datum/component/two_handed/proc/on_equip(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
 
-	if(require_twohands && slot == ITEM_SLOT_HANDS) // force equip the item
+	if(auto_wield)
+		if(slot == ITEM_SLOT_HANDS)
+			RegisterSignal(user, COMSIG_MOB_SWAP_HANDS, .proc/on_swap_hands)
+		else
+			UnregisterSignal(user, COMSIG_MOB_SWAP_HANDS)
+	if((auto_wield || require_twohands) && slot == ITEM_SLOT_HANDS) // force equip the item
 		wield(user)
 	if(!user.is_holding(parent) && wielded && !require_twohands)
 		unwield(user)
@@ -116,6 +137,8 @@
 /datum/component/two_handed/proc/on_drop(datum/source, mob/user)
 	SIGNAL_HANDLER
 
+	if(auto_wield)
+		UnregisterSignal(user, COMSIG_MOB_SWAP_HANDS)
 	if(require_twohands)
 		unwield(user, show_message=TRUE)
 	if(wielded)
@@ -126,6 +149,9 @@
 /// Triggered on attack self of the item containing the component
 /datum/component/two_handed/proc/on_attack_self(datum/source, mob/user)
 	SIGNAL_HANDLER
+
+	if(ignore_attack_self)
+		return
 
 	if(wielded)
 		unwield(user)
@@ -138,13 +164,13 @@
  * vars:
  * * user The mob/living/carbon that is wielding the item
  */
-/datum/component/two_handed/proc/wield(mob/living/carbon/user)
+/datum/component/two_handed/proc/wield(mob/living/carbon/user, swap_hands = FALSE)
 	if(wielded)
 		return
 	if(ismonkey(user))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		return
-	if(user.get_inactive_held_item())
+	if(swap_hands ? user.get_active_held_item() : user.get_inactive_held_item())
 		if(require_twohands)
 			to_chat(user, "<span class='notice'>[parent] is too cumbersome to carry in one hand!</span>")
 			user.dropItemToGround(parent, force=TRUE)
@@ -161,7 +187,8 @@
 	if(SEND_SIGNAL(parent, COMSIG_TWOHANDED_WIELD, user) & COMPONENT_TWOHANDED_BLOCK_WIELD)
 		return // blocked wield from item
 	wielded = TRUE
-	RegisterSignal(user, COMSIG_MOB_SWAP_HANDS, .proc/on_swap_hands)
+	if(!auto_wield)
+		RegisterSignal(user, COMSIG_MOB_SWAP_HANDS, .proc/on_swap_hands)
 
 	// update item stats and name
 	var/obj/item/parent_item = parent
@@ -191,7 +218,10 @@
 	offhand_item.desc = "Your second grip on [parent_item]."
 	offhand_item.wielded = TRUE
 	RegisterSignal(offhand_item, COMSIG_ITEM_DROPPED, .proc/on_drop)
-	user.put_in_inactive_hand(offhand_item)
+	if(swap_hands)
+		user.put_in_active_hand(offhand_item)
+	else
+		user.put_in_inactive_hand(offhand_item)
 
 /**
  * Unwield the two handed item
@@ -206,7 +236,8 @@
 
 	// wield update status
 	wielded = FALSE
-	UnregisterSignal(user, COMSIG_MOB_SWAP_HANDS)
+	if(!auto_wield)
+		UnregisterSignal(user, COMSIG_MOB_SWAP_HANDS)
 	SEND_SIGNAL(parent, COMSIG_TWOHANDED_UNWIELD, user)
 
 	// update item stats
@@ -297,9 +328,15 @@
 	SIGNAL_HANDLER
 
 	if(!held_item)
+		//We are swapping to our two handed object.
+		if(auto_wield)
+			wield(user, TRUE)
 		return
 	if(held_item == parent)
-		return COMPONENT_BLOCK_SWAP
+		if(unwield_on_swap)
+			unwield(user, FALSE)
+		else
+			return COMPONENT_BLOCK_SWAP
 
 /**
  * on_sharpen Triggers on usage of a sharpening stone on the item

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -388,7 +388,7 @@
 	name = "offhand"
 	icon_state = "offhand"
 	w_class = WEIGHT_CLASS_HUGE
-	item_flags = ABSTRACT
+	item_flags = ABSTRACT | DROPDEL
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/wielded = FALSE // Off Hand tracking of wielded status
 

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -122,7 +122,7 @@
 /// Triggered on equip of the item containing the component
 /datum/component/two_handed/proc/on_equip(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
-
+	
 	if(auto_wield)
 		if(slot == ITEM_SLOT_HANDS)
 			RegisterSignal(user, COMSIG_MOB_SWAP_HANDS, .proc/on_swap_hands)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -247,6 +247,7 @@
 	throwforce = 0 //Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
+	requires_wielding = FALSE
 
 /obj/item/gun/magic/tentacle/Initialize(mapload, silent)
 	. = ..()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -743,7 +743,7 @@
 	guns_left = 24
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/enchanted/arcane_barrage/blood
 	fire_sound = 'sound/magic/wand_teleport.ogg'
-
+	requires_wielding = FALSE
 
 /obj/item/ammo_box/magazine/internal/boltaction/enchanted/arcane_barrage/blood
 	ammo_type = /obj/item/ammo_casing/magic/arcane_barrage/blood

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -106,7 +106,7 @@
 	. = ..()
 	//Smaller weapons are better when used in a single hand.
 	if(requires_wielding)
-		AddComponent(/datum/component/two_handed, unwield_on_swap = TRUE, auto_wield = TRUE, ignore_attack_self = TRUE, force_wielded = force, force_unwielded = force, block_power_wielded = block_power, block_power_unwielded = block_power, wieldsound = 'sound/weapons/sawclose.ogg', unwieldsound = 'sound/weapons/sawopen.ogg')
+		AddComponent(/datum/component/two_handed, unwield_on_swap = TRUE, auto_wield = TRUE, ignore_attack_self = TRUE, force_wielded = force, force_unwielded = force, block_power_wielded = block_power, block_power_unwielded = block_power)
 
 /obj/item/gun/proc/wield()
 	is_wielded = TRUE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -42,6 +42,7 @@
 	var/dual_wield_spread = 24			//additional spread when dual wielding
 	var/spread = 0						//Spread induced by the gun itself.
 	var/spread_multiplier = 1			//Multiplier for shotgun spread
+	var/requires_wielding = TRUE
 	var/spread_unwielded				//Spread induced by holding the gun with 1 hand. (40 for light weapons, 60 for medium by default)
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
 
@@ -97,13 +98,15 @@
 	build_zooming()
 	if(isnull(spread_unwielded))
 		spread_unwielded = weapon_weight * 20 + 20
-	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/wield)
-	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/unwield)
+	if(requires_wielding)
+		RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/wield)
+		RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/unwield)
 
 /obj/item/gun/ComponentInitialize()
 	. = ..()
 	//Smaller weapons are better when used in a single hand.
-	AddComponent(/datum/component/two_handed, unwield_on_swap = TRUE, auto_wield = TRUE, ignore_attack_self = TRUE, force_wielded = force, force_unwielded = force, block_power_wielded = block_power, block_power_unwielded = block_power, wieldsound = 'sound/effects/suitstep1.ogg', unwieldsound = 'sound/effects/suitstep2.ogg')
+	if(requires_wielding)
+		AddComponent(/datum/component/two_handed, unwield_on_swap = TRUE, auto_wield = TRUE, ignore_attack_self = TRUE, force_wielded = force, force_unwielded = force, block_power_wielded = block_power, block_power_unwielded = block_power, wieldsound = 'sound/effects/suitstep1.ogg', unwieldsound = 'sound/effects/suitstep2.ogg')
 
 /obj/item/gun/proc/wield()
 	is_wielded = TRUE
@@ -346,7 +349,7 @@
 		randomized_gun_spread =	rand(0,spread)
 	if(HAS_TRAIT(user, TRAIT_POOR_AIM)) //nice shootin' tex
 		bonus_spread += 25
-	if(!is_wielded)
+	if(!is_wielded && requires_wielding)
 		bonus_spread += spread_unwielded
 	var/randomized_bonus_spread = rand(0, bonus_spread)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -95,7 +95,7 @@
 	if(!canMouseDown) //Some things like beam rifles override this.
 		canMouseDown = automatic //Nsv13 / Bee change.
 	build_zooming()
-	if(!spread_unwielded)
+	if(isnull(spread_unwielded))
 		spread_unwielded = weapon_weight * 20 + 20
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/wield)
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/unwield)
@@ -139,14 +139,13 @@
 
 /obj/item/gun/examine(mob/user)
 	. = ..()
-	if(no_pin_required)
-		return
 
-	if(pin)
-		. += "It has \a [pin] installed."
-		. += "<span class='info'>[pin] looks like it could be removed with some <b>tools</b>.</span>"
-	else
-		. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
+	if(!no_pin_required)
+		if(pin)
+			. += "It has \a [pin] installed."
+			. += "<span class='info'>[pin] looks like it could be removed with some <b>tools</b>.</span>"
+		else
+			. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
 
 	if(gun_light)
 		. += "It has \a [gun_light] [can_flashlight ? "" : "permanently "]mounted on it."
@@ -161,6 +160,10 @@
 			. += "<span class='info'>[bayonet] looks like it can be <b>unscrewed</b> from [src].</span>"
 	else if(can_bayonet)
 		. += "It has a <b>bayonet</b> lug on it."
+
+	if(weapon_weight == WEAPON_HEAVY)
+		. += "This weapon is too heavy to use with just 1 hand!"
+
 
 /obj/item/gun/equipped(mob/living/user, slot)
 	. = ..()
@@ -250,8 +253,7 @@
 				user.dropItemToGround(src, TRUE)
 				return
 
-	var/obj/item/bodypart/other_hand = user.has_hand_for_held_index(user.get_inactive_hand_index()) //returns non-disabled inactive hands
-	if(weapon_weight == WEAPON_HEAVY && (!istype(user.get_inactive_held_item(), /obj/item/offhand) || !other_hand))
+	if(weapon_weight == WEAPON_HEAVY && !is_wielded)
 		balloon_alert(user, "You need both hands free to fire")
 		return
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -42,8 +42,10 @@
 	var/dual_wield_spread = 24			//additional spread when dual wielding
 	var/spread = 0						//Spread induced by the gun itself.
 	var/spread_multiplier = 1			//Multiplier for shotgun spread
-	var/spread_unwielded				//Spread induced by holding the gun with 1 hand. Can be set to 0 to disable autocalc. (40 for light weapons, 60 for medium by default)
+	var/spread_unwielded				//Spread induced by holding the gun with 1 hand. (40 for light weapons, 60 for medium by default)
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
+
+	var/is_wielded = FALSE
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
@@ -93,8 +95,21 @@
 	if(!canMouseDown) //Some things like beam rifles override this.
 		canMouseDown = automatic //Nsv13 / Bee change.
 	build_zooming()
-	if(isnull(spread_unwielded))
-		spread_unwielded = weapon_weight * 20 + 20 //{40, 60, 80}
+	if(!spread_unwielded)
+		spread_unwielded = weapon_weight * 20 + 20
+	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/wield)
+	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/unwield)
+
+/obj/item/gun/ComponentInitialize()
+	. = ..()
+	//Smaller weapons are better when used in a single hand.
+	AddComponent(/datum/component/two_handed, unwield_on_swap = TRUE, auto_wield = TRUE, ignore_attack_self = TRUE, force_wielded = force, force_unwielded = force, block_power_wielded = block_power, block_power_unwielded = block_power, wieldsound = 'sound/effects/suitstep1.ogg', unwieldsound = 'sound/effects/suitstep2.ogg')
+
+/obj/item/gun/proc/wield()
+	is_wielded = TRUE
+
+/obj/item/gun/proc/unwield()
+	is_wielded = FALSE
 
 /obj/item/gun/Destroy()
 	if(isobj(pin)) //Can still be the initial path, then we skip
@@ -107,6 +122,7 @@
 		QDEL_NULL(chambered)
 	if(azoom)
 		QDEL_NULL(azoom)
+	UnregisterSignal(list(COMSIG_TWOHANDED_WIELD, COMSIG_TWOHANDED_UNWIELD))
 	return ..()
 
 /obj/item/gun/handle_atom_del(atom/A)
@@ -123,13 +139,14 @@
 
 /obj/item/gun/examine(mob/user)
 	. = ..()
+	if(no_pin_required)
+		return
 
-	if(!no_pin_required)
-		if(pin)
-			. += "It has \a [pin] installed."
-			. += "<span class='info'>[pin] looks like it could be removed with some <b>tools</b>.</span>"
-		else
-			. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
+	if(pin)
+		. += "It has \a [pin] installed."
+		. += "<span class='info'>[pin] looks like it could be removed with some <b>tools</b>.</span>"
+	else
+		. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
 
 	if(gun_light)
 		. += "It has \a [gun_light] [can_flashlight ? "" : "permanently "]mounted on it."
@@ -145,19 +162,6 @@
 	else if(can_bayonet)
 		. += "It has a <b>bayonet</b> lug on it."
 
-	if(weapon_weight == WEAPON_HEAVY)
-		. += "You need both hands free to fire."
-	else
-		switch(spread_unwielded)
-			if(1 to 20)
-				. += "You could probably keep this reasonably on-target with one hand."
-			if(21 to 40)
-				. += "You can't aim this very accurately with one hand."
-			if(41 to 60)
-				. += "You are unlikely to hit anything if you fire this with one hand."
-			if(61 to INFINITY)
-				. += "You can't hit shit firing this one handed."
-
 /obj/item/gun/equipped(mob/living/user, slot)
 	. = ..()
 	if(zoomed && user.get_active_held_item() != src)
@@ -171,10 +175,6 @@
 //i.e if clicking would make it shoot
 /obj/item/gun/proc/can_shoot()
 	return TRUE
-
-/obj/item/gun/proc/check_wielded(mob/living/user)
-	var/obj/item/bodypart/other_hand = user.has_hand_for_held_index(user.get_inactive_hand_index()) //returns non-disabled inactive hands
-	return !(user.get_inactive_held_item() || !other_hand)
 
 /obj/item/gun/proc/shoot_with_empty_chamber(mob/living/user as mob|obj)
 	balloon_alert(user, "Gun clicks")
@@ -250,7 +250,8 @@
 				user.dropItemToGround(src, TRUE)
 				return
 
-	if(weapon_weight == WEAPON_HEAVY && !check_wielded(user))
+	var/obj/item/bodypart/other_hand = user.has_hand_for_held_index(user.get_inactive_hand_index()) //returns non-disabled inactive hands
+	if(weapon_weight == WEAPON_HEAVY && (!istype(user.get_inactive_held_item(), /obj/item/offhand) || !other_hand))
 		balloon_alert(user, "You need both hands free to fire")
 		return
 
@@ -343,7 +344,7 @@
 		randomized_gun_spread =	rand(0,spread)
 	if(HAS_TRAIT(user, TRAIT_POOR_AIM)) //nice shootin' tex
 		bonus_spread += 25
-	if(!check_wielded(user))
+	if(!is_wielded)
 		bonus_spread += spread_unwielded
 	var/randomized_bonus_spread = rand(0, bonus_spread)
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -106,7 +106,7 @@
 	. = ..()
 	//Smaller weapons are better when used in a single hand.
 	if(requires_wielding)
-		AddComponent(/datum/component/two_handed, unwield_on_swap = TRUE, auto_wield = TRUE, ignore_attack_self = TRUE, force_wielded = force, force_unwielded = force, block_power_wielded = block_power, block_power_unwielded = block_power, wieldsound = 'sound/effects/suitstep1.ogg', unwieldsound = 'sound/effects/suitstep2.ogg')
+		AddComponent(/datum/component/two_handed, unwield_on_swap = TRUE, auto_wield = TRUE, ignore_attack_self = TRUE, force_wielded = force, force_unwielded = force, block_power_wielded = block_power, block_power_unwielded = block_power, wieldsound = 'sound/weapons/sawclose.ogg', unwieldsound = 'sound/weapons/sawopen.ogg')
 
 /obj/item/gun/proc/wield()
 	is_wielded = TRUE

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -139,7 +139,7 @@
 				return
 			bolt_locked = FALSE
 		if(BOLT_TYPE_PUMP)
-			if(user?.get_inactive_held_item())
+			if(user?.get_inactive_held_item() && !istype(user.get_inactive_held_item(), /obj/item/offhand))
 				to_chat(user, "<span class='warning'>You require your other hand to be free to rack the [bolt_wording] of \the [src]!</span>")
 				return
 	if(user)

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -139,7 +139,7 @@
 				return
 			bolt_locked = FALSE
 		if(BOLT_TYPE_PUMP)
-			if(user?.get_inactive_held_item() && !istype(user.get_inactive_held_item(), /obj/item/offhand))
+			if(!is_wielded)
 				to_chat(user, "<span class='warning'>You require your other hand to be free to rack the [bolt_wording] of \the [src]!</span>")
 				return
 	if(user)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -226,7 +226,7 @@
 	fire_rate = 6
 	spread = 7
 	pin = /obj/item/firing_pin/implant/pindicate
-	spread_unwielded = 15 //This can't be fired onehanded?
+	spread_unwielded = 15
 	bolt_type = BOLT_TYPE_OPEN
 	mag_display = TRUE
 	mag_display_ammo = TRUE

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -226,7 +226,6 @@
 	fire_rate = 6
 	spread = 7
 	pin = /obj/item/firing_pin/implant/pindicate
-	spread_unwielded = 15
 	bolt_type = BOLT_TYPE_OPEN
 	mag_display = TRUE
 	mag_display_ammo = TRUE

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -83,7 +83,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact/shoot_live_shot(mob/living/user, pointblank, atom/pbtarget, message)
-	if(check_wielded(user))
+	if(!is_wielded)
 		recoil = 6
 	else
 		recoil = initial(recoil)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -319,6 +319,7 @@
 	use_cyborg_cell = TRUE
 	automatic = 1
 	fire_rate = 6
+	requires_wielding = FALSE
 
 /obj/item/gun/energy/printer/update_icon()
 	return

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -30,6 +30,7 @@
 	can_flashlight = FALSE
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
+	requires_wielding = FALSE
 
 /obj/item/gun/energy/disabler
 	name = "disabler"
@@ -47,12 +48,14 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
-	
+	requires_wielding = FALSE
+
 /obj/item/gun/energy/pulse/carbine/cyborg
 	name = "cyborg pulse carbine"
 	desc = "An integrated pulse rifle"
 	can_charge = FALSE
 	use_cyborg_cell = TRUE
+	requires_wielding = FALSE
 
 /obj/item/gun/energy/disabler/personal
 	name = "PTSD"
@@ -60,7 +63,7 @@
 	icon_state = "personal"
 	item_state = "gun"
 	pin = /obj/item/firing_pin/dna //Personal.
-	w_class = WEIGHT_CLASS_SMALL 
+	w_class = WEIGHT_CLASS_SMALL
 	cell_type = /obj/item/stock_parts/cell{charge = 320; maxcharge = 320} //Should be about 8 shots. 3 times less than the regular one.
 	ammo_x_offset = 2
 	charge_sections = 2

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -20,6 +20,7 @@
 	clumsy_check = 0
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses magic instead
 	pin = /obj/item/firing_pin/magic
+	requires_wielding = FALSE	//Magic has no recoil, just hold with 1 hand
 
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi' //not really a gun and some toys use these inhands
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -5,6 +5,7 @@
 	icon_state = "chronogun"
 	item_state = "chronogun"
 	w_class = WEIGHT_CLASS_NORMAL
+	requires_wielding = FALSE
 
 	var/mob/living/current_target
 	var/last_check = 0


### PR DESCRIPTION
## Description

This PR partially reverts #5762 but keeps some of the improvements Francium made.
This PR also makes it so gun subtypes that aren't actually gun's don't need 2 hands (IE wands.)

Removes all other hand checks in the gun firing, instead just checks if the item is wielded. This means that guns should now work with mobs that can have more than 2 hands (previously weapons like shotguns and LMGs wouldn't function correctly).

Magical guns, cyborg guns, medbeam and the tentacle don't require wielding.

In the twohanded component, unwield no longer takes user as an argument. Instead when wielded, the twohanded component remembers who is wielding the object and when unwield is called, the user who was wielding the object is used as the holder. This will prevent bugs that occur when an object moves via telekenisis as the user argument passed was a turf. If wielded via telekenisis, every time something that can be wielded moves, it would be unwielded automatically, so you can no longer wield things at range.

~~The sound for wielding has also been swapped out for a more metal / gun grabby sounding noise.~~ there's no noise for the gun thing

:cl:
add: Adds in the gun wielding icon in your off-hand.
fix: Magical wands, tentacle arms and cyborg guns no longer require wielding.
fix: Fixes a bugged interaction between telekenisis and twohanded component that allows you to drop the offhand object.
/:cl: