### PR TITLE
Fixes Radial Hard Dels

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 
 /atom/movable/screen/radial/Destroy()
 	if(parent)
+		parent.elements -= src
 		UnregisterSignal(parent, COMSIG_PARENT_QDELETING)
 	. = ..()
 
@@ -313,6 +314,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		stoplag(1)
 
 /datum/radial_menu/Destroy()
+	QDEL_LIST(elements)
 	Reset()
 	hide()
 	QDEL_NULL(custom_check_callback)

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -9,6 +9,11 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	plane = ABOVE_HUD_PLANE
 	var/datum/radial_menu/parent
 
+/atom/movable/screen/radial/Destroy()
+	if(parent)
+		UnregisterSignal(parent, COMSIG_PARENT_QDELETING)
+	. = ..()
+
 /atom/movable/screen/radial/proc/set_parent(new_value)
 	if(parent)
 		UnregisterSignal(parent, COMSIG_PARENT_QDELETING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Radial slice objects are creating a ton of hard deletions.
I believe this is because of a change that made it so radial slices qdelete themselves upon their parent being removed rather than setting parent to null.

I located 2 potential hard delete sources:
1: The radial components are held in a list on their parent, and never removed from it.
2: The radial components register a signal to their parent and never unregister it

## Why It's Good For The Game

Massive hard dels cause immense lag whenever the aiming feature is used. These resulted in ~10 seconds of hard deletions within a short period of the round, making GC one of the most CPU intensive processes on the server and causing a large amount of input lag.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/164061204-0e17dd4e-919b-4dc5-9c50-f8c8fb916a6d.png)

![image](https://user-images.githubusercontent.com/26465327/164061215-b2044886-1217-4fdd-803b-2cc4439cf316.png)

![image](https://user-images.githubusercontent.com/26465327/164061239-e5d7ee2c-eb15-43cc-b109-0d06dcd6b964.png)


## Changelog
:cl:
fix: Removes a hard del from radial menus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
