### PR TITLE
Fixes #6054 - Fixes void thrusters not operating without a heater

### DIFF
--- a/code/game/machinery/shuttle/shuttle_engine.dm
+++ b/code/game/machinery/shuttle/shuttle_engine.dm
@@ -77,6 +77,7 @@
 	attached_heater = null
 	var/obj/machinery/atmospherics/components/unary/shuttle/heater/as_heater = locate() in heater_turf
 	if(!as_heater)
+		update_engine()
 		return
 	if(as_heater.dir != dir)
 		return
@@ -89,6 +90,10 @@
 	return
 
 /obj/machinery/shuttle/engine/proc/update_engine()
+	if(panel_open)
+		thruster_active = FALSE
+		icon_state = icon_state_open
+		return
 	if(!needs_heater)
 		icon_state = icon_state_closed
 		thruster_active = TRUE
@@ -98,23 +103,12 @@
 		thruster_active = FALSE
 		return
 	var/obj/machinery/atmospherics/components/unary/shuttle/heater/resolved_heater = attached_heater.resolve()
-	if(panel_open)
-		thruster_active = FALSE
-	else if(resolved_heater?.hasFuel(1))
+	if(resolved_heater?.hasFuel(1))
 		icon_state = icon_state_closed
 		thruster_active = TRUE
 	else
 		thruster_active = FALSE
 		icon_state = icon_state_off
-	return
-
-/obj/machinery/shuttle/engine/void/update_engine()
-	if(panel_open)
-		thruster_active = FALSE
-		return
-	thruster_active = TRUE
-	icon_state = icon_state_closed
-	return
 
 //Thanks to spaceheater.dm for inspiration :)
 /obj/machinery/shuttle/engine/proc/fireEngine()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes https://github.com/BeeStation/BeeStation-Hornet/issues/6054

Issue reported from Round ID: 34995 (BeeStation Sage - Roleplay)

Reporting client version: 514.1568

The void thruster cannot operate independently of fuel/engine heater as intended. When Launch initiation is attempted, text output will say "Cannot enter supercruise, Insufficient Power to engine"(paraphrase)

Void Thrusters normally should not require fuel and thus no engine heater.

Reproduction: Build a normal custom shuttle but use only a void thruster for thrust, error will occur.

## Why It's Good For The Game

Bug fix.
Note: Did not test void thrusters not functioning before applying the fixes, but can confirm that I could launch a shuttle with only heater-less void thrusters after applying these.
Also should fix the icon state of open thrusters.

## Changelog
:cl:
fix: Fixes void thrusters not working without a heater.
fix: Fixes thrusters with open panels having the wrong icon state.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
