### PR TITLE
Buffs laser shotgun shells.

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -105,7 +105,7 @@
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/weak
-	pellets = 12
+	pellets = 6
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/techshell

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -105,7 +105,7 @@
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
 	projectile_type = /obj/item/projectile/beam/weak
-	pellets = 6
+	pellets = 12
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/techshell

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -40,7 +40,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/item/projectile/beam/weak
-	damage = 8
+	damage = 12
 
 /obj/item/projectile/beam/weak/penetrator //laser gatling and centcom shuttle turret
 	damage = 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the damage of laser shotgun shells from 8 to 12.

## Why It's Good For The Game

Laser shotgun shells have an insanely high spread and worse damage than regular shotgun shells.
This increases the damage of them from 8 to 12, so that they are better than normal buckshot shells in terms of damage and range (however their spread makes them suck at long range).

## Changelog
:cl:
balance: Laser shotgun shell damage increased from 8 to 12 per pellet.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
