### PR TITLE
Removes Soporific Slugs

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -15,12 +15,6 @@
 	projectile_type = /obj/item/projectile/bullet/shotgun_beanbag
 	materials = list(/datum/material/iron=250)
 
-/obj/item/ammo_casing/shotgun/sleepytime
-	name = "soporific shell"
-	desc = "A shotgun shell loaded with a hypodermic needle containing a low strength knock-out agent that will confuse a target on the first shot, and put them to sleep on the second."
-	icon_state = "sleepy"
-	projectile_type = /obj/item/projectile/bullet/sleepy
-
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -12,23 +12,6 @@
 	name = "incendiary slug"
 	damage = 20
 
-/obj/item/projectile/bullet/sleepy
-	name = "soporific slug"
-	damage = 0
-
-/obj/item/projectile/bullet/sleepy/on_hit(atom/target, blocked = FALSE)
-	if((blocked != 100) && ishuman(target))
-		var/mob/living/L = target
-		if(!L.can_inject(null, FALSE, def_zone || BODY_ZONE_CHEST))
-			return ..()
-		//If block is 0, then factor = 1, if block is 1 then factor = 0
-		var/factor = CLAMP((100 - blocked) / 100, 0, 1)
-		if(L.confused > 40)
-			L.Sleeping(50 * factor)
-		else
-			L.confused = 80 * factor
-	return ..()
-
 /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
 	damage = 5

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -19,7 +19,7 @@
 /obj/item/projectile/bullet/sleepy/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && ishuman(target))
 		var/mob/living/L = target
-		if(!L.can_inject(null, FALSE, BODY_ZONE_CHEST))
+		if(!L.can_inject(null, FALSE, def_zone || BODY_ZONE_CHEST))
 			return ..()
 		//If block is 0, then factor = 1, if block is 1 then factor = 0
 		var/factor = CLAMP((100 - blocked) / 100, 0, 1)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,12 +17,16 @@
 	damage = 0
 
 /obj/item/projectile/bullet/sleepy/on_hit(atom/target, blocked = FALSE)
-	if(!blocked && ishuman(target))
+	if((blocked != 100) && ishuman(target))
 		var/mob/living/L = target
-		if(L.confused)
-			L.Sleeping(50)
+		if(!L.can_inject(null, FALSE, BODY_ZONE_CHEST))
+			return ..()
+		//If block is 0, then factor = 1, if block is 1 then factor = 0
+		var/factor = CLAMP((100 - blocked) / 100, 0, 1)
+		if(L.confused > 40)
+			L.Sleeping(50 * factor)
 		else
-			L.confused = 80
+			L.confused = 80 * factor
 	return ..()
 
 /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,7 +17,7 @@
 	damage = 0
 
 /obj/item/projectile/bullet/sleepy/on_hit(atom/target, blocked = FALSE)
-	if((blocked != 100) && ishuman(target))
+	if(!blocked && ishuman(target))
 		var/mob/living/L = target
 		if(L.confused)
 			L.Sleeping(50)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -44,15 +44,6 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/sleepy/sec
-	name = "Soporific Shell"
-	id = "sleepy"
-	build_type = PROTOLATHE
-	category = list("Ammo")
-	materials = list(/datum/material/iron = 4000, /datum/material/silver = 400, /datum/material/copper = 400)
-	build_path = /obj/item/ammo_casing/shotgun/sleepytime
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-
 /datum/design/rubbershot/sec
 	id = "sec_rshot"
 	build_type = PROTOLATHE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~Apparently sopophoric slugs work against targets that cannot be peirced, which I don't think should have been the case.
Additionally makes sopophoric slugs effect depend on the targets armour: If a target has 50 armour the sleeping effect is only 50% effective.~~

Completely removes soporific slugs from the game.

## Why It's Good For The Game

Sopophoric can take out a nukie in 2 shots, despite their armour being penetration resistant. Despite requiring exploration disks, these shells are too strong for an easilly mass-producable shell.

The problem with them isn't necessarilly the fact that they are too powerful, its the fact that they are unfair by design which is why I favour removing them over simply nerfing them.

closes: #6606

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/161397798-8464275b-3b72-42a3-a31b-7be8f20205b3.png)

## Changelog
:cl:
remove: Removes the soporific slugs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
