### PR TITLE
Stun baton is more likely to have a large affect from EMPs.

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -201,7 +201,7 @@
 		deductcharge(cell.charge)
 	else
 		//Otherwise just deduct a smaller amount of power
-		deductcharge(1000 / severity)
+		deductcharge(5000 / severity)
 
 //Makeshift stun baton. Replacement for stun gloves.
 /obj/item/melee/baton/cattleprod

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -193,8 +193,14 @@
 	return 1
 
 /obj/item/melee/baton/emp_act(severity)
-	. = ..()
-	if (!(. & EMP_PROTECT_SELF))
+	//Stun baton is protected from EMPs
+	if (..() & EMP_PROTECT_SELF)
+		return
+	//Large probability to have its power consumed
+	if(prob(100 / severity))
+		deductcharge(cell.charge)
+	else
+		//Otherwise just deduct a smaller amount of power
 		deductcharge(1000 / severity)
 
 //Makeshift stun baton. Replacement for stun gloves.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

**This PR is redundant and will be replaced by a follow-up PR.**

## About The Pull Request

Stun batons have a 100% chance for heavy emps and a 50% chance for light EMPs to have their power fully drained.

## Why It's Good For The Game

Currently stun batons have almost no effect to EMPs, it drains 1000 power from the heaviest EMP which is the equivilent of hitting someone a single time.
This makes it so stun batons are more likely to be affected by EMP blasts. Considering the strength of the stun baton and with changelings no longer being able to block stun baton attacks, an EMP taking a single charge from the baton definitely needs changing.

## Changelog
:cl:
balance: Stun batons are now more affected by EMP attacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
