### PR TITLE
nerfs silver extracts

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1471,7 +1471,9 @@ If it ever becomes necesary to get a more performant REF(), this lies here in wa
 		/obj/item/reagent_containers/food/snacks/clothing,
 		/obj/item/reagent_containers/food/snacks/grown/shell, //base types
 		/obj/item/reagent_containers/food/snacks/store/bread,
-		/obj/item/reagent_containers/food/snacks/grown/nettle
+		/obj/item/reagent_containers/food/snacks/grown/nettle,
+		/obj/item/reagent_containers/food/snacks/burger/roburger,
+		/obj/item/reagent_containers/food/snacks/grown/shell/gatfruit
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -158,18 +158,13 @@
 
 	for(var/mob/living/carbon/C in viewers(T))
 		C.flash_act()
-
-	for(var/i in 1 to 4 + rand(1,2))
-		var/chosen = getbork()
-		var/obj/B = new chosen(T)
-		if(prob(5))//Fry it!
-			var/obj/item/reagent_containers/food/snacks/deepfryholder/fried
-			fried = new(T, B)
-			fried.fry() // actually set the name and colour it
-			B = fried
-		if(prob(50))
-			for(var/j in 1 to rand(1, 3))
-				step(B, pick(NORTH,SOUTH,EAST,WEST))
+	var/chosen = getbork()
+	var/obj/B = new chosen(T)
+	if(prob(5))//Fry it!
+		var/obj/item/reagent_containers/food/snacks/deepfryholder/fried
+		fried = new(T, B)
+		fried.fry() // actually set the name and colour it
+		B = fried
 	..()
 
 /datum/chemical_reaction/slime/slimebork/proc/getbork()


### PR DESCRIPTION

## About The Pull Request
silver extracts now only spawn 1 food or drink items, instead of 5 to 6 items
silver extracts can no longer spawn gatfruit or roburgers

## Why It's Good For The Game
Xenobio shouldnt be able to walk into the bar with a bag of silver extracts and render the chef and bartender completely useless with a bit of plasma.

roburger nanomachines shouldnt be obtainable in reagent form, gatfruit can majorly throw off round balance if given to botany

## Changelog
:cl:
balance: silver extracts now only spawn one item
balance: silver extracts can no longer spawn gatfruit or roburgers
/:cl:
