### PR TITLE
Fixes ninja suit terminate() proc not being called on ninja's death.

### DIFF
--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -93,13 +93,17 @@ Contents:
 
 //Simply deletes all the attachments and self, killing all related procs.
 /obj/item/clothing/suit/space/space_ninja/proc/terminate()
-	qdel(n_hood)
-	qdel(n_gloves)
-	qdel(n_shoes)
-	if(energyKatana)
+	if(!QDELETED(n_hood))
+		qdel(n_hood)
+	if(!QDELETED(n_gloves))
+		qdel(n_gloves)
+	if(!QDELETED(n_shoes))
+		qdel(n_shoes)
+	if(!QDELETED(energyKatana))
 		energyKatana.visible_message("<span class='warning'>[src] flares and then turns to dust!</span>")
 		qdel(energyKatana)
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 //Randomizes suit parameters.
 /obj/item/clothing/suit/space/space_ninja/proc/randomize_param()

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -79,7 +79,17 @@ Contents:
 /obj/item/clothing/suit/space/space_ninja/Destroy()
 	QDEL_NULL(spark_system)
 	QDEL_NULL(cell)
+	if(ismob(loc))
+		UnregisterSignal(loc, COMSIG_PARENT_QDELETING)
 	return ..()
+
+/obj/item/clothing/suit/space/space_ninja/equipped(mob/user, slot)
+	. = ..()
+	RegisterSignal(user, COMSIG_PARENT_QDELETING, .proc/terminate)
+
+/obj/item/clothing/suit/space/space_ninja/dropped(mob/user)
+	UnregisterSignal(user, COMSIG_PARENT_QDELETING)
+	. = ..()
 
 //Simply deletes all the attachments and self, killing all related procs.
 /obj/item/clothing/suit/space/space_ninja/proc/terminate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Registers the ninja suit's terminate proc to the deletion of its user, so that its properly called when the user is destroyed.
Currently it has a loop that checks if the user is deleted, however user deletion also deletes the suit that the ninja is wearing, so terminate() never gets called.

## Why It's Good For The Game

The space ninja's sword will now delete as intended when the ninja is destroyed.

## Changelog
:cl:
fix: The ninja's energy katana now gets properly deleted when the ninja is killed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
