### PR TITLE
Map votes now draw from a hat

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -90,8 +90,11 @@ SUBSYSTEM_DEF(vote)
 					else
 						factor = 1.4
 				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
-	//get all options with that many votes and return them in a list
 	. = list()
+	if(mode == "map")
+		. += pickweight(choices) //map is chosen by drawing votes from a hat, instead of automatically going to map with the most votes. 
+		return .
+	//get all options with that many votes and return them in a list
 	if(greatest_votes)
 		for(var/option in choices)
 			if(choices[option] == greatest_votes)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1708,7 +1708,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						default += " ([config.defaultmap.map_name])"
 					for (var/M in config.maplist)
 						var/datum/map_config/VM = config.maplist[M]
-						if(!VM.votable)
+						if(!VM.votable || (SSmapping.config.map_name == VM.map_name && REALTIMEOFDAY - SSticker.round_start_time >= 24000)) //current map will be excluded from the vote if round has lasted more than 40 minutes. 
 							continue
 						var/friendlyname = "[VM.map_name] "
 						if (VM.voteweight <= 0)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1708,7 +1708,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						default += " ([config.defaultmap.map_name])"
 					for (var/M in config.maplist)
 						var/datum/map_config/VM = config.maplist[M]
-						if(!VM.votable || (SSmapping.config.map_name == VM.map_name && REALTIMEOFDAY - SSticker.round_start_time >= 24000)) //current map will be excluded from the vote if round has lasted more than 40 minutes. 
+						if(!VM.votable || SSmapping.config.map_name == VM.map_name) //current map will be excluded from the vote
 							continue
 						var/friendlyname = "[VM.map_name] "
 						if (VM.voteweight <= 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the server holds a map vote, it no longer automatically choses the map with the most votes, but instead pools all of the votes together and picks one person's vote randomly. Map with the most votes is the most likely to be picked, but the map picked will not always be Metastation when a vote is held. This allows maps to be variable and ensures they all see some play, but also allows players to most frequently play on popular maps that more people like. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Enabling votes resolves the issue of being locked into the same map over and over... except that it sometimes doesn't because then it would nearly always be the same map - the one with the most support every time a vote is called. This allows player votes to matter in deciding next map without guaranteeing only the single most popular map sees play. Stations which are less popular will still show up (so long as at least one person votes for it) but they won't be there as often.  

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Tested by @Mat05usz to ensure it works properly. 

## Changelog
:cl: Mat05usz, Rukofamicom
tweak: Map votes are now weighted by number of votes rather than picking the map with the most votes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
