### PR TITLE
Remove wallshove, RNG Disarm

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -114,12 +114,6 @@
 #define SHOVE_KNOCKDOWN_TABLE 30
 #define SHOVE_KNOCKDOWN_COLLATERAL 10
 #define SHOVE_CHAIN_PARALYZE 40
-//Shove slowdown
-#define SHOVE_GRIPFAILING_LENGTH 50
-//Shove disarming item list
-GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
-	/obj/item/gun)))
-
 
 // Combat object defines
 

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -110,14 +110,12 @@
 #define DEFAULT_MESSAGE_RANGE 7
 
 //Shove knockdown lengths (deciseconds)
-#define SHOVE_KNOCKDOWN_SOLID 30
 #define SHOVE_KNOCKDOWN_HUMAN 30
 #define SHOVE_KNOCKDOWN_TABLE 30
 #define SHOVE_KNOCKDOWN_COLLATERAL 10
 #define SHOVE_CHAIN_PARALYZE 40
 //Shove slowdown
-#define SHOVE_SLOWDOWN_LENGTH 30
-#define SHOVE_SLOWDOWN_STRENGTH 0.85 //multiplier
+#define SHOVE_GRIPFAILING_LENGTH 50
 //Shove disarming item list
 GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 	/obj/item/gun)))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1037,15 +1037,6 @@
 			if(C.blocks_shove_knockdown)
 				return TRUE
 	return FALSE
-
-/mob/living/carbon/human/proc/clear_shove()
-	switch(faltering_grip)
-		if(1 to 2)
-			faltering_grip--
-			return
-		if(3 to INFINITY) //failsafe since the value should be immediately reset to 0 upon reaching 3, and can never go below 0. 
-			message_admins("human variable faltering_strength has achieved an unintended value. Please report this to a coder with as much surrounding information as possible.")
-			faltering_grip = 0
 			
 /mob/living/carbon/human/updatehealth()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/mob/human.dmi'
 	icon_state = ""
 	appearance_flags = KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE
+	var/faltering_grip = 0
 
 /mob/living/carbon/human/Initialize(mapload)
 	add_verb(/mob/living/proc/mob_sleep)
@@ -1037,12 +1038,15 @@
 				return TRUE
 	return FALSE
 
-/mob/living/carbon/human/proc/clear_shove_slowdown()
-	remove_movespeed_modifier(MOVESPEED_ID_SHOVE)
-	var/active_item = get_active_held_item()
-	if(is_type_in_typecache(active_item, GLOB.shove_disarming_types))
-		visible_message("<span class='warning'>[src.name] regains their grip on \the [active_item]!</span>", "<span class='warning'>You regain your grip on \the [active_item].</span>", null, COMBAT_MESSAGE_RANGE)
-
+/mob/living/carbon/human/proc/clear_shove()
+	switch(faltering_grip)
+		if(1 to 2)
+			faltering_grip--
+			return
+		if(3 to INFINITY) //failsafe since the value should be immediately reset to 0 upon reaching 3, and can never go below 0. 
+			message_admins("human variable faltering_strength has achieved an unintended value. Please report this to a coder with as much surrounding information as possible.")
+			faltering_grip = 0
+			
 /mob/living/carbon/human/updatehealth()
 	. = ..()
 	dna?.species.spec_updatehealth(src)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1515,12 +1515,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					for(var/obj/O in target_shove_turf)
 						if(O.flags_1 & ON_BORDER_1 && O.dir == turn(shove_dir, 180) && O.density)
 							break
-			/*if((!target_table && !target_collateral_human && !target_disposal_bin && !target_pool) || directional_blocked)
-				target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
-				target.drop_all_held_items()
-				user.visible_message("<span class='danger'>[user.name] shoves [target.name], knocking [target.p_them()] down!</span>",
-					"<span class='danger'>You shove [target.name], knocking [target.p_them()] down!</span>", null, COMBAT_MESSAGE_RANGE)
-				log_combat(user, target, "shoved", "knocking them down")*/
 			if(target_table)
 				target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
 				target.drop_all_held_items()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1547,32 +1547,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		user.visible_message("<span class='danger'>[user.name] shoves [target.name]!</span>",
 			"<span class='danger'>You shove [target.name]!</span>", null, COMBAT_MESSAGE_RANGE)
 		var/target_held_item = target.get_active_held_item()
-		var/knocked_item = FALSE
-		if(!is_type_in_typecache(target_held_item, GLOB.shove_disarming_types))
-			target_held_item = null
 		if(target_held_item)
-			switch(target.faltering_grip)
-				if(0 to 1)
-					target.faltering_grip++
-					addtimer(CALLBACK(target, /mob/living/carbon/human/proc/clear_shove), SHOVE_GRIPFAILING_LENGTH)
-					target.visible_message("<span class='danger'>[target.name]'s grip on \the [target_held_item] loosens!</span>",
-										"<span class='danger'>Your grip on \the [target_held_item] loosens!</span>", null, COMBAT_MESSAGE_RANGE)
-				if(2)
-					target.faltering_grip = 0
-					target.dropItemToGround(target_held_item)
-					knocked_item = TRUE
-					target.visible_message("<span class='danger'>[target.name] drops \the [target_held_item]!!</span>",
-											"<span class='danger'>You drop \the [target_held_item]!!</span>", null, COMBAT_MESSAGE_RANGE)
-					var/append_message = ""
-					if(target_held_item)
-						if(knocked_item)
-							append_message = "causing them to drop [target_held_item]"
-						else
-							append_message = "loosening their grip on [target_held_item]"
-					log_combat(user, target, "shoved [append_message]")
-				else //failsafe in case an unintended value is somehow achieved. 
-					target.faltering_grip = 0
-					message_admins("human variable faltering_strength has achieved an unintended value. Please report this to a coder with as much surrounding information as possible.")
+			if(prob(20)) //Trying to disarm should be a last ditch effort in a no-win situation, not a guaranteed outcome.
+				target.dropItemToGround(target_held_item)
+				target.visible_message("<span class='danger'>[target.name] fumbles their grip and drops \the [target_held_item]!!</span>",
+										"<span class='danger'>You lose your grip and drop \the [target_held_item]!!</span>", null, COMBAT_MESSAGE_RANGE)
+				log_combat(user, target, "shoved, causing them to drop [target_held_item]")
+			else
+				log_combat(user, target, "shoved")
 
 /datum/species/proc/spec_hitby(atom/movable/AM, mob/living/carbon/human/H)
 	return

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1506,25 +1506,22 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			log_combat(user, target, "kicks", "onto their side (paralyzing)")
 
 		if(shove_blocked && !target.is_shove_knockdown_blocked() && !target.buckled)
-			var/directional_blocked = FALSE
 			if(shove_dir in GLOB.cardinals) //Directional checks to make sure that we're not shoving through a windoor or something like that
 				var/target_turf = get_turf(target)
 				for(var/obj/O in target_turf)
 					if(O.flags_1 & ON_BORDER_1 && O.dir == shove_dir && O.density)
-						directional_blocked = TRUE
 						break
 				if(target_turf != target_shove_turf) //Make sure that we don't run the exact same check twice on the same tile
 					for(var/obj/O in target_shove_turf)
 						if(O.flags_1 & ON_BORDER_1 && O.dir == turn(shove_dir, 180) && O.density)
-							directional_blocked = TRUE
 							break
-			if((!target_table && !target_collateral_human && !target_disposal_bin && !target_pool) || directional_blocked)
+			/*if((!target_table && !target_collateral_human && !target_disposal_bin && !target_pool) || directional_blocked)
 				target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
 				target.drop_all_held_items()
 				user.visible_message("<span class='danger'>[user.name] shoves [target.name], knocking [target.p_them()] down!</span>",
 					"<span class='danger'>You shove [target.name], knocking [target.p_them()] down!</span>", null, COMBAT_MESSAGE_RANGE)
-				log_combat(user, target, "shoved", "knocking them down")
-			else if(target_table)
+				log_combat(user, target, "shoved", "knocking them down")*/
+			if(target_table)
 				target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
 				target.drop_all_held_items()
 				user.visible_message("<span class='danger'>[user.name] shoves [target.name] onto \the [target_table]!</span>",
@@ -1538,13 +1535,13 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					"<span class='danger'>You shove [target.name] into [target_collateral_human.name]!</span>", null, COMBAT_MESSAGE_RANGE)
 				log_combat(user, target, "shoved", "into [target_collateral_human.name]")
 			else if(target_disposal_bin)
-				target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
+				target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
 				target.forceMove(target_disposal_bin)
 				user.visible_message("<span class='danger'>[user.name] shoves [target.name] into \the [target_disposal_bin]!</span>",
 					"<span class='danger'>You shove [target.name] into \the [target_disposal_bin]!</span>", null, COMBAT_MESSAGE_RANGE)
 				log_combat(user, target, "shoved", "into [target_disposal_bin] (disposal bin)")
 			else if(target_pool)
-				target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
+				target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
 				target.forceMove(target_pool)
 				user.visible_message("<span class='danger'>[user.name] shoves [target.name] into \the [target_pool]!</span>",
 					"<span class='danger'>You shove [target.name] into \the [target_pool]!</span>", null, COMBAT_MESSAGE_RANGE)
