### PR TITLE
Makes clockcult more robust against antag_pick failures

### DIFF
--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -59,6 +59,9 @@ GLOBAL_VAR(clockcult_eminence)
 		if(!antag_candidates.len)
 			break
 		var/datum/mind/clockie = antag_pick(antag_candidates, ROLE_SERVANT_OF_RATVAR)
+		//In case antag_pick breaks
+		if(!clockie)
+			continue
 		antag_candidates -= clockie
 		selected_servants += clockie
 		clockie.assigned_role = ROLE_SERVANT_OF_RATVAR

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -443,8 +443,8 @@
 		var/mob/dead/new_player/player = get_mob_by_ckey(p_ckey)
 		if(!player)
 			candidates -= mind
-		else
-			total_tickets += min(((role in player.client.prefs.be_special) ? SSpersistence.antag_rep[p_ckey] : 0) + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
+			continue
+		total_tickets += min(((role in player.client.prefs.be_special) ? SSpersistence.antag_rep[p_ckey] : 0) + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
 
 	var/antag_select = rand(1,total_tickets)
 	var/current = 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -441,7 +441,10 @@
 	for(var/datum/mind/mind in candidates)
 		p_ckey = ckey(mind.key)
 		var/mob/dead/new_player/player = get_mob_by_ckey(p_ckey)
-		total_tickets += min(((role in player.client.prefs.be_special) ? SSpersistence.antag_rep[p_ckey] : 0) + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
+		if(!player)
+			candidates -= mind
+		else
+			total_tickets += min(((role in player.client.prefs.be_special) ? SSpersistence.antag_rep[p_ckey] : 0) + DEFAULT_ANTAG_TICKETS, MAX_TICKETS_PER_ROLL)
 
 	var/antag_select = rand(1,total_tickets)
 	var/current = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes antag_pick slightly safer against having nulls in the antag candidates list.
Makes clockcult safer against antag_pick failures by continuing if it returns null.

## Why It's Good For The Game

More defensive code, less likely to have errors cascading down and causing larger and larger issues.
If someone disconnects with the right timing, it shouldn't breka.

## Testing Photographs and Procedure

Quite difficult to test, I ran a ?compile to ensure that lists can have elements removed from them while enumerating through them.

## Changelog
:cl:
fix: Fixes clockcult sometimes failing due to antag_pick runtiming.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
