### PR TITLE
Chaplains arrive with their nullrod + armor beacon + smoke spell book

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12934,14 +12934,13 @@
 /area/library)
 "aJT" = (
 /obj/structure/table/wood,
-/obj/item/nullrod,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aJU" = (
 /obj/structure/table/wood,
 /obj/item/pen,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "aJV" = (
@@ -13316,6 +13315,10 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/structure/table/wood/fancy,
+/obj/item/soulstone/anybody/chaplain,
+/obj/item/organ/heart,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aLa" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13319,6 +13319,7 @@
 /obj/item/soulstone/anybody/chaplain,
 /obj/item/organ/heart,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/book/granter/spell/smoke/lesser,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aLa" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -100930,10 +100930,9 @@
 /area/maintenance/port/aft)
 "edm" = (
 /obj/structure/table/wood/fancy,
-/obj/item/book/granter/spell/smoke/lesser,
-/obj/item/nullrod,
 /obj/item/organ/heart,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "edn" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -100933,6 +100933,7 @@
 /obj/item/organ/heart,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
 /obj/item/soulstone/anybody/chaplain,
+/obj/item/book/granter/spell/smoke/lesser,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "edn" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -39936,6 +39936,7 @@
 	pixel_y = 7
 	},
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/book/granter/spell/smoke/lesser,
 /turf/open/floor/plasteel/cult,
 /area/chapel/office)
 "jcL" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -39935,9 +39935,7 @@
 	pixel_x = 8;
 	pixel_y = 7
 	},
-/obj/item/book/granter/spell/smoke/lesser{
-	name = "mysterious old book of cloud-chasing"
-	},
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/plasteel/cult,
 /area/chapel/office)
 "jcL" = (
@@ -42451,7 +42449,6 @@
 /area/crew_quarters/toilet/restrooms)
 "jJR" = (
 /obj/structure/table/wood,
-/obj/item/nullrod,
 /obj/item/folder,
 /turf/open/floor/carpet,
 /area/chapel/office)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -47001,16 +47001,13 @@
 /area/chapel/office)
 "bta" = (
 /obj/structure/table/wood/fancy,
-/obj/item/book/granter/spell/smoke/lesser{
-	pixel_y = 4
-	},
-/obj/item/nullrod{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/clothing/suit/hooded/chaplain_hoodie,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/soulstone/anybody/chaplain,
+/obj/item/organ/heart,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "btb" = (
@@ -85296,10 +85293,9 @@
 /area/maintenance/fore)
 "cBg" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/suit/hooded/chaplain_hoodie,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -47008,6 +47008,7 @@
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
 /obj/item/soulstone/anybody/chaplain,
 /obj/item/organ/heart,
+/obj/item/book/granter/spell/smoke/lesser,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "btb" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -69819,15 +69819,9 @@
 /area/chapel/office)
 "cMa" = (
 /obj/structure/table/wood,
-/obj/item/book/granter/spell/smoke/lesser{
-	name = "mysterious old book of cloud-chasing"
-	},
 /obj/item/reagent_containers/food/drinks/bottle/holywater{
 	pixel_x = -2;
 	pixel_y = 2
-	},
-/obj/item/nullrod{
-	pixel_x = 4
 	},
 /obj/item/organ/heart,
 /obj/item/soulstone/anybody/chaplain,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -69825,6 +69825,7 @@
 	},
 /obj/item/organ/heart,
 /obj/item/soulstone/anybody/chaplain,
+/obj/item/book/granter/spell/smoke/lesser,
 /turf/open/floor/plasteel/cult,
 /area/chapel/office)
 "cMb" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45170,6 +45170,9 @@
 /obj/structure/table/wood/fancy,
 /obj/item/folder,
 /obj/item/pen,
+/obj/item/organ/heart,
+/obj/item/soulstone/anybody/chaplain,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cru" = (
@@ -45383,7 +45386,7 @@
 /area/chapel/office)
 "cso" = (
 /obj/structure/table/wood,
-/obj/item/nullrod,
+/obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csp" = (
@@ -45432,11 +45435,6 @@
 /area/chapel/office)
 "csC" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/holywater{
-	name = "flask of holy water";
-	pixel_x = -2;
-	pixel_y = 2
-	},
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csE" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45173,6 +45173,7 @@
 /obj/item/organ/heart,
 /obj/item/soulstone/anybody/chaplain,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/book/granter/spell/smoke/lesser,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cru" = (

--- a/code/_globalvars/religion.dm
+++ b/code/_globalvars/religion.dm
@@ -8,7 +8,3 @@ GLOBAL_VAR(favor)
 GLOBAL_VAR(bible_name)
 GLOBAL_VAR(bible_icon_state)
 GLOBAL_VAR(bible_item_state)
-
-//gear
-GLOBAL_VAR(holy_weapon_type)
-GLOBAL_VAR(holy_armor_type)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -51,15 +51,9 @@
 	return holy_item_list
 
 /obj/item/choice_beacon/holy/spawn_option(obj/choice,mob/living/M)
-	if(!GLOB.holy_armor_type)
-		..()
-		playsound(src, 'sound/effects/pray_chaplain.ogg', 40, 1)
-		SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
-		GLOB.holy_armor_type = choice
-	else
-		to_chat(M, "<span class='warning'>A selection has already been made. Self-Destructing...</span>")
-		return
-
+	..()
+	playsound(src, 'sound/effects/pray_chaplain.ogg', 40, 1)
+	SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
 
 /obj/item/storage/box/holy
 	name = "Templar Kit"
@@ -268,8 +262,6 @@
 		reskin_holy_weapon(user)
 
 /obj/item/nullrod/proc/reskin_holy_weapon(mob/M)
-	if(GLOB.holy_weapon_type)
-		return
 	var/obj/item/nullrod/holy_weapon
 	var/list/holy_weapons_list = typesof(/obj/item/nullrod)
 	var/list/display_names = list()
@@ -284,8 +276,6 @@
 
 	var/A = display_names[choice] // This needs to be on a separate var as list member access is not allowed for new
 	holy_weapon = new A
-
-	GLOB.holy_weapon_type = holy_weapon.type
 
 	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[choice]")
 

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -39,9 +39,6 @@
 		B.item_state = GLOB.bible_item_state
 		to_chat(H, "There is already an established religion onboard the station. You are an acolyte of [GLOB.deity]. Defer to the Chaplain.")
 		H.equip_to_slot_or_del(B, ITEM_SLOT_BACKPACK)
-		var/nrt = GLOB.holy_weapon_type || /obj/item/nullrod
-		var/obj/item/nullrod/N = new nrt(H)
-		H.put_in_hands(N)
 		GLOB.religious_sect?.on_conversion(H)
 		return
 	H.mind?.holy_role = HOLY_ROLE_HIGHPRIEST
@@ -122,6 +119,10 @@
 	belt = /obj/item/pda/chaplain
 	ears = /obj/item/radio/headset/headset_srv
 	uniform = /obj/item/clothing/under/rank/civilian/chaplain
-	backpack_contents = list(/obj/item/camera/spooky = 1)
+	backpack_contents = list(
+		/obj/item/nullrod = 1,
+		/obj/item/choice_beacon/holy = 1,
+		/obj/item/camera/spooky = 1
+	)
 	backpack = /obj/item/storage/backpack/cultpack
 	satchel = /obj/item/storage/backpack/cultpack

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -122,6 +122,7 @@
 	backpack_contents = list(
 		/obj/item/nullrod = 1,
 		/obj/item/choice_beacon/holy = 1,
+		/obj/item/book/granter/spell/smoke/lesser = 1,
 		/obj/item/camera/spooky = 1
 	)
 	backpack = /obj/item/storage/backpack/cultpack

--- a/code/modules/jobs/job_types/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain.dm
@@ -122,7 +122,6 @@
 	backpack_contents = list(
 		/obj/item/nullrod = 1,
 		/obj/item/choice_beacon/holy = 1,
-		/obj/item/book/granter/spell/smoke/lesser = 1,
 		/obj/item/camera/spooky = 1
 	)
 	backpack = /obj/item/storage/backpack/cultpack

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -399,8 +399,7 @@
 	product_ads = "Are you being bothered by cultists or pesky revenants? Then come and dress like the holy man!;Clothes for men of the cloth!"
 	vend_reply = "Thank you for using the ChapDrobe!"
 	light_color = LIGHT_COLOR_WHITE
-	products = list(/obj/item/choice_beacon/holy = 1,
-					/obj/item/storage/backpack/cultpack = 1,
+	products = list(/obj/item/storage/backpack/cultpack = 1,
 					/obj/item/clothing/accessory/pocketprotector/cosmetology = 1,
 					/obj/item/clothing/under/rank/civilian/chaplain = 1,
 					/obj/item/clothing/under/rank/civilian/chaplain/skirt = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chaplains now arrive on the station (whether roundstart or latejoin) with their own reskinnable nullrod, their own armaments beacon (not from ChapDrobes anymore), and a lesser smoke spell book. Also, newly spawned null rods and armaments beacons can actually be used instead of either not reskinning (as is the case with null rods) or not working altogether (as is the case with armaments beacons).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Latejoin curators already get their own gear instead of it being exclusive to the first one, why can't latejoin chaplains? This also fixes the issue of chaplains cryo'ing and leaving new latejoin chaplains with no gear.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Chaplains now come with their null rods and armor beacons
tweak: Null rods have been removed from the hidden chapel locations across maps, and the chaplain's armaments beacons have been removed from ChapDrobes.
fix: Newly spawned null rods can be reskinned and newly spawned holy armor beacons actually work (instead of deleting themselves).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
