### PR TITLE
Fixes unmanaged z-level runtimes

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -103,15 +103,17 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 /datum/crewmonitor/ui_data(mob/user)
 	var/z = user.get_virtual_z_level()
+	var/turf/T = get_turf(user)
 	if(!z)
-		var/turf/T = get_turf(user)
 		z = T.get_virtual_z_level()
-	var/list/zdata = update_data(z)
+	var/list/zdata = update_data(z, T.z)
 	. = list()
 	.["sensors"] = zdata
 	.["link_allowed"] = isAI(user)
 
-/datum/crewmonitor/proc/update_data(z)
+//Z represents the virtual z-level the user is on
+//zlevel represents the physical z-level the mob is at.
+/datum/crewmonitor/proc/update_data(z, zlevel)
 	if(data_by_z["[z]"] && last_update["[z]"] && world.time <= last_update["[z]"] + SENSORS_UPDATE_PERIOD)
 		return data_by_z["[z]"]
 
@@ -137,7 +139,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			nanite_sensors = TRUE
 		// Check if their z-level is correct and if they are wearing a uniform.
 		// Accept H.z==0 as well in case the mob is inside an object.
-		if ((H.z == 0 || H.get_virtual_z_level() == z || (is_station_level(H.z) && is_station_level(z))) && (istype(H.w_uniform, /obj/item/clothing/under) || nanite_sensors))
+		if ((H.z == 0 || H.get_virtual_z_level() == z || (is_station_level(H.z) && is_station_level(zlevel))) && (istype(H.w_uniform, /obj/item/clothing/under) || nanite_sensors))
 			U = H.w_uniform
 
 			//Radio transmitters are jammed
@@ -149,7 +151,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				pos = H.z == 0 || (nanite_sensors || U.sensor_mode == SENSOR_COORDS) ? get_turf(H) : null
 
 				// Special case: If the mob is inside an object confirm the z-level on turf level.
-				if (H.z == 0 && (!pos || (pos.get_virtual_z_level() != z) && !(is_station_level(pos.z) && is_station_level(z))))
+				if (H.z == 0 && (!pos || (pos.get_virtual_z_level() != z) && !(is_station_level(pos.z) && is_station_level(zlevel))))
 					continue
 
 				I = H.wear_id ? H.wear_id.GetID() : null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug caused by checking is_station_z_level of a virtual z-level. This makes it so that crew monitoring consoles get physical z-level in the update_data proc as well as the virtual z-level so that they can check if they are on the station.

## Changelog
:cl: Kuberoot, Powerfulbacon
fix: Fixes a runtime in the crew monitoring console caused by crew monitoring consoles being inside a virtual z-level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
