### PR TITLE
Revert harmbaton nerf

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -6,7 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
-	force = 5
+	force = 10
 	throwforce = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("enforced the law upon")

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -6,7 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
-	force = 10
+	force = 8
 	throwforce = 7
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("enforced the law upon")


### PR DESCRIPTION
## About The Pull Request

I was wondering why stunbatons only do 5 brute damage here unlike other codebases (which is even less than punches lol), and lo and behold realised it got [stealth nerfed](https://github.com/BeeStation/BeeStation-Hornet/pull/295) by Toxic ages ago. This increases the brute damage back to 8, which is less than as billy clubs (and doesn't do stamina damage when unpowered like it either).

## Why It's Good For The Game

It's dumb that whacking someone with a metal stick does less damage than punches. Also gives sec a weapon that they spawn with that can actually be used to fight simplemobs.

## Changelog
:cl:
balance: Harmbaton damage increase from 5 to 8. No more doing less damage than punches. 
/:cl: