### PR TITLE
Adds a Check to Inhand BS Bodybag Deployment

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -8,13 +8,11 @@
 	var/unfoldedbag_path = /obj/structure/closet/body_bag
 
 /obj/item/bodybag/attack_self(mob/user)
-	deploy_bodybag(user, user.loc)
+	if(isopenturf(user.loc))
+		deploy_bodybag(user, user.loc)
+	else
+		to_chat(user, "<span class='notice'>You cannot deploy a [src] inside of something!</span>")
 
-/obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
-	. = ..()
-	if(proximity)
-		if(isopenturf(target))
-			deploy_bodybag(user, target)
 
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
 	var/obj/structure/closet/body_bag/R = new unfoldedbag_path(location)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -11,7 +11,7 @@
 	if(isopenturf(user.loc))
 		deploy_bodybag(user, user.loc)
 	else
-		to_chat(user, "<span class='notice'>You cannot deploy [src] inside of something!</span>")
+		to_chat(user, "<span class='warning'>You cannot deploy [src] inside of something!</span>")
 
 
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -11,7 +11,7 @@
 	if(isopenturf(user.loc))
 		deploy_bodybag(user, user.loc)
 	else
-		to_chat(user, "<span class='notice'>You cannot deploy a [src] inside of something!</span>")
+		to_chat(user, "<span class='notice'>You cannot deploy [src] inside of something!</span>")
 
 
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -13,7 +13,6 @@
 	else
 		to_chat(user, "<span class='warning'>You cannot deploy [src] inside of something!</span>")
 
-//Allows deployment of a bodybag from your hand to a tile you are not standing on. NOT REDUNDANT
 /obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	if(proximity)

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -13,6 +13,12 @@
 	else
 		to_chat(user, "<span class='warning'>You cannot deploy [src] inside of something!</span>")
 
+//Allows deployment of a bodybag from your hand to a tile you are not standing on. NOT REDUNDANT
+/obj/item/bodybag/afterattack(atom/target, mob/user, proximity)
+	. = ..()
+	if(proximity)
+		if(isopenturf(target))
+			deploy_bodybag(user, target)
 
 /obj/item/bodybag/proc/deploy_bodybag(mob/user, atom/location)
 	var/obj/structure/closet/body_bag/R = new unfoldedbag_path(location)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check to the inhand use proc for deploying bodybags.

Without this check, there would be weird behavior with ~~Bullshit~~ Bluespace Bodybags allowing you to deploy a bodybag while inside it, while folded, leading then to soft duping of the bag.

Adds a to_chat message providing feedback as to why they cannot open the bodybag item at the moment for this specific case.

closes #6243

I had picked which proc would remain via testing with breakpoints. First proc to reach a breakpoint on their first line of execution would remain.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes extremely weird glitch for BS Bodybags. User feedback good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>

<summary>Screenshots&Videos</summary>

![Nodeploy message!](https://user-images.githubusercontent.com/68963748/151322522-4a4c3970-01d5-4b62-98b4-b66e97a43ff7.png)
Note the user feedback message in the chat pane.

</details>

## Changelog
:cl: DatBoiTim
fix: A weird bug regarding BS bodybags soft-duping
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
