### PR TITLE
Adds proper salting to file checksums

### DIFF
--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -75,7 +75,7 @@
 /// Grabs md5 checksum from a file and rehashes it with config specified salt ( md5(md5(file) + salt) )
 /// Used because md5ing files stored in the rsc sometimes gives incorrect md5 results.
 /proc/md5asfile(hashtarget)
-	if(isAdminAdvancedProcCall())
+	if(IsAdminAdvancedProcCall())
 		CRASH("Admin proc calls are not allowed. Called by: [usr]")
 	if(!hashtarget)
 		CRASH("Invalid hash target")

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -72,17 +72,11 @@
 /proc/pathflatten(path)
 	return replacetext(path, "/", "_")
 
-/// Returns the md5 of a file at a given path.
-/proc/md5filepath(path)
-	. = md5(file(path))
-
-/// Save file as an external file then md5 it.
+/// Grabs md5 checksum from a file and rehashes it with config specified salt ( md5(md5(file) + salt) )
 /// Used because md5ing files stored in the rsc sometimes gives incorrect md5 results.
-/proc/md5asfile(file)
-	var/static/notch = 0
-	// its importaint this code can handle md5filepath sleeping instead of hard blocking, if it's converted to use rust_g.
-	var/filename = "tmp/md5asfile.[world.realtime].[world.timeofday].[world.time].[world.tick_usage].[notch]"
-	notch = WRAP(notch+1, 0, 2**15)
-	fcopy(file, filename)
-	. = md5filepath(filename)
-	fdel(filename)
+/proc/md5asfile(hashtarget)
+	if(isAdminAdvancedProcCall())
+		CRASH("Admin proc calls are not allowed. Called by: [usr]")
+	if(!hashtarget)
+		CRASH("Invalid hash target")
+	return md5(md5(hashtarget) + CONFIG_GET(string/md5_salt))

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -353,7 +353,7 @@
 /datum/config_entry/flag/check_randomizer
 
 /datum/config_entry/string/md5_salt
-	protection = CONFIG_ENTRY_HIDDEN
+	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/string/md5_salt/ValidateAndSet(str_val)
 	if(str_val == "PLEASE_CHANGE_ME123")

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -352,6 +352,14 @@
 
 /datum/config_entry/flag/check_randomizer
 
+/datum/config_entry/string/md5_salt
+	protection = CONFIG_ENTRY_HIDDEN
+
+/datum/config_entry/string/md5_salt/ValidateAndSet(str_val)
+	if(str_val == "PLEASE_CHANGE_ME123")
+		WARNING("[name] is using the default salt, please change!")
+	return ..()
+
 /datum/config_entry/string/ipintel_email
 
 /datum/config_entry/string/ipintel_email/ValidateAndSet(str_val)

--- a/config/config.txt
+++ b/config/config.txt
@@ -594,3 +594,6 @@ ELASTICSEARCH_METRICS_ENDPOINT http://10.0.0.40:9201/ss13-metrics-stream/_doc
 
 ## ElasticSearch API key. This is formatted into the headers. Look at the ElasticSearch doc for how to make this
 ELASTICSEARCH_METRICS_APIKEY thisIsSomethingThatsBased64Encoded==
+
+## Salt string used in certain md5 hashes.
+@MD5_SALT PLEASE_CHANGE_ME123


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

md5asfile() now uses a config specified salt

## Why It's Good For The Game

Currently you can leverage the two md5 file procs from the GAGS PR to 
A) Check if the specified file exists or not
B) Retrieve the md5 hash of the file

If you managed to grab a checksum of a file (i.e config), you can brute force file data locally to get a file matching the checksum. This is very hard to do for most files due to their size and variation. But there are plenty of config files (including many in our repo) with only one or two unknown fields, allowing them bruteforced in a practical amount of time (depending on the strength of the key/password/whatever)

## Changelog
:cl:
fix: md5asfile() is now salted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
