### PR TITLE
Arena Object Type Touchups

### DIFF
--- a/_maps/arenas/2sides.dmm
+++ b/_maps/arenas/2sides.dmm
@@ -3,7 +3,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/tdome/arena)
 "b" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/mineral/plastitanium/red,
 /area/tdome/arena)
 "c" = (
@@ -18,7 +18,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/tdome/arena)
 "f" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/mineral/titanium/blue,
 /area/tdome/arena)
 "g" = (

--- a/_maps/arenas/Stage.dmm
+++ b/_maps/arenas/Stage.dmm
@@ -6,8 +6,7 @@
 "b" = (
 /obj/structure/chair/sofa/corner{
 	color = "#c45c57";
-	dir = 1;
-	icon_state = "sofacorner"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/tdome/arena)
@@ -52,15 +51,15 @@
 /area/tdome/arena)
 "i" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "j" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 6
+	dir = 6;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
@@ -76,8 +75,8 @@
 "l" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_corner_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
@@ -86,9 +85,9 @@
 /area/tdome/arena)
 "n" = (
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
+	color = "#c45c57";
 	dir = 8;
-	color = "#c45c57"
+	icon_state = "sofaend_left"
 	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
@@ -96,97 +95,72 @@
 /area/tdome/arena)
 "o" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 10
+	dir = 10;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "p" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	density = 0;
 	dir = 9;
 	icon_state = "railing"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 9
