### PR TITLE
fixes infinite iron duplication with riggit toolboxes

### DIFF
--- a/code/game/machinery/fabricators/modular_fabricator.dm
+++ b/code/game/machinery/fabricators/modular_fabricator.dm
@@ -482,7 +482,7 @@
 	else
 		for(var/i=1, i<=multiplier, i++)
 			var/obj/item/new_item = new being_built.build_path(A)
-			new_item.materials = new_item.materials.Copy()
+			new_item.materials.Cut()	//appearantly the material datum gets initialized in a subsystem so there is no need to qdelete it but we still need to empty the list
 			for(var/mat in materials_used)
 				new_item.materials[mat] = materials_used[mat] / multiplier
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a bug where you could create basically infinite iron by creating toolboxes using the autlath that are not made out of iron. Obviously this would have worked with any item that can have a custom material to be made out of with the autolath.
closes: https://github.com/BeeStation/BeeStation-Hornet/issues/6362
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->



</details>

## Changelog
:cl:
fix: fixes another infinite iron duplication exploit
code: removes a redundant list copy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
