### PR TITLE
Ports holding down space to toggle throw mode from tg

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -50,6 +50,7 @@
 
 //click cooldowns, in tenths of a second, used for various combat actions
 #define CLICK_CD_MELEE 8
+#define CLICK_CD_THROW 4
 #define CLICK_CD_RANGE 4
 #define CLICK_CD_RAPID 2
 #define CLICK_CD_CLICK_ABILITY 6

--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -18,6 +18,7 @@
 #define COMSIG_KB_CARBON_SELECTDISARMINTENT_DOWN "keybinding_carbon_selectdisarmintent_down"
 #define COMSIG_KB_CARBON_SELECTGRABINTENT_DOWN "keybinding_carbon_selectgrabintent_down"
 #define COMSIG_KB_CARBON_SELECTHARMINTENT_DOWN "keybinding_carbon_selectharmintent_down"
+#define COMSIG_KB_CARBON_HOLDTHROWMODE_DOWN "keybinding_carbon_holdthrowmode_down"
 #define COMSIG_KB_CARBON_GIVEITEM_DOWN "keybinding_carbon_giveitem_down"
 
 //Client

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -435,3 +435,8 @@
 #define BODY_SIZE_NORMAL 1
 #define BODY_SIZE_SHORT 0.93
 #define BODY_SIZE_TALL 1.03
+
+/// Throw modes, defines whether or not to turn off throw mode after
+#define THROW_MODE_DISABLED 0
+#define THROW_MODE_TOGGLE 1
+#define THROW_MODE_HOLD 2

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -118,7 +118,9 @@
 		RestrainedClickOn(A)
 		return
 
-	if(in_throw_mode && throw_item(A))
+	if(throw_mode)
+		changeNext_move(CLICK_CD_THROW)
+		throw_item(A)
 		return
 
 	var/obj/item/W = get_active_held_item()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -118,12 +118,12 @@
 		RestrainedClickOn(A)
 		return
 
-	if(throw_mode)
+	var/obj/item/W = get_active_held_item()
+
+	if(throw_mode && W)
 		changeNext_move(CLICK_CD_THROW)
 		throw_item(A)
 		return
-
-	var/obj/item/W = get_active_held_item()
 
 	if(W == A)
 		W.attack_self(src)

--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -89,6 +89,27 @@
 	user.mob?.a_intent_change(INTENT_HARM)
 	return TRUE
 
+/datum/keybinding/carbon/hold_throw_mode
+	key = "Space"
+	name = "hold_throw_mode"
+	full_name = "Hold throw mode"
+	description = "Hold this to turn on throw mode, and release it to turn off throw mode"
+	category = CATEGORY_CARBON
+	keybind_signal = COMSIG_KB_CARBON_HOLDTHROWMODE_DOWN
+
+/datum/keybinding/carbon/hold_throw_mode/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/carbon_user = user.mob
+	carbon_user.throw_mode_on(THROW_MODE_HOLD)
+
+/datum/keybinding/carbon/hold_throw_mode/up(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/carbon/carbon_user = user.mob
+	carbon_user.throw_mode_off(THROW_MODE_HOLD)
 /datum/keybinding/carbon/give
 	key = "G"
 	name = "Give_Item"
@@ -101,6 +122,6 @@
 	. = ..()
 	if(.)
 		return
-	var/mob/living/carbon/C = user.mob
-	C.give()
+	var/mob/living/carbon/carbon_user = user.mob
+	carbon_user.give()
 	return TRUE

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -163,7 +163,7 @@
 	if(active)
 		if(iscarbon(thrower))
 			var/mob/living/carbon/C = thrower
-			C.throw_mode_on() //so they can catch it on the return.
+			C.throw_mode_on(THROW_MODE_TOGGLE) //so they can catch it on the return.
 	return ..()
 
 /obj/item/shield/energy/bananium/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -202,7 +202,7 @@
 	if(iscarbon(loc))
 		to_chat(loc, "[src] begins to beep.")
 		var/mob/living/carbon/C = loc
-		C.throw_mode_on()
+		C.throw_mode_on(THROW_MODE_TOGGLE)
 	bomb.preprime(loc, null, FALSE)
 
 /obj/item/grown/bananapeel/bombanana/ComponentInitialize()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -703,7 +703,7 @@
 			to_chat(user, "<span class='notice'>You yank [I] towards yourself.</span>")
 			log_combat(user, target, "disarmed", src)
 			if(!user.get_inactive_held_item())
-				user.throw_mode_on()
+				user.throw_mode_on(THROW_MODE_TOGGLE)
 				user.swap_hand()
 				I.throw_at(user, 10, 2)
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -310,8 +310,8 @@
 	..()
 
 /obj/item/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)
-	if(H.in_throw_mode)
-		H.throw_mode_off() //Don't annoy the changeling if he doesn't catch the item
+	if(H.throw_mode)
+		H.throw_mode_off(THROW_MODE_TOGGLE) //Don't annoy the changeling if he doesn't catch the item
 
 /obj/item/projectile/tentacle/proc/tentacle_grab(mob/living/carbon/human/H, mob/living/carbon/C)
 	if(H.Adjacent(C))
@@ -341,7 +341,7 @@
 		var/obj/item/I = target
 		if(!I.anchored)
 			to_chat(firer, "<span class='notice'>You pull [I] towards yourself.</span>")
-			H.throw_mode_on()
+			H.throw_mode_on(THROW_MODE_TOGGLE)
 			I.throw_at(H, 10, 2)
 			. = BULLET_ACT_HIT
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	36
+#define SAVEFILE_VERSION_MAX	37
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -74,6 +74,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		//the keybindings are defined as "key" = list("action") in the savefile (for multiple actions -> 1 key)
 		//so im doing that
 		key_bindings += list("W" = list("move_north"), "A" = list("move_west"), "S" = list("move_south"), "D" = list("move_east"))
+		WRITE_FILE(S["key_bindings"], key_bindings)
+	if(current_version < 37)
+		key_bindings = S["key_bindings"]
+		key_bindings += list("Space" = list("hold_throw_mode"))
 		WRITE_FILE(S["key_bindings"], key_bindings)
 	return
 

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -117,9 +117,6 @@
 /obj/item/reagent_containers/food/snacks/grown/firelemon/attack_self(mob/living/user)
 	user.visible_message("<span class='warning'>[user] primes [src]!</span>", "<span class='userdanger'>You prime [src]!</span>")
 	log_bomber(user, "primed a", src, "for detonation")
-	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		C.throw_mode_on()
 	icon_state = "firelemon_active"
 	playsound(loc, 'sound/weapons/armbomb.ogg', 75, 1, -3)
 	addtimer(CALLBACK(src, .proc/prime), rand(10, 60))

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -65,8 +65,8 @@ GLOBAL_LIST_INIT(valid_keys, list(
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		kbs += kb
 	kbs = sortList(kbs, /proc/cmp_keybinding_dsc)
-	for (var/datum/keybinding/kb in kbs)
-		if (kb.can_use(src) && kb.down(src))
+	for(var/datum/keybinding/kb in kbs)
+		if(kb.can_use(src) && kb.down(src))
 			break
 
 	if(holder)
@@ -93,8 +93,8 @@ GLOBAL_LIST_INIT(valid_keys, list(
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		kbs += kb
 	kbs = sortList(kbs, /proc/cmp_keybinding_dsc)
-	for (var/datum/keybinding/kb in kbs)
-		if (kb.up(src))
+	for(var/datum/keybinding/kb in kbs)
+		if(kb.can_use(src) && kb.up(src))
 			break
 
 	if(holder)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -80,8 +80,8 @@
 				visible_message("<span class='danger'>[victim] catches [src]!</span>",\
 					"<span class='userdanger'>[victim] catches you!</span>")
 				grabbedby(victim, TRUE)
-				victim.throw_mode_off()
-				log_combat(victim, src, "caught (thrown mob)")
+				victim.throw_mode_off(THROW_MODE_TOGGLE)
+				log_combat(victim, src, "caught [src]")
 				return
 			if(hurt)
 				victim.take_bodypart_damage(10,check_armor = TRUE)
@@ -109,20 +109,22 @@
 /mob/living/carbon/proc/toggle_throw_mode()
 	if(stat)
 		return
-	if(in_throw_mode)
-		throw_mode_off()
+	if(throw_mode)
+		throw_mode_off(THROW_MODE_TOGGLE)
 	else
-		throw_mode_on()
+		throw_mode_on(THROW_MODE_TOGGLE)
 
 
-/mob/living/carbon/proc/throw_mode_off()
-	in_throw_mode = 0
+/mob/living/carbon/proc/throw_mode_off(method)
+	if(throw_mode > method) //A toggle doesnt affect a hold
+		return
+	throw_mode = THROW_MODE_DISABLED
 	if(client && hud_used)
 		hud_used.throw_icon.icon_state = "act_throw_off"
 
 
-/mob/living/carbon/proc/throw_mode_on()
-	in_throw_mode = 1
+/mob/living/carbon/proc/throw_mode_on(mode = THROW_MODE_TOGGLE)
+	throw_mode = mode
 	if(client && hud_used)
 		hud_used.throw_icon.icon_state = "act_throw_on"
 
@@ -133,7 +135,7 @@
 
 /mob/living/carbon/throw_item(atom/target)
 	. = ..()
-	throw_mode_off()
+	throw_mode_off(THROW_MODE_TOGGLE)
 	if(!target || !isturf(loc))
 		return FALSE
 	if(istype(target, /atom/movable/screen))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -45,7 +45,7 @@
 
 /mob/living/carbon/proc/can_catch_item(skip_throw_mode_check)
 	. = FALSE
-	if(!skip_throw_mode_check && !in_throw_mode)
+	if(!skip_throw_mode_check && !throw_mode)
 		return
 	if(get_active_held_item())
 		return
@@ -65,7 +65,7 @@
 					if(get_active_held_item() == I) //if our attack_hand() picks up the item...
 						visible_message("<span class='warning'>[src] catches [I]!</span>", \
 										"<span class='userdanger'>You catch [I] in mid-air!</span>")
-						throw_mode_off()
+						throw_mode_off(THROW_MODE_TOGGLE)
 						return 1
 	..(AM, skipcatch, hitpush, blocked, throwingdatum)
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -127,7 +127,7 @@
 
 /mob/living/carbon/human/proc/check_block()
 	if(mind)
-		if(mind.martial_art && prob(mind.martial_art.block_chance) && mind.martial_art.can_use(src) && in_throw_mode && !incapacitated(FALSE, TRUE))
+		if(mind.martial_art && prob(mind.martial_art.block_chance) && mind.martial_art.can_use(src) && throw_mode && !incapacitated(FALSE, TRUE))
 			return TRUE
 	return FALSE
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -145,7 +145,7 @@
 	var/research_scanner = FALSE
 
 	/// Is the mob throw intent on
-	var/in_throw_mode = 0
+	var/throw_mode = THROW_MODE_DISABLED
 
 	/// What job does this mob have
 	var/job = null//Living

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
@@ -9,7 +9,7 @@
 			to_chat(H, "<span class='notice'>A throwing star has been created in your hand!</span>")
 		else
 			qdel(N)
-		H.throw_mode_on() //So they can quickly throw it.
+		H.throw_mode_on(THROW_MODE_TOGGLE) //So they can quickly throw it.
 
 
 /obj/item/throwing_star/ninja

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -62,7 +62,7 @@
 		if(C.can_catch_item(TRUE))
 			var/datum/action/innate/origami/origami_action = locate() in C.actions
 			if(origami_action?.active) //if they're a master of origami and have the ability turned on, force throwmode on so they'll automatically catch the plane.
-				C.throw_mode_on()
+				C.throw_mode_on(THROW_MODE_TOGGLE)
 
 	if(..() || !ishuman(hit_atom))//if the plane is caught or it hits a nonhuman
 		return

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -353,7 +353,7 @@
 /obj/effect/proc_holder/spell/targeted/conjure_item/spellpacket/cast(list/targets, mob/user = usr)
 	..()
 	for(var/mob/living/carbon/C in targets)
-		C.throw_mode_on()
+		C.throw_mode_on(THROW_MODE_TOGGLE)
 
 /obj/item/spellpacket/lightningbolt
 	name = "\improper Lightning bolt Spell Packet"

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -465,7 +465,7 @@
 	else if((findtext(message, throwmode_words)))
 		cooldown = COOLDOWN_MEME
 		for(var/mob/living/carbon/C in listeners)
-			C.throw_mode_on()
+			C.throw_mode_on(THROW_MODE_TOGGLE)
 
 	//FLIP
 	else if((findtext(message, flip_words)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PORTS: https://github.com/tgstation/tgstation/pull/57331

Title. Allows holding down space to toggle throw mode. Also removes a few things automatically toggling your throw mode, mainly priming exploding lemons from botany. Adds a CD for throwing stuff too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to catch things as a moments notice is vital when fighting experienced players who know how good thrown weapons are (read: bolas). 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://user-images.githubusercontent.com/22431091/158853348-b357f1ef-1da8-4c4e-b477-8b640f2f5105.mp4




</details>

## Changelog
:cl:
add: You can now toggle throw mode by pressing space bar!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
