### PR TITLE
Shuttle Docking Camera now changes size to the shuttle size + Fixes hyperspace being an area on all shuttles

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -392,7 +392,7 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	for(var/i in 1 to all_turfs.len)
 		var/turf/curT = all_turfs[i]
 		var/area/shuttle/cur_area = curT.loc
-		if(istype(cur_area, area_type))
+		if(istype(cur_area, area_type) && !istype(cur_area, /area/shuttle/transit))
 			shuttle_areas[cur_area] = TRUE
 			if(!cur_area.mobile_port)
 				cur_area.link_to_shuttle(src)

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -397,7 +397,7 @@ GLOBAL_VAR_INIT(shuttle_docking_jammed, FALSE)
 					if(current_user)
 						to_chat(usr, "<span class='warning'>Somebody is already docking the shuttle.</span>")
 						return
-					view_range = max(mobile_port.width, mobile_port.height) + 4
+					view_range = max(mobile_port.width, mobile_port.height, mobile_port.dwidth, mobile_port.dheight) * 0.5 - 4
 					give_eye_control(usr)
 					eyeobj.forceMove(locate(world.maxx * 0.5, world.maxy * 0.5, shuttleObject.docking_target.linked_z_level[1].z_value))
 					return

--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
@@ -52,10 +52,10 @@
 		shuttle_port = null
 		return
 
-	eyeobj = new /mob/camera/ai_eye/remote/shuttle_docker(null, src)
+	var/turf/origin = locate(shuttle_port.x, shuttle_port.y, shuttle_port.z)
+	eyeobj = new /mob/camera/ai_eye/remote/shuttle_docker(origin, src)
 	var/mob/camera/ai_eye/remote/shuttle_docker/the_eye = eyeobj
 	the_eye.setDir(shuttle_port.dir)
-	var/turf/origin = locate(shuttle_port.x, shuttle_port.y, shuttle_port.z)
 	for(var/V in shuttle_port.shuttle_areas)
 		var/area/A = V
 		for(var/turf/T in A)
@@ -83,7 +83,6 @@
 	user.remote_control = eyeobj
 	user.reset_perspective(eyeobj)
 	eyeobj.setLoc(eyeobj.loc)
-	user.client.view_size.supress()
 	if(!QDELETED(user) && user.client)
 		var/mob/camera/ai_eye/remote/shuttle_docker/the_eye = eyeobj
 		var/list/to_add = list()
@@ -109,8 +108,6 @@
 		user.reset_perspective(null)
 		if(eyeobj.visible_icon && user.client)
 			user.client.images -= eyeobj.user_image
-
-		user.client.view_size.unsupress()
 
 	eyeobj.eye_user = null
 	user.remote_control = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #6670

## About The Pull Request

Fixes a pretty big underlying issue with shuttles: When shuttles are created they are spawned in hyperspace, and any area withing the bounds of the shuttle that is of type /area/shuttle will be set to be part of the shuttle. Unfortunately, hyperspace has the type /area/shuttle/transit, meaning that the hyperspace area will be set to be a part of all shuttles. This means that shuttles have turfs that exist on another z-level which probably causes a lot of issues under the hood, one of which is that despite being in a fully green area shuttle docking will still fail for no apparent reason. I'll be honest, I have no idea how this didn't cause more problems.

This also makes it so that the shuttle docking camera resizes to the size of the shuttle you are docking, so that you can actually see what is blocked.

(These 2 are together, since I discovered the hyperspace bug when testing shuttle docking and found that areas that should be valid where not allowing the shuttles to dock.)

## Why It's Good For The Game

Fixes a pretty major issue with shuttles and improves QoL.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/163353850-22c95e78-24bb-4444-bcc3-bff1a3558100.png)

I did a lot of testing to actually find this bug in the first place and I can confirm that this now works.

## Changelog
:cl:
fix: Fixes docking randomly failing due to hyperspace being an area registered to all shuttles.
refactor: Shuttle docking camera will now correctly resize to the size of the shuttle being docked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
