### PR TITLE
Moves the full auto var to the guns themselves

### DIFF
--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -421,6 +421,7 @@
 	mag_type = /obj/item/ammo_box/magazine/recharge/ctf
 	desc = "This looks like it could really hurt in melee."
 	force = 50
+	full_auto = TRUE //Rule of cool.
 
 /obj/item/gun/ballistic/automatic/laser/ctf/dropped()
 	. = ..()

--- a/code/modules/projectiles/autofire.dm
+++ b/code/modules/projectiles/autofire.dm
@@ -33,25 +33,6 @@ Everything else should be handled for you. Good luck soldier.
 			autofire_component?.default_fire_delay = (10 / var_value)
 			return
 
-//Place any guns that you want to be fully automatic here (for record-keeping and so NSV can avoid conflicts please and thank.)
-/obj/item/gun/ballistic/automatic/l6_saw
-	full_auto = TRUE
-
-/obj/item/gun/ballistic/automatic/c20r
-	full_auto = TRUE
-
-/obj/item/gun/energy/minigun
-	full_auto = TRUE
-
-/obj/item/gun/ballistic/automatic/laser/ctf
-	full_auto = TRUE //Rule of cool.
-
-/obj/item/gun/ballistic/automatic/wt550
-	full_auto = TRUE
-
-/obj/item/gun/ballistic/shotgun/bulldog
-	full_auto = TRUE
-
 /obj/item/gun/Initialize()
 	. = ..()
 	if(full_auto)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -73,6 +73,7 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
+	full_auto = TRUE
 
 /obj/item/gun/ballistic/automatic/c20r/unrestricted
 	pin = /obj/item/firing_pin
@@ -97,6 +98,7 @@
 	empty_indicator = TRUE
 	fire_rate = 3
 	w_class = WEIGHT_CLASS_BULKY
+	full_auto = TRUE
 
 /obj/item/gun/ballistic/automatic/wt550/rubber_loaded
 	mag_type = /obj/item/ammo_box/magazine/wt550m9/rubber
@@ -233,6 +235,7 @@
 	tac_reloads = FALSE
 	fire_sound = 'sound/weapons/rifleshot.ogg'
 	rack_sound = 'sound/weapons/chunkyrack.ogg'
+	full_auto = TRUE
 
 /obj/item/gun/ballistic/automatic/l6_saw/unrestricted
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -168,6 +168,7 @@
 	automatic = 1
 	recoil = 0
 	bolt_type = BOLT_TYPE_STANDARD	//Not using a pump
+	full_auto = TRUE
 
 /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -125,6 +125,7 @@
 	can_charge = FALSE
 	fire_sound = 'sound/weapons/laser.ogg'
 	item_flags = NEEDS_PERMIT | SLOWS_WHILE_IN_HAND
+	full_auto = TRUE
 	var/cooldown = 0
 	var/obj/item/minigunpack/ammo_pack
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the full-auto variable of guns onto the actual gun definitions themselves.

## Why It's Good For The Game

1: The guns will be specific to beestation and may not exist on other codebases, meaning modularizing this 1 specific variable into this file isn't necessary really. (Would only make removing the var harder)
2: It breaks ctrl-clicking on parent typepaths in visual studio, as it opens up the autofire.dm file instead of the gun file which almost nobody actually wants. (The main reason for doing this, it's so annoying)
3: If a gun is removed from the game, the autofire var may not be removed on accident, keeping it there
4: Splitting the specific variables of a gun into multiple files makes it difficult to see at a glance what the gun does. If you are investigating the saw, you won't know it's full auto unless you open up autofire.dm

## Changelog
:cl:
code: Moved the auto-fire variable to the guns themselves rather than autofire.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
