### PR TITLE
Fixes whiteships and other shuttle ruins not loading

### DIFF
--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -192,6 +192,29 @@
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/space,
 /turf/open/floor/plasteel/airless,
 /area/shuttle/caravan/freighter1)
+"it" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "caravantrade1_bolt"
+	},
+/obj/docking_port/mobile{
+	callTime = 250;
+	dir = 2;
+	dwidth = 5;
+	dynamic_id = 1;
+	height = 11;
+	id = "caravantrade1";
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Small Freighter";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 21
+	},
+/turf/open/floor/plating,
+/area/shuttle/caravan/freighter1)
 "jg" = (
 /obj/machinery/door/airlock{
 	name = "Restroom"
@@ -264,21 +287,6 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/shuttle/caravan/freighter1)
-"mZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -889,6 +897,25 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/shuttle/caravan/freighter1)
+"OI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/shuttle/caravan/freighter1)
 "OK" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -1036,28 +1063,6 @@
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
-/area/shuttle/caravan/freighter1)
-"VD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 2
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
-	id_tag = "caravantrade1_bolt"
-	},
-/obj/docking_port/mobile{
-	callTime = 250;
-	dir = 2;
-	dwidth = 5;
-	height = 11;
-	id = "caravantrade1";
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Small Freighter";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 21
-	},
-/turf/open/floor/plating,
 /area/shuttle/caravan/freighter1)
 "VN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1390,7 +1395,7 @@ Jv
 Jv
 "}
 (16,1,1) = {"
-VD
+it
 lM
 si
 yC
@@ -1445,7 +1450,7 @@ Jv
 Jv
 LM
 LM
-mZ
+OI
 Ow
 LM
 LM

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -109,6 +109,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/caravan/pirate)
+"gb" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "caravanpirate_bolt_port"
+	},
+/obj/docking_port/mobile{
+	callTime = 150;
+	dir = 2;
+	dwidth = 14;
+	dynamic_id = 1;
+	height = 13;
+	id = "caravanpirate";
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Pirate Cutter";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 22
+	},
+/turf/open/floor/plating,
+/area/shuttle/caravan/pirate)
 "hh" = (
 /mob/living/simple_animal/hostile/pirate{
 	environment_smash = 0
@@ -347,15 +370,6 @@
 /area/shuttle/caravan/pirate)
 "oL" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shuttle/caravan/pirate)
