### PR TITLE
Hypospray refills work again

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -129,7 +129,7 @@
 	user.visible_message("<span class='suicide'>[user] begins to choke on \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return OXYLOSS//ironic. he could save others from oxyloss, but not himself.
 
-/obj/item/reagent_containers/hypospray/inject(mob/living/M, mob/user)
+/obj/item/reagent_containers/hypospray/medipen/inject(mob/living/M, mob/user)
 	. = ..()
 	if(.)
 		reagents.maximum_volume = 0 //Makes them useless afterwards

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -80,6 +80,7 @@
 	volume = 90
 	possible_transfer_amounts = list(10,15,30,45)
 	ignore_flags = 1 // So they can heal their comrades.
+	reagent_flags = TRANSPARENT // Do not allow piercing hyposprays to be refilled, but should be able to see remaining amount
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/stabilizing_nanites = 15)
 
 /obj/item/reagent_containers/hypospray/combat/nanites

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -80,7 +80,6 @@
 	volume = 90
 	possible_transfer_amounts = list(10,15,30,45)
 	ignore_flags = 1 // So they can heal their comrades.
-	reagent_flags = TRANSPARENT // Do not allow piercing hyposprays to be refilled, but should be able to see remaining amount
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/stabilizing_nanites = 15)
 
 /obj/item/reagent_containers/hypospray/combat/nanites


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Resolves a bug introduced in #6245 which forcibly set ALL hyposprays to a maximum capacity of 0 and also removed their reagent flags that allowed reagent transfers to take place between containers. 

Closes #6369 and #6632

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug bad. Bugfix good. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/164884741-a19e8e01-f6da-4183-a50b-6223c3d18ee3.png)

Tested Medipens, Base and CMO Hypospray as well as Combat Hyposprays. 

Medipens may be drawn with syringes before use, but cannot be filled
Hyposprays may be filled with beakers and syringes as well as emptied with syringes and on the floor.

</details>

## Changelog
:cl:
fix: Hyposprays may be refilled after use again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
