### PR TITLE
Fix runtime on empy folder examination, alt-click

### DIFF
--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -26,7 +26,7 @@
 
 /obj/item/folder/examine()
 	. = ..()
-	if(contents)
+	if(length(contents))
 		. += "<span class='notice'>Alt-click to remove [contents[1]].</span>"
 
 /obj/item/folder/proc/rename(mob/user)

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -52,7 +52,7 @@
 
 /obj/item/folder/AltClick(mob/user)
 	..()
-	if(contents)
+	if(length(contents))
 		remove_item(contents[1], user)
 
 /obj/item/folder/update_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
Fixes a list index out of bounds exception that occurs when you examine an empty folder.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtimes are bad.
closes #6151 

(I know in that report I said I wasn't planning on setting up bee dev, but our fork can just yoink this from upstream so I might as well put it up here instead.)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Changelog
:cl:
fix: Fixed a runtime when examining empty folders
/:cl:
(I didn't find any guidelines on when something's too trivial to changelog, so I can only hope this is correct)
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
