### PR TITLE
Adds the split personality trait (neutral)

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -104,7 +104,7 @@
 	value = 0
 	gain_text = null // Handled by trauma.
 	lose_text = null
-	medical_record_text = "Patient has an untreatable complete lobe separation, resulting in dramatic shifts in personality."
+	medical_record_text = "Patient has an untreatable complete lobe separation, resulting in potentially dramatic shifts in personality."
 
 /datum/quirk/split_personality/add()
 	var/datum/brain_trauma/severe/split_personality/T = new()

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -97,3 +97,16 @@
 
 /datum/quirk/monochromatic/remove()
 	quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
+
+/datum/quirk/split_personality
+	name = "Split Personality"
+	desc = "Sometimes you're not quite yourself"
+	value = 0
+	gain_text = null // Handled by trauma.
+	lose_text = null
+	medical_record_text = "Patient has an untreatable complete lobe separation, resulting in dramatic shifts in personality."
+
+/datum/quirk/split_personality/add()
+	var/datum/brain_trauma/severe/split_personality/T = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's pretty much all in the title. It adds a 0-cost neutral trait for players who wish to play with a split personality. 
Companion PR to #6827 because it is wildly immersion breaking for someone to demand a drug overdose at roundstart for the sake of enhancing their round. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a much better alternative to Ketamine granting the trauma. No more of players without previous drug addictions choosing to randomly overdose on ketamine at the start of a round when they want a buddy in their head. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Not tested yet. Will update as soon as I can figure out how to connect multiple instances to a vscode server. 

## Changelog
:cl:
add: Split personality may now be selected as a neutral trait. No ketamine addiction required. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
