### PR TITLE
Prioritized Job Note On Late join Screen

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -382,6 +382,8 @@
 
 /mob/dead/new_player/proc/LateChoices()
 	var/list/dat = list("<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]</div>")
+	if(SSjob.prioritized_jobs.len > 0)
+		dat+="<div class='priority' style='text-align:center'>Jobs in Green have been prioritized by the Head of Personnel.<br>Please consider joining the game as that role.</div>"
 	if(SSshuttle.emergency)
 		switch(SSshuttle.emergency.mode)
 			if(SHUTTLE_ESCAPE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After seeing multiple new people asking "Why are these jobs green?", I pulled on some coding socks, and added a label to the latejoin screen, encouraging players to consider playing as the prioritized job.

## Why It's Good For The Game

Reduces people asking mentors why these jobs are green when it's a feature of the game and should be explained in game.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/100493881/155865609-550e1a5a-1120-485d-a6d9-e9f0976b7f4c.png)

![image](https://user-images.githubusercontent.com/100493881/155865615-ac5c3ffd-2409-4ea6-a0d1-7fbd00c6b4b8.png)

![image](https://user-images.githubusercontent.com/100493881/155865617-f441384a-776e-4d4c-a784-bebb5929c32d.png)

<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/100493881/155865617-f441384a-776e-4d4c-a784-bebb5929c32d.png)

</details>

## Changelog
:cl:
add: Adds a label to the latejoin screen explaining prioritized jobs
/:cl:
