### PR TITLE
Shuttle hacking + Fixes ports breaking when shuttle console is deconstructed

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -61407,7 +61407,7 @@
 	pixel_x = -3;
 	pixel_y = 1
 	},
-/obj/item/circuitboard/computer/mining_shuttle{
+/obj/item/circuitboard/computer/shuttle/mining_shuttle{
 	pixel_x = -4;
 	pixel_y = -1
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -36996,7 +36996,7 @@
 	c_tag = "Tech Storage";
 	dir = 2
 	},
-/obj/item/circuitboard/computer/monastery_shuttle,
+/obj/item/circuitboard/computer/shuttle/monastery_shuttle,
 /obj/effect/spawner/lootdrop/techstorage/service,
 /obj/machinery/airalarm{
 	dir = 2;

--- a/_maps/shuttles/exploration_corg.dmm
+++ b/_maps/shuttles/exploration_corg.dmm
@@ -666,7 +666,7 @@
 /area/shuttle/exploration)
 "GI" = (
 /obj/structure/closet/crate/science,
-/obj/item/circuitboard/computer/exploration_shuttle,
+/obj/item/circuitboard/computer/shuttle/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/five,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/plastitanium,

--- a/_maps/shuttles/exploration_delta.dmm
+++ b/_maps/shuttles/exploration_delta.dmm
@@ -413,7 +413,7 @@
 /area/shuttle/exploration)
 "Yi" = (
 /obj/structure/closet/crate,
-/obj/item/circuitboard/computer/exploration_shuttle,
+/obj/item/circuitboard/computer/shuttle/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/five,
 /obj/item/pickaxe,
 /obj/item/mining_scanner,

--- a/_maps/shuttles/exploration_fland.dmm
+++ b/_maps/shuttles/exploration_fland.dmm
@@ -213,7 +213,7 @@
 /obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/item/multitool,
 /obj/item/gps/mining,
-/obj/item/circuitboard/computer/exploration_shuttle,
+/obj/item/circuitboard/computer/shuttle/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/fifty,
 /turf/open/floor/plasteel/tech/grid,
 /area/shuttle/exploration)

--- a/_maps/shuttles/exploration_shuttle.dmm
+++ b/_maps/shuttles/exploration_shuttle.dmm
@@ -207,7 +207,7 @@
 "C" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/science,
-/obj/item/circuitboard/computer/exploration_shuttle,
+/obj/item/circuitboard/computer/shuttle/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/five,
 /obj/item/gps/mining,
 /obj/item/storage/toolbox/mechanical,

--- a/_maps/shuttles/science_outpost.dmm
+++ b/_maps/shuttles/science_outpost.dmm
@@ -36,7 +36,7 @@
 /area/shuttle/science)
 "i" = (
 /obj/structure/closet/crate/science,
-/obj/item/circuitboard/computer/science_shuttle,
+/obj/item/circuitboard/computer/shuttle/science_shuttle,
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/stack/cable_coil/orange,

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -233,11 +233,6 @@
 	else
 		return ..()
 
-/obj/item/circuitboard/computer/monastery_shuttle
-	name = "monastery shuttle console (Computer Board)"
-	icon_state = "generic"
-	build_path = /obj/machinery/computer/shuttle_flight/monastery_shuttle
-
 /obj/item/circuitboard/computer/olddoor
 	name = "DoorMex (Computer Board)"
 	icon_state = "generic"
@@ -258,6 +253,7 @@
 	icon_state = "generic"
 	build_path = /obj/machinery/computer/pod/old/swf
 
+//Not inhereting the hackability from shuttle subtypes
 /obj/item/circuitboard/computer/syndicate_shuttle
 	name = "syndicate shuttle console (Computer Board)"
 	icon_state = "generic"
@@ -277,24 +273,6 @@
 	name = "ProComp Executive (Computer Board)"
 	icon_state = "generic"
 	build_path = /obj/machinery/computer/pod/old/syndicate
-
-/obj/item/circuitboard/computer/white_ship
-	name = "white ship control (Computer Board)"
-	icon_state = "generic"
-	build_path = /obj/machinery/computer/shuttle_flight/white_ship
-
-/obj/item/circuitboard/computer/white_ship/pod
-	name = "salvage pod control (Computer Board)"
-	build_path = /obj/machinery/computer/shuttle_flight/white_ship/pod
-
-/obj/item/circuitboard/computer/white_ship/pod/recall
-	name = "salvage pod recall control (Computer Board)"
-	build_path = /obj/machinery/computer/shuttle_flight/white_ship/pod/recall
-
-/obj/item/circuitboard/computer/shuttle/flight_control
-	name = "shuttle flight control (Computer Board)"
-	icon_state = "generic"
-	build_path = /obj/machinery/computer/shuttle_flight/custom_shuttle
 
 //Medical
 
@@ -413,16 +391,6 @@
 
 //Security
 
-
-/obj/item/circuitboard/computer/labor_shuttle
-	name = "labor shuttle console (Computer Board)"
-	icon_state = "security"
-	build_path = /obj/machinery/computer/shuttle_flight/labor
-
-/obj/item/circuitboard/computer/labor_shuttle/one_way
-	name = "prisoner shuttle console (Computer Board)"
-	build_path = /obj/machinery/computer/shuttle_flight/labor/one_way
-
 /obj/item/circuitboard/computer/gulag_teleporter_console
 	name = "labor camp teleporter console (Computer Board)"
 	icon_state = "security"
@@ -503,29 +471,76 @@
 	icon_state = "supply"
 	build_path = /obj/machinery/computer/cargo/request
 
-/obj/item/circuitboard/computer/ferry
-	name = "transport ferry control (Computer Board)"
-	icon_state = "supply"
-	build_path = /obj/machinery/computer/shuttle_flight/ferry
-
-/obj/item/circuitboard/computer/ferry/request
-	name = "transport ferry console (Computer Board)"
-	build_path = /obj/machinery/computer/shuttle_flight/ferry/request
-
 /obj/item/circuitboard/computer/mining
 	name = "outpost status display (Computer Board)"
 	icon_state = "supply"
 	build_path = /obj/machinery/computer/security/mining
 
-/obj/item/circuitboard/computer/mining_shuttle
+//Shuttles
+
+/obj/item/circuitboard/computer/shuttle
+	var/hacked = FALSE
+
+/obj/item/circuitboard/computer/shuttle/attacked_by(obj/item/I, mob/living/user)
+	if(I.tool_behaviour == TOOL_MULTITOOL)
+		hacked = !hacked
+		if(hacked)
+			to_chat(user, "<span class='notice'>You disable the circuitboard's ID scanning protocols.</span>")
+		else
+			to_chat(user, "<span class='notice'>You reset the circuitboard's ID scanning protocols.</span>")
+		return
+	. = ..()
+
+/obj/item/circuitboard/computer/shuttle/white_ship
+	name = "white ship control (Computer Board)"
+	icon_state = "generic"
+	build_path = /obj/machinery/computer/shuttle_flight/white_ship
+
+/obj/item/circuitboard/computer/shuttle/white_ship/pod
+	name = "salvage pod control (Computer Board)"
+	build_path = /obj/machinery/computer/shuttle_flight/white_ship/pod
+
+/obj/item/circuitboard/computer/shuttle/white_ship/pod/recall
+	name = "salvage pod recall control (Computer Board)"
+	build_path = /obj/machinery/computer/shuttle_flight/white_ship/pod/recall
+
+/obj/item/circuitboard/computer/shuttle/flight_control
+	name = "shuttle flight control (Computer Board)"
+	icon_state = "generic"
+	build_path = /obj/machinery/computer/shuttle_flight/custom_shuttle
+
+/obj/item/circuitboard/computer/shuttle/labor_shuttle
+	name = "labor shuttle console (Computer Board)"
+	icon_state = "security"
+	build_path = /obj/machinery/computer/shuttle_flight/labor
+
+/obj/item/circuitboard/computer/shuttle/labor_shuttle/one_way
+	name = "prisoner shuttle console (Computer Board)"
+	build_path = /obj/machinery/computer/shuttle_flight/labor/one_way
+
+/obj/item/circuitboard/computer/shuttle/ferry
+	name = "transport ferry control (Computer Board)"
+	icon_state = "supply"
+	build_path = /obj/machinery/computer/shuttle_flight/ferry
+
+/obj/item/circuitboard/computer/shuttle/ferry/request
+	name = "transport ferry console (Computer Board)"
+	build_path = /obj/machinery/computer/shuttle_flight/ferry/request
+
+/obj/item/circuitboard/computer/shuttle/mining_shuttle
 	name = "mining shuttle console (Computer Board)"
 	icon_state = "supply"
 	build_path = /obj/machinery/computer/shuttle_flight/mining
 
-/obj/item/circuitboard/computer/science_shuttle
+/obj/item/circuitboard/computer/shuttle/science_shuttle
 	name = "science shuttle console (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle_flight/science
 
-/obj/item/circuitboard/computer/exploration_shuttle
+/obj/item/circuitboard/computer/shuttle/exploration_shuttle
 	name = "exploration shuttle console (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle_flight/custom_shuttle/exploration
+
+/obj/item/circuitboard/computer/shuttle/monastery_shuttle
+	name = "monastery shuttle console (Computer Board)"
+	icon_state = "generic"
+	build_path = /obj/machinery/computer/shuttle_flight/monastery_shuttle

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -481,7 +481,7 @@
 /obj/item/circuitboard/computer/shuttle
 	var/hacked = FALSE
 
-/obj/item/circuitboard/computer/shuttle/attacked_by(obj/item/I, mob/living/user)
+/obj/item/circuitboard/computer/shuttle/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_MULTITOOL)
 		hacked = !hacked
 		if(hacked)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -518,12 +518,12 @@
 	name = "prisoner shuttle console (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle_flight/labor/one_way
 
-/obj/item/circuitboard/computer/shuttle/ferry
+/obj/item/circuitboard/computer/ferry
 	name = "transport ferry control (Computer Board)"
 	icon_state = "supply"
 	build_path = /obj/machinery/computer/shuttle_flight/ferry
 
-/obj/item/circuitboard/computer/shuttle/ferry/request
+/obj/item/circuitboard/computer/ferry/request
 	name = "transport ferry console (Computer Board)"
 	build_path = /obj/machinery/computer/shuttle_flight/ferry/request
 

--- a/code/modules/exploration_crew/exploration_shuttle.dm
+++ b/code/modules/exploration_crew/exploration_shuttle.dm
@@ -1,7 +1,7 @@
 /obj/machinery/computer/shuttle_flight/custom_shuttle/exploration
 	name = "exploration shuttle console"
 	desc = "Used to pilot the exploration shuttle."
-	circuit = /obj/item/circuitboard/computer/exploration_shuttle
+	circuit = /obj/item/circuitboard/computer/shuttle/exploration_shuttle
 	shuttleId = "exploration"
 	possible_destinations = "exploration_home"
 	req_access = list(ACCESS_EXPLORATION)

--- a/code/modules/mining/laborcamp/laborshuttle.dm
+++ b/code/modules/mining/laborcamp/laborshuttle.dm
@@ -1,7 +1,7 @@
 /obj/machinery/computer/shuttle_flight/labor
 	name = "labor shuttle console"
 	desc = "Used to call and send the labor camp shuttle."
-	circuit = /obj/item/circuitboard/computer/labor_shuttle
+	circuit = /obj/item/circuitboard/computer/shuttle/labor_shuttle
 	shuttleId = "laborcamp"
 	possible_destinations = "laborcamp_home;laborcamp_away;laborcamp_perma;laborcamp_arrival;laborcamp_bridge"
 	req_access = list(ACCESS_BRIG)
@@ -11,5 +11,5 @@
 	name = "prisoner shuttle console"
 	desc = "A one-way shuttle console, used to summon the shuttle to the labor camp."
 	recall_docking_port_id = "laborcamp_away"
-	circuit = /obj/item/circuitboard/computer/labor_shuttle/one_way
+	circuit = /obj/item/circuitboard/computer/shuttle/labor_shuttle/one_way
 	req_access = list( )

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -74,7 +74,7 @@
 /obj/machinery/computer/shuttle_flight/mining
 	name = "mining shuttle console"
 	desc = "Used to call and send the mining shuttle."
-	circuit = /obj/item/circuitboard/computer/mining_shuttle
+	circuit = /obj/item/circuitboard/computer/shuttle/mining_shuttle
 	shuttleId = "mining"
 	possible_destinations = "mining_home;mining_away;landing_zone_dock;mining_public"
 	req_access = list(ACCESS_MINING)
@@ -92,7 +92,7 @@
 /obj/machinery/computer/shuttle_flight/science
 	name = "science outpost shuttle console"
 	desc = "Used to call and send the science shuttle."
-	circuit = /obj/item/circuitboard/computer/science_shuttle
+	circuit = /obj/item/circuitboard/computer/shuttle/science_shuttle
 	shuttleId = "science"
 	possible_destinations = "science_station;science_outpost"
 

--- a/code/modules/ruins/spaceruin_code/caravanambush.dm
+++ b/code/modules/ruins/spaceruin_code/caravanambush.dm
@@ -28,28 +28,28 @@
 
 /obj/machinery/computer/shuttle_flight/caravan
 
-/obj/item/circuitboard/computer/caravan
+/obj/item/circuitboard/computer/shuttle/caravan
 	build_path = /obj/machinery/computer/shuttle_flight/caravan
 
-/obj/item/circuitboard/computer/caravan/trade1
+/obj/item/circuitboard/computer/shuttle/caravan/trade1
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/trade1
 
-/obj/item/circuitboard/computer/caravan/pirate
+/obj/item/circuitboard/computer/shuttle/caravan/pirate
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/pirate
 
-/obj/item/circuitboard/computer/caravan/syndicate1
+/obj/item/circuitboard/computer/shuttle/caravan/syndicate1
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/syndicate1
 
-/obj/item/circuitboard/computer/caravan/syndicate2
+/obj/item/circuitboard/computer/shuttle/caravan/syndicate2
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/syndicate2
 
-/obj/item/circuitboard/computer/caravan/syndicate3
+/obj/item/circuitboard/computer/shuttle/caravan/syndicate3
 	build_path = /obj/machinery/computer/shuttle_flight/caravan/syndicate3
 
 /obj/machinery/computer/shuttle_flight/caravan/trade1
 	name = "Small Freighter Shuttle Console"
 	desc = "Used to control the Small Freighter."
-	circuit = /obj/item/circuitboard/computer/caravan/trade1
+	circuit = /obj/item/circuitboard/computer/shuttle/caravan/trade1
 	shuttleId = "caravantrade1"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;caravantrade1_custom;caravantrade1_ambush"
 
@@ -59,7 +59,7 @@
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	light_color = LIGHT_COLOR_RED
-	circuit = /obj/item/circuitboard/computer/caravan/pirate
+	circuit = /obj/item/circuitboard/computer/shuttle/caravan/pirate
 	shuttleId = "caravanpirate"
 	possible_destinations = "caravanpirate_custom;caravanpirate_ambush"
 
@@ -70,7 +70,7 @@
 	icon_keyboard = "syndie_key"
 	light_color = LIGHT_COLOR_RED
 	req_access = list(ACCESS_SYNDICATE)
-	circuit = /obj/item/circuitboard/computer/caravan/syndicate1
+	circuit = /obj/item/circuitboard/computer/shuttle/caravan/syndicate1
 	shuttleId = "caravansyndicate1"
 	possible_destinations = "caravansyndicate1_custom;caravansyndicate1_ambush;caravansyndicate1_listeningpost"
 
@@ -81,7 +81,7 @@
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
 	light_color = LIGHT_COLOR_RED
-	circuit = /obj/item/circuitboard/computer/caravan/syndicate2
+	circuit = /obj/item/circuitboard/computer/shuttle/caravan/syndicate2
 	shuttleId = "caravansyndicate2"
 	possible_destinations = "caravansyndicate2_custom;caravansyndicate2_ambush;caravansyndicate1_listeningpost"
 
@@ -92,6 +92,6 @@
 	icon_keyboard = "syndie_key"
 	req_access = list(ACCESS_SYNDICATE)
 	light_color = LIGHT_COLOR_RED
-	circuit = /obj/item/circuitboard/computer/caravan/syndicate3
+	circuit = /obj/item/circuitboard/computer/shuttle/caravan/syndicate3
 	shuttleId = "caravansyndicate3"
 	possible_destinations = "caravansyndicate3_custom;caravansyndicate3_ambush;caravansyndicate3_listeningpost"

--- a/code/modules/ruins/spaceruin_code/whiteshipruin_box.dm
+++ b/code/modules/ruins/spaceruin_code/whiteshipruin_box.dm
@@ -1,8 +1,8 @@
 ///////////	ruined whiteship
 
-/obj/item/circuitboard/computer/white_ship/ruin
+/obj/item/circuitboard/computer/shuttle/white_ship/ruin
 	build_path = /obj/machinery/computer/shuttle_flight/white_ship/ruin
 
 /obj/machinery/computer/shuttle_flight/white_ship/ruin
 	shuttleId = "whiteship_ruin"
-	circuit = /obj/item/circuitboard/computer/white_ship/ruin
+	circuit = /obj/item/circuitboard/computer/shuttle/white_ship/ruin

--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -1,7 +1,7 @@
 /obj/machinery/computer/shuttle_flight/ferry
 	name = "transport ferry console"
 	desc = "A console that controls the transport ferry."
-	circuit = /obj/item/circuitboard/computer/shuttle/ferry
+	circuit = /obj/item/circuitboard/computer/ferry
 	shuttleId = "ferry"
 	possible_destinations = "ferry_home;ferry_away"
 	req_access = list(ACCESS_CENT_GENERAL)
@@ -23,7 +23,7 @@
 
 /obj/machinery/computer/shuttle_flight/ferry/request
 	name = "ferry console"
-	circuit = /obj/item/circuitboard/computer/shuttle/ferry/request
+	circuit = /obj/item/circuitboard/computer/ferry/request
 	var/last_request //prevents spamming admins
 	var/cooldown = 600
 	possible_destinations = "ferry_home;ferry_away"

--- a/code/modules/shuttle/ferry.dm
+++ b/code/modules/shuttle/ferry.dm
@@ -1,7 +1,7 @@
 /obj/machinery/computer/shuttle_flight/ferry
 	name = "transport ferry console"
 	desc = "A console that controls the transport ferry."
-	circuit = /obj/item/circuitboard/computer/ferry
+	circuit = /obj/item/circuitboard/computer/shuttle/ferry
 	shuttleId = "ferry"
 	possible_destinations = "ferry_home;ferry_away"
 	req_access = list(ACCESS_CENT_GENERAL)
@@ -23,7 +23,7 @@
 
 /obj/machinery/computer/shuttle_flight/ferry/request
 	name = "ferry console"
-	circuit = /obj/item/circuitboard/computer/ferry/request
+	circuit = /obj/item/circuitboard/computer/shuttle/ferry/request
 	var/last_request //prevents spamming admins
 	var/cooldown = 600
 	possible_destinations = "ferry_home;ferry_away"

--- a/code/modules/shuttle/monastery.dm
+++ b/code/modules/shuttle/monastery.dm
@@ -1,6 +1,6 @@
 /obj/machinery/computer/shuttle_flight/monastery_shuttle
 	name = "monastery shuttle console"
 	desc = "Used to control the monastery shuttle."
-	circuit = /obj/item/circuitboard/computer/monastery_shuttle
+	circuit = /obj/item/circuitboard/computer/shuttle/monastery_shuttle
 	shuttleId = "pod1"
 	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station"

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -46,7 +46,7 @@ GLOBAL_VAR_INIT(shuttle_docking_jammed, FALSE)
 /obj/machinery/computer/shuttle_flight/Destroy()
 	. = ..()
 	SSorbits.open_orbital_maps -= SStgui.get_all_open_uis(src)
-	shuttleObject.UnregisterReference(src)
+	shuttleObject = null
 	//De-link the port
 	if(my_port)
 		my_port.delete_after = TRUE

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -46,7 +46,22 @@ GLOBAL_VAR_INIT(shuttle_docking_jammed, FALSE)
 /obj/machinery/computer/shuttle_flight/Destroy()
 	. = ..()
 	SSorbits.open_orbital_maps -= SStgui.get_all_open_uis(src)
-	shuttleObject = null
+	shuttleObject.UnregisterReference(src)
+	//De-link the port
+	if(my_port)
+		my_port.delete_after = TRUE
+		my_port.id = null
+		my_port.name = "Old [my_port.name]"
+		my_port = null
+
+/obj/machinery/computer/shuttle_flight/examine(mob/user)
+	. = ..()
+	var/obj/item/circuitboard/computer/shuttle/circuit_board = circuit
+	if(istype(circuit_board))
+		if(circuit_board.hacked)
+			. += "It's access requirements have been disabled."
+		else
+			. += "It's access requirements could be disabled by disassembling the computer and using a multitool on the circuitboard."
 
 /obj/machinery/computer/shuttle_flight/process()
 	. = ..()
@@ -530,3 +545,8 @@ GLOBAL_VAR_INIT(shuttle_docking_jammed, FALSE)
 	obj_flags |= EMAGGED
 	to_chat(user, "<span class='notice'>You fried the consoles ID checking system.</span>")
 
+/obj/machinery/computer/shuttle_flight/allowed(mob/M)
+	var/obj/item/circuitboard/computer/shuttle/circuit_board = circuit
+	if(istype(circuit_board) && circuit_board.hacked)
+		return TRUE
+	return ..()

--- a/code/modules/shuttle/white_ship.dm
+++ b/code/modules/shuttle/white_ship.dm
@@ -1,21 +1,21 @@
 /obj/machinery/computer/shuttle_flight/white_ship
 	name = "White Ship Console"
 	desc = "Used to control the White Ship."
-	circuit = /obj/item/circuitboard/computer/white_ship
+	circuit = /obj/item/circuitboard/computer/shuttle/white_ship
 	shuttleId = "whiteship"
 	possible_destinations = "whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;whiteship_custom"
 
 /obj/machinery/computer/shuttle_flight/white_ship/pod
 	name = "Salvage Pod Console"
 	desc = "Used to control the Salvage Pod."
-	circuit = /obj/item/circuitboard/computer/white_ship/pod
+	circuit = /obj/item/circuitboard/computer/shuttle/white_ship/pod
 	shuttleId = "whiteship_pod"
 	possible_destinations = "whiteship_pod_home;whiteship_pod_custom"
 
 /obj/machinery/computer/shuttle_flight/white_ship/pod/recall
 	name = "Salvage Pod Recall Console"
 	desc = "Used to recall the Salvage Pod."
-	circuit = /obj/item/circuitboard/computer/white_ship/pod/recall
+	circuit = /obj/item/circuitboard/computer/shuttle/white_ship/pod/recall
 	possible_destinations = "whiteship_pod_home"
 
 /obj/effect/spawner/lootdrop/whiteship_cere_ripley


### PR DESCRIPTION
…tructed

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements the ability to hack shuttle computers. Shuttles can be hacked by using a multitool on their circuitboard to disable ID checks. The syndicate infiltrator cannot be hacked.
Also fixes a bug where if a shuttle console was deconstructed and rebuilt while a custom location was designated the shuttle would permanently be stuck.

## Why It's Good For The Game

Fixes a bug, allows hacking of otherwise unhackable shuttles

## Testing Photographs and Procedure

it just works yo
![image](https://user-images.githubusercontent.com/26465327/148282455-1c8f5cb7-bb4d-49b3-a181-98531eebcdb3.png)


## Changelog
:cl:
balance: Shuttle computers can now be hacked by using a multitool on their circuitboard to disable ID checks.
fix: Deconstructing shuttle computers will no longer break shuttle docking if the shuttle has a custom dock defined.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
