### PR TITLE
Sparks and lasers no longer count towards turf's lumcount value

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -8,6 +8,9 @@
 ///Is a movable light source attached to another movable (its loc), meaning that the lighting component should go one level deeper.
 #define LIGHT_ATTACHED (1<<0)
 
+///This light doesn't affect turf's lumcount calculations. Set to 1<<15 to ignore conflicts
+#define LIGHT_NO_LUMCOUNT (1<<15)
+
 //Bay lighting engine shit, not in /code/modules/lighting because BYOND is being shit about it
 #define LIGHTING_INTERVAL       5 // frequency, in 1/10ths of a second, of the lighting process
 

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -27,7 +27,9 @@
 	///Ceiling of range, integer without decimal entries.
 	var/lumcount_range = 0
 	///How much this light affects the dynamic_lumcount of turfs.
-	var/lum_power = 0.5
+	var/real_lum_power = 0.5
+	///The lum power being used
+	var/used_lum_power = 0.5
 	///Transparency value.
 	var/set_alpha = 0
 	///For light sources that can be turned on and off.
@@ -97,7 +99,7 @@
 		set_parent_attached_to(ismovable(movable_parent.loc) ? movable_parent.loc : null)
 	if(movable_parent.light_flags & LIGHT_NO_LUMCOUNT)
 		overlay_lighting_flags |= LIGHT_NO_LUMCOUNT
-		set_lum_power(lum_power)
+		set_lum_power(real_lum_power)
 	check_holder()
 	if(movable_parent.light_on)
 		turn_on()
@@ -133,7 +135,7 @@
 /datum/component/overlay_lighting/proc/clean_old_turfs()
 	for(var/t in affected_turfs)
 		var/turf/lit_turf = t
-		lit_turf.dynamic_lumcount -= lum_power
+		lit_turf.dynamic_lumcount -= used_lum_power
 	affected_turfs = null
 
 
@@ -142,7 +144,7 @@
 	if(!current_holder)
 		return
 	for(var/turf/lit_turf in view(lumcount_range, get_turf(current_holder)))
-		lit_turf.dynamic_lumcount += lum_power
+		lit_turf.dynamic_lumcount += used_lum_power
 		LAZYADD(affected_turfs, lit_turf)
 
 
@@ -321,11 +323,11 @@
 		if(!(movable_parent.light_flags & LIGHT_NO_LUMCOUNT)) //Gained the NO_LUMCOUNT property
 			overlay_lighting_flags |= LIGHT_NO_LUMCOUNT
 			//Recalculate affecting
-			set_lum_power(lum_power)
+			set_lum_power(real_lum_power)
 	else if(movable_parent.light_flags & LIGHT_NO_LUMCOUNT)	//Lost the NO_LUMCOUNT property
 		overlay_lighting_flags &= ~LIGHT_NO_LUMCOUNT
 		//Recalculate affecting
-		set_lum_power(lum_power)
+		set_lum_power(real_lum_power)
 
 ///Toggles the light on.
 /datum/component/overlay_lighting/proc/turn_on()
@@ -349,22 +351,25 @@
 
 ///Here we append the behavior associated to changing lum_power.
 /datum/component/overlay_lighting/proc/set_lum_power(new_lum_power)
-	//Get the simulated luminosity count
-	var/used_lum_power = new_lum_power
+	//Get the simulated luminosity count (If we have no lumcount, this is set to 0)
+	var/simulated_lum_power = new_lum_power
 	if(overlay_lighting_flags & LIGHT_NO_LUMCOUNT)
-		used_lum_power = 0
+		simulated_lum_power = 0
 	//The new lum power is the same
-	if(lum_power == used_lum_power)
+	if(used_lum_power == simulated_lum_power)
 		//This light doesn't affect lumcount, but lum_power must be updated regardless
-		if(new_lum_power != used_lum_power)
-			. = lum_power
-			lum_power = new_lum_power
+		if(new_lum_power != simulated_lum_power)
+			. = real_lum_power
+			real_lum_power = new_lum_power
 		return
 	//Set the return value to the old lum power
-	. = lum_power
-	lum_power = new_lum_power
+	. = real_lum_power
+	real_lum_power = new_lum_power
+	//Get the old used lum power
+	var/old_lum_power = used_lum_power
+	used_lum_power = simulated_lum_power
 	//Calculate the difference
-	var/difference = . - lum_power
+	var/difference = old_lum_power - used_lum_power
 	//Apply it to any turf we are affecting
 	for(var/t in affected_turfs)
 		var/turf/lit_turf = t

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -95,6 +95,9 @@
 	if(movable_parent.light_flags & LIGHT_ATTACHED)
 		overlay_lighting_flags |= LIGHTING_ATTACHED
 		set_parent_attached_to(ismovable(movable_parent.loc) ? movable_parent.loc : null)
+	if(movable_parent.light_flags & LIGHT_NO_LUMCOUNT)
+		overlay_lighting_flags |= LIGHT_NO_LUMCOUNT
+		set_lum_power(lum_power)
 	check_holder()
 	if(movable_parent.light_on)
 		turn_on()
@@ -314,6 +317,15 @@
 		overlay_lighting_flags &= ~LIGHTING_ATTACHED
 		set_parent_attached_to(null)
 
+	if(new_value & LIGHT_NO_LUMCOUNT)
+		if(!(movable_parent.light_flags & LIGHT_NO_LUMCOUNT)) //Gained the NO_LUMCOUNT property
+			overlay_lighting_flags |= LIGHT_NO_LUMCOUNT
+			//Recalculate affecting
+			set_lum_power(lum_power)
+	else if(movable_parent.light_flags & LIGHT_NO_LUMCOUNT)	//Lost the NO_LUMCOUNT property
+		overlay_lighting_flags &= ~LIGHT_NO_LUMCOUNT
+		//Recalculate affecting
+		set_lum_power(lum_power)
 
 ///Toggles the light on.
 /datum/component/overlay_lighting/proc/turn_on()
@@ -337,11 +349,23 @@
 
 ///Here we append the behavior associated to changing lum_power.
 /datum/component/overlay_lighting/proc/set_lum_power(new_lum_power)
-	if(lum_power == new_lum_power)
+	//Get the simulated luminosity count
+	var/used_lum_power = new_lum_power
+	if(overlay_lighting_flags & LIGHT_NO_LUMCOUNT)
+		used_lum_power = 0
+	//The new lum power is the same
+	if(lum_power == used_lum_power)
+		//This light doesn't affect lumcount, but lum_power must be updated regardless
+		if(new_lum_power != used_lum_power)
+			. = lum_power
+			lum_power = new_lum_power
 		return
+	//Set the return value to the old lum power
 	. = lum_power
 	lum_power = new_lum_power
+	//Calculate the difference
 	var/difference = . - lum_power
+	//Apply it to any turf we are affecting
 	for(var/t in affected_turfs)
 		var/turf/lit_turf = t
 		lit_turf.dynamic_lumcount -= difference

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -24,6 +24,7 @@
 	light_range = 2
 	light_power = 0.5
 	light_color = LIGHT_COLOR_FIRE
+	light_flags = LIGHT_NO_LUMCOUNT
 
 /obj/effect/particle_effect/sparks/Initialize()
 	..()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -164,9 +164,9 @@
 
 /obj/item/rod_of_asclepius/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, damage, attack_type)
 	if(!activated)
-		return FALSE 
+		return FALSE
 	return ..()
-	
+
 
 /obj/item/rod_of_asclepius/attack_self(mob/user)
 	if(activated)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -13,6 +13,7 @@
 	light_range = 2
 	light_power = 1
 	light_color = LIGHT_COLOR_RED
+	light_flags = LIGHT_NO_LUMCOUNT
 	ricochets_max = 50	//Honk!
 	ricochet_chance = 80
 	reflectable = REFLECT_NORMAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes #5964

## About The Pull Request

Sparks and lasers no longer count towards turf's lumcount value. This means that when get_lumcount is called, lasers and sparks will not be counted.
This means that nightmares will be considered in the dark, even if the light from a laser is on top of them.
They are temporary and low ranged lights, so shouldn't be considered towards lighting up a turf. (They have their power bumped up to appear brighter)

## Why It's Good For The Game

Tiny and insigificant lights such as lasers and sparks shouldn't count towards get_lumcount, and can make it so lasers will always hit nightmares which is somewhat unfair considering nightmares cannot destroy laser lights.

## Changelog
:cl:
code: Overlay light sources can be set to not count towards get_lumcount calculations
code: Lasers and sparks no longer count towards get_lumcount calculations.
balance: Nightmares will now dodge lasers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
