### PR TITLE
Adds One (1) [Uno] Bluespace Matter Bin to the animal hospital.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -124,9 +124,14 @@
 /turf/open/floor/plasteel,
 /area/ruin/powered/animal_hospital)
 "aw" = (
-/obj/structure/bed/roller,
+/obj/structure/table,
+/obj/item/retractor,
+/obj/item/hemostat,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/defibrillator_mount{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
@@ -182,12 +187,16 @@
 /area/ruin/powered/animal_hospital)
 "aC" = (
 /obj/structure/table/optable,
+/obj/item/paper{
+	info = "Doc - As a heads up, that matter bin we ordered forever ago for saving.. less alive pets' finally come in. Sad thing is I can't figure out how to work the smartfridge board back into organ storage, can you do it for me? The matter bin'll let it repair organs, we'll be way better going! -Ted";
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "aD" = (
-/obj/structure/table,
-/obj/item/retractor,
-/obj/item/hemostat,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/random/five,
+/obj/item/circuitboard/machine/smartfridge,
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "aE" = (
@@ -268,7 +277,6 @@
 /area/ruin/powered/animal_hospital)
 "be" = (
 /obj/effect/decal/cleanable/oil,
-/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/ruin/powered/animal_hospital)
 "bh" = (
@@ -589,6 +597,10 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"cu" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/white,
+/area/ruin/powered/animal_hospital)
 "cx" = (
 /obj/machinery/light{
 	dir = 4
@@ -964,6 +976,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "wd" = (
@@ -1454,8 +1467,8 @@
 	},
 /area/ruin/powered/animal_hospital)
 "Zx" = (
-/obj/machinery/defibrillator_mount,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/item/stock_parts/matter_bin/bluespace,
+/turf/open/floor/plasteel/white,
 /area/ruin/powered/animal_hospital)
 "ZX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1954,7 +1967,7 @@ ab
 cn
 ae
 Vg
-ao
+Zx
 aB
 ae
 oD
@@ -1984,7 +1997,7 @@ ab
 ac
 ae
 Fv
-ao
+cu
 aC
 ae
 hl
@@ -2044,7 +2057,7 @@ aa
 ab
 ae
 ae
-Zx
+ae
 ae
 ae
 ae


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds one bluespace matter bin to the animal hospital, and fixes the defibrillator wall mount so that it can actually be used somewhere other than that awkward little corner.
![image](https://user-images.githubusercontent.com/50649185/149674220-5ae3f08d-751e-4e7d-a0c4-76d4191603ac.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Tl;dr - Upgraded smartfridges repair organ damage. Animal hospital is meant to be a way for new players to learn *proper* medical roles in the most chaotic environ for it - lavaland.
Yet almost nobody knows this is a thing the smartfridge can do, and much sooner would opt for cybernetics - even on /tg/, where lux pens and cybernetic hearts don't mix.
So, in minorly heavy-handed fashion - this adds a spot for a new smartfridge, a board, and a matter bin for new players to learn it firsthand.

Oh, also it moves to the toolbox to surgery too. I dunno if IPC players were really rooting for that one, but it's just more convenient for the other changes I was making, so.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Changelog
:cl:
tweak: The lavaland animal hospital can now actually repair organ damage now through their new smartfridge, meaning they can actually revive even lava-ridden, dead organ miners if given the chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
