### PR TITLE
Adds in the assassination objective and fixes alien artifact mission.

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3173,6 +3173,7 @@
 #include "code\modules\shuttle\super_cruise\orbital_poi_generator\loot\research_disks.dm"
 #include "code\modules\shuttle\super_cruise\orbital_poi_generator\loot\vortex_rifle.dm"
 #include "code\modules\shuttle\super_cruise\orbital_poi_generator\objective_types\alien_artifact.dm"
+#include "code\modules\shuttle\super_cruise\orbital_poi_generator\objective_types\assassination.dm"
 #include "code\modules\shuttle\super_cruise\orbital_poi_generator\objective_types\nuke_ruin.dm"
 #include "code\modules\shuttle\super_cruise\orbital_poi_generator\objective_types\recover_blackbox.dm"
 #include "code\modules\shuttle\super_cruise\orbital_poi_generator\objective_types\vip_extraction.dm"

--- a/code/controllers/subsystem/processing/orbits.dm
+++ b/code/controllers/subsystem/processing/orbits.dm
@@ -120,7 +120,8 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 	var/static/list/valid_objectives = list(
 		/datum/orbital_objective/recover_blackbox = 3,
 		/datum/orbital_objective/nuclear_bomb = 1,
-		/datum/orbital_objective/artifact = 1,
+		/datum/orbital_objective/assassination = 1,
+		/datum/orbital_objective/artifact = 2,
 		/datum/orbital_objective/vip_recovery = 1
 	)
 	if(!length(possible_objectives))

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/artifact_defenses.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/artifact_defenses.dm
@@ -33,7 +33,7 @@
 /obj/structure/alien_artifact/watcher/HasProximity(atom/movable/AM)
 	if(cooldown > world.time)
 		return
-	if (istype(AM, /obj/effect))
+	if (iseffect(AM) || isprojectile(AM))
 		return
 	cooldown = world.time + 50
 	//Trigger nearby protectors

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -17,7 +17,7 @@
 		valid_turfs += F
 	//Shuffle the list
 	shuffle_inplace(valid_turfs)
-	for(var/i in rand(6, 15))
+	for(var/i in 1 to rand(6, 15))
 		if(valid_turfs.len < i)
 			message_admins("Ran out of valid turfs to create artifact defenses on.")
 			return

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -9,7 +9,7 @@
 /datum/orbital_objective/artifact/generate_objective_stuff(turf/chosen_turf)
 	generated = TRUE
 	linked_artifact = new(chosen_turf)
-	var/list/turfs = RANGE_TURFS(30, chosen_turf)
+	var/list/turfs = RANGE_TURFS(30, linked_artifact)
 	var/list/valid_turfs = list()
 	for(var/turf/open/floor/F in turfs)
 		if(locate(/obj/structure) in F)
@@ -18,7 +18,7 @@
 	//Shuffle the list
 	shuffle_inplace(valid_turfs)
 	for(var/i in 1 to rand(6, 15))
-		if(valid_turfs.len < i)
+		if(i > valid_turfs.len)
 			message_admins("Ran out of valid turfs to create artifact defenses on.")
 			return
 		var/turf/selected_turf = valid_turfs[i]

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -1,0 +1,102 @@
+/datum/orbital_objective/assassination
+	name = "Assassination"
+	var/generated = FALSE
+	var/mob/mob_to_kill
+	min_payout = 15000
+	max_payout = 40000
+
+/datum/orbital_objective/assassination/get_text()
+	return "We have located a hostile agent currently stranded at [station_name]. We need you to send in a team and eliminate the \
+		target. Our intelligence suggests that the target will be armed and dangerous, thus a security team is recommended in this mission."
+
+//If nobody takes up the ghost role, then we dont care if they died.
+//I know, its a bit sad.
+/datum/orbital_objective/assassination/check_failed()
+	if(generated)
+		//Deleted
+		if(QDELETED(mob_to_kill))
+			complete_objective()
+			return FALSE
+		//Left behind
+		if(mob_to_kill in SSzclear.nullspaced_mobs)
+			complete_objective()
+			return FALSE
+		//Recovered and alive
+		if(mob_to_recover.stat == DEAD)
+			complete_objective()
+			return FALSE
+	return FALSE
+
+/datum/orbital_objective/assassination/generate_objective_stuff(turf/chosen_turf)
+	var/mob/living/carbon/human/created_human = new(chosen_turf)
+	//Maybe polling ghosts would be better than the shintience code
+	created_human.set_playable()
+	created_human.mind_initialize()
+	//Remove nearby dangers
+	for(var/mob/living/simple_animal/hostile/SA in range(10, created_human))
+		qdel(SA)
+	//Give them a space worthy suit
+	var/turf/open/T = locate() in shuffle(view(1, created_human))
+	if(T)
+		new /obj/item/clothing/suit/space/hardsuit/ancient(T)
+		new /obj/item/tank/internals/oxygen(T)
+		new /obj/item/clothing/mask/gas(T)
+		new /obj/item/storage/belt/utility/full(T)
+	switch(pickweight(list("dictator" = 1, "operative" = 1, "greytide" = 3)))
+		if("dictator")
+			created_human.flavor_text = "It has been months since your regime fell. Once a hero, you're now just someone wishing that they will see the next sunrise. You know those \
+				Nanotrasen pigs are after you, and will stop at nothing to capture you. All you want at this point is to get out and survive, however it is likely you will never leave \
+				without being captured."
+			created_human.equipOutfit(/datum/outfit/vip_dictator)
+		if("greytide")
+			created_human.flavor_text = "You are just an assistant on a lonely derelict station. You dream of going home, \
+				but a powerful corporation wants you dead. Stay alive."
+			created_human.equipOutfit(/datum/outfit/greytide)
+		if("operative")
+			created_human.flavor_text = "You are a syndicate operative standed by your team aboard an ancient ruin. You know it won't take long for Nanotrasen \
+				to catch up and eliminate you, stay on your guard."
+			created_human.equipOutfit(/datum/output/vip_operative)
+	created_human.mind.store_memory("Someone is out to assassinate you... Stay alive.")
+	created_human.mind.add_antag_datum(/datum/antagonist/survivalist)
+	mob_to_recover = created_human
+	generated = TRUE
+
+//=====================
+// Operative
+//=====================
+
+/datum/outfit/vip_operative
+	name = "Operative VIP"
+
+	uniform = /obj/item/clothing/under/syndicate
+	suit = /obj/item/clothing/suit/armor/bulletproof
+	suit_store = /obj/item/gun/ballistic/automatic/pistol
+	shoes = /obj/item/clothing/shoes/jackboots
+	gloves = /obj/item/clothing/gloves/combat
+	ears = /obj/item/radio/headset
+	glasses = /obj/item/clothing/glasses/sunglasses/advanced
+	belt = /obj/item/storage/belt/military
+	l_pocket = /obj/item/ammo_box/magazine/m10mm
+	r_pocket = /obj/item/grenade/smokebomb
+	id = /obj/item/card/id/away/old
+
+//=====================
+// Matryr Dictator
+//=====================
+
+/datum/outfit/vip_dictator
+	name = "Dictator VIP"
+
+	uniform = /obj/item/clothing/under/rank/security/head_of_security/white
+	suit = /obj/item/clothing/suit/armor/hos
+	suit_store = /obj/item/gun/ballistic/automatic/pistol/m1911
+	shoes = /obj/item/clothing/shoes/jackboots
+	gloves = /obj/item/clothing/gloves/combat
+	ears = /obj/item/radio/headset
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch
+	belt = /obj/item/storage/belt/sabre
+	l_pocket = /obj/item/ammo_box/magazine/m45
+	r_pocket = /obj/item/grenade/smokebomb
+	id = /obj/item/card/id/away/old
+	neck = /obj/item/clothing/neck/crucifix
+	head = /obj/item/clothing/head/HoS/beret/syndicate

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -7,7 +7,8 @@
 
 /datum/orbital_objective/assassination/get_text()
 	return "We have located a hostile agent currently stranded at [station_name]. We need you to send in a team and eliminate the \
-		target. Our intelligence suggests that the target will be armed and dangerous, thus a security team is recommended in this mission."
+		target. Our intelligence suggests that the target will be armed and dangerous, thus a security team is recommended in this mission. \
+		Please keep in mind that the Nanotrasen approved exploration handheld laser gun is not adept at handling human based targets."
 
 //If nobody takes up the ghost role, then we dont care if they died.
 //I know, its a bit sad.
@@ -58,7 +59,7 @@
 			created_human.equipOutfit(/datum/outfit/vip_operative)
 	created_human.mind.store_memory("Someone is out to assassinate you... Stay alive.")
 	created_human.mind.add_antag_datum(/datum/antagonist/survivalist)
