### PR TITLE
Reinforced and nar'sien bolas now knockdown instead

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -368,7 +368,7 @@
 		SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 		to_chat(C, "<span class='userdanger'>\The [src] ensnares you!</span>")
 		if(knockdown)
-			C.Paralyze(knockdown)
+			C.Knockdown(knockdown)
 		playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 
 /obj/item/restraints/legcuffs/bola/tactical//traitor variant


### PR DESCRIPTION
## About The Pull Request

Reinforced and nar'sien bolas now knockdown instead.

## Why It's Good For The Game

A backpack of ranged stuns is pretty busted, and since even a long knockdown gives you the strong upperhand in a fight (similarly to flashbangs). This change makes bolas less of an instawin and gets rid of one of the few remaining ancient stun combat items. This is complementary to the bible immunity PR.  

## Changelog
:cl:
balance: Reinforced and nar'sien bolas now knockdown instead.
/:cl: