### PR TITLE
Removes Nar'sie plushie cheese

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -472,7 +472,6 @@
 	icon_state = "narplush"
 	divine = TRUE
 	var/clashing
-	var/is_invoker = TRUE
 	gender = FEMALE	//it's canon if the toy is
 
 /obj/item/toy/plush/narplush/Moved()

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -482,7 +482,6 @@
 
 /obj/item/toy/plush/narplush/hugbox
 	desc = "A small stuffed doll of the elder goddess Nar'Sie. Who thought this was a good children's toy? <b>It looks sad.</b>"
-	is_invoker = FALSE
 
 /obj/item/toy/plush/lizardplushie
 	name = "lizard plushie"

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -116,9 +116,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 	if(user)
 		invokers += user
 	if(req_cultists > 1 || istype(src, /obj/effect/rune/convert))
-		var/obj/item/toy/plush/narplush/plushsie = locate() in range(1, src)
-		if(plushsie?.is_invoker)
-			invokers += plushsie
 		for(var/mob/living/L in viewers(1, src))
 			if(iscultist(L))
 				if(L == user)


### PR DESCRIPTION
## About The Pull Request

Apparently it was possible to bypass all interaction with fellow cult members by placing a Nar'sie plushie on a cult rune and invoke like this. The plushie would count towards the invokers so you can easily and stealthy (without a second person and/or using the summon ghost rune) convert people, or do other stuff that requires more than one person.

## Why It's Good For The Game

Being able to silently and single handendly convert people removes one of the core concepts of any teamwork antag, in that it's supposed to be TEAMWORK. The only ways to convert should either be with another cultist, or using the spirit realm rune, which lets you convert more silently at the cost of being unreliable.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: You can no longer use Nar'Sie plushie to invoke cult runes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
