### PR TITLE
Power monitors correctly hide cogged APCs

### DIFF
--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -94,7 +94,7 @@
 					"name" = A.area.name,
 					"charge" = A.integration_cog ? 100 : A.cell ? A.cell.percent() : 0,
 					"load" = DisplayPower(A.lastused_total),
-					"charging" = A.charging,
+					"charging" = A.integration_cog ? 2 : A.charging,
 					"eqp" = A.equipment,
 					"lgt" = A.lighting,
 					"env" = A.environ

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -121,7 +121,7 @@
 					"name" = A.area.name,
 					"charge" = cell_charge,
 					"load" = DisplayPower(A.lastused_total),
-					"charging" = A.charging,
+					"charging" = A.integration_cog ? 2 : A.charging,
 					"eqp" = A.equipment,
 					"lgt" = A.lighting,
 					"env" = A.environ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right now they show as charging while at 100% forever on monitors, this changes them to show fully charged and correctly hide themselves.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cogs hiding from power monitors now actually works.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Integration Cogs will now correctly hide from Power Monitors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
