### PR TITLE
Observers can no longer use OOC pre-game

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -16,6 +16,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		if(!GLOB.ooc_allowed)
 			to_chat(src, "<span class='danger'>OOC is globally muted.</span>")
 			return
+		if(mob.stat == DEAD && SSticker.current_state < GAME_STATE_PLAYING)
+			to_chat(src, "<span class='danger'>Observers cannot use OOC pre-game.</span>")
+			return
 		if(!GLOB.dooc_allowed && (mob.stat == DEAD))
 			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
 			return

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -16,12 +16,13 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		if(!GLOB.ooc_allowed)
 			to_chat(src, "<span class='danger'>OOC is globally muted.</span>")
 			return
-		if(mob.stat == DEAD && SSticker.current_state < GAME_STATE_PLAYING)
-			to_chat(src, "<span class='danger'>Observers cannot use OOC pre-game.</span>")
-			return
-		if(!GLOB.dooc_allowed && (mob.stat == DEAD))
-			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
-			return
+		if(mob.stat == DEAD)
+			if(SSticker.current_state < GAME_STATE_PLAYING)
+				to_chat(src, "<span class='danger'>Observers cannot use OOC pre-game.</span>")
+				return
+			if(!GLOB.dooc_allowed)
+				to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
+				return
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='danger'>You cannot use OOC (muted).</span>")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #6675

## About The Pull Request

Disables OOC for dead mobs before the game starts.

## Why It's Good For The Game

Players that observe during the round setup should not be able to use OOC to give away meta-information about the round. This should be bannable, but also shouldn't be allowed by the code.

## Changelog
:cl:
tweak: Observers can no longer use OOC pre-game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
