### PR TITLE
Stops current sounds when you go deaf

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -157,6 +157,7 @@
 	if(..())
 		return
 	ADD_TRAIT(owner, TRAIT_DEAF, GENETIC_MUTATION)
+	SEND_SOUND(owner, sound(null))
 
 /datum/mutation/human/deaf/on_losing(mob/living/carbon/human/owner)
 	if(..())

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -80,6 +80,8 @@
 	var/obj/item/organ/ears/ears = getorgan(/obj/item/organ/ears)
 	if(ears)
 		ears.adjustEarDamage(ddmg, ddeaf)
+		if(ears.deaf)
+			SEND_SOUND(src, sound(null))
 
 /mob/proc/minimumDeafTicks()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes sounds stop immediately when you acquire the deaf mutation or become deaf due to ear damage.

## Why It's Good For The Game
More realistic deafness. Long sounds don't have to finish before it actually seems like you're deaf.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Test Procedure (Genetic)</summary>

1. Be something that can get mutations
2. Get a deafness mutator (spawn /obj/item/dnainjector/deafmut)
3. Get a sound playing. The portal storm sound is really good for this because it's long.
4. Stick yourself with the injector
5. The sound should stop immediately

<summary>Test Procedure (Ear damage)</summary>

1. Have ears
2. Get a sound playing. The portal storm sound is really good for this because it's long.
3. Be near a loud sound that deafens you
5. The sound should stop immediately

</details>

## Changelog
:cl:
tweak: Deafness now immediately silences sounds instead of letting them finish
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
