### PR TITLE
Fixes d-sword always being red

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -36,20 +36,20 @@
 	var/list/possible_colors = list("red", "blue", "green", "purple")
 
 /obj/item/dualsaber/Initialize(mapload)
-	. = ..()
-	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
-	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
 	if(LAZYLEN(possible_colors))
 		saber_color = pick(possible_colors)
 		switch(saber_color)
 			if("red")
-				light_color = LIGHT_COLOR_RED
+				set_light(l_color = LIGHT_COLOR_RED)
 			if("green")
-				light_color = LIGHT_COLOR_GREEN
+				set_light(l_color = LIGHT_COLOR_GREEN)
 			if("blue")
-				light_color = LIGHT_COLOR_LIGHT_CYAN
+				set_light(l_color = LIGHT_COLOR_CYAN)
 			if("purple")
-				light_color = LIGHT_COLOR_LAVENDER
+				set_light(l_color = LIGHT_COLOR_LAVENDER)
+	. = ..()
+	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
+	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
 
 /obj/item/dualsaber/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
Fixes the dual energy sword always being red.

:cl:
fix: Fixes dual energy sword always being red
/:cl: