### PR TITLE
Reverts changes to chat, limits number of messages that can be displayed in one location

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -102,5 +102,6 @@
 #define INVOCATION_EMOTE "emote"
 #define INVOCATION_WHISPER "whisper"
 
-//Used in visible_message_flags, audible_message_flags and message_mods
-#define CHATMESSAGE_EMOTE "emotemessage"
+//Used in visible_message_flags, audible_message_flags and runechat_flags
+#define EMOTE_MESSAGE (1<<0)
+#define RADIO_MESSAGE (1<<1)

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -148,6 +148,13 @@
 
 	friend_talk(message)
 
+/mob/camera/imaginary_friend/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
+	//Get message flags
+	var/flags = message_mods.Find(MODE_RADIO_MESSAGE) ? RADIO_MESSAGE : NONE
+	if (client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker)))
+		create_chat_message(speaker, message_language, raw_message, spans, runechat_flags = flags)
+	to_chat(src, compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods))
+
 /mob/camera/imaginary_friend/proc/friend_talk(message)
 	message = capitalize(trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)))
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -22,6 +22,8 @@
 #define CHAT_MESSAGE_ICON_SIZE		7
 /// How much the message moves up before fading out.
 #define MESSAGE_FADE_PIXEL_Y 10
+/// How many messages can be generated in one spot
+#define MAX_MESSAGE_COUNT 2
 
 #define BUCKET_LIMIT (world.time + TICKS2DS(min(BUCKET_LEN - (SSrunechat.practical_offset - DS2TICKS(world.time - SSrunechat.head_offset)) - 1, BUCKET_LEN - 1)))
 #define BALLOON_TEXT_WIDTH 200
@@ -208,10 +210,15 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	message_loc = get_atom_on_turf(target)
-	if (owned_by.seen_messages)
+
+	if(owned_by.seen_messages)
 		var/idx = 1
 		var/combined_height = approx_lines
-		for(var/datum/chatmessage/m as() in message_loc.chat_messages)
+		// This line here assumes we won't ever have more than 3 messages at once.
+		if(length(owned_by.seen_messages[message_loc]) > MAX_MESSAGE_COUNT)
+			qdel(owned_by.seen_messages[message_loc][1])
+
+		for(var/datum/chatmessage/m as() in owned_by.seen_messages[message_loc])
 			if(!m?.message)
 				continue
 			animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -23,11 +23,6 @@
 /// How much the message moves up before fading out.
 #define MESSAGE_FADE_PIXEL_Y 10
 
-// Message types
-#define CHATMESSAGE_CANNOT_HEAR 0
-#define CHATMESSAGE_HEAR 1
-#define CHATMESSAGE_SHOW_LANGUAGE_ICON 2
-
 #define BUCKET_LIMIT (world.time + TICKS2DS(min(BUCKET_LEN - (SSrunechat.practical_offset - DS2TICKS(world.time - SSrunechat.head_offset)) - 1, BUCKET_LEN - 1)))
 #define BALLOON_TEXT_WIDTH 200
 #define BALLOON_TEXT_SPAWN_TIME (0.2 SECONDS)
@@ -60,8 +55,8 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	var/image/message
 	/// The location in which the message is appearing
 	var/atom/message_loc
-	/// A list of clients who hear this message
-	var/list/client/hearers
+	/// The client who heard this message
+	var/client/owned_by
 	/// Contains the scheduled destruction time, used for scheduling EOL
 	var/scheduled_destruction
 	/// Contains the time that the EOL for the message will be complete, used for qdel scheduling
@@ -87,22 +82,22 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
   * * extra_classes - Extra classes to apply to the span that holds the text
   * * lifespan - The lifespan of the message in deciseconds
   */
-/datum/chatmessage/New(text, atom/target, list/client/hearers, language_icon, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN)
+/datum/chatmessage/New(text, atom/target, mob/owner, datum/language/language, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN)
 	. = ..()
 	if (!istype(target))
 		CRASH("Invalid target given for chatmessage")
-	INVOKE_ASYNC(src, .proc/generate_image, text, target, hearers, language_icon, extra_classes, lifespan)
+	if(QDELETED(owner) || !istype(owner) || !owner.client)
+		stack_trace("/datum/chatmessage created with [isnull(owner) ? "null" : "invalid"] mob owner")
+		qdel(src)
+		return
+	INVOKE_ASYNC(src, .proc/generate_image, text, target, owner, language, extra_classes, lifespan)
 
 /datum/chatmessage/Destroy()
-	if (hearers)
-		for(var/client/C in hearers)
-			if(!C)
-				continue
-			C.images.Remove(message)
-			UnregisterSignal(C, COMSIG_PARENT_QDELETING)
-	if(!QDELETED(message_loc))
-		LAZYREMOVE(message_loc.chat_messages, src)
-	hearers = null
+	if (owned_by)
+		if (owned_by.seen_messages)
+			LAZYREMOVEASSOC(owned_by.seen_messages, message_loc, src)
+		owned_by.images.Remove(message)
+	owned_by = null
 	message_loc = null
 	message = null
 	leave_subsystem()
@@ -113,6 +108,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
   */
 /datum/chatmessage/proc/on_parent_qdel()
 	SIGNAL_HANDLER
+
 	qdel(src)
 
 /**
@@ -126,32 +122,22 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
   * * extra_classes - Extra classes to apply to the span that holds the text
   * * lifespan - The lifespan of the message in deciseconds
   */
-/datum/chatmessage/proc/generate_image(text, atom/target, list/client/hearers, datum/language/language, list/extra_classes, lifespan)
+/datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, datum/language/language, list/extra_classes, lifespan)
 	/// Cached icons to show what language the user is speaking
 	var/static/list/language_icons
 
-	// Store the hearers
-	src.hearers = hearers
-
-	if(!LAZYLEN(hearers))
-		return
-
-	var/client/first_hearer = hearers[1]
-
-	// Delete when the atom its above gets deleted.
-	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/on_parent_qdel)
-
-	for(var/client/C as() in hearers)
-		if(C)
-			RegisterSignal(C, COMSIG_PARENT_QDELETING, .proc/client_deleted)
+	// Register client who owns this message
+	owned_by = owner.client
+	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/on_parent_qdel)
 
 	// Remove spans in the message from things like the recorder
 	var/static/regex/span_check = new(@"<\/?span[^>]*>", "gi")
 	text = replacetext(text, span_check, "")
 
 	// Clip message
-	if (length_char(text) > CHAT_MESSAGE_MAX_LENGTH)
-		text = copytext_char(text, 1, CHAT_MESSAGE_MAX_LENGTH + 1) + "..." // BYOND index moment
+	var/maxlen = owned_by.prefs.max_chat_length
+	if (length_char(text) > maxlen)
+		text = copytext_char(text, 1, maxlen + 1) + "..." // BYOND index moment
 
 	//The color of the message.
 
@@ -204,7 +190,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 
 	// Append language icon if the language uses one
 	var/datum/language/language_instance = GLOB.language_datum_instances[language]
-	if (language_instance?.display_icon(first_hearer.mob))
+	if (language_instance?.display_icon(owner))
 		var/icon/language_icon = LAZYACCESS(language_icons, language)
 		if (isnull(language_icon))
 			language_icon = icon(language_instance.icon, icon_state = language_instance.icon_state)
@@ -217,12 +203,12 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 
 	// Approximate text height
 	var/complete_text = "<span class='center [extra_classes.Join(" ")]' style='color: [tgt_color]'>[text]</span>"
-	var/mheight = WXH_TO_HEIGHT(first_hearer.MeasureText(complete_text, null, CHAT_MESSAGE_WIDTH))
+	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(complete_text, null, CHAT_MESSAGE_WIDTH))
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	message_loc = get_atom_on_turf(target)
-	if (LAZYLEN(message_loc.chat_messages))
+	if (owned_by.seen_messages)
 		var/idx = 1
 		var/combined_height = approx_lines
 		for(var/datum/chatmessage/m as() in message_loc.chat_messages)
@@ -235,46 +221,34 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 			// scheduled time once the EOL completion time has been set.
 			var/sched_remaining = m.scheduled_destruction - world.time
 			if (!m.eol_complete)
-				var/remaining_time = (sched_remaining) * (CHAT_MESSAGE_EXP_DECAY ** idx++) * (CHAT_MESSAGE_HEIGHT_DECAY ** CEILING(combined_height, 1))
+				var/remaining_time = (sched_remaining) * (CHAT_MESSAGE_EXP_DECAY ** idx++) * (CHAT_MESSAGE_HEIGHT_DECAY ** combined_height)
 				m.enter_subsystem(world.time + remaining_time) // push updated time to runechat SS
 
 	// Reset z index if relevant
 	if (current_z_idx >= CHAT_LAYER_MAX_Z)
 		current_z_idx = 0
 
-	var/bound_height = world.icon_size
-	var/bound_width = world.icon_size
-	if(ismovableatom(message_loc))
-		var/atom/movable/AM = message_loc
-		bound_height = AM.bound_height
-		bound_width = AM.bound_width
 	// Build message image
 	message = image(loc = message_loc, layer = CHAT_LAYER + CHAT_LAYER_Z_STEP * current_z_idx++)
 	message.plane = RUNECHAT_PLANE
 	message.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA | KEEP_APART
 	message.alpha = 0
-	message.pixel_y = bound_height - MESSAGE_FADE_PIXEL_Y
+	message.pixel_y = owner.bound_height - MESSAGE_FADE_PIXEL_Y
 	message.maptext_width = CHAT_MESSAGE_WIDTH
 	message.maptext_height = mheight
-	message.maptext_x = (CHAT_MESSAGE_WIDTH - bound_width) * -0.5
+	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5
 	if(extra_classes.Find("italics"))
 		message.color = "#CCCCCC"
 	message.maptext = MAPTEXT(complete_text)
 
-	// Show the message to clients
-	for(var/client/C as() in hearers)
-		C?.images |= message
-	animate(message, alpha = 255, pixel_y = bound_height, time = CHAT_MESSAGE_SPAWN_TIME)
-
-	LAZYADD(message_loc.chat_messages, src)
+	// View the message
+	LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
+	owned_by.images |= message
+	animate(message, alpha = 255, pixel_y = owner.bound_height, time = CHAT_MESSAGE_SPAWN_TIME)
 
 	// Register with the runechat SS to handle EOL and destruction
 	scheduled_destruction = world.time + (lifespan - CHAT_MESSAGE_EOL_FADE)
 	enter_subsystem()
-
-/datum/chatmessage/proc/client_deleted(client/source)
-	SIGNAL_HANDLER
-	hearers -= source
 
 /**
   * Applies final animations to overlay CHAT_MESSAGE_EOL_FADE deciseconds prior to message deletion,
@@ -288,109 +262,6 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	animate(message, alpha = 0, pixel_y = message.pixel_y + MESSAGE_FADE_PIXEL_Y, time = fadetime, flags = ANIMATION_PARALLEL)
 	enter_subsystem(eol_complete) // re-enter the runechat SS with the EOL completion time to QDEL self
 
-/mob/proc/should_show_chat_message(atom/movable/speaker, datum/language/message_language, is_emote = FALSE, is_heard = FALSE)
-	if(!client)
-		return CHATMESSAGE_CANNOT_HEAR
-	if(!client.prefs.chat_on_map || (!client.prefs.see_chat_non_mob && !ismob(speaker)))
-		return CHATMESSAGE_CANNOT_HEAR
-	if(!client.prefs.see_rc_emotes && is_emote)
-		return CHATMESSAGE_CANNOT_HEAR
-	if(is_heard && !can_hear())
-		return CHATMESSAGE_CANNOT_HEAR
-	//If the speaker is a virtual speaker, check to make sure we couldnt hear the original message.
-	if(istype(speaker, /atom/movable/virtualspeaker))
-		var/atom/movable/virtualspeaker/v = speaker
-		//Dont create the overhead chat if we said the message.
-		if(v.source == src)
-			return CHATMESSAGE_CANNOT_HEAR
-		//Dont create the overhead radio chat if we are a ghost and can hear global messages.
-		if(isobserver(src))
-			return CHATMESSAGE_CANNOT_HEAR
-		//Dont create the overhead radio chat if we heard the speaker speak
-		if(get_dist(get_turf(v.source), get_turf(src)) <= 1)
-			return CHATMESSAGE_CANNOT_HEAR
-		//The AI shouldn't be able to see the overhead chat trough the static
-		if(isAI(src) && !GLOB.cameranet.checkCameraVis(v.source))
-			return CHATMESSAGE_CANNOT_HEAR
-	var/datum/language/language_instance = GLOB.language_datum_instances[message_language]
-	if(language_instance?.display_icon(src))
-		return CHATMESSAGE_SHOW_LANGUAGE_ICON
-	return CHATMESSAGE_HEAR
-
-/mob/living/should_show_chat_message(atom/movable/speaker, datum/language/message_language, is_emote = FALSE, is_heard = FALSE)
-	if(stat != CONSCIOUS && stat != DEAD)
-		return CHATMESSAGE_CANNOT_HEAR
-	return ..()
-
-/proc/create_chat_message(atom/movable/speaker, datum/language/message_language, list/hearers, raw_message, list/spans, list/message_mods)
-	if(!length(hearers))
-		return
-
-	if(!islist(message_mods))
-		message_mods = list()
-
-	// Ensure the list we are using, if present, is a copy so we don't modify the list provided to us
-	spans = spans ? spans.Copy() : list()
-
-	// Check for virtual speakers (aka hearing a message through a radio)
-	if (istype(speaker, /atom/movable/virtualspeaker))
-		var/atom/movable/virtualspeaker/v = speaker
-		speaker = v.source
-		spans |= "virtual-speaker"
-
-	//If the message has the radio message flag
-	else if (message_mods[MODE_RADIO_MESSAGE])
-		//You are now a virtual speaker
-		spans |= "virtual-speaker"
-		//You are no longer italics
-		spans -= "italics"
-
-	// Display visual above source
-	if(message_mods.Find(CHATMESSAGE_EMOTE))
-		var/list/clients = list()
-		for(var/mob/M as() in hearers)
-			if(M?.should_show_chat_message(speaker, message_language, TRUE))
-				clients += M.client
-		new /datum/chatmessage(raw_message, speaker, clients, message_language, list("emote"))
-	else
-		//4 Possible chat message states:
-		//Show Icon, Understand (Most other languages)
-		//Hide Icon, Understand (Normal galactic common)
-		//Show Icon, Don't understand (Most languages you can't understand)
-		//Hide Icon, Don't understand (Not understanding common)
-		var/list/client/show_icon_understand
-		var/list/client/hide_icon_understand
-		var/list/client/show_icon_scrambled
-		var/list/client/hide_icon_scrambled
-		for(var/mob/M as() in hearers)
-			switch(M?.should_show_chat_message(speaker, message_language, FALSE))
-				if(CHATMESSAGE_HEAR)
-					if(!message_language || M.has_language(message_language))
-						LAZYADD(hide_icon_understand, M.client)
-					else
-						LAZYADD(hide_icon_scrambled, M.client)
-				if(CHATMESSAGE_SHOW_LANGUAGE_ICON)
-					if(!message_language || M.has_language(message_language))
-						LAZYADD(show_icon_understand, M.client)
-					else
-						LAZYADD(show_icon_scrambled, M.client)
-		var/scrambled_message
-		var/datum/language/language_instance = message_language ? GLOB.language_datum_instances[message_language] : null
-		if(LAZYLEN(show_icon_scrambled) || LAZYLEN(hide_icon_scrambled))
-			scrambled_message = language_instance?.scramble(raw_message) || scramble_message_replace_chars(raw_message, 100)
-		//Show the correct message to people who should see the icon and understand the language
-		if(LAZYLEN(show_icon_understand))
-			new /datum/chatmessage(raw_message, speaker, show_icon_understand, message_language, spans)
-		//Show the correct message to people who should see the icon but not understand the language
-		if(LAZYLEN(hide_icon_understand))
-			new /datum/chatmessage(raw_message, speaker, hide_icon_understand, message_language, spans)
-		//Show the correct message to people who don't understand the language and should see the icon
-		if(LAZYLEN(show_icon_scrambled))
-			new /datum/chatmessage(scrambled_message, speaker, show_icon_scrambled, message_language, spans)
-		//Show the correct message to people who don't understand the language but no icon should be displayed
-		if(LAZYLEN(hide_icon_scrambled))
-			new /datum/chatmessage(scrambled_message, speaker, hide_icon_scrambled, message_language, spans)
-
 /**
   * Creates a message overlay at a defined location for a given speaker
   *
@@ -400,7 +271,41 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
   * * raw_message - The text content of the message
   * * spans - Additional classes to be added to the message
   */
+/mob/proc/create_chat_message(atom/movable/speaker, datum/language/message_language, raw_message, list/spans, runechat_flags = NONE)
+	// Ensure the list we are using, if present, is a copy so we don't modify the list provided to us
+	spans = spans ? spans.Copy() : list()
 
+	// Check for virtual speakers (aka hearing a message through a radio)
+	if (istype(speaker, /atom/movable/virtualspeaker))
+		var/atom/movable/virtualspeaker/v = speaker
+		//===================
+		//Check to make sure we didnt hear the source message
+		//===================
+		//Dont create the overhead chat if we said the message.
+		if(v.source == src)
+			return
+		//Dont create the overhead radio chat if we are a ghost and can hear global messages.
+		if(isobserver(src))
+			return
+		//Dont create the overhead radio chat if we heard the speaker speak
+		if(get_dist(get_turf(v.source), get_turf(src)) <= 1)
+			return
+		//===================
+		speaker = v.source
+		spans |= "virtual-speaker"
+
+	//If the message has the radio message flag
+	else if (runechat_flags & RADIO_MESSAGE)
+		//You are now a virtual speaker
+		spans |= "virtual-speaker"
+		//You are no longer italics
+		spans -= "italics"
+
+	// Display visual above source
+	if(runechat_flags & EMOTE_MESSAGE)
+		new /datum/chatmessage(raw_message, speaker, src, message_language, list("emote"))
+	else
+		new /datum/chatmessage(lang_treat(speaker, message_language, raw_message, spans, null, TRUE), speaker, src, message_language, spans)
 
 
 // Tweak these defines to change the available color ranges
@@ -491,7 +396,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 
 /datum/chatmessage/balloon_alert/generate_image(text, atom/target, mob/owner)
 	// Register client who owns this message
-	var/client/owned_by = owner.client
+	owned_by = owner.client
 	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/on_parent_qdel)
 
 	var/bound_width = world.icon_size
@@ -565,6 +470,3 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 #undef BALLOON_TEXT_SPAWN_TIME
 #undef BALLOON_TEXT_TOTAL_LIFETIME
 #undef BALLOON_TEXT_WIDTH
