### PR TITLE
Sentinel's Compromise tweaks

### DIFF
--- a/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
@@ -13,7 +13,9 @@
 /datum/clockcult/scripture/slab/sentinelscompromise/click_on(atom/A)
 	if(!(invoker in viewers(7, get_turf(A))))
 		return
-	var/mob/living/carbon/M = A
+	if(!ishuman(invoker))
+		return
+	var/mob/living/M = A
 	if(!istype(M))
 		return
 	if(!is_servant_of_ratvar(M))

--- a/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
@@ -13,7 +13,7 @@
 /datum/clockcult/scripture/slab/sentinelscompromise/click_on(atom/A)
 	if(!(invoker in viewers(7, get_turf(A))))
 		return
-	var/mob/living/M = A
+	var/mob/living/carbon/M = A
 	if(!istype(M))
 		return
 	if(!is_servant_of_ratvar(M))

--- a/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
@@ -50,5 +50,5 @@
 	new /obj/effect/temp_visual/heal(get_turf(M), "#f8d984")
 	playsound(M, 'sound/magic/magic_missile.ogg', 50, TRUE)
 	playsound(invoker, 'sound/magic/magic_missile.ogg', 50, TRUE)
-	invoker.adjustToxLoss(min(total_damage/2, 80), FALSE, TRUE)
+	invoker.adjustToxLoss(min(total_damage/2, 80), TRUE, TRUE)
 	return TRUE

--- a/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/sentinels_compromise.dm
@@ -14,6 +14,7 @@
 	if(!(invoker in viewers(7, get_turf(A))))
 		return
 	if(!ishuman(invoker))
+		to_chat(invoker, "<span class='warning'>Non humanoid servants can't use this power!</span>")
 		return
 	var/mob/living/M = A
 	if(!istype(M))
@@ -49,5 +50,5 @@
 	new /obj/effect/temp_visual/heal(get_turf(M), "#f8d984")
 	playsound(M, 'sound/magic/magic_missile.ogg', 50, TRUE)
 	playsound(invoker, 'sound/magic/magic_missile.ogg', 50, TRUE)
-	invoker.adjustToxLoss(min(total_damage/2, 80))
+	invoker.adjustToxLoss(min(total_damage/2, 80), FALSE, TRUE)
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Compromise now checks if the invoker is /mob/living/carbon/human, namely to prevent cogscarabs from abusing it with no downside. closes #6301
Oozelings now also take damage from Sentinel's compromise. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cogscarabs should not be able to make someone nigh unkillable with no downside.
Oozelings should not be able to bypass this either. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Scarabs can't use Sentinels compromise anymore.
tweak:Oozelings now take toxin damage from Sentinel's compromise.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
