### PR TITLE
shield generators no longer gib mobs

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -420,7 +420,7 @@
 		setDir(get_dir(gen_primary, gen_secondary))
 	for(var/mob/living/L in get_turf(src))
 		visible_message("<span class='danger'>\The [src] zaps through \The [L]!</span>")
-		L.electrocute_act(30, src, 1, FALSE, FALSE, FALSE, FALSE, TRUE)
+		L.electrocute_act(30, src)
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,6 +418,9 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
+	for(var/mob/living/L in get_turf(src))
+		visible_message("<span class='danger'>\The [src] zaps through \The [L]!</span>")
+		L.electrocute_act(30, src, 1, FALSE, FALSE, FALSE, FALSE, TRUE)
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,9 +418,6 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
-	for(var/mob/living/L in get_turf(src))
-		visible_message("<span class='danger'>\The [src] is suddenly occupying the same space as \the [L]!</span>")
-		L.gib()
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -419,7 +419,7 @@
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
 	for(var/mob/living/L in get_turf(src))
-		visible_message("<span class='danger'>\The [src] zaps through \The [L]!</span>")
+		visible_message("<span class='danger'>\The [src] zaps through [L]!</span>")
 		L.electrocute_act(30, src)
 
 /obj/machinery/shieldwall/Destroy()


### PR DESCRIPTION
## About The Pull Request
Shield generators no longer instantly gib mobs as soon as they are turned on, instead applying an electric shock.

## Why It's Good For The Game
Removes a method of cheep instagibbing on targets. This behavior is unintuitive (nothing else in the game acts this way, the closest being that doors crush you when closed), and instant gibs are cheap. The shield generator doesnt break other objects in its path, why should it be able to kill mobs instantly?


## Testing Photographs and Procedure
not necessary

## Changelog
:cl:
balance: shield generators no longer gib mobs when activated. instead, they apply an electric shock
/:cl:
