### PR TITLE
TGUI Communications Console fixes

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -194,6 +194,8 @@
 			var/datum/map_template/shuttle/shuttle = locate(params["shuttle"]) in shuttles
 			if (!istype(shuttle))
 				return
+			if (!can_purchase_this_shuttle(shuttle))
+				return
 			if (!shuttle.prerequisites_met())
 				to_chat(usr, "<span class='alert'>You have not met the requirements for purchasing this shuttle.</span>")
 				return
@@ -409,7 +411,7 @@
 					var/datum/map_template/shuttle/shuttle_template = SSmapping.shuttle_templates[shuttle_id]
 					if (shuttle_template.credit_cost == INFINITY)
 						continue
-					if (!shuttle_template.can_be_bought && !shuttle_template.illegal_shuttle)
+					if (!can_purchase_this_shuttle(shuttle_template))
 						continue
 					shuttles += list(list(
 						"name" = shuttle_template.name,
@@ -464,6 +466,19 @@
 		return "The shuttle is already in transit."
 	if (SSshuttle.shuttle_purchased)
 		return "A replacement shuttle has already been purchased."
+	return TRUE
+
+/// Returns whether we are authorized to buy this specific shuttle.
+/// Does not handle prerequisite checks, as those should still *show*.
+/obj/machinery/computer/communications/proc/can_purchase_this_shuttle(datum/map_template/shuttle/shuttle_template)
+	if(shuttle_template.credit_cost == INFINITY)
+		return FALSE
+	var/obj/item/circuitboard/computer/communications/CM = circuit
+	if(shuttle_template.illegal_shuttle && !((obj_flags & EMAGGED) || CM.insecure))
+		return FALSE
+	if(!shuttle_template.can_be_bought && !shuttle_template.illegal_shuttle)
+		return FALSE
+
 	return TRUE
 
 /obj/machinery/computer/communications/proc/can_send_messages_to_other_sectors(mob/user)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -205,7 +205,7 @@
 			SSshuttle.existing_shuttle = SSshuttle.emergency
 			SSshuttle.action_load(shuttle)
 			bank_account.adjust_money(-shuttle.credit_cost)
-			minor_announce("[usr.real_name] has purchased [shuttle.name] for [shuttle.credit_cost] credits.[shuttle.extra_desc ? " [shuttle.extra_desc]" : ""]" , "Shuttle Purchase")
+			minor_announce("[shuttle.name] has been purchased for [shuttle.credit_cost] credits! Purchase authorized by [authorize_name] [shuttle.extra_desc ? " [shuttle.extra_desc]" : ""]" , "Shuttle Purchase")
 			message_admins("[ADMIN_LOOKUPFLW(usr)] purchased [shuttle.name].")
 			log_game("[key_name(usr)] has purchased [shuttle.name].")
 			SSblackbox.record_feedback("text", "shuttle_purchase", 1, shuttle.name)
@@ -407,12 +407,15 @@
 
 				for (var/shuttle_id in SSmapping.shuttle_templates)
 					var/datum/map_template/shuttle/shuttle_template = SSmapping.shuttle_templates[shuttle_id]
-					if (!shuttle_template.can_be_bought || shuttle_template.credit_cost == INFINITY)
+					if (shuttle_template.credit_cost == INFINITY)
+						continue
+					if (!shuttle_template.can_be_bought && !shuttle_template.illegal_shuttle)
 						continue
 					shuttles += list(list(
 						"name" = shuttle_template.name,
 						"description" = shuttle_template.description,
 						"creditCost" = shuttle_template.credit_cost,
+						"illegal" = shuttle_template.illegal_shuttle,
 						"prerequisites" = shuttle_template.prerequisites,
 						"ref" = REF(shuttle_template),
 					))

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -267,9 +267,10 @@
 				return
 			if (!(params["state"] in approved_states))
 				return
-			if (state == STATE_BUYING_SHUTTLE && can_buy_shuttles(usr) != TRUE)
+			var/newState = params["state"]
+			if (newState == STATE_BUYING_SHUTTLE && can_buy_shuttles(usr) != TRUE)
 				return
-			set_state(usr, params["state"])
+			set_state(usr, newState)
 			playsound(src, "terminal_type", 50, FALSE)
 			. = TRUE
 		if ("setStatusMessage")

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -1,7 +1,7 @@
 import { sortBy } from "common/collections";
 import { capitalize } from "common/string";
 import { useBackend, useLocalState } from "../backend";
-import { Blink, Box, Button, Dimmer, Flex, Icon, Input, Modal, NoticeBox, Section, Stack, Tabs, TextArea } from "../components";
+import { Blink, Box, Button, Dimmer, Flex, Icon, Input, Modal, NoticeBox, Section, Stack, Tabs, TextArea, Tooltip } from "../components";
 import { Window } from "../layouts";
 import { sanitizeText } from "../sanitize";
 
@@ -668,6 +668,25 @@ const PageMessages = (props, context) => {
   );
 };
 
+const ConditionalTooltip = (props, context) => {
+  const {
+    condition,
+    children,
+    ...rest
+  } = props;
+
+  if (!condition)
+  {
+    return children;
+  }
+  
+  return (
+    <Tooltip {...rest}>
+      {children}
+    </Tooltip>
+  );
+};
+
 export const CommunicationsConsole = (props, context) => {
   const { act, data } = useBackend(context);
   const {
@@ -724,19 +743,18 @@ export const CommunicationsConsole = (props, context) => {
                       </Tabs.Tab>
 
                       {(canBuyShuttles !== 0) && (
-                        <Tabs.Tab fluid
-                          icon="shopping-cart"
-                          selected={page===STATE_BUYING_SHUTTLE}
-                          onClick={() => act("setState", 
-                            { state: STATE_BUYING_SHUTTLE }
-                          )}
-                          disabled={canBuyShuttles !== 1}
-                          tooltip={canBuyShuttles !== 1
-                            ? canBuyShuttles 
-                            : undefined}
-                          tooltipPosition="right">
-                          Purchase Shuttle
-                        </Tabs.Tab>
+                        <ConditionalTooltip
+                          condition={canBuyShuttles !== 1}
+                          content={canBuyShuttles}>
+                          <Tabs.Tab fluid
+                            icon="shopping-cart"
+                            selected={page===STATE_BUYING_SHUTTLE}
+                            onClick={() => act("setState", 
+                              { state: STATE_BUYING_SHUTTLE }
+                            )}>
+                            Purchase Shuttle
+                          </Tabs.Tab>
+                        </ConditionalTooltip>
                       )}
                     </Tabs>
                   </Section>

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -3,6 +3,7 @@ import { capitalize } from "common/string";
 import { useBackend, useLocalState } from "../backend";
 import { Blink, Box, Button, Dimmer, Flex, Icon, Input, Modal, NoticeBox, Section, Stack, Tabs, TextArea } from "../components";
 import { Window } from "../layouts";
+import { sanitizeText } from "../sanitize";
 
 const STATE_BUYING_SHUTTLE = "buying_shuttle";
 const STATE_CHANGING_STATUS = "changing_status";
@@ -629,6 +630,10 @@ const PageMessages = (props, context) => {
             );
           }
 
+          const textHtml = {
+            __html: sanitizeText(message.content),
+          };
+
           return (
             <Section
               title={message.title}
@@ -643,7 +648,8 @@ const PageMessages = (props, context) => {
                   })}
                 />
               )}>
-              <Box>{message.content}</Box>
+              <Box
+                dangerouslySetInnerHTML={textHtml} />
 
               {answers}
             </Section>

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -13,8 +13,7 @@ const STATE_MESSAGES = "messages";
 const SWIPE_NEEDED = "SWIPE_NEEDED";
 
 const ILLEGAL_SHUTTLE_NOTICE
-  = "This shuttle is deemed significantly dangerous to the crew, and is only supplied by the Syndicate.";
-
+  = "Warning: Safety features disabled. This shuttle is uncertified. Order at your own peril."
 const sortShuttles = sortBy(
   shuttle => !shuttle.illegal,
   shuttle => shuttle.creditCost

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -13,7 +13,7 @@ const STATE_MESSAGES = "messages";
 const SWIPE_NEEDED = "SWIPE_NEEDED";
 
 const ILLEGAL_SHUTTLE_NOTICE
-  = "Warning: Safety features disabled. This shuttle is uncertified. Order at your own peril."
+  = "Warning: Safety features disabled. This shuttle is uncertified. Order at your own peril.";
 const sortShuttles = sortBy(
   shuttle => !shuttle.illegal,
   shuttle => shuttle.creditCost

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -12,7 +12,13 @@ const STATE_MESSAGES = "messages";
 // Used for whether or not you need to swipe to confirm an alert level change
 const SWIPE_NEEDED = "SWIPE_NEEDED";
 
-const sortByCreditCost = sortBy(shuttle => shuttle.creditCost);
+const ILLEGAL_SHUTTLE_NOTICE
+  = "This shuttle is deemed significantly dangerous to the crew, and is only supplied by the Syndicate.";
+
+const sortShuttles = sortBy(
+  shuttle => !shuttle.illegal,
+  shuttle => shuttle.creditCost
+);
 
 const AlertButton = (props, context) => {
   const { act, data } = useBackend(context);
@@ -164,7 +170,7 @@ const PageBuyingShuttle = (props, context) => {
         <Stack.Item grow>
           <Section fill scrollable>
             <Stack vertical>
-              {sortByCreditCost(data.shuttles).slice(0, 6).map(shuttle => (
+              {sortShuttles(data.shuttles).map(shuttle => (
                 <Stack.Item key={shuttle.ref}>
                   <Section
                     title={(
@@ -181,6 +187,7 @@ const PageBuyingShuttle = (props, context) => {
                         content={
                           `${shuttle.creditCost.toLocaleString()} credits`
                         }
+                        color={shuttle.illegal ? "red" : "default"}
                         disabled={
                           !canBuyShuttles || data.budget < shuttle.creditCost
                         }
@@ -188,11 +195,12 @@ const PageBuyingShuttle = (props, context) => {
                           shuttle: shuttle.ref,
                         })}
                         tooltip={
-                          data.budget < shuttle.creditCost
-                            ? `You need ${
-                              shuttle.creditCost - data.budget
-                            } more credits.`
-                            : undefined
+                          data.budget < shuttle.creditCost ? (`You need ${
+                            shuttle.creditCost - data.budget
+                          } more credits.`
+                          ) : (shuttle.illegal 
+                            ? ILLEGAL_SHUTTLE_NOTICE 
+                            : undefined)
                         }
                         tooltipPosition="left"
                       />

--- a/tgui/packages/tgui/sanitize.js
+++ b/tgui/packages/tgui/sanitize.js
@@ -1,0 +1,33 @@
+/**
+ * Uses DOMPurify to purify/sanitise HTML.
+ */
+
+import DOMPurify from 'dompurify';
+
+// Default values
+let defTag = [
+  'br', 'code', 'li', 'p', 'pre',
+  'span', 'table', 'td', 'tr', 'i',
+  'th', 'ul', 'ol', 'menu', 'font', 'b',
+  'center', 'table', 'tr', 'th', 'hr',
+];
+let defAttr = ['class', 'style'];
+
+/**
+ * Feed it a string and it should spit out a sanitized version.
+ *
+ * @param {string} input
+ * @param {array} tags
+ * @param {array} forbidAttr
+ */
+export const sanitizeText = (input, tags = defTag, forbidAttr = defAttr) => {
+  // This is VERY important to think first if you NEED
+  // the tag you put in here.  We are pushing all this
+  // though dangerouslySetInnerHTML and even though
+  // the default DOMPurify kills javascript, it dosn't
+  // kill href links or such
+  return DOMPurify.sanitize(input, {
+    ALLOWED_TAGS: tags,
+    FORBID_ATTR: forbidAttr,
+  });
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/BeeStation/BeeStation-Hornet/issues/6110

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/54765
- https://github.com/tgstation/tgstation/pull/62056
  - Heavily modified to match https://github.com/BeeStation/BeeStation-Hornet/pull/2920
- **Only small parts of** https://github.com/tgstation/tgstation/pull/58389
  - Ported the `can_buy_this_shuttle` proc and usages of it to facilitate easier porting of illegal shuttles.

Fixes the following issues:
- HTML formatting didn't work in messages displayed in the comms console. Now the formatting uses custom sanitisation, restricted to safe tags only.
- I previously accidentally removed the illegal shuttle restrictions - I didn't remember we had it, and didn't notice it since the port was a full system replacement. I have now implemented it back in, based on tg's version, modified to fit our existing code.
- I fucked up. No, really. I left in debug code that restricted the shuttles available in the console *to the 6 cheapest shuttles only.* I believe I put the debug code in when trying to figure out why scrolling was broken.
- The tooltip on the shuttle purchase tab wasn't working - this is because I converted it from buttons to tabs, which do not have built-in tooltips, and forgot to code in a tooltip for it.
- There is a check in the code that prevents you from opening the shuttle purchase menu if you cannot buy shuttles. However, the check is inverted, which means it instead prevents you from *leaving* the shuttle purchase menu. This issue comes from upstream, but presumably wasn't noted due to the button being completely disabled when shuttles cannot be purchased.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfixes are good, accidentally stealthremoving a feature is very bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/6917698/149595267-18091531-a9de-481b-b8b0-4b3ed4c30af6.png)

![image](https://user-images.githubusercontent.com/6917698/149595300-fee51b01-240f-46c2-a75e-9e8c8d2b6f9b.png)

![image](https://user-images.githubusercontent.com/6917698/149595316-646e8559-2bcd-4104-a4dd-9ba3d93f3904.png)

</details>

## Changelog
:cl: KubeRoot, prodirus, Mothblocks, Frostahr
add: Reintroduced the accidentally removed illegal shuttle restriction. Illegal shuttles cannot be normally purchased, consoles need to be hacked or emagged to purchase them. Emagging a console will additionally allow you to log into console without access, while obscuring your real name.
fix: The communications shuttle now supports HTML formatting in messages.
fix: Fixes an embarrasing mistake where the communications console was hardcoded to only list the first 6 shuttles for purchase.
fix: Fixes minor issues with the communications console interface.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
