### PR TITLE
[PORT] Split personality communication

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3244,6 +3244,7 @@
 #include "code\modules\spells\spell_types\lightning.dm"
 #include "code\modules\spells\spell_types\mime.dm"
 #include "code\modules\spells\spell_types\mind_transfer.dm"
+#include "code\modules\spells\spell_types\personality_commune.dm"
 #include "code\modules\spells\spell_types\pointed.dm"
 #include "code\modules\spells\spell_types\projectile.dm"
 #include "code\modules\spells\spell_types\rightandwrong.dm"

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -19,7 +19,12 @@
 
 /datum/brain_trauma/severe/split_personality/proc/make_backseats()
 	stranger_backseat = new(owner, src)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/stranger_spell = new(src)
+	stranger_backseat.AddSpell(stranger_spell)
+
 	owner_backseat = new(owner, src)
+	var/obj/effect/proc_holder/spell/targeted/personality_commune/owner_spell = new(src)
+	owner_backseat.AddSpell(owner_spell)
 
 /datum/brain_trauma/severe/split_personality/proc/get_ghost()
 	set waitfor = FALSE

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -1,0 +1,32 @@
+/obj/effect/proc_holder/spell/targeted/personality_commune
+	name = "Personality Commune"
+	desc = "Sends thoughts to your alternate consciousness."
+	charge_max = 0
+	clothes_req = FALSE
+	range = -1
+	include_user = TRUE
+	action_icon_state = "telepathy"
+	action_background_icon_state = "bg_spell"
+	var/datum/brain_trauma/severe/split_personality/trauma
+	var/flufftext = "You hear an echoing voice in the back of your head..."
+
+/obj/effect/proc_holder/spell/targeted/personality_commune/New(datum/brain_trauma/severe/split_personality/T)
+	. = ..()
+	trauma = T
+
+// Pillaged and adapted from telepathy code
+/obj/effect/proc_holder/spell/targeted/personality_commune/cast(list/targets, mob/user)
+	if(!istype(trauma))
+		to_chat(user, "<span class='warning'>Something is wrong; Either due a bug or admemes, you are trying to cast this spell without a split personality!</span>")
+		return
+	var/msg = stripped_input(usr, "What would you like to tell your other self?", null , "")
+	if(!msg)
+		charge_counter = charge_max
+		return
+	to_chat(user, "<span class='boldnotice'>You concentrate and send thoughts to your other self:</span> <span class='notice'>[msg]</span>")
+	to_chat(trauma.owner, "<span class='boldnotice'>[flufftext]</span> <span class='notice'>[msg]</span>")
+	log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")
+	for(var/ded in GLOB.dead_mob_list)
+		if(!isobserver(ded))
+			continue
+		to_chat(ded, "[FOLLOW_LINK(ded, user)] <span class='boldnotice'>[user] [name]:</span> <span class='notice'>\"[msg]\" to</span><span class='name'>[trauma]</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR ports split personality communication from https://github.com/tgstation/tgstation/pull/46875. It adds a new ability for the backseat personality to directly communicate with whoever is currently controlling the body, the active personality will still have to talk out loud to communicate with the backseat personality however.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Allows both personalities to communicate better without having to wait for each other's turn.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![image](https://user-images.githubusercontent.com/66234359/159527749-3fac612e-e19d-495d-a476-37ab0ad3d329.png)

![image](https://user-images.githubusercontent.com/66234359/159528048-c6a9c655-551d-4199-ac51-978f6c9f4fae.png)


</details>

## Changelog
:cl:Hardly, MCterra10
add: Split personalities can now communicate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
