### PR TITLE
Remove hypnotic stupor from fourth wall

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2235,7 +2235,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	var/list/trauma_list
 
 /datum/reagent/consumable/ethanol/fourthwall/proc/traumaweightpick(var/mild,var/severe,var/special)
-	return pick(pickweight(list(subtypesof(/datum/brain_trauma/mild) = mild, subtypesof(/datum/brain_trauma/severe) - /datum/brain_trauma/severe/split_personality = severe, subtypesof(/datum/brain_trauma/special) - /datum/brain_trauma/special/imaginary_friend = special)))
+	return pick(pickweight(list(subtypesof(/datum/brain_trauma/mild) = mild, subtypesof(/datum/brain_trauma/severe) - /datum/brain_trauma/severe/split_personality - /datum/brain_trauma/severe/hypnotic_stupor = severe, subtypesof(/datum/brain_trauma/special) - /datum/brain_trauma/special/imaginary_friend = special)))
 
 /datum/reagent/consumable/ethanol/fourthwall/on_mob_metabolize(mob/living/carbon/M)
 	trauma_list = list()


### PR DESCRIPTION
## About The Pull Request

As title says, removes it from the list of brain traumas you can get by drinking the Fourth Wall. 

## Why It's Good For The Game

While very loggable, this trauma can be abused.

## Testing Photographs and Procedure

Drink ? 

There is one peculiarity which is that imaginary friend is blacklisted, but imaginary friend that traps you within is not blacklisted. 

## Changelog
:cl: Froststahr
tweak: Hypnotic Stupor is removed from the Fourth Wall. You will only be self\-antagging your liver. 
/:cl: