### PR TITLE
Fixes an error in quirk mob transfer

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -38,21 +38,25 @@
 	if(quirk_holder)
 		remove()
 		UnregisterSignal(quirk_holder, COMSIG_PARENT_QDELETING)
-		to_chat(quirk_holder, lose_text)
+		if(!QDELETED(quirk_holder))
+			to_chat(quirk_holder, lose_text)
 		quirk_holder.roundstart_quirks -= src
 		if(mob_trait)
 			REMOVE_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)
+		quirk_holder = null
 	SSquirks.quirk_objects -= src
 	return ..()
 
 /datum/quirk/proc/transfer_mob(mob/living/to_mob)
 	quirk_holder.roundstart_quirks -= src
+	UnregisterSignal(quirk_holder, COMSIG_PARENT_QDELETING)
 	to_mob.roundstart_quirks += src
 	if(mob_trait)
 		REMOVE_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)
 		ADD_TRAIT(to_mob, mob_trait, ROUNDSTART_TRAIT)
 	quirk_holder = to_mob
 	on_transfer()
+	RegisterSignal(quirk_holder, COMSIG_PARENT_QDELETING, .proc/handle_parent_del)
 
 /datum/quirk/proc/add() //special "on add" effects
 /datum/quirk/proc/on_spawn() //these should only trigger when the character is being created for the first time, i.e. roundstart/latejoin
@@ -66,7 +70,6 @@
 
 /datum/quirk/proc/handle_parent_del()
 	SIGNAL_HANDLER
-	quirk_holder = null
 	qdel(src)
 
 /datum/quirk/process(delta_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a simple error in quirk mob transfer, that didn't transfer the signals of quirks when the mob changed.

## Why It's Good For The Game

This may or may not fix a hard del. I was unable to reproduce the hard-dels that were on the server, however I attempted to remove everything that I could see potentially causing hard-dels.

Previously deletion code would null the owner, meaning the quirk wouldn't be deleted from the owner on deletion.
When a quirk changed mob, there was also no change of signal.

## Testing Photographs and Procedure

Checked hard dels on the server but was unable to reproduce them, so cannot test for sure if it was fixed or not. Fixes some bad logic in this code anyway.

## Changelog
:cl:
fix: Fixes some mistakes in quirk code mob transfer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
