### PR TITLE
Change brig timer to use real time instead of server time

### DIFF
--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -78,7 +78,7 @@
 		return
 
 	if(timing)
-		if(world.timeofday - activation_time >= timer_duration)
+		if(world.REALTIMEOFDAY - activation_time >= timer_duration)
 			timer_end() // open doors, reset timer, clear status screen
 		update_icon()
 
@@ -93,7 +93,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return 0
 
-	activation_time = world.timeofday
+	activation_time = world.REALTIMEOFDAY
 	timing = TRUE
 
 	for(var/datum/weakref/door_ref as anything in doors)
@@ -159,7 +159,7 @@
 
 
 /obj/machinery/door_timer/proc/time_left(seconds = FALSE)
-	. = max(0,timer_duration - (activation_time ? world.timeofday - activation_time : 0))
+	. = max(0,timer_duration - (activation_time ? world.REALTIMEOFDAY - activation_time : 0))
 	if(seconds)
 		. /= 10
 
@@ -293,7 +293,7 @@
 			investigate_log("[key_name(usr)] set cell [id]'s timer to [preset_time/10] seconds", INVESTIGATE_RECORDS)
 			user.log_message("set cell [id]'s timer to [preset_time/10] seconds", LOG_ATTACK)
 			if(timing)
-				activation_time = world.timeofday
+				activation_time = world.REALTIMEOFDAY
 		else
 			. = FALSE
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -78,7 +78,7 @@
 		return
 
 	if(timing)
-		if(world.REALTIMEOFDAY - activation_time >= timer_duration)
+		if(maths.REALTIMEOFDAY - activation_time >= timer_duration)
 			timer_end() // open doors, reset timer, clear status screen
 		update_icon()
 
@@ -93,7 +93,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return 0
 
-	activation_time = world.REALTIMEOFDAY
+	activation_time = maths..REALTIMEOFDAY
 	timing = TRUE
 
 	for(var/datum/weakref/door_ref as anything in doors)
@@ -159,7 +159,7 @@
 
 
 /obj/machinery/door_timer/proc/time_left(seconds = FALSE)
-	. = max(0,timer_duration - (activation_time ? world.REALTIMEOFDAY - activation_time : 0))
+	. = max(0,timer_duration - (activation_time ? maths.REALTIMEOFDAY - activation_time : 0))
 	if(seconds)
 		. /= 10
 
@@ -293,7 +293,7 @@
 			investigate_log("[key_name(usr)] set cell [id]'s timer to [preset_time/10] seconds", INVESTIGATE_RECORDS)
 			user.log_message("set cell [id]'s timer to [preset_time/10] seconds", LOG_ATTACK)
 			if(timing)
-				activation_time = world.REALTIMEOFDAY
+				activation_time = maths.REALTIMEOFDAY
 		else
 			. = FALSE
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -78,7 +78,7 @@
 		return
 
 	if(timing)
-		if(maths.REALTIMEOFDAY - activation_time >= timer_duration)
+		if(REALTIMEOFDAY - activation_time >= timer_duration)
 			timer_end() // open doors, reset timer, clear status screen
 		update_icon()
 
@@ -93,7 +93,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return 0
 
-	activation_time = maths..REALTIMEOFDAY
+	activation_time = REALTIMEOFDAY
 	timing = TRUE
 
 	for(var/datum/weakref/door_ref as anything in doors)
@@ -159,7 +159,7 @@
 
 
 /obj/machinery/door_timer/proc/time_left(seconds = FALSE)
-	. = max(0,timer_duration - (activation_time ? maths.REALTIMEOFDAY - activation_time : 0))
+	. = max(0,timer_duration - (activation_time ? REALTIMEOFDAY - activation_time : 0))
 	if(seconds)
 		. /= 10
 
@@ -293,7 +293,7 @@
 			investigate_log("[key_name(usr)] set cell [id]'s timer to [preset_time/10] seconds", INVESTIGATE_RECORDS)
 			user.log_message("set cell [id]'s timer to [preset_time/10] seconds", LOG_ATTACK)
 			if(timing)
-				activation_time = maths.REALTIMEOFDAY
+				activation_time = REALTIMEOFDAY
 		else
 			. = FALSE
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -78,7 +78,7 @@
 		return
 
 	if(timing)
-		if(world.time - activation_time >= timer_duration)
+		if(world.timeofday - activation_time >= timer_duration)
 			timer_end() // open doors, reset timer, clear status screen
 		update_icon()
 
@@ -93,7 +93,7 @@
 	if(stat & (NOPOWER|BROKEN))
 		return 0
 
-	activation_time = world.time
+	activation_time = world.timeofday
 	timing = TRUE
 
 	for(var/datum/weakref/door_ref as anything in doors)
@@ -159,7 +159,7 @@
 
 
 /obj/machinery/door_timer/proc/time_left(seconds = FALSE)
-	. = max(0,timer_duration - (activation_time ? world.time - activation_time : 0))
+	. = max(0,timer_duration - (activation_time ? world.timeofday - activation_time : 0))
 	if(seconds)
 		. /= 10
 
@@ -293,7 +293,7 @@
 			investigate_log("[key_name(usr)] set cell [id]'s timer to [preset_time/10] seconds", INVESTIGATE_RECORDS)
 			user.log_message("set cell [id]'s timer to [preset_time/10] seconds", LOG_ATTACK)
 			if(timing)
-				activation_time = world.time
+				activation_time = world.timeofday
 		else
 			. = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Closes #6107 Changes brig timer so that the time entered is counted in real world minutes. This effectively makes it ignore time dilation, so server lag will no longer extend your time in the brig.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This pr is arguably beneficial, but I just write the code, I'll let the maintainers decide on whether or not it's good for the game. Best case scenario it has no effect or cuts down on some annoyance, worst case an antag is let out before their mess has been cleaned up.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
refactor: Brig timers are more accurate and no longer lengthened by lag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
