### PR TITLE
Fixes thick runtime

### DIFF
--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -239,7 +239,7 @@
 		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
 		return
 
-	if(istype(victim)) // check to see if the limb is actually exposed
+	if(ishuman(victim)) // check to see if the limb is actually exposed
 		var/mob/living/carbon/human/victim_human = victim
 		if(!victim_human.can_inject(user, TRUE, limb.body_zone, penetrate_thick = FALSE))
 			return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -406,44 +406,49 @@
 /mob/living/carbon/human/proc/canUseHUD()
 	return (mobility_flags & MOBILITY_USE)
 
-/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, var/penetrate_thick = 0)
-	. = 1 // Default to returning true.
+/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE)
+	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
+		return FALSE
+	if(penetrate_thick)
+		return TRUE
+
 	if(!target_zone)
 		if(user)
 			target_zone = user.zone_selected
 		else
 			target_zone = BODY_ZONE_CHEST
-	if(HAS_TRAIT(src, TRAIT_PIERCEIMMUNE))
-		. = 0
 	// If targeting the head, see if the head item is thin enough.
 	// If targeting anything else, see if the wear suit is thin enough.
-	if (!penetrate_thick)
-		if(above_neck(target_zone))
-			if(head && isclothing(head))
-				var/obj/item/clothing/head/CH = head
-				if(CH.clothing_flags & THICKMATERIAL)
-					balloon_alert(user, "There is no exposed flesh on [p_their()] head")
+	if(above_neck(target_zone))
+		if(!head || !isclothing(head))
+			return TRUE
+		var/obj/item/clothing/head/CH = head
+		if(CH.clothing_flags & THICKMATERIAL)
+			balloon_alert(user, "There is no exposed flesh on [p_their()] head")
+			return FALSE
+		return TRUE
+	if(!wear_suit || !isclothing(wear_suit))
+		return TRUE
+	var/obj/item/clothing/suit/CS = wear_suit
+	if(CS.clothing_flags & THICKMATERIAL)
+		switch(target_zone)
+			if(BODY_ZONE_CHEST)
+				if(CS.body_parts_covered & CHEST)
+					balloon_alert(user, "There is no exposed flesh on this chest")
 					return FALSE
-		if(wear_suit && isclothing(wear_suit))
-			var/obj/item/clothing/suit/CS = wear_suit
-			if(CS.clothing_flags & THICKMATERIAL)
-				switch(target_zone)
-					if(BODY_ZONE_CHEST)
-						if(CS.body_parts_covered & CHEST)
-							balloon_alert(user, "There is no exposed flesh on this chest")
-							return FALSE
-					if(BODY_ZONE_PRECISE_GROIN)
-						if(CS.body_parts_covered & GROIN)
-							balloon_alert(user, "There is no exposed flesh on this groin")
-							return FALSE
-					if(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
-						if(CS.body_parts_covered & ARMS)
-							balloon_alert(user, "There is no exposed flesh on these arms")
-							return FALSE
-					if(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-						if(CS.body_parts_covered & LEGS)
-							balloon_alert(user, "There is no exposed flesh on these legs")
-							return FALSE
+			if(BODY_ZONE_PRECISE_GROIN)
+				if(CS.body_parts_covered & GROIN)
+					balloon_alert(user, "There is no exposed flesh on this groin")
+					return FALSE
+			if(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
+				if(CS.body_parts_covered & ARMS)
+					balloon_alert(user, "There is no exposed flesh on these arms")
+					return FALSE
+			if(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+				if(CS.body_parts_covered & LEGS)
+					balloon_alert(user, "There is no exposed flesh on these legs")
+					return FALSE
+	return TRUE
 
 /mob/living/carbon/human/assess_threat(judgment_criteria, lasercolor = "", datum/callback/weaponcheck=null)
 	if(judgment_criteria & JUDGE_EMAGGED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you'd cast can pierce into a mob there is no arg penetrate_thick so that would result in some very weird runtime.
Small refactor to can_inject included.

## Why is it good for the game

Runtime fix

## Changelog
:cl:
fix: fixed bad arg penetrate_thick
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