-#undef CHATMESSAGE_CANNOT_HEAR
-#undef CHATMESSAGE_HEAR
-#undef CHATMESSAGE_SHOW_LANGUAGE_ICON

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -77,9 +77,9 @@
 			M.show_message("[FOLLOW_LINK(M, user)] [dchatmsg]")
 
 	if(emote_type == EMOTE_AUDIBLE)
-		user.audible_message(msg, audible_message_flags = list(CHATMESSAGE_EMOTE = TRUE))
+		user.audible_message(msg, audible_message_flags = EMOTE_MESSAGE)
 	else
-		user.visible_message(msg, visible_message_flags = list(CHATMESSAGE_EMOTE = TRUE))
+		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE)
 
 /datum/emote/proc/get_sound(mob/living/user)
 	return sound //by default just return this var.

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -104,9 +104,6 @@
 	///AI controller that controls this atom. type on init, then turned into an instance during runtime
 	var/datum/ai_controller/ai_controller
 
-	/// Lazylist of all messages currently on this atom
-	var/list/chat_messages
-
 /**
   * Called when an atom is created in byond (built in engine proc)
   *

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -424,8 +424,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		var/datum/holocall/HC = I
 		if(HC.connected_holopad == src && speaker != HC.hologram)
 			HC.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
-			if(HC.user.should_show_chat_message(speaker, message_language, FALSE, is_heard = TRUE))
-				create_chat_message(speaker, message_language, list(HC.user), raw_message, spans, message_mods)
 
 	if(outgoing_call && speaker == outgoing_call.user)
 		outgoing_call.hologram.say(raw_message)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -186,15 +186,8 @@
 	var/spans = data["spans"]
 	var/list/message_mods = data["mods"]
 	var/rendered = virt.compose_message(virt, language, message, frequency, spans)
-	var/list/show_overhead_message_to = list()
 	for(var/atom/movable/hearer in receive)
-		if(ismob(hearer))
-			var/mob/M = hearer
-			if(M.should_show_chat_message(virt, language, FALSE, is_heard = TRUE))
-				show_overhead_message_to += M
 		hearer.Hear(rendered, virt, language, message, frequency, spans, message_mods)
-	if(length(show_overhead_message_to))
-		create_chat_message(virt, language, show_overhead_message_to, message, spans, message_mods)
 
 	// This following recording is intended for research and feedback in the use of department radio channels
 	if(length(receive))

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -37,15 +37,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 /atom/movable/proc/send_speech(message, range = 7, obj/source = src, bubble_type, list/spans, datum/language/message_language = null, list/message_mods = list())
 	var/rendered = compose_message(src, message_language, message, , spans, message_mods)
-	var/list/show_overhead_message_to = list()
 	for(var/atom/movable/AM as() in get_hearers_in_view(range, source))
-		if(ismob(AM))
-			var/mob/M = AM
-			if(M.should_show_chat_message(source, message_language, FALSE, is_heard = TRUE))
-				show_overhead_message_to += M
 		AM.Hear(rendered, src, message_language, message, , spans, message_mods)
-	if(length(show_overhead_message_to))
-		create_chat_message(src, message_language, show_overhead_message_to, message, spans, message_mods)
 
 /atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE)
 	//This proc uses text() because it is faster than appending strings. Thanks BYOND.

--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -128,6 +128,11 @@ the new instance inside the host to be updated to the template's stats.
 		link = FOLLOW_LINK(src, to_follow)
 	else
 		link = ""
+	//Get message flags
+	var/flags = message_mods.Find(MODE_RADIO_MESSAGE) ? RADIO_MESSAGE : NONE
+	// Create map text prior to modifying message for runechat
+	if (client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker)))
+		create_chat_message(speaker, message_language, raw_message, spans, runechat_flags = flags)
 	// Recompose the message, because it's scrambled by default
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 	to_chat(src, "[link] [message]")

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -119,3 +119,6 @@
 
 	//Tick when ghost roles are useable again
 	var/next_ghost_role_tick = 0
+
+	/// Messages currently seen by this client
+	var/list/seen_messages

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -550,6 +550,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(movingmob != null)
 		movingmob.client_mobs_in_contents -= mob
 		UNSETEMPTY(movingmob.client_mobs_in_contents)
+	seen_messages = null
 	Master.UpdateTickRate()
 	return ..()
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -33,6 +33,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	///Runechat preference. If true, certain messages will be displayed on the map, not ust on the chat area. Boolean.
 	var/chat_on_map = TRUE
+	///Limit preference on the size of the message. Requires chat_on_map to have effect.
+	var/max_chat_length = CHAT_MESSAGE_MAX_LENGTH
 	///Whether non-mob messages will be displayed, such as machine vendor announcements. Requires chat_on_map to have effect. Boolean.
 	var/see_chat_non_mob = TRUE
 	///Whether emotes will be displayed on runechat. Requires chat_on_map to have effect. Boolean.
@@ -536,6 +538,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>tgui Monitors:</b> <a href='?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary" : "All"]</a><br>"
 			dat += "<b>tgui Style:</b> <a href='?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy" : "No Frills"]</a><br>"
 			dat += "<b>Show Runechat Chat Bubbles:</b> <a href='?_src_=prefs;preference=chat_on_map'>[chat_on_map ? "Enabled" : "Disabled"]</a><br>"
+			dat += "<b>Runechat message char limit:</b> <a href='?_src_=prefs;preference=max_chat_length;task=input'>[max_chat_length]</a><br>"
 			dat += "<b>See Runechat for non-mobs:</b> <a href='?_src_=prefs;preference=see_chat_non_mob'>[see_chat_non_mob ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>See Runechat emotes:</b> <a href='?_src_=prefs;preference=see_rc_emotes'>[see_rc_emotes ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>See Balloon alerts: </b> <a href='?_src_=prefs;preference=see_balloon_alerts;task=input'>[see_balloon_alerts]</a>"
@@ -1602,7 +1605,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/new_backbag = input(user, "Choose your character's style of bag:", "Character Preference")  as null|anything in GLOB.backbaglist
 					if(new_backbag)
 						backbag = new_backbag
-
+				
 				if("suit")
 					if(jumpsuit_style == PREF_SUIT)
 						jumpsuit_style = PREF_SKIRT
@@ -1662,6 +1665,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/pickedPDAColor = input(user, "Choose your PDA Interface color.", "Character Preference", pda_color) as color|null
 					if(pickedPDAColor)
 						pda_color = pickedPDAColor
+				if ("max_chat_length")
+					var/desiredlength = input(user, "Choose the max character length of shown Runechat messages. Valid range is 1 to [CHAT_MESSAGE_MAX_LENGTH] (default: [initial(max_chat_length)]))", "Character Preference", max_chat_length)  as null|num
+					if (!isnull(desiredlength))
+						max_chat_length = clamp(desiredlength, 1, CHAT_MESSAGE_MAX_LENGTH)
 				if ("see_balloon_alerts")
 					var/pickedstyle = input(user, "Choose how you want balloon alerts displayed", "Balloon alert preference", BALLOON_ALERT_ALWAYS) as null|anything in list(BALLOON_ALERT_ALWAYS, BALLOON_ALERT_WITH_CHAT, BALLOON_ALERT_NEVER)
 					if (!isnull(pickedstyle))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -63,7 +63,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				purchased_gear += n_gear
 	if(current_version < 33)
 		chat_on_map = TRUE
-//		max_chat_length = CHAT_MESSAGE_MAX_LENGTH			> Depreciated as of 31/07/2021
+		max_chat_length = CHAT_MESSAGE_MAX_LENGTH
 		see_chat_non_mob = TRUE
 		see_rc_emotes = TRUE
 		S.dir.Remove("overhead_chat")
@@ -171,6 +171,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["outline_enabled"], outline_enabled)
 	READ_FILE(S["hotkeys"], hotkeys)
 	READ_FILE(S["chat_on_map"], chat_on_map)
+	READ_FILE(S["max_chat_length"], max_chat_length)
 	READ_FILE(S["see_chat_non_mob"] , see_chat_non_mob)
 	READ_FILE(S["see_rc_emotes"] , see_rc_emotes)
 	READ_FILE(S["see_balloon_alerts"], see_balloon_alerts)
@@ -224,6 +225,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	UI_style		= sanitize_inlist(UI_style, GLOB.available_ui_styles, GLOB.available_ui_styles[1])
 	hotkeys			= sanitize_integer(hotkeys, FALSE, TRUE, initial(hotkeys))
 	chat_on_map		= sanitize_integer(chat_on_map, FALSE, TRUE, initial(chat_on_map))
+	max_chat_length = sanitize_integer(max_chat_length, TRUE, CHAT_MESSAGE_MAX_LENGTH, initial(max_chat_length))
 	see_chat_non_mob	= sanitize_integer(see_chat_non_mob, FALSE, TRUE, initial(see_chat_non_mob))
 	tgui_fancy		= sanitize_integer(tgui_fancy, FALSE, TRUE, initial(tgui_fancy))
 	tgui_lock		= sanitize_integer(tgui_lock, FALSE, TRUE, initial(tgui_lock))
@@ -278,6 +280,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["outline_color"], outline_color)
 	WRITE_FILE(S["hotkeys"], hotkeys)
 	WRITE_FILE(S["chat_on_map"], chat_on_map)
+	WRITE_FILE(S["max_chat_length"], max_chat_length)
 	WRITE_FILE(S["see_chat_non_mob"], see_chat_non_mob)
 	WRITE_FILE(S["see_rc_emotes"], see_rc_emotes)
 	WRITE_FILE(S["see_balloon_alerts"], see_balloon_alerts)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -714,7 +714,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		var/image/speech_overlay = image('icons/mob/talk.dmi', person, "default0", layer = ABOVE_MOB_LAYER)
 		INVOKE_ASYNC(GLOBAL_PROC, /proc/flick_overlay, speech_overlay, list(target.client), 30)
 	if (target.client?.prefs.chat_on_map)
-		create_chat_message(person, understood_language, list(target), chosen, spans)
+		target.create_chat_message(person, understood_language, chosen, spans)
 	to_chat(target, message)
 	qdel(src)
 

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -27,6 +27,11 @@
 		else
 			to_follow = V.source
 	var/link = FOLLOW_LINK(src, to_follow)
+	//Get message flags
+	var/flags = message_mods.Find(MODE_RADIO_MESSAGE) ? RADIO_MESSAGE : NONE
+	// Create map text prior to modifying message for goonchat
+	if(client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker)))
+		create_chat_message(speaker, message_language, raw_message, spans, runechat_flags = flags)
 	// Recompose the message, because it's scrambled by default
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 	to_chat(src, "[link] [message]")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -266,13 +266,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(eavesdrop_range && get_dist(source, AM) > message_range && !(the_dead[AM]))
 			if(ismob(AM))
 				var/mob/M = AM
-				if(M.should_show_chat_message(src, message_language, FALSE, is_heard = TRUE))
+				if(should_show_chat_message(M, message_language, FALSE, is_heard = TRUE))
 					show_overhead_message_to_eavesdrop += M
 			AM.Hear(eavesrendered, src, message_language, eavesdropping, , spans, message_mods)
 		else
 			if(ismob(AM))
 				var/mob/M = AM
-				if(M.should_show_chat_message(src, message_language, FALSE, is_heard = TRUE))
+				if(should_show_chat_message(M, message_language, FALSE, is_heard = TRUE))
 					show_overhead_message_to += M
 			AM.Hear(rendered, src, message_language, message, , spans, message_mods)
 	if(length(show_overhead_message_to))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -225,6 +225,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		deaf_message = "<span class='notice'>You can't hear yourself!</span>"
 		deaf_type = 2 // Since you should be able to hear yourself without looking
 
+	var/flags = message_mods.Find(MODE_RADIO_MESSAGE) ? RADIO_MESSAGE : NONE
+
+	// Create map text prior to modifying message for goonchat
+	if(client?.prefs.chat_on_map && stat != UNCONSCIOUS && (client.prefs.see_chat_non_mob || ismob(speaker)) && can_hear())
+		create_chat_message(speaker, message_language, raw_message, spans, runechat_flags = flags)
+
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
@@ -259,26 +265,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		eavesdropping = stars(message)
 		eavesrendered = compose_message(src, message_language, eavesdropping, , spans, message_mods)
 
-	var/list/show_overhead_message_to = list()
-	var/list/show_overhead_message_to_eavesdrop = list()
 	var/rendered = compose_message(src, message_language, message, , spans, message_mods)
 	for(var/atom/movable/AM as() in listening)
 		if(eavesdrop_range && get_dist(source, AM) > message_range && !(the_dead[AM]))
-			if(ismob(AM))
-				var/mob/M = AM
-				if(should_show_chat_message(M, message_language, FALSE, is_heard = TRUE))
-					show_overhead_message_to_eavesdrop += M
 			AM.Hear(eavesrendered, src, message_language, eavesdropping, , spans, message_mods)
 		else
-			if(ismob(AM))
-				var/mob/M = AM
-				if(should_show_chat_message(M, message_language, FALSE, is_heard = TRUE))
-					show_overhead_message_to += M
 			AM.Hear(rendered, src, message_language, message, , spans, message_mods)
-	if(length(show_overhead_message_to))
-		create_chat_message(src, message_language, show_overhead_message_to, message, spans)
-	if(length(show_overhead_message_to_eavesdrop))
-		create_chat_message(src, message_language, show_overhead_message_to_eavesdrop, eavesdropping, spans)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LIVING_SAY_SPECIAL, src, message)
 
 	//speech bubble

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -933,6 +933,11 @@
 
 	var/rendered = "<i><span class='game say'>[start]<span class='name'>[hrefpart][namepart] ([jobpart])</a> </span><span class='message'>[treated_message]</span></span></i>"
 
+	var/flags = message_mods.Find(MODE_RADIO_MESSAGE) ? RADIO_MESSAGE : NONE
+
+	if (client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker)))
+		create_chat_message(speaker, message_language, raw_message, spans, runechat_flags = flags)
+
 	show_message(rendered, 2)
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname,newname)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -386,7 +386,7 @@ Difficulty: Medium
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/dragon/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, list/visible_message_flags)
+/mob/living/simple_animal/hostile/megafauna/dragon/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, visible_message_flags = NONE)
 	if(swooping & SWOOP_INVULNERABLE) //to suppress attack messages without overriding every single proc that could send a message saying we got hit
 		return
 	return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -180,7 +180,7 @@
 	to_chat(src, msg)
 
 
-/atom/proc/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, list/visible_message_flags)
+/atom/proc/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, visible_message_flags = NONE)
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
@@ -195,12 +195,8 @@
 		hearers -= src
 
 	var/raw_msg = message
-	var/is_emote = FALSE
-	if(LAZYFIND(visible_message_flags, CHATMESSAGE_EMOTE))
+	if(visible_message_flags & EMOTE_MESSAGE)
 		message = "<span class='emote'><b>[src]</b> [message]</span>"
-		is_emote = TRUE
-
-	var/list/show_to = list()
 
 	for(var/mob/M as() in hearers)
 		if(!M.client)
@@ -216,16 +212,12 @@
 		if(!msg)
 			continue
 
-		if(is_emote && M.should_show_chat_message(src, null, TRUE) && !is_blind(M))
-			show_to += M
+		if(visible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, visible_message_flags) && !is_blind(M))
+			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = visible_message_flags)
 
 		M.show_message(msg, MSG_VISUAL, blind_message, MSG_AUDIBLE)
 
-	//Create the chat message
-	if(length(show_to))
-		create_chat_message(src, null, show_to, raw_msg, null, visible_message_flags)
-
-/mob/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, list/visible_message_flags)
+/mob/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, visible_message_flags = NONE)
 	. = ..()
 	if(self_message)
 		show_message(self_message, MSG_VISUAL, blind_message, MSG_AUDIBLE)
@@ -241,25 +233,19 @@
   * * deaf_message (optional) is what deaf people will see.
   * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
   */
-/atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, list/audible_message_flags)
+/atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, audible_message_flags = NONE)
 	var/list/hearers = get_hearers_in_view(hearing_distance, src)
 	if(self_message)
 		hearers -= src
 
 	var/raw_msg = message
-	var/is_emote = FALSE
-	if(LAZYFIND(audible_message_flags, CHATMESSAGE_EMOTE))
-		is_emote = TRUE
+	if(audible_message_flags & EMOTE_MESSAGE)
 		message = "<span class='emote'><b>[src]</b> [message]</span>"
 
-	var/list/show_to = list()
 	for(var/mob/M in hearers)
-		if(is_emote && M.should_show_chat_message(src, null, TRUE, is_heard = TRUE))
-			show_to += M
+		if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags) && M.can_hear())
+			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)
 		M.show_message(message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
-
-	if(length(show_to))
-		create_chat_message(src, null, show_to, raw_message = raw_msg, spans = list("italics"), message_mods = audible_message_flags)
 
 /**
   * Show a message to all mobs in earshot of this one
@@ -272,23 +258,23 @@
   * * deaf_message (optional) is what deaf people will see.
   * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
   */
-/mob/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, list/audible_message_flags)
+/mob/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, audible_message_flags = NONE)
 	. = ..()
 	if(self_message)
 		show_message(self_message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
 
 ///Returns the client runechat visible messages preference according to the message type.
-/atom/proc/runechat_prefs_check(mob/target, list/visible_message_flags)
+/atom/proc/runechat_prefs_check(mob/target, visible_message_flags = NONE)
 	if(!target.client?.prefs.chat_on_map || !target.client.prefs.see_chat_non_mob)
 		return FALSE
-	if(LAZYFIND(visible_message_flags, CHATMESSAGE_EMOTE) && !target.client.prefs.see_rc_emotes)
+	if(visible_message_flags & EMOTE_MESSAGE && !target.client.prefs.see_rc_emotes)
 		return FALSE
 	return TRUE
 
-/mob/runechat_prefs_check(mob/target, list/visible_message_flags)
+/mob/runechat_prefs_check(mob/target, visible_message_flags = NONE)
 	if(!target.client?.prefs.chat_on_map)
 		return FALSE
-	if(LAZYFIND(visible_message_flags, CHATMESSAGE_EMOTE) && !target.client.prefs.see_rc_emotes)
+	if(visible_message_flags & EMOTE_MESSAGE && !target.client.prefs.see_rc_emotes)
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts what bacon did to the runechat.

Oldest message will delete itself instead of translating if you have more than 2 messages above this location.

When testing I found out that it is translating that causes *most* of the overhead.
It happens because the subsystem doesn't delete messages in time, when high dilation happens, this means messages stack and more of them have to be translated.

## Why It's Good For The Game

Simpler solution, better solution.
Also messages don't get weirdly translated anymore.

## Changelog
:cl:
add: Runechat messages amount has been limited to a maximum of 3 per loc.
fix: Fixed runechat messages sometimes translating themselves upwards when there was no message underneath.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
