### PR TITLE
Stops magic SMES from dividing infinity by infinity

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -442,6 +442,10 @@
 	charge = INFINITY
 	..()
 
+//don't divide by infinity or zero, just display max
+/obj/machinery/power/smes/magical/chargedisplay()
+	return 5
+
 
 #undef SMESRATE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When trying to update the icon, a SMES divides its charge by its capacity. Magic SMESes have infinite capacity and infinite charge. Dividing infinity by infinity is undefined.

## Why It's Good For The Game
Makes the magic SMES overlay correctly and not throw errors.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Test procedure</summary>

1. Spawn magic SMES
2. Observe lights

</details>

## Changelog
:cl:
fix: Makes magic SMES always appear full and not do undefined math
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
