### PR TITLE
Fix Plane_Master_Controller Hard_Del Issue

### DIFF
--- a/code/_onclick/hud/plane_master_controller.dm
+++ b/code/_onclick/hud/plane_master_controller.dm
@@ -23,7 +23,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 	controlled_planes = assoc_controlled_planes
 
 /atom/movable/plane_master_controller/Destroy()
-	owner_hud = null
+	owner_hud.plane_master_controllers -= src
 	controlled_planes.Cut()
 	return ..()
 

--- a/code/_onclick/hud/plane_master_controller.dm
+++ b/code/_onclick/hud/plane_master_controller.dm
@@ -23,7 +23,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 	controlled_planes = assoc_controlled_planes
 
 /atom/movable/plane_master_controller/Destroy()
-	owner_hud.plane_master_controllers -= src
+	if(owner_hud)
+		owner_hud.plane_master_controllers -= src
 	controlled_planes.Cut()
 	return ..()
 

--- a/code/_onclick/hud/plane_master_controller.dm
+++ b/code/_onclick/hud/plane_master_controller.dm
@@ -13,8 +13,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 	if(!istype(hud))
 		return
 	owner_hud = hud
-	if(istype(owner_hud))
-		return INITIALIZE_HINT_QDEL
 	var/assoc_controlled_planes = list()
 	for(var/i in controlled_planes)
 		var/atom/movable/screen/plane_master/instance = owner_hud.plane_masters["[i]"]

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -82,6 +82,8 @@
 	ignore += typesof(/obj/structure/alien/resin/flower_bud_enemy)
 	//Expects a mob to holderize, we have nothing to give
 	ignore += typesof(/obj/item/clothing/head/mob_holder)
+	//Expects a hud, generally created for player occupied mobs. There won't be any and this causes issues for us.
+	ignore += typesof(/atom/movable/plane_master_controller)
 
 	var/list/cached_contents = spawn_at.contents.Copy()
 	var/baseturf_count = length(spawn_at.baseturfs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ok. So.

The Plane_Master_Controller Hard_del issue is that they happen very frequently. This was due to these being used in huds, which are made for every occupied mob.

So at best, every player roundstart creates 1 harddel'd instance assuming nobody spawns in.

This hard_del issue actually causes problems with rotatium runtiming, which interacts with mob/hud_used/var/list/atom/movable/plane_master_controller/plane_master_controllers.

These were set to hard-del after init by #6356 

Now, there should be far fewer of these being deleted.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improve Run Speed.

Gimme the hug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
If you're really interested, breakpoint the/atom/movable/plane_master_controller/Destroy() follow the execution chain up, where you will find it being destroyed on initialize, which is run whenever a new hud is made.

Additionally, if you looked in an occupied mob hud_used, looked for the only value in var/list/atom/movable/plane_master_controller/plane_master_controllers, it would show up as deleted, even on brand new mobs once occupied(or made on roundstart).

## Changelog
:cl: DatBoiTim
fix: fixed large number of plane_master_controller harddels
fix: Rotatium now works properly
tweak: create_and_destroy unit test ignores plane_master_controllers to avoid runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
