### PR TITLE
Supply Manifest Fix

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -43,7 +43,7 @@
 	var/obj/item/paper/P = new(T)
 
 	P.name = "requisition form - #[id] ([pack.name])"
-	P.info += "<h2>[station_name()] Supply Requisition</h2>"
+	P.info += "<h2>[GLOB.station_name] Supply Requisition</h2>"
 	P.info += "<hr/>"
 	P.info += "Order #[id]<br/>"
 	P.info += "Item: [pack.name]<br/>"
@@ -60,7 +60,7 @@
 /datum/supply_order/proc/generateManifest(obj/structure/closet/crate/C, var/owner, var/packname) //generates-the-manifests.
 	var/obj/item/paper/fluff/jobs/cargo/manifest/P = new(C, id, 0)
 
-	var/station_name = (P.errors & MANIFEST_ERROR_NAME) ? new_station_name() : station_name()
+	var/station_name = (P.errors & MANIFEST_ERROR_NAME) ? new_station_name() : GLOB.station_name
 
 	P.name = "shipping manifest - [packname?"#[id] ([pack.name])":"(Grouped Item Crate)"]"
 	P.info += "<h2>[command_name()] Shipping Manifest</h2>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Supply Manifests will now properly have the station name in them, rather than a randomized station name EXCEPT when they are deliberately wrong due to cargo RNG.

The proc that was used seems to always generate a new station name rather than simply using the existing station name.
I don't know why it needed to be a separate proc in the first place.

## Why It's Good For The Game

This is an admittedly very minor fix, but it wasn't working as intended and should probably be fixed.


## Testing Photographs and Procedure

Tested by simply ordering a bunch of crates and checking that the manifests were working correctly.



<summary>Screenshots&Videos</summary>

![ss+(2022-02-24+at+03 38 58)](https://user-images.githubusercontent.com/62958508/155626490-334e7a06-2192-4398-a136-4c85dc0e5ffd.png)






</details>

## Changelog
:cl:
fix: Cargo Manifests will now show the correct station name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
