### PR TITLE
fixes retaliate signal runtime and some possible harddeletes that would come out of this

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -60,3 +60,12 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(enemy_to_remove, COMSIG_PARENT_QDELETING)
 	enemies -= enemy_to_remove
+	if(enemy_to_remove == target) // if its the same we null the reference in target
+		target = null
+
+/mob/living/simple_animal/hostile/retaliate/add_target(new_target)
+	if(target && !(target in enemies)) //we should not remove the signal if it still exists in the enemies list
+		UnregisterSignal(target, COMSIG_PARENT_QDELETING)
+	target = new_target
+	if(target) //we could also check here again if this is in the enemies list but override = TRUE might be the better idea here
+		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/remove_enemy, override = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now the issue here is that retaliate mobs basically have a second system that basically also handles enemies to attack etc. this list basically goes agains the target variable on hostile thanks to that we need to basically consider both systems especially if the target reference qdeleted so i overwrote some procs to handle the behavior with both systems.

## Why It's Good For The Game

runtimes and (quite possible) harddelete bad

</details>

## Changelog
:cl:
fix: fixes runtime for retaliate mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
