### PR TITLE
Space vines fix

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -280,8 +280,9 @@
 	holder.obj_integrity = holder.max_integrity
 
 /datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
-	if(I.is_sharp())
-		. = expected_damage * 0.5
+	if (I)
+		if(I.is_sharp())
+			. = expected_damage * 0.5
 	else
 		. = expected_damage
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -280,7 +280,7 @@
 	holder.obj_integrity = holder.max_integrity
 
 /datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
-	if(I?.is_sharp)
+	if(I?.is_sharp())
 		. = expected_damage * 0.5
 	else
 		. = expected_damage

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -280,8 +280,7 @@
 	holder.obj_integrity = holder.max_integrity
 
 /datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
-	if (I)
-		if(I.is_sharp())
+	if(I?.is_sharp)
 			. = expected_damage * 0.5
 	else
 		. = expected_damage

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -281,7 +281,7 @@
 
 /datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
 	if(I?.is_sharp)
-			. = expected_damage * 0.5
+		. = expected_damage * 0.5
 	else
 		. = expected_damage
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Space vines make a null reference when attacked with an empty hand. ~~I'm not sure if DM can break during an evaluation, so let me know if it does and I can make this a bit prettier.~~ Me thinks this many nulls is bad practice
## Changelog
:cl:
fix: Removed null reference in space vines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
