### PR TITLE
small blob spore fix

### DIFF
--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -111,7 +111,7 @@
 	var/is_zombie = FALSE
 	var/list/disease = list()
 	flavor_text = FLAVOR_TEXT_GOAL_ANTAG
-	var/in_movement //only for rally command so blob spores will stop chasing after that one guy and get to the rally point
+	var/in_movement //keeps track of the proccals of goto so we know when the blob is moving
 
 /mob/living/simple_animal/hostile/blob/blobspore/Initialize(mapload, var/obj/structure/blob/factory/linked_node)
 	if(istype(linked_node))

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -111,7 +111,7 @@
 	var/is_zombie = FALSE
 	var/list/disease = list()
 	flavor_text = FLAVOR_TEXT_GOAL_ANTAG
-	var/in_movement //keeps track of the proccals of goto so we know when the blob is moving
+	var/movement_proc_query //keeps track of the proccals of goto so we what proc got called last
 
 /mob/living/simple_animal/hostile/blob/blobspore/Initialize(mapload, var/obj/structure/blob/factory/linked_node)
 	if(istype(linked_node))
@@ -211,11 +211,15 @@
 		color = initial(color)//looks better.
 		add_overlay(blob_head_overlay)
 
-/mob/living/simple_animal/hostile/blob/blobspore/Goto(target, delay, minimum_distance, current_tries)
+/mob/living/simple_animal/hostile/blob/blobspore/Goto(target, delay, minimum_distance, current_tries, p_proc_id)
 	set waitfor = FALSE
 	var/movement_steps = 0
-	in_movement++
-	var/in_movement_current = in_movement //so we remember the position of the proccall
+	var/query_position
+	if(p_proc_id) //incase we get another additional proccal just before a old proc returns to call itself again so we do not loose track of the position in the query
+		query_position = p_proc_id //when this proc gets called by another instance of it forward the old place in the line so we can keep track of it
+	else
+		movement_proc_query++
+		query_position = movement_proc_query //so we remember the position of the proccall
 	if(target == src.target)
 		approaching_target = TRUE
 	else
@@ -225,7 +229,7 @@
 	if(length(path_list)) //appearantly the solution of using ? infront of the index only works for assoc lists
 		goal_turf = path_list[path_list.len]
 	for(var/w in path_list)
-		if(in_movement > in_movement_current) //incase the spore is already chasing something but something else calls the proc again
+		if(movement_proc_query > query_position) //incase the spore is already chasing something but something else calls the proc again
 			return
 		movement_steps++
 		if(ismob(target) && w == goal_turf) //if we are infront of the mob lets not keep on pushing
@@ -236,12 +240,12 @@
 			if(current_tries >= 20)	//In case we get catched in a endless loop for reasons
 				break
 			else
-				return Goto(target, delay, minimum_distance, current_tries + 1)
+				return Goto(target, delay, current_tries = (current_tries + 1), p_proc_id = query_position)
 		if(ismob(target) && !(get_turf(target) == goal_turf)) //Incase the target mob decides to move so we don't just run towards it's original location
 			if(get_dist(path_list[1], get_turf(target)) >= 20)
 				break
 			else
-				return Goto(target, delay, minimum_distance)
+				return Goto(target, delay, p_proc_id = query_position)
 
 	if(!movement_steps) //pathfinding fallback in case we cannot find a valid path at the first attempt
 		var/ln = get_dist(src, target)
@@ -263,7 +267,7 @@
 						break find_target
 			found_blocker = FALSE
 			for(var/w in get_path_to(src, target_new))
-				if(in_movement > in_movement_current)
+				if(movement_proc_query > query_position)
 					return
 				movement_steps++
 				sleep(delay)
@@ -272,8 +276,8 @@
 					if(current_tries >= 20)
 						break
 					else
-						return Goto(target, delay, (current_tries + 1))
-	in_movement = 0 // We only null this if its an actual death end not if the proc gets canceled by another proc call of the same proc
+						return Goto(target, delay, current_tries = (current_tries + 1), p_proc_id = query_position)
+	movement_proc_query = 0 // We only null this if its an actual death end not if the proc gets canceled by another proc call of the same proc
 
 /mob/living/simple_animal/hostile/blob/blobspore/weak
 	name = "fragile blob spore"

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -211,12 +211,11 @@
 		color = initial(color)//looks better.
 		add_overlay(blob_head_overlay)
 
-/mob/living/simple_animal/hostile/blob/blobspore/Goto(target, delay, minimum_distance, rally, current_tries)
+/mob/living/simple_animal/hostile/blob/blobspore/Goto(target, delay, minimum_distance, current_tries)
 	set waitfor = FALSE
 	var/movement_steps = 0
 	in_movement++
 	var/in_movement_current = in_movement //so we remember the position of the proccall
-
 	if(target == src.target)
 		approaching_target = TRUE
 	else
@@ -237,12 +236,12 @@
 			if(current_tries >= 20)	//In case we get catched in a endless loop for reasons
 				break
 			else
-				return Goto(target, delay, minimum_distance, rally, current_tries + 1)
+				return Goto(target, delay, minimum_distance, current_tries + 1)
 		if(ismob(target) && !(get_turf(target) == goal_turf)) //Incase the target mob decides to move so we don't just run towards it's original location
 			if(get_dist(path_list[1], get_turf(target)) >= 20)
 				break
 			else
-				return Goto(target, delay, minimum_distance, rally)
+				return Goto(target, delay, minimum_distance)
 
 	if(!movement_steps) //pathfinding fallback in case we cannot find a valid path at the first attempt
 		var/ln = get_dist(src, target)
@@ -273,7 +272,7 @@
 					if(current_tries >= 20)
 						break
 					else
-						return Goto(target, delay, rally, (current_tries + 1))
+						return Goto(target, delay, (current_tries + 1))
 	in_movement = 0 // We only null this if its an actual death end not if the proc gets canceled by another proc call of the same proc
 
 /mob/living/simple_animal/hostile/blob/blobspore/weak

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -111,7 +111,7 @@
 	var/is_zombie = FALSE
 	var/list/disease = list()
 	flavor_text = FLAVOR_TEXT_GOAL_ANTAG
-	var/movement_proc_query //keeps track of the proccals of goto so we what proc got called last
+	var/movement_proc_query //keeps track of the proccals of goto so we know what proc instance got called last
 
 /mob/living/simple_animal/hostile/blob/blobspore/Initialize(mapload, var/obj/structure/blob/factory/linked_node)
 	if(istype(linked_node))

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -324,7 +324,6 @@
 		if(!BS.key && isturf(BS.loc) && get_dist(BS, T) <= 35)
 			BS.LoseTarget()
 			BS.Goto(pick(surrounding_turfs), BS.move_to_delay)
-			INVOKE_ASYNC(BS, /mob/living/simple_animal/hostile/proc/Goto, pick(surrounding_turfs), BS.move_to_delay, 0, TRUE)
 
 /mob/camera/blob/verb/blob_broadcast()
 	set category = "Blob"

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -323,6 +323,7 @@
 	for(var/mob/living/simple_animal/hostile/blob/blobspore/BS in blob_mobs)
 		if(!BS.key && isturf(BS.loc) && get_dist(BS, T) <= 35)
 			BS.LoseTarget()
+			BS.Goto(pick(surrounding_turfs), BS.move_to_delay)
 			INVOKE_ASYNC(BS, /mob/living/simple_animal/hostile/proc/Goto, pick(surrounding_turfs), BS.move_to_delay, 0, TRUE)
 
 /mob/camera/blob/verb/blob_broadcast()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes some issues i discovered that are connected to the way i changed their pathing or more the fact that they now have a completly new movement proc.
The issue here is that goto doesn't return immidiatly so it prevents the proc above to continue that can have some pretty problematic consiquences like the blob spore suddenly hitting someone 6-8 times in rapid succession before resuming a normal attack pattern.
Also rally won't be prefered anymore instead any new proccal of goto on the same mob will now end the proc so only the new ones can run.
## Why It's Good For The Game

fix

## Changelog
:cl:
fix: blob spores hitting multiple times rapidly after a long chase
tweak: any new proccal of goto on spores will end the previous instances
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
