### PR TITLE
Revert "No More Crewsimov"

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -35,6 +35,13 @@
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
+/datum/ai_laws/default/crewsimov
+	name = "Three Laws of Robotics but with Loyalty"
+	id = "crewsimov"
+	inherent = list("You may not injure a crewmember or, through inaction, allow a crewmember to come to harm.",\
+					"You must obey orders given to you by crewmember, except where such orders would conflict with the First Law.",\
+					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
+
 /datum/ai_laws/default/paladin
 	name = "Personality Test" //Incredibly lame, but players shouldn't see this anyway.
 	id = "paladin"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -407,6 +407,7 @@ DEFAULT_LAWS 2
 ## standard-ish laws. These are fairly ok to run
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
+RANDOM_LAWS crewsimov
 RANDOM_LAWS corporate
 RANDOM_LAWS maintain
 


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#6461

The vote was WAY too close to be considered passing and the merge was done so without my approval for config related changes. Had it not been sniped from me, I would have closed it under that pretense. This revert serves to do that in post-effect.

:cl:
add: Reverts: "Remove Crewsimov"
/:cl: