### PR TITLE
Syndie Team Leaders start loudmode

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -150,6 +150,7 @@
 	R.freqlock = TRUE
 	if(command_radio)
 		R.command = TRUE
+		R.use_command = TRUE
 
 	if(ispath(uplink_type, /obj/item/uplink/nuclear) || tc) // /obj/item/uplink/nuclear understands 0 tc
 		var/obj/item/U = new uplink_type(H, H.key, tc)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -168,6 +168,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/heads
 	command = TRUE
+	use_command = TRUE
 
 /obj/item/radio/headset/heads/captain
 	name = "\proper the captain's headset"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -168,7 +168,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/heads
 	command = TRUE
-	use_command = TRUE
 
 /obj/item/radio/headset/heads/captain
 	name = "\proper the captain's headset"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Syndie nuke op team leaders start on loud mode (They can still toggle it back into normal mode via alt-click).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is important for people to hear their leaders so this will be a bit of QoL. For those who do not want to be heard, you can just turn it back into normal text size via an alt-click on the headset as usual. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<details>
<summary>Screenshots&Videos</summary>

Testing nuke op team leader (Spawned myself as the syndie leader outfit and spoke):

![image](https://user-images.githubusercontent.com/55861563/162598678-603c6717-f33d-4c36-b4c9-f8d228678783.png)

</details>

## Changelog
:cl: Phil Smith
tweak: Nukie Team Leaders start on loud mode (can still go into normal mode via an alt-click on the headset)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
