### PR TITLE
borgs can hold kpa normally again

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -71,6 +71,7 @@
 /obj/item/gun/energy/kinetic_accelerator/cyborg
 	holds_charge = TRUE
 	unique_frequency = TRUE
+	requires_wielding = FALSE
 	max_mod_capacity = 80
 
 /obj/item/gun/energy/kinetic_accelerator/minebot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently when borg tries to hold kpa borg it receives message "You attempt to wield the proto-kinetic accelerator via the power of telekenisis, but it is too much for you to handle..." and can't shoot straight because its KPA is two-handed but borg doesn't have two "hands" so this PR changes it so cyborg KPA is no longer thohanded
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
cyborg miner can shoot straight again
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
tweak: cyborg KPA is no longer two-handed so mining borg can shoot straight again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
