### PR TITLE
Fixes a potential runtime in zclear

### DIFF
--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -106,7 +106,7 @@ SUBSYSTEM_DEF(zclear)
 	for(var/datum/space_level/level as() in autowipe)
 		if(!level)
 			autowipe -= level
-			
+
 		//Check if free
 		if(active_levels["[level.z_value]"])
 			if(!living_levels["[level.z_value]"] && mob_levels["[level.z_value]"] && !announced_zombie_levels["[level.z_value]"])
@@ -309,6 +309,10 @@ SUBSYSTEM_DEF(zclear)
 	for(var/datum/space_level/D as() in SSmapping.z_list)
 		if (D.linkage == CROSSLINKED)
 			possible_transtitons += D.z_value
+
+	if(!possible_transtitons)
+		possible_transtitons = list(SSmapping.empty_space)
+
 	var/_z = pick(possible_transtitons)
 
 	//now select coordinates for a border turf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a potential runtime in zclear by making it pick the empty space level if no transition levels were found.

## Why It's Good For The Game

Just a potential runtime fix

## Changelog
:cl:
fix: Fixes a potential runtime if z clear cannot find any free z-levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
