### PR TITLE
Random rooms now load at roundstart

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -259,7 +259,7 @@ SUBSYSTEM_DEF(mapping)
 			R.template.stationinitload(get_turf(R), centered = R.template.centerspawner)
 		qdel(R)
 	//We don't need those anymore
-	random_room_templates = list()
+	random_room_templates = null
 	INIT_ANNOUNCE("Loaded Random Rooms in [(REALTIMEOFDAY - start_time)/10]s!")
 
 /datum/controller/subsystem/mapping/proc/loadWorld()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -237,29 +237,6 @@ SUBSYSTEM_DEF(mapping)
 		INIT_ANNOUNCE("Loaded [name] in [(REALTIMEOFDAY - start_time)/10]s!")
 	return parsed_maps
 
-/datum/controller/subsystem/mapping/proc/LoadStationRooms()
-	var/start_time = REALTIMEOFDAY
-	for(var/obj/effect/spawner/room/R as() in GLOB.room_spawners)
-		var/list/possibletemplates = list()
-		var/datum/map_template/random_room/candidate = null
-		shuffle_inplace(random_room_templates)
-		for(var/ID in random_room_templates)
-			candidate = random_room_templates[ID]
-			if(!istype(candidate, /datum/map_template/random_room) || candidate.spawned || R.room_height != candidate.template_height || R.room_width != candidate.template_width)
-				candidate = null
-				continue
-			if(!candidate.spawned)
-				possibletemplates[candidate] = candidate.weight
-		if(possibletemplates.len)
-			R.template = pickweight(possibletemplates)
-			R.template.stock--
-			R.template.weight = (R.template.weight / 2)
-			if(R.template.stock <= 0)
-				R.template.spawned = TRUE
-			R.template.stationinitload(get_turf(R), centered = R.template.centerspawner)
-		qdel(R)
-	INIT_ANNOUNCE("Loaded Random Rooms in [(REALTIMEOFDAY - start_time)/10]s!")
-
 /datum/controller/subsystem/mapping/proc/loadWorld()
 	//if any of these fail, something has gone horribly, HORRIBLY, wrong
 	var/list/FailedZs = list()
@@ -273,7 +250,6 @@ SUBSYSTEM_DEF(mapping)
 	LoadGroup(FailedZs, "Station", config.map_path, config.map_file, config.traits, ZTRAITS_STATION, orbital_body_type = /datum/orbital_object/z_linked/station)
 
 	LoadStationRoomTemplates()
-	LoadStationRooms()
 
 	if(SSdbcore.Connect())
 		var/datum/DBQuery/query_round_map_name = SSdbcore.NewQuery({"

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -237,6 +237,29 @@ SUBSYSTEM_DEF(mapping)
 		INIT_ANNOUNCE("Loaded [name] in [(REALTIMEOFDAY - start_time)/10]s!")
 	return parsed_maps
 
+/datum/controller/subsystem/mapping/proc/LoadStationRooms()
+	var/start_time = REALTIMEOFDAY
+	for(var/obj/effect/spawner/room/R as() in GLOB.room_spawners)
+		var/list/possibletemplates = list()
+		var/datum/map_template/random_room/candidate = null
+		shuffle_inplace(random_room_templates)
+		for(var/ID in random_room_templates)
+			candidate = random_room_templates[ID]
+			if(!istype(candidate, /datum/map_template/random_room) || candidate.spawned || R.room_height != candidate.template_height || R.room_width != candidate.template_width)
+				candidate = null
+				continue
+			if(!candidate.spawned)
+				possibletemplates[candidate] = candidate.weight
+		if(possibletemplates.len)
+			R.template = pickweight(possibletemplates)
+			R.template.stock--
+			R.template.weight = (R.template.weight / 2)
+			if(R.template.stock <= 0)
+				R.template.spawned = TRUE
+			R.template.stationinitload(get_turf(R), centered = R.template.centerspawner)
+		qdel(R)
+	INIT_ANNOUNCE("Loaded Random Rooms in [(REALTIMEOFDAY - start_time)/10]s!")
+
 /datum/controller/subsystem/mapping/proc/loadWorld()
 	//if any of these fail, something has gone horribly, HORRIBLY, wrong
 	var/list/FailedZs = list()
@@ -250,6 +273,7 @@ SUBSYSTEM_DEF(mapping)
 	LoadGroup(FailedZs, "Station", config.map_path, config.map_file, config.traits, ZTRAITS_STATION, orbital_body_type = /datum/orbital_object/z_linked/station)
 
 	LoadStationRoomTemplates()
+	LoadStationRooms()
 
 	if(SSdbcore.Connect())
 		var/datum/DBQuery/query_round_map_name = SSdbcore.NewQuery({"

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(mapping)
 	var/list/shuttle_templates = list()
 	var/list/shelter_templates = list()
 
-	///Random rooms template list, gets initialized and filled when server starts then after rooms are created it gets cleared.
+	///Random rooms template list, gets initialized and filled when server starts.
 	var/list/random_room_templates = list()
 	var/list/holodeck_templates = list()
 
@@ -258,8 +258,6 @@ SUBSYSTEM_DEF(mapping)
 				R.template.spawned = TRUE
 			R.template.stationinitload(get_turf(R), centered = R.template.centerspawner)
 		qdel(R)
-	//We don't need those anymore
-	random_room_templates = null
 	INIT_ANNOUNCE("Loaded Random Rooms in [(REALTIMEOFDAY - start_time)/10]s!")
 
 /datum/controller/subsystem/mapping/proc/loadWorld()

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_EMPTY(room_spawners)
+
 //random room spawner. takes random rooms from their appropriate map file and places them. the room will spawn with the spawner in the bottom left corner
 
 /obj/effect/spawner/room
@@ -9,15 +11,12 @@
 	var/room_width = 0
 	var/room_height = 0
 
-/obj/effect/spawner/room/proc/LateSpawn()
-	template.load(get_turf(src), centered = template.centerspawner)
-	qdel(src)
+/obj/effect/spawner/room/New(loc, ...)
+	. = ..()
+	GLOB.room_spawners += src
 
 /obj/effect/spawner/room/Initialize()
 	..()
-	return INITIALIZE_HINT_LATELOAD
-
-/obj/effect/spawner/room/LateInitialize()
 	var/list/possibletemplates = list()
 	var/datum/map_template/random_room/cantidate = null
 	shuffle_inplace(SSmapping.random_room_templates)
@@ -33,11 +32,11 @@
 		template.weight = (template.weight / 2)
 		if(template.stock <= 0)
 			template.spawned = TRUE
-		addtimer(CALLBACK(src, /obj/effect/spawner/room.proc/LateSpawn), 600)
-	else
-		template = null
-	if(!template)
-		qdel(src)
+		template.load(get_turf(src), centered = template.centerspawner)
+
+/obj/effect/spawner/room/Destroy(force)
+	GLOB.room_spawners -= src
+	. = ..()
 
 /obj/effect/spawner/room/fivexfour
 	name = "5x4 room spawner"

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -17,6 +17,8 @@ GLOBAL_LIST_EMPTY(room_spawners)
 
 /obj/effect/spawner/room/Initialize()
 	..()
+	if(!length(SSmapping.random_room_templates))
+		return INITIALIZE_HINT_QDEL
 	var/list/possibletemplates = list()
 	var/datum/map_template/random_room/cantidate = null
 	shuffle_inplace(SSmapping.random_room_templates)

--- a/code/game/objects/effects/spawners/roomspawner.dm
+++ b/code/game/objects/effects/spawners/roomspawner.dm
@@ -1,6 +1,4 @@
-GLOBAL_LIST_EMPTY(room_spawners)
-
-//random room spawner. takes random rooms from their appropriate map file and places them. the room will spawn with the spawner in the bottom left corner
+//This effect spawns a random room. Make sure the ssmapping is initialized and the room is correct size.
 
 /obj/effect/spawner/room
 	name = "random room spawner"
@@ -11,23 +9,26 @@ GLOBAL_LIST_EMPTY(room_spawners)
 	var/room_width = 0
 	var/room_height = 0
 
-/obj/effect/spawner/room/New(loc, ...)
-	. = ..()
-	GLOB.room_spawners += src
-
 /obj/effect/spawner/room/Initialize()
 	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/spawner/room/LateInitialize()
+	. = ..()
 	if(!length(SSmapping.random_room_templates))
-		return INITIALIZE_HINT_QDEL
+		message_admins("Room spawner created with no templates available. This shouldn't happen.")
+		qdel(src)
+		return
 	var/list/possibletemplates = list()
-	var/datum/map_template/random_room/cantidate = null
+	var/datum/map_template/random_room/candidate
 	shuffle_inplace(SSmapping.random_room_templates)
 	for(var/ID in SSmapping.random_room_templates)
-		cantidate = SSmapping.random_room_templates[ID]
-		if(istype(cantidate, /datum/map_template/random_room) && room_height == cantidate.template_height && room_width == cantidate.template_width)
-			if(!cantidate.spawned)
-				possibletemplates[cantidate] = cantidate.weight
-		cantidate = null
+		candidate = SSmapping.random_room_templates[ID]
+		if(!istype(candidate, /datum/map_template/random_room) || candidate.spawned || room_height != candidate.template_height || room_width != candidate.template_width)
+			candidate = null
+			continue
+		if(!candidate.spawned)
+			possibletemplates[candidate] = candidate.weight
 	if(possibletemplates.len)
 		template = pickweight(possibletemplates)
 		template.stock --
@@ -35,10 +36,7 @@ GLOBAL_LIST_EMPTY(room_spawners)
 		if(template.stock <= 0)
 			template.spawned = TRUE
 		template.load(get_turf(src), centered = template.centerspawner)
-
-/obj/effect/spawner/room/Destroy(force)
-	GLOB.room_spawners -= src
-	. = ..()
+	qdel(src)
 
 /obj/effect/spawner/room/fivexfour
 	name = "5x4 room spawner"

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -122,6 +122,15 @@
 
 	return level
 
+//just loads, no other bullshits, please don't use this proc if you're not calling it while the station is initing
+/datum/map_template/proc/stationinitload(turf/T, centered = FALSE)
+	if(centered)
+		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)
+	if(!T || T.x+width > world.maxx || T.y+height > world.maxy)
+		return
+	var/datum/parsed_map/parsed = new(file(mappath))
+	parsed.load(T.x, T.y, T.z, cropMap=TRUE, no_changeturf=TRUE, placeOnTop=should_place_on_top)
+
 /datum/map_template/proc/load(turf/T, centered = FALSE, init_atmos = TRUE)
 	if(centered)
 		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Based on #5443 with my edits but the code is mostly the same
## Why It's Good For The Game
We don't have to rely on timers

All the credit goes to jupyterkat


## Changelog 
:cl: jupyterkat
add: Random rooms are initialized at the start of the round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
