### PR TITLE
All shuttles now have sound

### DIFF
--- a/code/modules/shuttle/arrivals.dm
+++ b/code/modules/shuttle/arrivals.dm
@@ -13,7 +13,6 @@
 
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 0)
 
-	var/sound_played
 	var/damaged	//too damaged to undock?
 	var/list/areas	//areas in our shuttle
 	var/list/queued_announces	//people coming in that we have to announce

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -13,6 +13,9 @@
 			remove_ripples()
 			return DOCKING_IMMOBILIZED
 
+	//Count the number of engines (and also for sound effect)
+	current_engines = count_engines()
+
 	var/obj/docking_port/stationary/old_dock = get_docked()
 
 	// The area that gets placed under where the shuttle moved from

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -303,7 +303,6 @@
 	height = 11
 	dir = EAST
 	port_direction = WEST
-	var/sound_played = 0 //If the launch sound has been sent to all players on the shuttle itself
 	var/hijack_status = NOT_BEGUN
 
 /obj/docking_port/mobile/emergency/canDock(obj/docking_port/stationary/S)

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -306,6 +306,8 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	//The virtual Z-Value of the shuttle
 	var/virtual_z
 
+	var/sound_played = 0 //If the launch sound has been sent to all players on the shuttle itself
+
 	var/shuttle_object_type = /datum/orbital_object/shuttle
 
 /obj/docking_port/mobile/proc/register()
@@ -635,11 +637,13 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 //used by shuttle subsystem to check timers
 /obj/docking_port/mobile/proc/check()
 	check_effects()
+	check_sound()
 
 	if(mode == SHUTTLE_IGNITING)
 		check_transit_zone()
 
-	if(timeLeft(1) > 0)
+	var/time_left = timeLeft(1)
+	if(time_left > 0)
 		return
 	// If we can't dock or we don't have a transit slot, wait for 20 ds,
 	// then try again
@@ -680,6 +684,18 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	mode = SHUTTLE_IDLE
 	timer = 0
 	destination = null
+
+/obj/docking_port/mobile/proc/check_sound()
+	var/time_left = timeLeft(1)
+	switch(mode)
+		if(SHUTTLE_IGNITING)
+			if(time_left <= 50 && sound_played != mode)
+				hyperspace_sound(HYPERSPACE_WARMUP, shuttle_areas)
+			if(time_left <= 0)
+				hyperspace_sound(HYPERSPACE_LAUNCH, shuttle_areas)
+		if(SHUTTLE_CALL)
+			if(sound_played != mode && time_left <= HYPERSPACE_END_TIME)
+				hyperspace_sound(HYPERSPACE_END, shuttle_areas)
 
 /obj/docking_port/mobile/proc/check_effects()
 	if(!ripples.len)
@@ -832,6 +848,7 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	return null
 
 /obj/docking_port/mobile/proc/hyperspace_sound(phase, list/areas)
+	sound_played = mode
 	var/selected_sound
 	switch(phase)
 		if(HYPERSPACE_WARMUP)
@@ -867,6 +884,9 @@ GLOBAL_LIST_INIT(shuttle_turf_blacklist, typecacheof(list(
 	if(distant_source)
 		for(var/mob/M as() in SSmobs.clients_by_zlevel[z])
 			var/dist_far = get_dist(M, distant_source)
+			//Cannot hear shuttles from other shuttles
+			if(M.get_virtual_z_level() != get_virtual_z_level())
+				continue
 			if(dist_far <= long_range && dist_far > range)
 				M.playsound_local(distant_source, "sound/effects/[selected_sound]_distance.ogg", 100, falloff_exponent = 20)
 			else if(dist_far <= range)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that all shuttles will play hyperspace sounds, instead of just the e-shuttle and arrivals shuttle.

## Why It's Good For The Game

Some more ambient sounds to hear off in the distance as shuttles are coming and going.

## Changelog
:cl:
soundadd: All shuttles now place hyperspace sound effects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
