### PR TITLE
Magical / Holy EMP + explosions are protected by anti-magic

### DIFF
--- a/code/controllers/subsystem/explosion.dm
+++ b/code/controllers/subsystem/explosion.dm
@@ -169,7 +169,7 @@ SUBSYSTEM_DEF(explosions)
 // 5 explosion power is a (0, 1, 3) explosion.
 // 1 explosion power is a (0, 0, 1) explosion.
 
-/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = TRUE, ignorecap = FALSE, flame_range = 0, silent = FALSE, smoke = FALSE)
+/proc/explosion(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = TRUE, ignorecap = FALSE, flame_range = 0, silent = FALSE, smoke = FALSE, magic = FALSE, holy = FALSE)
 	. = SSexplosions.explode(arglist(args))
 
 #define CREAK_DELAY 5 SECONDS //Time taken for the creak to play after explosion, if applicable.
@@ -182,7 +182,7 @@ SUBSYSTEM_DEF(explosions)
 #define FREQ_UPPER 40 //The upper limit for the randomly selected frequency.
 #define FREQ_LOWER 25 //The lower of the above.
 
-/datum/controller/subsystem/explosions/proc/explode(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog, ignorecap, flame_range, silent, smoke, explode_z = TRUE)
+/datum/controller/subsystem/explosions/proc/explode(atom/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog, ignorecap, flame_range, silent, smoke, magic, holy, explode_z = TRUE)
 	epicenter = get_turf(epicenter)
 	if(!epicenter)
 		return
@@ -300,6 +300,8 @@ SUBSYSTEM_DEF(explosions)
 	//flash mobs
 	if(flash_range)
 		for(var/mob/living/L in viewers(flash_range, epicenter))
+			if(L.anti_magic_check(magic, holy))
+				continue
 			L.flash_act()
 
 	var/list/affected_turfs = GatherSpiralTurfs(max_range, epicenter)
@@ -316,6 +318,10 @@ SUBSYSTEM_DEF(explosions)
 		var/turf/T = TI
 		var/init_dist = cheap_hypotenuse(T.x, T.y, x0, y0)
 		var/dist = init_dist
+
+		//Phew, that was a close one.
+		if(holy && (locate(/obj/effect/blessing) in T))
+			continue
 
 		if(reactionary)
 			var/turf/Trajectory = T
@@ -340,6 +346,11 @@ SUBSYSTEM_DEF(explosions)
 			var/list/items = list()
 			for(var/I in T)
 				var/atom/A = I
