### PR TITLE
Forces minimist's resolution to 1.2.6

### DIFF
--- a/tgui/package.json
+++ b/tgui/package.json
@@ -56,7 +56,8 @@
     "webpack-cli": "^4.7.2"
   },
   "resolutions": {
-    "ajv": "^6.12.3"
+    "ajv": "^6.12.3",
+    "minimist": "^1.2.6"
   },
   "packageManager": "yarn@3.1.1"
 }

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -5978,7 +5978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.5":
+"minimist@npm:^1.2.6":
   version: 1.2.6
   resolution: "minimist@npm:1.2.6"
   checksum: d15428cd1e11eb14e1233bcfb88ae07ed7a147de251441d61158619dfb32c4d7e9061d09cab4825fdee18ecd6fce323228c8c47b5ba7cd20af378ca4048fb3fb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Even though we're already on 1.2.6, this'll ensure that our sub-dependencies can't request a vulnerable version.


## Changelog
:cl:
server: Minimist's resolution set to ^1.2.6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