@@ -1552,28 +1549,33 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		else
 			user.visible_message("<span class='danger'>[user.name] shoves [target.name]!</span>",
 				"<span class='danger'>You shove [target.name]!</span>", null, COMBAT_MESSAGE_RANGE)
-			/*var/target_held_item = target.get_active_held_item()
+			var/target_held_item = target.get_active_held_item()
 			var/knocked_item = FALSE
 			if(!is_type_in_typecache(target_held_item, GLOB.shove_disarming_types))
 				target_held_item = null
-			if(!target.has_movespeed_modifier(MOVESPEED_ID_SHOVE))
-				target.add_movespeed_modifier(MOVESPEED_ID_SHOVE, multiplicative_slowdown = SHOVE_SLOWDOWN_STRENGTH)
-				if(target_held_item)
-					target.visible_message("<span class='danger'>[target.name]'s grip on \the [target_held_item] loosens!</span>",
-						"<span class='danger'>Your grip on \the [target_held_item] loosens!</span>", null, COMBAT_MESSAGE_RANGE)
-				addtimer(CALLBACK(target, /mob/living/carbon/human/proc/clear_shove_slowdown), SHOVE_SLOWDOWN_LENGTH)
-			else if(target_held_item)
-				target.dropItemToGround(target_held_item)
-				knocked_item = TRUE
-				target.visible_message("<span class='danger'>[target.name] drops \the [target_held_item]!!</span>",
-					"<span class='danger'>You drop \the [target_held_item]!!</span>", null, COMBAT_MESSAGE_RANGE)
-			var/append_message = ""
 			if(target_held_item)
-				if(knocked_item)
-					append_message = "causing them to drop [target_held_item]"
-				else
-					append_message = "loosening their grip on [target_held_item]"*/
-			log_combat(user, target, "shoved")
+				switch(target.faltering_grip)
+					if(0 to 1)
+						target.faltering_grip++
+						addtimer(CALLBACK(target, /mob/living/carbon/human/proc/clear_shove), SHOVE_GRIPFAILING_LENGTH)
+						target.visible_message("<span class='danger'>[target.name]'s grip on \the [target_held_item] loosens!</span>",
+											"<span class='danger'>Your grip on \the [target_held_item] loosens!</span>", null, COMBAT_MESSAGE_RANGE)
+					if(2)
+						target.faltering_grip = 0
+						target.dropItemToGround(target_held_item)
+						knocked_item = TRUE
+						target.visible_message("<span class='danger'>[target.name] drops \the [target_held_item]!!</span>",
+												"<span class='danger'>You drop \the [target_held_item]!!</span>", null, COMBAT_MESSAGE_RANGE)
+						var/append_message = ""
+						if(target_held_item)
+							if(knocked_item)
+								append_message = "causing them to drop [target_held_item]"
+							else
+								append_message = "loosening their grip on [target_held_item]"
+						log_combat(user, target, "shoved [append_message]")
+					else //failsafe in case an unintended value is somehow achieved. 
+						target.faltering_grip = 0
+						message_admins("human variable faltering_strength has achieved an unintended value. Please report this to a coder with as much surrounding information as possible.")
 
 /datum/species/proc/spec_hitby(atom/movable/AM, mob/living/carbon/human/H)
 	return

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1548,7 +1548,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			"<span class='danger'>You shove [target.name]!</span>", null, COMBAT_MESSAGE_RANGE)
 		var/target_held_item = target.get_active_held_item()
 		if(target_held_item)
-			if(prob(20)) //Trying to disarm should be a last ditch effort in a no-win situation, not a guaranteed outcome.
+			if(prob(16)) //Trying to disarm should be a last ditch effort in a no-win situation, not a guaranteed outcome.
 				target.dropItemToGround(target_held_item)
 				target.visible_message("<span class='danger'>[target.name] fumbles their grip and drops \the [target_held_item]!!</span>",
 										"<span class='danger'>You lose your grip and drop \the [target_held_item]!!</span>", null, COMBAT_MESSAGE_RANGE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes wallshoving as a cheap and easy way to immediately flip the tide of battle. 
Re-introduces disarm intent as a way to cause someone to drop items without factoring direct positioning into the mix, but in a way that does not guarantee success so that armed combatants are much more likely to retain a combat advantage over unarmed ones. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes those who have dangerous equipment more of a threat and discourages unarmed validhunters from challenging dangerous people. It mechanically encourages unarmed players to act believably and in accordance with the server's rules. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

I have not had time to meaningfully test yet. I covered the basic initial testing but I have run out of time for the moment and am more interested in getting immediate feedback on what will be a very controversial change. 

## Changelog
:cl:
add: Disarm intent can now force someone to drop their held item on a 16% chance. Attempting unarmed combat should be a last resort. 
del: Shoving someone into a wall will no longer produce an immediate knockdown and item drop. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->