### PR TITLE
Fixes cult and clockie magic not checking for holy protection, nerfs the bible.

### DIFF
--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -7,7 +7,7 @@
 	var/datum/callback/reaction
 	var/datum/callback/expire
 
-/datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire)
+/datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire, _allowed_slots)
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
@@ -23,6 +23,8 @@
 	blocks_self = _blocks_self
 	reaction = _reaction
 	expire = _expire
+	if(!isnull(_allowed_slots))
+		allowed_slots = _allowed_slots
 
 /datum/component/anti_magic/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -41,9 +41,9 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/deity_name = "Christ"
 	force_string = "holy"
 
-/obj/item/storage/book/bible/Initialize()
+/obj/item/storage/book/bible/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE, _allowed_slots = ITEM_SLOT_HANDS)
 
 /obj/item/storage/book/bible/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -56,7 +56,7 @@
 	force += force_buff
 	. = ..()
 	force -= force_buff
-	if(!QDELETED(target) && target.stat != DEAD && !is_servant_of_ratvar(target) && !target.anti_magic_check(major=FALSE))
+	if(!QDELETED(target) && target.stat != DEAD && !is_servant_of_ratvar(target) && !target.anti_magic_check(holy = TRUE, major=FALSE))
 		hit_effect(target, user)
 
 /obj/item/clockwork/weapon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -66,7 +66,7 @@
 	if(isliving(hit_atom))
 		var/mob/living/target = hit_atom
 		if(!.)
-			if(!target.anti_magic_check() && !is_servant_of_ratvar(target))
+			if(!target.anti_magic_check(holy = TRUE) && !is_servant_of_ratvar(target))
 				hit_effect(target, throwingdatum.thrower, TRUE)
 
 /obj/item/clockwork/weapon/proc/hit_effect(mob/living/target, mob/living/user, thrown=FALSE)

--- a/code/modules/antagonists/clock_cult/scriptures/kindle.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/kindle.dm
@@ -25,7 +25,7 @@
 	if(is_servant_of_ratvar(M))
 		return FALSE
 	//Anti magic abilities
-	var/anti_magic_source = M.anti_magic_check()
+	var/anti_magic_source = M.anti_magic_check(holy = TRUE)
 	if(anti_magic_source)
 		M.mob_light(_color = LIGHT_COLOR_HOLY_MAGIC, _range = 2, _duration = 100)
 		var/mutable_appearance/forbearance = mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)

--- a/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
@@ -32,7 +32,7 @@
 		return TRUE
 	if(M.stat == DEAD)
 		return FALSE
-	var/amc = M.anti_magic_check()
+	var/amc = M.anti_magic_check(holy = TRUE)
 	if(amc)
 		return FALSE
 	if(HAS_TRAIT(M, TRAIT_NODEATH))
@@ -73,7 +73,7 @@
 		else
 			visible_message("<span class='neovgre'>\The [src] fails to heal [M]!</span>", "<span class='neovgre'>There is insufficient vitality to heal your wounds!</span>")
 	else
-		if(M.anti_magic_check())
+		if(M.anti_magic_check(holy = TRUE))
 			return
 		if(is_convertable_to_clockcult(M) && !GLOB.gateway_opening)
 			visible_message("<span class='neovgre'>\The [src] refuses to siphon [M]'s vitality, their mind has great potential!</span>")

--- a/code/modules/antagonists/clock_cult/structure/clockwork_sigil.dm
+++ b/code/modules/antagonists/clock_cult/structure/clockwork_sigil.dm
@@ -65,7 +65,7 @@
 	var/mob/living/M = AM
 	if(!istype(M))
 		return FALSE
-	var/amc = M.anti_magic_check()
+	var/amc = M.anti_magic_check(holy = TRUE)
 	if(amc)
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -422,7 +422,7 @@
 
 		user.mob_light(_range = 3, _color = LIGHT_COLOR_BLOOD_MAGIC, _duration = 0.2 SECONDS)
 
-		var/anti_magic_source = L.anti_magic_check()
+		var/anti_magic_source = L.anti_magic_check(holy = TRUE)
 		if(anti_magic_source)
 
 			L.mob_light(_range = 2, _color = LIGHT_COLOR_HOLY_MAGIC, _duration = 10 SECONDS)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -675,7 +675,7 @@
 			else
 				L.visible_message("<span class='warning'>[src] bounces off of [L], as if repelled by an unseen force!</span>")
 		else if(!..())
-			if(!L.anti_magic_check())
+			if(!L.anti_magic_check(holy = TRUE))
 				L.Knockdown(50)
 			break_spear(T)
 	else
@@ -946,7 +946,7 @@
 			else
 				L.visible_message("<span class='warning'>[src] bounces off of [L], as if repelled by an unseen force!</span>")
 		else if(!..())
-			if(!L.anti_magic_check())
+			if(!L.anti_magic_check(holy = TRUE))
 				L.Knockdown(30)
 				if(D?.thrower)
 					for(var/mob/living/Next in orange(2, T))

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -780,7 +780,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			var/atom/I = L.anti_magic_check(major = FALSE)
+			var/atom/I = L.anti_magic_check(holy = TRUE, major = FALSE)
 			if(I)
 				if(isitem(I))
 					to_chat(L, "<span class='userdanger'>[I] suddenly burns hotly before returning to normal!</span>")
@@ -808,7 +808,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			if(L.anti_magic_check(major = FALSE))
+			if(L.anti_magic_check(holy = TRUE, major = FALSE))
 				continue
 			L.take_overall_damage(tick_damage*multiplier, tick_damage*multiplier)
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -60,7 +60,7 @@
 		var/mob/living/carbon/human/tar = target
 		if(tar.check_shields(src,10, "the [tar.name]"))
 			return ..()
-		if(tar.anti_magic_check())
+		if(tar.anti_magic_check(holy = TRUE))
 			tar.visible_message("<span class='danger'>Spell bounces off of [target]!</span>","<span class='danger'>The spell bounces off of you!</span>")
 			return ..()
 	var/datum/mind/M = user.mind
@@ -155,7 +155,7 @@
 	playsound(user, 'sound/magic/demon_attack1.ogg', 75, TRUE)
 	if(ishuman(target))
 		var/mob/living/carbon/human/tar = target
-		if(tar.anti_magic_check())
+		if(tar.anti_magic_check(holy = TRUE))
 			tar.visible_message("<span class='danger'>Spell bounces off of [target]!</span>","<span class='danger'>The spell bounces off of you!</span>")
 			return ..()
 	var/mob/living/carbon/human/C2 = user
@@ -252,7 +252,7 @@
 		var/mob/living/carbon/human/target = X
 		if(target == user)
 			continue
-		if(target.anti_magic_check())
+		if(target.anti_magic_check(holy = TRUE))
 			to_chat(user, "<span class='warning'>The spell had no effect!</span>")
 			target.visible_message("<span class='danger'>[target]'s veins flash with fire, but their magic protection repulses the blaze!</span>", \
 							"<span class='danger'>Your veins flash with fire, but your magic protection repels the blaze!</span>")
@@ -324,7 +324,7 @@
 			break
 
 		for(var/mob/living/L in T.contents)
-			if(L.anti_magic_check())
+			if(L.anti_magic_check(holy = TRUE))
 				L.visible_message("<span class='danger'>Spell bounces off of [L]!</span>","<span class='danger'>The spell bounces off of you!</span>")
 				continue
 			if(L in hit_list || L == source)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -179,6 +179,7 @@
 /datum/species/golem/silver/on_species_loss(mob/living/carbon/C)
 	REMOVE_TRAIT(C, TRAIT_HOLY, SPECIES_TRAIT)
 	..()
+
 // Softer and faster, but conductive
 /datum/species/golem/copper
 	name = "Copper Golem"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes #6030

## About The Pull Request

Makes all cult and clockcult spells check for holy magic protection. This will mean that TRAIT_HOLY will protect from cult and clockcult spells such as the stuns.
In addition to this, makes it so that the bible needs to be held in hands to provide holy protection, as otherwise full protection to cult and clockcult stuns would be available to all people.

## Why It's Good For The Game

Makes silver golems properly immune to cult and clockie spells, makes cult and clockie spells actually check the right anti-magic sources, nerfs the bible to not be too overpowered.

## Changelog
:cl:
fix: Cult and clockie spells now check for holy anti-magic sources.
balance: The bible now needs to be held in hand to function as an anti-magic source (The bible also now protects against clockie and cult spells)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
