### PR TITLE
Fixes a mistake

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/artifact_defenses.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/artifact_defenses.dm
@@ -88,7 +88,7 @@
 	hierophant_burst(null, T, 7)
 
 /datum/protector_effect/emp_stun/trigger(obj/source, turf/T, atom/movable/target)
-	playsound(TAIL_SWEEP_COMBO,'sound/machines/airlockopen.ogg', 200, 1)
+	playsound(T,'sound/machines/airlockopen.ogg', 200, 1)
 	T.visible_message("<span class='hierophant'>\"Svhivw vigmizih.\"</span>")
 	empulse(T, 2, 6)
 	if(isliving(target))


### PR DESCRIPTION
Whoops!

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Screenshots&Videos</summary>



Put screenshots and Videos documenting testing and execution of intended behaviors here


</details>

## Changelog
:cl:
fix: fixes ruin artifact defenses playing from the wrong place
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
