### PR TITLE
Hostile Ruin Adjustments

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_ratvar.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_ratvar.dm
@@ -18,7 +18,6 @@
 		/obj/effect/spawner/structure/ratvar_skewer_trap = 4,
 		/obj/effect/spawner/structure/ratvar_flipper_trap = 2,
 		/obj/effect/spawner/structure/ratvar_skewer_trap_kill = 1,
-		/obj/structure/destructible/clockwork/sigil/transgression = 2,
 		/mob/living/simple_animal/hostile/clockwork_marauder = 1,
 		/obj/structure/destructible/clockwork/wall_gear/displaced = 10,
 		/obj/effect/spawner/ocular_warden_setup = 1,

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_xeno.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_xeno.dm
@@ -5,29 +5,29 @@
 
 /datum/generator_settings/xeno/get_floortrash()
 	. = list(
-		/obj/effect/decal/cleanable/dirt = 3,
-		/obj/effect/decal/cleanable/blood/old = 6,
-		/obj/effect/decal/cleanable/oil = 2,
-		/obj/effect/decal/cleanable/robot_debris/old = 1,
-		/obj/effect/decal/cleanable/vomit/old = 4,
-		/obj/effect/decal/cleanable/blood/gibs/old = 6,
-		/obj/effect/decal/cleanable/greenglow/filled = 3,
-		/obj/effect/spawner/lootdrop/glowstick/lit = 5,
-		/obj/effect/spawner/lootdrop/glowstick = 1,
-		/obj/effect/spawner/lootdrop/maintenance = 3,
-		/obj/item/ammo_casing/c9mm = 4,
+		/obj/effect/decal/cleanable/dirt = 9,
+		/obj/effect/decal/cleanable/blood/old = 18,
+		/obj/effect/decal/cleanable/oil = 6,
+		/obj/effect/decal/cleanable/robot_debris/old = 18,
+		/obj/effect/decal/cleanable/vomit/old = 12,
+		/obj/effect/decal/cleanable/blood/gibs/old = 18,
+		/obj/effect/decal/cleanable/greenglow/filled = 18,
+		/obj/effect/spawner/lootdrop/glowstick/lit = 15,
+		/obj/effect/spawner/lootdrop/glowstick = 3,
+		/obj/effect/spawner/lootdrop/maintenance = 9,
+		/obj/item/ammo_casing/c9mm = 12,
 		/obj/item/gun/ballistic/automatic/pistol/no_mag = 1,
 		/mob/living/simple_animal/hostile/alien/drone = 1,
 		/mob/living/simple_animal/hostile/alien/sentinel = 1,
 		/mob/living/simple_animal/hostile/alien = 1,
-		/obj/structure/alien/egg = 1,
-		/obj/structure/alien/weeds/node = 8,
-		/obj/structure/alien/gelpod = 4,
-		/obj/effect/mob_spawn/human/corpse/nanotrasensoldier = 1,
-		/obj/effect/mob_spawn/human/corpse/assistant = 1,
-		/obj/effect/mob_spawn/human/corpse/cargo_tech = 1,
-		/obj/effect/mob_spawn/human/corpse/damaged = 1,
-		null = 90
+		/obj/structure/alien/egg = 3,
+		/obj/structure/alien/weeds/node = 24,
+		/obj/structure/alien/gelpod = 12,
+		/obj/effect/mob_spawn/human/corpse/nanotrasensoldier = 3,
+		/obj/effect/mob_spawn/human/corpse/assistant = 3,
+		/obj/effect/mob_spawn/human/corpse/cargo_tech = 3,
+		/obj/effect/mob_spawn/human/corpse/damaged = 3,
+		null = 270
 	)
 	for(var/trash in subtypesof(/obj/item/trash))
 		.[trash] = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes blindness sigils from ratvar ruins.
Scales xenomorph spawnrate on xeno ruins by 1/3rd.
(to do this I scaled everything else up by 3x)

Also scales steckin spawn rate on xeno ruins by 1/3rd because finding like 10 steckins is kind of dumb, even if you cant use them.

## Why It's Good For The Game

Stepping on a single trap and being essentially removed from the game for 5 minutes by being blinded is NOT FUN WHATSOEVER.

Also the xeno ruins just have too many xenos. On a larger ruin you could have 30 or so xenos which is a ridiculous amount to expect 3 or less explorers to be able to deal with

## Changelog
:cl:
balance: Removed blindness traps on ratvar ruins.
balance: Xeno spawns on xeno ruins scaled by 1/3rd.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
