### PR TITLE
Quadruple Sec/Quintuple Sec nerf and Silencer/Papier Blanc rebalance

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -724,7 +724,7 @@
 	name = "Blank Paper"
 	id = /datum/reagent/consumable/ethanol/blank_paper
 	results = list(/datum/reagent/consumable/ethanol/blank_paper = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol/silencer = 1, /datum/reagent/consumable/nothing = 1, /datum/reagent/consumable/nuka_cola = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol/silencer = 1, /datum/reagent/consumable/nothing = 1, /datum/reagent/consumable/nuka_cola = 1, /datum/reagent/consumable/clownstears = 1)
 
 
 /datum/chemical_reaction/wizz_fizz

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1154,9 +1154,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink from Mime Heaven."
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/M)
+	M.silent = max(M.silent, 1.25)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
-		M.heal_bodypart_damage(1,1)
+		M.heal_bodypart_damage(1 , 1)
 		. = 1
 	return ..() || .
 
@@ -1484,16 +1484,16 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/quadruple_sec/on_mob_life(mob/living/carbon/M)
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes
 	if(M.mind && HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		M.heal_bodypart_damage(1, 1)
-		M.adjustBruteLoss(-2,0)
-		. = 1
+		M.heal_bodypart_damage(0.5 , 0.5)
+		M.adjust_nutrition(-1)
+		. = TRUE
 	return ..()
 
 /datum/reagent/consumable/ethanol/quintuple_sec
 	name = "Quintuple Sec"
 	description = "Law, Order, Alcohol, and Police Brutality distilled into one single elixir of JUSTICE."
 	color = "#ff3300"
-	boozepwr = 80
+	boozepwr = 60
 	quality = DRINK_FANTASTIC
 	taste_description = "THE LAW"
 	glass_icon_state = "quintuple_sec"
@@ -1504,12 +1504,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/quintuple_sec/on_mob_life(mob/living/carbon/M)
 	//Securidrink in line with the Screwdriver for engineers or Nothing for mimes but STRONG..
 	if(M.mind && HAS_TRAIT(M.mind, TRAIT_LAW_ENFORCEMENT_METABOLISM))
-		M.heal_bodypart_damage(2,2,2)
-		M.adjustBruteLoss(-5,0)
-		M.adjustOxyLoss(-5,0)
-		M.adjustFireLoss(-5,0)
-		M.adjustToxLoss(-5,0)
-		. = 1
+		M.heal_bodypart_damage(1 , 1 , 1)
+		M.adjust_nutrition(-2)//BECOME HONGRY
+		. = TRUE
 	return ..()
 
 /datum/reagent/consumable/ethanol/grasshopper
@@ -1830,7 +1827,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/blank_paper
 	name = "Blank Paper"
 	description = "A bubbling glass of blank paper. Just looking at it makes you feel fresh."
-	nutriment_factor = 1 * REAGENTS_METABOLISM
+	nutriment_factor = 2 * REAGENTS_METABOLISM
 	color = "#DCDCDC" // rgb: 220, 220, 220
 	boozepwr = 20
 	quality = DRINK_GOOD
@@ -1841,8 +1838,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	random_unrestricted = TRUE
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/M)
+	M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 	if(ishuman(M) && M.job == "Mime")
-		M.silent = max(M.silent, MIMEDRINK_SILENCE_DURATION)
 		M.heal_bodypart_damage(1,1)
 		. = 1
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On request of Oscari and Gatling on discord, I have nerfed Quadruple and Quintuple sec to yield less health on drink and made the Silencer and the white paper to be viable and distinguishable for your average mime.

Quadruple sec: .5 brute/burn damage each tick and hunger instead of 1 brute/burn each tick.
Quintuple sec: 1 brute/burn/stamina each tick and even more hunger instead of 2 brute/burn/stamina each tick and extra robustness to everything (also less alcoholic to incentivize the creation and use of that drink).

Silencer and Papier Blanc: now will mute everyone, with the silencer muting them for roughly 15 seconds and the Papier blanc for a minute, will still heal the mime.

Also I've adjusted the recipe for the papier blanc by adding clown tears to the mix to be more hard to get, as it gives a solid minute of silence on the user.

## Why It's Good For The Game

Security being rampant bad, silencer that mute people (arguably) good.

## Changelog
:cl:
tweak: Tweaked the Quadruple and Quintuple Sec to yield less healing.
balance: Rebalanced the White paper and the Silencer to mute everyone aside mimes.
/:cl:
