### PR TITLE
virus food no longer improves non-virus virus speed

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -178,6 +178,8 @@
 /datum/reagent/consumable/virus_food/on_mob_life(mob/living/carbon/M)
 	. = ..()
 	for(var/datum/disease/D in M.diseases)
+		if(D.spread_flags & DISEASE_SPREAD_SPECIAL || D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS)
+			continue
 		if(prob(D.stage_prob * 10))
 			D.update_stage(min(D.stage += 1, D.max_stages))
 


### PR DESCRIPTION
## About The Pull Request
virus food no longer speeds up viruses that have NON_CONTAGIOUS or SPECIAL transmission flags 

## Why It's Good For The Game
viruses with these flags generally arent meant to be conventional viruses. this prevents round removal using this and virus reagents


## Changelog
:cl:
tweak: virus food no longer speeds up special viruses
/:cl:

