### PR TITLE
Fixes to Clockwork Cult VS Blood Cult

### DIFF
--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -103,7 +103,13 @@ GLOBAL_VAR(clockcult_eminence)
 		SSticker.news_report = CLOCK_PROSELYTIZATION
 
 /datum/game_mode/clockcult/check_finished(force_ending)
-	return force_ending
+	//Check to see if a Blood Cult-aligned player exists; the round continues if so.
+	if(GLOB.cult_narsie)
+		priority_announce("Excellent work, crew! The Gateway is destroyed... but we are still reading strange signals from your station. Stay alert.",  SSstation.announcer.get_rand_report_sound())
+		return FALSE
+	//End the round if Blood Cult doesn't exist
+	else
+		return TRUE
 
 /datum/game_mode/clockcult/proc/check_cult_victory()
 	return GLOB.ratvar_risen


### PR DESCRIPTION



## About The Pull Request

Changes the Check_Finished method to first check to see if the Blood Cult is active, and doesn't roundend if one exists. This allows the Blood Cult to succeed in rounds where they co-exist with Clockies, as without this change, Blood Cult cannot summon Nar'sie while the Gateway is active, but destroying the Gateway ends the round immediately, preventing the Blood Cult from being able to summon.


## Why It's Good For The Game

If Clock Cult's Arc is destroyed or Ratvar is summoned, the game immediately ends, preventing Blood Cult from being able to summon. This change allows them to do so, either summoning Nar'sie after defeating the Clockwork Cultists, or giving them the chance to summon Nar'sie to commence a Battle of the Gods.



## Changelog
:cl:

tweak: The round will no longer end after Ratvar is summoned or the Gateway is destroyed if the Blood Cult currently exists.

/:cl:

