### PR TITLE
Adds Character-based gear loadouts

### DIFF
--- a/code/modules/client/loadout/loadout_footwear.dm
+++ b/code/modules/client/loadout/loadout_footwear.dm
@@ -17,12 +17,12 @@
 /datum/gear/footwear/winterboots
 	display_name = "winter boots"
 	path = /obj/item/clothing/shoes/winterboots
-	cost = 4000
+	cost = -10
 
 /datum/gear/footwear/swagshoes
 	display_name = "swag shoes"
 	path = /obj/item/clothing/shoes/swagshoes
-	cost = 31000 
+	cost = -10
 
 //Standard shoes
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -724,6 +724,23 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						type_blacklist += G.subtype_path
 					else
 						equipped_gear.Cut(i,i+1)
+			if(path)
+				var/savefile/S = new /savefile(path)
+				if(S)
+					dat += "<center>"
+					var/name
+					var/unspaced_slots = 0
+					for(var/i=1, i<=max_save_slots, i++)
+						unspaced_slots++
+						if(unspaced_slots > 4)
+							dat += "<br>"
+							unspaced_slots = 0
+						S.cd = "/character[i]"
+						S["real_name"] >> name
+						if(!name)
+							name = "Character[i]"
+						dat += "<a style='white-space:nowrap;' href='?_src_=prefs;preference=changeslot;num=[i];' [i == default_slot ? "class='linkOn'" : ""]>[name]</a> "
+					dat += "</center>"
 
 			var/fcolor =  "#3366CC"
 			var/metabalance = user.client.get_metabalance()
@@ -1308,13 +1325,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						to_chat(user, "<span class='warning'>Can't equip [TG.display_name]. It conflicts with an already-equipped item.</span>")
 				else
 					log_href_exploit(user)
-			save_preferences()
+			save_character()
 
 		else if(href_list["select_category"])
 			gear_tab = href_list["select_category"]
 		else if(href_list["clear_loadout"])
 			equipped_gear.Cut()
-			save_preferences()
+			save_character()
 
 		ShowChoices(user)
 		return

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -217,7 +217,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["key_bindings"], key_bindings)
 
 	READ_FILE(S["purchased_gear"], purchased_gear)
-	READ_FILE(S["equipped_gear"], equipped_gear)
+
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -318,7 +318,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["pda_color"], pda_color)
 	WRITE_FILE(S["show_credits"], show_credits)
 	WRITE_FILE(S["purchased_gear"], purchased_gear)
-	WRITE_FILE(S["equipped_gear"], equipped_gear)
+
 
 	if (!key_bindings)
 		key_bindings = deepCopyList(GLOB.keybinding_list_by_key)
@@ -420,6 +420,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Quirks
 	READ_FILE(S["all_quirks"], all_quirks)
 
+	READ_FILE(S["equipped_gear"], equipped_gear)
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
 		update_character(needs_update, S)		//needs_update == savefile_version if we need an update (positive integer)
@@ -574,6 +575,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Quirks
 	WRITE_FILE(S["all_quirks"]			, all_quirks)
+
+	WRITE_FILE(S["equipped_gear"], equipped_gear)
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Adds character-based gear loadouts, instead of the client-based loadouts.
I also set a negative beecoins cost to some shoes, so that the loadouts can be tested; this will be removed.
This is my first PR. it worked fine on my end, but there might (surely) be bugs i have overlooked.

## Why It's Good For The Game

Changing your loadouts manually each time you wanted to play another character is a pain, this is less painful.

## Testing Photographs and Procedure

Here are some screenshots

<img width="551" alt="cloadout1" src="https://user-images.githubusercontent.com/53836108/167026411-53e64352-ee26-41f0-b60a-5419125e4aa6.png">

<img width="551" alt="cloadout2" src="https://user-images.githubusercontent.com/53836108/167026430-1afb2aea-9fab-4ced-bbfd-b510bada673c.png">

## Changelog
:cl:
add: Added character selection slots in beecoin shop
add: Added equipped_loadout to save_character
/:cl: