### PR TITLE
Fixes crewmonitor's width

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -62,7 +62,7 @@ const HealthStat = props => {
 export const CrewConsole = () => {
   return (
     <Window
-      width={600}
+      width={800}
       height={600}>
       <Window.Content scrollable>
         <Section minHeight="540px">


### PR DESCRIPTION
## About The Pull Request

600px crewmonitor sucks ass. 800 is the way.

## Why It's Good For The Game

We have several areas that with 600px monitor they break to a newline, which looks bad.

800px is the way.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/29757616/164837624-c37b4ca8-5d7a-4c4d-b1a2-47d89ac862ac.png)



</details>

## Changelog
:cl:
tweak: Crewmonitor is 800px wide again
/:cl: