### PR TITLE
Makes automatic conveyors actually start

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	. = ..()
 	operating = TRUE
 	update_move_direction()
+	begin_processing()
 
 /obj/machinery/conveyor/auto/update()
 	if(stat & BROKEN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Automatic conveyors are supposed to always be on unless they're not receiving power, but since they inherit their processing behavior from regular conveyors, they showed the right animation but didn't actually move things. This makes them work.
It's better to do it here than as an init flag because we want it to update its move direction first.

## Why It's Good For The Game
Makes auto conveyors work properly

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing procedure</summary>

1. Spawn or map an auto conveyor
2. Put an object on it
3. Observe the object moves as it should

</details>

## Changelog
:cl:
fix: Fixed automatic conveyors not moving items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
