### PR TITLE
Chat messages with no language are now handled correctly.

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -313,9 +313,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		if(isAI(src) && !GLOB.cameranet.checkCameraVis(v.source))
 			return CHATMESSAGE_CANNOT_HEAR
 	var/datum/language/language_instance = GLOB.language_datum_instances[message_language]
-	if(!language_instance)
-		return CHATMESSAGE_HEAR
-	if(language_instance.display_icon(src))
+	if(language_instance?.display_icon(src))
 		return CHATMESSAGE_SHOW_LANGUAGE_ICON
 	return CHATMESSAGE_HEAR
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -313,7 +313,9 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		if(isAI(src) && !GLOB.cameranet.checkCameraVis(v.source))
 			return CHATMESSAGE_CANNOT_HEAR
 	var/datum/language/language_instance = GLOB.language_datum_instances[message_language]
-	if(language_instance?.display_icon(src))
+	if(!language_instance)
+		return CHATMESSAGE_HEAR
+	if(language_instance.display_icon(src))
 		return CHATMESSAGE_SHOW_LANGUAGE_ICON
 	return CHATMESSAGE_HEAR
 
@@ -331,6 +333,13 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 
 	// Ensure the list we are using, if present, is a copy so we don't modify the list provided to us
 	spans = spans ? spans.Copy() : list()
+
+	var/handled_message = raw_message
+
+	// Message language override, if no language was spoken emote 'makes a strange noise'
+	if(!message_language)
+		message_mods |= CHATMESSAGE_EMOTE
+		handled_message = "makes a strange sound."
 
 	// Check for virtual speakers (aka hearing a message through a radio)
 	if (istype(speaker, /atom/movable/virtualspeaker))
@@ -351,7 +360,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		for(var/mob/M as() in hearers)
 			if(M?.should_show_chat_message(speaker, message_language, TRUE))
 				clients += M.client
-		new /datum/chatmessage(raw_message, speaker, clients, message_language, list("emote"))
+		new /datum/chatmessage(handled_message, speaker, clients, message_language, list("emote"))
 	else
 		//4 Possible chat message states:
 		//Show Icon, Understand (Most other languages)
@@ -377,13 +386,13 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		var/scrambled_message
 		var/datum/language/language_instance = message_language ? GLOB.language_datum_instances[message_language] : null
 		if(LAZYLEN(show_icon_scrambled) || LAZYLEN(hide_icon_scrambled))
-			scrambled_message = language_instance?.scramble(raw_message) || scramble_message_replace_chars(raw_message, 100)
+			scrambled_message = language_instance?.scramble(handled_message) || scramble_message_replace_chars(handled_message, 100)
 		//Show the correct message to people who should see the icon and understand the language
 		if(LAZYLEN(show_icon_understand))
-			new /datum/chatmessage(raw_message, speaker, show_icon_understand, message_language, spans)
+			new /datum/chatmessage(handled_message, speaker, show_icon_understand, message_language, spans)
 		//Show the correct message to people who should see the icon but not understand the language
 		if(LAZYLEN(hide_icon_understand))
-			new /datum/chatmessage(raw_message, speaker, hide_icon_understand, message_language, spans)
+			new /datum/chatmessage(handled_message, speaker, hide_icon_understand, message_language, spans)
 		//Show the correct message to people who don't understand the language and should see the icon
 		if(LAZYLEN(show_icon_scrambled))
 			new /datum/chatmessage(scrambled_message, speaker, show_icon_scrambled, message_language, spans)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes #6111

## About The Pull Request

Overhead chat messages created with a null language now are replaced with *makes a strange sound emote.

## Why It's Good For The Game

Fixes a bug that meant if someone speaks without a languge

![image](https://user-images.githubusercontent.com/26465327/148285782-5c96a5b0-06da-47fd-bb23-19724562ffad.png)


## Changelog
:cl:
fix: Runechat now properly handles null languages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