-	mob_to_recover = created_human
+	mob_to_kill = created_human
 	generated = TRUE
 
 //=====================

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -22,7 +22,7 @@
 			complete_objective()
 			return FALSE
 		//Recovered and alive
-		if(mob_to_recover.stat == DEAD)
+		if(mob_to_kill.stat == DEAD)
 			complete_objective()
 			return FALSE
 	return FALSE
@@ -55,7 +55,7 @@
 		if("operative")
 			created_human.flavor_text = "You are a syndicate operative standed by your team aboard an ancient ruin. You know it won't take long for Nanotrasen \
 				to catch up and eliminate you, stay on your guard."
-			created_human.equipOutfit(/datum/output/vip_operative)
+			created_human.equipOutfit(/datum/outfit/vip_operative)
 	created_human.mind.store_memory("Someone is out to assassinate you... Stay alive.")
 	created_human.mind.add_antag_datum(/datum/antagonist/survivalist)
 	mob_to_recover = created_human

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -42,18 +42,12 @@
 		new /obj/item/clothing/mask/gas(T)
 		new /obj/item/storage/belt/utility/full(T)
 	var/antag_elligable = FALSE
-	switch(pickweight(list("centcom_official" = 4, "dictator" = 1, "greytide" = 3)))
+	switch(pickweight(list("centcom_official" = 4, "greytide" = 3)))
 		if("centcom_official")
 			created_human.flavor_text = "You are a CentCom official onboard a badly damaged station. Making your way back to Space Station 13 to uncover the secrets you hold is \
 				your top priority as far as Nanotrasen is concerned, but surviving just one more day is all you can ask for."
 			created_human.equipOutfit(/datum/outfit/centcom_official_vip)
 			antag_elligable = TRUE
-		if("dictator")
-			created_human.flavor_text = "It has been months since your regime fell. Once a hero, you're now just someone wishing that they will see the next sunrise. You know those \
-				Nanotrasen pigs are after you, and will stop at nothing to capture you. All you want at this point is to get out and survive, however it is likely you will never leave \
-				without being captured."
-			created_human.equipOutfit(/datum/outfit/vip_dictator)
-			created_human.mind.add_antag_datum(/datum/antagonist/vip_dictator)
 		if("greytide")
 			created_human.flavor_text = "You are just an assistant on a lonely derelict station. You dream of going home, \
 				but it would take another one of the miracles that kept you alive to get you home."
@@ -88,34 +82,6 @@
 	l_hand = /obj/item/clipboard
 	r_hand = /obj/item/gps
 	id = /obj/item/card/id/away/old
-
-//=====================
-// Matryr Dictator
-//=====================
-
-/datum/antagonist/vip_dictator
-	name = "Insane VIP"
-	show_in_antagpanel = TRUE
-	roundend_category = "Ruin VIPs"
-	antagpanel_category = "Other"
-
-/datum/outfit/vip_dictator
-	name = "Dictator VIP"
-
-	uniform = /obj/item/clothing/under/rank/security/head_of_security/white
-	suit = /obj/item/clothing/suit/armor/hos
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/m1911
-	shoes = /obj/item/clothing/shoes/jackboots
-	gloves = /obj/item/clothing/gloves/combat
-	ears = /obj/item/radio/headset
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch
-	belt = /obj/item/storage/belt/sabre
-	l_pocket = /obj/item/ammo_box/magazine/m45
-	r_pocket = /obj/item/grenade/smokebomb
-	id = /obj/item/card/id/away/old
-	neck = /obj/item/clothing/neck/crucifix
-	head = /obj/item/clothing/head/HoS/beret/syndicate
-	r_hand = /obj/item/gps
 
 //=====================
 // Greytide


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in the assassination supercruise objective. This objective is simple: kill a target.
The payout for this mission is between 15000 and 40000 credits. There are now 5 objectives in total for supercruise.

Also fixes the alien artifact mission's artifact defense system spawning.

## Why It's Good For The Game

New supercruise objective, the dictator is no longer an extractable VIP as it causes confusion.

## Changelog
:cl:
add: Adds in a new assassination objective for supercruise.
tweak: The dictator is no longer a VIP extraction target, but an assassination target.
fix: Alien artifact mission's defenses will now spawn correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
