### PR TITLE
Kilo Quick Fix #1

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6300,7 +6300,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/engine/atmos)
 "akt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{


### PR DESCRIPTION
## About The Pull Request

Fixes a missing floortile under an airlock in atmospherics

## Why It's Good For The Game

whoops
## Testing Photographs and Procedure
<details>
</details>

## Changelog
:cl:dog132
fix: fixed missing floortile in kilo station atmos airlock
/:cl: