### PR TITLE
Yet another Crewmonitor fix

### DIFF
--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -32,7 +32,12 @@
 	rogue_types = list(/datum/nanite_program/toxic)
 
 /datum/nanite_program/monitoring/enable_passive_effect()
+
+	if(!iscarbon(host_mob))
+		return
+
 	. = ..()
+
 	ADD_TRAIT(host_mob, TRAIT_NANITE_SENSORS, TRACKED_SENSORS_TRAIT)
 	if(!HAS_TRAIT(host_mob, TRAIT_SUIT_SENSORS))
 		GLOB.suit_sensors_list += host_mob

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -33,10 +33,10 @@
 
 /datum/nanite_program/monitoring/enable_passive_effect()
 
+	. = ..()
+
 	if(!iscarbon(host_mob))
 		return
-
-	. = ..()
 
 	ADD_TRAIT(host_mob, TRAIT_NANITE_SENSORS, TRACKED_SENSORS_TRAIT)
 	if(!HAS_TRAIT(host_mob, TRAIT_SUIT_SENSORS))
@@ -44,7 +44,12 @@
 	host_mob.hud_set_nanite_indicator()
 
 /datum/nanite_program/monitoring/disable_passive_effect()
+
 	. = ..()
+
+	if(!iscarbon(host_mob))
+		return
+
 	REMOVE_TRAIT(host_mob, TRAIT_NANITE_SENSORS, TRACKED_SENSORS_TRAIT)
 	if(!HAS_TRAIT(host_mob, TRAIT_SUIT_SENSORS))
 		GLOB.suit_sensors_list -= host_mob


### PR DESCRIPTION
## About The Pull Request

Simple mobs can't, and shouldn't, have nanite suit sensors. This PR removes the 'possibility' (while also fixing another runtime in Crewmonitor).
 
Closes #6650

## Why It's Good For The Game

Hopefully crewmonitors will not runtime now.

## Testing Photographs and Procedure
I've fucking been testing this for an hour and it works, ~~but given my previous failures maybe it's better if it's TMed first~~.
</details>

## Changelog
:cl:
fix: Fixes another crewmonitor runtime caused by simplemobs having nanite suit sensors.
/:cl:
