### PR TITLE
Removes support for invalid timers

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -571,10 +571,10 @@ SUBSYSTEM_DEF(timer)
 		CRASH("addtimer called without a callback")
 
 	if (wait < 0)
-		CRASH("addtimer was called with negative time. It was called with a [callback] callback by the [callback.object] [callback.object.name]!")
+		CRASH("addtimer was called with negative time. It was called with a [callback] callback by the [callback.object]!")
 
 	if (callback.object != GLOBAL_PROC && QDELETED(callback.object) && !QDESTROYING(callback.object))
-		CRASH("addtimer called with a callback assigned to a qdeleted object. It was called with a [callback] callback ")
+		CRASH("addtimer called with a callback assigned to a qdeleted object. It was called with a [callback] callback [callback.object]!")
 
 	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -571,10 +571,10 @@ SUBSYSTEM_DEF(timer)
 		CRASH("addtimer called without a callback")
 
 	if (wait < 0)
-		CRASH("addtimer was called with negative time. It was called with a [callback] callback by the [callback.object]!")
+		CRASH("addtimer was called with negative time. It was called with a [callback] callback by the [callback.object]. Calling file [file] at [line]!")
 
 	if (callback.object != GLOBAL_PROC && QDELETED(callback.object) && !QDESTROYING(callback.object))
-		CRASH("addtimer called with a callback assigned to a qdeleted object. It was called with a [callback] callback [callback.object]!")
+		CRASH("addtimer called with a callback assigned to a qdeleted object. It was called with a [callback] callback [callback.object]. Calling file [file] at [line]!")
 
 	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -571,10 +571,10 @@ SUBSYSTEM_DEF(timer)
 		CRASH("addtimer called without a callback")
 
 	if (wait < 0)
-		stack_trace("addtimer called with a negative wait. Converting to [world.tick_lag]")
+		CRASH("addtimer was called with negative time. It was called with a [callback] callback!")
 
 	if (callback.object != GLOBAL_PROC && QDELETED(callback.object) && !QDESTROYING(callback.object))
-		stack_trace("addtimer called with a callback assigned to a qdeleted object. In the future such timers will not be supported and may refuse to run or run with a 0 wait")
+		CRASH("addtimer called with a callback assigned to a qdeleted object. It was called with a [callback] callback!")
 
 	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -571,10 +571,10 @@ SUBSYSTEM_DEF(timer)
 		CRASH("addtimer called without a callback")
 
 	if (wait < 0)
-		CRASH("addtimer was called with negative time. It was called with a [callback] callback!")
+		CRASH("addtimer was called with negative time. It was called with a [callback] callback by the [callback.object] [callback.object.name]!")
 
 	if (callback.object != GLOBAL_PROC && QDELETED(callback.object) && !QDESTROYING(callback.object))
-		CRASH("addtimer called with a callback assigned to a qdeleted object. It was called with a [callback] callback!")
+		CRASH("addtimer called with a callback assigned to a qdeleted object. It was called with a [callback] callback ")
 
 	wait = max(CEILING(wait, world.tick_lag), world.tick_lag)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Timers with value negative values or timers assigned to qdeleted objects will now crash.
Hopefully it will help us catch which timers are badly configured.
Testmerge before merging.


## Changelog
:cl:
server: removed support for invalid timers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
