### PR TITLE
Detective starts with lethal rounds again

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -391,8 +391,8 @@
 /obj/item/clothing/accessory/holster/detective/Initialize()
 	. = ..()
 	new /obj/item/gun/ballistic/revolver/detective(src)
-	new /obj/item/ammo_box/c38/match/bouncy(src)
-	new /obj/item/ammo_box/c38/match/bouncy(src)
+	new /obj/item/ammo_box/c38(src)
+	new /obj/item/ammo_box/c38(src)
 
 //Poppy Pin
 /obj/item/clothing/accessory/poppy_pin

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -79,7 +79,7 @@
 	fire_sound = 'sound/weapons/revolver38shot.ogg'
 	icon_state = "detective"
 	fire_rate = 2
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38/rubber
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	obj_flags = UNIQUE_RENAME
 	unique_reskin = list("Default" = "detective",
 						"Fitz Special" = "detective_fitz",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Partial revert of BeeStation#5646, makes the detective start with lethal rounds again, but leaves the rubber shot as an option to be printed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Short and sweet: providing the detective with lethal rounds maintains a role and flavor distinct from playing sec officer, it invites different considerations in justifying the use of force, and it better matches the typical threats a detective will face in a round. Leaves in the ammo type and associated stuff, just changes what the detective starts with.

Longer justification:
SOP makes it clear the detective shouldn't be arresting anyone, but for some reason they've been stripped of a unique role and been made into a sub-par security officer. Instead of the potential for interesting interactions inherent in possessing a lethal weapon, such as being forced to justify use of force or consider whether a threat justifies lethal force, now the detective has a weapon whose use is about as consequential as a few whacks with a stun baton.
An argument could be made that for any threat the detective faces, rubber rounds will do just as well as lethals, but this isn't necessarily the case. Since the detective isn't supposed to be making arrests, and they shouldn't be going around chasing after criminals, the primary way they're going to be encountering threats is when crawling through maints or something, looking for clues and following up on leads, and these threats are going to be the big ones. per SOP, "The Detective may not.. fire their revolver unless there is a clear and present danger to their life.". Put another way, the only time the detective should be using their revolver is against serious threats, like changelings or nuclear operatives, or against armed and imminently threatening individuals. The sort of people against whom lethal force is authorized, and the sort who are most capable of shrugging off stamina damage.
Sec officers have a plethora of non-lethal options because they typically face a low-level threat, break-ins or thieves, for a good portion of a round, only getting lethals from the armory once the threat level increases. The Detective is explicitly forbidden IC (and somewhat OOC) from engaging low level threats, so the only thing they should possibly encounter are higher level, potentially deadly threats, and their weaponry should reflect that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->


<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
## Changelog
:cl:
add: detective starts with lethal rounds
del: detective no longer starts with rubber rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
