### PR TITLE
Fix "Cryogenic Storage" area on Delta, and Delta exploration shuttle's airlocks

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2245,9 +2245,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/genetics{
-	name = "Cryogenic Storage"
-	})
+/area/maintenance/starboard)
 "adM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -103716,6 +103714,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"fHx" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/genetics)
 "fLc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -115203,6 +115217,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"udO" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/genetics)
 "ueK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -158218,8 +158245,8 @@ inw
 dvc
 dwG
 dvc
-din
-dgR
+udO
+fHx
 dCy
 dCy
 dCy

--- a/_maps/shuttles/exploration_delta.dmm
+++ b/_maps/shuttles/exploration_delta.dmm
@@ -43,6 +43,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "hl" = (
@@ -270,6 +273,9 @@
 /obj/machinery/door/airlock/external/glass,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)


### PR DESCRIPTION
## About The Pull Request

closes #6093
closes #5641

## Why It's Good For The Game

+ Fix some area being misplaced or badly named.
+ Add airlock helpers in delta exploration shuttle

## Screenshots and details

<details>

One turf with a gen area for no reason:
![image](https://user-images.githubusercontent.com/69859497/152369262-e77ae809-bccd-42a8-bc11-0c7aff289f6c.png)

Whole genetics being called "Cryogenic Storage" for no reason, as stated in #6093: 
![delta-aera-fix2](https://user-images.githubusercontent.com/69859497/152366686-308e4669-c8bf-4d45-bf90-ef72ab344811.PNG)

Add airlock helpers on delta exploration shuttle:
![delta-shuttle-fix1](https://user-images.githubusercontent.com/69859497/152442774-2ee1d7e2-23b8-47ea-b47b-ef9ecf6179c3.PNG)
![delta-shuttle-fix2](https://user-images.githubusercontent.com/69859497/152442773-9d659c23-92a3-4ea2-a941-b5782453dd22.PNG)

</details>

## Changelog
:cl:
fix: Fixed some genetics area on Delta called "Cryogenic Storage" instead of their usual names.
fix: Fixed Delta exploration shuttle's airlocks by adding airlocks helpers.
/:cl:
