### PR TITLE
fixes shuttles spamming zlevel generation for effects/other non items objects with the indestructible flag

### DIFF
--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -44,9 +44,9 @@
 	var/_z = 2
 
 	var/should_make_level = ismob(AM)
-	if(!should_make_level && isobj(AM))
+	if(!should_make_level && isitem(AM))
 		var/obj/O = AM
-		if(isitem(AM) && (O.resistance_flags & INDESTRUCTIBLE))	//incase there is an important item
+		if(O.resistance_flags & INDESTRUCTIBLE)	//incase there is an important item
 			should_make_level = TRUE
 
 	if(should_make_level)

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -46,7 +46,7 @@
 	var/should_make_level = ismob(AM)
 	if(!should_make_level && isobj(AM))
 		var/obj/O = AM
-		if(isitem(AM) && O.resistance_flags & INDESTRUCTIBLE)	//incase there is an important item
+		if(isitem(AM) && (O.resistance_flags & INDESTRUCTIBLE))	//incase there is an important item
 			should_make_level = TRUE
 
 	if(should_make_level)

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -45,8 +45,8 @@
 
 	var/should_make_level = ismob(AM)
 	if(!should_make_level && isitem(AM))
-		var/obj/O = AM
-		if(O.resistance_flags & INDESTRUCTIBLE)	//incase there is an important item
+		var/obj/item/I = AM
+		if(I.resistance_flags & INDESTRUCTIBLE)	//incase there is an important item
 			should_make_level = TRUE
 
 	if(should_make_level)

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -46,7 +46,7 @@
 	var/should_make_level = ismob(AM)
 	if(!should_make_level && isobj(AM))
 		var/obj/O = AM
-		if(O.resistance_flags & INDESTRUCTIBLE)
+		if(isitem(AM) && O.resistance_flags & INDESTRUCTIBLE)	//incase there is an important item
 			should_make_level = TRUE
 
 	if(should_make_level)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a simple check for if an object that has a INDESTRUCTIBLE flag is actually an item to allow it to get its own zlevel when it falls out of a shuttle.

## Why It's Good For The Game

Having explosion effects spamming the server with add_new_zlevel proc calls once it ran dry of free zlevels is bad

</details>

## Changelog
:cl:
fix: fixes effects and other indistructable non items from generating zlevels when falling out of a shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
