### PR TITLE
Nerfs xenobio cheese

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -237,7 +237,7 @@
 	stage3	= list("<span class='danger'>Your appendages are melting away.</span>", "<span class='danger'>Your limbs begin to lose their shape.</span>")
 	stage4	= list("<span class='danger'>You are turning into a slime.</span>")
 	stage5	= list("<span class='danger'>You have become a slime.</span>")
-	new_form = /mob/living/simple_animal/slime/random
+	new_form = /mob/living/simple_animal/slime
 
 /datum/disease/transformation/slime/stage_act()
 	..()


### PR DESCRIPTION
## About The Pull Request
advanced mutation toxin now transforms the target into a mundane slime, instead of a random slime

## Why It's Good For The Game
getting black slimes no longer allows you to bypass the entirety of the xenobiology minigame using monkeys
(for those who dont know, you can smoke monkeys with advanced mutation toxin to get pretty much every slime variety, including rainbow)

## Testing Photographs and Procedure
(simple var change, unecessary)


## Changelog
:cl:
tweak: advanced mutation toxin slime transformation no longer has random colors
/:cl:

