### PR TITLE
Fixes mutations not revealing

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -217,6 +217,7 @@
 	name = "Overload"
 	desc = "Allows an Ethereal to overload their skin to cause a bright flash."
 	quality = POSITIVE
+	locked = TRUE
 	text_gain_indication = "<span class='notice'>Your skin feels more crackly.</span>"
 	instability = 30
 	power = /obj/effect/proc_holder/spell/self/overload
@@ -250,6 +251,7 @@
 	name = "Acidic Hands"
 	desc = "Allows an Oozeling to metabolize some of their blood into acid, concentrated on their hands."
 	quality = POSITIVE
+	locked = TRUE
 	text_gain_indication = "<span class='notice'>Your hands feel sore.</span>"
 	instability = 30
 	power = /obj/effect/proc_holder/spell/targeted/touch/acidooze

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -380,6 +380,7 @@
 	name = "Strengthened Wings"
 	desc = "Subject's wing muscle volume rapidly increases."
 	quality = POSITIVE
+	locked = TRUE
 	difficulty = 12
 	instability = 15
 	species_allowed = list(SPECIES_APID, SPECIES_MOTH)
@@ -423,6 +424,7 @@
 	name = "Cat Claws"
 	desc = "Subject's hands grow sharpened claws."
 	quality = POSITIVE
+	locked = TRUE
 	difficulty = 12
 	instability = 25
 	species_allowed = list(SPECIES_FELINID)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Species specific mutations (which can't be revealed outside of a specific species) can no longer generate in the DNA of other species.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having impossible-to-solve genes is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Genetics will no longer be stuck with impossible to solve mutations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
