### PR TITLE
EMP destroys energy based snares

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -332,6 +332,10 @@
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg
 	breakouttime = 20 // Cyborgs shouldn't have a strong restraint
 
+/obj/item/restraints/legcuffs/beartrap/energy/emp_act(severity)
+	do_sparks(1, TRUE, src)
+	qdel(src)
+
 /obj/item/restraints/legcuffs/bola
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."
@@ -401,6 +405,12 @@
 		B.spring_trap(null, hit_atom)
 		qdel(src)
 	. = ..()
+
+/obj/item/restraints/legcuffs/bola/energy/emp_act(severity)
+	if(prob(25 * severity))
+		return
+	do_sparks(1, TRUE, src)
+	qdel(src)
 
 /obj/item/restraints/legcuffs/bola/gonbola
 	name = "gonbola"

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -111,3 +111,7 @@
 /obj/item/projectile/energy/trap/cyborg/on_range()
 	do_sparks(1, TRUE, src)
 	qdel(src)
+
+/obj/item/projectile/energy/trap/cyborg/emp_act(severity)
+	do_sparks(1, TRUE, src)
+	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Energy based snares will be destroyed by EMPs.
Anyone ensnared by an energy snare will be freed when affected by an EMP.
The energy bola will be destroyed by EMPs with a chance of 75% for heavy EMPs and 50% for light EMPs.

## Why It's Good For The Game

Energy based things get affected by EMPs. Allows the EMP implant, traitor EMPs and cult EMPs to let themselves get freed by EMPs. (While I don't think cultists EMP should get a buff, it happens as a side effect and I think it should be weakened in another PR)

Tested and it works.

## Changelog
:cl:
balance: EMPs now destroy energy bolas and free anyone trapped by an energy snare.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
