### PR TITLE
Makes overriding signals more clear as to what is being overriden.

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -104,7 +104,7 @@
 	var/list/sig_types = islist(sig_type_or_types) ? sig_type_or_types : list(sig_type_or_types)
 	for(var/sig_type in sig_types)
 		if(!override && procs[target][sig_type])
-			stack_trace("[sig_type] overridden. Use override = TRUE to suppress this warning")
+			stack_trace("[sig_type] overridden on [target.type]. Use override = TRUE to suppress this warning")
 
 		procs[target][sig_type] = proctype
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Includes the type of what is being overriden in the overriding signal stack trace.

## Why It's Good For The Game

Unfortunately stack_trace is a bit rubish and often doesn't show anything on the stack.

## Changelog
:cl:
code: overriden signals will now display the type of the object causing an error.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
