### PR TITLE
Gave positronic brains non-crew harm

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -21,7 +21,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	var/welcome_message = "<span class='warning'>ALL PAST LIVES ARE FORGOTTEN.</span>\n\
 	<b>You are a positronic brain, brought into existence aboard Space Station 13.\n\
 	As a synthetic intelligence, you answer to all crewmembers and the AI.\n\
-	Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>"
+	Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm to crewmembers and the AI.</b>"
 	var/new_mob_message = "<span class='notice'>The positronic brain chimes quietly.</span>"
 	var/dead_message = "<span class='deadsay'>It appears to be completely inactive. The reset light is blinking.</span>"
 	var/recharge_message = "<span class='warning'>The positronic brain isn't ready to activate again yet! Give it some time to recharge.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Positronic brains are given a prompt upon spawning in as one from a ghost role. In this original prompt, it is stated that "Above all else, do no harm". This infers that a positronic brain, even when placed inside of a mech, is unable to commit harm of any kind to anything.

This PR changes that to "Above all else, do no harm to crewmembers and the AI." Effectively, it allows positronic brains to harm anything that isn't a crewmember or the AI.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allowing positronic players to do harm to non-crewmembers would create a meaningful benefit for using mech suits for positronic brains. As is, there's very little benefit for posistronic brain mechs as they aren't allowed by the current prompt to fight. 

With this change, there may be incentive for players to insert positronic brains into mechs for a wider variety of reasons, such as defending the station. Positronic brains would still be unable to harm crewmembers and the AI with this prompt change, but they would finally be able to fight enemies of the station to aide and protect their fellow crewmembers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
tweak: Changed the positronic brain prompt for players spawning in to allow harm to anything that isn't a crewmember or the AI instead of disallowing harm altogether.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
