### PR TITLE
Fixes eminence getting flashbanged and vendors throwing items at it

### DIFF
--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -10,7 +10,8 @@
 		/obj/docking_port,
 		/atom/movable/lighting_object,
 		/obj/item/projectile,
-		/obj/structure/chisel_message
+		/obj/structure/chisel_message,
+		/mob/living/simple_animal/eminence
 		))
 	var/list/processing_list = list(location)
 	. = list()
@@ -29,7 +30,7 @@
 /proc/radiation_pulse(atom/source, intensity, range_modifier, log=FALSE, can_contaminate=TRUE)
 	if(!SSradiation.can_fire)
 		return
-	
+
 	var/list/things = get_rad_contents(isturf(source) ? source : get_turf(source)) //copypasta because I don't want to put special code in waves to handle their origin
 	for(var/k in 1 to things.len)
 		var/atom/thing = things[k]
@@ -47,5 +48,5 @@
 		if(log)
 			var/turf/_source_T = isturf(source) ? source : get_turf(source)
 			log_game("Radiation pulse with intensity: [intensity] and range modifier: [range_modifier] in [loc_name(_source_T)] ")
-	
+
 	return TRUE

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -138,6 +138,9 @@
 /mob/living/simple_animal/eminence/update_health_hud()
 	return
 
+/mob/living/simple_animal/eminence/flash_act(intensity, override_blindness_check, affect_silicon, visual, type)
+	return
+
 //Eminence abilities
 
 /obj/effect/proc_holder/spell/targeted/eminence

--- a/code/modules/antagonists/clock_cult/mobs/eminence.dm
+++ b/code/modules/antagonists/clock_cult/mobs/eminence.dm
@@ -69,6 +69,9 @@
 /mob/living/simple_animal/eminence/start_pulling(atom/movable/AM, state, force = move_force, supress_message = FALSE)
 	return FALSE
 
+/mob/living/simple_animal/eminence/rad_act(amount)
+	return
+
 /mob/living/simple_animal/eminence/Initialize(mapload)
 	. = ..()
 	GLOB.clockcult_eminence = src

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -192,6 +192,9 @@
 		return BULLET_ACT_FORCE_PIERCE
 	return ..()
 
+/mob/living/simple_animal/revenant/rad_act(amount)
+	return
+
 //damage, gibbing, and dying
 /mob/living/simple_animal/revenant/attackby(obj/item/W, mob/living/user, params)
 	. = ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1029,7 +1029,7 @@
 /mob/living/rad_act(amount)
 	. = ..()
 
-	if(!amount || (amount < RAD_MOB_SKIN_PROTECTION) || HAS_TRAIT(src, TRAIT_RADIMMUNE) || istype(src, /mob/living/simple_animal/revenant) || istype(src, /mob/living/simple_animal/eminence))
+	if(!amount || (amount < RAD_MOB_SKIN_PROTECTION) || HAS_TRAIT(src, TRAIT_RADIMMUNE))
 		return
 
 	amount -= RAD_BACKGROUND_RADIATION // This will always be at least 1 because of how skin protection is calculated

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1029,7 +1029,7 @@
 /mob/living/rad_act(amount)
 	. = ..()
 
-	if(!amount || (amount < RAD_MOB_SKIN_PROTECTION) || HAS_TRAIT(src, TRAIT_RADIMMUNE))
+	if(!amount || (amount < RAD_MOB_SKIN_PROTECTION) || HAS_TRAIT(src, TRAIT_RADIMMUNE) || istype(src, /mob/living/simple_animal/revenant) || istype(src, /mob/living/simple_animal/eminence))
 		return
 
 	amount -= RAD_BACKGROUND_RADIATION // This will always be at least 1 because of how skin protection is calculated

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -858,7 +858,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/proc/throw_item()
 	var/obj/throw_item = null
 	var/mob/living/target = locate() in view(7,src)
-	if(!target)
+	if(!target && iseminence(target))
 		return 0
 
 	for(var/datum/data/vending_product/R in shuffle(product_records))

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -858,7 +858,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/proc/throw_item()
 	var/obj/throw_item = null
 	var/mob/living/target = locate() in view(7,src)
-	if(!target && iseminence(target))
+	if(!target || iseminence(target))
 		return 0
 
 	for(var/datum/data/vending_product/R in shuffle(product_records))

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -858,7 +858,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/proc/throw_item()
 	var/obj/throw_item = null
 	var/mob/living/target = locate() in view(7,src)
-	if(!target || iseminence(target))
+	if(!target || target.incorporeal_move >= INCORPOREAL_MOVE_BASIC)
 		return 0
 
 	for(var/datum/data/vending_product/R in shuffle(product_records))


### PR DESCRIPTION
## About The Pull Request

Fixes: #6874

Fixes eminence getting flashbanged and vendors throwing items. Bacon told me to override flash_act on the eminence, so I did.
Rev and eminence can no longer be irradiated by the SM (or anything else).

## Why It's Good For The Game

Bugs bad

## Testing Photographs and Procedure

Spawn eminence as a mob `/mob/living/simple_animal/eminence`. Possess the eminence. Spawn flashbang. Call `prime()` with no arguments, see that eminence is no longer flashed. Now go towards nearest vendors, go into it's vars and set `shoot_inventory` to 1 and set shoot chance to 100, notice it's no longer shooting at you.

## Changelog
:cl:
fix: Fixes eminence being targeted by things that shouldn't see it.
fix: Revenant and eminence can no longer be irradiated.
/:cl:
