### PR TITLE
Hopefully prevents some grief: 2 electric boogaloo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1140,6 +1140,7 @@
 	name = "Particle Accelerator Crate"
 	desc = "A supermassive black hole or hyper-powered teslaball are the perfect way to spice up any party! This \"My First Apocalypse\" kit contains everything you need to build your own Particle Accelerator! Ages 10 and up."
 	cost = 2700
+	access = ACCESS_CE
 	contains = list(/obj/structure/particle_accelerator/fuel_chamber,
 					/obj/machinery/particle_accelerator/control_box,
 					/obj/structure/particle_accelerator/particle_emitter/center,
@@ -1164,6 +1165,7 @@
 	name = "Singularity Generator Crate"
 	desc = "The key to unlocking the power of Lord Singuloth. Particle Accelerator not included."
 	cost = 4700
+	access = ACCESS_CE
 	contains = list(/obj/machinery/the_singularitygen)
 	crate_name = "singularity generator crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering
@@ -1226,6 +1228,7 @@
 	name = "Tesla Generator Crate"
 	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."
 	cost = 5000
+	access = ACCESS_CE
 	contains = list(/obj/machinery/the_singularitygen/tesla)
 	crate_name = "tesla generator crate"
 	crate_type = /obj/structure/closet/crate/secure/engineering


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adding on to #6224 Hopefully prevents some grief. TLDR PA/Singulo/Tesla crates are locked, but can still be ordered by anyone. Whyyy??Y?Y??Y??!!!!
(first time using github who this)

## Why It's Good For The Game

Quoting the previous PR: "Prevents griefing, or at least adds a few extra steps to it". But it honestly imo it just becomes an arms race between the code and the griefer to find a way to grief the station. Perhaps having an admeme available on lowpop/asian timezone would be more effective.


## Changelog
:cl:
balance: Particle Accelerator, Tesla generator and Singularity generator crates can now be only ordered by the CE.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
