### PR TITLE
Ketamine now causes a randomized trauma

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -512,8 +512,8 @@
 /datum/reagent/drug/ketamine/overdose_process(mob/living/M)
 	//Dissociative anesthetics? Overdosing? Time to dissociate hard.
 	var/obj/item/organ/brain/B = M.getorgan(/obj/item/organ/brain)
-	if(B.can_gain_trauma(/datum/brain_trauma/severe/split_personality, 5))
-		B.brain_gain_trauma(/datum/brain_trauma/severe/split_personality, 5)
+	if(B.can_gain_trauma(/datum/brain_trauma/severe/split_personality, TRAUMA_RESILIENCE_SURGERY))
+		B.gain_trauma(BRAIN_TRAUMA_SEVERE)
 		. = 1
 	M.hallucination += 10
 	//Uh Oh Someone is tired

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -510,11 +510,11 @@
 	..()
 
 /datum/reagent/drug/ketamine/overdose_process(mob/living/M)
-	//Dissociative anesthetics? Overdosing? Time to dissociate hard.
 	var/obj/item/organ/brain/B = M.getorgan(/obj/item/organ/brain)
-	if(B.can_gain_trauma(/datum/brain_trauma/severe/split_personality, TRAUMA_RESILIENCE_SURGERY))
-		B.gain_trauma(BRAIN_TRAUMA_SEVERE)
-		. = 1
+	var/gained_trauma = FALSE
+	if(!gained_trauma)
+		B.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_SURGERY)
+		gained_trauma = TRUE
 	M.hallucination += 10
 	//Uh Oh Someone is tired
 	if(prob(40))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ketamine now causes a random severe trauma instead of specifically split personality
Companion PR to #6828

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Drug overdoses should not provide guaranteed, desirable effects, it's highly immersion breaking for someone to be demanding ketamine because they specifically want this effect when what they're actually requesting is to be overdosed on a dangerous drug. 

If roundstart split personality is something we want to enable for players, then it should be a trait they pick when making their character, not something they run up to chemistry for at the start of a round. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->


## Changelog
:cl:
tweak: Ketamine overdose is now a random severe brain trauma. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
