### PR TITLE
Makes local testing less CBT

### DIFF
--- a/code/_debugger.dm
+++ b/code/_debugger.dm
@@ -2,6 +2,7 @@
 //Datum gets created in master.dm because for whatever reason global code in there gets runs first
 //In case we ever figure out how to manipulate global init order please move the datum creation into this file
 /datum/debugger
+	var/enabled = FALSE
 
 /datum/debugger/New()
 		enable_debugger()
@@ -11,3 +12,4 @@
 	if (dll)
 		call(dll, "auxtools_init")()
 		enable_debugging()
+		enabled = TRUE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -244,6 +244,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(CONFIG_GET(flag/enable_localhost_rank) && !connecting_admin)
 		var/localhost_addresses = list("127.0.0.1", "::1")
 		if(isnull(address) || (address in localhost_addresses))
+			if(Debugger?.enabled)
+				to_chat_immediate(src, "<span class='userdanger'>Debugger enabled. Make sure you untick \"Runtime errors\" in the bottom left of VSCode's Run and Debug tab.</span>")
 			var/datum/admin_rank/localhost_rank = new("!localhost!", R_EVERYTHING, R_DBRANKS, R_EVERYTHING) //+EVERYTHING -DBRANKS *EVERYTHING
 			new /datum/admins(localhost_rank, ckey, 1, 1)
 	//preferences datum - also holds some persistent data for the client (because we may as well keep these datums to a minimum)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -165,6 +165,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			unlock_content = C.IsByondMember()
 			if(unlock_content)
 				max_save_slots = 8
+		else if(!length(key_bindings)) // Guests need default keybinds
+			key_bindings = deepCopyList(GLOB.keybinding_list_by_key)
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
 		if("6030fe461e610e2be3a2c3e75c06067e" in purchased_gear) //MD5 hash of, "extra character slot"

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(valid_keys, list(
 		full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
 
 	var/list/kbs = list()
-	for (var/kb_name in prefs.key_bindings[full_key])
+	for (var/kb_name in prefs.key_bindings?[full_key])
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		kbs += kb
 	kbs = sortList(kbs, /proc/cmp_keybinding_dsc)
@@ -89,7 +89,7 @@ GLOBAL_LIST_INIT(valid_keys, list(
 	// We don't do full key for release, because for mod keys you
 	// can hold different keys and releasing any should be handled by the key binding specifically
 	var/list/kbs = list()
-	for (var/kb_name in prefs.key_bindings[_key])
+	for (var/kb_name in prefs.key_bindings?[_key])
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		kbs += kb
 	kbs = sortList(kbs, /proc/cmp_keybinding_dsc)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(valid_keys, list(
 		full_key = "[AltMod][CtrlMod][ShiftMod][_key]"
 
 	var/list/kbs = list()
-	for (var/kb_name in prefs.key_bindings?[full_key])
+	for (var/kb_name in prefs.key_bindings[full_key])
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		kbs += kb
 	kbs = sortList(kbs, /proc/cmp_keybinding_dsc)
@@ -89,7 +89,7 @@ GLOBAL_LIST_INIT(valid_keys, list(
 	// We don't do full key for release, because for mod keys you
 	// can hold different keys and releasing any should be handled by the key binding specifically
 	var/list/kbs = list()
-	for (var/kb_name in prefs.key_bindings?[_key])
+	for (var/kb_name in prefs.key_bindings[_key])
 		var/datum/keybinding/kb = GLOB.keybindings_by_name[kb_name]
 		kbs += kb
 	kbs = sortList(kbs, /proc/cmp_keybinding_dsc)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5714543/161364147-50a5a014-5f02-43b7-945a-2302178fee61.png)

## Changelog
:cl:
add: People running a local testing server through VSCode will now get a big warning reminding them to disable breakpoints on runtime errors.
fix: Fixed a keybind runtime caused by guest ckeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
