### PR TITLE
Fixes runtime when headspidering, fixes another changeling exploit and removes mentions of hivemind chat

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -36,8 +36,6 @@
 #define MODE_ALIEN "alientalk"
 #define MODE_HOLOPAD "holopad"
 
-#define MODE_CHANGELING "changeling"
-
 #define MODE_VOCALCORDS "cords"
 #define MODE_KEY_VOCALCORDS "x"
 

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -37,8 +37,6 @@
 #define MODE_HOLOPAD "holopad"
 
 #define MODE_CHANGELING "changeling"
-#define MODE_KEY_CHANGELING "g"
-#define MODE_TOKEN_CHANGELING ":g"
 
 #define MODE_VOCALCORDS "cords"
 #define MODE_KEY_VOCALCORDS "x"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -364,7 +364,6 @@
 /datum/antagonist/changeling/greet()
 	if (you_are_greet)
 		to_chat(owner.current, "<span class='boldannounce'>You are [changelingID], a changeling! You have absorbed and taken the form of a human.</span>")
-	to_chat(owner.current, "<span class='boldannounce'>Use say \"[MODE_TOKEN_CHANGELING] message\" to communicate with your fellow changelings.</span>")
 	to_chat(owner.current, "<b>You must complete the following tasks:</b>")
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -26,7 +26,7 @@
 		user.fakedeath("changeling") //play dead
 		user.update_stat()
 		user.update_mobility()
-		addtimer(CALLBACK(src, .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
+		addtimer(CALLBACK(src, .proc/ready_to_regenerate, user.mind), LING_FAKEDEATH_TIME, TIMER_UNIQUE)
 	return TRUE
 
 /datum/action/changeling/fakedeath/proc/revive(mob/living/user)
@@ -36,11 +36,11 @@
 	user.revive(full_heal = TRUE)
 	user.regenerate_organs()
 
-/datum/action/changeling/fakedeath/proc/ready_to_regenerate(mob/user)
-	if(user?.mind && ishuman(user.mind.current))
-		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
+/datum/action/changeling/fakedeath/proc/ready_to_regenerate(datum/mind/mind)
+	if(mind && ishuman(mind.current))
+		var/datum/antagonist/changeling/C = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(C?.purchasedpowers)
-			to_chat(user, "<span class='notice'>We are ready to revive.</span>")
+			to_chat(mind.current, "<span class='notice'>We are ready to revive.</span>")
 			name = "Revive"
 			desc = "We arise once more."
 			button_icon_state = "revive"

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -37,7 +37,7 @@
 	user.regenerate_organs()
 
 /datum/action/changeling/fakedeath/proc/ready_to_regenerate(mob/user)
-	if(user?.mind && ishuman(usr))
+	if(user?.mind && ishuman(user.mind.current))
 		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(C?.purchasedpowers)
 			to_chat(user, "<span class='notice'>We are ready to revive.</span>")

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -37,7 +37,7 @@
 	user.regenerate_organs()
 
 /datum/action/changeling/fakedeath/proc/ready_to_regenerate(mob/user)
-	if(user?.mind)
+	if(user?.mind && ishuman(usr))
 		var/datum/antagonist/changeling/C = user.mind.has_antag_datum(/datum/antagonist/changeling)
 		if(C?.purchasedpowers)
 			to_chat(user, "<span class='notice'>We are ready to revive.</span>")

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -48,7 +48,6 @@
 	// Headcrab transformation is *very* unique; origin mob death happens *before* resulting mob's creation. Action removal should happen beforehand.
 	for(var/datum/action/cp in user.actions)
 		cp.Remove(user)
-	user.gib()
 	. = TRUE
 	var/mob/living/simple_animal/hostile/headcrab/crab = new(T)
 	for(var/obj/item/organ/I in organs)
@@ -57,4 +56,5 @@
 	if(crab.origin)
 		crab.origin.active = 1
 		crab.origin.transfer_to(crab)
+		user.gib()
 		to_chat(crab, "<span class='warning'>You burst out of the remains of your former body in a shower of gore!</span>")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -74,8 +74,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return new_msg
 
 /mob/living/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	var/static/list/crit_allowed_modes = list(WHISPER_MODE = TRUE, MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)
-	var/static/list/unconscious_allowed_modes = list(MODE_CHANGELING = TRUE, MODE_ALIEN = TRUE)
+	var/static/list/crit_allowed_modes = list(WHISPER_MODE = TRUE, MODE_ALIEN = TRUE)
+	var/static/list/unconscious_allowed_modes = list(MODE_ALIEN = TRUE)
 
 	var/ic_blocked = FALSE
 	if(client && !forced && CHAT_FILTER_CHECK(message))

--- a/html/antagtips/changeling.html
+++ b/html/antagtips/changeling.html
@@ -3,13 +3,12 @@
 	<h1>You are a Changeling!</h1>
 	<img src="changeling.gif"/>
 	<p>You are a Changeling, a shapeshifting alien assuming the form of a crewmember on Space Station 13.</p>
-	<p><img src="hivemind.png"/>Changelings can anonymously communicate with one another over a <b>hivemind channel</b> by using 'say :g' before their speech.</p>
 	<p>The goal of many changelings is to acquire 5-7 DNA strains. To do this, it must take ANY human, living or dead, and acquire their DNA.</p>
 	<p><img src="sting_extract.png"/>Use the <b>DNA Extraction Sting</b> and sting a target to stealthily steal their DNA. This will count towards your objective.</p>
 	<p><img src="absorb.png"/>Alternatively, you can <b>absorb</b> humans to drain their DNA. Have them in an aggressive grab and click the absorb button on the top left of the screen.</p>
 	<p><img src="emporium.gif"/>Use the <b>Cellular Emporium</b> to acquire special abilities which will help you achieve your objectives.</p>
 	<p>Absorbing a human will allow you to <b>readapt</b> and purchase different abilities.</p>
 	<p><img src="tentacle.png"/>Work together with the other changelings to complete your objectives, but be cautious. Other changelings could have an objective to absorb you.</p>
-	<p>For further information visit <b>https://wiki.beestation13.com/view/Changeling</b></p>	
+	<p>For further information visit <b>https://wiki.beestation13.com/view/Changeling</b></p>
 	</center>
 </html>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes headspidering causing a runtime because of the human mob being deleted before the transfer, you can no longer save up a revive for an instant aheal by headspidering in revival stasis, removes some mentions of now non existance changeling hivemind
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtime bad, exploit bad, mentions to removed stuff bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
I checked in game and the runtime no longer happens and you don't become able to revive as a headspider
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
del: Removes mentions of changeling hivemind chat
fix: Headspidering no longer causes a runtime
fix: You can no longer headspider in revival stasis for a free aheal later on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
