### PR TITLE
adds a check for moveloops to check if the loop it tries to add already exists

### DIFF
--- a/code/controllers/subsystem/movement/move_handler.dm
+++ b/code/controllers/subsystem/movement/move_handler.dm
@@ -77,7 +77,7 @@ SUBSYSTEM_DEF(move_manager)
 /datum/movement_packet/proc/add_loop(datum/controller/subsystem/movement/subsystem, datum/move_loop/loop_type, priority, flags, datum/extra_info)
 	var/datum/move_loop/existing_loop = existing_loops[subsystem]
 
-	if(existing_loop && existing_loop.compare_vars(arglist(args.Copy(2))))
+	if(existing_loop?.compare_vars(arglist(args.Copy(2))))
 		return //it already exists stop trying to make the same moveloop
 
 	if(existing_loop && existing_loop.priority > priority)

--- a/code/controllers/subsystem/movement/move_handler.dm
+++ b/code/controllers/subsystem/movement/move_handler.dm
@@ -76,10 +76,13 @@ SUBSYSTEM_DEF(move_manager)
 ///Adds a loop to our parent. Returns the created loop if a success, null otherwise
 /datum/movement_packet/proc/add_loop(datum/controller/subsystem/movement/subsystem, datum/move_loop/loop_type, priority, flags, datum/extra_info)
 	var/datum/move_loop/existing_loop = existing_loops[subsystem]
+
+	if(existing_loop && existing_loop.compare_vars(arglist(args.Copy(2))))
+		return //it already exists stop trying to make the same moveloop
+
 	if(existing_loop && existing_loop.priority > priority)
 		if(!(existing_loop.flags & MOVEMENT_LOOP_IGNORE_PRIORITY) && !(flags & MOVEMENT_LOOP_IGNORE_PRIORITY))
 			return //Give up
-
 	var/datum/move_loop/new_loop = new loop_type(src, subsystem, parent, priority, flags, extra_info) //Pass the mob to move and ourselves in via new
 	var/list/arguments = args.Copy(6) //Just send the args we've not already dealt with
 

--- a/code/controllers/subsystem/movement/move_handler.dm
+++ b/code/controllers/subsystem/movement/move_handler.dm
@@ -77,12 +77,13 @@ SUBSYSTEM_DEF(move_manager)
 /datum/movement_packet/proc/add_loop(datum/controller/subsystem/movement/subsystem, datum/move_loop/loop_type, priority, flags, datum/extra_info)
 	var/datum/move_loop/existing_loop = existing_loops[subsystem]
 
-	if(existing_loop?.compare_loops(arglist(args.Copy(2))))
-		return //it already exists stop trying to make the same moveloop
-
 	if(existing_loop && existing_loop.priority > priority)
 		if(!(existing_loop.flags & MOVEMENT_LOOP_IGNORE_PRIORITY) && !(flags & MOVEMENT_LOOP_IGNORE_PRIORITY))
 			return //Give up
+
+	if(existing_loop?.compare_loops(arglist(args.Copy(2))))
+		return //it already exists stop trying to make the same moveloop
+
 	var/datum/move_loop/new_loop = new loop_type(src, subsystem, parent, priority, flags, extra_info) //Pass the mob to move and ourselves in via new
 	var/list/arguments = args.Copy(6) //Just send the args we've not already dealt with
 

--- a/code/controllers/subsystem/movement/move_handler.dm
+++ b/code/controllers/subsystem/movement/move_handler.dm
@@ -77,7 +77,7 @@ SUBSYSTEM_DEF(move_manager)
 /datum/movement_packet/proc/add_loop(datum/controller/subsystem/movement/subsystem, datum/move_loop/loop_type, priority, flags, datum/extra_info)
 	var/datum/move_loop/existing_loop = existing_loops[subsystem]
 
-	if(existing_loop?.compare_vars(arglist(args.Copy(2))))
+	if(existing_loop?.compare_loops(arglist(args.Copy(2))))
 		return //it already exists stop trying to make the same moveloop
 
 	if(existing_loop && existing_loop.priority > priority)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -42,6 +42,13 @@
 	src.lifetime = timeout
 	return TRUE
 
+/datum/move_loop/proc/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY) //exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite
+	if(loop_type == type && priority == src.priority && flags == src.flags && delay == src.delay && timeout == lifetime)
+		return TRUE
+	else
+		return FALSE
+
+
 /datum/move_loop/proc/start_loop()
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_START)
@@ -133,6 +140,18 @@
 		return
 	direction = dir
 
+/datum/move_loop/move/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, dir)
+	. = ..()
+	if(!.)
+		return
+
+	if(direction == dir)
+		return TRUE
+	else
+		return FALSE
+
+
+
 /datum/move_loop/move/move()
 	var/atom/old_loc = moving.loc
 	moving.Move(get_step(moving, direction), direction)
@@ -207,6 +226,16 @@
 
 	if(!isturf(target))
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/handle_no_target) //Don't do this for turfs, because we don't care
+
+/datum/move_loop/has_target/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing)
+	. = ..()
+	if(!.)
+		return
+
+	if(chasing == target)
+		return TRUE
+	else
+		return FALSE
 
 /datum/move_loop/has_target/Destroy()
 	target = null
@@ -333,6 +362,16 @@
 	src.skip_first = skip_first
 	if(istype(id, /obj/item/card/id))
 		RegisterSignal(id, COMSIG_PARENT_QDELETING, .proc/handle_no_id) //I prefer erroring to harddels. If this breaks anything consider making id info into a datum or something
+
+/datum/move_loop/has_target/jps/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, repath_delay, max_path_length, minimum_distance, obj/item/card/id/id, simulated_only, turf/avoid, skip_first)
+	. = ..()
+	if(!.)
+		return
+
+	if(repath_delay == src.repath_delay && max_path_length == src.max_path_length && minimum_distance == src.minimum_distance && id == src.id && simulated_only == src.simulated_only && avoid == src.avoid)
+		return TRUE
+	else
+		return FALSE
 
 /datum/move_loop/has_target/jps/start_loop()
 	. = ..()
@@ -505,6 +544,16 @@
 		return
 	distance = dist
 
+/datum/move_loop/has_target/dist_bound/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, dist = 0)
+	. = ..()
+	if(!.)
+		return
+
+	if(distance == dist)
+		return TRUE
+	else
+		return FALSE
+
 ///Returns FALSE if the movement should pause, TRUE otherwise
 /datum/move_loop/has_target/dist_bound/proc/check_dist()
 	return FALSE
@@ -657,6 +706,16 @@
 			UnregisterSignal(moving, COMSIG_MOVABLE_MOVED)
 	return ..()
 
+/datum/move_loop/has_target/move_towards/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, home = FALSE)
+	. = ..()
+	if(!.)
+		return
+
+	if(home == src.home)
+		return TRUE
+	else
+		return FALSE
+
 /datum/move_loop/has_target/move_towards/move()
 	//Move our tickers forward a step, we're guaranteed at least one step forward because of how the code is written
 	if(x_rate) //Did you know that rounding by 0 throws a divide by 0 error?
@@ -796,6 +855,16 @@
 	if(!.)
 		return
 	potential_directions = directions
+
+/datum/move_loop/move_rand/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
+	. = ..()
+	if(!.)
+		return
+
+	if(potential_directions == directions) //i guess this could be usefull if actually it really has yet to move
+		return TRUE
+	else
+		return FALSE
 
 /datum/move_loop/move_rand/move()
 	var/list/potential_dirs = potential_directions.Copy()

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -823,7 +823,7 @@
 	potential_directions = directions
 
 /datum/move_loop/move_rand/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
-	if(..() && (length(potential_directions | directions) == length(directions))) //i guess this could be usefull if actually it really has yet to move
+	if(..() && (length(potential_directions | directions) == length(potential_directions))) //i guess this could be usefull if actually it really has yet to move
 		return TRUE
 
 /datum/move_loop/move_rand/move()

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -147,6 +147,7 @@
 		return TRUE
 	else
 		return FALSE
+
 /datum/move_loop/move/move()
 	var/atom/old_loc = moving.loc
 	moving.Move(get_step(moving, direction), direction)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -149,9 +149,6 @@
 		return TRUE
 	else
 		return FALSE
-
-
-
 /datum/move_loop/move/move()
 	var/atom/old_loc = moving.loc
 	moving.Move(get_step(moving, direction), direction)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -11,7 +11,7 @@
 	var/datum/extra_info
 	///The thing we're moving about
 	var/atom/movable/moving
-	///Defines how different move loops override each other. Lower numbers beat higher numbers
+	///Defines how different move loops override each other. Higher numbers beat lower numbers
 	var/priority = MOVEMENT_DEFAULT_PRIORITY
 	///Bitfield of different things that affect how a loop operates
 	var/flags

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -41,6 +41,7 @@
 	src.delay = max(delay, world.tick_lag) //Please...
 	src.lifetime = timeout
 	return TRUE
+
 ///proc that exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite the old one
 /datum/move_loop/proc/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -46,8 +46,6 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(loop_type == type && priority == src.priority && flags == src.flags && delay == src.delay && timeout == lifetime)
 		return TRUE
-	else
-		return FALSE
 
 /datum/move_loop/proc/start_loop()
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -823,11 +823,8 @@
 	potential_directions = directions
 
 /datum/move_loop/move_rand/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
-	if(..())
-		var/list/temp_dir = directions
-		temp_dir |= potential_directions
-		if(length(directions) == length(temp_dir)) //i guess this could be usefull if actually it really has yet to move
-			return TRUE
+	if(..() && (length(potential_directions | directions) == length(directions))) //i guess this could be usefull if actually it really has yet to move
+		return TRUE
 
 /datum/move_loop/move_rand/move()
 	var/list/potential_dirs = potential_directions.Copy()

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -47,8 +47,6 @@
 		return TRUE
 	else
 		return FALSE
-
-
 /datum/move_loop/proc/start_loop()
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_START)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -41,8 +41,8 @@
 	src.delay = max(delay, world.tick_lag) //Please...
 	src.lifetime = timeout
 	return TRUE
-
-/datum/move_loop/proc/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY) //exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite
+///proc that exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite the old one
+/datum/move_loop/proc/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY)
 	SHOULD_CALL_PARENT(TRUE)
 	if(loop_type == type && priority == src.priority && flags == src.flags && delay == src.delay && timeout == lifetime)
 		return TRUE
@@ -823,8 +823,11 @@
 	potential_directions = directions
 
 /datum/move_loop/move_rand/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
-	if(..() && potential_directions == directions) //i guess this could be usefull if actually it really has yet to move
-		return TRUE
+	if(..())
+		var/list/temp_dir = directions
+		temp_dir |= potential_directions
+		if(length(directions) == length(temp_dir)) //i guess this could be usefull if actually it really has yet to move
+			return TRUE
 
 /datum/move_loop/move_rand/move()
 	var/list/potential_dirs = potential_directions.Copy()

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -43,6 +43,7 @@
 	return TRUE
 
 /datum/move_loop/proc/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY) //exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite
+	SHOULD_CALL_PARENT(TRUE)
 	if(loop_type == type && priority == src.priority && flags == src.flags && delay == src.delay && timeout == lifetime)
 		return TRUE
 	else
@@ -140,8 +141,7 @@
 	direction = dir
 
 /datum/move_loop/move/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, dir)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 
 	if(direction == dir)
@@ -225,8 +225,7 @@
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/handle_no_target) //Don't do this for turfs, because we don't care
 
 /datum/move_loop/has_target/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 
 	if(chasing == target)
@@ -361,8 +360,7 @@
 		RegisterSignal(id, COMSIG_PARENT_QDELETING, .proc/handle_no_id) //I prefer erroring to harddels. If this breaks anything consider making id info into a datum or something
 
 /datum/move_loop/has_target/jps/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, repath_delay, max_path_length, minimum_distance, obj/item/card/id/id, simulated_only, turf/avoid, skip_first)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 
 	if(repath_delay == src.repath_delay && max_path_length == src.max_path_length && minimum_distance == src.minimum_distance && id == src.id && simulated_only == src.simulated_only && avoid == src.avoid)
@@ -542,8 +540,7 @@
 	distance = dist
 
 /datum/move_loop/has_target/dist_bound/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, dist = 0)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 
 	if(distance == dist)
@@ -704,8 +701,7 @@
 	return ..()
 
 /datum/move_loop/has_target/move_towards/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, home = FALSE)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 
 	if(home == src.home)
@@ -854,8 +850,7 @@
 	potential_directions = directions
 
 /datum/move_loop/move_rand/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
-	. = ..()
-	if(!.)
+	if(!..())
 		return
 
 	if(potential_directions == directions) //i guess this could be usefull if actually it really has yet to move

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -42,7 +42,7 @@
 	src.lifetime = timeout
 	return TRUE
 
-/datum/move_loop/proc/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY) //exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite
+/datum/move_loop/proc/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay = 1, timeout = INFINITY) //exists so we can check if this exact moveloop datum already exists (in terms of vars) and so we can stop it from needlessly create a new one to overwrite
 	SHOULD_CALL_PARENT(TRUE)
 	if(loop_type == type && priority == src.priority && flags == src.flags && delay == src.delay && timeout == lifetime)
 		return TRUE
@@ -140,14 +140,9 @@
 		return
 	direction = dir
 
-/datum/move_loop/move/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, dir)
-	if(!..())
-		return
-
-	if(direction == dir)
+/datum/move_loop/move/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, dir)
+	if(..() && direction == dir)
 		return TRUE
-	else
-		return FALSE
 
 /datum/move_loop/move/move()
 	var/atom/old_loc = moving.loc
@@ -224,14 +219,9 @@
 	if(!isturf(target))
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/handle_no_target) //Don't do this for turfs, because we don't care
 
-/datum/move_loop/has_target/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing)
-	if(!..())
-		return
-
-	if(chasing == target)
+/datum/move_loop/has_target/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing)
+	if(..() && chasing == target)
 		return TRUE
-	else
-		return FALSE
 
 /datum/move_loop/has_target/Destroy()
 	target = null
@@ -359,14 +349,9 @@
 	if(istype(id, /obj/item/card/id))
 		RegisterSignal(id, COMSIG_PARENT_QDELETING, .proc/handle_no_id) //I prefer erroring to harddels. If this breaks anything consider making id info into a datum or something
 
-/datum/move_loop/has_target/jps/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, repath_delay, max_path_length, minimum_distance, obj/item/card/id/id, simulated_only, turf/avoid, skip_first)
-	if(!..())
-		return
-
-	if(repath_delay == src.repath_delay && max_path_length == src.max_path_length && minimum_distance == src.minimum_distance && id == src.id && simulated_only == src.simulated_only && avoid == src.avoid)
+/datum/move_loop/has_target/jps/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, repath_delay, max_path_length, minimum_distance, obj/item/card/id/id, simulated_only, turf/avoid, skip_first)
+	if(..() && repath_delay == src.repath_delay && max_path_length == src.max_path_length && minimum_distance == src.minimum_distance && id == src.id && simulated_only == src.simulated_only && avoid == src.avoid)
 		return TRUE
-	else
-		return FALSE
 
 /datum/move_loop/has_target/jps/start_loop()
 	. = ..()
@@ -539,14 +524,9 @@
 		return
 	distance = dist
 
-/datum/move_loop/has_target/dist_bound/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, dist = 0)
-	if(!..())
-		return
-
-	if(distance == dist)
+/datum/move_loop/has_target/dist_bound/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, dist = 0)
+	if(..() && distance == dist)
 		return TRUE
-	else
-		return FALSE
 
 ///Returns FALSE if the movement should pause, TRUE otherwise
 /datum/move_loop/has_target/dist_bound/proc/check_dist()
@@ -700,14 +680,9 @@
 			UnregisterSignal(moving, COMSIG_MOVABLE_MOVED)
 	return ..()
 
-/datum/move_loop/has_target/move_towards/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, home = FALSE)
-	if(!..())
-		return
-
-	if(home == src.home)
+/datum/move_loop/has_target/move_towards/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, atom/chasing, home = FALSE)
+	if(..() && home == src.home)
 		return TRUE
-	else
-		return FALSE
 
 /datum/move_loop/has_target/move_towards/move()
 	//Move our tickers forward a step, we're guaranteed at least one step forward because of how the code is written
@@ -849,14 +824,9 @@
 		return
 	potential_directions = directions
 
-/datum/move_loop/move_rand/compare_vars(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
-	if(!..())
-		return
-
-	if(potential_directions == directions) //i guess this could be usefull if actually it really has yet to move
+/datum/move_loop/move_rand/compare_loops(datum/move_loop/loop_type, priority, flags, extra_info, delay, timeout, list/directions)
+	if(..() && potential_directions == directions) //i guess this could be usefull if actually it really has yet to move
 		return TRUE
-	else
-		return FALSE
 
 /datum/move_loop/move_rand/move()
 	var/list/potential_dirs = potential_directions.Copy()

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -47,6 +47,7 @@
 		return TRUE
 	else
 		return FALSE
+
 /datum/move_loop/proc/start_loop()
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_START)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -313,11 +313,6 @@
 	return 0
 
 /mob/living/simple_animal/hostile/proc/Goto(target, delay, minimum_distance)
-	var/datum/move_loop/has_target/dist_bound/move_to/movement_loop = move_packet?.existing_loops[SSmovement]
-
-	if(movement_loop && movement_loop.target == target && movement_loop.delay == delay && movement_loop.distance == minimum_distance) //this might be a bit much honestly but condsidering how much stuff calls this proc there could be a case where we really just have like a single argument different
-		return //lets not try to make a new moveloop every single time this proc gets called okay?
-
 	if(target == src.target)
 		approaching_target = TRUE
 	else

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -313,6 +313,11 @@
 	return 0
 
 /mob/living/simple_animal/hostile/proc/Goto(target, delay, minimum_distance)
+	var/datum/move_loop/has_target/dist_bound/move_to/movement_loop = move_packet?.existing_loops[SSmovement]
+
+	if(movement_loop && movement_loop.target == target && movement_loop.delay == delay && movement_loop.distance == minimum_distance) //this might be a bit much honestly but condsidering how much stuff calls this proc there could be a case where we really just have like a single argument different
+		return //lets not try to make a new moveloop every single time this proc gets called okay?
+
 	if(target == src.target)
 		approaching_target = TRUE
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This basically adds a proc that will check if the arguments forwarded to generate the new moveloop are identical with the ones on maybe an old loop before it allows it to overwrite it that way we won't endlessly make new loops and destroy old ones even trough there is no reason to.
Also fixes closes https://github.com/BeeStation/BeeStation-Hornet/issues/6844
turned out goliaths have a move delay of 4 Seconds enough time for the handle automatic movement proc to keep on overwriting the moveloop causing it to basically never allow the moveloop to fire
## Why It's Good For The Game
Bug fix good

## Changelog
:cl:
add: adds a check to ensure we won't keep on overwriting basically the same moveloop
fix: fixes mobs that would have an insane long move delay thus overwriting their moveloop before it could fire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
