### PR TITLE
Yellow slime cores now have a more reasonable recharge rate

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -63,7 +63,7 @@
 	else
 		return PROCESS_KILL
 	if(emp_timer)
-		emp_timer -= delta_time
+		emp_timer -= delta_time // Both vars are in seconds
 		if(emp_timer <= 0)
 			emp_timer = 0
 			chargerate = emp_chargerate_save

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -24,7 +24,7 @@
 	var/self_recharge = FALSE
 	///stores the chargerate to restore when hit with EMP, for slime cores
 	var/emp_chargerate_save
-	///Timer for EMPs so that recharging cells know when to start charging again. 
+	///Time in SECONDS for EMPs so that recharging cells know when to start charging again. 
 	var/emp_timer = 0
 	var/ratingdesc = TRUE
 	/// If it's a grown that acts as a battery, add a wire overlay to it.

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -368,7 +368,7 @@
 	icon_state = "yellow slime extract"
 	materials = list()
 	rating = 5 //self-recharge makes these desirable
-	self_recharge = 1 // Infused slime cores self-recharge, over time
+	self_recharge = TRUE // Infused slime cores self-recharge, over time
 	chargerate = 100
 	maxcharge = 2000
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -63,10 +63,8 @@
 	else
 		return PROCESS_KILL
 	if(emp_timer)
-		to_chat(loc, "<span class='warning'>\The [src] currently processing EMP: Timer = [emp_timer]</span>")
 		emp_timer -= delta_time
 		if(emp_timer <= 0)
-		to_chat(loc, "<span class='warning'>\The [src] is no longer under the effects of an EMP</span>")
 			emp_timer = 0
 			chargerate = emp_chargerate_save
 
@@ -157,7 +155,6 @@
 			emp_chargerate_save = chargerate
 			chargerate = 0
 		emp_timer = 300		//30 seconds
-		to_chat(loc, "<span class='warning'>\The [src] has been hit with an EMP: Timer = [emp_timer]</span>")
 	
 
 /obj/item/stock_parts/cell/ex_act(severity, target)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -63,8 +63,10 @@
 	else
 		return PROCESS_KILL
 	if(emp_timer)
+		to_chat(loc, "<span class='warning'>\The [src] currently processing EMP: Timer = [emp_timer]</span>")
 		emp_timer -= delta_time
 		if(emp_timer <= 0)
+		to_chat(loc, "<span class='warning'>\The [src] is no longer under the effects of an EMP</span>")
 			emp_timer = 0
 			chargerate = emp_chargerate_save
 
@@ -154,9 +156,8 @@
 		if(chargerate)
 			emp_chargerate_save = chargerate
 			chargerate = 0
-		emp_timer += 300		//30 seconds
-		if(emp_timer > 300)		//don't let the effect stack beyond 30 seconds
-			emp_timer = 300
+		emp_timer = 300		//30 seconds
+		to_chat(loc, "<span class='warning'>\The [src] has been hit with an EMP: Timer = [emp_timer]</span>")
 	
 
 /obj/item/stock_parts/cell/ex_act(severity, target)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -154,7 +154,7 @@
 		if(chargerate)
 			emp_chargerate_save = chargerate
 			chargerate = 0
-		emp_timer = 30		//30 seconds
+		emp_timer = 30		// emp_timer is in seconds
 	
 
 /obj/item/stock_parts/cell/ex_act(severity, target)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -23,8 +23,6 @@
 	///does it self recharge, over time, or not?
 	var/self_recharge = FALSE
 	///stores the chargerate to restore when hit with EMP, for slime cores
-	var/emp_chargerate_save
-	///Time in SECONDS for EMPs so that recharging cells know when to start charging again. 
 	var/emp_timer = 0
 	var/ratingdesc = TRUE
 	/// If it's a grown that acts as a battery, add a wire overlay to it.
@@ -58,15 +56,12 @@
 	. = ..()
 
 /obj/item/stock_parts/cell/process(delta_time)
+	if(emp_timer < world.time)
+		return
 	if(self_recharge)
 		give(chargerate * 0.125 * delta_time)
 	else
 		return PROCESS_KILL
-	if(emp_timer)
-		emp_timer -= delta_time // Both vars are in seconds
-		if(emp_timer <= 0)
-			emp_timer = 0
-			chargerate = emp_chargerate_save
 
 /obj/item/stock_parts/cell/update_icon()
 	cut_overlays()
@@ -151,10 +146,7 @@
 	if (charge < 0)
 		charge = 0
 	if(self_recharge)
-		if(chargerate)
-			emp_chargerate_save = chargerate
-			chargerate = 0
-		emp_timer = 30		// emp_timer is in seconds
+		emp_timer = world.time + 30 SECONDS
 	
 
 /obj/item/stock_parts/cell/ex_act(severity, target)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -56,7 +56,7 @@
 	. = ..()
 
 /obj/item/stock_parts/cell/process(delta_time)
-	if(emp_timer < world.time)
+	if(emp_timer > world.time)
 		return
 	if(self_recharge)
 		give(chargerate * 0.125 * delta_time)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -154,7 +154,7 @@
 		if(chargerate)
 			emp_chargerate_save = chargerate
 			chargerate = 0
-		emp_timer = 300		//30 seconds
+		emp_timer = 30		//30 seconds
 	
 
 /obj/item/stock_parts/cell/ex_act(severity, target)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -21,7 +21,7 @@
 	///how much power is given every tick in a recharger
 	var/chargerate = 100 
 	///does it self recharge, over time, or not?
-	var/self_recharge = 0 
+	var/self_recharge = FALSE
 	///stores the chargerate to restore when hit with EMP, for slime cores
 	var/emp_chargerate_save
 	///EMP counter, so that emp effects don't end early when EMPs are stacked

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -171,8 +171,8 @@ Slimecrossing Items
 	name = "hypercharged slime core"
 	desc = "A charged yellow slime extract, infused with even more plasma. It almost hurts to touch."
 	rating = 7 //Roughly 1.5 times the original.
-	maxcharge = 20000 //2 times the normal one.
-	chargerate = 2250 //1.5 times the normal rate.
+	maxcharge = 10000 //5 times the normal one.
+	chargerate = 300 //2 times the normal rate.
 
 //Barrier cube - Chilling Grey
 /obj/item/barriercube

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -172,7 +172,7 @@ Slimecrossing Items
 	desc = "A charged yellow slime extract, infused with even more plasma. It almost hurts to touch."
 	rating = 7 //Roughly 1.5 times the original.
 	maxcharge = 10000 //5 times the normal one.
-	chargerate = 300 //2 times the normal rate.
+	chargerate = 300 //3 times the normal one.
 
 //Barrier cube - Chilling Grey
 /obj/item/barriercube


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It reduces the ludicrous rate at which charged and hypercharged slime cores regenerate power, and also lowers their capacity to make them a unique trade-off instead of a direct upgrade. EMPs now block the regeneration for 30 seconds, so that if one is drained to zero, it isn't back to having charge the next second. 

### Exact values changed:
Normal Yellow:
Regeneration: 375/s -> 25/s
Max Charge: 10k -> 5k
It is suitable for APCs and cyborgs which do not experience high drain. Not recommended for mechs and negligible effect in SMES

Hypercharged Yellow:
Regeneration: 562/s -> 75/s
Max Charge: 20k -> 10k
Suitable for all purposes and has a charge rate that feels decent, even if not infinite like it used to be. Still won't notice them much in SMES, but they will help somewhat. 


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Yellow slime cores do not provide a power cell that recharges itself over time, they provide a a power cell with infinite power that stays full almost all the time unless you're using the heaviest power drains available. Said power drains have such high costs to limit their number of uses, and slime cores totally negate this.

A normal yellow core currently recharges at a rate of 375 per second, and hypercharged at a rate of 562.5. Compare this to the costs of tools on Cyborgs and mechs

I didn't do the exact math because when it came to APCs and SMES, even normal slime cores always produced more power than I could possibly get to drain from either. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Tested EMP mechanics with (now deleted) debug messages to ensure regeneration was halting when expected and resuming when expected. Tested in APCs, SMES and Cyborgs, though I did not extensively test beyond EMPs and ensuring that recharging was occurring since this is just a value adjustment. 

![image](https://user-images.githubusercontent.com/9547572/166171001-d5a02eba-c25a-4e8c-b140-7183392dae1e.png)
Showing debug messages from when I realized delta_time is in seconds instead of deciseconds. 


## Changelog
:cl:
balance: Yellow slime cores are now cells that recharge over time instead of being effectively infinite.
balance: EMPs now halt regeneration for 30 seconds on slime cores. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
