### PR TITLE
Makes not using VSCode an error

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -111,6 +111,7 @@
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error Switch to the VSCode text editor instead, where you can press Ctrl+Shift+B to build (or VSCode's other build buttons).
+#error And don't forget to add the recommended VSCode extensions. You'll be prompted when you first open the codebase in VSCode.
 #endif
 
 #define AUXMOS (world.system_type == MS_WINDOWS ? "auxtools/auxmos.dll" : __detect_auxmos())

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -111,7 +111,6 @@
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error Switch to VSCode and when prompted install the recommended extensions, you can then either use the UI or press Ctrl+Shift+B to build the codebase.
-#error And don't forget to add the recommended VSCode extensions. You'll be prompted when you first open the codebase in VSCode.
 #endif
 
 #define AUXMOS (world.system_type == MS_WINDOWS ? "auxtools/auxmos.dll" : __detect_auxmos())

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -109,9 +109,8 @@
 #endif
 
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
-#warn Building with Dream Maker is no longer supported and will result in errors.
-#warn In order to build, run BUILD.bat in the root directory.
-#warn Consider switching to VSCode editor instead, where you can press Ctrl+Shift+B to build.
+#error Building with Dream Maker is no longer supported and will result in errors.
+#error Switch to the VSCode text editor instead, where you can press Ctrl+Shift+B to build.
 #endif
 
 #define AUXMOS (world.system_type == MS_WINDOWS ? "auxtools/auxmos.dll" : __detect_auxmos())

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -110,7 +110,7 @@
 
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
-#error Switch to the VSCode text editor instead, where you can press Ctrl+Shift+B to build.
+#error Switch to the VSCode text editor instead, where you can press Ctrl+Shift+B to build (or VSCode's other build buttons).
 #endif
 
 #define AUXMOS (world.system_type == MS_WINDOWS ? "auxtools/auxmos.dll" : __detect_auxmos())

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -110,7 +110,7 @@
 
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
-#error Switch to the VSCode text editor instead, where you can press Ctrl+Shift+B to build (or VSCode's other build buttons).
+#error Switch to VSCode and when prompted install the recommended extensions, you can then either use the UI or press Ctrl+Shift+B to build the codebase.
 #error And don't forget to add the recommended VSCode extensions. You'll be prompted when you first open the codebase in VSCode.
 #endif
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It needs to be an error, they can't just choose to compile it in DM anyways and expect it to work.
Also removed mention of `BUILD.bat` to encourage VSCode adoption. They need the linter to yell at them.

## Changelog
:cl:
code: Made it more explicit that coders need to be compiling with VSCode, not BYOND's Dream Maker editor.
tweak: Adjusted the error message to also mention installing the recommended VSCode extensions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
