### PR TITLE
Makes ectoscopic sniffer more obvious, plus fix

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22474,7 +22474,6 @@
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
 	},
-/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bow" = (
@@ -47418,6 +47417,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"hYs" = (
+/obj/machinery/ecto_sniffer,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
 "hZj" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/cigbutt/roach,
@@ -105480,7 +105483,7 @@ aXq
 bds
 bfV
 bhx
-biL
+hYs
 biL
 cHO
 blG

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -178,6 +178,7 @@
 /area/science/robotics/lab)
 "aaw" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "aay" = (
@@ -88637,7 +88638,6 @@
 	pixel_y = 38
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dzL" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -53250,6 +53250,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel/grid/steel,
 /area/science/robotics/lab)
 "mll" = (
@@ -75431,7 +75432,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "rHr" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12453,6 +12453,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "aul" = (
@@ -38960,7 +38961,6 @@
 /obj/item/assembly/flash/handheld/weak,
 /obj/item/assembly/flash/handheld/weak,
 /obj/item/assembly/flash/handheld/weak,
-/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bhC" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -68244,7 +68244,6 @@
 	},
 /obj/item/borg/upgrade/rename,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cIO" = (
@@ -83180,6 +83179,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wqA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/ecto_sniffer,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "wtq" = (
 /turf/closed/wall,
 /area/maintenance/aft/secondary)
@@ -112263,7 +112269,7 @@ cDb
 cEk
 cFd
 cGb
-cGb
+wqA
 cHQ
 cIJ
 cYc

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27255,7 +27255,6 @@
 	},
 /obj/item/crowbar,
 /obj/structure/table,
-/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "brz" = (
@@ -60467,6 +60466,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"tWw" = (
+/obj/machinery/ecto_sniffer,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "tXm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -99906,7 +99909,7 @@ bgC
 bkv
 blF
 bmM
-bmM
+tWw
 wug
 bqh
 brx

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -19,21 +19,23 @@
 	wires = new/datum/wires/ecto_sniffer(src)
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)
-	. = ..()
+	///don't call ..() due to special ghost functionality
 	if(!on || !sensor_enabled || !is_operational())
 		return
 
 	if(ectoplasmic_residues[user.ckey])
+		to_chat(user, "<span class='warning'>You must wait for your ectoplasmic residue to decay off of [src]'s sensors!</span>")
 		return
 	activate(user)
 
 /obj/machinery/ecto_sniffer/proc/activate(mob/activator)
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 25)
+	visible_message("<span class='notice'>[src] beeps, detecting ectoplasm! There may be additional positronic brain matrixes available!</span>")
 	use_power(10)
 	if(activator?.ckey)
 		ectoplasmic_residues[activator.ckey] = TRUE
-		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 15 SECONDS)
+		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 30 SECONDS)
 
 /obj/machinery/ecto_sniffer/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
@@ -52,9 +54,7 @@
 
 
 /obj/machinery/ecto_sniffer/wrench_act(mob/living/user, obj/item/tool)
-	tool.play_tool_sound(src, 15)
-	setAnchored(!anchored)
-	balloon_alert(user, "sniffer [anchored ? "anchored" : "unanchored"]")
+	return default_unfasten_wrench(user, tool)
 
 /obj/machinery/ecto_sniffer/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -25,6 +25,10 @@
 	if(ectoplasmic_residues[user.ckey])
 		to_chat(user, "<span class='warning'>You must wait for your ectoplasmic residue to decay off of [src]'s sensors!</span>")
 		return
+
+	if(is_banned_from(user.ckey, ROLE_POSIBRAIN))
+		to_chat(user, "<span class='warning'>Central Command outlawed your soul from interacting with the living...</span>")
+		return
 	activate(user)
 
 /obj/machinery/ecto_sniffer/proc/activate(mob/activator)

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -19,7 +19,6 @@
 	wires = new/datum/wires/ecto_sniffer(src)
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)
-	///don't call ..() due to special ghost functionality
 	if(!on || !sensor_enabled || !is_operational())
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Most roboticists who do not lurk on github or view change log, and do not know the sniffer even exists, much less whatever the hell that beeping noise in robotics is. This should make it more obvious.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Fixed the wrench_act proc for the sniffer to use default_unfasten_wrench (shouldn't this be more universal?), as well as making it more obvious for roboticsts, doubling the delay to 30 seconds to compensate.

As per deadchat advice, move the sniffer in front of the circuit printer for most (corg is fine) maps so it is not covered by clutter.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/30960302/161357070-97c0f523-5c55-46f7-9072-bd1d91e36e63.png)

</details>

## Changelog
:cl:
add: More info messages for ectoscopic sniffer.
fix: Ectoscopic sniffer wrenching.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