+				//Ignore magic protected things.
+				if(ismob(A))
+					var/mob/M = A
+					if(M.anti_magic_check(magic, holy, TRUE, TRUE))
+						continue
 				if (length(A.contents) && !(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
 					items += A.GetAllContents(ignore_flag_1 = PREVENT_CONTENTS_EXPLOSION_1)
 			for(var/thing in items)
@@ -353,6 +364,16 @@ SUBSYSTEM_DEF(explosions)
 						SSexplosions.med_mov_atom += movable_thing
 					if(EXPLODE_LIGHT)
 						SSexplosions.low_mov_atom += movable_thing
+
+		//Protect turfs if there is holyness on them
+		if(magic || holy)
+			var/divine_protection = FALSE
+			for(var/mob/living/L in T.contents)
+				if(L.anti_magic_check(magic, holy, TRUE))
+					divine_protection = TRUE
+					break
+			if(divine_protection)
+				continue
 
 		switch(dist)
 			if(EXPLODE_DEVASTATE)

--- a/code/datums/diseases/rhumba_beat.dm
+++ b/code/datums/diseases/rhumba_beat.dm
@@ -40,6 +40,6 @@
 		if(5)
 			to_chat(affected_mob, "<span class='danger'>Your body is unable to contain the Rhumba Beat...</span>")
 			if(prob(50))
-				explosion(get_turf(affected_mob), -1, 0, 2, 3, 0, 2) // This is equivalent to a lvl 1 fireball
+				explosion(get_turf(affected_mob), -1, 0, 2, 3, 0, 2, magic=TRUE) // This is equivalent to a lvl 1 fireball
 		else
 			return

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -138,6 +138,7 @@
 	exp_light = 0
 	exp_flash = 0
 	exp_fire= 4
+	magic = FALSE
 
 /datum/mutation/human/void
 	name = "Void Magnet"

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -1,4 +1,4 @@
-/proc/empulse(turf/epicenter, heavy_range, light_range, log=0)
+/proc/empulse(turf/epicenter, heavy_range, light_range, log=0, magic=FALSE, holy=FALSE)
 	if(!epicenter)
 		return
 
@@ -15,7 +15,22 @@
 	if(heavy_range > light_range)
 		light_range = heavy_range
 
-	for(var/atom/A as() in spiral_range(light_range, epicenter))
+	var/list/empulse_atoms = list()
+
+	for(var/turf/T as() in spiral_range_turfs(light_range, epicenter))
+		//Blessing protects from holy EMPS
+		if(holy && (locate(/obj/effect/blessing) in T))
+			continue
+		for(var/atom/A as() in T)
+			//Magic check.
+			if(ismob(A))
+				var/mob/M = A
+				if(M.anti_magic_check(magic, holy, TRUE, T==epicenter))
+					continue
+			empulse_atoms += A
+		empulse_atoms += T
+
+	for(var/atom/A as() in empulse_atoms)
 		var/distance = get_dist(epicenter, A)
 		if(distance < 0)
 			distance = 0

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -159,7 +159,7 @@
 
 /obj/item/book/granter/spell/fireball/recoil(mob/user)
 	..()
-	explosion(user.loc, 1, 0, 2, 3, FALSE, FALSE, 2)
+	explosion(user.loc, 1, 0, 2, 3, FALSE, FALSE, 2, magic = TRUE)
 	qdel(src)
 
 /obj/item/book/granter/spell/sacredflame
@@ -286,7 +286,7 @@
 /obj/item/book/granter/spell/charge/recoil(mob/user)
 	..()
 	to_chat(user,"<span class='warning'>[src] suddenly feels very warm!</span>")
-	empulse(src, 1, 1)
+	empulse(src, 1, 1, magic=TRUE)
 
 /obj/item/book/granter/spell/summonitem
 	spell = /obj/effect/proc_holder/spell/targeted/summonitem

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -454,7 +454,7 @@
 		P.say(pick("Nooooo...", "Not die. To y-", "Die. Ratv-", "Sas tyen re-"))
 		playsound(src, 'sound/magic/clockwork/anima_fragment_attack.ogg', 50, TRUE, frequency = 2)
 		playsound(P, 'sound/magic/demon_dies.ogg', 50, TRUE, frequency = 2)
-		explosion(P, 0, 0, 1)
+		explosion(P, 0, 0, 1, holy = TRUE)
 		qdel(P)
 		clash_target = null
 	else
@@ -462,7 +462,7 @@
 		P.say(pick("Ha.", "Ra'sha fonn dest.", "You fool. To come here."))
 		playsound(src, 'sound/magic/clockwork/anima_fragment_death.ogg', 62, TRUE, frequency = 2)
 		playsound(P, 'sound/magic/demon_attack1.ogg', 50, TRUE, frequency = 2)
-		explosion(src, 0, 0, 1)
+		explosion(src, 0, 0, 1, holy = TRUE)
 		qdel(src)
 		P.clashing = FALSE
 

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -56,7 +56,7 @@
 	force += force_buff
 	. = ..()
 	force -= force_buff
-	if(!QDELETED(target) && target.stat != DEAD && !is_servant_of_ratvar(target) && !target.anti_magic_check(holy = TRUE, major=FALSE))
+	if(!QDELETED(target) && target.stat != DEAD && !is_servant_of_ratvar(target) && !target.anti_magic_check(magic=FALSE,holy=TRUE,major=FALSE))
 		hit_effect(target, user)
 
 /obj/item/clockwork/weapon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -66,7 +66,7 @@
 	if(isliving(hit_atom))
 		var/mob/living/target = hit_atom
 		if(!.)
-			if(!target.anti_magic_check(holy = TRUE) && !is_servant_of_ratvar(target))
+			if(!target.anti_magic_check(magic=FALSE,holy=TRUE) && !is_servant_of_ratvar(target))
 				hit_effect(target, throwingdatum.thrower, TRUE)
 
 /obj/item/clockwork/weapon/proc/hit_effect(mob/living/target, mob/living/user, thrown=FALSE)

--- a/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sigil_of_vitality.dm
@@ -32,7 +32,7 @@
 		return TRUE
 	if(M.stat == DEAD)
 		return FALSE
-	var/amc = M.anti_magic_check(holy = TRUE)
+	var/amc = M.anti_magic_check(magic=FALSE,holy=TRUE)
 	if(amc)
 		return FALSE
 	if(HAS_TRAIT(M, TRAIT_NODEATH))
@@ -73,7 +73,7 @@
 		else
 			visible_message("<span class='neovgre'>\The [src] fails to heal [M]!</span>", "<span class='neovgre'>There is insufficient vitality to heal your wounds!</span>")
 	else
-		if(M.anti_magic_check(holy = TRUE))
+		if(M.anti_magic_check(magic=FALSE,holy=TRUE))
 			return
 		if(is_convertable_to_clockcult(M) && !GLOB.gateway_opening)
 			visible_message("<span class='neovgre'>\The [src] refuses to siphon [M]'s vitality, their mind has great potential!</span>")

--- a/code/modules/antagonists/clock_cult/structure/clockwork_sigil.dm
+++ b/code/modules/antagonists/clock_cult/structure/clockwork_sigil.dm
@@ -65,7 +65,7 @@
 	var/mob/living/M = AM
 	if(!istype(M))
 		return FALSE
-	var/amc = M.anti_magic_check(holy = TRUE)
+	var/amc = M.anti_magic_check(magic=FALSE,holy=TRUE)
 	if(amc)
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -162,7 +162,7 @@
 	owner.whisper(invocation, language = /datum/language/common)
 	owner.visible_message("<span class='warning'>[owner]'s hand flashes a bright blue!</span>", \
 						 "<span class='cultitalic'>You speak the cursed words, emitting an EMP blast from your hand.</span>")
-	empulse(owner, 2, 5)
+	empulse(owner, 2, 5, holy=TRUE)
 	charges--
 	if(charges<=0)
 		qdel(src)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -680,7 +680,7 @@
 			else
 				L.visible_message("<span class='warning'>[src] bounces off of [L], as if repelled by an unseen force!</span>")
 		else if(!..())
-			if(!L.anti_magic_check(holy = TRUE))
+			if(!L.anti_magic_check(magic=FALSE,holy=TRUE))
 				L.Knockdown(50)
 			break_spear(T)
 	else
@@ -951,7 +951,7 @@
 			else
 				L.visible_message("<span class='warning'>[src] bounces off of [L], as if repelled by an unseen force!</span>")
 		else if(!..())
-			if(!L.anti_magic_check(holy = TRUE))
+			if(!L.anti_magic_check(magic=FALSE,holy=TRUE))
 				L.Knockdown(30)
 				if(D?.thrower)
 					for(var/mob/living/Next in orange(2, T))

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -780,7 +780,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			var/atom/I = L.anti_magic_check(holy = TRUE, major = FALSE)
+			var/atom/I = L.anti_magic_check(magic=FALSE,holy=TRUE,major = FALSE)
 			if(I)
 				if(isitem(I))
 					to_chat(L, "<span class='userdanger'>[I] suddenly burns hotly before returning to normal!</span>")
@@ -808,7 +808,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			if(L.anti_magic_check(holy = TRUE, major = FALSE))
+			if(L.anti_magic_check(magic=FALSE,holy=TRUE,major = FALSE))
 				continue
 			L.take_overall_damage(tick_damage*multiplier, tick_damage*multiplier)
 
@@ -980,7 +980,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	visible_message("<span class='warning'>A colossal shockwave of energy bursts from the rune, disintegrating it in the process!</span>")
 	for(var/mob/living/L in viewers(3, src))
 		L.Paralyze(30)
-	empulse(T, 0.42*(intensity), 1)
+	empulse(T, 0.42*(intensity), 1, holy=TRUE)
 	var/list/images = list()
 	var/zmatch = T.get_virtual_z_level()
 	var/datum/atom_hud/AH = GLOB.huds[DATA_HUD_SECURITY_ADVANCED]

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -60,7 +60,7 @@
 		var/mob/living/carbon/human/tar = target
 		if(tar.check_shields(src,10, "the [tar.name]"))
 			return ..()
-		if(tar.anti_magic_check(holy = TRUE))
+		if(tar.anti_magic_check(magic=FALSE,holy=TRUE))
 			tar.visible_message("<span class='danger'>Spell bounces off of [target]!</span>","<span class='danger'>The spell bounces off of you!</span>")
 			return ..()
 	var/datum/mind/M = user.mind
@@ -155,7 +155,7 @@
 	playsound(user, 'sound/magic/demon_attack1.ogg', 75, TRUE)
 	if(ishuman(target))
 		var/mob/living/carbon/human/tar = target
-		if(tar.anti_magic_check(holy = TRUE))
+		if(tar.anti_magic_check(magic=FALSE,holy=TRUE))
 			tar.visible_message("<span class='danger'>Spell bounces off of [target]!</span>","<span class='danger'>The spell bounces off of you!</span>")
 			return ..()
 	var/mob/living/carbon/human/C2 = user
@@ -252,7 +252,7 @@
 		var/mob/living/carbon/human/target = X
 		if(target == user)
 			continue
-		if(target.anti_magic_check(holy = TRUE))
+		if(target.anti_magic_check(magic=FALSE,holy=TRUE))
 			to_chat(user, "<span class='warning'>The spell had no effect!</span>")
 			target.visible_message("<span class='danger'>[target]'s veins flash with fire, but their magic protection repulses the blaze!</span>", \
 							"<span class='danger'>Your veins flash with fire, but your magic protection repels the blaze!</span>")
@@ -324,7 +324,7 @@
 			break
 
 		for(var/mob/living/L in T.contents)
-			if(L.anti_magic_check(holy = TRUE))
+			if(L.anti_magic_check(magic=FALSE,holy=TRUE))
 				L.visible_message("<span class='danger'>Spell bounces off of [L]!</span>","<span class='danger'>The spell bounces off of you!</span>")
 				continue
 			if(L in hit_list || L == source)

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -261,7 +261,7 @@
 		if(8)
 			//Fueltank Explosion
 			T.visible_message("<span class='userdanger'>An explosion bursts into existence around [user]!</span>")
-			explosion(get_turf(user),-1,0,2, flame_range = 2)
+			explosion(get_turf(user),-1,0,2, flame_range = 2, magic = TRUE)
 		if(9)
 			//Cold
 			var/datum/disease/D = new /datum/disease/cold()

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -209,5 +209,5 @@
 
 /obj/item/gun/magic/wand/fireball/zap_self(mob/living/user)
 	..()
-	explosion(user.loc, -1, 0, 2, 3, 0, flame_range = 2)
+	explosion(user.loc, -1, 0, 2, 3, 0, flame_range = 2, magic = TRUE)
 	charges--

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -668,6 +668,8 @@
 	var/exp_light = 2
 	var/exp_flash = 3
 	var/exp_fire = 2
+	var/magic = TRUE
+	var/holy = FALSE
 
 /obj/item/projectile/magic/aoe/fireball/New(loc, spell_level)
 	. = ..()
@@ -685,7 +687,7 @@
 			return BULLET_ACT_BLOCK
 		M.take_overall_damage(0,10) //between this 10 burn, the 10 brute, the explosion brute, and the onfire burn, your at about 65 damage if you stop drop and roll immediately
 	var/turf/T = get_turf(target)
-	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire)
+	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, magic = magic, holy = holy)
 
 /obj/item/projectile/magic/aoe/fireball/infernal
 	name = "infernal fireball"
@@ -693,6 +695,8 @@
 	exp_light = -1
 	exp_flash = 4
 	exp_fire= 5
+	magic = FALSE
+	holy = TRUE
 
 /obj/item/projectile/magic/aoe/fireball/infernal/on_hit(target)
 	. = ..()
@@ -702,7 +706,7 @@
 			return BULLET_ACT_BLOCK
 	var/turf/T = get_turf(target)
 	for(var/i=0, i<50, i+=10)
-		addtimer(CALLBACK(GLOBAL_PROC, .proc/explosion, T, -1, exp_heavy, exp_light, exp_flash, FALSE, FALSE, exp_fire), i)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/explosion, T, -1, exp_heavy, exp_light, exp_flash, FALSE, FALSE, FALSE, TRUE), i)
 
 //still magic related, but a different path
 

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -296,7 +296,7 @@
 	required_other = TRUE
 
 /datum/chemical_reaction/slime/slimeoverload/on_reaction(datum/reagents/holder, created_volume)
-	empulse(get_turf(holder.my_atom), 3, 7)
+	empulse(get_turf(holder.my_atom), 3, 7, magic=TRUE)
 	..()
 
 /datum/chemical_reaction/slime/slimecell

--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -327,7 +327,7 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 				break
 	if(C?.charge)
 		do_sparks(5,FALSE,C)
-		INVOKE_ASYNC(src, .proc/empulse, rune_turf, 1, 1)
+		INVOKE_ASYNC(src, .proc/empulse, rune_turf, 1, 1, FALSE, TRUE, FALSE)
 		C.use(C.charge)
 		activated_on_step = TRUE
 	. = ..()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -278,7 +278,7 @@
 		if(SLIME_ACTIVATE_MAJOR)
 			user.visible_message("<span class='warning'>[user]'s skin starts flashing intermittently...</span>", "<span class='warning'>Your skin starts flashing intermittently...</span>")
 			if(do_after(user, 25, target = user))
-				empulse(user, 1, 2)
+				empulse(user, 1, 2, magic=TRUE)
 				user.visible_message("<span class='warning'>[user]'s skin flashes!</span>", "<span class='warning'>Your skin flashes as you emit an electromagnetic pulse!</span>")
 				return 600
 

--- a/code/modules/spells/spell_types/emplosion.dm
+++ b/code/modules/spells/spell_types/emplosion.dm
@@ -13,5 +13,5 @@
 	for(var/mob/living/target in targets)
 		if(target.anti_magic_check() && target != user)
 			continue
-		empulse(target.loc, emp_heavy, emp_light)
+		empulse(target.loc, emp_heavy, emp_light, magic=TRUE)
 	return

--- a/code/modules/spells/spell_types/explosion.dm
+++ b/code/modules/spells/spell_types/explosion.dm
@@ -11,6 +11,6 @@
 	for(var/mob/living/target in targets)
 		if(target.anti_magic_check())
 			continue
-		explosion(target.loc,ex_severe,ex_heavy,ex_light,ex_flash)
+		explosion(target.loc,ex_severe,ex_heavy,ex_light,ex_flash, magic = TRUE)
 
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Magical (explosion/empulse) Behaviours:
 - Explosions will not affect turfs with magic protected mobs on them.
 - Empulses will not affect contents of mobs with magic protection.

Holy (explosion/empulse) behaviours
 - Explosions will not affect turfs with holy mobs or bless turfs on them.
 - Empulses will not affect turfs with blessings on them, or mobs with holy protection.

## Why It's Good For The Game

Magic explosions and EMPs can now be blocked by the correct magic sources.
Nerfs cult EMPs by making them blockable by holding a bible, or by the chaplain blessing the station.
Fireball explosion will no longer affect the chaplain

## Testing Photographs and Procedure

I tested this but don't have any screenshots.

## Changelog
:cl:
balance: Magical EMPs no longer affect magic protected mobs
balance: Magic explosions (fireball) no longer affect magic protected mobs
balance: Holy/cult EMPs no longer affect blessed turfs
balance: Holy/cult EMPs no longer affect mobs with holy protection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
