### PR TITLE
Fixes shuttle parallax

### DIFF
--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -167,7 +167,8 @@
 
 		L.transform = newtransform
 
-		animate(L, transform = matrix(), time = T, loop = -1, flags = ANIMATION_END_NOW)
+		animate(L, transform = matrix(), time = T, loop = -1)
+		animate(transform = newtransform, time = 0, loop = -1)
 
 /datum/hud/proc/update_parallax()
 	var/client/C = mymob.client


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

#closes #6853

## About The Pull Request

Fixes the shuttle parallax effect.

I'm not 100% sure as to why it wasn't working, however my theory was that ANIMATION_END_NOW caused the animation to stop itself when it looped or something.
For some reason at the end of the animation, transform wasn't being reset back to its original value, so I added another step to the animation with a time of 0 that sets the transform back to the original position.

## Why It's Good For The Game

The parallax shuttle effect now works again.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/168467980-16113a5f-2864-4291-a834-a24c32e69c7d.png)

(Its moving and has been for a few minutes)

![image](https://user-images.githubusercontent.com/26465327/168467988-6376dfa6-54a7-4a06-afa0-6b967667694c.png)

Back on the station and its not moving anymore

## Changelog
:cl:
fix: Fixes parallax move direction not working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
