### PR TITLE
Fixes misuse of transform in some animate() calls

### DIFF
--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -21,6 +21,8 @@
 /datum/component/waddling/proc/Waddle()
 	SIGNAL_HANDLER
 
-	animate(parent, pixel_z = 4, time = 0)
-	animate(pixel_z = 0, transform = turn(matrix(), pick(-12, 0, 12)), time=2)
-	animate(pixel_z = 0, transform = matrix(), time = 0)
+	var/rot_degrees = pick(-12, 0, 12)
+	var/mob/living/L = parent
+	animate(L, pixel_z = 4, time = 0)
+	animate(pixel_z = 0, transform = turn(L.transform, rot_degrees), time=2)
+	animate(pixel_z = 0, transform = turn(L.transform, -rot_degrees), time = 0)

--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -22,7 +22,7 @@
 	SIGNAL_HANDLER
 
 	var/rot_degrees = pick(-12, 0, 12)
-	var/atom/A = parent
-	animate(A, pixel_z = 4, time = 0)
-	animate(pixel_z = 0, transform = turn(A.transform, rot_degrees), time=2)
-	animate(pixel_z = 0, transform = turn(A.transform, -rot_degrees), time = 0)
+	var/atom/movable/AM = parent
+	animate(AM, pixel_z = 4, time = 0)
+	animate(pixel_z = 0, transform = turn(AM.transform, rot_degrees), time=2)
+	animate(pixel_z = 0, transform = turn(AM.transform, -rot_degrees), time = 0)

--- a/code/datums/components/waddling.dm
+++ b/code/datums/components/waddling.dm
@@ -22,7 +22,7 @@
 	SIGNAL_HANDLER
 
 	var/rot_degrees = pick(-12, 0, 12)
-	var/mob/living/L = parent
-	animate(L, pixel_z = 4, time = 0)
-	animate(pixel_z = 0, transform = turn(L.transform, rot_degrees), time=2)
-	animate(pixel_z = 0, transform = turn(L.transform, -rot_degrees), time = 0)
+	var/atom/A = parent
+	animate(A, pixel_z = 4, time = 0)
+	animate(pixel_z = 0, transform = turn(A.transform, rot_degrees), time=2)
+	animate(pixel_z = 0, transform = turn(A.transform, -rot_degrees), time = 0)

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -571,9 +571,13 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	. = ..()
 	var/mob/living/carbon/M = A.affected_mob
 	to_chat(M, "<span class='notice'>You lose your balance and stumble as you shrink, and your legs come out from underneath you!</span>")
+	M.resize = 1/sizemult
+	M.update_transform()
+	/*
 	animate(M, pixel_z = 4, time = 0) //size is fixed by having the player do one waddle. Animation for some reason resets size, meaning waddling can desize you
 	animate(pixel_z = 0, transform = turn(matrix(), pick(-12, 0, 12)), time=2) //waddle desizing is an issue, because you can game it to use this symptom and become small
 	animate(pixel_z = 0, transform = matrix(), time = 0) //so, instead, we use waddle desizing to desize you from this symptom, instead of a transformation, because it wont shrink you naturally
+	*/
 
 //they are used for the maintenance spawn, for ling teratoma see changeling\teratoma.dm
 /obj/effect/mob_spawn/teratomamonkey //spawning these is one of the downsides of overclocking the symptom

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -573,11 +573,6 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	to_chat(M, "<span class='notice'>You lose your balance and stumble as you shrink, and your legs come out from underneath you!</span>")
 	M.resize = 1/sizemult
 	M.update_transform()
-	/*
-	animate(M, pixel_z = 4, time = 0) //size is fixed by having the player do one waddle. Animation for some reason resets size, meaning waddling can desize you
-	animate(pixel_z = 0, transform = turn(matrix(), pick(-12, 0, 12)), time=2) //waddle desizing is an issue, because you can game it to use this symptom and become small
-	animate(pixel_z = 0, transform = matrix(), time = 0) //so, instead, we use waddle desizing to desize you from this symptom, instead of a transformation, because it wont shrink you naturally
-	*/
 
 //they are used for the maintenance spawn, for ling teratoma see changeling\teratoma.dm
 /obj/effect/mob_spawn/teratomamonkey //spawning these is one of the downsides of overclocking the symptom

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -351,76 +351,32 @@
 		sleep(20)
 
 /obj/machinery/jukebox/disco/proc/dance3(var/mob/living/M)
-	var/total_x = 0 //To reset after the dance is over
-	var/total_y = 0 //We can't just save the current matrix because its likely other dances are animating as well
-	var/matrix/initial_matrix = matrix(M.transform)
-	var/matrix/new_offsets //uses linear algebra to update the total_x and total_y variables if the dancer's matrix changes between iterations, see dance5 for the equation.
 	for (var/i in 1 to 75)
 		if (!M)
 			return
 		switch(i)
 			if (1 to 15)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(0,1)
-				total_y++
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_y = M.pixel_y + 1, time = 1, loop = 0)
 			if (16 to 30)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(1,-1)
-				total_x++
-				total_y--
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x + 1, pixel_y = M.pixel_y - 1, time = 1, loop = 0)
 			if (31 to 45)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(-1,-1)
-				total_x--
-				total_y--
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x - 1, pixel_y = M.pixel_y - 1, time = 1, loop = 0)
 			if (46 to 60)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(-1,1)
-				total_x--
-				total_y++
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x - 1, pixel_y = M.pixel_y + 1, time = 1, loop = 0)
 			if (61 to 75)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(1,0)
-				total_x++
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x + 1, time = 1, loop = 0)
 		M.setDir(turn(M.dir, 90))
 		switch (M.dir)
 			if (NORTH)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(0,3)
-				total_y += 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_y = M.pixel_y + 3, time = 1, loop = 0)
 			if (SOUTH)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(0,-3)
-				total_y -= 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_y = M.pixel_y - 3, time = 1, loop = 0)
 			if (EAST)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(3,0)
-				total_x += 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x + 3, time = 1, loop = 0)
 			if (WEST)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(-3,0)
-				total_x -= 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x - 3, time = 1, loop = 0)
 		sleep(1)
-		new_offsets = matrix(matrix(initial_matrix, MATRIX_INVERT), M.transform, MATRIX_MULTIPLY)
-		if(new_offsets.Translate(-new_offsets.c,-new_offsets.f) ~= matrix())
-			new_offsets = matrix(matrix(total_x,0,0,total_y,0,0), new_offsets, MATRIX_MULTIPLY)
-			total_x = new_offsets.a
-			total_y = new_offsets.d
-	initial_matrix.Translate(-total_x,-total_y)
-	animate(M, transform = initial_matrix, time = 1, loop = 0)
-
-//A good breakpoint for testing
-/proc/NOP()
-	return
+	animate(M, pixel_x = M.get_standard_pixel_x_offset(), pixel_y = M.get_standard_pixel_y_offset(), time = 1, loop = 0)
 
 /obj/machinery/jukebox/disco/proc/dance4(var/mob/living/M)
 	var/speed = rand(1,3)
@@ -435,61 +391,26 @@
 		 time--
 
 /obj/machinery/jukebox/disco/proc/dance5(var/mob/living/M)
-	var/total_x = 0 //See dance3
-	var/total_y = 0
-	animate(M, transform = matrix(M.transform, 180, MATRIX_ROTATE), time = 1, loop = 0)
-	var/matrix/initial_matrix = matrix(M.transform)
-	var/matrix/new_offsets //[new_total_x; new_total_y; junk] = M.transform * inital_matrix^-1 * [total_x; total_y; 0]		see dance3 for explaination
+	animate(M, transform = matrix(M.transform).Scale(-1), time = 1, loop = 0)
 	for (var/i in 1 to 60)
 		if (!M)
 			return
 		if (i<31)
-			initial_matrix = matrix(M.transform)
-			initial_matrix.Translate(0,1)
-			total_y++
-			animate(M, transform = initial_matrix, time = 1, loop = 0)
+			animate(M, pixel_y = M.pixel_y + 1, time = 1, loop = 0)
 		if (i>30)
-			initial_matrix = matrix(M.transform)
-			initial_matrix.Translate(0,-1)
-			total_y--
-			animate(M, transform = initial_matrix, time = 1, loop = 0)
+			animate(M, pixel_y = M.pixel_y - 1, time = 1, loop = 0)
 		M.setDir(turn(M.dir, 90))
 		switch (M.dir)
 			if (NORTH)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(0,3)
-				total_y += 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_y = M.pixel_y + 3, time = 1, loop = 0)
 			if (SOUTH)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(0,-3)
-				total_y -= 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_y = M.pixel_y - 3, time = 1, loop = 0)
 			if (EAST)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(3,0)
-				total_x += 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x + 3, time = 1, loop = 0)
 			if (WEST)
-				initial_matrix = matrix(M.transform)
-				initial_matrix.Translate(-3,0)
-				total_x -= 3
-				animate(M, transform = initial_matrix, time = 1, loop = 0)
+				animate(M, pixel_x = M.pixel_x - 3, time = 1, loop = 0)
 		sleep(1)
-		new_offsets = matrix(matrix(initial_matrix, MATRIX_INVERT), M.transform, MATRIX_MULTIPLY)
-		if(new_offsets.Translate(-new_offsets.c,-new_offsets.f) ~= matrix())
-			new_offsets = matrix(matrix(total_x,0,0,total_y,0,0), new_offsets, MATRIX_MULTIPLY)
-			total_x = new_offsets.a
-			total_y = new_offsets.d
-	initial_matrix.Translate(-total_x,-total_y)
-	initial_matrix = matrix(initial_matrix, 180, MATRIX_ROTATE)
-	animate(M, transform = initial_matrix, time = 1, loop = 0) //dance end
-
-/* THIS IS VERY BAD, NO NOT DO THIS
-/mob/living/proc/lying_fix()
-	animate(src, transform = null, time = 1, loop = 0)
-	lying_prev = 0
-*/
+	animate(M, transform = matrix(M.transform).Scale(-1), pixel_x = M.get_standard_pixel_x_offset(), pixel_y = M.get_standard_pixel_y_offset(), time = 1, loop = 0) //dance end
 
 /obj/machinery/jukebox/proc/dance_over()
 	for(var/mob/living/L in rangers)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request reworks some animate calls to not hardset the transform of mobs to the identity matrix, potentially causing bugs with other objects that affect the transform such as gigantism/dwarfsim genes, growth serum, being buckled to a bed, etc.

The 3 things that were reworked are the waddle component, pituitary disruption virus symptom (which used waddling previously), and the dance machine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While messing with transforms in weird ways can be fun, rotating your character or getting extremely big or small, the potential for this bug to be game breaking in combat is too great, especially for becoming extremely small. Size changes should be balanced.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>Pituitary Disruption and Waddling</summary>



https://user-images.githubusercontent.com/51838176/155658299-4719b6ce-d194-43e4-80ca-f52a251cd654.mp4


</details>

<details>
<summary>Dance Machine</summary>

https://user-images.githubusercontent.com/51838176/155658711-59e0c8c5-ba40-4e3a-bf57-c8f80ae71b32.mp4

(Music is only for testing and is not included in the PR)

</details>

## Changelog
:cl:
fix: Waddling, pituitary disruption, and the dance machine now properly reset transforms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
