### PR TITLE
Stops Nightmares from bricking Borgs

### DIFF
--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -14,6 +14,9 @@
 	else
 		camera_mode_on(user)
 
+/obj/item/camera/siliconcam/lighteater_act(obj/item/light_eater/light_eater)
+	return
+
 /obj/item/camera/siliconcam/proc/camera_mode_off(mob/user)
 	in_camera_mode = FALSE
 	to_chat(user, "<B>Camera Mode deactivated</B>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lighteater_act would destroy this, causing a runtime in the borg's onclick, rendering them unable to click anything.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This ain't fun for anyone.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Screenshots&Videos</summary>



Put screenshots and Videos documenting testing and execution of intended behaviors here


</details>

## Changelog
:cl:
fix: Nightmares will no longer softlock borgs that they attack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
