### PR TITLE
Fixes a null override

### DIFF
--- a/code/game/mecha/mecha_wreckage.dm
+++ b/code/game/mecha/mecha_wreckage.dm
@@ -79,7 +79,7 @@
 			to_chat(user, "<span class='warning'>You don't see anything that can be pried with [I]!</span>")
 
 
-/obj/structure/mecha_wreckage/transfer_ai(interaction, mob/user, null, obj/item/aicard/card)
+/obj/structure/mecha_wreckage/transfer_ai(interaction, mob/user, mob/living/silicon/ai/ai_mob, obj/item/aicard/card)
 	if(!..())
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About the Pull Request

You can't declare an arg as `null`.

`/obj/structure/mecha_wreckage/transfer_ai(interaction, mob/user, null, obj/item/aicard/card)`

The third argument in this proc is not the `null` value type. It's a var named `null`. Literally `var/null`.

Guess what else it does?

It'll be used in place of the `null` keyword:
![image](https://user-images.githubusercontent.com/5714543/162020315-066e5c0a-8baa-4891-9c70-934d12bff7fc.png)

Ergo we made it an error in OD and filed a BYOND bug report that hasn't been fixed yet.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
