### PR TITLE
Buffs Lethal Lasers, Disablers Unaffected.

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -7,7 +7,7 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/item/projectile/beam/laser
-	e_cost = 71
+	e_cost = 50
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old


### PR DESCRIPTION
## About The Pull Request

Decreases energy cost of firing lasers.

Current: 1000/71 = 14 shots
PR: 1000/50 = 20 shots


## Why It's Good For The Game

Some quick Math:

Auto Rifle:
20 shots, 20 damage each. 20*20 = 400 dmg / mag.
Immune to EMP, can be reloaded mid combat.

Shotgun (slugs).
7 shots, 60 damage each. 7*60 = 420 dmg / mag.
Immune to EMP, can somewhat be reloaded mid combat.

! Old ! laser gun.
14 shots, 20 damage each. 14*20 = 280 dmg / mag.
Vulnerable to EMP, cannot be reloaded mid combat.

! PR ! laser gun.
20 shots, 20 damage each. 14*20 = 400 dmg / mag.
Vulnerable to EMP, cannot be reloaded mid combat.

As can be seen by the math, lethal lasers are pretty bad currently. This PR bring them somewhat in line with other primaries. Lethal lasers are still worse then auto rifles and shotguns due to their EMP vulnerability and lack of reloadability in combat. They have the advantage of shooting through glass as somewhat of a trade off.



In case you were wondering, disablers cost 40e / shot.
1000/40 = 25

25*28 = 700 stam dmg / mag.

(albeit this is not as OP as it sounds since stam damage is constantly decreasing and most armour is very effective against stam damage, however its still pretty damn good).

## Changelog
:cl:
balance: Laser guns now contain 20 lasers per charge instead of 14. Disablers unaffected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
