### PR TITLE
fixes anchored bug with contaiment field gens and change glass to plasma on deltastation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -59232,10 +59232,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cjd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cje" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable{
@@ -62940,7 +62936,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "crM" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -141775,13 +141771,13 @@ aaa
 aad
 aaa
 aad
-cjd
-cjd
-cjd
+roT
+roT
+roT
 crM
-cjd
-cjd
-cjd
+roT
+roT
+roT
 aad
 aaa
 aad
@@ -142032,13 +142028,13 @@ car
 roT
 roT
 roT
-cjd
+roT
 coZ
 cqq
 crN
 cqq
 cuP
-cjd
+roT
 roT
 roT
 roT
@@ -142289,13 +142285,13 @@ chu
 cje
 cje
 cje
-cjd
+roT
 cpa
 cqr
 cqr
 ctp
 cuQ
-cjd
+roT
 cje
 cje
 cAK

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -60392,7 +60392,8 @@
 	dir = 9
 	},
 /obj/machinery/field/generator{
-	anchored = 1
+	anchored = 1;
+	state = 1
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -60401,7 +60402,8 @@
 	dir = 5
 	},
 /obj/machinery/field/generator{
-	anchored = 1
+	anchored = 1;
+	state = 1
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -65528,7 +65530,8 @@
 	dir = 10
 	},
 /obj/machinery/field/generator{
-	anchored = 1
+	anchored = 1;
+	state = 1
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -65537,7 +65540,8 @@
 	dir = 6
 	},
 /obj/machinery/field/generator{
-	anchored = 1
+	anchored = 1;
+	state = 1
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -113150,6 +113154,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"roT" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rpP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -142021,9 +142029,9 @@ car
 cdH
 car
 car
-cjd
-cjd
-cjd
+roT
+roT
+roT
 cjd
 coZ
 cqq
@@ -142031,9 +142039,9 @@ crN
 cqq
 cuP
 cjd
-cjd
-cjd
-cjd
+roT
+roT
+roT
 car
 car
 cFM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR simply changes some windows on delta towards reinforced plasma so they let the radiation trough properly and also fixes a issue where you had to unanchor and reanchor the containment field generators to have them actually be properly secured. (only for the generators pre spawned at the engine area) this issue had people first unsecure and then secure the generators else especially with tesla this could lead to a bad outcome.

## Why It's Good For The Game

Radiation collectors behind reinforced glass makes no sense also the bugged containment field generators can easily lead to a  tesloose on delta

</details>

## Changelog
:cl:
tweak: changes the windows infront of singu engine area at delta to reinforced plasma windows
fix: fixes containment field generators at delta to be properly anchored from roundstart (only anchored not welded yet)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
