### PR TITLE
Force String Fix

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -376,6 +376,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			if(51 to INFINITY)
 				. += "[src] is as well weighted as possible for blocking"
 	if(force)
+		if(!force_string)
+			set_force_string()
 		. += "Force: [force_string]"
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Examining objects with a force value will no longer give an empty "Force:" string at the end, but will instead actually set the force_string properly.

## Why It's Good For The Game

This worked as intended for hovering over items, but not for examination.
Random empty strings are pointless and give the players no useful data.
closes #5902 

## Testing Photographs and Procedure
Examine any item with a Force value and one without a Force value.
<details>



<summary>Screenshots&Videos</summary>

![ss+(2022-02-24+at+04 04 25)](https://user-images.githubusercontent.com/62958508/155628544-c2a7ab3d-4f86-40f0-8059-ff04276d9d3f.png)





</details>

## Changelog
:cl:
fix: Examining an object will now show it's Force value properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
