### PR TITLE
Makes the traitor stim pack's stun resistance trait actually do something

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -146,8 +146,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_FAKEDEATH			"fakedeath" //Makes the owner appear as dead to most forms of medical examination
 #define TRAIT_DISFIGURED		"disfigured"
 #define TRAIT_XENO_HOST			"xeno_host"	//Tracks whether we're gonna be a baby alien's mummy.
-#define TRAIT_STUNIMMUNE		"stun_immunity"
-#define TRAIT_STUNRESISTANCE    "stun_resistance"
+#define TRAIT_STUNIMMUNE		"stun_immunity"	//Makes you completely immune to stuns
+#define TRAIT_STUNRESISTANCE    "stun_resistance"	//Allows you to take 40% of your max health more stun damage, you recover from stuns twice as fast and stay stunned for half as long
 #define TRAIT_CONFUSEIMMUNE		"confuse_immunity"
 #define TRAIT_SLEEPIMMUNE		"sleep_immunity"
 #define TRAIT_PUSHIMMUNE		"push_immunity"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -560,6 +560,10 @@
 
 /mob/living/carbon/update_stamina(extend_stam_crit = FALSE)
 	var/stam = getStaminaLoss()
+	var/stamina_crit_point = crit_threshold
+	//Stun resistant trait allows you to take extra stamina damage
+	if(HAS_TRAIT(src, TRAIT_STUNRESISTANCE))
+		stamina_crit_point -= maxHealth * 0.4
 	if(stam > DAMAGE_PRECISION && (maxHealth - stam) <= crit_threshold && !stat && !HAS_TRAIT(src, TRAIT_NOSTAMCRIT))
 		if(extend_stam_crit || !stam_paralyzed)
 			enter_stamcrit()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -353,6 +353,9 @@
 	//Increase damage the more stam damage
 	//Incraesed stamina healing when above 50 stamloss, up to 2x healing rate when at 100 stamloss.
 	stam_heal_multiplier = CLAMP(total_stamina_loss / 50, 1, 2)
+	//Heal stamina damage faster if stun reistant
+	if(HAS_TRAIT(src, TRAIT_STUNRESISTANCE))
+		stam_heal_multiplier *= 2
 	//Heal bodypart stamina damage
 	for(var/obj/item/bodypart/BP as() in bodyparts)
 		if(BP.needs_processing)

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -14,7 +14,7 @@
 	if(!IsParalyzed())
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going.</span>")
 	var/stamina_crit_timer = STAMINA_CRIT_TIME
-	if(HAS_TRAIT(owner, TRAIT_STUNRESISTANCE))
+	if(HAS_TRAIT(src, TRAIT_STUNRESISTANCE))
 		stamina_crit_timer *= 0.5
 	stam_regen_start_time = world.time + stamina_crit_timer
 	stam_paralyzed = TRUE

--- a/code/modules/mob/living/carbon/status_procs.dm
+++ b/code/modules/mob/living/carbon/status_procs.dm
@@ -13,7 +13,10 @@
 		return
 	if(!IsParalyzed())
 		to_chat(src, "<span class='notice'>You're too exhausted to keep going.</span>")
-	stam_regen_start_time = world.time + STAMINA_CRIT_TIME
+	var/stamina_crit_timer = STAMINA_CRIT_TIME
+	if(HAS_TRAIT(owner, TRAIT_STUNRESISTANCE))
+		stamina_crit_timer *= 0.5
+	stam_regen_start_time = world.time + stamina_crit_timer
 	stam_paralyzed = TRUE
 
 /mob/living/carbon/adjust_drugginess(amount)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -5,6 +5,11 @@
 
 ////////////////////////////// STUN ////////////////////////////////////
 
+/mob/living/proc/get_stun_resistance_multiplier()
+	if(HAS_TRAIT(src, TRAIT_STUNRESISTANCE))
+		return 0.5
+	return 1
+
 /mob/living/proc/IsStun() //If we're stunned
 	return has_status_effect(STATUS_EFFECT_STUN)
 
@@ -15,20 +20,20 @@
 	return 0
 
 /mob/living/proc/Stun(amount, updating = TRUE, ignore_canstun = FALSE) //Can't go below remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANSTUN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		var/datum/status_effect/incapacitating/stun/S = IsStun()
 		if(S)
-			S.duration = max(world.time + amount, S.duration)
+			S.duration = max(world.time + amount * get_stun_resistance_multiplier(), S.duration)
 		else if(amount > 0)
-			S = apply_status_effect(STATUS_EFFECT_STUN, amount, updating)
+			S = apply_status_effect(STATUS_EFFECT_STUN, amount * get_stun_resistance_multiplier(), updating)
 		return S
 
 /mob/living/proc/SetStun(amount, updating = TRUE, ignore_canstun = FALSE) //Sets remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANSTUN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		var/datum/status_effect/incapacitating/stun/S = IsStun()
@@ -36,25 +41,25 @@
 			if(S)
 				qdel(S)
 		else
-			if(absorb_stun(amount, ignore_canstun))
+			if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 				return
 			if(S)
-				S.duration = world.time + amount
+				S.duration = world.time + amount * get_stun_resistance_multiplier()
 			else
-				S = apply_status_effect(STATUS_EFFECT_STUN, amount, updating)
+				S = apply_status_effect(STATUS_EFFECT_STUN, amount * get_stun_resistance_multiplier(), updating)
 		return S
 
 /mob/living/proc/AdjustStun(amount, updating = TRUE, ignore_canstun = FALSE) //Adds to remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANSTUN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		var/datum/status_effect/incapacitating/stun/S = IsStun()
 		if(S)
-			S.duration += amount
+			S.duration += amount * get_stun_resistance_multiplier()
 		else if(amount > 0)
-			S = apply_status_effect(STATUS_EFFECT_STUN, amount, updating)
+			S = apply_status_effect(STATUS_EFFECT_STUN, amount * get_stun_resistance_multiplier(), updating)
 		return S
 
 ///////////////////////////////// KNOCKDOWN /////////////////////////////////////
@@ -69,20 +74,20 @@
 	return 0
 
 /mob/living/proc/Knockdown(amount, updating = TRUE, ignore_canstun = FALSE) //Can't go below remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
 		if(K)
-			K.duration = max(world.time + amount, K.duration)
+			K.duration = max(world.time + amount * get_stun_resistance_multiplier(), K.duration)
 		else if(amount > 0)
-			K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount, updating)
+			K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount * get_stun_resistance_multiplier(), updating)
 		return K
 
 /mob/living/proc/SetKnockdown(amount, updating = TRUE, ignore_canstun = FALSE) //Sets remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
@@ -90,25 +95,25 @@
 			if(K)
 				qdel(K)
 		else
-			if(absorb_stun(amount, ignore_canstun))
+			if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 				return
 			if(K)
-				K.duration = world.time + amount
+				K.duration = world.time + amount * get_stun_resistance_multiplier()
 			else
-				K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount, updating)
+				K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount * get_stun_resistance_multiplier(), updating)
 		return K
 
 /mob/living/proc/AdjustKnockdown(amount, updating = TRUE, ignore_canstun = FALSE) //Adds to remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
 		if(K)
-			K.duration += amount
+			K.duration += amount * get_stun_resistance_multiplier()
 		else if(amount > 0)
-			K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount, updating)
+			K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount * get_stun_resistance_multiplier(), updating)
 		return K
 
 ///////////////////////////////// IMMOBILIZED ////////////////////////////////////
@@ -122,20 +127,20 @@
 	return 0
 
 /mob/living/proc/Immobilize(amount, updating = TRUE, ignore_canstun = FALSE) //Can't go below remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
 		if(I)
-			I.duration = max(world.time + amount, I.duration)
+			I.duration = max(world.time + amount * get_stun_resistance_multiplier(), I.duration)
 		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount, updating)
