### PR TITLE
Fixes defibrillator overlay not appearing on the pre-loaded wallmount

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -19,6 +19,7 @@
 /obj/machinery/defibrillator_mount/loaded/Initialize(mapload) //loaded subtype for mapping use
 	. = ..()
 	defib = new/obj/item/defibrillator/loaded(src)
+	update_icon()
 
 /obj/machinery/defibrillator_mount/Destroy()
 	if(defib)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The loaded subtype of the defib wallmount doesn't show the overlay for the defibrillator initially, making it look like nothing is in it until it is acted upon in a way that updates the icon. This fixes it.

## Why It's Good For The Game
Makes an object display correctly

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![defib](https://user-images.githubusercontent.com/17987483/159170679-3870a61d-7bf8-40c8-824e-7f152832c788.png)

</details>

## Changelog
:cl:
fix: Fixed the pre-loaded defib wallmount overlay not appearing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
