### PR TITLE
Space heater buff

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -83,9 +83,9 @@
 
 		for(var/turf/T in block(
 				locate(
-					max(T.x - heating_range, 1), max(T.y - heating_range, 1), T.z
+					max(L.x - heating_range, 1), max(L.y - heating_range, 1), L.z
 				), locate(
-					min(T.x + heating_range, world.maxx), min(T.y + heating_range, world.maxy), T.z
+					min(L.x + heating_range, world.maxx), min(L.y + heating_range, world.maxy), L.z
 				)))
 			heat_turf(T)
 	else
@@ -133,7 +133,7 @@
 		cap += M.rating
 
 	heatingPower = laser * 20000
-	heating_range = laser
+	heating_range = laser - 1
 
 	settableTemperatureRange = cap * 30
 	efficiency = (cap + 1) * 5000

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -136,7 +136,7 @@
 	heating_range = laser - 1
 
 	settableTemperatureRange = cap * 30
-	efficiency = (cap + 1) * 5000
+	efficiency = (cap + 1) * 20000
 
 	targetTemperature = clamp(targetTemperature,
 		max(settableTemperatureMedian - settableTemperatureRange, TCMB),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Temperature is a pain in the ass to control and normalizes very, very slowly. This buffs the space heater and allows it to cool nearby tiles when upgraded.
With the most basic parts it will cool just the tile it is on, at the maximum upgrade level it will cool with a radius of 3 tiles around it.
Also buffs the efficiency of space heaters as when the range increases, the power usage sky rockets. At max level you will need a bluespace power cell if you don't want to lose power instantly.

## Why It's Good For The Game

Fires are pretty bad, but once dealt with the temperature changes stay for insane amounts of time and are more dangerous than the fire themselves. This adds in a decent way to deal with the hallways being 200 degrees.

## Changelog
:cl:
balance: The spaceheater has been buffed and can now heat tiles around it when upgraded with a better laser. This comes with a great power cost though, so be prepared to upgrade the power cell!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
