### PR TITLE
Hand Teles gib on teleport to closed turf

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -171,6 +171,13 @@
 		if(istype(M, /obj/item/projectile))
 			var/obj/item/projectile/P = M
 			P.ignore_source_check = TRUE
+		if(istype(real_target, /turf/closed) && istype(M, /mob/living))
+			var/mob/living/L = M
+			playsound(real_target, "sparks", 50, TRUE)
+			playsound(real_target, "sound/magic/disintegrate.ogg", 50, TRUE)
+			to_chat(L, "<span class='userdanger'>You teleport into the wall, the portal tries to save you, but-</span>")
+			real_target.ex_act(2) //Destroy the wall
+			L.gib()
 		return TRUE
 	return FALSE
 

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -98,7 +98,7 @@
  * Hand-tele
  */
 /obj/item/hand_tele
-	name = "hand tele"
+	name = "hand teleporter"
 	desc = "A portable item using blue-space technology."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "hand_tele"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you attempt to teleport into a closed turf via hand tele, you will be gibbed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right now the (Dangerous) option poses literally zero danger if you have a suit and internals. This adds some actual risk to the Dangerous option. A low risk, due to the proportion of closed to open turfs in the average 21x21 area, but not a non-zero risk.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
balance: Hand teleporters will gib you if you land on a closed turf via the Dangerous option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