+			I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount * get_stun_resistance_multiplier(), updating)
 		return I
 
 /mob/living/proc/SetImmobilized(amount, updating = TRUE, ignore_canstun = FALSE) //Sets remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
@@ -143,25 +148,25 @@
 			if(I)
 				qdel(I)
 		else
-			if(absorb_stun(amount, ignore_canstun))
+			if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 				return
 			if(I)
-				I.duration = world.time + amount
+				I.duration = world.time + amount * get_stun_resistance_multiplier()
 			else
-				I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount, updating)
+				I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount * get_stun_resistance_multiplier(), updating)
 		return I
 
 /mob/living/proc/AdjustImmobilized(amount, updating = TRUE, ignore_canstun = FALSE) //Adds to remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
 		if(I)
-			I.duration += amount
+			I.duration += amount * get_stun_resistance_multiplier()
 		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount, updating)
+			I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount * get_stun_resistance_multiplier(), updating)
 		return I
 
 ///////////////////////////////// PARALYZED //////////////////////////////////
@@ -175,21 +180,21 @@
 	return 0
 
 /mob/living/proc/Paralyze(amount, updating = TRUE, ignore_canstun = FALSE) //Can't go below remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		drop_all_held_items()
 		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
 		if(P)
-			P.duration = max(world.time + amount, P.duration)
+			P.duration = max(world.time + amount * get_stun_resistance_multiplier(), P.duration)
 		else if(amount > 0)
-			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount, updating)
+			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount * get_stun_resistance_multiplier(), updating)
 		return P
 
 /mob/living/proc/SetParalyzed(amount, updating = TRUE, ignore_canstun = FALSE) //Sets remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
@@ -197,25 +202,25 @@
 			if(P)
 				qdel(P)
 		else
-			if(absorb_stun(amount, ignore_canstun))
+			if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 				return
 			if(P)
-				P.duration = world.time + amount
+				P.duration = world.time + amount * get_stun_resistance_multiplier()
 			else
-				P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount, updating)
+				P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount * get_stun_resistance_multiplier(), updating)
 		return P
 
 /mob/living/proc/AdjustParalyzed(amount, updating = TRUE, ignore_canstun = FALSE) //Adds to remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount, updating, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount * get_stun_resistance_multiplier(), updating, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
+		if(absorb_stun(amount * get_stun_resistance_multiplier(), ignore_canstun))
 			return
 		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
 		if(P)
-			P.duration += amount
+			P.duration += amount * get_stun_resistance_multiplier()
 		else if(amount > 0)
-			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount, updating)
+			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount * get_stun_resistance_multiplier(), updating)
 		return P
 
 //Blanket

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -192,7 +192,10 @@
 		owner.updatehealth()
 		if(stamina > DAMAGE_PRECISION)
 			owner.update_stamina(TRUE)
-			owner.stam_regen_start_time = max(owner.stam_regen_start_time, world.time + STAMINA_REGEN_BLOCK_TIME)
+			var/stamina_regen_time = STAMINA_REGEN_BLOCK_TIME
+			if(HAS_TRAIT(owner, TRAIT_STUNRESISTANCE))
+				stamina_regen_time *= 0.5
+			owner.stam_regen_start_time = max(owner.stam_regen_start_time, world.time + stamina_regen_time)
 	consider_processing()
 	update_disabled()
 	return update_bodypart_damage_state()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs the stim-pack item by making the stun resistance trait actually do something. Previously the stun resistance trait didn't actually do anything.
The stun resistance trait now provides 40% of your max health more stun damage capacity, 50% shorter stamina crit duration and 200% stamina healing rate. Regular stuns such as paralysis will also only apply for half the duration.

## Why It's Good For The Game

The stun resistance trait doesn't actually do anything, and for a pretty good amount of TC, the stim pack should definitely provide more of a bonus.

## Changelog
:cl:
balance: The stun resistance trait gained from the traitor's stim packs now provides stun resistance rather than doing nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
