### PR TITLE
Fix: Fixes xenobiology camera checking area for flags instead of area.area_flags

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -376,7 +376,7 @@
 	var/mob/living/C = user
 	var/mob/camera/ai_eye/remote/xenobio/E = C.remote_control
 	var/area/mobarea = get_area(S.loc)
-	if(mobarea.name == E.allowed_area || (mobarea & XENOBIOLOGY_COMPATIBLE))
+	if(mobarea.name == E.allowed_area || (mobarea.area_flags & XENOBIOLOGY_COMPATIBLE))
 		slime_scan(S, C)
 
 //Feeds a potion to slime
@@ -393,7 +393,7 @@
 	if(QDELETED(X.current_potion))
 		to_chat(C, "<span class='warning'>No potion loaded.</span>")
 		return
-	if(mobarea.name == E.allowed_area ||(mobarea & XENOBIOLOGY_COMPATIBLE))
+	if(mobarea.name == E.allowed_area || (mobarea.area_flags & XENOBIOLOGY_COMPATIBLE))
 		X.current_potion.attack(S, C)
 
 //Picks up slime
@@ -407,7 +407,7 @@
 	var/mob/camera/ai_eye/remote/xenobio/E = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/X = E.origin
 	var/area/mobarea = get_area(S.loc)
-	if(mobarea.name == E.allowed_area || (mobarea & XENOBIOLOGY_COMPATIBLE))
+	if(mobarea.name == E.allowed_area || (mobarea.area_flags & XENOBIOLOGY_COMPATIBLE))
 		if(X.stored_slimes.len >= X.max_slimes)
 			to_chat(C, "<span class='warning'>Slime storage is full.</span>")
 			return
@@ -431,7 +431,7 @@
 	var/mob/camera/ai_eye/remote/xenobio/E = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/X = E.origin
 	var/area/turfarea = get_area(T)
-	if(turfarea.name == E.allowed_area || (turfarea & XENOBIOLOGY_COMPATIBLE))
+	if(turfarea.name == E.allowed_area || (turfarea.area_flags & XENOBIOLOGY_COMPATIBLE))
 		for(var/mob/living/simple_animal/slime/S in X.stored_slimes)
 			S.forceMove(T)
 			S.visible_message("[S] warps in!")
@@ -448,7 +448,7 @@
 	var/mob/camera/ai_eye/remote/xenobio/E = C.remote_control
 	var/obj/machinery/computer/camera_advanced/xenobio/X = E.origin
 	var/area/turfarea = get_area(T)
-	if(turfarea.name == E.allowed_area || (turfarea & XENOBIOLOGY_COMPATIBLE))
+	if(turfarea.name == E.allowed_area || (turfarea.area_flags & XENOBIOLOGY_COMPATIBLE))
 		if(X.monkeys >= 1)
 			var/mob/living/carbon/monkey/food = new /mob/living/carbon/monkey(T, TRUE, C)
 			if (!QDELETED(food))
@@ -473,7 +473,7 @@
 	if(!X.connected_recycler)
 		to_chat(C, "<span class='notice'>There is no connected monkey recycler.  Use a multitool to link one.</span>")
 		return
-	if(mobarea.name == E.allowed_area || (mobarea & XENOBIOLOGY_COMPATIBLE))
+	if(mobarea.name == E.allowed_area || (mobarea.area_flags & XENOBIOLOGY_COMPATIBLE))
 		if(!M.stat)
 			return
 		M.visible_message("[M] vanishes as [p_theyre()] reclaimed for recycling!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces instances of /area & area_flag with /area.area_flags & area_flag.

## Why It's Good For The Game

Fixes a runtime, fixes xenbiology camera not being able to feed, scan or move slimes with the hotkeys.

## Changelog
:cl:
fix: Fixes a runtime in xenobiology cameras that prevented the use of the hotkey actions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
