### PR TITLE
Fix tgui dev server autoreloading

### DIFF
--- a/tgui/packages/tgui-dev-server/link/client.cjs
+++ b/tgui/packages/tgui-dev-server/link/client.cjs
@@ -4,6 +4,8 @@
  * @license MIT
  */
 
+import 'whatwg-fetch';
+
 let socket;
 const queue = [];
 const subscribers = [];

--- a/tgui/packages/tgui-dev-server/package.json
+++ b/tgui/packages/tgui-dev-server/package.json
@@ -8,6 +8,7 @@
     "glob": "^7.1.7",
     "source-map": "^0.7.3",
     "stacktrace-parser": "^0.1.10",
+    "whatwg-fetch": "^3.6.2",
     "ws": "^7.5.3"
   }
 }

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -7848,6 +7848,7 @@ __metadata:
     glob: ^7.1.7
     source-map: ^0.7.3
     stacktrace-parser: ^0.1.10
+    whatwg-fetch: ^3.6.2
     ws: ^7.5.3
   languageName: unknown
   linkType: soft
@@ -8506,6 +8507,13 @@ __metadata:
   dependencies:
     iconv-lite: 0.4.24
   checksum: 5be4efe111dce29ddee3448d3915477fcc3b28f991d9cf1300b4e50d6d189010d47bca2f51140a844cf9b726e8f066f4aee72a04d687bfe4f2ee2767b2f5b1e6
+  languageName: node
+  linkType: hard
+
+"whatwg-fetch@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "whatwg-fetch@npm:3.6.2"
+  checksum: ee976b7249e7791edb0d0a62cd806b29006ad7ec3a3d89145921ad8c00a3a67e4be8f3fb3ec6bc7b58498724fd568d11aeeeea1f7827e7e1e5eae6c8a275afed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The TGUI dev server was silently failing when trying to hotreload the interface after receiving an update. After bumping up the log severity, I spotted the issue:
```
 379.886 client reload error Error: No browser support: need fetch API
  at __webpack_require__.hmrM (./tgui-workspace/webpack/runtime/jsonp chunk loading:499)
  at callReaction (core-js/modules/es.promise.js:116)
  at Anonymous function (core-js/modules/es.promise.js:278)
  at flush (core-js/internals/microtask.js:29)
```

Presumably some dependency update introduced a requirement for the fetch API.

This PR attempts to resolve the issue by adding the first google result when searching about the issue, which is a polyfill for the fetch API.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Autoreloading in the dev server is a useful tool for TGUI development.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

1. Start up the game
2. Open an APC
3. Start up the TGUI dev server
4. Refresh the APC interface with F5. If the bug icon doesn't appear, continue refreshing and check console for errors.
5. Open the `Apc.js` file and introduce a change to the interface. For example, introduce some text between `Window.Content` and `ApcContent`:
```jsx
      <Window.Content scrollable>
      REEEEEEEEEEEEEEEEEEEE
        <ApcContent />
```
6. Observe the APC interface in-game.

Before this fix, the interface should remain unchanged until manually refreshed with F5. After this fix, it should automatically update to reflect the change.

## Changelog
:cl:
fix: Fixed autoreloading in the tgui dev server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
