### PR TITLE
Fixes Explorer Lasgun Not Doing Bonus Damage to Simple Mobs

### DIFF
--- a/code/modules/exploration_crew/exploration_laser_gun.dm
+++ b/code/modules/exploration_crew/exploration_laser_gun.dm
@@ -29,12 +29,13 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/laser/anti_creature/on_hit(atom/target, blocked)
+/obj/item/projectile/beam/laser/anti_creature/prehit_pierce(atom/target)
 	damage = initial(damage)
 	if(!iscarbon(target) && !issilicon(target))
 		damage = 30
+		return PROJECTILE_PIERCE_NONE
 	. = ..()
-
+	
 //Cutting projectile - Damage against objects
 
 /obj/item/ammo_casing/energy/laser/cutting


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #6048
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
fix: Explorer Gun now properly does 30 damage to simplemobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
