### PR TITLE
Adds printable medipens

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -192,6 +192,39 @@
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+/datum/design/medipen_epi
+	name = "Epinephrine Medipen"
+	desc = "A rapid and safe way to stabilize patients in critical condition for personnel without advanced medical knowledge. Contains a powerful preservative that can delay decomposition when applied to a dead body."
+	id = "medipen_epi"
+	build_path = /obj/item/reagent_containers/hypospray/medipen
+	build_type = PROTOLATHE
+	materials = list(/datum/material/plastic = 200)
+	reagents_list = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/toxin/formaldehyde = 3)
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/medipen_dex
+	name = "Dexalin Medipen"
+	desc = "An autoinjector containing dexalin, used to heal oxygen damage quickly."
+	id = "medipen_dex"
+	build_path = /obj/item/reagent_containers/hypospray/medipen/dexalin
+	build_type = PROTOLATHE
+	materials = list(/datum/material/plastic = 200)
+	reagents_list = list(/datum/reagent/medicine/dexalin = 10)
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/medipen_atropine
+	name = "Atropine Medipen"
+	desc = "A rapid way to save a person from a critical injury state!"
+	id = "medipen_atropine"
+	build_path = /obj/item/reagent_containers/hypospray/medipen/atropine
+	build_type = PROTOLATHE
+	materials = list(/datum/material/plastic = 200)
+	reagents_list = list(/datum/reagent/medicine/atropine = 10)
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/surgical_drapes
 	name = "Surgical Drapes"
 	id = "surgical_drapes"

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -303,13 +303,13 @@
 		say("Not enough materials to complete prototype[amount > 1? "s" : ""].")
 		return FALSE
 	for(var/R in D.reagents_list)
-		if(!reagents.has_reagent(R, D.reagents_list[R]*amount/coeff))
+		if(!reagents.has_reagent(R, D.reagents_list[R]*amount))
 			say("Not enough reagents to complete prototype[amount > 1? "s" : ""].")
 			return FALSE
 	materials.mat_container.use_materials(efficient_mats, amount)
 	materials.silo_log(src, "built", -amount, "[D.name]", efficient_mats)
 	for(var/R in D.reagents_list)
-		reagents.remove_reagent(R, D.reagents_list[R]*amount/coeff)
+		reagents.remove_reagent(R, D.reagents_list[R]*amount)
 	busy = TRUE
 	if(production_animation)
 		flick(production_animation, src)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -74,7 +74,7 @@
 	display_name = "Biological Technology"
 	description = "What makes us tick."	//the MC, silly!
 	prereq_ids = list("base")
-	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "sleeper", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "healthanalyzer", "medspray","genescanner")
+	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "sleeper", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "healthanalyzer", "medspray","genescanner", "medipen_epi", "medipen_dex", "medipen_atropine")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/tgui/packages/tgui/interfaces/TechFab.js
+++ b/tgui/packages/tgui/interfaces/TechFab.js
@@ -269,8 +269,7 @@ const Recipe = (props, context) => {
     const reagent = reagents[id];
     const total = reagent?.volume || 0;
     const recipeReagent = recipe.reagents[id];
-    const amountNeeded = Math.floor(recipeReagent.volume 
-      / (recipe.efficiency_affects ? efficiency : 1));
+    const amountNeeded = Math.floor(recipeReagent.volume);
     const mat_max = Math.floor(total/amountNeeded);
     max = Math.min(max, mat_max);
     return (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/34888552/167182554-5588c950-744d-4250-acb0-96006b7d7599.png)

Adds printable epinephrine, atropine and dexaline medipens to the medical techfab after biotech research.

On a side note, reagent requirements for techfab designs no longer scale with efficiency. This should not be really an issue since only two other techfab designs use reagents.
This is done because otherwise this would allow reagent duping, when printing medipens even in basic configuration, but becoming more severe with upgrades. (On maximum efficiency atropine medipens would cost 4u of atropine to make despite containing 10u)

## Why It's Good For The Game

It seems to be a good compromise between adding medipen creators for every chemical and not being able to make them at all.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Trust me, it works. I have tested it.

</details>

## Changelog
:cl:
add: Epinephrine, Dexalin and Atropine medipens are now printable in the medical lathe.
tweak: Reagents in the protolathe recipes no longer scale with part efficiency.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
