### PR TITLE
Fixes shuttle docking on war-ops

### DIFF
--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -391,7 +391,7 @@ GLOBAL_VAR_INIT(shuttle_docking_jammed, FALSE)
 			if(params["port"] == "custom_location")
 				//Open up internal docking computer if any location is allowed.
 				if(shuttleObject.docking_target.can_dock_anywhere)
-					if(GLOB.shuttle_docking_jammed)
+					if(GLOB.shuttle_docking_jammed && !shuttleObject.stealth && istype(shuttleObject.docking_target, /datum/orbital_object/z_linked/station))
 						say("Shuttle docking computer jammed.")
 						return
 					if(current_user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #6702

## About The Pull Request

Shuttles can now dock at any location as long as the location isn't the station.

## Why It's Good For The Game

Shuttle's are meant to be able to dock with their ruins so the explorers can complete their objectives.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/163789031-5ec66b64-f329-419f-8a6d-06e1588a937a.png)


## Changelog
:cl:
fix: Fixes shuttle docking with away missions during war-ops.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
