### PR TITLE
Approximates chatmessage's height and width value

### DIFF
--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -46,12 +46,15 @@
 		"&" = null,\
 		"*" = null,\
 		"%" = null,\
+		"#" = null,\
 		"^" = null,\
 		"{" = null,\
 		"}" = null,\
 		"|" = null,\
 		"~" = null,\
 		"`" = null,\
+		"[" = null,\
+		"]" = null,\
 		"A" = null,\
 		"B" = null,\
 		"C" = null,\
@@ -104,5 +107,15 @@
 		"x" = null,\
 		"y" = null,\
 		"z" = null,\
+		"0" = null,\
+		"1" = null,\
+		"2" = null,\
+		"3" = null,\
+		"4" = null,\
+		"5" = null,\
+		"6" = null,\
+		"7" = null,\
+		"8" = null,\
+		"9" = null,\
 		MAX_CHAR_WIDTH = list(0, 0, 0)\
 	)

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -4,6 +4,8 @@
 /// Macro from Lummox used to get height from a MeasureText proc
 #define WXH_TO_HEIGHT(x) text2num(copytext(x, findtextEx(x, "x") + 1))
 
+#define WXH_TO_WIDTH(x) text2num(copytext(x, 1, findtextEx(x, "x") + 1))
+
 #define CENTER(text) {"<center>[##text]</center>"}
 
 #define SANITIZE_FILENAME(text) (GLOB.filename_forbidden_chars.Replace(text, ""))

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -10,4 +10,11 @@
 
 #define SANITIZE_FILENAME(text) (GLOB.filename_forbidden_chars.Replace(text, ""))
 
-#define MAX_CHAR_WIDTH "max_width"
+/// Index of normal sized character size in runechat lists
+#define NORMAL_FONT_INDEX 1
+
+/// Index of small sized character size in runechat lists
+#define SMALL_FONT_INDEX 2
+
+/// Index of big sized character size in runechat lists
+#define BIG_FONT_INDEX 3

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -9,3 +9,5 @@
 #define CENTER(text) {"<center>[##text]</center>"}
 
 #define SANITIZE_FILENAME(text) (GLOB.filename_forbidden_chars.Replace(text, ""))
+
+#define MAX_CHAR_WIDTH "max_width"

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -18,3 +18,91 @@
 
 /// Index of big sized character size in runechat lists
 #define BIG_FONT_INDEX 3
+
+/// Index of maximum possible calculated values
+#define MAX_CHAR_WIDTH "max_width"
+
+/// Initializes empty list of cache characters for runechat. Space is special case since measuring it returns 0.
+#define EMPTY_CHARACTERS_LIST list(\
+		"." = null,\
+		"," = null,\
+		"?" = null,\
+		"!" = null,\
+		"\"" = null,\
+		"/" = null,\
+		"$" = null,\
+		"(" = null,\
+		")" = null,\
+		"@" = null,\
+		"=" = null,\
+		":" = null,\
+		"'" = null,\
+		";" = null,\
+		"+" = null,\
+		"-" = null,\
+		"\\" = null,\
+		"<" = null,\
+		">" = null,\
+		"&" = null,\
+		"*" = null,\
+		"%" = null,\
+		"^" = null,\
+		"{" = null,\
+		"}" = null,\
+		"|" = null,\
+		"~" = null,\
+		"`" = null,\
+		"A" = null,\
+		"B" = null,\
+		"C" = null,\
+		"D" = null,\
+		"E" = null,\
+		"F" = null,\
+		"G" = null,\
+		"H" = null,\
+		"I" = null,\
+		"J" = null,\
+		"K" = null,\
+		"L" = null,\
+		"M" = null,\
+		"N" = null,\
+		"O" = null,\
+		"P" = null,\
+		"Q" = null,\
+		"R" = null,\
+		"S" = null,\
+		"T" = null,\
+		"U" = null,\
+		"V" = null,\
+		"W" = null,\
+		"X" = null,\
+		"Y" = null,\
+		"Z" = null,\
+		"a" = null,\
+		"b" = null,\
+		"c" = null,\
+		"d" = null,\
+		"e" = null,\
+		"f" = null,\
+		"g" = null,\
+		"h" = null,\
+		"i" = null,\
+		"j" = null,\
+		"k" = null,\
+		"l" = null,\
+		"m" = null,\
+		"n" = null,\
+		"o" = null,\
+		"p" = null,\
+		"q" = null,\
+		"r" = null,\
+		"s" = null,\
+		"t" = null,\
+		"u" = null,\
+		"v" = null,\
+		"w" = null,\
+		"x" = null,\
+		"y" = null,\
+		"z" = null,\
+		MAX_CHAR_WIDTH = list(0, 0, 0)\
+	)

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -69,8 +69,8 @@ TIMER_SUBSYSTEM_DEF(runechat)
 /datum/controller/subsystem/timer/runechat/proc/add_new_character_for_client(client/actor, character)
 	set waitfor = FALSE
 
-	//We're already initializing the list for this user
-	if(initialize_tokens[actor.ckey] != null)
+	//We're already initializing the list for this user or it wasn't yet initialized
+	if(initialize_tokens[actor.ckey] != null || letters[actor.ckey] == null)
 		return
 
 	initialize_tokens[actor.ckey] = 3

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -61,7 +61,6 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	for(var/key in additional_letters)
 		if(length(letters[ckey][key]) == 3 && !letters[ckey][key].Find(null))
 			continue
-		message_admins("Letter [key] not found!!!")
 		letters[ckey][key] = list(null, null, null)
 		handle_single_letter(key, actor, NORMAL_FONT_INDEX)
 		handle_single_letter(key, actor, SMALL_FONT_INDEX)

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -69,8 +69,6 @@ TIMER_SUBSYSTEM_DEF(runechat)
 /datum/controller/subsystem/timer/runechat/proc/add_new_character_for_client(client/actor, character)
 	set waitfor = FALSE
 
-	if(!actor)
-		return
 	var/ckey = actor.ckey
 
 	//We're already initializing the list for this user or it wasn't yet initialized
@@ -86,7 +84,7 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	while(initialize_tokens[ckey] > 0)
 		sleep(world.tick_lag)
 
-	for(var/value in letters[ckey][character])
+	for(!C || values.Find(null))
 		//We failed, client logged out mid measuring
 		if(isnull(value))
 			letters[ckey] = null

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -84,7 +84,8 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	while(initialize_tokens[ckey] > 0)
 		sleep(world.tick_lag)
 
-	if(!actor || letters[ckey][character].Find(null))
+	var/list/values = letters[ckey][character]
+	if(!actor || values.Find(null))
 		//We failed, client logged out mid measuring
 		letters[ckey] = null
 

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -99,36 +99,36 @@ TIMER_SUBSYSTEM_DEF(runechat)
 		addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
 		return
 
-	var/client/C = GLOB.clients[1]
+	var/client/first_client = GLOB.clients[1]
 
 	for(var/key in letters)
-		if(!C)
+		if(!first_client)
 			if(!length(GLOB.clients))
 				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
 				return
-			C = GLOB.clients[1]
+			first_client = GLOB.clients[1]
 		if(length(letters[key]) == 3 || key == " ")
 			continue
 
-		letters[key] = list(null, null, null)
-		letters[key][NORMAL_FONT_INDEX] = WXH_TO_WIDTH(C.MeasureText(MAPTEXT(key)))
+		letters[key] = list()
+		letters[key] += WXH_TO_WIDTH(first_client.MeasureText(MAPTEXT(key)))
 		if(letters[key][NORMAL_FONT_INDEX] > max_char_width[NORMAL_FONT_INDEX])
 			max_char_width[NORMAL_FONT_INDEX] = letters[key][NORMAL_FONT_INDEX]
-		if(!C)
+		if(!first_client)
 			if(!length(GLOB.clients))
 				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
 				return
-			C = GLOB.clients[1]
+			first_client = GLOB.clients[1]
 
-		letters[key][SMALL_FONT_INDEX] = WXH_TO_WIDTH(C.MeasureText("<span class='small'>[key]</span>"))
+		letters[key] += WXH_TO_WIDTH(first_client.MeasureText("<span class='small'>[key]</span>"))
 		if(letters[key][SMALL_FONT_INDEX] > max_char_width[SMALL_FONT_INDEX])
 			max_char_width[SMALL_FONT_INDEX] = letters[key][SMALL_FONT_INDEX]
-		if(!C)
+		if(!first_client)
 			if(!length(GLOB.clients))
 				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
 				return
-			C = GLOB.clients[1]
+			first_client = GLOB.clients[1]
 
-		letters[key][BIG_FONT_INDEX] = WXH_TO_WIDTH(C.MeasureText("<span class='big'>[key]</span>"))
+		letters[key] += WXH_TO_WIDTH(first_client.MeasureText("<span class='big'>[key]</span>"))
 		if(letters[key][BIG_FONT_INDEX] > max_char_width[BIG_FONT_INDEX])
 			max_char_width[BIG_FONT_INDEX] = letters[key][BIG_FONT_INDEX]

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -1,10 +1,13 @@
 TIMER_SUBSYSTEM_DEF(runechat)
 	name = "Runechat"
 	priority = FIRE_PRIORITY_RUNECHAT
-	/// List of most characters in the font. DO NOT CHANGE IT. ESPECIALLY VAREDIT.
+	/// Biggest calculated char width. Used if character is not included in the list bellow. Includes all font sizes.
+	var/list/max_char_width = list(0, 0, 0)
+	/// List of most characters in the font. Do not varedit it in game.
+	/// Format of it is as follows: character, size when normal, size when small, size when big.
 	var/list/letters = list(
 		//Special case, measuring " " returns 0 since it's empty string
-		" " = 2,
+		" " = list(2, 2, 2),
 		"." = null,
 		"," = null,
 		"?" = null,
@@ -84,8 +87,7 @@ TIMER_SUBSYSTEM_DEF(runechat)
 		"w" = null,
 		"x" = null,
 		"y" = null,
-		"z" = null,
-		MAX_CHAR_WIDTH = 0
+		"z" = null
 	)
 
 /datum/controller/subsystem/timer/runechat/PreInit()
@@ -105,8 +107,28 @@ TIMER_SUBSYSTEM_DEF(runechat)
 				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
 				return
 			C = GLOB.clients[1]
-		if(letters[key] || key == " ")
+		if(length(letters[key]) == 3 || key == " ")
 			continue
-		letters[key] = WXH_TO_WIDTH(C.MeasureText(MAPTEXT(key)))
-		if(letters[key] > letters[MAX_CHAR_WIDTH])
-			letters[MAX_CHAR_WIDTH] = letters[key]
+
+		letters[key] = list(null, null, null)
+		letters[key][NORMAL_FONT_INDEX] = WXH_TO_WIDTH(C.MeasureText(MAPTEXT(key)))
+		if(letters[key][NORMAL_FONT_INDEX] > max_char_width[NORMAL_FONT_INDEX])
+			max_char_width[NORMAL_FONT_INDEX] = letters[key][NORMAL_FONT_INDEX]
+		if(!C)
+			if(!length(GLOB.clients))
+				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
+				return
+			C = GLOB.clients[1]
+
+		letters[key][SMALL_FONT_INDEX] = WXH_TO_WIDTH(C.MeasureText("<span class='small'>[key]</span>"))
+		if(letters[key][SMALL_FONT_INDEX] > max_char_width[SMALL_FONT_INDEX])
+			max_char_width[SMALL_FONT_INDEX] = letters[key][SMALL_FONT_INDEX]
+		if(!C)
+			if(!length(GLOB.clients))
+				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
+				return
+			C = GLOB.clients[1]
+
+		letters[key][BIG_FONT_INDEX] = WXH_TO_WIDTH(C.MeasureText("<span class='big'>[key]</span>"))
+		if(letters[key][BIG_FONT_INDEX] > max_char_width[BIG_FONT_INDEX])
+			max_char_width[BIG_FONT_INDEX] = letters[key][BIG_FONT_INDEX]

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -69,25 +69,29 @@ TIMER_SUBSYSTEM_DEF(runechat)
 /datum/controller/subsystem/timer/runechat/proc/add_new_character_for_client(client/actor, character)
 	set waitfor = FALSE
 
+	if(!actor)
+		return
+	var/ckey = actor.ckey
+
 	//We're already initializing the list for this user or it wasn't yet initialized
-	if(initialize_tokens[actor.ckey] != null || letters[actor.ckey] == null)
+	if(initialize_tokens[ckey] != null || letters[ckey] == null)
 		return
 
-	initialize_tokens[actor.ckey] = 3
-	letters[actor.ckey][character] = list(null, null, null)
+	initialize_tokens[ckey] = 3
+	letters[ckey][character] = list(null, null, null)
 	handle_single_letter(character, actor, NORMAL_FONT_INDEX)
 	handle_single_letter(character, actor, SMALL_FONT_INDEX)
 	handle_single_letter(character, actor, BIG_FONT_INDEX)
 
-	while(initialize_tokens[actor.ckey] > 0)
+	while(initialize_tokens[ckey] > 0)
 		sleep(world.tick_lag)
 
-	for(var/value in letters[actor.ckey][character])
+	for(var/value in letters[ckey][character])
 		//We failed, client logged out mid measuring
 		if(isnull(value))
-			letters[actor.ckey] = null
+			letters[ckey] = null
 
-	initialize_tokens[actor.ckey] = null
+	initialize_tokens[ckey] = null
 
 /datum/controller/subsystem/timer/runechat/proc/handle_single_letter(letter, client/measured_client, font_index)
 	set waitfor = FALSE

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -15,7 +15,7 @@ TIMER_SUBSYSTEM_DEF(runechat)
 		init_runechat_list(client)
 
 /datum/controller/subsystem/timer/runechat/proc/preinit_runechat_list(client/actor)
-	if(SSrunechat.letters[actor.ckey] == null)
+	if(!SSrunechat.letters[actor.ckey])
 		init_runechat_list(actor)
 	else
 		init_additional_letters(actor)
@@ -84,7 +84,7 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	while(initialize_tokens[ckey] > 0)
 		sleep(world.tick_lag)
 
-	for(!C || values.Find(null))
+	for(!actor || values.Find(null))
 		//We failed, client logged out mid measuring
 		if(isnull(value))
 			letters[ckey] = null

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -1,3 +1,109 @@
 TIMER_SUBSYSTEM_DEF(runechat)
 	name = "Runechat"
 	priority = FIRE_PRIORITY_RUNECHAT
+	/// List of most characters in the font. DO NOT CHANGE IT. ESPECIALLY VAREDIT.
+	var/list/letters = list(
+		//Special case, measuring " " returns 0 since it's empty string
+		" " = 2,
+		"." = null,
+		"," = null,
+		"?" = null,
+		"!" = null,
+		"\"" = null,
+		"/" = null,
+		"$" = null,
+		"(" = null,
+		")" = null,
+		"@" = null,
+		"=" = null,
+		":" = null,
+		"'" = null,
+		";" = null,
+		"+" = null,
+		"-" = null,
+		"\\" = null,
+		"<" = null,
+		">" = null,
+		"&" = null,
+		"*" = null,
+		"%" = null,
+		"^" = null,
+		"{" = null,
+		"}" = null,
+		"|" = null,
+		"~" = null,
+		"`" = null,
+		"A" = null,
+		"B" = null,
+		"C" = null,
+		"D" = null,
+		"E" = null,
+		"F" = null,
+		"G" = null,
+		"H" = null,
+		"I" = null,
+		"J" = null,
+		"K" = null,
+		"L" = null,
+		"M" = null,
+		"N" = null,
+		"O" = null,
+		"P" = null,
+		"Q" = null,
+		"R" = null,
+		"S" = null,
+		"T" = null,
+		"U" = null,
+		"V" = null,
+		"W" = null,
+		"X" = null,
+		"Y" = null,
+		"Z" = null,
+		"a" = null,
+		"b" = null,
+		"c" = null,
+		"d" = null,
+		"e" = null,
+		"f" = null,
+		"g" = null,
+		"h" = null,
+		"i" = null,
+		"j" = null,
+		"k" = null,
+		"l" = null,
+		"m" = null,
+		"n" = null,
+		"o" = null,
+		"p" = null,
+		"q" = null,
+		"r" = null,
+		"s" = null,
+		"t" = null,
+		"u" = null,
+		"v" = null,
+		"w" = null,
+		"x" = null,
+		"y" = null,
+		"z" = null
+	)
+
+/datum/controller/subsystem/timer/runechat/PreInit()
+	. = ..()
+	init_runechat_list()
+
+/datum/controller/subsystem/timer/runechat/proc/init_runechat_list()
+	if(!length(GLOB.clients))
+		addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
+		return
+
+	var/client/C = GLOB.clients[1]
+
+	for(var/key in letters)
+		if(!C)
+			if(!length(GLOB.clients))
+				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
+				return
+			C = GLOB.clients[1]
+		if(letters[key] || key == " ")
+			continue
+		letters[key] = WXH_TO_WIDTH(C.MeasureText(MAPTEXT(key)))

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -1,134 +1,103 @@
 TIMER_SUBSYSTEM_DEF(runechat)
 	name = "Runechat"
 	priority = FIRE_PRIORITY_RUNECHAT
-	/// Biggest calculated char width. Used if character is not included in the list bellow. Includes all font sizes.
-	var/list/max_char_width = list(0, 0, 0)
+	/// Each token indicates that a call to client's MeasureText() was made and is pending
+	var/initialize_tokens = list()
+	/// Tracks if current client initializing letter cache still exists
+	var/has_client = FALSE
 	/// List of most characters in the font. Do not varedit it in game.
-	/// Format of it is as follows: character, size when normal, size when small, size when big.
-	var/list/letters = list(
-		//Special case, measuring " " returns 0 since it's empty string
-		" " = list(2, 2, 2),
-		"." = null,
-		"," = null,
-		"?" = null,
-		"!" = null,
-		"\"" = null,
-		"/" = null,
-		"$" = null,
-		"(" = null,
-		")" = null,
-		"@" = null,
-		"=" = null,
-		":" = null,
-		"'" = null,
-		";" = null,
-		"+" = null,
-		"-" = null,
-		"\\" = null,
-		"<" = null,
-		">" = null,
-		"&" = null,
-		"*" = null,
-		"%" = null,
-		"^" = null,
-		"{" = null,
-		"}" = null,
-		"|" = null,
-		"~" = null,
-		"`" = null,
-		"A" = null,
-		"B" = null,
-		"C" = null,
-		"D" = null,
-		"E" = null,
-		"F" = null,
-		"G" = null,
-		"H" = null,
-		"I" = null,
-		"J" = null,
-		"K" = null,
-		"L" = null,
-		"M" = null,
-		"N" = null,
-		"O" = null,
-		"P" = null,
-		"Q" = null,
-		"R" = null,
-		"S" = null,
-		"T" = null,
-		"U" = null,
-		"V" = null,
-		"W" = null,
-		"X" = null,
-		"Y" = null,
-		"Z" = null,
-		"a" = null,
-		"b" = null,
-		"c" = null,
-		"d" = null,
-		"e" = null,
-		"f" = null,
-		"g" = null,
-		"h" = null,
-		"i" = null,
-		"j" = null,
-		"k" = null,
-		"l" = null,
-		"m" = null,
-		"n" = null,
-		"o" = null,
-		"p" = null,
-		"q" = null,
-		"r" = null,
-		"s" = null,
-		"t" = null,
-		"u" = null,
-		"v" = null,
-		"w" = null,
-		"x" = null,
-		"y" = null,
-		"z" = null
-	)
+	/// Format of it is as follows: ckey, characters, size when normal, size when small, size when big.
+	var/list/letters = list()
+	/// Additional letters that will be cached for each new client
+	var/list/additional_letters = list()
 
 /datum/controller/subsystem/timer/runechat/PreInit()
 	. = ..()
-	init_runechat_list()
+	for(var/client/client in GLOB.clients)
+		init_runechat_list(client)
 
-/datum/controller/subsystem/timer/runechat/proc/init_runechat_list()
-	if(!length(GLOB.clients))
-		addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
+/datum/controller/subsystem/timer/runechat/proc/init_runechat_list(client/actor)
+	has_client = TRUE
+
+	RegisterSignal(actor, COMSIG_PARENT_QDELETING, .proc/on_client_del)
+
+	letters[actor.ckey] = EMPTY_CHARACTERS_LIST
+	initialize_tokens[actor.ckey] = 0
+
+	for(var/key in (letters[actor.ckey] | additional_letters))
+		if(key == MAX_CHAR_WIDTH)
+			continue
+		letters[actor.ckey][key] = list(null, null, null)
+		initialize_tokens[actor.ckey] += 3
+		handle_single_letter(key, actor, NORMAL_FONT_INDEX)
+		handle_single_letter(key, actor, SMALL_FONT_INDEX)
+		handle_single_letter(key, actor, BIG_FONT_INDEX)
+
+	while(initialize_tokens[actor.ckey] > 0 && has_client)
+		sleep(world.tick_lag)
+
+	if(!has_client)
+		//something went wrong, we'll try again when he reconnects
+		letters[actor.ckey] = null
+		//We still need to wait for rest of the handles to return
+		while(initialize_tokens[actor.ckey] > 0)
+			sleep(world.tick_lag)
+	else
+		letters[actor.ckey][" "] = list(2, 2, 2)
+
+	UnregisterSignal(actor, COMSIG_PARENT_QDELETING)
+	initialize_tokens[actor.ckey] = null
+	has_client = FALSE
+
+/// If the character is not found in precoded list, it'll be calculated for each client and added to their respective list
+/datum/controller/subsystem/timer/runechat/proc/add_new_character_globally(character)
+	if(additional_letters[character] == TRUE)
 		return
 
-	var/client/first_client = GLOB.clients[1]
+	additional_letters[character] = TRUE
+	for(var/client/actor in GLOB.clients)
+		add_new_character_for_client(actor, character)
 
-	for(var/key in letters)
-		if(!first_client)
-			if(!length(GLOB.clients))
-				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
-				return
-			first_client = GLOB.clients[1]
-		if(length(letters[key]) == 3 || key == " ")
-			continue
+/datum/controller/subsystem/timer/runechat/proc/add_new_character_for_client(client/actor, character)
+	set waitfor = FALSE
 
-		letters[key] = list()
-		letters[key] += WXH_TO_WIDTH(first_client.MeasureText(MAPTEXT(key)))
-		if(letters[key][NORMAL_FONT_INDEX] > max_char_width[NORMAL_FONT_INDEX])
-			max_char_width[NORMAL_FONT_INDEX] = letters[key][NORMAL_FONT_INDEX]
-		if(!first_client)
-			if(!length(GLOB.clients))
-				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
-				return
-			first_client = GLOB.clients[1]
+	//We're already initializing the list for this user
+	if(initialize_tokens[actor.ckey] != null)
+		return
 
-		letters[key] += WXH_TO_WIDTH(first_client.MeasureText("<span class='small'>[key]</span>"))
-		if(letters[key][SMALL_FONT_INDEX] > max_char_width[SMALL_FONT_INDEX])
-			max_char_width[SMALL_FONT_INDEX] = letters[key][SMALL_FONT_INDEX]
-		if(!first_client)
-			if(!length(GLOB.clients))
-				addtimer(CALLBACK(src, .proc/init_runechat_list), 1 SECONDS, null, src)
-				return
-			first_client = GLOB.clients[1]
+	initialize_tokens[actor.ckey] = 3
+	letters[actor.ckey][character] = list(null, null, null)
+	handle_single_letter(character, actor, NORMAL_FONT_INDEX)
+	handle_single_letter(character, actor, SMALL_FONT_INDEX)
+	handle_single_letter(character, actor, BIG_FONT_INDEX)
 
-		letters[key] += WXH_TO_WIDTH(first_client.MeasureText("<span class='big'>[key]</span>"))
-		if(letters[key][BIG_FONT_INDEX] > max_char_width[BIG_FONT_INDEX])
-			max_char_width[BIG_FONT_INDEX] = letters[key][BIG_FONT_INDEX]
+	while(initialize_tokens[actor.ckey] > 0)
+		sleep(world.tick_lag)
+
+	for(var/value in letters[actor.ckey][character])
+		//We failed, client logged out mid measuring
+		if(isnull(value))
+			letters[actor.ckey] = null
+
+	initialize_tokens[actor.ckey] = null
+
+/datum/controller/subsystem/timer/runechat/proc/handle_single_letter(letter, client/measured_client, font_index)
+	set waitfor = FALSE
+	var/font_class
+	if(font_index == NORMAL_FONT_INDEX)
+		font_class = ""
+	else if(font_index == SMALL_FONT_INDEX)
+		font_class = "small"
+	else
+		font_class = "big"
+	if(!measured_client)
+		return FALSE
+	var/response = WXH_TO_WIDTH(measured_client.MeasureText("<span class='[font_class]'>[letter]</span>"))
+	letters[measured_client.ckey][letter][font_index] = response
+	if(response > letters[measured_client.ckey][MAX_CHAR_WIDTH][font_index])
+		letters[measured_client.ckey][MAX_CHAR_WIDTH][font_index] = response
+	initialize_tokens[measured_client.ckey]--
+	return TRUE
+
+/datum/controller/subsystem/timer/runechat/proc/on_client_del()
+	has_client = FALSE

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -84,7 +84,8 @@ TIMER_SUBSYSTEM_DEF(runechat)
 		"w" = null,
 		"x" = null,
 		"y" = null,
-		"z" = null
+		"z" = null,
+		MAX_CHAR_WIDTH = 0
 	)
 
 /datum/controller/subsystem/timer/runechat/PreInit()
@@ -107,3 +108,5 @@ TIMER_SUBSYSTEM_DEF(runechat)
 		if(letters[key] || key == " ")
 			continue
 		letters[key] = WXH_TO_WIDTH(C.MeasureText(MAPTEXT(key)))
+		if(letters[key] > letters[MAX_CHAR_WIDTH])
+			letters[MAX_CHAR_WIDTH] = letters[key]

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -84,7 +84,7 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	while(initialize_tokens[ckey] > 0)
 		sleep(world.tick_lag)
 
-	for(!actor || values.Find(null))
+	if(!actor || values.Find(null))
 		//We failed, client logged out mid measuring
 		if(isnull(value))
 			letters[ckey] = null

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -16,6 +16,12 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	for(var/client/client in GLOB.clients)
 		init_runechat_list(client)
 
+/datum/controller/subsystem/timer/runechat/proc/preinit_runechat_list(client/actor)
+	if(SSrunechat.letters[actor.ckey] == null)
+		init_runechat_list(actor)
+	else
+		init_additional_letters(actor)
+
 /datum/controller/subsystem/timer/runechat/proc/init_runechat_list(client/actor)
 	has_client = TRUE
 
@@ -48,6 +54,18 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	UnregisterSignal(actor, COMSIG_PARENT_QDELETING)
 	initialize_tokens[actor.ckey] = null
 	has_client = FALSE
+
+/datum/controller/subsystem/timer/runechat/proc/init_additional_letters(client/actor)
+	var/ckey = actor.ckey
+
+	for(var/key in additional_letters)
+		if(length(letters[ckey][key]) == 3 && !letters[ckey][key].Find(null))
+			continue
+		message_admins("Letter [key] not found!!!")
+		letters[ckey][key] = list(null, null, null)
+		handle_single_letter(key, actor, NORMAL_FONT_INDEX)
+		handle_single_letter(key, actor, SMALL_FONT_INDEX)
+		handle_single_letter(key, actor, BIG_FONT_INDEX)
 
 /// If the character is not found in precoded list, it'll be calculated for each client and added to their respective list
 /datum/controller/subsystem/timer/runechat/proc/add_new_character_globally(character)

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -59,7 +59,8 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	var/ckey = actor.ckey
 
 	for(var/key in additional_letters)
-		if(length(letters[ckey][key]) == 3 && !letters[ckey][key].Find(null))
+		var/list/values = letters[ckey][key]
+		if(length(values) == 3 && !values.Find(null))
 			continue
 		letters[ckey][key] = list(null, null, null)
 		handle_single_letter(key, actor, NORMAL_FONT_INDEX)

--- a/code/controllers/subsystem/runechat.dm
+++ b/code/controllers/subsystem/runechat.dm
@@ -84,10 +84,9 @@ TIMER_SUBSYSTEM_DEF(runechat)
 	while(initialize_tokens[ckey] > 0)
 		sleep(world.tick_lag)
 
-	if(!actor || values.Find(null))
+	if(!actor || letters[ckey][character].Find(null))
 		//We failed, client logged out mid measuring
-		if(isnull(value))
-			letters[ckey] = null
+		letters[ckey] = null
 
 	initialize_tokens[ckey] = null
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -664,9 +664,9 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		var/size = letters[string[i]]
 		if(!size)
 			size = 1000
-		value++ //To account for 1 px black outline at the left side of the symbol
 		value += CHAR_WIDTH(size, font_size)
-	return value + 1 //To account for the 1px black outline at the right side of the last symbol
+	value += length(string) + 1 //To account for 1px outlines
+	return value
 
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -575,6 +575,14 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	var/duration = BALLOON_TEXT_TOTAL_LIFETIME(duration_mult)
 	fadertimer = addtimer(CALLBACK(src, .proc/end_of_life), duration, TIMER_STOPPABLE|TIMER_DELETE_ME, SSrunechat)
 
+/**
+ * Approximates the chatmesseges width based on cached widths of each char.
+ * If the character is not found in this cache we assume the worst and add the highest possible value.
+ *
+ * Arguments:
+ * * string - string to measure width
+ * * font size - font size that the displayed string will be in, used to calculate font size multiplier
+ */
 /datum/chatmessage/proc/approx_str_width(var/string, var/font_size = DEFAULT_FONT_SIZE)
 	var/value = 0
 	var/font_multiplier = font_size / DEFAULT_FONT_SIZE

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -212,7 +212,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	var/font_size = DEFAULT_FONT_SIZE
 	if (extra_classes.Find("megaphone"))
 		font_size = BIG_FONT_SIZE
-	else if (extra_classes.Find("italics"))
+	else if (extra_classes.Find("italics") || extra_classes.Find("emote"))
 		font_size = WHISPER_FONT_SIZE
 
 	// Append language icon if the language uses one
@@ -225,12 +225,15 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 			LAZYSET(language_icons, language, language_icon)
 		LAZYADD(prefixes, "\icon[language_icon]")
 
-	//Add on the icons.
+	// Approximate text height
+	approx_lines = CEILING(approx_str_width(text, font_size) / CHAT_MESSAGE_WIDTH, 1)
+
+	//Add on the icons. The icon isn't measured in str_width
 	text = "[prefixes?.Join("&nbsp;")][text]"
 
-	// Approximate text height
+	// Complete the text with rest of extra classes
 	var/complete_text = "<span class='center [extra_classes.Join(" ")]' style='color: [tgt_color]'>[text]</span>"
-	approx_lines = CEILING(approx_str_width(text, font_size) / CHAT_MESSAGE_WIDTH, 1)
+
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	message_loc = get_atom_on_turf(target)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -182,7 +182,6 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
   * * lifespan - The lifespan of the message in deciseconds
   */
 /datum/chatmessage/New(text, atom/target, list/client/hearers, language_icon, list/extra_classes = list(), lifespan = CHAT_MESSAGE_LIFESPAN)
-	. = ..()
 	if (!istype(target))
 		CRASH("Invalid target given for chatmessage")
 	generate_image(text, target, hearers, language_icon, extra_classes, lifespan)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -27,7 +27,7 @@
 /// Default font size (defined in skin.dmf), those are 1 size bigger than in skin, to account 1px black outline
 #define DEFAULT_FONT_SIZE 8
 /// Big font size, used by megaphones and such
-#define BIG_FONT_SIZE 10
+#define BIG_FONT_SIZE 9
 /// Small font size, used mostly by whispering
 #define WHISPER_FONT_SIZE 7
 
@@ -609,7 +609,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	if(is_bold)
 		value += length(string)
 	if(has_icon)
-		value += 8
+		value += CHAT_MESSAGE_ICON_SIZE
 	return value
 
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -583,7 +583,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
  * * string - string to measure width
  * * font size - font size that the displayed string will be in, used to calculate font size multiplier
  */
-/datum/chatmessage/proc/approx_str_width(var/string, var/font_size = DEFAULT_FONT_SIZE)
+/datum/chatmessage/proc/approx_str_width(string, font_size = DEFAULT_FONT_SIZE)
 	var/value = 0
 	var/font_multiplier = font_size / DEFAULT_FONT_SIZE
 	for(var/i in 1 to length(string))

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 			if (!m.isFading)
 				var/sched_remaining = timeleft(m.fadertimer, SSrunechat)
 				var/remaining_time = (sched_remaining) * (CHAT_MESSAGE_EXP_DECAY ** idx++) * (CHAT_MESSAGE_HEIGHT_DECAY ** CEILING(combined_height, 1))
-				if (remaining_time)
+				if (remaining_time > 0)
 					deltimer(m.fadertimer, SSrunechat)
 					m.fadertimer = addtimer(CALLBACK(m, .proc/end_of_life), remaining_time, TIMER_STOPPABLE|TIMER_DELETE_ME, SSrunechat)
 				else

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -535,7 +535,7 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	else
 		message_loc = get_atom_on_turf(target)
 
-	approx_lines = CEILING(approx_str_width(text, DEFAULT_FONT_SIZE, FALSE, owned_by.ckey) / CHAT_MESSAGE_WIDTH, 1)
+	approx_lines = CEILING(approx_str_width(text, DEFAULT_FONT_SIZE, FALSE, FALSE, owned_by.ckey) / CHAT_MESSAGE_WIDTH, 1)
 
 	// Build message image
 	message = image(loc = message_loc, layer = CHAT_LAYER)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -572,6 +572,16 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	var/duration = BALLOON_TEXT_TOTAL_LIFETIME(duration_mult)
 	fadertimer = addtimer(CALLBACK(src, .proc/end_of_life), duration, TIMER_STOPPABLE|TIMER_DELETE_ME, SSrunechat)
 
+/datum/chatmessage/proc/approx_str_width(var/string, var/font_size = DEFAULT_FONT_SIZE)
+	var/value = 0
+	var/font_multiplier = font_size / DEFAULT_FONT_SIZE
+	for(var/i in 1 to length(string))
+		var/size = SSrunechat.letters[string[i]]
+		if(!size)
+			size = SSrunechat.letters[MAX_CHAR_WIDTH]
+		value += size * font_multiplier
+	return value
+
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT
 #undef CHAT_MESSAGE_SPAWN_TIME

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -22,16 +22,14 @@
 #define CHAT_MESSAGE_ICON_SIZE		7
 /// How much the message moves up before fading out.
 #define MESSAGE_FADE_PIXEL_Y 10
-/// Approximation of char width in px
-#define CHAR_WIDTH(x, size) x * 0.001 * size
 /// Approximation of the height
-#define APPROX_HEIGHT(font_size, lines) font_size * 1.7 * lines
-/// Default font size (defined in skin.dmf)
-#define DEFAULT_FONT_SIZE 7
+#define APPROX_HEIGHT(font_size, lines) (font_size * 1.7 * lines) + 2
+/// Default font size (defined in skin.dmf), those are 1 size bigger than in skin, to account 1px black outline
+#define DEFAULT_FONT_SIZE 8
 /// Big font size, used by megaphones and such
-#define BIG_FONT_SIZE 9
+#define BIG_FONT_SIZE 10
 /// Small font size, used mostly by whispering
-#define WHISPER_FONT_SIZE 6
+#define WHISPER_FONT_SIZE 7
 
 // Message types
 #define CHATMESSAGE_CANNOT_HEAR 0
@@ -86,90 +84,6 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	var/fadertimer = null
 	/// States if end_of_life is being executed
 	var/isFading = FALSE
-	/// List of most characters in the font. DO NOT CHANGE IT. ESPECIALLY VAREDIT.
-	var/static/list/letters = list(
-		" " = 222,
-		"." = 222,
-		"," = 222,
-		"?" = 556,
-		"!" = 222,
-		"\"" = 444,
-		"/" = 333,
-		"$" = 667,
-		"(" = 333,
-		")" = 333,
-		"@" = 1000,
-		"=" = 556,
-		":" = 222,
-		"'" = 222,
-		";" = 222,
-		"+" = 444,
-		"-" = 333,
-		"\\" = 333,
-		"<" = 556,
-		">" = 556,
-		"&" = 667,
-		"*" = 333,
-		"%" = 778,
-		"^" = 444,
-		"{" = 333,
-		"}" = 333,
-		"|" = 222,
-		"~" = 556,
-		"`" = 333,
-		"A" = 889,
-		"B" = 778,
-		"C" = 667,
-		"D" = 778,
-		"E" = 667,
-		"F" = 667,
-		"G" = 778,
-		"H" = 778,
-		"I" = 444,
-		"J" = 556,
-		"K" = 778,
-		"L" = 556,
-		"M" = 1000,
-		"N" = 778,
-		"O" = 778,
-		"P" = 667,
-		"Q" = 778,
-		"R" = 667,
-		"S" = 556,
-		"T" = 556,
-		"U" = 667,
-		"V" = 778,
-		"W" = 778,
-		"X" = 778,
-		"Y" = 778,
-		"Z" = 556,
-		"a" = 556,
-		"b" = 556,
-		"c" = 556,
-		"d" = 556,
-		"e" = 556,
-		"f" = 556,
-		"g" = 556,
-		"h" = 556,
-		"i" = 222,
-		"j" = 222,
-		"k" = 556,
-		"l" = 222,
-		"m" = 889,
-		"n" = 556,
-		"o" = 556,
-		"p" = 556,
-		"q" = 556,
-		"r" = 333,
-		"s" = 444,
-		"t" = 333,
-		"u" = 556,
-		"v" = 556,
-		"w" = 667,
-		"x" = 556,
-		"y" = 556,
-		"z" = 444
-	)
 
 /**
   * Constructs a chat message overlay
@@ -658,16 +572,6 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 	var/duration = BALLOON_TEXT_TOTAL_LIFETIME(duration_mult)
 	fadertimer = addtimer(CALLBACK(src, .proc/end_of_life), duration, TIMER_STOPPABLE|TIMER_DELETE_ME, SSrunechat)
 
-/datum/chatmessage/proc/approx_str_width(var/string, var/font_size = DEFAULT_FONT_SIZE)
-	var/value = 0
-	for(var/i in 1 to length(string))
-		var/size = letters[string[i]]
-		if(!size)
-			size = 1000
-		value += CHAR_WIDTH(size, font_size)
-	value += length(string) + 1 //To account for 1px outlines
-	return value
-
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT
 #undef CHAT_MESSAGE_SPAWN_TIME
@@ -688,7 +592,6 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 #undef CHATMESSAGE_CANNOT_HEAR
 #undef CHATMESSAGE_HEAR
 #undef CHATMESSAGE_SHOW_LANGUAGE_ICON
-#undef CHAR_WIDTH
 #undef APPROX_HEIGHT
 #undef DEFAULT_FONT_SIZE
 #undef BIG_FONT_SIZE

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -664,8 +664,9 @@ GLOBAL_LIST_INIT(job_colors_pastel, list(
 		var/size = letters[string[i]]
 		if(!size)
 			size = 1000
+		value++ //To account for 1 px black outline at the left side of the symbol
 		value += CHAR_WIDTH(size, font_size)
-	return value
+	return value + 1 //To account for the 1px black outline at the right side of the last symbol
 
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MULT

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -461,8 +461,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	mob.UpdateMobStat(TRUE)
 
 	//Initialize runechat letter cache for this client
-	if(SSrunechat.letters[ckey] == null)
-		SSrunechat.init_runechat_list(src)
+	SSrunechat.preinit_runechat_list(src)
 
 /client/proc/time_to_redirect()
 	var/redirect_address = CONFIG_GET(string/redirect_address)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -460,6 +460,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	//Load the TGUI stat in case of TGUI subsystem not ready (startup)
 	mob.UpdateMobStat(TRUE)
 
+	//Initialize runechat letter cache for this client
+	if(SSrunechat.letters[ckey] == null)
+		SSrunechat.init_runechat_list(src)
+
 /client/proc/time_to_redirect()
 	var/redirect_address = CONFIG_GET(string/redirect_address)
 	GLOB.ckey_redirects -= ckey


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes call to MeasureText(), effectively making creating chatmessages synchronous.
This fixes a few possible runtimes and weird undefined behaviors.

~~`CHAR_WIDTH` is (`width` / 1000) * `font_size`~~
~~Where width is width as calculated by FontForge. `width` / 1000 is the conversion between FontForge's em-size value and 1000 em-size is just 1 em.~~
~~Check the FontForge's docs for better explanation. https://fontforge.org/docs/~~
~~`APPROX_HEIGHT` is `font_size` * 1.7~~
~~Where 1.7 is approximation, based on comparing results of the MeasureText() and used font.~~

~~The values from FontForge are saved in static list. If something isn't on the list we assume the worst and give it width of 1000.~~

The values from font forge were inacurate. The approx width compared to measured one differed by about 20%.
The more naive solution has been implemented - measure cache of some sort. Every client should have the same viewport so the measurements between clients should be the same. Thus, once, we calculate values for every character and keep using them.
After testing it is about ~1% inacurate (which is huge improvement over 20%).

~~Additionally the values are cached now per client plus every uncached character will be calculated for all the clients.~~

I changed my mind. I precalculated values for first 1500 characters for unicode. That should cover all the characters you would ever need. Anything that isn't included gets replaced with "?". 
If you ever need a new character you can modify json with the value.

## Why It's Good For The Game

Less chatmessage bugs and better performance.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![obraz](https://user-images.githubusercontent.com/37456678/166166524-189acf87-e720-490a-898f-bf1437895fe7.png)

![obraz](https://user-images.githubusercontent.com/37456678/166166534-b31078d1-9834-419b-a1f9-7114634cf65a.png)
![obraz](https://user-images.githubusercontent.com/37456678/166166539-1a76f8a8-9c55-4f11-a4d6-d92249397ffa.png)

![obraz](https://user-images.githubusercontent.com/37456678/166166547-3d8414c1-674c-4600-bd8d-eaaa7cf100c4.png)

![obraz](https://user-images.githubusercontent.com/37456678/166166557-0213ee94-e785-495c-98b6-dae9df13edff.png)

![obraz](https://user-images.githubusercontent.com/37456678/166166567-e4b8f2ef-a834-435f-896e-fecd525aa3b3.png)

![obraz](https://user-images.githubusercontent.com/37456678/166166582-d9c335e7-be62-4e93-8d04-6e88f139d5de.png)

NEW CONTENT BELLOW
(old is still relevant though)
![image](https://github.com/user-attachments/assets/e3a93345-b7eb-4320-9a34-505ca05c3d25)
sunglasses emoji was replaced with "?"

</details>

## Changelog
:cl:
refactor: refactored how chatmessage width and height is calculated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
