### PR TITLE
Fixes beakers, chem grenades, and mood events hardelling

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -34,6 +34,13 @@
 /datum/component/mood/Destroy()
 	STOP_PROCESSING(SSmood, src)
 	unmodify_hud()
+	for(var/i in mood_events)
+		var/datum/mood_event/event = mood_events[i]
+		event.owner = null
+		if(event.timer)
+			deltimer(event.timer)
+		qdel(event)
+	mood_events.Cut()
 	return ..()
 
 /datum/component/mood/proc/print_mood(mob/user)
@@ -263,7 +270,7 @@
 			clear_event(null, category)
 		else
 			if(the_event.timeout)
-				addtimer(CALLBACK(src, .proc/clear_event, null, category), the_event.timeout, TIMER_UNIQUE|TIMER_OVERRIDE)
+				the_event.timer = addtimer(CALLBACK(src, .proc/clear_event, null, category), the_event.timeout, TIMER_STOPPABLE|TIMER_UNIQUE|TIMER_OVERRIDE)
 			return 0 //Don't have to update the event.
 	the_event = new type(src, param)
 

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -34,13 +34,7 @@
 /datum/component/mood/Destroy()
 	STOP_PROCESSING(SSmood, src)
 	unmodify_hud()
-	for(var/i in mood_events)
-		var/datum/mood_event/event = mood_events[i]
-		event.owner = null
-		if(event.timer)
-			deltimer(event.timer)
-		qdel(event)
-	mood_events.Cut()
+	QDEL_LIST_ASSOC_VAL(mood_events)
 	return ..()
 
 /datum/component/mood/proc/print_mood(mob/user)

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -2,6 +2,7 @@
 	var/description ///For descriptions, use the span classes bold nicegreen, nicegreen, none, warning and boldwarning in order from great to horrible.
 	var/mood_change = 0
 	var/timeout = 0
+	var/timer //Timer ID for this event (if it has a timeout)
 	var/hidden = FALSE//Not shown on examine
 	var/category //string of what category this mood was added in as
 	var/special_screen_obj //if it isn't null, it will replace or add onto the mood icon with this (same file). see happiness drug for example

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -15,6 +15,9 @@
 
 /datum/mood_event/Destroy()
 	remove_effects()
+	owner = null
+	if(timer)
+		deltimer(timer)
 	return ..()
 
 /datum/mood_event/proc/add_effects(param)

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -52,7 +52,7 @@
 
 /datum/wires/Destroy()
 	holder = null
-	assemblies = list()
+	QDEL_LIST_ASSOC_VAL(assemblies)
 	return ..()
 
 /datum/wires/proc/add_duds(duds)

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -52,7 +52,7 @@
 
 /datum/wires/Destroy()
 	holder = null
-	QDEL_LIST_ASSOC_VAL(assemblies)
+	assemblies.Cut()
 	return ..()
 
 /datum/wires/proc/add_duds(duds)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -28,8 +28,7 @@
 
 /obj/item/grenade/chem_grenade/Destroy()
 	QDEL_LIST(beakers)
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	return ..()
 
 /obj/item/grenade/chem_grenade/examine(mob/user)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -26,6 +26,12 @@
 	stage_change() // If no argument is set, it will change the stage to the current stage, useful for stock grenades that start READY.
 	wires = new /datum/wires/explosive/chem_grenade(src)
 
+/obj/item/grenade/chem_grenade/Destroy()
+	QDEL_LIST(beakers)
+	qdel(wires)
+	wires = null
+	return ..()
+
 /obj/item/grenade/chem_grenade/examine(mob/user)
 	display_timer = (stage == GRENADE_READY)	//show/hide the timer based on assembly state
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a few harddels and does some general Destroy() cleanup. Untested but it should all work.

Didn't port these from TG.

## Changelog
:cl:
fix: Fixed beakers in chem grenades hard deleting
fix: Fixed chem grenades hard deleting
fix: Fixed mood events hard deleting
code: Improved assembly deletion when attached to a wire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
