### PR TITLE
Fixes #6017 - Pubbystation book scanner too far away from inventory console, preventing book upload

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -43590,13 +43590,6 @@
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
-"clk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/libraryscanner,
-/turf/open/floor/plasteel/dark,
-/area/library/lounge)
 "clm" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
@@ -47001,12 +46994,6 @@
 "czO" = (
 /obj/structure/table/wood,
 /obj/item/instrument/saxophone,
-/turf/open/floor/plasteel/dark,
-/area/library)
-"czP" = (
-/obj/structure/table/wood,
-/obj/item/stack/packageWrap,
-/obj/item/coin/gold,
 /turf/open/floor/plasteel/dark,
 /area/library)
 "czQ" = (
@@ -50890,6 +50877,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"hjk" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/stack/packageWrap,
+/obj/item/coin/gold,
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
 "hjz" = (
 /obj/effect/turf_decal/stripes/line,
 /mob/living/simple_animal/bot/cleanbot/medbay,
@@ -62971,6 +62967,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"xCy" = (
+/obj/machinery/libraryscanner,
+/turf/open/floor/plasteel/dark,
+/area/library)
 "xCE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -80951,7 +80951,7 @@ ckl
 ckD
 ckS
 clg
-clk
+hjk
 cwe
 cwe
 cyB
@@ -82509,7 +82509,7 @@ ckH
 czp
 ckH
 ckH
-czP
+xCy
 ckH
 ckH
 cjp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes #6017

## About The Pull Request

Moves the pubbystation book scanner closer to the book inventory management console, so books on pubby can be uploaded.

## Why It's Good For The Game

Bug fix.

## Changelog
:cl:
fix: Pubbystation book inventory management console is now close enough to the scanner to upload books.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
