### PR TITLE
Medical records console QoL

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -55,6 +55,47 @@
 <BR><A href='?src=[REF(src)];logout=1'>{Log Out}</A><BR>
 "}
 				if(2)
+					dat += "<body onload='selectTextField(); updateSearch();' onkeyup='updateSearch();'>"
+					dat += {"
+					<script src="[SSassets.transport.get_asset_url("jquery.min.js")]"></script>
+					<script type='text/javascript'>
+
+						function updateSearch(){
+							var filter_text = document.getElementById('filter');
+							var filter = filter_text.value.toLowerCase();
+
+							if(complete_list != null && complete_list != ""){
+								var mtbl = document.getElementById("maintable_data_archive");
+								mtbl.innerHTML = complete_list;
+							}
+
+							if(filter.value == ""){
+								return;
+							}else{
+								$("#maintable_data").children("tbody").children("tr").children("td").children("input").filter(function(index)
+								{
+									return $(this)\[0\].value.toLowerCase().indexOf(filter) == -1
+								}).parent("td").parent("tr").hide()
+							}
+						}
+
+						function selectTextField(){
+							var filter_text = document.getElementById('filter');
+							filter_text.focus();
+							filter_text.select();
+						}
+
+					</script>
+					"}
+					dat += {"
+						<table width='560' align='center' cellspacing='0' cellpadding='5' id='maintable'>
+							<tr id='search_tr'>
+								<td align='center'>
+									<b>Search:</b> <input type='text' id='filter' value='' style='width:300px;'>
+								</td>
+							</tr>
+						</table>
+					"}
 					dat += {"
 </p>
 <table style="text-align:center;" cellspacing="0" width="100%">
@@ -62,7 +103,8 @@
 <th>Records:</th>
 </tr>
 </table>
-<table style="text-align:center;" border="1" cellspacing="0" width="100%">
+<span id='maintable_data_archive'>
+<table id='maintable_data' style="text-align:center;" border="1" cellspacing="0" width="100%">
 <tr>
 <th><A href='?src=[REF(src)];choice=Sorting;sort=name'>Name</A></th>
 <th><A href='?src=[REF(src)];choice=Sorting;sort=id'>ID</A></th>
@@ -92,13 +134,23 @@
 							else
 								background = "'background-color:#4F7529;'"
 
-							dat += text("<tr style=[]><td><A href='?src=[REF(src)];d_rec=[]'>[]</a></td>", background, R.fields["id"], R.fields["name"])
+							dat += text("<tr style=[]>", background)
+
+							dat += text("<td><input type='hidden' value='[] [] [] []'></input><A href='?src=[REF(src)];d_rec=[]'>[]</a></td>",
+										R.fields["name"], R.fields["id"], b_dna, R.fields["fingerprint"], R.fields["id"], R.fields["name"])
+
 							dat += text("<td>[]</td>", R.fields["id"])
 							dat += text("<td><b>F:</b> []<BR><b>D:</b> []</td>", R.fields["fingerprint"], b_dna)
 							dat += text("<td>[]</td>", blood_type)
 							dat += text("<td>[]</td>", R.fields["p_stat"])
 							dat += text("<td>[]</td></tr>", R.fields["m_stat"])
-					dat += "</table><hr width='75%' />"
+					dat += {"
+						</table></span>
+						<script type='text/javascript'>
+							var maintable = document.getElementById("maintable_data_archive");
+							var complete_list = maintable.innerHTML;
+						</script>
+						<hr width='75%' />"}
 					dat += "<HR><A href='?src=[REF(src)];screen=1'>Back</A>"
 				if(3)
 					dat += "<B>Records Maintenance</B><HR>\n<A href='?src=[REF(src)];back=1'>Backup To Disk</A><BR>\n<A href='?src=[REF(src)];u_load=1'>Upload From Disk</A><BR>\n<A href='?src=[REF(src)];del_all=1'>Delete All Records</A><BR>\n<BR>\n<A href='?src=[REF(src)];screen=1'>Back</A>"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -45,8 +45,7 @@
 			switch(src.screen)
 				if(1)
 					dat += {"
-<A href='?src=[REF(src)];search=1'>Search Records</A>
-<BR><A href='?src=[REF(src)];screen=2'>List Records</A>
+<A href='?src=[REF(src)];screen=2'>List Records</A>
 <BR>
 <BR><A href='?src=[REF(src)];screen=5'>Virus Database</A>
 <BR><A href='?src=[REF(src)];screen=6'>Medbot Tracking</A>
@@ -110,6 +109,7 @@
 <th><A href='?src=[REF(src)];choice=Sorting;sort=id'>ID</A></th>
 <th>Fingerprints (F) | DNA (D)</th>
 <th><A href='?src=[REF(src)];choice=Sorting;sort=bloodtype'>Blood Type</A></th>
+<th><A href='?src=[REF(src)];choice=Sorting;sort=species'> Species</A></th>
 <th>Physical Status</th>
 <th>Mental Status</th>
 </tr>"}
@@ -136,12 +136,13 @@
 
 							dat += text("<tr style=[]>", background)
 
-							dat += text("<td><input type='hidden' value='[] [] [] []'></input><A href='?src=[REF(src)];d_rec=[]'>[]</a></td>",
-										R.fields["name"], R.fields["id"], b_dna, R.fields["fingerprint"], R.fields["id"], R.fields["name"])
+							dat += text("<td><input type='hidden' value='[] [] [] [] []'></input><A href='?src=[REF(src)];d_rec=[]'>[]</a></td>",
+										R.fields["name"], R.fields["id"], b_dna, R.fields["fingerprint"], R.fields["species"], R.fields["id"], R.fields["name"])
 
 							dat += text("<td>[]</td>", R.fields["id"])
 							dat += text("<td><b>F:</b> []<BR><b>D:</b> []</td>", R.fields["fingerprint"], b_dna)
 							dat += text("<td>[]</td>", blood_type)
+							dat += text("<td>[]</td>", R.fields["species"])
 							dat += text("<td>[]</td>", R.fields["p_stat"])
 							dat += text("<td>[]</td></tr>", R.fields["m_stat"])
 					dat += {"
@@ -152,6 +153,7 @@
 						</script>
 						<hr width='75%' />"}
 					dat += "<HR><A href='?src=[REF(src)];screen=1'>Back</A>"
+					dat += "</body>"
 				if(3)
 					dat += "<B>Records Maintenance</B><HR>\n<A href='?src=[REF(src)];back=1'>Backup To Disk</A><BR>\n<A href='?src=[REF(src)];u_load=1'>Upload From Disk</A><BR>\n<A href='?src=[REF(src)];del_all=1'>Delete All Records</A><BR>\n<BR>\n<A href='?src=[REF(src)];screen=1'>Back</A>"
 				if(4)
@@ -234,7 +236,7 @@
 				else
 		else
 			dat += "<A href='?src=[REF(src)];login=1'>{Log In}</A>"
-	var/datum/browser/popup = new(user, "med_rec", "Medical Records Console", 600, 400)
+	var/datum/browser/popup = new(user, "med_rec", "Medical Records Console", 1000, 500)
 	popup.set_content(dat)
 	popup.open()
 
@@ -541,28 +543,6 @@
 			else if(href_list["del_c"])
 				if((istype(src.active2, /datum/data/record) && src.active2.fields[text("com_[]", href_list["del_c"])]))
 					src.active2.fields[text("com_[]", href_list["del_c"])] = "<B>Deleted</B>"
-
-			else if(href_list["search"])
-				var/t1 = stripped_input(usr, "Search String: (Name, DNA, or ID)", "Med. records")
-				if(!canUseMedicalRecordsConsole(usr, t1))
-					return
-				src.active1 = null
-				src.active2 = null
-				t1 = lowertext(t1)
-				for(var/datum/data/record/R in GLOB.data_core.medical)
-					if((lowertext(R.fields["name"]) == t1 || t1 == lowertext(R.fields["id"]) || t1 == lowertext(R.fields["b_dna"])))
-						src.active2 = R
-					else
-						//Foreach continue //goto(3229)
-				if(!( src.active2 ))
-					src.temp = text("Could not locate record [].", sanitize(t1))
-				else
-					for(var/datum/data/record/E in GLOB.data_core.general)
-						if((E.fields["name"] == src.active2.fields["name"] || E.fields["id"] == src.active2.fields["id"]))
-							src.active1 = E
-						else
-							//Foreach continue //goto(3334)
-					src.screen = 4
 
 			else if(href_list["print_p"])
 				if(!( src.printing ))

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -1,5 +1,3 @@
-
-
 /obj/machinery/computer/med_data//TODO:SANITY
 	name = "medical records console"
 	desc = "This can be used to check medical records."
@@ -54,7 +52,7 @@
 <BR><A href='?src=[REF(src)];logout=1'>{Log Out}</A><BR>
 "}
 				if(2)
-					dat += "<body onload='selectTextField(); updateSearch();' onkeyup='updateSearch();'>"
+					// JS scripts for the filter
 					dat += {"
 					<script src="[SSassets.transport.get_asset_url("jquery.min.js")]"></script>
 					<script type='text/javascript'>
@@ -86,6 +84,9 @@
 
 					</script>
 					"}
+					dat += "<body onload='selectTextField(); updateSearch();' onkeyup='updateSearch();'>"
+
+					// Filter
 					dat += {"
 						<table width='560' align='center' cellspacing='0' cellpadding='5' id='maintable'>
 							<tr id='search_tr'>
@@ -95,6 +96,7 @@
 							</tr>
 						</table>
 					"}
+
 					dat += {"
 </p>
 <table style="text-align:center;" cellspacing="0" width="100%">
@@ -216,7 +218,7 @@
 						if(!Dis.desc)
 							continue
 						dat += "<br><a href='?src=[REF(src)];vir=[Dt]'>[Dis.name]</a>"
-					dat += "<br><a href='?src=[REF(src)];screen=1'>Back</a>"
+					dat += "<br><br><a href='?src=[REF(src)];screen=1'>Back</a>"
 				if(6)
 					dat += "<center><b>Medical Robot Monitor</b></center>"
 					dat += "<a href='?src=[REF(src)];screen=1'>Back</a>"
@@ -236,6 +238,7 @@
 				else
 		else
 			dat += "<A href='?src=[REF(src)];login=1'>{Log In}</A>"
+
 	var/datum/browser/popup = new(user, "med_rec", "Medical Records Console", 1000, 500)
 	popup.set_content(dat)
 	popup.open()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -456,7 +456,7 @@
 				else
 		else
 			dat += "<A href='?src=[REF(src)];choice=Log In'>{Log In}</A>"
-	var/datum/browser/popup = new(user, "secure_rec", "Security Records Console", 600, 400)
+	var/datum/browser/popup = new(user, "secure_rec", "Security Records Console", 700, 500)
 	popup.set_content(dat)
 	popup.open()
 	return


### PR DESCRIPTION
## About The Pull Request

Using medical records console has always been painful, no way of filtering, search was terrible as you needed to type in EXACTLY what you wanted to get, otherwise it'd show nothing. This PR changes it.

Basically what I did was take the filter functionality from security records console and added it to medical, so now you can very nicely filter records and get what you want.
Additionally, record list now shows one's species (in order to make sillycone players life a little bit easier).
With the new filter addition, the search option was completely removed as the filter does what it did but 1000x better and less painfully.

Also makes the medical records console bigger to make space for species data (and because previously things would overflow to next line and look badly). Made security console a little bit bigger due to overflows too.

## Why It's Good For The Game

QoL good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

**How the list looks like now:**
![image](https://user-images.githubusercontent.com/29757616/160250720-2ca85991-48b0-42dc-af71-79e05d27f57b.png)

**Some photos showing random filter results:**
![image](https://user-images.githubusercontent.com/29757616/160250739-6b765151-a8cc-47a8-8949-0ac5181514cc.png)

![image](https://user-images.githubusercontent.com/29757616/160250752-8ebdc4aa-5843-4330-ba1c-6984a357acb5.png)

![image](https://user-images.githubusercontent.com/29757616/160250763-37308c93-b82f-42b9-a3de-81d86eebd630.png)


</details>

## Changelog
:cl: Mat05usz
tweak: Medical records console now shows species while displaying the list and allows filtering, to make life easier
/:cl: