### PR TITLE
Improves the winter boots no slip

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -300,6 +300,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define ABSTRACT_ITEM_TRAIT "abstract-item"
 #define STATUS_EFFECT_TRAIT "status-effect"
 #define CLOTHING_TRAIT "clothing"
+#define CLOTHING_FEET_TRAIT "feet"
 #define VEHICLE_TRAIT "vehicle" // inherited from riding vehicles
 #define INNATE_TRAIT "innate"
 #define GLASSES_TRAIT "glasses"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -150,7 +150,7 @@
 
 /obj/item/clothing/shoes/winterboots/noslip
 	name = "high-traction winter boots"
-	desc = "Boots lined with 'snythetic' animal fur and coated with a special freeze resistant anti-slip coating."
+	desc = "Boots lined with 'synthetic' animal fur and coated with a special freeze resistant anti-slip coating."
 
 /obj/item/clothing/shoes/winterboots/noslip/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -151,7 +151,15 @@
 /obj/item/clothing/shoes/winterboots/noslip
 	name = "high-traction winter boots"
 	desc = "Boots lined with 'snythetic' animal fur and coated with a special freeze resistant anti-slip coating."
-	clothing_flags = NOSLIP
+
+/obj/item/clothing/shoes/winterboots/noslip/equipped(mob/user, slot)
+	. = ..()
+	if(slot == ITEM_SLOT_FEET)
+		ADD_TRAIT(user, TRAIT_NOSLIPALL, CLOTHING_FEET_TRAIT)
+
+/obj/item/clothing/shoes/winterboots/noslip/dropped(mob/user)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_NOSLIPALL, CLOTHING_FEET_TRAIT)
 
 /obj/item/clothing/shoes/workboots
 	name = "work boots"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The no-slip boots I gave to the Mr.Freeze special kit do not protect against perma-frost slips that the gluon frag grenades have. This gives the wearer of the boots complete slip protection from everything including lube and gluon frag slips.

## Why It's Good For The Game

Gives proper slip protection to the Mr.Freeze kit as intended.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/162916924-9c23f055-7d3f-4c35-bf96-ec4ab9c7297f.png)

Tested putting it on feet not slipping
Tested removing and holding in hand slipping
Tested picking up slipping
Tested putting back on again not slipping

## Changelog
:cl:
fix: The Mr.Freeze no-slip boots now protect from gluon frag grenade slips.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
