### PR TITLE
Stimulum has a drawback again, and also flavor text

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1348,7 +1348,6 @@
 	if(M.losebreath > 2 && !warn)
 		M.visible_message("<span class='danger'>You feel like you can't breathe!</span>")
 		warn++
-	M.visible_message("<span class='warning'>Losebreath value = [M.losebreath]</span>")   // DEBUG MESSAGE, DELETE
 	..()
 
 /datum/reagent/nitryl

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1322,7 +1322,7 @@
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "E1A116"
 	taste_description = "sourness"
-	var/warn = 0
+	var/warned = 0
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
 	..()
@@ -1345,9 +1345,9 @@
 /datum/reagent/stimulum/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2*REM, 0)
 	M.losebreath += (current_cycle*0.05) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
-	if(M.losebreath > 2 && !warn)
+	if(M.losebreath > 2 && !warned)
 		M.visible_message("<span class='danger'>You feel like you can't breathe!</span>")
-		warn++
+		warned++
 	..()
 
 /datum/reagent/nitryl

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1323,7 +1323,7 @@
 	color = "E1A116"
 	taste_description = "sourness"
 	///stores whether or not the mob has been warned that they are having difficulty breathing. 
-	var/warned = 0
+	var/warned = FALSE
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
 	..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1349,7 +1349,7 @@
 		M.losebreath += min(current_cycle*0.05, 2) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
 	if(M.losebreath > 2 && !warned)
 		M.visible_message("<span class='danger'>You feel like you can't breathe!</span>")
-		warned++
+		warned = TRUE
 	..()
 
 /datum/reagent/nitryl

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1322,6 +1322,7 @@
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "E1A116"
 	taste_description = "sourness"
+	///stores whether or not the mob has been warned that they are having difficulty breathing. 
 	var/warned = 0
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1317,7 +1317,7 @@
 
 /datum/reagent/stimulum
 	name = "Stimulum"
-	description = "An unstable experimental gas that greatly increases the energy of those that inhale it, but also causes hypoxia"
+	description = "An unstable experimental gas that greatly increases the energy of those that inhale it, but also causes hypoxia."
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "E1A116"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1346,7 +1346,7 @@
 /datum/reagent/stimulum/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2*REM, 0)
 	if(M.losebreath <= 10)
-		M.losebreath += (min(current_cycle*0.05) 2) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
+		M.losebreath += (min(current_cycle*0.05), 2) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
 	if(M.losebreath > 2 && !warned)
 		M.visible_message("<span class='danger'>You feel like you can't breathe!</span>")
 		warned++

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1346,7 +1346,7 @@
 /datum/reagent/stimulum/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2*REM, 0)
 	if(M.losebreath <= 10)
-		M.losebreath += (min(current_cycle*0.05), 2) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
+		M.losebreath += min(current_cycle*0.05, 2) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
 	if(M.losebreath > 2 && !warned)
 		M.visible_message("<span class='danger'>You feel like you can't breathe!</span>")
 		warned++

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1322,6 +1322,7 @@
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "E1A116"
 	taste_description = "sourness"
+	var/warn = 0
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)
 	..()
@@ -1330,7 +1331,7 @@
 	ADD_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	ADD_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	ADD_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
-	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
+	L.visible_message("<span class='warning'>You feel like nothing can stop you!</span>")
 
 /datum/reagent/stimulum/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_STUNIMMUNE, type)
@@ -1338,11 +1339,16 @@
 	REMOVE_TRAIT(L, TRAIT_IGNOREDAMAGESLOWDOWN, type)
 	REMOVE_TRAIT(L, TRAIT_NOSTAMCRIT, type)
 	REMOVE_TRAIT(L, TRAIT_NOLIMBDISABLE, type)
-	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
+	L.visible_message("<span class='warning'>You can feel your brief high wearing off</span>")
 	..()
 
 /datum/reagent/stimulum/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2*REM, 0)
+	M.losebreath += (current_cycle*0.05) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
+	if(M.losebreath > 2 && !warn)
+		M.visible_message("<span class='danger'>You feel like you can't breathe!</span>")
+		warn++
+	M.visible_message("<span class='warning'>Losebreath value = [M.losebreath]</span>")   // DEBUG MESSAGE, DELETE
 	..()
 
 /datum/reagent/nitryl

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1345,7 +1345,8 @@
 
 /datum/reagent/stimulum/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(-2*REM, 0)
-	M.losebreath += (current_cycle*0.05) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
+	if(M.losebreath <= 10)
+		M.losebreath += (min(current_cycle*0.05) 2) // gradually builds up suffocation, will not be noticable for several ticks but effects will linger afterwards
 	if(M.losebreath > 2 && !warned)
 		M.visible_message("<span class='danger'>You feel like you can't breathe!</span>")
 		warned++

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1317,7 +1317,7 @@
 
 /datum/reagent/stimulum
 	name = "Stimulum"
-	description = "An unstable experimental gas that greatly increases the energy of those that inhale it, while dealing increasing toxin damage over time."
+	description = "An unstable experimental gas that greatly increases the energy of those that inhale it, but also causes hypoxia"
 	reagent_state = GAS
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because stimulum/nitryl are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "E1A116"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes PR adds a downside to stimulum again as well as limiting its effective uptime. Stimulum may be combined with medicines which restore Oxyloss to expand its effective uptime, but it may never achieve 100% uptime. Without additional drugs players may take a single huff (indicated by a redtext message, so internals may be disabled) for a ~50 second high. During the high they will be warned that they feel like they cannot breathe, and as soon as it ends they will be alerted again by feeling the effects of the high wear off. The difficulty breathing persists for about 20 seconds after the high ends, and the oxyloss takes about another 30 seconds to resolve.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
In short: This adds an expected downside to an extremely powerful atmos drug. 

In long: In its current state, stimulum offers total immunity to a wide variety of non-lethal effects (Sleep, Stuns, Stamina Crit, Limb disables, Slowdown from losing HP) with no obvious tell that it is being used and almost no downside for the user whatsoever. Also players believe it is supposed to have a downside and that this is a bugged state, due to the gas being described both in-game and on the wiki as being toxic. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

### Total oxyloss from one huff, which grants 50 seconds of stun immunity.
![image](https://user-images.githubusercontent.com/9547572/167258540-7cdaabc5-0f1c-4c92-9896-1d42eb73c37b.png)
![image](https://user-images.githubusercontent.com/9547572/167258552-e7fdad2b-6c5d-4c26-86c0-0fbe494255a8.png)

### Keeping in mind you can easily acquire reagents like Epinephrine to counteract the downside for a limited time, even without access to a chemistry dispenser

![image](https://user-images.githubusercontent.com/9547572/167259200-2ff5aada-93ea-4eab-aed9-36c2f23cfc9e.png)
![image](https://user-images.githubusercontent.com/9547572/167259319-392a4dd8-4f85-4300-9bb2-d620b7973698.png)

## Changelog
:cl:
balance: Stimulum is toxic again!
tweak: Stimulum now causes difficulty breathing and oxyloss instead of plain toxin damage, and has new notifications to assist in its usage. Recommended usage is huffing one breath of stimulum for a high, and then waiting two minutes for it to wear off before huffing again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
