### PR TITLE
Fixes clockcult pressure sensors

### DIFF
--- a/code/modules/antagonists/clock_cult/traps/senders/pressure_sensor.dm
+++ b/code/modules/antagonists/clock_cult/traps/senders/pressure_sensor.dm
@@ -20,7 +20,10 @@
 
 /datum/component/clockwork_trap/pressure_sensor/Initialize()
 	. = ..()
-	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/on_entered)
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/on_entered,
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
 
 /datum/component/clockwork_trap/pressure_sensor/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Clockcult pressure sensors have been broken since the movable update, this fixes them.

## Why It's Good For The Game

Bug fix.

## Changelog
:cl:
fix: Fixes clockcult pressure trap not working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
