### PR TITLE
Fixes some small issues with get_hearers_in_view regarding invisible mobs

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -241,7 +241,13 @@
 
 	return found_mobs
 
-/// Returns a list of hearers in view(view_radius) from source (ignoring luminosity). uses important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE]
+/**
+ * Returns a list of hearers in view(view_radius) from source (ignoring luminosity). uses important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE]
+ * vars:
+ * * view_radius is distance we look for potential hearers
+ * * source is obviously the source attom from where we start looking
+ * * invis_flags is for if we want to include invisible mobs or even ghosts etc the default value 0 means only visible mobs are included SEE_INVISIBLE_OBSERVER would also include ghosts.
+ */
 /proc/get_hearers_in_view(view_radius, atom/source, invis_flags = 0)
 	var/turf/center_turf = get_turf(source)
 	. = list()

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -242,12 +242,12 @@
 	return found_mobs
 
 /// Returns a list of hearers in view(view_radius) from source (ignoring luminosity). uses important_recursive_contents[RECURSIVE_CONTENTS_HEARING_SENSITIVE]
-/proc/get_hearers_in_view(view_radius, atom/source)
+/proc/get_hearers_in_view(view_radius, atom/source, invis_flags = 0)
 	var/turf/center_turf = get_turf(source)
 	. = list()
 	if(!center_turf)
 		return
-	for(var/atom/movable/movable in dview(view_radius, center_turf))
+	for(var/atom/movable/movable in dview(view_radius, center_turf, invis_flags))
 		var/list/recursive_contents = LAZYACCESS(movable.important_recursive_contents, RECURSIVE_CONTENTS_HEARING_SENSITIVE)
 		if(recursive_contents)
 			. += recursive_contents

--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -161,7 +161,7 @@
 	var/list/old = hearing_mobs.Copy()
 	hearing_mobs.len = 0
 	var/turf/source = get_turf(parent)
-	for(var/mob/M in get_hearers_in_view(instrument_range, source))
+	for(var/mob/M in get_hearers_in_view(instrument_range, source, SEE_INVISIBLE_OBSERVER))
 		hearing_mobs[M] = get_dist(M, source)
 	var/list/exited = old - hearing_mobs
 	for(var/i in exited)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -242,7 +242,7 @@
   * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
   */
 /atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, list/audible_message_flags)
-	var/list/hearers = get_hearers_in_view(hearing_distance, src)
+	var/list/hearers = get_hearers_in_view(hearing_distance, src, SEE_INVISIBLE_OBSERVER)
 	if(self_message)
 		hearers -= src
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR simply adds another argument to get_hearers_in_view that then can be forwarded towards dview for the invisibility flag that way we can still also include normally invisible mobs like ghosts etc.

## Why It's Good For The Game

Ghosts can hear music or other stuff again

## Changelog
:cl:
fix: ghosts not beeing able to hear instruments
fix: pai card alert ping not visible to ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
