### PR TITLE
Fixes Cat Claws, lowers Acid Ooze power.

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -295,7 +295,7 @@
 	if(H.blood_volume < 40)
 		to_chat(user, "<span class='warning'>You don't have enough blood to do that!</span>")
 		return FALSE
-	if(target.acid_act(75, 15))
+	if(target.acid_act(50, 15))
 		user.visible_message("<span class='warning'>[user] rubs globs of vile stuff all over [target].</span>")
 		H.blood_volume = max(H.blood_volume - 20, 0)
 		return ..()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -432,7 +432,7 @@
 	if(..())
 		return
 	added_damage = min(17, 6 * GET_MUTATION_POWER(src) + owner.dna.species.punchdamage)
-	owner.dna.species.punchdamage += added_damage
+	owner.dna.species.punchdamage = added_damage
 	to_chat(owner, "<span class='notice'>Claws extend from your fingertips.</span>")
 	owner.dna.species.attack_verb = "slash"
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -432,7 +432,8 @@
 	if(..())
 		return
 	added_damage = min(17, 6 * GET_MUTATION_POWER(src) + owner.dna.species.punchdamage)
-	owner.dna.species.punchdamage = added_damage
+	added_damage -= owner.dna.species.punchdamage
+	owner.dna.species.punchdamage += added_damage
 	to_chat(owner, "<span class='notice'>Claws extend from your fingertips.</span>")
 	owner.dna.species.attack_verb = "slash"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I made a very big mistake in cat claws which resulted in felinids getting 20 damage punches.
Acid ooze's power has been lowered from 75 to 50
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
20 damage punches are probably a bit op
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Cat Claws no longer deal 20 damage with punches.
balance: Acid Ooze hands now have 2/3 of their previous power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
