### PR TITLE
remove incorrect usage of LAZYLEN

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -261,7 +261,7 @@
 	. = ..()
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
-	if(LAZYLEN(contents) && !reagents.total_volume)
+	if(length(contents) && !reagents.total_volume)
 		for(var/atom/movable/A in contents)
 			A.forceMove(eater.loc)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
LAZYLEN is supposed to be used only for lazy lists, and to indicate they are as such. I saw this in a code review for a mirror on austation, and couldn't cope. Just bite the bullet and merge #4373 when?
Unbased zesko moment in #5899
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Using defines for what they're supposed to be used for is good, actually. This should not be the defacto standard for all lists.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: remove incorrect lazylen usage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
