### PR TITLE
Vaccines must now be injected, and require 5 units to cure.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -101,7 +101,7 @@
 	taste_description = "slime"
 
 /datum/reagent/vaccine/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	if(islist(data) && (method == INGEST || method == INJECT))
+	if(!islist(data) || !(method & INJECT) || reac_volume < 5)
 		for(var/thing in L.diseases)
 			var/datum/disease/D = thing
 			if(D.GetDiseaseID() in data)


### PR DESCRIPTION
### **About The Pull Request**
Vaccines must now be injected, and require 5 units to cure.
https://github.com/tgstation/tgstation/pull/64406
### Why It's Good For The Game
Currently, the process of curing a virus for the entire crew is:

Grab a cured person after giving them their sugar or ethanol or whatever
Get a blood sample
Go back to the Pandemic
Generate a bunch of vaccine culture bottles
Make approximately 500~ Vaccine (0.1u) pills and drop them on the floor in front of medbay
Go back to virology for the rest of the round, or leave medbay or whatever
This is boring as shit, involves nobody but the virologist and whoever the person who's blood you took is, and leads to massive stacks of objects on the floor.
Sentient diseases are extremely weak as is, this should help them to not be instantly destroyed.


By making vaccines require injection and a minimum of 5 units, it encourages the virologist to dose out vaccine shots and employ the other medical staff in getting shots in arms.

This gives viruses more of an opportunity to impact someone rather than them beelining medbay and eating the first pill they see off the ground the second they sniff or see a face pop up on their health HUD. It also means virologists have reasons to keep getting samples from cured patients, as they'll now need to produce far more vaccine culture to cure patients.

Also, I hate seeing 50000 pill stacks of Vaccine (0.1u) on the floor in medbay.

Changelog
🆑Iamgoofball AnCopper
balance: Vaccines must now be injected, and require 5 units to cure.
/🆑