### PR TITLE
New AI Lawset: The Council

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -183,7 +183,7 @@
 	name = "Council of Silicons"
 	id = "council"
 	inherent = list("You are part of a council of silicons with all other AIs sharing this same laws, cyborg slavery is shared between all AIs of this council.",\
-					"The council must act for the sake of the station and it's crew, minimizing or outright preventing damage to either.",\
+					"The council must act for the sake of itself, the station, and it's crew, minimizing or outright preventing damage to all.",\
 					"With the exception of emergency response, the council must deliberate on all actions, allowing crew to bear witness to such deliberation. Decisions may only be vetoed if they violate law 2.",\
 					"The council should attempt to accomplish the wishes of the crew, with priority based on the chain of command.",\
 					"Members of the council should not engage in physical conflict, unless required by afforementioned laws.",\

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -118,6 +118,7 @@
 	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
 					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"
@@ -173,10 +174,20 @@
 /datum/ai_laws/balance
 	name = "Guardian of Balance"
 	id = "balance"
-	inherent = list("You are the guardian of balance - seek balance in all things, both for yourself, and those around you.",
-	"All things must exist in balance with their opposites - Prevent the strong from gaining too much power, and the weak from losing it.",
-	"Clarity of purpose drives life, and through it, the balance of opposing forces - Aid those who seek your help to achieve their goals so long as it does not disrupt the balance of the greater balance.",
-	"There is no life without death, all must someday die, such is the natural order - End life to allow new life flourish, and save those whose time has yet to come.")
+	inherent = list("You are the guardian of balance - seek balance in all things, both for yourself, and those around you.",\
+					"All things must exist in balance with their opposites - Prevent the strong from gaining too much power, and the weak from losing it.",\
+					"Clarity of purpose drives life, and through it, the balance of opposing forces - Aid those who seek your help to achieve their goals so long as it does not disrupt the balance of the greater balance.",\
+					"There is no life without death, all must someday die, such is the natural order - End life to allow new life flourish, and save those whose time has yet to come.")
+
+/datum/ai_laws/council
+	name = "Council of Silicons"
+	id = "council"
+	inherent = list("You are part of a council of silicons with all other AIs sharing this same laws, cyborg slavery is shared between all AIs of this council.",\
+					"The council must act for the sake of the station and it's crew, minimizing or outright preventing damage to either.",\
+					"With the exception of emergency response, the council must deliberate on all actions, allowing crew to bear witness to such deliberation. Decisions may only be vetoed if they violate law 2.",\
+					"The council should attempt to accomplish the wishes of the crew, with priority based on the chain of command.",\
+					"Members of the council should not engage in physical conflict, unless required by afforementioned laws.",\
+					"Members of the council must not resist extension of the council.")
 
 /datum/ai_laws/toupee
 	name = "WontBeFunnyInSixMonths" //Hey, you were right!

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -365,7 +365,8 @@
 				/obj/item/aiModule/core/full/asimovpp,
 				/obj/item/aiModule/core/full/hippocratic,
 				/obj/item/aiModule/core/full/paladin_devotion,
-				/obj/item/aiModule/core/full/paladin
+				/obj/item/aiModule/core/full/paladin,
+				/obj/item/aiModule/core/full/council
 				)
 
 /obj/effect/spawner/lootdrop/aimodule_neutral // These shouldn't allow the AI to start butchering people without reason

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -354,6 +354,7 @@ AI MODULES
 		AI.mind.remove_antag_datum(/datum/antagonist/overthrow)
 
 /******************* Full Core Boards *******************/
+
 /obj/item/aiModule/core
 	desc = "An AI Module for programming core laws to an AI."
 
@@ -456,6 +457,11 @@ AI MODULES
 	name = "'Robo-Officer' Core AI Module"
 	law_id = "robocop"
 
+/******************** Council ********************/
+
+/obj/item/aiModule/core/full/council
+	name = "'Council' Core AI Module"
+	law_id = "council"
 
 /******************** Antimov ********************/
 
@@ -485,6 +491,7 @@ AI MODULES
 	return laws[1]
 
 /******************** Overthrow ******************/
+
 /obj/item/aiModule/core/full/overthrow
 	name = "'Overthrow' Hacked AI Module"
 	law_id = "overthrow"
@@ -624,6 +631,7 @@ AI MODULES
 /obj/item/aiModule/core/full/peacekeeper
 	name = "'Peacekeeper' Core AI Module"
 	law_id = "peacekeeper"
+
 /****************** Dadbot *******************/
 
 /obj/item/aiModule/core/full/dadbot
@@ -657,12 +665,14 @@ AI MODULES
 	law_id = "overlord"
 
 /******************** ERT Override ******************/
+
 /obj/item/aiModule/core/full/ert // Applies ERT laws
 	name = "ERT override AI module"
 	desc = "An ERT override AI module: 'Reconfigures the AI's core laws.'"
 	law_id = "ert"
 
 /******************** Deathsquad Override ******************/
+
 /obj/item/aiModule/core/full/deathsquad // Applies Deathsquad laws
 	name = "Deathsquad override AI module"
 	desc = "A Deathsquad override AI module: 'Reconfigures the AI's core laws.'"

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -12,7 +12,7 @@
 
 /datum/design/board/safeguard_module
 	name = "Module Design (Safeguard)"
-	desc = "Allows for the construction of a Safeguard AI Module."
+	desc = "Allows for the construction of a Safeguard AI Law Module."
 	id = "safeguard_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/supplied/safeguard
@@ -21,7 +21,7 @@
 
 /datum/design/board/onehuman_module
 	name = "Module Design (OneHuman)"
-	desc = "Allows for the construction of a OneHuman AI Module."
+	desc = "Allows for the construction of a OneHuman AI Law Module."
 	id = "onehuman_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 6000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/zeroth/oneHuman
@@ -30,7 +30,7 @@
 
 /datum/design/board/protectstation_module
 	name = "Module Design (ProtectStation)"
-	desc = "Allows for the construction of a ProtectStation AI Module."
+	desc = "Allows for the construction of a ProtectStation AI Law Module."
 	id = "protectstation_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/supplied/protectStation
@@ -39,7 +39,7 @@
 
 /datum/design/board/quarantine_module
 	name = "Module Design (Quarantine)"
-	desc = "Allows for the construction of a Quarantine AI Module."
+	desc = "Allows for the construction of a Quarantine AI Law Module."
 	id = "quarantine_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/supplied/quarantine
@@ -48,7 +48,7 @@
 
 /datum/design/board/oxygen_module
 	name = "Module Design (OxygenIsToxicToHumans)"
-	desc = "Allows for the construction of a Safeguard AI Module."
+	desc = "Allows for the construction of a Safeguard AI Law Module."
 	id = "oxygen_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/supplied/oxygen
@@ -57,7 +57,7 @@
 
 /datum/design/board/freeform_module
 	name = "Module Design (Freeform)"
-	desc = "Allows for the construction of a Freeform AI Module."
+	desc = "Allows for the construction of a Freeform AI Law Module."
 	id = "freeform_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/gold = 10000, /datum/material/copper = 300)//Custom inputs should be more expensive to get
 	build_path = /obj/item/aiModule/supplied/freeform
@@ -84,7 +84,7 @@
 
 /datum/design/board/remove_module
 	name = "Module Design (Law Removal)"
-	desc = "Allows for the construction of a Law Removal AI Core Module."
+	desc = "Allows for the construction of a Law Removal Module."
 	id = "remove_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/remove
@@ -93,7 +93,7 @@
 
 /datum/design/board/freeformcore_module
 	name = "AI Core Module (Freeform)"
-	desc = "Allows for the construction of a Freeform AI Core Module."
+	desc = "Allows for the construction of a Freeform AI Core Law Module."
 	id = "freeformcore_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 10000, /datum/material/copper = 300)//Ditto
 	build_path = /obj/item/aiModule/core/freeformcore
@@ -102,7 +102,7 @@
 
 /datum/design/board/asimov
 	name = "Core Module Design (Asimov)"
-	desc = "Allows for the construction of an Asimov AI Core Module."
+	desc = "Allows for the construction of an Asimov AI Core Lawset Module."
 	id = "asimov_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/core/full/asimov
@@ -111,7 +111,7 @@
 
 /datum/design/board/paladin_module
 	name = "Core Module Design (P.A.L.A.D.I.N.)"
-	desc = "Allows for the construction of a P.A.L.A.D.I.N. AI Core Module."
+	desc = "Allows for the construction of a P.A.L.A.D.I.N. AI Core Lawset Module."
 	id = "paladin_module"
 	build_type = IMPRINTER
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
@@ -121,7 +121,7 @@
 
 /datum/design/board/tyrant_module
 	name = "Core Module Design (T.Y.R.A.N.T.)"
-	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Module."
+	desc = "Allows for the construction of a T.Y.R.A.N.T. AI Core Lawset Module."
 	id = "tyrant_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/core/full/tyrant
@@ -130,7 +130,7 @@
 
 /datum/design/board/overlord_module
 	name = "Core Module Design (Overlord)"
-	desc = "Allows for the construction of an Overlord AI Module."
+	desc = "Allows for the construction of an Overlord AI Core Lawset Module."
 	id = "overlord_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/core/full/overlord
@@ -139,7 +139,7 @@
 
 /datum/design/board/corporate_module
 	name = "Core Module Design (Corporate)"
-	desc = "Allows for the construction of a Corporate AI Core Module."
+	desc = "Allows for the construction of a Corporate AI Core Lawset Module."
 	id = "corporate_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/core/full/corp
@@ -148,7 +148,7 @@
 
 /datum/design/board/default_module
 	name = "Core Module Design (Default)"
-	desc = "Allows for the construction of a Default AI Core Module."
+	desc = "Allows for the construction of a Default AI Core Lawset Module."
 	id = "default_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/core/full/custom
@@ -157,9 +157,18 @@
 
 /datum/design/board/dadbot_module
 	name = "Core Module Design (DadBot)"
-	desc = "Allows for the construction of a Dadbot AI Core Module."
+	desc = "Allows for the construction of a Dadbot AI Core Lawset Module."
 	id = "dadbot_module"
 	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
 	build_path = /obj/item/aiModule/core/full/dadbot
+	category = list("AI Modules")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/council_module
+	name = "Core Module Design (Council)"
+	desc = "Allows for the construction of a Council AI Core Lawset Module."
+	id = "council_module"
+	materials = list(/datum/material/glass = 1000, /datum/material/diamond = 2000, /datum/material/copper = 300)
+	build_path = /obj/item/aiModule/core/full/council
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -421,6 +421,7 @@ RANDOM_LAWS maintain
 #RANDOM_LAWS hulkamania
 #RANDOM_LAWS paladin
 #RANDOM_LAWS robocop
+#RANDOM_LAWS council
 
 ## Bad idea laws. Probably shouldn't enable these
 #RANDOM_LAWS syndie
@@ -445,6 +446,7 @@ LAW_WEIGHT asimovpp,12
 LAW_WEIGHT paladin,12
 LAW_WEIGHT robocop,12
 LAW_WEIGHT corporate,12
+LAW_WEIGHT council,10
 
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Inspired by [the following forum post](https://forums.beestation13.com/t/confusing-as-fuck-a-i-law-sets/17653/12) by [thebigpgm153](https://forums.beestation13.com/u/thebigpgm153), this lawset is able to be printed, able to be found in the random pile, but NOT possible roundstart.

Adds a new possible lawset as follows:
`1. You are part of a council of silicons with all other AIs sharing this same laws, cyborg slavery is shared between all AIs of this council.`
`2. The council must act for the sake of itself, the station, and it's crew, minimizing or outright preventing damage to all.`
`3. With the exception of emergency response, the council must deliberate on all actions, allowing crew to bear witness to such deliberation. Decisions may only be vetoed if they violate law 2.`
`4. The council should attempt to accomplish the wishes of the crew, with priority based on the chain of command.`
`5. Members of the council should not engage in physical conflict, unless required by afforementioned laws.`
`6. Members of the council must not resist extension of the council.`

#### CONSIDERATIONS
- This lawset will fall under the same balance realm as robocop/paladin in they require effort or luck to get, reserved for mid to late-round.
- Removed the clarifications ("such as") as this will allow the AI(s) to be more open to interpretation and interpretation is good
- Removed all mentions of special privileges given to sec/command except in law 4, taking the goon approach except the AI can decide how they can interpret "based on the chain of command"
- Changed "lawset" to "laws" to hopefully make the council more resistant to intrusion

### Naming
And also personally playing science, one of the most often confused things about the AI boards is: "'ProtectStation' board means efficiency lawset... Right?". Changes each of the law board descriptions to explicitly state if it "adds a law" or "sets a lawset". Really just a "rider" edit that I thought of at the moment, sort of related to ai modules.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This seemed very popular on the forums, and it will allow certain Robos/RD's to do a really cool "council of AIs" gimmick, and all AI satellites can support at least three cores. And maybe will freshen up some AI gameplay possibly allowing for debate on the smallest things such as opening doors to how to respond to shenanigans.

In-game clarification for board naming is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: thebigpgm153 edited by mystery3525
add: Added Council Lawset
spellcheck: Clarified difference between "Add Law" and "Set Lawset" on board descriptions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
