### PR TITLE
Simplifies the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,29 +8,14 @@
 ## Why It's Good For The Game
 
 <!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
-closes #123456789
 -->
 
 ## Testing Photographs and Procedure
-<!--
-Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
-Ideally testing should cover:
-Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
-Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
-Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
-Pulls from Upstream are generally exempt from this.
--->
+<!-- Include any screenshots/videos of the modified code functioning successfully ideally including edge cases. -->
 <details>
-
-
-
 <summary>Screenshots&Videos</summary>
 
-
-
 Put screenshots and Videos documenting testing and execution of intended behaviors here
-
 
 </details>
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 -->
 
 ## Testing Photographs and Procedure
-<!-- Include any screenshots/videos of the modified code functioning successfully ideally including edge cases. -->
+<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
 <details>
 <summary>Screenshots&Videos</summary>
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 <details>
 <summary>Screenshots&Videos</summary>
 
-Put screenshots and Videos documenting testing and execution of intended behaviors here
+Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
 
 </details>
 


### PR DESCRIPTION
Simplifies the PR template, removing a lot of blank space in the details section and simplifying an unnecessarilly long comment in the testing photographs section that makes it too long to read, too long to be useful and too long to be easilly deleted.
Removes the part stating to add closing tags in the 'why its good for the game' section since they are placed at the top of the PR rather than in the good for the game section.

'Include any screenshots/videos of the modified code functioning successfully ideally including edge cases.' says everything that needs to be said without too much bloat.

New details section (looks the same):
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and Videos documenting testing and execution of intended behaviors here

</details>

## Changelog
:cl:
code: Simplifies the PR template.
/:cl:
