### PR TITLE
Fixes fireman carry bug

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -53,6 +53,7 @@
 		buckled_mobs = list()
 
 	if(!is_buckle_possible(M, force, check_loc))
+		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
 		return FALSE
 
 	M.buckling = src
@@ -62,6 +63,7 @@
 		else
 			to_chat(usr, "<span class='warning'>You are unable to buckle [M] to [src]!</span>")
 		M.buckling = null
+		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
 		return FALSE
 
 	if(M.pulledby)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -53,7 +53,6 @@
 		buckled_mobs = list()
 
 	if(!is_buckle_possible(M, force, check_loc))
-		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
 		return FALSE
 
 	M.buckling = src
@@ -63,7 +62,6 @@
 		else
 			to_chat(usr, "<span class='warning'>You are unable to buckle [M] to [src]!</span>")
 		M.buckling = null
-		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
 		return FALSE
 
 	if(M.pulledby)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1012,10 +1012,12 @@
 	riding_datum.handle_vehicle_layer()
 	. = ..(target, force, check_loc)
 
-	//Something went wrong with buckling, unbuckle!
+	//Something went wrong with buckling, remove inhands and restore target's position!
 	if(!.)
-		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, target, force)
-		to_chat(src, "<span class='warning'>You seem to be unable to buckle [target] to yourself!</span>")
+		riding_datum.unequip_buckle_inhands(src)
+		riding_datum.unequip_buckle_inhands(target)
+		riding_datum.restore_position(target)
+		to_chat(src, "<span class='warning'>You seem to be unable to carry [target]!</span>")
 
 /mob/living/carbon/human/proc/is_shove_knockdown_blocked() //If you want to add more things that block shove knockdown, extend this
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1012,6 +1012,11 @@
 	riding_datum.handle_vehicle_layer()
 	. = ..(target, force, check_loc)
 
+	//Something went wrong with buckling, unbuckle!
+	if(!.)
+		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, target, force)
+		to_chat(src, "<span class='warning'>You seem to be unable to buckle [target] to yourself!</span>")
+
 /mob/living/carbon/human/proc/is_shove_knockdown_blocked() //If you want to add more things that block shove knockdown, extend this
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
 	for(var/bp in body_parts)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -944,7 +944,6 @@
   */
 /mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(M.buckled)
-		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
 		return FALSE
 	var/turf/T = get_turf(src)
 	if(M.loc != T)
@@ -953,7 +952,6 @@
 		var/can_step = step_towards(M, T)
 		density = old_density
 		if(!can_step)
-			SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
 			return FALSE
 	return ..()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -944,7 +944,8 @@
   */
 /mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(M.buckled)
-		return 0
+		SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
+		return FALSE
 	var/turf/T = get_turf(src)
 	if(M.loc != T)
 		var/old_density = density
@@ -952,7 +953,8 @@
 		var/can_step = step_towards(M, T)
 		density = old_density
 		if(!can_step)
-			return 0
+			SEND_SIGNAL(src, COMSIG_MOVABLE_UNBUCKLE, M, force)
+			return FALSE
 	return ..()
 
 ///Call back post buckle to a mob to offset your visual height


### PR DESCRIPTION
## About The Pull Request

Fixes: #6575

What this PR does is send a COMSIG_MOVABLE_UNBUCKLE every time buckling fails, so you can't try to buckle something to you (for example when standing on a table or in a wall), bug it out to get an offhand and be able to teleport the buckled person anywhere at will.

I tried several solutions, some of them not working or being much uglier than this one, this is so far the best I've come up with and can't seem to figure out a better way. If there is one, please do tell.

## Why It's Good For The Game

Bugs bad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixes fireman carry bug
/:cl: