### PR TITLE
Fingerguns can't trigger reactive armor

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -69,6 +69,7 @@
 		var/obj/item/projectile/P = hitby
 		if(P.martial_arts_no_deflect)
 			return FALSE
+	return TRUE
 
 //When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive/teleport

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -62,7 +62,7 @@
 	reactivearmor_cooldown = world.time + 200
 
 ///checks whether the armor should react to being hit. 
-/obj/item/clothing/suit/armor/reactive/check_response()
+/obj/item/clothing/suit/armor/reactive/check_response(atom/movable/hitby)
 	if(!active)
 		return FALSE
 	if(isprojectile(hitby))
@@ -79,7 +79,7 @@
 	reactivearmor_cooldown_duration = 100
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response())
+	if(!check_response(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
@@ -115,7 +115,7 @@
 	desc = "An experimental suit of armor with a reactive sensor array rigged to a flame emitter. For the stylish pyromaniac."
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response())
+	if(!check_response(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -138,7 +138,7 @@
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response())
+	if(!check_response(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -175,7 +175,7 @@
 		user.flags_1 |= TESLA_IGNORE_1
 
 /obj/item/clothing/suit/armor/reactive/tesla/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response())
+	if(!check_response(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -197,7 +197,7 @@
 	var/repulse_force = MOVE_FORCE_EXTREMELY_STRONG
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response())
+	if(!check_response(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -223,7 +223,7 @@
 	var/tele_range = 10
 
 /obj/item/clothing/suit/armor/reactive/table/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response())
+	if(!check_response(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -70,8 +70,12 @@
 	reactivearmor_cooldown_duration = 100
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
-		return 0
+	if(!active)
+		return FALSE
+	if(isprojectile(hitby))
+		var/obj/item/projectile/P = hitby
+		if(P.martial_arts_no_deflect)
+			return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
 		if(world.time < reactivearmor_cooldown)
@@ -106,8 +110,12 @@
 	desc = "An experimental suit of armor with a reactive sensor array rigged to a flame emitter. For the stylish pyromaniac."
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
-		return 0
+	if(!active)
+		return FALSE
+	if(isprojectile(hitby))
+		var/obj/item/projectile/P = hitby
+		if(P.martial_arts_no_deflect)
+			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			owner.visible_message("<span class='danger'>The reactive incendiary armor on [owner] activates, but fails to send out flames as it is still recharging its flame jets!</span>")
@@ -129,8 +137,12 @@
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
+	if(!active)
 		return FALSE
+	if(isprojectile(hitby))
+		var/obj/item/projectile/P = hitby
+		if(P.martial_arts_no_deflect)
+			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			owner.visible_message("<span class='danger'>The reactive stealth system on [owner] activates, but is still recharging its holographic emitters!</span>")
@@ -168,6 +180,10 @@
 /obj/item/clothing/suit/armor/reactive/tesla/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!active)
 		return FALSE
+	if(isprojectile(hitby))
+		var/obj/item/projectile/P = hitby
+		if(P.martial_arts_no_deflect)
+			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
@@ -188,8 +204,12 @@
 	var/repulse_force = MOVE_FORCE_EXTREMELY_STRONG
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
-		return 0
+	if(!active)
+		return FALSE
+	if(isprojectile(hitby))
+		var/obj/item/projectile/P = hitby
+		if(P.martial_arts_no_deflect)
+			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			owner.visible_message("<span class='danger'>The repulse generator is still recharging!</span>")
@@ -214,8 +234,12 @@
 	var/tele_range = 10
 
 /obj/item/clothing/suit/armor/reactive/table/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
+	if(!active)
 		return FALSE
+	if(isprojectile(hitby))
+		var/obj/item/projectile/P = hitby
+		if(P.martial_arts_no_deflect)
+			return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
 		if(world.time < reactivearmor_cooldown)

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -61,6 +61,15 @@
 	item_state = "reactiveoff"
 	reactivearmor_cooldown = world.time + 200
 
+///checks whether the armor should react to being hit. 
+/obj/item/clothing/suit/armor/reactive/check_response()
+	if(!active)
+		return FALSE
+	if(isprojectile(hitby))
+		var/obj/item/projectile/P = hitby
+		if(P.martial_arts_no_deflect)
+		return FALSE
+
 //When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive/teleport
 	name = "reactive teleport armor"
@@ -70,12 +79,8 @@
 	reactivearmor_cooldown_duration = 100
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!check_response())
 		return FALSE
-	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
-		if(P.martial_arts_no_deflect)
-			return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
 		if(world.time < reactivearmor_cooldown)
@@ -110,12 +115,8 @@
 	desc = "An experimental suit of armor with a reactive sensor array rigged to a flame emitter. For the stylish pyromaniac."
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!check_response())
 		return FALSE
-	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
-		if(P.martial_arts_no_deflect)
-			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			owner.visible_message("<span class='danger'>The reactive incendiary armor on [owner] activates, but fails to send out flames as it is still recharging its flame jets!</span>")
@@ -137,12 +138,8 @@
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!check_response())
 		return FALSE
-	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
-		if(P.martial_arts_no_deflect)
-			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			owner.visible_message("<span class='danger'>The reactive stealth system on [owner] activates, but is still recharging its holographic emitters!</span>")
@@ -178,12 +175,8 @@
 		user.flags_1 |= TESLA_IGNORE_1
 
 /obj/item/clothing/suit/armor/reactive/tesla/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!check_response())
 		return FALSE
-	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
-		if(P.martial_arts_no_deflect)
-			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
@@ -204,12 +197,8 @@
 	var/repulse_force = MOVE_FORCE_EXTREMELY_STRONG
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!check_response())
 		return FALSE
-	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
-		if(P.martial_arts_no_deflect)
-			return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
 			owner.visible_message("<span class='danger'>The repulse generator is still recharging!</span>")
@@ -234,12 +223,8 @@
 	var/tele_range = 10
 
 /obj/item/clothing/suit/armor/reactive/table/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!check_response())
 		return FALSE
-	if(isprojectile(hitby))
-		var/obj/item/projectile/P = hitby
-		if(P.martial_arts_no_deflect)
-			return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
 		if(world.time < reactivearmor_cooldown)

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -62,7 +62,7 @@
 	reactivearmor_cooldown = world.time + 200
 
 ///checks whether the armor should react to being hit. 
-/obj/item/clothing/suit/armor/reactive/check_response(atom/movable/hitby)
+/obj/item/clothing/suit/armor/reactive/proc/does_react(atom/movable/hitby)
 	if(!active)
 		return FALSE
 	if(isprojectile(hitby))
@@ -79,7 +79,7 @@
 	reactivearmor_cooldown_duration = 100
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response(hitby))
+	if(!does_react(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
@@ -115,7 +115,7 @@
 	desc = "An experimental suit of armor with a reactive sensor array rigged to a flame emitter. For the stylish pyromaniac."
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response(hitby))
+	if(!does_react(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -138,7 +138,7 @@
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response(hitby))
+	if(!does_react(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -175,7 +175,7 @@
 		user.flags_1 |= TESLA_IGNORE_1
 
 /obj/item/clothing/suit/armor/reactive/tesla/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response(hitby))
+	if(!does_react(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -197,7 +197,7 @@
 	var/repulse_force = MOVE_FORCE_EXTREMELY_STRONG
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response(hitby))
+	if(!does_react(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -223,7 +223,7 @@
 	var/tele_range = 10
 
 /obj/item/clothing/suit/armor/reactive/table/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!check_response(hitby))
+	if(!does_react(hitby))
 		return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -70,7 +70,7 @@
 	reactivearmor_cooldown_duration = 100
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
 		return 0
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
@@ -106,7 +106,7 @@
 	desc = "An experimental suit of armor with a reactive sensor array rigged to a flame emitter. For the stylish pyromaniac."
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
 		return 0
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -129,7 +129,7 @@
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -188,7 +188,7 @@
 	var/repulse_force = MOVE_FORCE_EXTREMELY_STRONG
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
 		return 0
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -214,7 +214,7 @@
 	var/tele_range = 10
 
 /obj/item/clothing/suit/armor/reactive/table/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active)
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
 		return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -68,7 +68,7 @@
 	if(isprojectile(hitby))
 		var/obj/item/projectile/P = hitby
 		if(P.martial_arts_no_deflect)
-		return FALSE
+			return FALSE
 
 //When the wearer gets hit, this armor will teleport the user a short distance away (to safety or to more danger, no one knows. That's the fun of it!)
 /obj/item/clothing/suit/armor/reactive/teleport

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -70,7 +70,7 @@
 	reactivearmor_cooldown_duration = 100
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
 		return 0
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
@@ -106,7 +106,7 @@
 	desc = "An experimental suit of armor with a reactive sensor array rigged to a flame emitter. For the stylish pyromaniac."
 
 /obj/item/clothing/suit/armor/reactive/fire/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
 		return 0
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -129,7 +129,7 @@
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
 		return FALSE
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -188,7 +188,7 @@
 	var/repulse_force = MOVE_FORCE_EXTREMELY_STRONG
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
 		return 0
 	if(prob(hit_reaction_chance))
 		if(world.time < reactivearmor_cooldown)
@@ -214,7 +214,7 @@
 	var/tele_range = 10
 
 /obj/item/clothing/suit/armor/reactive/table/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime && hitby.damage == 0)) //fingerguns aren't real unless you're a mime. 
+	if(!active || (isprojectile(hitby) && hitby.type == /obj/item/projectile/bullet/c38/mime)) //fingerguns aren't real unless you're a mime. 
 		return FALSE
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check to reactive armors so that they ignore harmless fingergun bullets (but not advanced mimery ones)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
TBH it's kind of a funny reaction that might be worth keeping in the game. I made this PR in response to some random griefer on round 38134 using it as part of his attempts to enrage the RD. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Tested harmless fingerguns - they have no effect
Tested advanced mimery fingergun - it processes like normal
Tested a random laser weapon - it processes like normal

## Changelog
:cl:
fix: Reactive armor now ignores imaginary bullets instead of activating. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
