### PR TITLE
Enable new TGUI message types by default

### DIFF
--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -15,9 +15,7 @@ export const createPage = obj => {
   let acceptedTypes = {};
 
   for (let typeDef of MESSAGE_TYPES) {
-    if (typeDef.important) {
-      acceptedTypes[typeDef.type] = true;
-    }
+    acceptedTypes[typeDef.type] = !!typeDef.important;
   }
 
   return {

--- a/tgui/packages/tgui-panel/chat/reducer.js
+++ b/tgui/packages/tgui-panel/chat/reducer.js
@@ -28,6 +28,17 @@ export const chatReducer = (state = initialState, action) => {
     if (payload?.version !== state.version) {
       return state;
     }
+    // Enable any filters that are not explicitly set, that are
+    // enabled by default on the main page.
+    for (let id of Object.keys(payload.pageById)) {
+      const page = payload.pageById[id];
+      const filters = page.acceptedTypes;
+      const defaultFilters = mainPage.acceptedTypes;
+      for (let type of Object.keys(defaultFilters)) {
+        if (filters[type] === undefined)
+          filters[type] = defaultFilters[type];
+      }
+    }
     // Reset page message counts
     // NOTE: We are mutably changing the payload on the assumption
     // that it is a copy that comes straight from the web storage.

--- a/tgui/packages/tgui-panel/chat/reducer.js
+++ b/tgui/packages/tgui-panel/chat/reducer.js
@@ -30,6 +30,7 @@ export const chatReducer = (state = initialState, action) => {
     }
     // Enable any filters that are not explicitly set, that are
     // enabled by default on the main page.
+    // NOTE: This mutates acceptedTypes on the state.
     for (let id of Object.keys(payload.pageById)) {
       const page = payload.pageById[id];
       const filters = page.acceptedTypes;

--- a/tgui/packages/tgui-panel/chat/reducer.js
+++ b/tgui/packages/tgui-panel/chat/reducer.js
@@ -35,8 +35,9 @@ export const chatReducer = (state = initialState, action) => {
       const filters = page.acceptedTypes;
       const defaultFilters = mainPage.acceptedTypes;
       for (let type of Object.keys(defaultFilters)) {
-        if (filters[type] === undefined)
+        if (filters[type] === undefined) {
           filters[type] = defaultFilters[type];
+        }
       }
     }
     // Reset page message counts


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Properly fixes mentor PMs being disabled for some people.

Merged upstream as:
- https://github.com/tgstation/tgstation/pull/65145

Right now, when a message type is disabled by default, it's simply not set. This means information about it is not stored in the configuration. This PR changes that so message types that are disabled by default are explicitly set to `false`.

With this PR: when loading tabs from config, fetch all message types from the page created by `createMainPage()`, and check all tabs to see if any message types in the main page are not set. For any that aren't set, set them to the value they have in the default main page.

As a result:
- New message types will be automatically enabled **on all tabs** for anybody joining after those were added.
  - This includes Mentor PMs for anybody that has been playing since before Mentor PMs got their own filter, and hasn't manually toggled the filter in the settings.
- **All** message types in custom tabs, that were created before this PR, that weren't toggled on and off, will be enabled. This is because there is currently no way to distinguish between message types that were newly added and message types that weren't configured by the user. 
  - This is exacerbated somewhat by the fact that chat settings are shared between different servers. This means anybody who plays on a different server joining BeeStation will have our defaults applied to custom tabs. As far as I know, this is an issue that cannot be solved unless every server updates tguichat to use a widely accepted solution.

Also note, that this is not a destructive or irreversible process in any way. No changes are made to the format of the saved data, only to the defaults of that data and known missing fields in the data. This means we remain entirely compatible with other servers, only causing the one-time issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes the mentor PM filter fiasco once and for all.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->

1. Checkout a commit from before mentor PMs were added.
2. Clear your IE cache.
3. Join the server hosted on that version, verify chat settings were cleared.
4. Checkout a commit after mentor PMs were added.
5. Join the server hosted on that version. Check that the Mentor PMs filter is disabled in the main tab. **Do not click the setting.**
6. Checkout a commit including the changes in this PR.
7. Join the server hosted on that version. Check that the Mentor PMs filter is now enabled.

## Changelog
:cl:
tweak: Newly added chat filters will be enabled by default in all tabs. This will mess up any custom tabs you have created, requiring you to configure the filters again.
code: Newly created tabs have disabled filters set to false rather than omitted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
