### PR TITLE
Speedmerge plz. Fixes a miners redeeming points they shouldn't. 

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -144,7 +144,7 @@
 	var/datum/techweb/stored_research
 	var/link_id = null
 	var/points = 0
-	var/allow_point_redemption = TRUE
+	var/allow_point_redemption = FALSE
 
 /obj/machinery/mineral/processing_unit/laborcamp
 	allow_point_redemption = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The changes in #6509 allow miners to redeem points via the smelter on lavaland. This means they are getting points while the materials they gather stay on lavaland. I spoke to @PowerfulBacon and he believed a smelter would only give points if linked to the station, but linking machines across Z levels is not possible. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Points should only be awarded to miners who turn ores in for the station to use, not for simply mining them. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

## Changelog
:cl:
fix: Miners being able to redeem points without providing ores to the station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
