### PR TITLE
Fixes #6031 - Xenos can no longer pickup items embedded in them.

### DIFF
--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -215,7 +215,7 @@
 
 /// This proc handles the final step and actual removal of an embedded/stuck item from a carbon, whether or not it was actually removed safely.
 /// Pass TRUE for to_hands if we want it to go to the victim's hands when they pull it out
-/datum/component/embedded/proc/safeRemove(to_hands)
+/datum/component/embedded/proc/safeRemove(mob/to_hands)
 	SIGNAL_HANDLER
 
 	var/mob/living/carbon/victim = parent
@@ -224,7 +224,8 @@
 
 	if(!weapon.unembedded()) // if it hasn't deleted itself due to drop del
 		UnregisterSignal(weapon, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
-		if(to_hands)
+		//If a mob was passed in and it can hold items, put it in the mob's hand.
+		if(istype(to_hands) && to_hands.can_hold_items())
 			INVOKE_ASYNC(to_hands, /mob.proc/put_in_hands, weapon)
 		else
 			INVOKE_ASYNC(weapon, /atom/movable.proc/forceMove, get_turf(victim))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes #6031

## About The Pull Request

1.get an item, any item if you duct tape it

2.throw it at the beno

3.have the beno click on itself with an empty hand in help intent

    have it remove the embedded item

    it now holds the item and can throw it or even use it


## Why It's Good For The Game

Fixes a bug

## Changelog
:cl:
fix: Mobs that are unable to hold items will drop embedded items to the ground when removed, rather than have that item go to their hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
