### PR TITLE
Fixes #5998 - Sunglasses not providing protection from welding tools is now intentional.

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -348,6 +348,7 @@
 	toolspeed = 0.1
 	light_system = NO_LIGHT_SUPPORT
 	light_range = 0
+	light_intensity = 0
 	change_icons = 0
 
 /obj/item/weldingtool/abductor/process()
@@ -373,7 +374,7 @@
 	var/last_gen = 0
 	change_icons = 0
 	can_off_process = 1
-	light_range = 1
+	light_intensity = 1
 	toolspeed = 0.5
 	var/nextrefueltick = 0
 
@@ -383,7 +384,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	icon_state = "brasswelder"
 	item_state = "brasswelder"
-
+	light_intensity = 1
 
 /obj/item/weldingtool/experimental/process(delta_time)
 	..()

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -36,6 +36,7 @@
 	light_color = LIGHT_COLOR_FIRE
 	var/progress_flash_divisor = 10
 	var/burned_fuel_for = 0	//when fuel was last removed
+	var/light_intensity = 2
 	heat = 3800
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 1
@@ -247,14 +248,14 @@
 /obj/item/weldingtool/tool_start_check(mob/living/user, amount=0)
 	. = tool_use_check(user, amount)
 	if(. && user)
-		user.flash_act(light_range)
+		user.flash_act(light_intensity)
 
 // Flash the user during welding progress
 /obj/item/weldingtool/tool_check_callback(mob/living/user, amount, datum/callback/extra_checks)
 	. = ..()
 	if(. && user)
 		if (progress_flash_divisor == 0)
-			user.flash_act(min(light_range,1))
+			user.flash_act(min(light_intensity,1))
 			progress_flash_divisor = initial(progress_flash_divisor)
 		else
 			progress_flash_divisor--


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Closes #5998

## About The Pull Request

Makes it so that welding tools bypassing flash protection is a feature rather than something sneakilly added

## Why It's Good For The Game

Seperates the light range variable which is for interfacing with the lighting system from the welder's light_intensity which interfaces with how much eye damage the welder does.

## Changelog
:cl:
code: Seperates light_range from light_intensity on welders. Sunglasses not protecting from welding tools is now an intentional feature.
balance: Clockwork welding tools cause less eye damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
