### PR TITLE
Fix tablet battery ejection

### DIFF
--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -59,6 +59,8 @@
 			to_chat(user, "<span class='notice'>You detach \the [battery] from \the [src].</span>")
 		else
 			battery.forceMove(drop_location())
+
+		battery = null
 		return TRUE
 
 /obj/item/stock_parts/cell/computer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When ejecting batteries from computers (which is hard to do), the field wasn't nulled in the power controller, so the battery was still "in" the tablet. This led to weirdness like seemingly infinite batteries (not actually infinite - it was always the same one, it just kept teleporting to a new location every time you "removed" it). Also, you could put the battery in a charger and keep the tablet charged, since the battery was still "in" the tablet as well.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
Screwdriver the power controller out of a tablet, which dumps the battery on the floor. (This is the only way to remove the battery). Without the fix, you can't put the battery back in, because it still counts as "in". You also will be able to teleport the battery by putting the power controller in and screwdrivering it out again in a different spot.

All of that is fixed now.

## Changelog
:cl:
fix: batteries are removed properly when removing the power controller from tablets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
