### PR TITLE
Fixes #6025 - Swarmer blockades can be walked through by anyone

### DIFF
--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -637,6 +637,7 @@
 	icon_state = "barricade"
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	max_integrity = 50
+	density = TRUE
 
 /obj/structure/swarmer/blockade/CanAllowThrough(atom/movable/O)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

```
Spawn/build a swarmer blockade and then walk through it as something other than a swarmer.

I've seen this get the initial swarmers killed before and it's killed me several times.
```

Makes swarmer blockades dense.

## Why It's Good For The Game

Swarmers and disablers can now pass through their own blockades, other mobs cannot.

## Changelog
:cl:
fix: Swarmer blockades are now dense.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
