### PR TITLE
The Eminence can no longer jump to cultists on the CC Z Level

### DIFF
--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -213,6 +213,9 @@
 		to_chat(user, "<span class='warning'>They are no longer a servant of Rat'var!</span>")
 		return
 	var/turf/T = get_turf(M)
+	if(SSmapping.level_trait(T.z, ZTRAIT_CENTCOM))
+		to_chat(user, "<span class='warning'>They are out of your reach!</span>")
+		return
 	user.forceMove(get_turf(T))
 	SEND_SOUND(user, sound('sound/magic/magic_missile.ogg'))
 	flash_color(user, flash_color = "#AF0AAF", flash_time = 25)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Eminence is able to move through closed turfs, and if it runs around (which it can do at high speed) it will likely run into a cordon and be deleted.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Eminence can no longer teleport to Servants of Rat'Var on the CentCom Z Level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
