### PR TITLE
nerfs stacking of nanites, mutations, and viruses

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -16,6 +16,7 @@
 	var/start_time = 0 ///Timestamp to when the nanites were first inserted in the host
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans
 	var/diagnostics = TRUE //if TRUE, displays program list when scanned by nanite scanners
+	COOLDOWN_DECLARE(malfunction_cooldown)
 
 /datum/component/nanites/Initialize(amount = 100, cloud = 0)
 	if(!isliving(parent) && !istype(parent, /datum/nanite_cloud_backup))
@@ -32,6 +33,7 @@
 			return COMPONENT_INCOMPATIBLE
 
 		start_time = world.time
+		COOLDOWN_START(src, malfunction_cooldown, 300)
 
 		host_mob.hud_set_nanite_indicator()
 		START_PROCESSING(SSnanites, src)
@@ -117,6 +119,19 @@
 		if(cloud_id && cloud_active && world.time > next_sync)
 			cloud_sync()
 			next_sync = world.time + NANITE_SYNC_DELAY
+		if(COOLDOWN_FINISHED(src, malfunction_cooldown) && iscarbon(host_mob))
+			var/mob/living/carbon/C = host_mob
+			var/datum/nanite_program/malfunction = pick(programs)
+			switch(C.dna.update_instability(FALSE))
+				if(1 to 30)
+					malfunction.software_error(rand(1, 5))
+				if(31 to 50)
+					malfunction.software_error(rand(1, 4))
+				if(51 to 65)
+					malfunction.software_error(rand(2, 4))
+				if(66 to 80)
+					malfunction.software_error(rand(3, 4))
+			COOLDOWN_START(src, malfunction_cooldown, rand(300, 900))
 	set_nanite_bar()
 
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -564,8 +564,11 @@
 		A.initial = FALSE //diseases *only* mutate when spreading. they wont mutate from any other kind of injection
 	infectee.diseases += A
 	A.affected_mob = infectee
+	if(iscarbon(infectee))
+		var/mob/living/carbon/C = infectee
+		C.dna.update_instability(FALSE)
 	SSdisease.active_diseases += A //Add it to the active diseases list, now that it's actually in a mob and being processed.
-
+	
 	A.after_add()
 	infectee.med_hud_set_status()
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -217,6 +217,11 @@
 
 /datum/dna/proc/update_instability(alert=TRUE)
 	stability = 100
+	if(holder)
+		for(var/datum/disease/advance/A as() in holder.diseases)
+			for(var/datum/symptom/S as() in A.symptoms)
+				if(S.severity < 0)
+					stability = max(20, stability - (S.severity * 20))
 	for(var/datum/mutation/human/M in mutations)
 		if(M.class == MUT_EXTRA)
 			stability -= M.instability * GET_MUTATION_STABILIZER(M)
@@ -240,6 +245,7 @@
 			holder.apply_status_effect(STATUS_EFFECT_DNA_MELT)
 		if(message)
 			to_chat(holder, message)
+		return stability 
 
 //used to update dna UI, UE, and dna.real_name.
 /datum/dna/proc/update_dna_identity()


### PR DESCRIPTION
## About The Pull Request
genetic instability now causes nanites to malfunction every 30 to 90 seconds. the severity of the malfunction depends on how high instability is, and doesnt kick in until 20 instability
viruses add up to 80 genetic instability, depending on their symptoms (every symptom with negative severity lowers stability by 20 times its severity)

## Why It's Good For The Game
genetics, viro, and nanites are balanced in a vacuum, and become greatly unbalanced when stacked. This change discourages stacking the three

## Testing Photographs and Procedure
[will test when i get home]

## Changelog
:cl:
balance: positive viruses increase genetic instability, up to 80. 
balance: high genetic instability can cause nanites to malfunction
/:cl:
