### PR TITLE
Make autotransfer vote use real time

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(autotransfer)
 	var/targettime
 
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
-	starttime = world.time
+	starttime = REALTIMEOFDAY
 	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
 
 	if(!CONFIG_GET(flag/vote_autotransfer_enabled))
@@ -16,6 +16,6 @@ SUBSYSTEM_DEF(autotransfer)
 	. = ..()
 
 /datum/controller/subsystem/autotransfer/fire()
-	if(world.time > targettime)
+	if(REALTIMEOFDAY > targettime)
 		SSvote.initiate_vote("transfer", null)
 		targettime = targettime + CONFIG_GET(number/vote_autotransfer_interval)


### PR DESCRIPTION
## About The Pull Request

Simple PR that changes the autotransfer vote to check whether it should fire using REALTIMEOFDAY, instead of world.time

## Why It's Good For The Game

Transfer vote is a purely OOC concept, therefore it should be using regular 'normal' timer instead of internal one. Also currently it's very inconsistent as 90 minutes into the game, TiDi varies a lot from round to round, leading to dumb situations like sometimes vote triggering at 100 minute mark, sometimes at 120 and, on high pop rounds, possibly even later.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Mat05usz
tweak: Autotransfer vote is now using real time instead of time-dilated timer, making it trigger consistently at 90 minutes.
/:cl:
