### PR TITLE
readds an accidentally removed feature

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -199,6 +199,15 @@
 		A.anomalyNeutralize()
 	return TRUE
 
+/obj/item/assembly/signaler/anomaly/activate()
+	if(!..())//cooldown processing
+		return FALSE
+	var/type = src.anomaly_type
+	var/obj/effect/anomaly/B = new type(get_turf(src))
+	B.anomalyEffect()
+	B.Destroy()
+	return TRUE
+
 /obj/item/assembly/signaler/anomaly/manual_suicide(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user]'s [src] is reacting to the radio signal, warping [user.p_their()] body!</span>")
 	user.set_suicide(TRUE)


### PR DESCRIPTION

## About The Pull Request
re-adds anomaly core activation effects. These were added in #1218, but were later removed, i assume by accident, by #1623

## Why It's Good For The Game
readds a missing feature, noticed it was missing when checking the code for it



## Changelog
:cl:
fix: anomaly cores now have assembly activation effects again
/:cl:


