### PR TITLE
Probably fixes quirk harddels

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -35,13 +35,7 @@
 /datum/quirk/Destroy()
 	if(process)
 		STOP_PROCESSING(SSquirks, src)
-	if(quirk_holder)
-		remove()
-		UnregisterSignal(quirk_holder, COMSIG_PARENT_QDELETING)
-		to_chat(quirk_holder, lose_text)
-		quirk_holder.roundstart_quirks -= src
-		if(mob_trait)
-			REMOVE_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)
+	clear_refs()
 	SSquirks.quirk_objects -= src
 	return ..()
 
@@ -64,9 +58,19 @@
 /datum/quirk/proc/clone_data() //return additional data that should be remembered by cloning
 /datum/quirk/proc/on_clone(data) //create the quirk from clone data
 
+/datum/quirk/proc/clear_refs()
+	if(quirk_holder)
+		remove()
+		UnregisterSignal(quirk_holder, COMSIG_PARENT_QDELETING)
+		to_chat(quirk_holder, lose_text)
+		quirk_holder.roundstart_quirks -= src
+		if(mob_trait)
+			REMOVE_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)
+		quirk_holder = null
+
 /datum/quirk/proc/handle_parent_del()
 	SIGNAL_HANDLER
-	quirk_holder = null
+	clear_refs()
 	qdel(src)
 
 /datum/quirk/process(delta_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is actually a bandaid until we can port a much bigger quirk refactor at the top of the todo list. But I'm fairly certain it fixes quirk harddels, because quirks should be able to actually clear their refs on a mob that's being deleted.

Untested.

## Changelog
:cl:
fix: Quirks probably no longer hard delete.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
