### PR TITLE
Disables the corporate and maintain lawsets in the random lawset config.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -408,8 +408,8 @@ DEFAULT_LAWS 2
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
 RANDOM_LAWS crewsimov
-RANDOM_LAWS corporate
-RANDOM_LAWS maintain
+#RANDOM_LAWS corporate
+#RANDOM_LAWS maintain
 
 ## Quirky laws. Shouldn't cause too much harm
 #RANDOM_LAWS hippocratic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the corporate lawset and the maintain lawset in the config. Which prevents them from being rolled in the "random lawset" roundstart roll.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A roundstart lawset for an AI should always be some form of "simov" lawset. Antagonists for example should always be protected by the roundstart AI's lawset. Apart from that maintain and corporate lawsets and basically any lawset that isn't a "simov" one give the AI way too much freedom. 
A corporate and maintain AI basically functions as a "semi-purged" Ai, as they allow the AI to do basically anything with a little bit of intelligent thinking/decision making.

The Ai is at the bottom of the food chain, right above cyborgs. Even an assistant has more authority than the AI. An AI needs to aid the crew and follow their orders, which is part of what makes the AI fun in my opinion. 
The roundstart AI should not have any authority nor actually command people around. Which is what they easily can and often do on corporate/maintain. The AI role isn't a "command" role and shouldn't be played with a command mindset (until you get your laws changed or go rogue of course). As a roundstart AI you are put into place by NT to serve and assist the crew. Not command it around or lead a departement. Atleast that's what i consider the AI role to be like. 

I really disliked the random lawsets since they got added and i truly believe that they have only lead to even more bad interactions with silicons, as again, the silicons on maintain/corporate have _alot_ of freedom and are able to basically ignore any law 2 questions with some decent wording. 
The "simov" lawsets are the best roundstart lawsets especially also because our silicon policy was made with a "simov" lawset in mind.
(Before you ask, i have around 120h as AI)

## Testing Photographs and Procedure
I don't have any pictures here but i only tested the code 3 times. I simply put a # infront of two config lines though so i considered these 3 tests to be enough.

</details>

## Changelog
:cl:
config: Disabled the maintain and corporate lawsets from being rolled as a random lawset.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
