### PR TITLE
Cult bolas no longer affect holy-proof individuals.

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -263,8 +263,7 @@
 		return
 	if(ismob(hit_atom))
 		var/mob/M = hit_atom
-		var/anti_magic_source = M.anti_magic_check(holy = TRUE)
-		if(anti_magic_source)
+		if(M.anti_magic_check(holy = TRUE))
 			M.visible_message("[src] passes right through [M]!")
 			return
 	. = ..()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -261,6 +261,12 @@
 /obj/item/restraints/legcuffs/bola/cult/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(iscultist(hit_atom))
 		return
+	if(ismob(hit_atom))
+		var/mob/M = hit_atom
+		var/anti_magic_source = M.anti_magic_check(holy = TRUE)
+		if(anti_magic_source)
+			M.visible_message("[src] passes right through [M]!")
+			return
 	. = ..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cult bola's will now pass through anyone with holy magic protection.

## Why It's Good For The Game

Cult bolas are an incredibly powerful tool, and despite being magic are not affected by anti-holy magic.
In practice this means that holding a bible in one of your hands will prevent cult bolas from protecting you.

## Changelog
:cl:
balance: Cult bolas no longer affect people with holy magic protection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
