### PR TITLE
Vend-a-tray shards fix + new breaking sound. 

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -70,11 +70,14 @@
 	update_icon()
 
 /obj/structure/displaycase/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
-	switch(damage_type)
-		if(BRUTE)
-			playsound(src, 'sound/effects/glasshit.ogg', 75, 1)
-		if(BURN)
-			playsound(src, 'sound/items/welder.ogg', 100, 1)
+	if(!shatter)
+		playsound(src, 'sound/weapons/egloves.ogg', 50, 1)
+	else
+		switch(damage_type)
+			if(BRUTE)
+				playsound(src, 'sound/effects/glasshit.ogg', 75, 1)
+			if(BURN)
+				playsound(src, 'sound/items/welder.ogg', 100, 1)
 
 /obj/structure/displaycase/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -14,6 +14,7 @@
 	var/alert = TRUE
 	var/open = FALSE
 	var/openable = TRUE
+	var/shatter = TRUE
 	var/custom_glass_overlay = FALSE ///If we have a custom glass overlay to use.
 	var/obj/item/electronics/airlock/electronics
 	var/start_showpiece_type = null //add type for items on display
@@ -79,7 +80,8 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		dump()
 		if(!disassembled)
-			new /obj/item/shard(drop_location())
+			if(shatter)
+				new /obj/item/shard(drop_location())
 			trigger_alarm()
 	qdel(src)
 
@@ -87,8 +89,11 @@
 	if(!broken && !(flags_1 & NODECONSTRUCT_1))
 		density = FALSE
 		broken = TRUE
-		new /obj/item/shard(drop_location())
-		playsound(src, "shatter", 70, TRUE)
+		if(shatter)
+			new /obj/item/shard(drop_location())
+			playsound(src, "shatter", 70, TRUE)
+		else
+			playsound(src, "sound/magic/summonitems_generic.ogg", 70, TRUE)
 		update_icon()
 		trigger_alarm()
 
@@ -385,6 +390,7 @@
 	density = FALSE
 	max_integrity = 100
 	req_access = null
+	shatter = FALSE
 	alert = FALSE //No, we're not calling the fire department because someone stole your cookie.
 	glass_fix = FALSE //Fixable with tools instead.
 	pass_flags = PASSTABLE ///Can be placed and moved onto a table.

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -71,7 +71,7 @@
 
 /obj/structure/displaycase/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	if(!shatter)
-		playsound(src, 'sound/weapons/egloves.ogg', 50, 1)
+		playsound(src, 'sound/weapons/egloves.ogg', 35, 1)
 	else
 		switch(damage_type)
 			if(BRUTE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #6710 
Also updated the sounds when striking and breaking the case to fit the sort of energy field the case is producing. 

## Why It's Good For The Game

TBH this is a pretty minor bug, but the lack of glass and new sound effect is a much better fit. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

https://user-images.githubusercontent.com/9547572/165871488-fee8a64a-e123-4dd5-ad5a-6687042a6667.mp4

## Changelog
:cl:
fix: vend-a-tray no longer drop glass shards when broken since they aren't made of glass
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
