### PR TITLE
Tweaks xeno chestbursting

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -63,7 +63,7 @@
 	if(!next_stage_time)
 		next_stage_time = world.time + 1 MINUTES
 		return
-	if(next_stage_time <= world.time)
+	if(next_stage_time <= world.time && stage < 5)
 		next_stage_time = world.time + rand(1 MINUTES, 1.5 MINUTES) // Somewhere from 5-7 minutes to fully grow
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
 	var/stage = 0
+	var/next_stage_time = 0
 	var/bursting = FALSE
 
 /obj/item/organ/body_egg/alien_embryo/on_find(mob/living/finder)
@@ -50,24 +51,33 @@
 			to_chat(owner, "<span class='danger'>You feel something tearing its way out of your stomach.</span>")
 			owner.adjustToxLoss(10)
 
+/obj/item/organ/body_egg/alien_embryo/on_death()
+	. = ..()
+	if(!owner && next_stage_time) // No growing outside the body
+		next_stage_time = 0
+
 /obj/item/organ/body_egg/alien_embryo/egg_process()
 	var/mob/living/L = owner
 	if(L.IsInStasis())
 		return
-	if(stage < 5 && prob(3))
+	if(!next_stage_time)
+		next_stage_time = world.time + 1 MINUTES
+		return
+	if(next_stage_time <= world.time)
+		next_stage_time = world.time + rand(1 MINUTES, 1.5 MINUTES) // Somewhere from 4-7 minutes to fully grow
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)
 
 	if(stage == 5 && prob(50))
 		for(var/datum/surgery/S in owner.surgeries)
 			if(S.location == BODY_ZONE_CHEST && istype(S.get_surgery_step(), /datum/surgery_step/manipulate_organs))
-				AttemptGrow(0)
+				AttemptGrow(FALSE)
 				return
 		AttemptGrow()
 
 
 
-/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success=TRUE)
+/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(kill_on_success = TRUE)
 	if(!owner || bursting)
 		return
 
@@ -106,13 +116,17 @@
 		new_xeno.notransform = 0
 		new_xeno.invisibility = 0
 
-	if(gib_on_success)
+	var/mob/living/carbon/host = owner
+	if(kill_on_success)
 		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner] in a shower of gore!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
-		owner.gib(TRUE)
+		var/obj/item/bodypart/BP = owner.get_bodypart(BODY_ZONE_CHEST)
+		if(BP)
+			BP.receive_damage(brute = 200) // Kill them dead
+			BP.dismember()
 	else
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)
-		owner.cut_overlay(overlay)
+	host.cut_overlay(overlay)
 	qdel(src)
 
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
 	var/stage = 0
-	var/next_stage_time = 0
+	COOLDOWN_DECLARE(next_stage_time)
 	var/bursting = FALSE
 
 /obj/item/organ/body_egg/alien_embryo/on_find(mob/living/finder)
@@ -54,17 +54,17 @@
 /obj/item/organ/body_egg/alien_embryo/on_death()
 	. = ..()
 	if(!owner && next_stage_time) // No growing outside the body
-		next_stage_time = 0
+		COOLDOWN_RESET(src, next_stage_time)
 
 /obj/item/organ/body_egg/alien_embryo/egg_process()
 	var/mob/living/L = owner
 	if(L.IsInStasis())
 		return
 	if(!next_stage_time)
-		next_stage_time = world.time + 1 MINUTES
+		COOLDOWN_START(src, next_stage_time, 1 MINUTES)
 		return
-	if(next_stage_time <= world.time && stage < 5)
-		next_stage_time = world.time + rand(1 MINUTES, 1.5 MINUTES) // Somewhere from 5-7 minutes to fully grow
+	if(COOLDOWN_FINISHED(src, next_stage_time) && stage < 5)
+		COOLDOWN_START(src, next_stage_time, rand(1 MINUTES, 1.5 MINUTES)) // Somewhere from 5-7 minutes to fully grow
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -64,7 +64,7 @@
 		next_stage_time = world.time + 1 MINUTES
 		return
 	if(next_stage_time <= world.time)
-		next_stage_time = world.time + rand(1 MINUTES, 1.5 MINUTES) // Somewhere from 4-7 minutes to fully grow
+		next_stage_time = world.time + rand(1 MINUTES, 1.5 MINUTES) // Somewhere from 5-7 minutes to fully grow
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)
 
@@ -123,6 +123,8 @@
 		if(BP)
 			BP.receive_damage(brute = 200) // Kill them dead
 			BP.dismember()
+		else
+			owner.apply_damage(200)
 	else
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -53,8 +53,9 @@
 
 /obj/item/organ/body_egg/alien_embryo/on_death()
 	. = ..()
-	if(!owner && next_stage_time) // No growing outside the body
-		COOLDOWN_RESET(src, next_stage_time)
+	if(!owner) // If we're out of the body, kill us and stop processing
+		applyOrganDamage(maxHealth)
+		STOP_PROCESSING(SSobj, src)
 
 /obj/item/organ/body_egg/alien_embryo/egg_process()
 	var/mob/living/L = owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Someone suggested this to me at some point a while ago, but I never got around to coding it in (so sorry to whoever that was).
This PR makes it so that chestbursters won't gib their hosts. Instead, it'll just kill them and make all the organs in their chest spill out.
I also tweaked the logic on alien embryo growths to be a bit more consistent. Now, instead of checking prob(3) every time the egg processes, it just sets a timer from 1-1.5 minutes for each stage and progresses when that timer's up. If the embryo's removed, the stage timer resets. 
There's probably a better way to manage the stage times, but I'm not entirely sure if there's something else I should use. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Because full gibbing + brain deletion from a worm coming out of you never really made sense to me. That, and getting fully round removed kinda sucks.

The change for growth should also hopefully make embryo growth more consistent. 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
It compiles, and there's no runtimes or incredibly broken things during embryo processing/chestbursting.

## Changelog
:cl:
tweak: Xeno chestbursters no longer gib their hosts.
tweak: Tweaks alien embryo growth logic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
