### PR TITLE
flight potions can no longer be mass produced

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,6 +418,9 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
+	for(var/mob/living/L in get_turf(src))
+		visible_message("<span class='danger'>\The [src] is suddenly occupying the same space as \the [L]!</span>")
+		L.gib()
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,9 +418,23 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
+<<<<<<< Updated upstream
 	for(var/mob/living/L in get_turf(src))
 		visible_message("<span class='danger'>\The [src] is suddenly occupying the same space as \the [L]!</span>")
 		L.gib()
+=======
+<<<<<<< Updated upstream
+=======
+	for(var/mob/living/L in get_turf(src))
+<<<<<<< HEAD
+		visible_message("<span class='danger'>\The [src] zaps through \The [L]!</span>")
+		L.electrocute_act(30, src, 1, FALSE, FALSE, FALSE, FALSE, TRUE)
+=======
+		visible_message("<span class='danger'>\The [src] is suddenly occupying the same space as \the [L]!</span>")
+		L.gib()
+>>>>>>> parent of dc3717a... shield generators no longer gib mobs
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,9 +418,6 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
-	for(var/mob/living/L in get_turf(src))
-		visible_message("<span class='danger'>\The [src] zaps through \The [L]!</span>")
-		L.electrocute_act(30, src, 1, FALSE, FALSE, FALSE, FALSE, TRUE)
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,6 +418,9 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
+	for(var/mob/living/L in get_turf(src))
+		visible_message("<span class='danger'>\The [src] zaps through \The [L]!</span>")
+		L.electrocute_act(30, src, 1, FALSE, FALSE, FALSE, FALSE, TRUE)
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,23 +418,9 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
-<<<<<<< Updated upstream
 	for(var/mob/living/L in get_turf(src))
 		visible_message("<span class='danger'>\The [src] is suddenly occupying the same space as \the [L]!</span>")
 		L.gib()
-=======
-<<<<<<< Updated upstream
-=======
-	for(var/mob/living/L in get_turf(src))
-<<<<<<< HEAD
-		visible_message("<span class='danger'>\The [src] zaps through \The [L]!</span>")
-		L.electrocute_act(30, src, 1, FALSE, FALSE, FALSE, FALSE, TRUE)
-=======
-		visible_message("<span class='danger'>\The [src] is suddenly occupying the same space as \the [L]!</span>")
-		L.gib()
->>>>>>> parent of dc3717a... shield generators no longer gib mobs
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -418,9 +418,6 @@
 	if(gen_primary && gen_secondary)
 		needs_power = TRUE
 		setDir(get_dir(gen_primary, gen_secondary))
-	for(var/mob/living/L in get_turf(src))
-		visible_message("<span class='danger'>\The [src] is suddenly occupying the same space as \the [L]!</span>")
-		L.gib()
 
 /obj/machinery/shieldwall/Destroy()
 	gen_primary = null

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -652,6 +652,7 @@
 	description = "Strange mutagenic compound of unknown origins."
 	reagent_state = LIQUID
 	process_flags = ORGANIC | SYNTHETIC
+	can_synth = FALSE
 	color = "#FFEBEB"
 
 /datum/reagent/flightpotion/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)


### PR DESCRIPTION
## About The Pull Request
Botany can no longer farm for, and mass produce, flight potions

## Why It's Good For The Game
flight is a highly impactful game mechanic, especially given i removed the restriction between it and having a backpack awhile back. Allowing it to be easily mass-produced, and have angel wings given to the entire crew, is disruptive. This does not stop flight potion from occuring in floorpills.

## Testing Photographs and Procedure
unecessary

## Changelog
:cl:
tweak: flight potion now has can_synth set to FALSE
/:cl:


