### PR TITLE
'Fix' Exploration Artifact Watchers Having X-Ray Vision.

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/artifact_defenses.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/artifact_defenses.dm
@@ -15,10 +15,12 @@
 	desc = "It sends a shiver down your spine."
 	icon_state = "watcher"
 	var/cooldown = 0
+	var/range //Trigger range
 
 /obj/structure/alien_artifact/watcher/Initialize(mapload)
 	. = ..()
-	proximity_monitor = new(src, rand(3, 6))
+	range = rand(3, 6)
+	proximity_monitor = new(src, range)
 	var/turf/T = get_turf(src)
 	var/list/turfs = RANGE_TURFS(2, T)
 	var/list/valid_turfs = list()
@@ -31,9 +33,7 @@
 	new /obj/structure/alien_artifact/protector(valid_turfs[1])
 
 /obj/structure/alien_artifact/watcher/HasProximity(atom/movable/AM)
-	if(cooldown > world.time)
-		return
-	if (iseffect(AM) || isprojectile(AM))
+	if(cooldown > world.time || iseffect(AM) || isprojectile(AM) || !(locate(AM) in view(range ,src)))
 		return
 	cooldown = world.time + 50
 	//Trigger nearby protectors


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Exploration artifact watchers can detect you through walls, and cause protectors to attack you. This is quite annoying and has led to quite a few annoying and confusing deaths. 
I'm under the impression this is unintended. 

The fix checks if the triggering target is in view. This also means explorer can smash lights, create darkness, to essentially disable watchers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Reduces confusion and removes possible bug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
Fix: Exploration Artifact Watchers now check if the proximity-atom is in view. 
/:cl:

![Alberto](https://user-images.githubusercontent.com/40559528/167084456-4e3ab8a0-f2de-465d-ae85-a79d294483bd.png)