### PR TITLE
Inducers are now clearly different and printable in their respective lathes

### DIFF
--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -1,6 +1,6 @@
 /obj/item/inducer
 	name = "heavy-duty inducer"
-	desc = "A tool for inductively charging internal power cells."
+	desc = "A tool for inductively charging internal power cells. It is ruggedized for frequent use."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "inducer-engi"
 	item_state = "inducer-engi"
@@ -169,6 +169,16 @@
 			add_overlay("inducer-nobat")
 		else
 			add_overlay("inducer-bat")
+
+///Starts empty for engineering protolathe
+/obj/item/inducer/eng
+	name = "heavy-duty inducer"
+	cell_type = null
+	opened = TRUE
+
+/obj/item/inducer/eng/Initialize(mapload)
+	. = ..()
+	update_icon()
 
 /obj/item/inducer/sci
 	name = "inducer"

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -1,5 +1,5 @@
 /obj/item/inducer
-	name = "inducer"
+	name = "heavy-duty inducer"
 	desc = "A tool for inductively charging internal power cells."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "inducer-engi"
@@ -171,6 +171,7 @@
 			add_overlay("inducer-bat")
 
 /obj/item/inducer/sci
+	name = "inducer"
 	icon_state = "inducer-sci"
 	item_state = "inducer-sci"
 	desc = "A tool for inductively charging internal power cells. This one has a science color scheme, and is less potent than its engineering counterpart."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -898,10 +898,10 @@
 	charge = 5000
 
 /datum/supply_pack/engineering/inducers
-	name = "NT-75 Electromagnetic Power Inducers Crate"
-	desc = "No rechargers? No problem, with the NT-75 EPI, you can recharge any standard cell-based equipment anytime, anywhere. Contains two Inducers."
-	cost = 1500
-	contains = list(/obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}, /obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
+	name = "NT-100 Heavy-Duty Inducers Crate"
+	desc = "No rechargers? No problem, with the NT-100 EPI, you can recharge any standard cell-based equipment anytime, anywhere, twice faster than consumer alternatives! Contains two Engineering inducers."
+	cost = 2000
+	contains = list(/obj/item/inducer {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}, /obj/item/inducer {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
 	crate_name = "inducer crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
@@ -1737,6 +1737,13 @@
 					/obj/item/stock_parts/manipulator)
 	crate_name = "recharging station crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+
+/datum/supply_pack/science/inducers
+	name = "NT-50 Inducers Crate"
+	desc = "No rechargers? No problem, with the NT-50 EPI, you can recharge any standard cell-based equipment anytime, anywhere! Contains two Science inducers."
+	cost = 1000
+	contains = list(/obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}, /obj/item/inducer/sci {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
+	crate_name = "inducer crate"
 
 /datum/supply_pack/science/rped
 	name = "RPED crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -901,7 +901,7 @@
 	name = "NT-100 Heavy-Duty Inducers Crate"
 	desc = "No rechargers? No problem, with the NT-100 EPI, you can recharge any standard cell-based equipment anytime, anywhere, twice faster than consumer alternatives! Contains two Engineering inducers."
 	cost = 2000
-	contains = list(/obj/item/inducer {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}, /obj/item/inducer {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
+	contains = list(/obj/item/inducer {cell_type = /obj/item/stock_parts/cell/high; opened = 0}, /obj/item/inducer {cell_type = /obj/item/stock_parts/cell/inducer_supply; opened = 0}) //FALSE doesn't work in modified type paths apparently.
 	crate_name = "inducer crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -68,14 +68,24 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/inducer
-	name = "Inducer"
-	desc = "The NT-75 Electromagnetic Power Inducer can wirelessly induce electric charge in an object, allowing you to recharge power cells without having to remove them."
+	name = "NT-100 Inducer"
+	desc = "Inducers can wirelessly induce electric charge in an object, allowing you to recharge power cells without having to remove them. This heavy-duty model is more potent."
 	id = "inducer"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 6000, /datum/material/glass = 2000, /datum/material/copper = 200)
+	build_path = /obj/item/inducer/
+	category = list("Power Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
+/datum/design/inducer/sci
+	name = "NT-50 Inducer"
+	desc = "Inducers can wirelessly induce electric charge in an object, allowing you to recharge power cells without having to remove them. This civilian model is less potent."
+	id = "inducersci"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 3000, /datum/material/glass = 1000, /datum/material/copper = 100)
 	build_path = /obj/item/inducer/sci
 	category = list("Power Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/pacman
 	name = "Machine Design (PACMAN-type Generator Board)"

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -68,17 +68,17 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE | DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/inducer
-	name = "NT-100 Inducer"
+	name = "Heavy-Duty Inducer"
 	desc = "Inducers can wirelessly induce electric charge in an object, allowing you to recharge power cells without having to remove them. This heavy-duty model is more potent."
 	id = "inducer"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 6000, /datum/material/glass = 2000, /datum/material/copper = 200)
-	build_path = /obj/item/inducer/
+	build_path = /obj/item/inducer/eng
 	category = list("Power Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/inducer/sci
-	name = "NT-50 Inducer"
+	name = "Inducer"
 	desc = "Inducers can wirelessly induce electric charge in an object, allowing you to recharge power cells without having to remove them. This civilian model is less potent."
 	id = "inducersci"
 	build_type = PROTOLATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -510,7 +510,7 @@
 	display_name = "Electromagnetic Theory"
 	description = "Study into usage of frequencies in the electromagnetic spectrum."
 	prereq_ids = list("base")
-	design_ids = list("holosign", "holosignsec", "holosignengi", "holosignatmos", "inducer", "tray_goggles", "holopad")
+	design_ids = list("holosign", "holosignsec", "holosignengi", "holosignatmos", "inducer", "inducersci", "tray_goggles", "holopad")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-names inducers, adds them to their respective lathes and gives them new crates in cargo

## Why It's Good For The Game

I doubt more than a handful of people know the difference between engineering and science inducers. Engineering ones are 2x powerful and almost never leave their closet. This is also a problem as the electrical supplies locker is the only place you can find them, the lathe prints out science ones.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
https://imgur.com/a/GfjSZ7E

## Changelog
:cl:
tweak: Inducers are now called "NT-50" and "NT-100" for Science and Engineering respectively. Referred to as "inducer" and "heavy-duty inducer".
tweak: Renamed "inducer" to "heavy-duty inducer".
add: Added empty variant of engineering inducers for the protolathes.
add: NT-100 Inducers can now be printed at engineering protolathes.
balance: NT-100 Inducers cost 2x the materials compared to NT-50.
add: Added new Science and Engineering Inducers crates at cargo.
balance: Engineering Inducers come with high powered cells.
balance: Science inducers crate now costs 1000 credits. Engi inducers crate costs 2000 to reflect twice the potential.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
