### PR TITLE
Fixes a double qdel in twohanded.

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -306,7 +306,8 @@
 	// Remove the object in the offhand
 	if(offhand_item)
 		UnregisterSignal(offhand_item, COMSIG_ITEM_DROPPED)
-		qdel(offhand_item)
+		if(!QDELETED(offhand_item))
+			qdel(offhand_item)
 	// Clear any old refrence to an item that should be gone now
 	offhand_item = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the potential for qdel() being called on an already qdeleted object caused by dropping a twohanded item which calls destroy() on drop and destroy() from a signal.

## Why It's Good For The Game

Prevents a minor runtime issue.

## Testing Photographs and Procedure

## Changelog
:cl:
fix: Fixes a double qdel if two handed items are dropped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
