### PR TITLE
X-ray guns have 60% armour penetration.

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -62,6 +62,7 @@
 	damage = 15
 	irradiate = 300
 	range = 15
+	armour_penetration = 100
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -62,7 +62,7 @@
 	damage = 15
 	irradiate = 300
 	range = 15
-	armour_penetration = 100
+	armour_penetration = 80
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -62,7 +62,7 @@
 	damage = 15
 	irradiate = 300
 	range = 15
-	armour_penetration = 80
+	armour_penetration = 60
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser


### PR DESCRIPTION
### About The Pull Request
gives xray lasers 60 armor penetration

https://github.com/tgstation/tgstation/pull/65629
### Why It's Good For The Game
an xray laser passes through solid objects, armor is a solid object so it makes sense xrays pass through it
xray doesnt really have that much of a niche, it literally does 5 less damage than roundstart laser guns while being late-game research. you kinda do need xray to use it effectively. this should give it a niche outside that and its pretty cool i think

### Changelog
:cl: Fikou, AnCopper
balance: xray lasers now have 60 armor penetration
/:cl: