### PR TITLE
Fixes escape pods

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -586,14 +586,18 @@
 	width = 3
 	height = 4
 	launch_status = UNLAUNCHED
+	var/launched = FALSE
 
 /obj/docking_port/mobile/pod/request(obj/docking_port/stationary/S)
 	var/obj/machinery/computer/shuttle_flight/C = getControlConsole()
 	if(!istype(C, /obj/machinery/computer/shuttle_flight/pod))
+		launched = TRUE
 		return ..()
-	if(GLOB.security_level >= SEC_LEVEL_RED || (C && (C.obj_flags & EMAGGED)))
+	//If the pod launches and then the security level is lowered, the pod should still function.
+	if(GLOB.security_level >= SEC_LEVEL_RED || (C && (C.obj_flags & EMAGGED)) || launched)
 		if(launch_status == UNLAUNCHED)
 			launch_status = EARLY_LAUNCHED
+			launched = TRUE
 			return ..()
 	else
 		to_chat(usr, "<span class='warning'>Escape pods will only launch during \"Code Red\" security alert.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes escape pods being stuck in a limbo state if the alert is lowered after they are launched.

## Changelog
:cl:
fix: Once an escape pod launches, it will now be able to dock with its destination if the alert level is lowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
