### PR TITLE
Hopefully final crewmonitor fix

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -171,7 +171,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// Check for a uniform if not using nanites
 		var/obj/item/clothing/under/uniform = tracked_human.w_uniform
 
-		if (!istype(uniform))
+		if (!nanite_sensors && !istype(uniform))
 			stack_trace("Human without a suit sensors compatible uniform is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform?.type])")
 			continue
 

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -180,8 +180,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			stack_trace("Human without active nanite and suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform.type])")
 			continue
 
-		//	Radio transmitters are jammed
-		if(nanite_sensors ? tracked_human.is_jammed() : uniform?.is_jammed())
+		// Radio transmitters are jammed
+		if(tracked_human.is_jammed())
 			continue
 
 		// The entry for this human

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -177,7 +177,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		// Are the suit sensors on?
 		if (!nanite_sensors && (uniform?.has_sensor <= NO_SENSORS || !uniform?.sensor_mode))
-			stack_trace("Human without active suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform.type])")
+			stack_trace("Human without active nanite and suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform.type])")
 			continue
 
 		//	Radio transmitters are jammed

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -137,20 +137,16 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 	var/list/results = list()
 
-	for(var/tracked_mob in GLOB.suit_sensors_list)
-		if(!tracked_mob)
+	for(var/mob/living/carbon/human/tracked_human as () in GLOB.suit_sensors_list)
+		if(!tracked_human)
 			stack_trace("Null reference in suit sensors list")
-			GLOB.suit_sensors_list -= tracked_mob
+			GLOB.suit_sensors_list -= tracked_human
 			continue
 
-		var/mob/living/tracked_living_mob = tracked_mob
-
-		var/turf/pos = get_turf(tracked_living_mob)
+		var/turf/pos = get_turf(tracked_human)
 		if(!pos)
-			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_living_mob] ([tracked_living_mob.type])")
+			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_human] ([tracked_human.type])")
 			continue
-
-		var/mob/living/carbon/human/tracked_human = tracked_living_mob
 
 		// Check their humanity.
 		if(!ishuman(tracked_human))

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -35,7 +35,7 @@
 
 	. = ..()
 
-	if(!iscarbon(host_mob))
+	if(!ishuman(host_mob))
 		return
 
 	ADD_TRAIT(host_mob, TRAIT_NANITE_SENSORS, TRACKED_SENSORS_TRAIT)
@@ -47,7 +47,7 @@
 
 	. = ..()
 
-	if(!iscarbon(host_mob))
+	if(!ishuman(host_mob))
 		return
 
 	REMOVE_TRAIT(host_mob, TRAIT_NANITE_SENSORS, TRACKED_SENSORS_TRAIT)


### PR DESCRIPTION
## About The Pull Request

Fixes: #6766

Ports parts of: https://github.com/tgstation/tgstation/pull/56364
which basically adds stack_traces to various things that could possibly go wrong in crewmonitor, removing runtimes that crash the proc and result in nothing displaying.

Also monitoring nanites can only be applied to humans to avoid non human mobs popping out in sensors list.

## Why It's Good For The Game

Bug baad

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl: Mat05usz, Timberpoes
fix: Rare runtimes in crewmonitor
/:cl:
