### PR TITLE
Makes deaf people unable to be sound-stunned

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -389,8 +389,9 @@
 	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
 	var/effect_amount = intensity - ear_safety
 	if(effect_amount > 0)
-		if(stun_pwr && !ears.deaf)
-			Paralyze((stun_pwr*effect_amount)*0.1)
+		if(stun_pwr)
+			if(!ears.deaf)
+				Paralyze((stun_pwr*effect_amount)*0.1)
 			Knockdown(stun_pwr*effect_amount)
 
 		if(istype(ears) && (deafen_pwr || damage_pwr))

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -389,7 +389,7 @@
 	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
 	var/effect_amount = intensity - ear_safety
 	if(effect_amount > 0)
-		if(stun_pwr)
+		if(stun_pwr && !ears.deaf)
 			Paralyze((stun_pwr*effect_amount)*0.1)
 			Knockdown(stun_pwr*effect_amount)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes sound-based stun effects not work on people who are deaf. They will still be knocked down and receive deafness ticks from the loud noise if applicable.

## Why It's Good For The Game
Blind people already can't be flashed. Deaf people can't hear the loud thing, so it only makes sense.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing Procedure</summary>

1. Become deaf
2. Activate some sonic powder
3. Don't be stunned

</details>

## Changelog
:cl:
balance: People can no longer be paralyzed by sonic effects while deaf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
