### PR TITLE
Fixes certain gloves showing up as white gloves when worn

### DIFF
--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -3,26 +3,31 @@
 	desc = "Because you really needed another excuse to punch your crewmates."
 	icon_state = "boxing"
 	item_state = "boxing"
+	worn_icon_state = "boxing"
 	equip_delay_other = 60
 	species_exception = list(/datum/species/golem) // now you too can be a golem boxing champion
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"
 	item_state = "boxinggreen"
+	worn_icon_state = "boxinggreen"
 
 /obj/item/clothing/gloves/boxing/blue
 	icon_state = "boxingblue"
 	item_state = "boxingblue"
+	worn_icon_state = "boxingblue"
 
 /obj/item/clothing/gloves/boxing/yellow
 	icon_state = "boxingyellow"
 	item_state = "boxingyellow"
+	worn_icon_state = "boxingyellow"
 
 /obj/item/clothing/gloves/boxing/yellow/insulated
 	name = "budget boxing gloves"
 	desc = "Standard boxing gloves coated in a makeshift insulating coat. This can't possibly go wrong at all."
 	icon_state = "boxingyellow"
 	item_state = "boxingyellow"
+	worn_icon_state = "boxingyellow"
 	siemens_coefficient = 1	//Set to a default of 1, gets overridden in Initialize()
 
 /obj/item/clothing/gloves/boxing/yellow/insulated/Initialize(mapload)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -3,8 +3,8 @@
 	name = "fingerless gloves"
 	desc = "Plain black gloves without fingertips for the hard working."
 	icon_state = "fingerless"
-	worn_icon_state = "fingerless"
 	item_state = "fingerless"
+	worn_icon_state = "fingerless"
 	transfer_prints = TRUE
 	strip_delay = 40
 	equip_delay_other = 20
@@ -48,6 +48,7 @@
 	desc = "For when you're expecting to get slapped on the wrist. Offers modest protection to your arms."
 	icon_state = "bracers"
 	item_state = "bracers"
+	worn_icon_state = "bracers"
 	transfer_prints = TRUE
 	strip_delay = 40
 	equip_delay_other = 20
@@ -63,6 +64,7 @@
 	desc = "Just looking at these fills you with an urge to beat the shit out of people."
 	icon_state = "rapid"
 	item_state = "rapid"
+	worn_icon_state = "rapid"
 	transfer_prints = TRUE
 	var/warcry = "AT"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bone bracers, gloves of the north star, and all varieties of boxing gloves now have their intended appearance, rather than white gloves.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer will ashwalkers and FotNS enthusiasts be forced to wear clashing white gloves.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![](https://cdn.discordapp.com/attachments/305828469852602368/971258131445346314/unknown.png)


</details>

## Changelog
:cl:h42
fix: Bone bracers, gloves of the north star, and all varieties of boxing gloves now have their intended appearance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
