### PR TITLE
Motion cameras no longer detect invisible mobs.

### DIFF
--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -1,3 +1,5 @@
+#define MOTION_SENSOR_MINIMUM_ALPHA 200
+
 /obj/machinery/camera
 
 	var/list/datum/weakref/localMotionTargets = list()
@@ -72,7 +74,8 @@
 /obj/machinery/camera/HasProximity(atom/movable/AM as mob|obj)
 	// Motion cameras outside of an "ai monitored" area will use this to detect stuff.
 	if (!area_motion)
-		if(isliving(AM))
+		//Target must be living and visible enough to the camera
+		if(isliving(AM) && AM.invisibility <= SEE_INVISIBLE_LIVING && AM.alpha >= MOTION_SENSOR_MINIMUM_ALPHA)
 			newTarget(AM)
 
 /obj/machinery/camera/motion/thunderdome
@@ -109,3 +112,5 @@
 		detectTime = 0
 		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
 			TV.notify(FALSE)
+
+#undef

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -113,4 +113,4 @@
 		for(var/obj/machinery/computer/security/telescreen/entertainment/TV in GLOB.machines)
 			TV.notify(FALSE)
 
-#undef
+#undef MOTION_SENSOR_MINIMUM_ALPHA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/6021

## About The Pull Request

Motion cameras no longer detect mobs with an invisibility value greater than 25, and an alpha value less than 200.

## Why It's Good For The Game

Invisible mobs will no longer be detected by motion-sensing cameras.

## Changelog
:cl:
fix: Motion sensing cameras can no longer see invisible objects moving.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
