### PR TITLE
Energetic Chromosome Fix

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -84,7 +84,7 @@
 		owner.overlays_standing[layer_used] = mut_overlay
 		owner.apply_overlay(layer_used)
 	grant_spell() //we do checks here so nothing about hulk getting magic
-	if(!modified)
+	if(!modified && can_chromosome == CHROMOSOME_USED)
 		addtimer(CALLBACK(src, .proc/modify, 5)) //gonna want children calling ..() to run first
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/on_move)
 

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -94,6 +94,7 @@
 	power_coeff = 1
 
 /datum/mutation/human/firebreath/modify()
+	..()
 	if(power)
 		var/obj/effect/proc_holder/spell/aimed/firebreath/S = power
 		S.strength = GET_MUTATION_POWER(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes two bugs with the energetic chromosome in genetics. Previously, its effects would only be applied if the mutation had the chromosome prior to being injected into someone. Also, fire breath didn't call the superfunction for modify(), meaning it was completely unable to use the chromosome at all despite being able to apply it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the energetic chromosome more reliable and less buggy. bugs are bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Testing</summary>

https://user-images.githubusercontent.com/51838176/153685878-894b1ef3-a3f6-4b2e-a454-e36c004b05c4.mp4

First injection is the control group, second injection has the chromosome pre-applied, third injection is given the chromosome while it is active. Cooldown is working as intended.


</details>

## Changelog
:cl:
fix: Energetic chromosome now properly applies to active mutations and fire breath.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