+	dir = 9;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/window/plasma/reinforced{
-	alpha = 0;
-	dir = 1;
-	icon_state = "plasmarwindow"
-	},
-/obj/structure/window/plasma/reinforced{
-	alpha = 0;
-	dir = 8;
-	icon_state = "plasmarwindow"
-	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "q" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	density = 0;
 	dir = 1;
 	icon_state = "railing"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/window/plasma/reinforced{
-	alpha = 0;
-	dir = 1;
-	icon_state = "plasmarwindow"
-	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "r" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "s" = (
-/obj/structure/fluff/railing{
+/obj/structure/railing{
 	density = 0;
 	dir = 5;
 	icon_state = "railing"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 5
-	},
-/obj/structure/window/plasma/reinforced{
-	alpha = 0;
-	dir = 1;
-	icon_state = "plasmarwindow"
-	},
-/obj/structure/window/plasma/reinforced{
-	alpha = 0;
-	dir = 4;
-	icon_state = "plasmarwindow"
+	dir = 5;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "t" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "u" = (
-/obj/structure/fluff/railing/corner{
-	icon_state = "railing_corner";
-	dir = 1
+/obj/structure/railing/corner{
+	dir = 1;
+	icon_state = "railing_corner"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 1
+	dir = 1;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
@@ -199,13 +173,13 @@
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "w" = (
-/obj/structure/fluff/railing/corner{
-	icon_state = "railing_corner";
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 4;
+	icon_state = "railing_corner"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_corner_fill"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -247,19 +221,19 @@
 /area/tdome/arena)
 "E" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 4
+	dir = 4;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)
 "F" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 8
+	dir = 8;
+	icon_state = "trimline_fill"
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/arena)

--- a/_maps/arenas/aiupload.dmm
+++ b/_maps/arenas/aiupload.dmm
@@ -10,7 +10,7 @@
 /turf/open/floor/plasteel/techmaint,
 /area/space)
 "g" = (
-/obj/item/twohanded/required/kirbyplants/photosynthetic,
+/obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/techmaint,
 /area/space)
 "h" = (

--- a/_maps/arenas/bar.dmm
+++ b/_maps/arenas/bar.dmm
@@ -103,8 +103,8 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/stripes/line{
-	icon_state = "warningline";
-	dir = 8
+	dir = 8;
+	icon_state = "warningline"
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)

--- a/_maps/arenas/beach.dmm
+++ b/_maps/arenas/beach.dmm
@@ -11,7 +11,7 @@
 /turf/open/floor/plating/beach/sand,
 /area/tdome/arena)
 "c" = (
-/obj/item/reagent_containers/glass/beaker/instabitaluri{
+/obj/item/reagent_containers/glass/beaker{
 	list_reagents = list(/datum/reagent/consumable/cooking_oil = 50)
 	},
 /turf/open/floor/plating/beach/sand,
@@ -115,10 +115,6 @@
 /obj/item/clothing/head/collectable/paper,
 /turf/open/floor/plating/beach/sand,
 /area/tdome/arena)
-"z" = (
-/obj/item/toy/seashell,
-/turf/open/floor/plating/beach/sand,
-/area/tdome/arena)
 "A" = (
 /turf/open/floor/plating/beach/coastline_t,
 /area/tdome/arena)
@@ -126,10 +122,6 @@
 /turf/open/floor/plating/beach/coastline_t/sandwater_inner{
 	dir = 8
 	},
-/area/tdome/arena)
-"C" = (
-/obj/structure/fluff/beach_umbrella,
-/turf/open/floor/plating/beach/sand,
 /area/tdome/arena)
 "D" = (
 /obj/structure/chair/comfy/shuttle,
@@ -222,7 +214,7 @@ d
 d
 s
 d
-C
+d
 A
 L
 N
@@ -282,7 +274,7 @@ e
 m
 d
 d
-z
+d
 A
 L
 N
@@ -312,7 +304,7 @@ h
 d
 u
 d
-z
+d
 A
 L
 N
@@ -331,7 +323,7 @@ N
 j
 k
 d
-z
+d
 A
 J
 K

--- a/_maps/arenas/dorms.dmm
+++ b/_maps/arenas/dorms.dmm
@@ -89,8 +89,8 @@
 /area/tdome/arena)
 "l" = (
 /obj/effect/turf_decal/stripes/line{
-	icon_state = "warningline";
-	dir = 8
+	dir = 8;
+	icon_state = "warningline"
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
@@ -201,8 +201,8 @@
 "A" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
-	icon_state = "warningline";
-	dir = 8
+	dir = 8;
+	icon_state = "warningline"
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
@@ -249,8 +249,8 @@
 /area/tdome/arena)
 "G" = (
 /obj/effect/turf_decal/stripes/line{
-	icon_state = "warningline";
-	dir = 8
+	dir = 8;
+	icon_state = "warningline"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/tdome/arena)
@@ -323,7 +323,9 @@
 /area/tdome/arena)
 "P" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/arcade,
+/obj/machinery/computer/arcade{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/tdome/arena)
 "Q" = (
@@ -368,6 +370,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
+/area/tdome/arena)
+"V" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/arcade{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tdome/arena)
 
 (1,1,1) = {"
@@ -488,7 +497,7 @@ z
 n
 c
 c
-P
+V
 "}
 (13,1,1) = {"
 c

--- a/_maps/arenas/monkey.dmm
+++ b/_maps/arenas/monkey.dmm
@@ -1,56 +1,56 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "b" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "c" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "d" = (
 /obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "e" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "f" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "g" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "h" = (
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "i" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "k" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/spacevine,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "l" = (
 /obj/structure/flora/ausbushes/fernybush,
 /mob/living/carbon/monkey,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 "m" = (
 /obj/structure/flora/rock/jungle,
 /mob/living/carbon/monkey,
-/turf/open/floor/plating/grass,
+/turf/open/floor/grass,
 /area/tdome/arena)
 
 (1,1,1) = {"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bunch of typepaths used in the thunderdome arena templates. I was intending to touch up the random room maps for explorer missions (aaandddddddd maybe add a few of my own) originally, but uh. These are the first things I stumbled across, so I'm fixing them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more errors when someone loads these thunderdome templates.
As for removing the plasglass from the stage one, that was a preference thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
Twosides, now with actual windows again (As an example of one of the typepath fixed rooms):
![image](https://user-images.githubusercontent.com/50649185/149582899-32d7229c-a8f1-45f2-812a-8db4e9b28d8d.png)
Stage, as the only one I actually canged anything on (Besides beach, but no replacement objects for the shell or the beach umbrella were findable by my dumbass.):
![image](https://user-images.githubusercontent.com/50649185/149582919-e37ce3fd-3ff0-4ec0-80d6-45549a26638a.png)




</details>

## Changelog
:cl:
fix: A choice few thunderdome templates have had their objects updated, meaning they load without errors again - A true case of de-soulling in the modern day and age.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
