### PR TITLE
Removes try catch from exploration generators

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/asteroid_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/asteroid_generator.dm
@@ -5,11 +5,7 @@
 /proc/generate_asteroids(center_x, center_y, center_z, max_radius, weight_offset = 0, scale = 65)
 	var/datum/space_level/space_level = SSmapping.get_level(center_z)
 	space_level.generating = TRUE
-	try
-		_generate_asteroids(center_x, center_y, center_z, max_radius, weight_offset, scale)
-	catch(var/exception/e)
-		message_admins("Asteroid failed to generate!")
-		stack_trace("Asteroid failed to generate! [e] on [e.file]:[e.line]")
+	_generate_asteroids(center_x, center_y, center_z, max_radius, weight_offset, scale)
 	space_level.generating = FALSE
 
 /proc/_generate_asteroids(center_x, center_y, center_z, max_radius, weight_offset = 0, scale = 65)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/exoplanets/exoplanet_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/exoplanets/exoplanet_generator.dm
@@ -1,11 +1,7 @@
 /proc/generate_exoplanet(center_z)
 	var/datum/space_level/space_level = SSmapping.get_level(center_z)
 	space_level.generating = TRUE
-	try
-		_generate_exoplanet(center_z, new /datum/exoplanet_biome/lavaland)
-	catch(var/exception/e)
-		message_admins("Exoplanet failed to generate!")
-		stack_trace("Exoplanet failed to generate! [e] on [e.file]:[e.line]")
+	_generate_exoplanet(center_z, new /datum/exoplanet_biome/lavaland)
 	space_level.generating = FALSE
 
 /proc/_generate_exoplanet(center_z, datum/exoplanet_biome/biome)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_generator.dm
@@ -19,11 +19,7 @@
 /proc/generate_space_ruin(center_x, center_y, center_z, border_x, border_y, datum/orbital_objective/linked_objective, forced_decoration, datum/ruin_event/ruin_event)
 	var/datum/space_level/space_level = SSmapping.get_level(center_z)
 	space_level.generating = TRUE
-	try
-		_generate_space_ruin(center_x, center_y, center_z, border_x, border_y, linked_objective, forced_decoration, ruin_event)
-	catch(var/exception/e)
-		message_admins("Space ruin failed to generate!")
-		stack_trace("Space ruin failed to generate! [e] on [e.file]:[e.line]")
+	_generate_space_ruin(center_x, center_y, center_z, border_x, border_y, linked_objective, forced_decoration, ruin_event)
 	space_level.generating = FALSE
 
 /proc/_generate_space_ruin(center_x, center_y, center_z, border_x, border_y, datum/orbital_objective/linked_objective, forced_decoration, datum/ruin_event/ruin_event)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes this try catch from exploration generators.

Try catch behaviours in byond are extremely cursed. Having a try catch will make a proc less safe against runtimes, since instead of catching errors just in your proc, it will catch errors in super procs too. This meant that these try catches would just instantly end the ruin generator if an error occurs.

## Why It's Good For The Game

A single tiny runtime will no longer break the entire ruin generator.

## Changelog
:cl:
code: Removed try catch blocks from exploration generators.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
