### PR TITLE
Battle Royale fixes

### DIFF
--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -290,11 +290,10 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		SSticker.start_immediately = TRUE
 	SEND_SOUND(world, sound('sound/misc/server-ready.ogg'))
 	sleep(50)
-	//Clear client mobs
+	//Clear all living mobs
 	to_chat(world, "<span class='boldannounce'>Battle Royale: Clearing world mobs.</span>")
-	for(var/mob/M as() in GLOB.player_list)
-		if(isliving(M))
-			qdel(M)
+	for(var/mob/living/M as() in GLOB.mob_living_list)
+		qdel(M)
 		CHECK_TICK
 	sleep(50)
 	to_chat(world, "<span class='greenannounce'>Battle Royale: STARTING IN 30 SECONDS.</span>")

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -203,8 +203,8 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	. = ..()
 	GLOB.enter_allowed = TRUE
 
-	//Toggle ghost roles back
-	GLOB.ghost_role_flags ^= (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS)
+	//Don't let anyone join as posibrains/golems etc
+	ENABLE_BITFIELD(GLOB.ghost_role_flags, (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS))
 
 	world.update_status()
 	GLOB.battle_royale = null
@@ -271,7 +271,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	GLOB.enter_allowed = FALSE
 
 	//Don't let anyone join as posibrains/golems etc
-	GLOB.ghost_role_flags ^= (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS)
+	DISABLE_BITFIELD(GLOB.ghost_role_flags, (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS))
 
 	world.update_status()
 	if(SSticker.current_state < GAME_STATE_PREGAME)

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -202,6 +202,10 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		C.remove_verb(BATTLE_ROYALE_AVERBS)
 	. = ..()
 	GLOB.enter_allowed = TRUE
+
+	//Toggle ghost roles back
+	GLOB.ghost_role_flags ^= (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS)
+
 	world.update_status()
 	GLOB.battle_royale = null
 
@@ -265,6 +269,10 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	to_chat(world, "<span class='ratvar'><font size=24>Battle Royale will begin soon...</span></span>")
 	//Stop new player joining
 	GLOB.enter_allowed = FALSE
+
+	//Don't let anyone join as posibrains/golems etc
+	GLOB.ghost_role_flags ^= (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS)
+
 	world.update_status()
 	if(SSticker.current_state < GAME_STATE_PREGAME)
 		to_chat(world, "<span class=boldannounce>Battle Royale: Waiting for server to be ready...</span>")
@@ -336,12 +344,13 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 		var/obj/item/implant/weapons_auth/W = new
 		W.implant(H)
 		players += H
-		to_chat(M, "<span class='notice'>You have been given knock and pacafism for 30 seconds.</span>")
+		to_chat(M, "<span class='notice'>You have been given knock and pacifism for 30 seconds.</span>")
 	new /obj/effect/pod_landingzone(spawn_turf, pod)
 	SEND_SOUND(world, sound('sound/misc/airraid.ogg'))
 	to_chat(world, "<span class='boldannounce'>A 30 second grace period has been established. Good luck.</span>")
 	to_chat(world, "<span class='boldannounce'>WARNING: YOU WILL BE GIBBED IF YOU LEAVE THE STATION Z-LEVEL!</span>")
 	to_chat(world, "<span class='boldannounce'>[players.len] people remain...</span>")
+
 	//Start processing our world events
 	addtimer(CALLBACK(src, .proc/end_grace), 300)
 	generate_basic_loot(150)

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -203,7 +203,7 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	. = ..()
 	GLOB.enter_allowed = TRUE
 
-	//Don't let anyone join as posibrains/golems etc
+	//BR finished? Let people play as borgs/golems again
 	ENABLE_BITFIELD(GLOB.ghost_role_flags, (GHOSTROLE_SPAWNER | GHOSTROLE_SILICONS))
 
 	world.update_status()

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -45,6 +45,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		brainmob = new(src)
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SILICONS))
 		to_chat(user, "<span class='warning'>Central Command has temporarily outlawed posibrain sentience in this sector...</span>")
+		return
 	if(is_occupied())
 		to_chat(user, "<span class='warning'>This [name] is already active!</span>")
 		return


### PR DESCRIPTION
## About The Pull Request

Stops people from joining as posibrains/golems etc during Battle Royale, also you no longer can manually turn on a posibrain when sillycone sentience is disabled.

In addition, now the mode kills ALL living mobs, to prevent people from disconnection and then connecting again to avoid the wipe.

## Why It's Good For The Game

Borgo spam during Battle Royale is cringe, don't be cringe.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Mat05usz
fix: You can no longer join as borgs/golems etc during Battle Royale
fix: All living mobs are cleared when BR starts, no more disconnecting to avoid the wipe
/:cl: