### PR TITLE
Nerfs and Tweaks to Debtor

### DIFF
--- a/code/modules/crew_objectives/civilian_objectives.dm
+++ b/code/modules/crew_objectives/civilian_objectives.dm
@@ -296,3 +296,13 @@
 				if(!M.special_role && !(M.assigned_role == "Security Officer") && !(M.assigned_role == "Detective") && !(M.assigned_role == "Head of Security") && !(M.assigned_role == "Internal Affairs Agent") && !(M.assigned_role == "Warden") && get_area(M.current) != typesof(/area/security/prison))
 					return FALSE
 		return TRUE
+
+/datum/objective/crew/linger
+	explanation_text = "Survive on the station until the end of the shift. Do not escape on the shuttle!"
+	jobs = "debtor" // gimmick optionals likely belong in their own file, but as there's only one this stays in civilian_objectives.dm
+
+/datum/objective/crew/linger/check_completion()
+	if(owner?.current)
+		var/area/A = get_area(owner.current)
+		return considered_alive(owner) && is_station_level(A.z)
+	return FALSE

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -87,8 +87,8 @@
 	minimal_access = list(ACCESS_MAINT_TUNNELS)
 	gimmick = TRUE
 	chat_color = "#929292"
-	departments = NONE		//being hobo is not a real job
-	biohazard = 50 //hobos are very likely to have diseases 
+	departments = NONE	//being hobo is not a real job
+	biohazard = 50 //hobos are very likely to have diseases
 
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/hobo
@@ -108,13 +108,11 @@
 	..()
 	if(visualsOnly)
 		return
-	to_chat(H, "<span class='userdanger'>Although you're down on your luck, you're still a nanotrasen employee, and you are held to the same legal standards.</span>")
+	to_chat(H, "<span class='userdanger'>This station is your home and no one can convince you otherwise. Be careful not to break Nanotrasen's laws, because if you do so you may be arrested and forced out of your home!</span>")
 	var/list/possible_drugs = list(/obj/item/storage/pill_bottle/happy, /obj/item/storage/pill_bottle/zoom, /obj/item/storage/pill_bottle/stimulant, /obj/item/storage/pill_bottle/lsd, /obj/item/storage/pill_bottle/aranesp, /obj/item/storage/pill_bottle/floorpill/full)
 	var/chosen_drugs = pick(possible_drugs)
 	var/obj/item/storage/pill_bottle/I = new chosen_drugs(src)
 	H.equip_to_slot_or_del(I,ITEM_SLOT_BACKPACK)
-	var/datum/martial_art/psychotic_brawling/junkie = new //this fits well, but i'm unsure about it, cuz this martial art is so fucking rng dependent i swear...
-	junkie.teach(H)
 	ADD_TRAIT(H, TRAIT_APPRAISAL, JOB_TRAIT)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the martial art

Changes the flavor text to fit someone who is psychotically attached to the station

Adds a crew objective to remain on the station. 
## Why It's Good For The Game

Softer changes than just removing the debtor, this may be insufficient.

I do like some of the gimmick ideas put forth in the removal PR but this is just something quick. 

One problem with outright removal is that the maintenance goblin gimmick is likely inherently bannable under our current ruleset. 

Text and idea by Evelina#3104 on discord

## Changelog
:cl:Froststahr, Evelina
add: A new crew objective has been added for the debtor, which requires them to remain on the station alive. 
balance: Psychotic brawling has been removed from the debtor.
tweak: Debtor has received new flavor text. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
