### PR TITLE
Reworks gentle bluespace/bluespace extract luminescent interaction

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/gentle.dm
+++ b/code/modules/research/xenobiology/crossbreeding/gentle.dm
@@ -33,14 +33,14 @@
 		return
 	var/newcooldown = extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR)
 	if(newcooldown)
-		cooldown = newcooldown / 10 //activate gives cooldown in deciseconds
+		cooldown = newcooldown * 0.1 //activate gives cooldown in deciseconds
 
 /obj/item/slimecross/gentle/AltClick(mob/living/carbon/user, obj/item/I)
 	if(cooldown > 0 || user.incapacitated())
 		return
 	var/newcooldown = extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR)
 	if(newcooldown)
-		cooldown = newcooldown / 10
+		cooldown = newcooldown * 0.1
 
 /obj/item/slimecross/gentle/grey
 	extract_type = /obj/item/slime_extract/grey

--- a/code/modules/research/xenobiology/crossbreeding/gentle.dm
+++ b/code/modules/research/xenobiology/crossbreeding/gentle.dm
@@ -29,14 +29,14 @@
 	STOP_PROCESSING(SSobj,src)
 
 /obj/item/slimecross/gentle/attack_self(mob/living/carbon/user)
-	if(cooldown > 0 || user.incapacitated())
+	if(cooldown > 0 || user.incapacitated() || !iscarbon(user))
 		return
 	var/newcooldown = extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR)
 	if(newcooldown)
 		cooldown = newcooldown / 10 //activate gives cooldown in deciseconds
 
 /obj/item/slimecross/gentle/AltClick(mob/living/carbon/user, obj/item/I)
-	if(cooldown > 0 || user.incapacitated())
+	if(cooldown > 0 || user.incapacitated() || !iscarbon(user))
 		return
 	var/newcooldown = extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR)
 	if(newcooldown)

--- a/code/modules/research/xenobiology/crossbreeding/gentle.dm
+++ b/code/modules/research/xenobiology/crossbreeding/gentle.dm
@@ -28,27 +28,19 @@
 	. = ..()
 	STOP_PROCESSING(SSobj,src)
 
-/obj/item/slimecross/gentle/attack_self(mob/user)
-	if(cooldown > 0)
+/obj/item/slimecross/gentle/attack_self(mob/living/carbon/user)
+	if(cooldown > 0 || user.incapacitated())
 		return
-	var/datum/species/species
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		species = H.dna.species
-	var/newcooldown = extract.activate(user,species,SLIME_ACTIVATE_MINOR)
+	var/newcooldown = extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR)
 	if(newcooldown)
-		cooldown = newcooldown/10 //activate gives cooldown in deciseconds
+		cooldown = newcooldown / 10 //activate gives cooldown in deciseconds
 
 /obj/item/slimecross/gentle/AltClick(mob/living/carbon/user, obj/item/I)
-	if(cooldown > 0)
+	if(cooldown > 0 || user.incapacitated())
 		return
-	var/datum/species/species
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		species = H.dna.species
-	var/newcooldown = extract.activate(user,species,SLIME_ACTIVATE_MAJOR)
+	var/newcooldown = extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR)
 	if(newcooldown)
-		cooldown = newcooldown/10
+		cooldown = newcooldown / 10
 
 /obj/item/slimecross/gentle/grey
 	extract_type = /obj/item/slime_extract/grey

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -22,16 +22,13 @@ Regenerative extracts:
 	if(H.stat == DEAD)
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
+	if(!do_mob(user, H, 50))
+		to_chat(user, "<span class='notice'>You need to hold still to apply [src]!")
+		return
 	if(H != user)
-		if(!do_mob(user, H, 50))
-			to_chat(user, "<span class='notice'>You need to hold still to apply [src]!")
-			return
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
 	else
-		if(!do_mob(user, user, 50))
-			to_chat(user, "<span class='notice'>You need to hold still to apply [src]!")
-			return
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
 	core_effect_before(H, user)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -14,7 +14,7 @@ Regenerative extracts:
 /obj/item/slimecross/regenerative/proc/core_effect_before(mob/living/carbon/human/target, mob/user)
 	return
 
-/obj/item/slimecross/regenerative/afterattack(atom/target,mob/user,prox)
+/obj/item/slimecross/regenerative/afterattack(atom/target, mob/user, prox)
 	. = ..()
 	if(!prox || !isliving(target))
 		return
@@ -23,9 +23,15 @@ Regenerative extracts:
 		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 		return
 	if(H != user)
+		if(!do_mob(user, H, 50))
+			to_chat(user, "<span class='notice'>You need to hold still to apply [src]!")
+			return
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
 	else
+		if(!do_mob(user, user, 50))
+			to_chat(user, "<span class='notice'>You need to hold still to apply [src]!")
+			return
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
 	core_effect_before(H, user)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -521,26 +521,35 @@
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
 			to_chat(user, "<span class='warning'>You feel your body vibrating...</span>")
-			if(do_after(user, 25, target = user))
-				to_chat(user, "<span class='warning'>You teleport!</span>")
-				do_teleport(user, get_turf(user), 6, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
-				return 300
+			if(!do_after(user, 25, target = user))
+				return
+			to_chat(user, "<span class='warning'>You teleport!</span>")
+			do_teleport(user, get_turf(user), 6, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
+			return 100
 
 		if(SLIME_ACTIVATE_MAJOR)
 			if(!teleport_ready)
-				to_chat(user, "<span class='notice'>You feel yourself anchoring to this spot...</span>")
+				to_chat(user, "<span class='notice'>You feel yourself anchoring to this point...</span>")
+				if(!do_after(user, 25, target = user))
+					return
 				var/turf/T = get_turf(user)
 				teleport_x = T.x
 				teleport_y = T.y
 				teleport_z = T.z
 				teleport_ready = TRUE
+				to_chat(user, "<span class='notice'>You anchor yourself to this point!</span>")
 			else
+				to_chat(user, "<span class='notice'>You feel yourself being pulled back to your anchor point...</span>")
+				if(!do_after(user, 25, target = user))
+					to_chat(user, "<span class ='notice'>Your teleport was interrupted!</span>")
+					return
 				teleport_ready = FALSE
-				if(teleport_x && teleport_y && teleport_z)
-					var/turf/T = locate(teleport_x, teleport_y, teleport_z)
-					to_chat(user, "<span class='notice'>You snap back to your anchor point!</span>")
-					do_teleport(user, T,  asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
-					return 450
+				if(!(teleport_x && teleport_y && teleport_z))
+					CRASH("Bluespace extract teleport was somehow triggered without x,y,z coordinates!")
+				var/turf/T = locate(teleport_x, teleport_y, teleport_z)
+				to_chat(user, "<span class='notice'>You snap back to your anchor point!</span>")
+				do_teleport(user, T,  asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
+				return 450
 
 
 /obj/item/slime_extract/pyrite

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -520,8 +520,9 @@
 /obj/item/slime_extract/bluespace/activate(mob/living/carbon/human/user, datum/species/species, activation_type)
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
-			to_chat(user, "<span class='warning'>You feel your body vibrating...</span>")
+			to_chat(user, "<span class='notice'>You feel your body vibrating...</span>")
 			if(!do_after(user, 25, target = user))
+				to_chat(user, "<span class='warning'>You need to hold still to teleport!</span>")
 				return
 			to_chat(user, "<span class='warning'>You teleport!</span>")
 			do_teleport(user, get_turf(user), 6, asoundin = 'sound/weapons/emitter2.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
@@ -531,6 +532,7 @@
 			if(!teleport_ready)
 				to_chat(user, "<span class='notice'>You feel yourself anchoring to this point...</span>")
 				if(!do_after(user, 25, target = user))
+					to_chat(user, "<span class='notice'>You need to hold still to finish anchoring yourself!</span>")
 					return
 				var/turf/T = get_turf(user)
 				teleport_x = T.x
@@ -541,10 +543,11 @@
 			else
 				to_chat(user, "<span class='notice'>You feel yourself being pulled back to your anchor point...</span>")
 				if(!do_after(user, 25, target = user))
-					to_chat(user, "<span class ='notice'>Your teleport was interrupted!</span>")
+					to_chat(user, "<span class ='warning'>Your teleport was interrupted!</span>")
 					return
 				teleport_ready = FALSE
 				if(!(teleport_x && teleport_y && teleport_z))
+					to_chat(user, "<span class ='warning'>Somehow you managed to trigger this without setting an anchor point. Good job.</span>")
 					CRASH("Bluespace extract teleport was somehow triggered without x,y,z coordinates!")
 				var/turf/T = locate(teleport_x, teleport_y, teleport_z)
 				to_chat(user, "<span class='notice'>You snap back to your anchor point!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks the bluespace extract and fixes unintended behavior along the way.

All actions now have a 2.5 second delay. This includes setting your anchor point and teleporting to it. You can no longer teleport to it if you're in crit, dead(!!!) or otherwise incapacitated.

The minor effect has been buffed. The cooldown on using it is now only 10 seconds to encourage it's use.

Reworks the regenerative bluespace extract as well. It now has a 5 second application delay to prevent stuff like https://streamable.com/shlhos

Oh also early returns good.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is one of the most unbalanced abilities in the game, this makes it a tiny bit more balanced (not by much, but hey it's a start) and now sec can actually deal with it. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Screenshots&Videos</summary>

:3c 

</details>

## Changelog
:cl:
balance: Bluespace extract's major ability can no longer be activated while incapacitated
balance: Bluespace extract's major ability now has a delay before the anchor point is set and a delay until you're teleported back to it
balance: Shortened the minor bluespace extract ability cooldown
balance: Applying the regenerative bluespace extracts now has a delay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