-"oO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/pirate)
 "oT" = (
 /obj/structure/table,
@@ -716,7 +730,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Pirate Cutter APC";
-	pixel_x = -25;
+	pixel_x = -24;
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -839,28 +853,6 @@
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/white,
-/area/shuttle/caravan/pirate)
-"Jb" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 2
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
-	id_tag = "caravanpirate_bolt_port"
-	},
-/obj/docking_port/mobile{
-	callTime = 150;
-	dir = 2;
-	dwidth = 14;
-	height = 13;
-	id = "caravanpirate";
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Pirate Cutter";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 22
-	},
-/turf/open/floor/plating,
 /area/shuttle/caravan/pirate)
 "Jv" = (
 /turf/template_noop,
@@ -1005,6 +997,18 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/caravan/pirate)
+"TD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/frame/computer{
+	anchored = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/pirate)
@@ -1187,7 +1191,7 @@ af
 oL
 "}
 (8,1,1) = {"
-Jb
+gb
 Sd
 Rz
 kl
@@ -1372,7 +1376,7 @@ Jv
 Jv
 Jv
 Bi
-oO
+TD
 EB
 bd
 Bi

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -62,26 +62,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/syndicate3)
-"gl" = (
-/obj/machinery/door/airlock/hatch{
-	id_tag = "caravansyndicate3_bolt_port";
-	name = "External Airlock";
-	normalspeed = 0;
-	req_access_txt = "150"
-	},
-/obj/docking_port/mobile{
-	dir = 2;
-	dwidth = 6;
-	height = 7;
-	id = "caravansyndicate3";
-	name = "Syndicate Drop Ship";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 15
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/shuttle/caravan/syndicate3)
 "ha" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -105,7 +85,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
 	name = "Syndicate Drop Ship APC";
-	pixel_x = -25
+	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
@@ -154,6 +134,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/syndicate3)
+"oS" = (
+/obj/machinery/door/airlock/hatch{
+	id_tag = "caravansyndicate3_bolt_port";
+	name = "External Airlock";
+	normalspeed = 0;
+	req_access_txt = "150"
+	},
+/obj/docking_port/mobile{
+	dir = 2;
+	dwidth = 6;
+	dynamic_id = 1;
+	height = 7;
+	id = "caravansyndicate3";
+	name = "Syndicate Drop Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 15
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/shuttle/caravan/syndicate3)
 "qE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -192,17 +193,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/shuttle/caravan/syndicate3)
-"sb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/syndicate3)
 "sn" = (
 /obj/structure/chair/comfy/shuttle,
@@ -448,6 +438,21 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/shoes/sneakers/black,
 /turf/open/floor/mineral/plastitanium,
+/area/shuttle/caravan/syndicate3)
+"Ma" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/caravan/syndicate3)
 "NH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -701,7 +706,7 @@ Tn
 PL
 "}
 (9,1,1) = {"
-gl
+oS
 xC
 al
 cB
@@ -748,7 +753,7 @@ rU
 (14,1,1) = {"
 rU
 rU
-sb
+Ma
 rz
 ZK
 rU

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -43,18 +43,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/caravan/syndicate1)
-"uW" = (
-/obj/machinery/button/door{
-	id = "caravansyndicate1_bolt";
-	name = "External Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	req_access_txt = "150";
-	specialfunctions = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/caravan/syndicate1)
 "vD" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 4;
@@ -67,7 +55,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 8;
 	name = "Syndicate Fighter APC";
-	pixel_x = -25;
+	pixel_x = -24;
 	req_access = null;
 	req_access_txt = "150"
 	},
@@ -78,7 +66,7 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/caravan/syndicate1)
-"wV" = (
+"xg" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/hatch{
 	id_tag = "caravansyndicate1_bolt";
@@ -91,6 +79,7 @@
 	callTime = 50;
 	dir = 4;
 	dwidth = 4;
+	dynamic_id = 1;
 	height = 5;
 	id = "caravansyndicate1";
 	ignitionTime = 25;
@@ -104,6 +93,21 @@
 "Jv" = (
 /turf/template_noop,
 /area/template_noop)
+"Wr" = (
+/obj/machinery/button/door{
+	id = "caravansyndicate1_bolt";
+	name = "External Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -25;
+	req_access_txt = "150";
+	specialfunctions = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/caravan/syndicate1)
 "YP" = (
 /obj/structure/shuttle/engine/propulsion/burst{
 	dir = 8
@@ -119,7 +123,7 @@ Jv
 Jv
 YP
 fp
-wV
+xg
 fp
 YP
 Jv
@@ -129,7 +133,7 @@ Jv
 Jv
 YP
 fp
-uW
+Wr
 aA
 vK
 fp

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -12,25 +12,6 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
-"ae" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/docking_port/mobile{
-	callTime = 250;
-	dheight = 0;
-	dir = 2;
-	dwidth = 11;
-	height = 17;
-	id = "whiteship";
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Hospital Ship";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 34
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/crew)
 "ag" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/medbay)
@@ -383,7 +364,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Hospital Ship Crew Quarters APC";
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -1045,7 +1026,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Hospital Ship Medbay APC";
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = null
 	},
 /turf/open/floor/plasteel/white,
@@ -2126,7 +2107,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Hospital Ship Bridge APC";
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -2140,6 +2121,26 @@
 	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/engine)
+"pd" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/docking_port/mobile{
+	callTime = 250;
+	dheight = 0;
+	dir = 2;
+	dwidth = 11;
+	dynamic_id = 1;
+	height = 17;
+	id = "whiteship";
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Hospital Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 34
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/crew)
 "vk" = (
 /obj/structure/shuttle/engine/propulsion/left{
 	dir = 8
@@ -2578,7 +2579,7 @@ al
 cY
 "}
 (23,1,1) = {"
-ae
+pd
 aj
 ap
 aB

--- a/_maps/shuttles/whiteship_cere.dmm
+++ b/_maps/shuttles/whiteship_cere.dmm
@@ -5,25 +5,6 @@
 "ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned)
-"ac" = (
-/obj/machinery/door/airlock/titanium{
-	name = "mech bay external airlock"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/docking_port/mobile{
-	dheight = 0;
-	dir = 2;
-	dwidth = 8;
-	height = 16;
-	id = "whiteship";
-	launch_status = 0;
-	name = "NT Recovery White-Ship";
-	port_direction = 8;
-	preferred_direction = 1;
-	width = 16
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned)
 "ad" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1
@@ -148,8 +129,8 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate{
-	opened = 1;
-	name = "spare equipment crate"
+	name = "spare equipment crate";
+	opened = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/abandoned)
@@ -168,8 +149,8 @@
 	dir = 1
 	},
 /obj/structure/closet/crate{
-	opened = 1;
-	name = "spare equipment crate"
+	name = "spare equipment crate";
+	opened = 1
 	},
 /obj/item/pickaxe,
 /obj/item/pickaxe,
@@ -205,8 +186,8 @@
 	dir = 1
 	},
 /obj/structure/closet/crate{
-	opened = 1;
-	name = "spare equipment crate"
+	name = "spare equipment crate";
+	opened = 1
 	},
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe,
@@ -284,8 +265,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate{
-	opened = 1;
-	name = "spare equipment crate"
+	name = "spare equipment crate";
+	opened = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/mineral/titanium/yellow,
@@ -412,6 +393,26 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
+"bV" = (
+/obj/machinery/door/airlock/titanium{
+	name = "mech bay external airlock"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/docking_port/mobile{
+	dheight = 0;
+	dir = 2;
+	dwidth = 8;
+	dynamic_id = 1;
+	height = 16;
+	id = "whiteship";
+	launch_status = 0;
+	name = "NT Recovery White-Ship";
+	port_direction = 8;
+	preferred_direction = 1;
+	width = 16
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned)
 
 (1,1,1) = {"
 aa
@@ -522,7 +523,7 @@ aZ
 ar
 "}
 (7,1,1) = {"
-ac
+bV
 ah
 am
 am

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -14,25 +14,6 @@
 "ac" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
-"ad" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/docking_port/mobile{
-	callTime = 250;
-	dheight = 0;
-	dir = 2;
-	dwidth = 11;
-	height = 17;
-	id = "whiteship";
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "NT Frigate";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 27
-	},
-/turf/open/floor/plating,
-/area/shuttle/abandoned/crew)
 "ae" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/bar)
@@ -183,7 +164,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Frigate Bar APC";
-	pixel_x = -25;
+	pixel_x = -24;
 	req_access = null
 	},
 /obj/structure/spider/stickyweb,
@@ -478,7 +459,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Frigate Crew Quarters APC";
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1222,7 +1203,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Frigate Bridge APC";
-	pixel_x = -25;
+	pixel_x = -24;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -1378,17 +1359,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
-"cp" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bridge)
 "cq" = (
@@ -2256,7 +2226,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Frigate Cargo APC";
-	pixel_x = -25;
+	pixel_x = -24;
 	req_access = null
 	},
 /obj/structure/cable/yellow,
@@ -2515,6 +2485,41 @@
 "vm" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/medbay)
+"wF" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/docking_port/mobile{
+	callTime = 250;
+	dheight = 0;
+	dir = 2;
+	dwidth = 11;
+	dynamic_id = 1;
+	height = 17;
+	id = "whiteship";
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "NT Frigate";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 27
+	},
+/turf/open/floor/plating,
+/area/shuttle/abandoned/crew)
+"BP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
 "DZ" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2691,7 +2696,7 @@ bB
 bT
 bZ
 ch
-cp
+BP
 bT
 bB
 vm
@@ -2815,7 +2820,7 @@ dS
 vm
 "}
 (16,1,1) = {"
-ad
+wF
 ao
 aG
 aY

--- a/_maps/shuttles/whiteship_fland.dmm
+++ b/_maps/shuttles/whiteship_fland.dmm
@@ -304,34 +304,6 @@
 	},
 /turf/open/floor/grass,
 /area/shuttle/abandoned)
-"op" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/hidden{
-	dir = 10
-	},
-/obj/docking_port/mobile{
-	callTime = 250;
-	dir = 8;
-	dwidth = 10;
-	height = 11;
-	id = "whiteship";
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Eden Whiteship";
-	preferred_direction = 4;
-	width = 18
-	},
-/turf/open/floor/pod/dark,
-/area/shuttle/abandoned)
 "pO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -494,7 +466,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Eden Whiteship APC";
-	pixel_y = 23
+	pixel_y = 24
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/abandoned)
@@ -666,6 +638,35 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/built,
 /turf/open/floor/mineral/titanium,
+/area/shuttle/abandoned)
+"Nw" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/hidden{
+	dir = 10
+	},
+/obj/docking_port/mobile{
+	callTime = 250;
+	dir = 8;
+	dwidth = 10;
+	dynamic_id = 1;
+	height = 11;
+	id = "whiteship";
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Eden Whiteship";
+	preferred_direction = 4;
+	width = 18
+	},
+/turf/open/floor/pod/dark,
 /area/shuttle/abandoned)
 "NE" = (
 /obj/structure/glowshroom/single,
@@ -1040,7 +1041,7 @@ hL
 hL
 hL
 hL
-op
+Nw
 Yf
 QS
 Yf

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -31,26 +31,6 @@
 "ag" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/crew)
-"ah" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/docking_port/mobile{
-	callTime = 250;
-	can_move_docking_ports = 1;
-	dir = 2;
-	dwidth = 11;
-	height = 17;
-	id = "whiteship";
-	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "Salvage Ship";
-	port_direction = 8;
-	preferred_direction = 4;
-	width = 33
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/shuttle/abandoned/crew)
 "ai" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
@@ -1272,7 +1252,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Salvage Ship Bar APC";
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = null
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -1478,7 +1458,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Salvage Ship Bridge APC";
-	pixel_y = 23;
+	pixel_y = 24;
 	req_access = null
 	},
 /obj/item/camera{
@@ -1993,17 +1973,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/bridge)
-"cG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned/bridge)
 "cH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2038,7 +2007,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Salvage Ship Cargo APC";
-	pixel_x = -25;
+	pixel_x = -24;
 	req_access = null
 	},
 /obj/structure/cable/yellow{
@@ -3345,6 +3314,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
+"Ho" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/abandoned/bridge)
 "Jb" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/poddoor{
@@ -3368,6 +3352,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned/cargo)
+"NW" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/docking_port/mobile{
+	callTime = 250;
+	can_move_docking_ports = 1;
+	dir = 2;
+	dwidth = 11;
+	dynamic_id = 1;
+	height = 17;
+	id = "whiteship";
+	launch_status = 0;
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	name = "Salvage Ship";
+	port_direction = 8;
+	preferred_direction = 4;
+	width = 33
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/shuttle/abandoned/crew)
 "Pa" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
@@ -3722,7 +3727,7 @@ bD
 cW
 "}
 (18,1,1) = {"
-ah
+NW
 at
 aI
 aY
@@ -3826,7 +3831,7 @@ ai
 bR
 cg
 cv
-cG
+Ho
 bR
 bD
 dm

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -80,24 +80,6 @@
 	},
 /turf/open/floor/plating/abductor,
 /area/shuttle/abandoned)
-"o" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shuttle Airlock"
-	},
-/obj/docking_port/mobile{
-	dheight = 0;
-	dir = 8;
-	dwidth = 4;
-	height = 9;
-	id = "whiteship";
-	launch_status = 0;
-	name = "White Ship";
-	port_direction = 4;
-	preferred_direction = 1;
-	width = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/abandoned)
 "p" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -127,6 +109,25 @@
 "s" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /turf/closed/wall/mineral/titanium,
+/area/shuttle/abandoned)
+"v" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Shuttle Airlock"
+	},
+/obj/docking_port/mobile{
+	dheight = 0;
+	dir = 8;
+	dwidth = 4;
+	dynamic_id = 1;
+	height = 9;
+	id = "whiteship";
+	launch_status = 0;
+	name = "White Ship";
+	port_direction = 4;
+	preferred_direction = 1;
+	width = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/abandoned)
 
 (1,1,1) = {"
@@ -222,7 +223,7 @@ a
 a
 b
 k
-o
+v
 k
 b
 a

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -108,7 +108,7 @@
 #define CBT
 #endif
 
-#if !defined(CBT) && !defined(SPACEMAN_DMM)
+#if !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(FASTDMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error Switch to VSCode and when prompted install the recommended extensions, you can then either use the UI or press Ctrl+Shift+B to build the codebase.
 #endif

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -108,7 +108,7 @@
 #define CBT
 #endif
 
-#if !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(FASTDMM)
+#if !defined(CBT) && !defined(SPACEMAN_DMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error Switch to VSCode and when prompted install the recommended extensions, you can then either use the UI or press Ctrl+Shift+B to build the codebase.
 #endif

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -63,6 +63,8 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/datum/turf_reservation/preview_reservation
 
+	var/shuttles_loaded = FALSE
+
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	ordernum = rand(1, 9000)
 
@@ -85,6 +87,7 @@ SUBSYSTEM_DEF(shuttle)
 	return ..()
 
 /datum/controller/subsystem/shuttle/proc/initial_load()
+	shuttles_loaded = TRUE
 	for(var/s in stationary)
 		var/obj/docking_port/stationary/S = s
 		S.load_roundstart()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -199,6 +199,9 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	highlight("#f00")
 	#endif
 
+	if(SSshuttle.shuttles_loaded)
+		load_roundstart()
+
 /obj/docking_port/stationary/Destroy(force)
 	if(force)
 		SSshuttle.stationary -= src

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -15,10 +15,6 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	icon = 'icons/obj/device.dmi'
 	icon_state = "pinonfar"
 
-	FASTDMM_PROP(\
-		pinned_vars = list("name", "id", "width", "dwidth", "height", "dheight")\
-	)
-
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	anchored = TRUE
 	/// The identifier of the port or ship.

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -264,10 +264,6 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 
 	area_type = SHUTTLE_DEFAULT_SHUTTLE_AREA_TYPE
 
-	FASTDMM_PROP(\
-		pinned_vars = list("name", "id", "dynamic_id", "width", "dwidth", "height", "dheight")\
-	)
-
 	var/list/shuttle_areas
 
 	///used as a timer (if you want time left to complete move, use timeLeft proc)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -15,6 +15,10 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	icon = 'icons/obj/device.dmi'
 	icon_state = "pinonfar"
 
+	FASTDMM_PROP(\
+		pinned_vars = list("name", "id", "width", "dwidth", "height", "dheight")\
+	)
+
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	anchored = TRUE
 	/// The identifier of the port or ship.
@@ -264,6 +268,10 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 
 	area_type = SHUTTLE_DEFAULT_SHUTTLE_AREA_TYPE
 
+	FASTDMM_PROP(\
+		pinned_vars = list("name", "id", "dynamic_id", "width", "dwidth", "height", "dheight")\
+	)
+
 	var/list/shuttle_areas
 
 	///used as a timer (if you want time left to complete move, use timeLeft proc)
@@ -310,6 +318,8 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	var/virtual_z
 
 	var/shuttle_object_type = /datum/orbital_object/shuttle
+
+	var/dynamic_id = FALSE
 
 /obj/docking_port/mobile/proc/register()
 	SSshuttle.mobile |= src
@@ -387,6 +397,9 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 
 	if(!id)
 		id = "[SSshuttle.mobile.len]"
+	else if(dynamic_id)
+		name = "[name] [SSshuttle.mobile.len]"
+		id = "[id][SSshuttle.mobile.len]"
 	if(name == "shuttle")
 		name = "shuttle[SSshuttle.mobile.len]"
 
@@ -399,6 +412,13 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 			shuttle_areas[cur_area] = TRUE
 			if(!cur_area.mobile_port)
 				cur_area.link_to_shuttle(src)
+		//Link up shuttle consoles
+		if(dynamic_id)
+			var/obj/machinery/computer/shuttle_flight/flight_computer = locate() in curT
+			if(!flight_computer)
+				continue
+			flight_computer.shuttleId = "[id]"
+			flight_computer.shuttlePortId = "[id]_custom"
 
 	initial_engines = count_engines()
 	current_engines = initial_engines


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes post-round shuttle loading. Also allows multiple of the loaded shuttles to spawn in a single round.

Also adds fastdmm props to shuttle ports, to allow mappers using fastdmm to see important variables easier.

## Why It's Good For The Game

Shuttle templates do not load post-roundstart, causing whiteship and the ruin to break.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/163144233-c1e6eba4-d63d-494c-abce-b0665fe39073.png)
![image](https://user-images.githubusercontent.com/26465327/163183348-4c8b99dc-0c6e-4b1f-bf92-1b2fc2670004.png)



## Changelog
:cl:
fix: Fixes post round shuttle loading.
add: Multiple mapped shuttles can spawn per round.
fix: Fixes fastdmm not being able to compile the codebase.
add: Adds in some props to shutle ports to make fastdmm display important port variables such as width, height, dwidth and dheight first.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
