### PR TITLE
Fixes various maintenance sofas

### DIFF
--- a/_maps/RandomRooms/10x10/sk_rdm106_sanitarium.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm106_sanitarium.dmm
@@ -369,12 +369,12 @@
 "KV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = 6;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 6
 	},
 /obj/item/reagent_containers/food/drinks/sillycup{
-	pixel_y = -2;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = -2
 	},
 /obj/item/reagent_containers/food/drinks/sillycup,
 /obj/item/reagent_containers/food/drinks/sillycup,
@@ -571,7 +571,7 @@ KL
 Cz
 Jd
 lF
-bI
+KL
 "}
 (10,1,1) = {"
 gK

--- a/_maps/RandomRooms/10x10/sk_rdm106_sanitarium.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm106_sanitarium.dmm
@@ -555,7 +555,7 @@ lL
 yb
 ni
 lF
-bI
+KL
 Cz
 zX
 ni
@@ -567,7 +567,7 @@ fJ
 yb
 uS
 Eu
-KL
+bI
 Cz
 Jd
 lF

--- a/_maps/RandomRooms/10x10/sk_rdm144_smallmagician.dmm
+++ b/_maps/RandomRooms/10x10/sk_rdm144_smallmagician.dmm
@@ -155,7 +155,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "D" = (
-/obj/structure/chair/sofa/right{
+/obj/structure/chair/sofa/left{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
@@ -216,7 +216,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "Q" = (
-/obj/structure/chair/sofa/left{
+/obj/structure/chair/sofa/right{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It was backwards, along with other maint sofas
![image](https://user-images.githubusercontent.com/22421329/166165656-5c0e992b-2588-4c12-9174-981d84209a88.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
smh my immersion
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Various maintenance sofas now face the right direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
