### PR TITLE
Fixes ai Cntrl click on atmos machinary and some qol changes

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -15,7 +15,7 @@
 
 	if(ismob(A))
 		ai_actual_track(A)
-	else
+	else if(isturf(A))	//Getting the camera moved just because you double click on something to interact with it is annoying as hell
 		A.move_camera_by_click()
 
 /mob/living/silicon/ai/ClickOn(var/atom/A, params)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -203,6 +203,7 @@
 		return
 	hangup_all_calls()
 	add_hiddenprint(usr)
+
 /* Atmos machines */
 /obj/machinery/atmospherics/components/AICtrlClick(mob/living/silicon/ai/user)
 	if(!allowed(user))

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -204,6 +204,11 @@
 	hangup_all_calls()
 	add_hiddenprint(usr)
 
+/obj/machinery/atmospherics/components/AICtrlClick(mob/living/silicon/ai/user)
+	if(!allowed(user))
+		return
+	CtrlClick(user)
+
 //
 // Override TurfAdjacent for AltClicking
 //

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -203,7 +203,7 @@
 		return
 	hangup_all_calls()
 	add_hiddenprint(usr)
-
+/* Atmos machines */
 /obj/machinery/atmospherics/components/AICtrlClick(mob/living/silicon/ai/user)
 	if(!allowed(user))
 		return

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -15,7 +15,7 @@
 
 	if(ismob(A))
 		ai_actual_track(A)
-	else if(isturf(A))	//Getting the camera moved just because you double click on something to interact with it is annoying as hell
+	else if(!ismachinery(A))	//Getting the camera moved just because you double click on something to interact with it is annoying as hell
 		A.move_camera_by_click()
 
 /mob/living/silicon/ai/ClickOn(var/atom/A, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes / reimplements the ability of ai beeing able to cntrl click onto a pipe/filter etc to turn it on and off.
I say reimplement simply because i cannot find the code change that broke it / did this in the first place.
Also implements another check for ai double click jump so you don't suddenly have your camera jump around while you try to interact with machines.
closes https://github.com/BeeStation/BeeStation-Hornet/issues/6403

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Changelog
:cl:
tweak: adds a check for double clicking for ai so the ai camera won't jump if you click a machine
fix: fixes AI Atmos machines Cntrl click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
