### PR TITLE
Fixes Explorer Gun Damage Increase On Simple Mobs

### DIFF
--- a/code/modules/exploration_crew/exploration_laser_gun.dm
+++ b/code/modules/exploration_crew/exploration_laser_gun.dm
@@ -31,7 +31,7 @@
 
 /obj/item/projectile/beam/laser/anti_creature/prehit_pierce(atom/target)
     if(!iscarbon(target) && !issilicon(target))
-        damage += 15
+        damage = 30
     return ..()
 
 //Cutting projectile - Damage against objects

--- a/code/modules/exploration_crew/exploration_laser_gun.dm
+++ b/code/modules/exploration_crew/exploration_laser_gun.dm
@@ -29,11 +29,10 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/laser/anti_creature/on_hit(atom/target, blocked)
-	damage = initial(damage)
-	if(!iscarbon(target) && !issilicon(target))
-		damage = 30
-	. = ..()
+/obj/item/projectile/beam/laser/anti_creature/prehit_pierce(atom/target)
+    if(!iscarbon(target) && !issilicon(target))
+        damage += 15
+    return ..()
 
 //Cutting projectile - Damage against objects
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes Explorer Gun Damage Increase On Simple Mobs

Tested in local, damage increase applies to simplemobs and not to humans.

closes #6048

## Why It's Good For The Game

Fixes a bug, makes explorers be able to do their job better.

## Changelog
:cl: Zams, Isy232
fix: Explorer gun will not function as intended against simplemobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
