### PR TITLE
Fixes reflectors not rotating on shuttle move

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -44,14 +44,18 @@
 			else
 				. += "<span class='notice'>Use screwdriver to unlock the rotation.</span>"
 
-/obj/structure/reflector/proc/setAngle(new_angle)
-	if(can_rotate)
+/obj/structure/reflector/proc/setAngle(new_angle, force_rotate = FALSE)
+	if(can_rotate || force_rotate)
 		rotation_angle = new_angle
 		if(deflector_overlay)
 			cut_overlay(deflector_overlay)
 			deflector_overlay.transform = turn(matrix(), new_angle)
 			add_overlay(deflector_overlay)
 
+/obj/structure/reflector/shuttleRotate(rotation, params=ROTATE_DIR|ROTATE_SMOOTH|ROTATE_OFFSET)
+	. = ..()
+	if(params & ROTATE_DIR)
+		setAngle(rotation_angle + rotation, TRUE)
 
 /obj/structure/reflector/setDir(new_dir)
 	return ..(NORTH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes the reflector rotate with shuttles, that's it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Making machines more consistent with shuttle game mechanics is good. Lets players make more complicated systems on their shuttles without fearing it will break when they take off.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>



<summary>testing</summary>


https://user-images.githubusercontent.com/51838176/155906258-cc7eea1e-71b8-4415-a1dc-d1a821ccb78c.mp4




</details>

## Changelog
:cl:
fix: Reflectors now rotate on shuttles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
