### PR TITLE
Artifact Enemy Rebalance

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -17,7 +17,7 @@
 		valid_turfs += F
 	//Shuffle the list
 	shuffle_inplace(valid_turfs)
-	for(var/i in 1 to rand(6, 15))
+	for(var/i in 1 to rand(4, 10))
 		if(i > valid_turfs.len)
 			message_admins("Ran out of valid turfs to create artifact defenses on.")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This PR rebalances the Artifact Enemies found on Exploration missions.
These damage & range values should allow for explorers to actually retreat or rethink an attack, rather than getting stunlocked into death instantly from afar, with their headset knocked out at the same time.

## Why It's Good For The Game

An invisible 5 second stun is not fun.
Dying to walls of purple is not fun.
500 HP walls of health are not fun.

This should remain challenging for explorers, without causing instant death if they hit a cluster of artifacts.

## Changelog

:cl:
balance: Reduces the number of watchers/guardians on Artifact Recovery missions. (From 6-15 to 4-10) 
balance: Reduces the health/integrity of artifact watchers and guardians. (Watchers have 100(From 200), Guardians have 200(From 500))
balance: Artifact Guardians have a shorter leash range around Watchers. (2 tiles, down from 5)
balance: Guardians have a slightly longer cooldown between attacks. (1.5 seconds, up from 1 second)
balance: Chaser Guardians have had their damage reduced to 10 (Down from 20)
balance: Ranged Burst Guardians have had their burst radius reduced to 2 (Down from 5).
balance: Self Burst Guardians have had their burst radius reduced down to 3. (Down from 8)
balance: Both types of Burst Guardians have had their damage reduced to 7 (Down from 10)
balance: EMP Pulse Guardians have had their invisible stun removed entirely and replaced with a visible target location that indicates the location the EMP will strike. The EMP itself can now be dodged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
