### PR TITLE
Spirit realm now only sustains 1 cult ghost

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -822,7 +822,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	construct_invoke = FALSE
 	color = RUNE_COLOR_DARKRED
 	var/mob/living/affecting = null
-	var/ghost_limit = 3
+	var/ghost_limit = 1
 	var/ghosts = 0
 
 /obj/effect/rune/manifest/Initialize(mapload)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Cult spirit realm runes can now only sustain a single ghost at a time, as oppossed to 3.

## Why It's Good For The Game

Currently the spirit realm rune can be used to sustain 3 ghosts at once, which when used in combination with the cult pylons can essentially quadruple the amount of cultists at any time with cultists that spawn with free gear, can die freely and then respawn.

## Changelog
:cl:
balance: Reduces the number of cult ghosts a single person can summon from 3 to 1.
/:cl:
