### PR TITLE
Explosive ducks now have a brief, dramatic delay before exploding

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -125,7 +125,7 @@
 	if(ismob(AM))
 		checksmartmine(AM)
 	else
-		triggered = 1	//ensures multiple explosions aren't queued if/while the mine is delayed
+		triggered = TRUE	//ensures multiple explosions aren't queued if/while the mine is delayed
 		INVOKE_ASYNC(src, .proc/triggermine, AM)
 
 /obj/effect/mine/proc/checksmartmine(mob/living/target)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -133,7 +133,7 @@
 		if(smartmine && target.has_mindshield_hud_icon())
 			return
 		else if(dramatic_sound)
-			triggered = 1
+			triggered = TRUE
 			playsound(loc, dramatic_sound, 100, 1)
 			target.Paralyze(30, TRUE, TRUE) //"Trip" the mine if you will. Ignores stun immunity.
 			addtimer(CALLBACK(src, .proc/triggermine, target), 10)

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -136,7 +136,7 @@
 	triggered = 1	//ensures multiple explosions aren't queued if/while the mine is delayed
 	if(dramatic_sound && victim)
 		playsound(loc, dramatic_sound, 100, 1)
-		victim.Paralyze(30) //"Trip" the mine if you will. 
+		victim.Paralyze(30, TRUE, TRUE) //"Trip" the mine if you will. Ignores stun immunity. 
 		sleep(10)
 	visible_message("<span class='danger'>[victim] sets off [icon2html(src, viewers(src))] [src]!</span>")
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -96,6 +96,8 @@
 	var/smartmine = 0
 	var/disarm_time = 200
 	var/disarm_product = /obj/item/deployablemine // ie what drops when the mine is disarmed
+	///if this has a value, the explosion of the mine will be delayed slightly for dramatic effect while the sound plays
+	var/dramatic_sound
 
 /obj/effect/mine/Initialize(mapload)
 	. = ..()
@@ -116,8 +118,6 @@
 	to_chat(victim, "<span class='danger'>*click*</span>")
 
 /obj/effect/mine/proc/on_entered(datum/source, atom/movable/AM)
-	SIGNAL_HANDLER
-
 	if(!isturf(loc) || AM.throwing || (AM.movement_type & (FLYING | FLOATING)) || !AM.has_gravity())
 		return
 	if(ismob(AM))
@@ -130,14 +130,18 @@
 		if(!target.has_mindshield_hud_icon())
 			triggermine(target)
 
-/obj/effect/mine/proc/triggermine(mob/victim)
+/obj/effect/mine/proc/triggermine(mob/living/victim)
 	if(triggered)
 		return
+	triggered = 1	//ensures multiple explosions aren't queued if/while the mine is delayed
+	if(dramatic_sound && victim)
+		playsound(loc, dramatic_sound, 100, 1)
+		victim.Paralyze(30) //"Trip" the mine if you will. 
+		sleep(10)
 	visible_message("<span class='danger'>[victim] sets off [icon2html(src, viewers(src))] [src]!</span>")
 	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 	s.set_up(3, 1, src)
 	s.start()
-	triggered = 1
 	mineEffect(victim)
 	SEND_SIGNAL(src, COMSIG_MINE_TRIGGERED, victim)
 	qdel(src)
@@ -159,7 +163,7 @@
 	desc = "Rubber ducky you're so fine, you make bathtime lots of fuuun. Rubber ducky I'm awfully fooooond of yooooouuuu~"
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "rubberducky"
-	var/sound = 'sound/items/bikehorn.ogg'
+	dramatic_sound = 'sound/items/bikehorn.ogg'
 	range_heavy = 2
 	range_light = 3
 	range_flash = 4
@@ -174,10 +178,6 @@
 	disarm_product = /obj/item/deployablemine/traitor/bigboom
 
 /obj/effect/mine/explosive/mineEffect(mob/victim)
-	explosion(loc, range_devastation, range_heavy, range_light, range_flash)
-
-/obj/effect/mine/explosive/traitor/mineEffect(mob/victim)
-	playsound(loc, sound, 100, 1)
 	explosion(loc, range_devastation, range_heavy, range_light, range_flash)
 
 /obj/effect/mine/stun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tripping a rubber ducky mine now paralyzes you while it plays its honk out before exploding. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The dramatic effect makes the mine more enjoyable for the victim, and when you're getting blown up this can do a lot to lessen the buzzkill. Currently it's pretty common for the sound not to even play completely for the victim due to the deafening effect of the explosion that happens at the same time. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

### This is both an example of my change working and also an example of the deafening effect preventing players from hearing the current sound correctly - this explosion DID make sound, just not sound that the lizard player would be able to hear. 
https://user-images.githubusercontent.com/9547572/168131287-cd0afdd9-7982-44b2-bd68-6c60f82fe811.mp4

I rearranged when the `triggered` variable is set to ensure that multiple people cannot activate the mine, duplicating its explosive effect or causing runtimes. 

## Changelog
:cl:
tweak: The exploding rubber ducky now has a dramatic delay before exploding so the victim can truly appreciate the humor of their situation. This delay does not allow the victim any opportunity to move away from the explosion.
fix: Mines now have to be smartmines to use smartmine logic. Explosive ducks (and other mines) are now 100% more dangerous for security personnel who were previously immune to funny. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
