### PR TITLE
The turf reference is now set before rune activation or other teleports

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -150,6 +150,7 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 
 /obj/effect/warped_rune/proc/on_entered(datum/source, atom/movable/AM, oldloc)
 	SIGNAL_HANDLER
+
 	if(activated_on_step)
 		playsound(rune_turf, dir_sound, 20, TRUE)
 		visible_message("<span class='notice'>[src] fades.</span>")

--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -44,6 +44,10 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
+/obj/effect/warped_rune/Moved(atom/OldLoc, Dir)
+	. = ..()
+	rune_turf = get_turf(src)
+
 /obj/item/slimecross/warping/examine()
 	. = ..()
 	. += "It has [warp_charge] charge left"
@@ -138,7 +142,6 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 
 /obj/effect/warped_rune/attack_hand(mob/living/user)
 	. = ..()
-	rune_turf = get_turf(src)
 	do_effect(user)
 
 /obj/effect/warped_rune/proc/do_effect(mob/user)

--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -849,7 +849,6 @@ GLOBAL_DATUM(warped_room, /datum/map_template/warped_room)
 		if(!exit_turf)
 			if(GLOB.warped_room?.rainbow_runes.len)
 				var/obj/effect/warped_rune/WR = pick(GLOB.warped_room.rainbow_runes)
-				WR.rune_turf = get_turf(WR)
 				exit_turf = WR.rune_turf
 			else
 				exit_turf = find_safe_turf()

--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -138,6 +138,7 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 
 /obj/effect/warped_rune/attack_hand(mob/living/user)
 	. = ..()
+	rune_turf = get_turf(src)
 	do_effect(user)
 
 /obj/effect/warped_rune/proc/do_effect(mob/user)
@@ -149,7 +150,6 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 
 /obj/effect/warped_rune/proc/on_entered(datum/source, atom/movable/AM, oldloc)
 	SIGNAL_HANDLER
-
 	if(activated_on_step)
 		playsound(rune_turf, dir_sound, 20, TRUE)
 		visible_message("<span class='notice'>[src] fades.</span>")
@@ -845,6 +845,7 @@ GLOBAL_DATUM(warped_room, /datum/map_template/warped_room)
 		if(!exit_turf)
 			if(GLOB.warped_room?.rainbow_runes.len)
 				var/obj/effect/warped_rune/WR = pick(GLOB.warped_room.rainbow_runes)
+				WR.rune_turf = get_turf(WR)
 				exit_turf = WR.rune_turf
 			else
 				exit_turf = find_safe_turf()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #5883 

The turf var for the warping runes is now set to the current before actual activation and in other scant instances(such as leaving the warping rainbow area).

This is instead of previously setting the rune 1 time at initialization.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix bug(?) or unexpected behavior
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Screenshots&Videos</summary>

![Spawn Cross](https://user-images.githubusercontent.com/68963748/150048536-1f6f6849-2a5d-48e5-88b8-e98a5e7125c0.png)

![Console and Rune](https://user-images.githubusercontent.com/68963748/150048552-cd302fb0-fe8b-46b0-ba5e-178f536be769.png)


![Use rune](https://user-images.githubusercontent.com/68963748/150048573-2ea99c60-1c44-4d36-9a18-e8995b0c04a0.png)

![Get Console](https://user-images.githubusercontent.com/68963748/150048592-dae28f2c-8dda-4bb0-80b1-d48cbf60cc65.png)

![Setup and Launch Shuttle](https://user-images.githubusercontent.com/68963748/150048611-807cbdf8-3f55-4393-a475-10195520bff3.png)

![Leave and return to rune on shuttle](https://user-images.githubusercontent.com/68963748/150048625-47f45077-f33e-4009-a005-7c6738302992.png)

</details>

## Changelog
:cl: DatBoiTim
tweak: Warping runes now retrieve current turf whenever activated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
