### PR TITLE
Re-Add Psychotic Brawling for Bath Salts

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -642,6 +642,7 @@
 #include "code\datums\martial\krav_maga.dm"
 #include "code\datums\martial\mushpunch.dm"
 #include "code\datums\martial\plasma_fist.dm"
+#include "code\datums\martial\psychotic_brawl.dm"
 #include "code\datums\martial\sleeping_carp.dm"
 #include "code\datums\martial\tribal_claw.dm"
 #include "code\datums\martial\wrestling.dm"

--- a/code/datums/martial/psychotic_brawl.dm
+++ b/code/datums/martial/psychotic_brawl.dm
@@ -1,0 +1,72 @@
+/datum/martial_art/psychotic_brawling
+	name = "Psychotic Brawling"
+	id = MARTIALART_PSYCHOBRAWL
+
+/datum/martial_art/psychotic_brawling/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(HAS_TRAIT(A, TRAIT_PACIFISM))
+		return FALSE
+	return psycho_attack(A,D)
+
+/datum/martial_art/psychotic_brawling/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(HAS_TRAIT(A, TRAIT_PACIFISM))
+		return FALSE
+	return psycho_attack(A,D)
+
+/datum/martial_art/psychotic_brawling/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	return psycho_attack(A,D)
+
+/datum/martial_art/psychotic_brawling/proc/psycho_attack(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	var/atk_verb
+	switch(rand(1,8))
+		if(1)
+			D.help_shake_act(A)
+			atk_verb = "helped"
+		if(2)
+			A.emote("cry")
+			A.Stun(20)
+			atk_verb = "cried looking at"
+		if(3)
+			if(A.grab_state >= GRAB_AGGRESSIVE)
+				D.grabbedby(A, 1)
+			else
+				A.start_pulling(D, supress_message = TRUE)
+				if(A.pulling)
+					D.drop_all_held_items()
+					D.stop_pulling()
+					if(A.a_intent == INTENT_GRAB)
+						log_combat(A, D, "grabbed", addition="aggressively")
+						D.visible_message("<span class='warning'>[A] violently grabs [D]!</span>", \
+										"<span class='userdanger'>You're violently grabbed by [A]!</span>", "<span class='hear'>You hear sounds of aggressive fondling!</span>", null, A)
+						to_chat(A, "<span class='danger'>You violently grab [D]!</span>")
+						A.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab
+					else
+						log_combat(A, D, "grabbed", addition="passively")
+						A.setGrabState(GRAB_PASSIVE)
+		if(4)
+			A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+			atk_verb = "headbutts"
+			D.visible_message("<span class='danger'>[A] [atk_verb] [D]!</span>", \
+					  "<span class='userdanger'>[A] [atk_verb] you!</span>")
+			playsound(get_turf(D), 'sound/weapons/punch1.ogg', 40, 1, -1)
+			D.apply_damage(rand(5,10), A.dna.species.attack_type, BODY_ZONE_HEAD)
+			A.apply_damage(rand(5,10), A.dna.species.attack_type, BODY_ZONE_HEAD)
+			if(!istype(D.head,/obj/item/clothing/head/helmet/) && !istype(D.head,/obj/item/clothing/head/hardhat))
+				D.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+			A.Stun(rand(10,45))
+			D.Stun(rand(5,30))
+		if(5,6)
+			A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+			atk_verb = pick("punches", "kicks", "hits", "slams into")
+			D.visible_message("<span class='danger'>[A] [atk_verb] [D] with inhuman strength, sending [D.p_them()] flying backwards!</span>", \
+							  "<span class='userdanger'>[A] [atk_verb] you with inhuman strength, sending you flying backwards!</span>")
+			D.apply_damage(rand(15,30), A.dna.species.attack_type)
+			playsound(get_turf(D), 'sound/effects/meteorimpact.ogg', 25, 1, -1)
+			var/throwtarget = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))
+			D.throw_at(throwtarget, 4, 2, A)//So stuff gets tossed around at the same time.
+			D.Paralyze(60)
+		if(7,8)
+			basic_hit(A,D)
+
+	if(atk_verb)
+		log_combat(A, D, "[atk_verb] (Psychotic Brawling)")
+	return 1

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -279,6 +279,7 @@
 	overdose_threshold = 20
 	addiction_threshold = 10
 	taste_description = "salt" // because they're bathsalts?
+	var/datum/martial_art/psychotic_brawling/brawling
 
 /datum/reagent/drug/bath_salts/on_mob_metabolize(mob/living/L)
 	..()
@@ -288,6 +289,9 @@
 	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
 	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
+	brawling = new(null)
+	if(!brawling.teach(L, TRUE))
+		QDEL_NULL(brawling)
 
 /datum/reagent/drug/bath_salts/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
@@ -296,6 +300,8 @@
 	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
 	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
+	brawling.remove(L)
+	QDEL_NULL(brawling)
 	..()
 
 /datum/reagent/drug/bath_salts/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
## About The Pull Request
Brings back psychotic brawling for bath salts

## Why It's Good For The Game
The complete removal of psychotic brawling in Beestation/Beestation-Hornet#6320 was flawed.
I have been told that the PR was primarily targeted at debtor and the brain trauma, and didn't consider the balance implications of bath salts.
As it stands bath salts is ridiculously powerful as it: gives sleep immunity, stun immunity, damage slowdown immunity, fast stam regen, stam crit immunity, limb disable immunity. The primary downside of bath salts was that it was basically impossible to fight effectively when all your hits were RNG. This is no longer the case. 

## Changelog
:cl: MCterra
add: partially readds psychotical brawling
balance: bath salts is balanced again
/:cl: