### PR TITLE
Kilo Quick Fix #6

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -65285,7 +65285,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/engine/engineering)
+/area/engine/atmos)
 "bVn" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -70036,6 +70036,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "cbW" = (
@@ -72798,7 +72801,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/area/engine/atmos)
 "cgJ" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -85168,19 +85171,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
-"cAO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/power/terminal{
-	dir = 4;
-	icon_state = "term"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cAP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -95247,6 +95237,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "eXn" = (
@@ -95892,6 +95885,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
@@ -96565,6 +96561,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
@@ -97596,6 +97595,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "lAw" = (
@@ -97611,6 +97613,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/computer/shuttle_flight/science,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "lDf" = (
@@ -97659,6 +97662,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
@@ -98421,6 +98427,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "nTq" = (
@@ -99685,6 +99694,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
@@ -101374,6 +101386,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "vqb" = (
@@ -101569,6 +101584,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
@@ -102482,6 +102500,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "yeh" = (
@@ -102531,6 +102555,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/shuttledock)
 "yjA" = (
@@ -135661,7 +135688,7 @@ axa
 cpB
 axa
 cpB
-axa
+awu
 bVm
 cgH
 cDA
@@ -139770,7 +139797,7 @@ cnk
 axS
 axa
 cvw
-cAO
+cBt
 cwk
 cBt
 cwe


### PR DESCRIPTION
## About The Pull Request
Some more changes to Kilostation including a QoL change to the science shuttle

## Why It's Good For The Game
The science shuttle is untouched on almost all rounds ever since supercruise except for fland station. This PR aligns it to that. Plus the SMES Kilo fix in #6531 was never fixed.

## Testing Photographs and Procedure
<details>

<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/43061493/163367189-3c231d23-ddc6-4ac3-96e4-15a5e4efb5a1.png)

![image](https://user-images.githubusercontent.com/43061493/163367360-176cce7d-2893-4a64-8294-7c50171a89a4.png)

![image](https://user-images.githubusercontent.com/43061493/163367544-65d90e86-51dc-4959-bbbe-b77f7deb55b1.png)
</details>

## Changelog
:cl:
Updated Engineering/Atmospherics Airlock
Fixed Engineering SMES Wiring
Added wiring and science shuttle to science shuttle dock
/:cl:
