### PR TITLE
[PORT]Removes AOE hit detection from fireball

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -107,7 +107,7 @@
 	charge_max = 600
 	clothes_req = FALSE
 	range = 20
-	projectile_type = /obj/item/projectile/magic/aoe/fireball/firebreath
+	projectile_type = /obj/item/projectile/magic/fireball/firebreath
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
 	sound = 'sound/magic/demon_dies.ogg' //horrifying lizard noises
@@ -126,13 +126,13 @@
 			return FALSE
 
 /obj/effect/proc_holder/spell/aimed/firebreath/ready_projectile(obj/item/projectile/P, atom/target, mob/user, iteration)
-	if(!istype(P, /obj/item/projectile/magic/aoe/fireball))
+	if(!istype(P, /obj/item/projectile/magic/fireball))
 		return
-	var/obj/item/projectile/magic/aoe/fireball/F = P
+	var/obj/item/projectile/magic/fireball/F = P
 	F.exp_light = strength-1
 	F.exp_fire += strength
 
-/obj/item/projectile/magic/aoe/fireball/firebreath
+/obj/item/projectile/magic/fireball/firebreath
 	name = "fire breath"
 	exp_heavy = 0
 	exp_light = 0

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -39,7 +39,7 @@
 	random_color = FALSE
 	gold_core_spawnable = NO_SPAWN
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
+	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
 	discovery_points = 3000
 
@@ -62,12 +62,12 @@
 
 /mob/living/simple_animal/hostile/carp/ranged/xenobio
 	desc = "45% magic, 50% carp, 5% slime, 100% horrible."
-	allowed_projectile_types = list( /obj/item/projectile/magic/animate, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
+	allowed_projectile_types = list( /obj/item/projectile/magic/animate, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
 	gold_core_spawnable = HOSTILE_SPAWN
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos/xenobio
 	desc = "95% magic, 50% carp, 5% slime, 150% horrible."
-	allowed_projectile_types = list( /obj/item/projectile/magic/animate, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
+	allowed_projectile_types = list( /obj/item/projectile/magic/animate, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
 	gold_core_spawnable = HOSTILE_SPAWN

--- a/code/modules/projectiles/ammunition/special/magic.dm
+++ b/code/modules/projectiles/ammunition/special/magic.dm
@@ -31,7 +31,7 @@
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/fireball
-	projectile_type = /obj/item/projectile/magic/aoe/fireball
+	projectile_type = /obj/item/projectile/magic/fireball
 
 /obj/item/ammo_casing/magic/chaos
 	projectile_type = /obj/item/projectile/magic

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -46,7 +46,7 @@
 	recharge_rate = 2
 	no_den_usage = 1
 	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/aoe/fireball,
+	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
 	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage, /obj/item/projectile/magic/locker, /obj/item/projectile/magic/flying,
 	/obj/item/projectile/magic/bounty, /obj/item/projectile/magic/antimagic, /obj/item/projectile/magic/fetch, /obj/item/projectile/magic/sapping,
 	/obj/item/projectile/magic/necropotence, /obj/item/projectile/magic, /obj/item/projectile/temp/chill, /obj/item/projectile/magic/wipe)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -656,7 +656,7 @@
 	qdel(chain)
 	. = ..()
 
-/obj/item/projectile/magic/aoe/fireball
+/obj/item/projectile/magic/fireball
 	name = "bolt of fireball"
 	icon_state = "fireball"
 	damage = 10
@@ -671,14 +671,14 @@
 	var/magic = TRUE
 	var/holy = FALSE
 
-/obj/item/projectile/magic/aoe/fireball/New(loc, spell_level)
+/obj/item/projectile/magic/fireball/New(loc, spell_level)
 	. = ..()
 	exp_fire += spell_level
 	exp_flash += spell_level
 	exp_light += spell_level
 	exp_heavy = max(spell_level - 2, 0)
 
-/obj/item/projectile/magic/aoe/fireball/on_hit(target)
+/obj/item/projectile/magic/fireball/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target
@@ -689,7 +689,7 @@
 	var/turf/T = get_turf(target)
 	explosion(T, -1, exp_heavy, exp_light, exp_flash, 0, flame_range = exp_fire, magic = magic, holy = holy)
 
-/obj/item/projectile/magic/aoe/fireball/infernal
+/obj/item/projectile/magic/fireball/infernal
 	name = "infernal fireball"
 	exp_heavy = -1
 	exp_light = -1
@@ -698,7 +698,7 @@
 	magic = FALSE
 	holy = TRUE
 
-/obj/item/projectile/magic/aoe/fireball/infernal/on_hit(target)
+/obj/item/projectile/magic/fireball/infernal/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/living/M = target

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2346,9 +2346,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	desc = "You can feel heat rising from your stomach"
 	range = 20
 	charge_max = 300
-	projectile_type = /obj/item/projectile/magic/aoe/fireball/firebreath/weak
+	projectile_type = /obj/item/projectile/magic/fireball/firebreath/weak
 
-/obj/item/projectile/magic/aoe/fireball/firebreath/weak
+/obj/item/projectile/magic/fireball/firebreath/weak
 	exp_fire = 1
 
 /datum/reagent/consumable/ethanol/beesknees

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -361,7 +361,7 @@
 			if(MT)
 				visible_message("<span class='danger'>[src] dangerously overheats, launching a flaming fuel orb!</span>")
 				investigate_log("Experimentor has launched a <font color='red'>fireball</font> at [M]!", INVESTIGATE_EXPERIMENTOR)
-				var/obj/item/projectile/magic/aoe/fireball/FB = new /obj/item/projectile/magic/aoe/fireball(start)
+				var/obj/item/projectile/magic/fireball/FB = new /obj/item/projectile/magic/fireball(start)
 				FB.preparePixelProjectile(MT, start)
 				FB.fire()
 		else if(prob(EFFECT_PROB_LOW-badThingCoeff))

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -118,7 +118,7 @@
 	invocation_type = "shout"
 	range = 20
 	cooldown_min = 40 //10 deciseconds reduction per rank
-	projectile_type = /obj/item/projectile/magic/aoe/fireball
+	projectile_type = /obj/item/projectile/magic/fireball
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
 	sound = 'sound/magic/fireball.ogg'

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -84,7 +84,7 @@
 	invocation_type = "shout"
 	range = 2
 
-	projectile_type = /obj/item/projectile/magic/aoe/fireball/infernal
+	projectile_type = /obj/item/projectile/magic/fireball/infernal
 
 	action_background_icon_state = "bg_demon"
 


### PR DESCRIPTION
## About The Pull Request

_This is a port of https://github.com/tgstation/tgstation/pull/66828, done by [GoblinBackwards](https://github.com/GoblinBackwards)._

Since AoE detecting fireball might actually struck the wizard that cast them by accident (and also, makes them less obnoxious to fight against).

This will not alter the size of the fireball's explosion, but rather on how any fireball snap on a player walking next to it.

## Why It's Good For The Game

AoE that give a 3 tile wide hitbox in an universe where all the hallways are 3 tiles wide or less and self nuking bad, actually aiming your shot to send the fireball and not blowing up in the process good.

## Changelog
:cl:
balance: Fireball no longer has a 3 tile wide hitbox (courtesy of GoblinBackwards over in /tg/).
/:cl: