### PR TITLE
Removes airborne transmission from advanced diseases

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -21,7 +21,7 @@
 	var/list/viable_mobtypes = list() //typepaths of viable mobs
 	var/mob/living/carbon/affected_mob = null
 	var/list/cures = list() //list of cures if the disease has the CURABLE flag, these are reagent ids
-	var/infectivity = 20
+	var/infectivity = 10
 	var/cure_chance = 8
 	var/carrier = FALSE //If our host is only a carrier
 	var/bypasses_immunity = FALSE //Does it skip species virus immunity check? Some things may diseases and not viruses

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -21,7 +21,7 @@
 	var/list/viable_mobtypes = list() //typepaths of viable mobs
 	var/mob/living/carbon/affected_mob = null
 	var/list/cures = list() //list of cures if the disease has the CURABLE flag, these are reagent ids
-	var/infectivity = 65
+	var/infectivity = 20
 	var/cure_chance = 8
 	var/carrier = FALSE //If our host is only a carrier
 	var/bypasses_immunity = FALSE //Does it skip species virus immunity check? Some things may diseases and not viruses
@@ -46,12 +46,8 @@
 	infect(infectee, make_copy)
 	return TRUE
 
-/**
-* add the disease with no checks
-* Don't use this proc. use ForceContractDisease on mob/living/carbon instead
-*/
+//add the disease with no checks
 /datum/disease/proc/infect(var/mob/living/infectee, make_copy = TRUE)
-	PROTECTED_PROC(TRUE)
 	var/datum/disease/D = make_copy ? Copy() : src	
 	infectee.diseases += D
 	D.affected_mob = infectee

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -273,8 +273,7 @@
 	else
 		visibility_flags &= ~HIDDEN_SCANNER
 
-	SetSpread(CLAMP(2 ** (transmission - symptoms.len), DISEASE_SPREAD_BLOOD, DISEASE_SPREAD_AIRBORNE))
-
+	SetSpread()
 	permeability_mod = max(CEILING(0.4 * transmission, 1), 1)
 	cure_chance = 15 - CLAMP(resistance, -5, 5) // can be between 10 and 20
 	stage_prob = max(stage_rate, 2)
@@ -284,7 +283,7 @@
 
 
 // Assign the spread type and give it the correct description.
-/datum/disease/advance/proc/SetSpread(spread_id)
+/datum/disease/advance/proc/SetSpread()
 	if(faltered)
 		spread_flags = DISEASE_SPREAD_FALTERED
 		spread_text = "Intentional Injection"
@@ -292,25 +291,16 @@
 		spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 		spread_text = "None"
 	else
-		switch(spread_id)
-			if(DISEASE_SPREAD_NON_CONTAGIOUS)
-				spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-				spread_text = "None"
-			if(DISEASE_SPREAD_SPECIAL)
-				spread_flags = DISEASE_SPREAD_SPECIAL
-				spread_text = "None"
-			if(DISEASE_SPREAD_BLOOD)
+		switch(transmission)
+			if(-INFINITY to 5)
 				spread_flags = DISEASE_SPREAD_BLOOD
 				spread_text = "Blood"
-			if(DISEASE_SPREAD_CONTACT_FLUIDS)
+			if(6 to 10)
 				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS
 				spread_text = "Fluids"
-			if(DISEASE_SPREAD_CONTACT_SKIN)
+			if(11 to INFINITY)
 				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN
 				spread_text = "On contact"
-			if(DISEASE_SPREAD_AIRBORNE)
-				spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_AIRBORNE
-				spread_text = "Airborne"
 
 /datum/disease/advance/proc/SetDanger(level_sev)
 	switch(level_sev)

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -55,7 +55,7 @@ BONUS
 	if(A.stage_rate >= 6) //cough more often
 		symptom_delay_max = 10
 	if(A.transmission >= 11) //spread virus
-		infective = true
+		infective =TRUE
 
 /datum/symptom/cough/Activate(datum/disease/advance/A)
 	if(!..())
@@ -79,7 +79,7 @@ BONUS
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 12)
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 18)
 			if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED) && prob(50))
-				addtimer(CALLBACK(A, .proc/spread, 2), 20)
+				addtimer(CALLBACK(A, /datum/disease/.proc/spread, 2), 20)
 				M.visible_message("<span class='danger'>[M] roughly coughs, letting loose a spray of phlegm and saliva!</span>")
 
 

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -80,6 +80,5 @@ BONUS
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 18)
 			if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED) && prob(50))
 				addtimer(CALLBACK(A, /datum/disease/.proc/spread, 2), 20)
-				M.visible_message("<span class='danger'>[M] roughly coughs, letting loose a spray of phlegm and saliva!</span>")
 
 

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -33,7 +33,8 @@ BONUS
 	threshold_desc = "<b>Resistance 3:</b> Host will drop small items when coughing.<br>\
 					  <b>Resistance 10:</b> Occasionally causes coughing fits that stun the host.<br>\
 					  <b>Stage Speed 6:</b> Increases cough frequency.<br>\
-					  <b>Stealth 4:</b> The symptom remains hidden until active."
+					  <b>Stealth 4:</b> The symptom remains hidden until active.<br>\
+					  <b>Transmission 11:</b> The host's coughing will occasionally spread the virus."
 
 /datum/symptom/cough/severityset(datum/disease/advance/A)
 	. = ..()
@@ -53,6 +54,8 @@ BONUS
 			power = 2
 	if(A.stage_rate >= 6) //cough more often
 		symptom_delay_max = 10
+	if(A.transmission >= 11) //spread virus
+		infective = true
 
 /datum/symptom/cough/Activate(datum/disease/advance/A)
 	if(!..())
@@ -75,4 +78,8 @@ BONUS
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 6)
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 12)
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 18)
+			if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED) && prob(50))
+				addtimer(CALLBACK(A, .proc/spread, 2), 20)
+				M.visible_message("<span class='danger'>[M] roughly coughs, letting loose a spray of phlegm and saliva!</span>")
+
 

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -33,7 +33,6 @@ BONUS
 	threshold_desc = "<b>Resistance 3:</b> Host will drop small items when coughing.<br>\
 					  <b>Resistance 10:</b> Occasionally causes coughing fits that stun the host.<br>\
 					  <b>Stage Speed 6:</b> Increases cough frequency.<br>\
-					  <b>If Airborne:</b> Coughing will infect bystanders.<br>\
 					  <b>Stealth 4:</b> The symptom remains hidden until active."
 
 /datum/symptom/cough/severityset(datum/disease/advance/A)
@@ -48,8 +47,6 @@ BONUS
 		return
 	if(A.stealth >= 4)
 		suppress_warning = TRUE
-	if(A.spread_flags & DISEASE_SPREAD_AIRBORNE) //infect bystanders
-		infective = TRUE
 	if(A.resistance >= 3) //strong enough to drop items
 		power = 1.5
 		if(A.resistance >= 10) //strong enough to stun (rarely)
@@ -78,6 +75,4 @@ BONUS
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 6)
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 12)
 				addtimer(CALLBACK(M, /mob/.proc/emote, "cough"), 18)
-			if(infective && M.CanSpreadAirborneDisease())
-				A.spread(1)
 

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -72,7 +72,8 @@ Bonus
 	M.adjust_fire_stacks(1 * power)
 	M.take_overall_damage(burn = 3 * power, required_status = BODYTYPE_ORGANIC)
 	if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
-		A.spread(2)
+		addtimer(CALLBACK(A, .proc/spread, 2), 20)
+		M.visible_message("<span class='danger'>[M] bursts into flames, spreading burning sparks about the area!</span>")
 	return 1
 
 /datum/symptom/fire/proc/Firestacks_stage_5(mob/living/M, datum/disease/advance/A)
@@ -82,7 +83,8 @@ Bonus
 		M.adjust_fire_stacks(3 * power)
 	M.take_overall_damage(burn = 5 * power, required_status = BODYTYPE_ORGANIC)
 	if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
-		A.spread(4)
+		addtimer(CALLBACK(A, .proc/spread, 4), 20)
+		M.visible_message("<span class='danger'>[M] bursts into flames, spreading burning sparks about the area!</span>")
 	return 1
 
 

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -71,7 +71,7 @@ Bonus
 /datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
 	M.adjust_fire_stacks(1 * power)
 	M.take_overall_damage(burn = 3 * power, required_status = BODYTYPE_ORGANIC)
-	if(infective)
+	if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
 		A.spread(2)
 	return 1
 

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -72,7 +72,7 @@ Bonus
 	M.adjust_fire_stacks(1 * power)
 	M.take_overall_damage(burn = 3 * power, required_status = BODYTYPE_ORGANIC)
 	if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
-		addtimer(CALLBACK(A, .proc/spread, 2), 20)
+		addtimer(CALLBACK(A, /datum/disease/.proc/spread, 2), 20)
 		M.visible_message("<span class='danger'>[M] bursts into flames, spreading burning sparks about the area!</span>")
 	return 1
 
@@ -83,7 +83,7 @@ Bonus
 		M.adjust_fire_stacks(3 * power)
 	M.take_overall_damage(burn = 5 * power, required_status = BODYTYPE_ORGANIC)
 	if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
-		addtimer(CALLBACK(A, .proc/spread, 4), 20)
+		addtimer(CALLBACK(A, /datum/disease/.proc/spread, 4), 20)
 		M.visible_message("<span class='danger'>[M] bursts into flames, spreading burning sparks about the area!</span>")
 	return 1
 

--- a/code/datums/diseases/advance/symptoms/pierrot.dm
+++ b/code/datums/diseases/advance/symptoms/pierrot.dm
@@ -63,7 +63,7 @@
 				if(prob(5))
 					playsound(M.loc, 'sound/items/bikehorn.ogg', 100, 1)
 					if(honkspread && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
-						addtimer(CALLBACK(A, .proc/spread, 4), 20)
+						addtimer(CALLBACK(A, /datum/disease/.proc/spread, 4), 20)
 						M.visible_message("<span class='danger'>[M] lets out a terrifying HONK!</span>")
 
 /datum/symptom/pierrot/End(datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/pierrot.dm
+++ b/code/datums/diseases/advance/symptoms/pierrot.dm
@@ -62,8 +62,9 @@
 					give_clown_mask(A)
 				if(prob(5))
 					playsound(M.loc, 'sound/items/bikehorn.ogg', 100, 1)
-					if(honkspread)
-						A.spread(5 && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
+					if(honkspread && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
+						addtimer(CALLBACK(A, .proc/spread, 4), 20)
+						M.visible_message("<span class='danger'>[M] lets out a terrifying HONK!</span>")
 
 /datum/symptom/pierrot/End(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/pierrot.dm
+++ b/code/datums/diseases/advance/symptoms/pierrot.dm
@@ -63,7 +63,7 @@
 				if(prob(5))
 					playsound(M.loc, 'sound/items/bikehorn.ogg', 100, 1)
 					if(honkspread)
-						A.spread(5)
+						A.spread(5 && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
 
 /datum/symptom/pierrot/End(datum/disease/advance/A)
 	..()

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -51,5 +51,5 @@ Bonus
 		else
 			M.emote("sneeze")
 			if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED) && prob(40))
-				addtimer(CALLBACK(A, .proc/spread, 4), 20)
+				addtimer(CALLBACK(A, /datum/disease/.proc/spread, 4), 20)
 				M.visible_message("<span class='danger'>[M] sneezes, letting loose a spray of mucous!</span>")

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -50,6 +50,5 @@ Bonus
 				M.emote("sniff")
 		else
 			M.emote("sneeze")
-			if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED) && prob(40))
+			if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED))
 				addtimer(CALLBACK(A, /datum/disease/.proc/spread, 4), 20)
-				M.visible_message("<span class='danger'>[M] sneezes, letting loose a spray of mucous!</span>")

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -28,13 +28,17 @@ Bonus
 	symptom_delay_max = 35
 	prefixes = list("Nasal ")
 	bodies = list("Cold")
-	threshold_desc = "<b>Stealth 4:</b> The symptom remains hidden until active."
+	var/infective = FALSE
+	threshold_desc = "<b>Stealth 4:</b> The symptom remains hidden until active.<br>\
+					  <b>Transmission 12:</b> The host may spread the disease through sneezing."
 
 /datum/symptom/sneeze/Start(datum/disease/advance/A)
 	if(!..())
 		return
 	if(A.stealth >= 4)
 		suppress_warning = TRUE
+	if(A.transmission >= 12)
+		infective = TRUE
 
 /datum/symptom/sneeze/Activate(datum/disease/advance/A)
 	if(!..())
@@ -46,3 +50,6 @@ Bonus
 				M.emote("sniff")
 		else
 			M.emote("sneeze")
+			if(infective && !(A.spread_flags & DISEASE_SPREAD_FALTERED) && prob(40))
+				addtimer(CALLBACK(A, .proc/spread, 4), 20)
+				M.visible_message("<span class='danger'>[M] sneezes, letting loose a spray of mucous!</span>")


### PR DESCRIPTION
## About The Pull Request
Airborne disease transmission has no counterplay other than having a medhud or activating internals as soon as you hear coughing. This pr removes airborne transmission, and changes transmission values (blood is now 5 or under, fluids is 6 to 10, and contact is 11+)

This does not remove airborne transmission from simple viruses (fungal tuberculosis and the like)

## Why It's Good For The Game
airborne transmission has no counterplay, and many symptoms have interesting spread methods that are ignored in favor of standard airborne viruses. This should make contagious viruses less cancerous

## Changelog
:cl:
del: advanced diseases can no longer have airborne spread
balance: Disease transmission has been changed, check the wiki
tweak: simple diseases now spread less frequently
tweak: sneezing and coughing now spread viruses again, at a transmission threshold
tweak: virus symptoms that spread viruses now have a warning before spreading the virus, allowing perceptive players to back away in time
/:cl:

