### PR TITLE
makes dmi editor default viewer for dmi's

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
 		"source.fixAll.eslint": true
 	},
 	"workbench.editorAssociations": {
-		"*.dmi": "imagePreview.previewEditor"
+		"*.dmi": "dmiEditor.dmiEditor"
 	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,9 +12,6 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"workbench.editorAssociations": {
-		"*.dmi": "dmiEditor.dmiEditor"
-	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,
 	"gitlens.advanced.blame.customArguments": ["-w"],


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now that the new dmi extension for VSC exists lets make it the default editor/viewer for dmi's in vsc.
The extension already got included into the goon extension pack so it would be waste not to use it even trough it still seems to suffer from some issues ~~(at least i can't import new icon states yet)~~(apperantly the png you want to import has to perfectly match it width and high with the dmi files settings otherwise even if the dmi file' settings are bigger it will fail), still a big improvement than using the simple preview editor that does not give you any other relevant information about the dmi file.

## Why It's Good For The Game

Finally we can (somewhat) edit DMI's without DM

## Changelog
:cl:
config: Changes default editor settings for dmi files to the new dmi editor extension
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
