### PR TITLE
Converts ai tracking towards using signals

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -14,7 +14,7 @@
 		return
 
 	if(ismob(A))
-		ai_tracking_setup(A)
+		ai_start_tracking(A)
 	else if(!ismachinery(A))	//Getting the camera moved just because you double click on something to interact with it is annoying as hell
 		eyeobj.move_camera_by_click(A)
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -14,7 +14,7 @@
 		return
 
 	if(ismob(A))
-		ai_actual_track(A)
+		ai_tracking_setup(A)
 	else if(!ismachinery(A))	//Getting the camera moved just because you double click on something to interact with it is annoying as hell
 		A.move_camera_by_click()
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -16,7 +16,7 @@
 	if(ismob(A))
 		ai_tracking_setup(A)
 	else if(!ismachinery(A))	//Getting the camera moved just because you double click on something to interact with it is annoying as hell
-		A.move_camera_by_click()
+		eyeobj.move_camera_by_click(A)
 
 /mob/living/silicon/ai/ClickOn(var/atom/A, params)
 	if(world.time <= next_click)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -79,7 +79,7 @@
 	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/ai_stop_tracking)
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/ai_actual_track)
 	ai_tracking_target = target
-	eyeobj.setLoc(get_turf(target)) //on the first call of this we obviously need to jump to the target ourselfs else we will go there only after they moved once
+	eyeobj.setLoc(get_turf(target)) //on the first call of this we obviously need to jump to the target ourselfs else we would go there only after they moved once
 	to_chat(src, "<span class='notice'>Now tracking [target.get_visible_name()] on camera.</span>")
 
 /mob/living/silicon/ai/proc/ai_stop_tracking(var/reacquire_failed = FALSE) //stops ai tracking

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -68,57 +68,46 @@
 		trackable_mobs()
 
 	var/datum/weakref/target = (isnull(track.humans[target_name]) ? track.others[target_name] : track.humans[target_name])
+	ai_tracking_setup(target.resolve())
 
-	ai_actual_track(target.resolve())
-
-/mob/living/silicon/ai/proc/ai_actual_track(mob/living/target)
-	if(!istype(target))
+/mob/living/silicon/ai/proc/ai_tracking_setup(mob/living/target) //sets up ai tracking signals
+	if(!target || !target.can_track(src))
+		to_chat(src, "<span class='warning'>Target is not near any active cameras.</span>")
 		return
-	var/mob/living/silicon/ai/U = usr
+	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/ai_stop_tracking)
+	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/ai_actual_track)
+	ai_tracking_target = target
+	eyeobj.setLoc(get_turf(target)) //on the first call of this we obviously need to jump to the target ourselfs else we will go there only after they moved once
+	to_chat(src, "<span class='notice'>Now tracking [target.get_visible_name()] on camera.</span>")
 
-	U.cameraFollow = target
-	U.tracking = 1
+/mob/living/silicon/ai/proc/ai_stop_tracking(var/reacquire_failed = FALSE) //stops ai tracking
+	SIGNAL_HANDLER //this can technically be called by a signal too if the target gets qdeleted
+	UnregisterSignal(ai_tracking_target, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(ai_tracking_target, COMSIG_MOVABLE_MOVED)
+	ai_tracking_target = null
+	if(reacquire_failed) //checks if the reaquire timer ran out before we could find the target again
+		to_chat(src, "<span class='warning'>Unable to reacquire, cancelling track...</span>")
+		reacquire_timer = null
 
-	if(!target || !target.can_track(usr))
-		to_chat(U, "<span class='warning'>Target is not near any active cameras.</span>")
-		U.cameraFollow = null
-		return
+/mob/living/silicon/ai/proc/ai_actual_track() //proc that gets called by the moved signal of the target
+	SIGNAL_HANDLER
+	if(ai_tracking_target.can_track(src))
+		if(reacquire_timer)
+			deltimer(reacquire_timer)
+			reacquire_timer = null
+	else
+		if(reacquire_timer)
+			return
+		else
+			reacquire_timer = addtimer(CALLBACK(src, .proc/ai_stop_tracking, TRUE), 10 SECONDS, TIMER_STOPPABLE) //A timer for how long to wait before we stop tracking someone after loosing them
+			to_chat(src, "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>")
+			return
 
-	to_chat(U, "<span class='notice'>Now tracking [target.get_visible_name()] on camera.</span>")
-
-	var/cameraticks = 0
-	spawn(0)
-		while(U.cameraFollow == target)
-			if(U.cameraFollow == null)
-				return
-
-			if(!target.can_track(usr))
-				U.tracking = 1
-				if(!cameraticks)
-					to_chat(U, "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>")
-				cameraticks++
-				if(cameraticks > 9)
-					U.cameraFollow = null
-					to_chat(U, "<span class='warning'>Unable to reacquire, cancelling track...</span>")
-					tracking = 0
-					return
-				else
-					sleep(10)
-					continue
-
-			else
-				cameraticks = 0
-				U.tracking = 0
-
-			if(U.eyeobj)
-				U.eyeobj.setLoc(get_turf(target))
-
-			else
-				view_core()
-				U.cameraFollow = null
-				return
-
-			sleep(10)
+	if(eyeobj)
+		eyeobj.setLoc(get_turf(ai_tracking_target))
+	else
+		ai_stop_tracking()
+		view_core()
 
 /proc/near_camera(mob/living/M)
 	if (!isturf(M.loc))

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -109,6 +109,7 @@
 			return
 
 	eyeobj.setLoc(get_turf(ai_tracking_target))
+
 /proc/near_camera(mob/living/M)
 	if (!isturf(M.loc))
 		return FALSE

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -108,7 +108,7 @@
 			to_chat(src, "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>")
 			return
 
-		eyeobj.setLoc(get_turf(ai_tracking_target))
+	eyeobj.setLoc(get_turf(ai_tracking_target))
 /proc/near_camera(mob/living/M)
 	if (!isturf(M.loc))
 		return FALSE

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -68,10 +68,10 @@
 		trackable_mobs()
 
 	var/datum/weakref/target = (isnull(track.humans[target_name]) ? track.others[target_name] : track.humans[target_name])
-	ai_tracking_setup(target.resolve())
+	ai_start_tracking(target.resolve())
 
-/mob/living/silicon/ai/proc/ai_tracking_setup(mob/living/target) //sets up ai tracking signals
-	if(!target || !target.can_track(src))
+/mob/living/silicon/ai/proc/ai_start_tracking(mob/living/target) //starts ai tracking
+	if(!eyeobj || !target || !target.can_track(src))
 		to_chat(src, "<span class='warning'>Target is not near any active cameras.</span>")
 		return
 	if(ai_tracking_target) //if there is already a tracking going when this gets called makes sure the old tracking gets stopped before we register the new signals

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -74,6 +74,8 @@
 	if(!target || !target.can_track(src))
 		to_chat(src, "<span class='warning'>Target is not near any active cameras.</span>")
 		return
+	if(ai_tracking_target) //if there is already a tracking going when this gets called makes sure the old tracking gets stopped before we register the new signals
+		ai_stop_tracking()
 	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/ai_stop_tracking)
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/ai_actual_track)
 	ai_tracking_target = target
@@ -85,9 +87,12 @@
 	UnregisterSignal(ai_tracking_target, COMSIG_PARENT_QDELETING)
 	UnregisterSignal(ai_tracking_target, COMSIG_MOVABLE_MOVED)
 	ai_tracking_target = null
-	if(reacquire_failed) //checks if the reaquire timer ran out before we could find the target again
+	if(reacquire_timer)
+		if(reacquire_failed) //edge case when someone might jump to another camera while the reacquire timer is running
+			to_chat(src, "<span class='warning'>Unable to reacquire, cancelling track...</span>")
+		else
+			deltimer(reacquire_timer)
 		reacquire_timer = null
-		to_chat(src, "<span class='warning'>Unable to reacquire, cancelling track...</span>")
 
 /mob/living/silicon/ai/proc/ai_actual_track() //proc that gets called by the moved signal of the target
 	SIGNAL_HANDLER

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -97,16 +97,14 @@
 /mob/living/silicon/ai/proc/ai_actual_track() //proc that gets called by the moved signal of the target
 	SIGNAL_HANDLER
 	if(ai_tracking_target.can_track(src))
-		if(reacquire_timer)
+		if(reacquire_timer)	//if we can track our target again but there is a timer running delete the timer and null the timer id
 			deltimer(reacquire_timer)
 			reacquire_timer = null
 	else
-		if(reacquire_timer)
-			return
-		else
+		if(!reacquire_timer)
 			reacquire_timer = addtimer(CALLBACK(src, .proc/ai_stop_tracking, TRUE), 10 SECONDS, TIMER_STOPPABLE) //A timer for how long to wait before we stop tracking someone after loosing them
 			to_chat(src, "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>")
-			return
+		return
 
 	eyeobj.setLoc(get_turf(ai_tracking_target))
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -82,7 +82,7 @@
 	eyeobj.setLoc(get_turf(target)) //on the first call of this we obviously need to jump to the target ourselfs else we would go there only after they moved once
 	to_chat(src, "<span class='notice'>Now tracking [target.get_visible_name()] on camera.</span>")
 
-/mob/living/silicon/ai/proc/ai_stop_tracking(var/reacquire_failed = FALSE) //stops ai tracking
+/mob/living/silicon/ai/proc/ai_stop_tracking(atom, force, var/reacquire_failed = FALSE) //stops ai tracking
 	SIGNAL_HANDLER //this can technically be called by a signal too if the target gets qdeleted
 	UnregisterSignal(ai_tracking_target, COMSIG_PARENT_QDELETING)
 	UnregisterSignal(ai_tracking_target, COMSIG_MOVABLE_MOVED)
@@ -102,7 +102,7 @@
 			reacquire_timer = null
 	else
 		if(!reacquire_timer)
-			reacquire_timer = addtimer(CALLBACK(src, .proc/ai_stop_tracking, TRUE), 10 SECONDS, TIMER_STOPPABLE) //A timer for how long to wait before we stop tracking someone after loosing them
+			reacquire_timer = addtimer(CALLBACK(src, .proc/ai_stop_tracking, null, null, TRUE), 10 SECONDS, TIMER_STOPPABLE) //A timer for how long to wait before we stop tracking someone after loosing them
 			to_chat(src, "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>")
 		return
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -76,14 +76,17 @@
 		return
 	if(ai_tracking_target) //if there is already a tracking going when this gets called makes sure the old tracking gets stopped before we register the new signals
 		ai_stop_tracking()
-	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/ai_stop_tracking)
+	RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/tracking_target_qdeleted)
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/ai_actual_track)
 	ai_tracking_target = target
 	eyeobj.setLoc(get_turf(target)) //on the first call of this we obviously need to jump to the target ourselfs else we would go there only after they moved once
 	to_chat(src, "<span class='notice'>Now tracking [target.get_visible_name()] on camera.</span>")
 
-/mob/living/silicon/ai/proc/ai_stop_tracking(atom, force, var/reacquire_failed = FALSE) //stops ai tracking
-	SIGNAL_HANDLER //this can technically be called by a signal too if the target gets qdeleted
+/mob/living/silicon/ai/proc/tracking_target_qdeleted() //we wrap the ai_stop_tracking proc so we don't need to offset the arguments in ai_stop_tracking
+	SIGNAL_HANDLER
+	ai_stop_tracking()
+
+/mob/living/silicon/ai/proc/ai_stop_tracking(var/reacquire_failed = FALSE) //stops ai tracking
 	UnregisterSignal(ai_tracking_target, COMSIG_PARENT_QDELETING)
 	UnregisterSignal(ai_tracking_target, COMSIG_MOVABLE_MOVED)
 	ai_tracking_target = null
@@ -102,7 +105,7 @@
 			reacquire_timer = null
 	else
 		if(!reacquire_timer)
-			reacquire_timer = addtimer(CALLBACK(src, .proc/ai_stop_tracking, null, null, TRUE), 10 SECONDS, TIMER_STOPPABLE) //A timer for how long to wait before we stop tracking someone after loosing them
+			reacquire_timer = addtimer(CALLBACK(src, .proc/ai_stop_tracking, TRUE), 10 SECONDS, TIMER_STOPPABLE) //A timer for how long to wait before we stop tracking someone after loosing them
 			to_chat(src, "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>")
 		return
 

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -71,7 +71,7 @@
 	ai_start_tracking(target.resolve())
 
 /mob/living/silicon/ai/proc/ai_start_tracking(mob/living/target) //starts ai tracking
-	if(!eyeobj || !target || !target.can_track(src))
+	if(!target || !target.can_track(src))
 		to_chat(src, "<span class='warning'>Target is not near any active cameras.</span>")
 		return
 	if(ai_tracking_target) //if there is already a tracking going when this gets called makes sure the old tracking gets stopped before we register the new signals
@@ -108,12 +108,7 @@
 			to_chat(src, "<span class='warning'>Target is not near any active cameras. Attempting to reacquire...</span>")
 			return
 
-	if(eyeobj)
 		eyeobj.setLoc(get_turf(ai_tracking_target))
-	else
-		ai_stop_tracking()
-		view_core()
-
 /proc/near_camera(mob/living/M)
 	if (!isturf(M.loc))
 		return FALSE

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -86,8 +86,8 @@
 	UnregisterSignal(ai_tracking_target, COMSIG_MOVABLE_MOVED)
 	ai_tracking_target = null
 	if(reacquire_failed) //checks if the reaquire timer ran out before we could find the target again
-		to_chat(src, "<span class='warning'>Unable to reacquire, cancelling track...</span>")
 		reacquire_timer = null
+		to_chat(src, "<span class='warning'>Unable to reacquire, cancelling track...</span>")
 
 /mob/living/silicon/ai/proc/ai_actual_track() //proc that gets called by the moved signal of the target
 	SIGNAL_HANDLER

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -128,7 +128,7 @@
 /obj/item/multitool/ai_detect/proc/multitool_detect()
 	var/turf/our_turf = get_turf(src)
 	for(var/mob/living/silicon/ai/AI as anything in GLOB.ai_list)
-		if(AI.cameraFollow == src)
+		if(AI.ai_tracking_target == src)
 			detect_state = PROXIMITY_ON_SCREEN
 			return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -921,9 +921,6 @@
 /mob/living/proc/get_standard_pixel_y_offset(lying = 0)
 	return initial(pixel_y)
 
-/mob/living/cancel_camera()
-	..()
-	cameraFollow = null
 
 /mob/living/proc/can_track(mob/living/user)
 	//basic fast checks go first. When overriding this proc, I recommend calling ..() at the end.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -48,8 +48,6 @@
 
 	var/now_pushing = null //used by living/Bump() and living/PushAM() to prevent potential infinite loop.
 
-	var/cameraFollow = null
-
 	var/tod = null // Time of death
 
 	var/on_fire = 0 //The "Are we on fire?" var

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -467,7 +467,7 @@
 		if(name == string)
 			target += src
 		if(target.len)
-			ai_tracking_setup(pick(target))
+			ai_start_tracking(pick(target))
 		else
 			to_chat(src, "Target is not on or near any active cameras on the station.")
 		return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -44,7 +44,8 @@
 	radiomod = ";" //AIs will, by default, state their laws on the internal radio.
 	var/obj/item/multitool/aiMulti
 	var/mob/living/simple_animal/bot/Bot
-	var/tracking = FALSE //this is 1 if the AI is currently tracking somebody, but the track has not yet been completed.
+	var/mob/living/ai_tracking_target = null //current tracking target
+	var/reacquire_timer = null //saves the timer id for the tracking reacquire so we can delete it/check for its existence
 	var/datum/effect_system/spark_spread/spark_system //So they can initialize sparks whenever/N
 
 	//MALFUNCTION
@@ -401,6 +402,11 @@
 	to_chat(src, "<b>You are now [is_anchored ? "" : "un"]anchored.</b>")
 	// the message in the [] will change depending whether or not the AI is anchored
 
+/mob/living/silicon/ai/cancel_camera()
+	..()
+	if(ai_tracking_target)
+		ai_stop_tracking()
+
 /mob/living/silicon/ai/update_mobility() //If the AI dies, mobs won't go through it anymore
 	if(stat != CONSCIOUS)
 		mobility_flags = NONE
@@ -461,7 +467,7 @@
 		if(name == string)
 			target += src
 		if(target.len)
-			ai_actual_track(pick(target))
+			ai_tracking_setup(pick(target))
 		else
 			to_chat(src, "Target is not on or near any active cameras on the station.")
 		return
@@ -515,8 +521,8 @@
 	if(QDELETED(C))
 		return FALSE
 
-	if(!tracking)
-		cameraFollow = null
+	if(ai_tracking_target)
+		ai_stop_tracking()
 
 	if(QDELETED(eyeobj))
 		view_core()
@@ -659,7 +665,8 @@
 	set category = "AI Commands"
 	set name = "Jump To Network"
 	unset_machine()
-	cameraFollow = null
+	if(ai_tracking_target)
+		ai_stop_tracking()
 	var/cameralist[0]
 
 	if(incapacitated())

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -665,8 +665,6 @@
 	set category = "AI Commands"
 	set name = "Jump To Network"
 	unset_machine()
-	if(ai_tracking_target)
-		ai_stop_tracking()
 	var/cameralist[0]
 
 	if(incapacitated())
@@ -687,7 +685,8 @@
 				cameralist[i] = i
 	var/old_network = network
 	network = input(U, "Which network would you like to view?") as null|anything in sortList(cameralist)
-
+	if(ai_tracking_target)
+		ai_stop_tracking()
 	if(!U.eyeobj)
 		U.view_core()
 		return

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -13,7 +13,8 @@
 	if("[old_icon]_death_transition" in icon_states(icon))
 		flick("[old_icon]_death_transition", src)
 
-	cameraFollow = null
+	if(ai_tracking_target)
+		ai_stop_tracking()
 
 	anchored = FALSE //unbolt floorbolts
 	move_resist = MOVE_FORCE_NORMAL
@@ -31,7 +32,7 @@
 	if(explosive)
 		var/T = get_turf(src)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/explosion, T, 3, 6, 12, 15), 10)
-		
+
 	if(src.key)
 		for(var/each in GLOB.ai_status_displays) //change status
 			var/obj/machinery/status_display/ai/O = each

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -176,7 +176,8 @@
 		H.clear_holo(src)
 	else
 		current = null
-	ai_tracking_target = null
+	if(ai_tracking_target)
+		ai_stop_tracking()
 	unset_machine()
 
 	if(isturf(loc) && (QDELETED(eyeobj) || !eyeobj.loc))

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -136,13 +136,12 @@
 		QDEL_LIST(L)
 	return ..()
 
-/atom/proc/move_camera_by_click()
-	if(isAI(usr))
-		var/mob/living/silicon/ai/AI = usr
-		if(AI.eyeobj && (AI.multicam_on || (AI.client.eye == AI.eyeobj)) && (AI.eyeobj.get_virtual_z_level() == get_virtual_z_level()))
-			AI.ai_tracking_target = null
-			if (isturf(loc) || isturf(src))
-				AI.eyeobj.setLoc(src)
+/mob/camera/ai_eye/proc/move_camera_by_click(var/atom/target)
+	if((ai.multicam_on || (ai.client.eye == src)) && (get_virtual_z_level() == target.get_virtual_z_level()))
+		if(ai.ai_tracking_target)
+			ai.ai_stop_tracking()
+		if (isturf(target.loc) || isturf(target))
+			setLoc(target)
 
 // This will move the ai_eye. It will also cause lights near the eye to light up, if toggled.
 // This is handled in the proc below this one.

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -140,7 +140,7 @@
 	if(isAI(usr))
 		var/mob/living/silicon/ai/AI = usr
 		if(AI.eyeobj && (AI.multicam_on || (AI.client.eye == AI.eyeobj)) && (AI.eyeobj.get_virtual_z_level() == get_virtual_z_level()))
-			AI.cameraFollow = null
+			AI.ai_tracking_target = null
 			if (isturf(loc) || isturf(src))
 				AI.eyeobj.setLoc(src)
 
@@ -166,8 +166,8 @@
 	else
 		user.sprint = initial
 
-	if(!user.tracking)
-		user.cameraFollow = null
+	if(user.ai_tracking_target && !user.reacquire_timer)
+		user.ai_stop_tracking()
 
 // Return to the Core.
 /mob/living/silicon/ai/proc/view_core()
@@ -176,7 +176,7 @@
 		H.clear_holo(src)
 	else
 		current = null
-	cameraFollow = null
+	ai_tracking_target = null
 	unset_machine()
 
 	if(isturf(loc) && (QDELETED(eyeobj) || !eyeobj.loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR rewrites/refractors ai tracking code towards using signals instead going away from the god awfull spawn(0) while loop.
Most behavior stays the same except that the tracking proc doesn't sleep anymore that was most likely an attempt of the original coder of reducing the actual impact of their while loop but for this its obviously no longer needed so now the ai will no longer lag behind their tracking target.
When we start tracking (and if we can track said target) 2 Signals get registered first in case the target gets somehow qdeleted (this will simply call the stop tracking proc) and obviously a signal for when the target moves that will call the ai_actual_track proc.
Loosing a tracking target now gets handled by a timer that will call the ai_stop_tracking proc if it runs out however the timer can be stopped if the target moves into an area again where it can be tracked by the ai. The timer is set for 10 seconds that should line up with the previous behavior as before it would just be 10 loop iliterations and the loop would sleep for 10 deciseconds every illiteration.
Also moves move_camera_by_click proc to eye object instead of atom.

## Why It's Good For The Game

spawn bad especially if it creates a dedicated while loop

</details>

## Changelog
:cl:
code: converts ai tracking code towards using signals
tweak: the change camera network verb will not immidiatly stop ai tracking(until you select a network)
refactor: moves move_camera_by_click proc to the eyeobject
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
