### PR TITLE
Fixes bugged behaviour with jumpsuits

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -82,10 +82,6 @@
 		H.update_inv_w_uniform()
 	if(slot == ITEM_SLOT_ICLOTHING)
 		update_sensors(sensor_mode, TRUE)
-	else
-		REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
-		if(!HAS_TRAIT(user, TRAIT_SUIT_SENSORS) && !HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
-			GLOB.suit_sensors_list -= user
 
 	if(slot == ITEM_SLOT_ICLOTHING && freshly_laundered)
 		freshly_laundered = FALSE
@@ -99,15 +95,19 @@
 
 /obj/item/clothing/under/dropped(mob/user)
 	..()
+	var/mob/living/carbon/human/H = user
 	if(attached_accessory)
 		attached_accessory.on_uniform_dropped(src, user)
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			if(attached_accessory.above_suit)
-				H.update_inv_wear_suit()
-	REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
-	if(!HAS_TRAIT(user, TRAIT_SUIT_SENSORS) && !HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
-		GLOB.suit_sensors_list -= user
+		if(ishuman(H) && attached_accessory.above_suit)
+			H.update_inv_wear_suit()
+
+	if(ishuman(H))
+		if(H.w_uniform == src)
+			if(!HAS_TRAIT(user, TRAIT_SUIT_SENSORS))
+				return
+			REMOVE_TRAIT(user, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)
+			if(!HAS_TRAIT(user, TRAIT_SUIT_SENSORS) && !HAS_TRAIT(user, TRAIT_NANITE_SENSORS))
+				GLOB.suit_sensors_list -= user
 
 /obj/item/clothing/under/proc/attach_accessory(obj/item/I, mob/user, notifyAttach = 1)
 	. = FALSE
@@ -169,7 +169,7 @@
 	if(!ishuman(loc) || istype(loc, /mob/living/carbon/human/dummy))
 		return
 
-	if(sensor_mode > SENSOR_OFF)
+	if(has_sensor >= HAS_SENSORS && sensor_mode > SENSOR_OFF)
 		if(HAS_TRAIT(loc, TRAIT_SUIT_SENSORS))
 			return
 		ADD_TRAIT(loc, TRAIT_SUIT_SENSORS, TRACKED_SENSORS_TRAIT)


### PR DESCRIPTION
## About The Pull Request

Closes: #6780

The bug goes like this:

- Have jumpsuit on
- Pick up another jumpsuit
- You are removed from sensors list because when it checks for the slot in `equipped()`, which is also called when you pick up ites, it then goes into else block and removes sensors because wrong slot

Removed the bug from equipped and moved checking if the thing we are dropping was actually our uniform, if yes then remove from sensors.

Finally, adds a check to update sensors (maybe redundant) to first see if the uniform actually has sensors. 

## Why It's Good For The Game

Bug bad

## Testing Photographs and Procedure

Checked it with a variety of jumpsuits, had one on my character, then picked up/dropped jumpsuits and it wouldn't touch my sensors. Run through it with a debugger multiple times just to be sure.

## Changelog
:cl: Mat05usz
fix: People disappearing from sensors after picking up jumpsuits
/:cl:
