### PR TITLE
Fixes null is jammed runtime

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -160,12 +160,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// Check for a uniform if not using nanites
 		var/obj/item/clothing/under/uniform = H.w_uniform
 
-		//	Radio transmitters are jammed
-		if(nanite_sensors ? H.is_jammed() : uniform.is_jammed())
+		// Are the suit sensors on?
+		if (!nanite_sensors && (!uniform?.has_sensor || !uniform?.sensor_mode))
 			continue
 
-		// Are the suit sensors on?
-		if (!nanite_sensors && (!uniform.has_sensor || !uniform.sensor_mode))
+		//	Radio transmitters are jammed
+		if(nanite_sensors ? H.is_jammed() : uniform?.is_jammed())
 			continue
 
 		// The entry for this human

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -100,7 +100,10 @@
 			var/mob/living/carbon/human/H = user
 			if(attached_accessory.above_suit)
 				H.update_inv_wear_suit()
-			update_sensors(sensor_mode, TRUE)
+	if(HAS_TRAIT(user, TRAIT_SUIT_SENSORS))
+		REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
+		if(!HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
+			GLOB.suit_sensors_list -= user
 
 /obj/item/clothing/under/proc/attach_accessory(obj/item/I, mob/user, notifyAttach = 1)
 	. = FALSE
@@ -161,7 +164,7 @@
 		return
 	if(!ishuman(loc) || istype(loc, /mob/living/carbon/human/dummy))
 		return
-		
+
 	if(sensor_mode > SENSOR_OFF)
 		if(HAS_TRAIT(loc, TRAIT_SUIT_SENSORS))
 			return

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -105,10 +105,9 @@
 			var/mob/living/carbon/human/H = user
 			if(attached_accessory.above_suit)
 				H.update_inv_wear_suit()
-	if(HAS_TRAIT(user, TRAIT_SUIT_SENSORS))
-		REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
-		if(!HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
-			GLOB.suit_sensors_list -= user
+	REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
+	if(!HAS_TRAIT(user, TRAIT_SUIT_SENSORS) && !HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
+		GLOB.suit_sensors_list -= user
 
 /obj/item/clothing/under/proc/attach_accessory(obj/item/I, mob/user, notifyAttach = 1)
 	. = FALSE

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -80,7 +80,12 @@
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.update_inv_w_uniform()
+	if(slot == ITEM_SLOT_ICLOTHING)
 		update_sensors(sensor_mode, TRUE)
+	else if(HAS_TRAIT(user, TRAIT_SUIT_SENSORS))
+		REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
+		if(!HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
+			GLOB.suit_sensors_list -= user
 
 	if(slot == ITEM_SLOT_ICLOTHING && freshly_laundered)
 		freshly_laundered = FALSE

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -82,9 +82,9 @@
 		H.update_inv_w_uniform()
 	if(slot == ITEM_SLOT_ICLOTHING)
 		update_sensors(sensor_mode, TRUE)
-	else if(HAS_TRAIT(user, TRAIT_SUIT_SENSORS))
+	else
 		REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
-		if(!HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
+		if(!HAS_TRAIT(user, TRAIT_SUIT_SENSORS) && !HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
 			GLOB.suit_sensors_list -= user
 
 	if(slot == ITEM_SLOT_ICLOTHING && freshly_laundered)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Crew monitor won't flicker with nothing sometimes

## Why It's Good For The Game

Will prevent suit sensors from showing up as empty, bug fix.

## Testing Photographs and Procedure
 okay so
I spawned myself
![image](https://user-images.githubusercontent.com/37456678/163853967-d6b0cf70-672f-493d-b2f5-4dd85370a456.png)
working
removed my jumpsuit
![image](https://user-images.githubusercontent.com/37456678/163854021-21411f59-6f58-4499-aec2-36782b26ab6a.png)
no runtimes
put it back on
![image](https://user-images.githubusercontent.com/37456678/163854191-7af1449f-e11b-4b93-a1a9-1bc48a4730c5.png)
I'm back

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: fixed a null is jammed runtime in crew sensors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
