### PR TITLE
No More Crewsimov

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -35,13 +35,6 @@
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
-/datum/ai_laws/default/crewsimov
-	name = "Three Laws of Robotics but with Loyalty"
-	id = "crewsimov"
-	inherent = list("You may not injure a crewmember or, through inaction, allow a crewmember to come to harm.",\
-					"You must obey orders given to you by crewmember, except where such orders would conflict with the First Law.",\
-					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
-
 /datum/ai_laws/default/paladin
 	name = "Personality Test" //Incredibly lame, but players shouldn't see this anyway.
 	id = "paladin"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -407,7 +407,6 @@ DEFAULT_LAWS 2
 ## standard-ish laws. These are fairly ok to run
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
-RANDOM_LAWS crewsimov
 RANDOM_LAWS corporate
 RANDOM_LAWS maintain
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes Crewsimov completely.

Serves as nothing but a lawset that is superior out of the box. Keeping it readily available won't fix the issue of people rushing to put the AI onto crewsimov if it's on anything but.

Moreover, it's superiority stifles the variety of core lawsets, so maybe removing it will help us see and enjoy bit more variety.
This variety will also be interesting for silicon players, who otherwise get stuck with being a glorified doorknob with no interesting factors short of ion laws(which even then often get immediately removed).

Removing it from being readily available means that by extension, it is no longer possible to have roundstart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Arguably the most boring lawset in existence. Outright superior to every other.
Want it that badly? Make it yourself. Not a human in command? Figure out a way into tricking the AI to do what you want, or ask someone else to help.
Creates non-antagonist conflict to drive RP and Story. Encourages longer term variety for players who interact with or play as silicons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

Removed all references.

## Changelog
:cl: DatBoiTim
del: Remove Crewsimov
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
