### PR TITLE
Notifies silicon users when their TGUI window pool is exhausted

### DIFF
--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -89,6 +89,8 @@ SUBSYSTEM_DEF(tgui)
 			window_found = TRUE
 			break
 	if(!window_found)
+		if(issilicon(user)) // Tell gamer cyborgs and AIs that they've got too many windows open so they don't think it's broken
+			to_chat(user, "<span class='warning'>Warning: Processor limit reached. Close some windows before opening more.</span>")
 		log_tgui(user, "Error: Pool exhausted")
 		return null
 	return window


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a notification for silicon players when they reach their TGUI window limit.

## Why It's Good For The Game
On NSV we had some players that got confused by seemingly random windows failing to open, so we added this notice for them.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![tgui_warning](https://user-images.githubusercontent.com/17987483/159137047-5a500a07-9d4b-48fe-93e3-8d645a91e757.png)

</details>

## Changelog
:cl:
add: Added notice for silicons who attempt to have more than 9 TGUI windows open
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
