### PR TITLE
Auto map rotation is no longer based on RNG

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -535,9 +535,6 @@ SUBSYSTEM_DEF(ticker)
 
 	maprotatechecked = 1
 
-	//map rotate chance defaults to 75% of the length of the round (in minutes)
-	if (!prob((world.time/600)*CONFIG_GET(number/maprotatechancedelta)))
-		return
 	INVOKE_ASYNC(SSmapping, /datum/controller/subsystem/mapping/.proc/maprotate)
 
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()


### PR DESCRIPTION
## About The Pull Request

As the title says, removes the RNG from map rotation. Currently, when shuttle is usually called, so at 90 minute mark, there is only a 67.5% chance of map rotating, it gets worse when shuttle leaves earlier, being only 45% at 60 minute mark. It frequently results in people being bored and leaving.

## Why It's Good For The Game

Being forced to play the same map several times in a row is very boring.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Map rotation is no longer RNG based, instead switches map every round
/:cl: