### PR TITLE
Cyborgs will no longer be able to repair their own damage

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -409,7 +409,7 @@
 	if(W.tool_behaviour == TOOL_WELDER && (user.a_intent != INTENT_HARM || user == src))
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(src == user)
-			to_chat(user, "<span class='notice'>Safety mechanisms prevent you from turning your welding tool on yourself.</span>")
+			to_chat(user, "<span class='notice'>Safety mechanisms prevent you from directing your welder at yourself.</span>")
 			return
 		if (!getBruteLoss())
 			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -408,15 +408,14 @@
 /mob/living/silicon/robot/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_WELDER && (user.a_intent != INTENT_HARM || user == src))
 		user.changeNext_move(CLICK_CD_MELEE)
+		if(src == user)
+			to_chat(user, "<span class='notice'>Safety mechanisms prevent you from turning your welding tool on yourself.</span>")
+			return
 		if (!getBruteLoss())
 			to_chat(user, "<span class='warning'>[src] is already in good condition!</span>")
 			return
 		if (!W.tool_start_check(user, amount=0)) //The welder has 1u of fuel consumed by it's afterattack, so we don't need to worry about taking any away.
 			return
-		if(src == user)
-			to_chat(user, "<span class='notice'>You start fixing yourself.</span>")
-			if(!W.use_tool(src, user, 50))
-				return
 
 		adjustBruteLoss(-30)
 		updatehealth()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After the unfortunate loss of Space Station 17 as a result of a cyborg destroying its own chasis with a welder, Nanotrasen has passed stricter safety protocols when it comes to the construction of new Cyborgs. Moving forward all cyborg welders will have a safety mechanism triggered if the welder is focused upon any part of the cyborg in control of it to prevent such a casualty from repeating. 

Flavor aside, yes this is a nerf to cyborgs being able to self-repair adding to their already very high durability in combat any time flashes aren't involved. Get a self-repair module, or go ask someone else (even a different cyborg) to repair you if you need it. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The self-regenerative capabilities of the welder are a bit much in my opinion, as well as a number of others who have tried fending off a lone cyborg only to have them duck a corner and come back with full health seconds later. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/164946324-3341cffe-7bb0-46e6-adf5-d823de696eec.png)


</details>

## Changelog
:cl:
balance: Cyborgs may no longer repair themselves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
