### PR TITLE
Change the #warn for compiling using DM to #error so the compilor errors if you try to use DM to compile

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -3,6 +3,8 @@
 
 //#define DATUMVAR_DEBUGGING_MODE	//Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
 
+//#define DM_COMPILE // Uncomment to allow compiling with Dream Maker. NOT RECOMMENDED!!!
+
 // Comment this out if you are debugging problems that might be obscured by custom error handling in world/Error
 #ifdef DEBUG
 #define USE_CUSTOM_ERROR_HANDLER
@@ -81,10 +83,11 @@
 #define CBT
 #endif
 
-#if !defined(CBT) && !defined(SPACEMAN_DMM)
+#if !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(DM_COMPILE)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error In order to build, run BUILD.bat in the root directory.
 #error Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
+#error If you still want to compile with Dream Maker uncomment the define DM_COMPILE in code/_compile_options.dm line 6 (NOT RECOMMENDED).
 #endif
 
 #define AUXMOS (world.system_type == MS_WINDOWS ? "auxtools/auxmos.dll" : __detect_auxmos())

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -3,7 +3,7 @@
 
 //#define DATUMVAR_DEBUGGING_MODE	//Enables the ability to cache datum vars and retrieve later for debugging which vars changed.
 
-//#define DM_COMPILE // Uncomment to allow compiling with Dream Maker. NOT RECOMMENDED!!!
+//#define DM_COMPILE // Uncomment to allow compiling with Dream Maker. NOT RECOMMENDED!!! (Note you will need to compile TGUI manually)
 
 // Comment this out if you are debugging problems that might be obscured by custom error handling in world/Error
 #ifdef DEBUG

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -82,9 +82,9 @@
 #endif
 
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
-#warn Building with Dream Maker is no longer supported and will result in errors.
-#warn In order to build, run BUILD.bat in the root directory.
-#warn Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
+#error Building with Dream Maker is no longer supported and will result in errors.
+#error In order to build, run BUILD.bat in the root directory.
+#error Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
 #endif
 
 #define AUXMOS (world.system_type == MS_WINDOWS ? "auxtools/auxmos.dll" : __detect_auxmos())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR simply replaces the compile time warn directive with error so it stops compiling if you attempt to use DM to compile instead of just dropping a warning that most people appearantly ignore.
You might think this is obsolete but there have been multiple cases of people asking for help because their tgui chat didn't work just for it to turn out that they compiled using dm.

## Why It's Good For The Game

Instead of asking why their tgui chat isn't working people now will ask why they cannot compile with dm.

## Changelog
:cl:
tweak: make compiler error if someone tries to compile with Dream Maker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
