### PR TITLE
Fixes Spetsnaz Pyro Backpack icon_state and item_state

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -418,8 +418,8 @@
 /obj/item/watertank/op
 	name = "backpack water tank"
 	desc = "A New Russian backpack spray for systematic cleansing of carbon lifeforms."
-	icon_state = "waterbackop"
-	item_state = "waterbackop"
+	icon_state = "waterbackpackop"
+	item_state = "waterbackpackop"
 	w_class = WEIGHT_CLASS_NORMAL
 	volume = 2000
 	slowdown = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For a very long time(well over a year) the backpack had no inhand/worn sprite.

I fixed it. The icon_state was set wrong.

**THIS PR DOES NOT CHANGE ANY SPRITES**

![Inhand](https://user-images.githubusercontent.com/68963748/147892187-d6c70181-c90d-40dc-bc23-813d73839152.png)

![On back](https://user-images.githubusercontent.com/68963748/147892190-a6868c9d-af31-4699-bd94-f6e1df859ae9.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix Long Standing Bug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: DatBoiTim
fix: Spetsnaz Pyro Backpack Sprite now Referenced Correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
