### PR TITLE
Supermatter Explosion Releases an EMP

### DIFF
--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -1,4 +1,4 @@
-/proc/empulse(turf/epicenter, heavy_range, light_range, log=0, magic=FALSE, holy=FALSE)
+/proc/empulse(turf/epicenter, heavy_range, light_range, log=0, magic=FALSE, holy=FALSE, check_tick = FALSE)
 	if(!epicenter)
 		return
 
@@ -29,6 +29,8 @@
 					continue
 			empulse_atoms += A
 		empulse_atoms += T
+		if(check_tick)
+			CHECK_TICK
 
 	for(var/atom/A as() in empulse_atoms)
 		var/distance = get_dist(epicenter, A)
@@ -43,4 +45,6 @@
 				A.emp_act(EMP_LIGHT)
 		else if(distance <= light_range)
 			A.emp_act(EMP_LIGHT)
+		if(check_tick)
+			CHECK_TICK
 	return 1

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -1,4 +1,4 @@
-/proc/empulse(turf/epicenter, heavy_range, light_range, log=0, magic=FALSE, holy=FALSE, check_tick = FALSE)
+/proc/empulse(turf/epicenter, heavy_range, light_range, log=0, magic=FALSE, holy=FALSE, check_tick=FALSE)
 	if(!epicenter)
 		return
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -304,7 +304,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/turf/T = get_turf(src)
 
 	//Big empulse
-	INVOKE_ASYNC(GLOBAL_PROC, /proc/empulse, T, 200 * gasmix_power_ratio, 300 * gasmix_power_ratio, check_tick = TRUE)
+	INVOKE_ASYNC(GLOBAL_PROC, /proc/empulse, T, 200 * max(0.2, gasmix_power_ratio), 300 * max(0.2, gasmix_power_ratio), TRUE, FALSE, FALSE, TRUE)
 
 	//Reality distortion
 	for(var/mob/M in GLOB.player_list)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -290,6 +290,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	explode()
 
 /obj/machinery/power/supermatter_crystal/proc/explode()
+
 	for(var/mob in GLOB.alive_mob_list)
 		var/mob/living/L = mob
 		if(istype(L) && L.get_virtual_z_level() == get_virtual_z_level())
@@ -301,6 +302,11 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			L.rad_act(rads)
 
 	var/turf/T = get_turf(src)
+
+	//Big empulse
+	INVOKE_ASYNC(GLOBAL_PROC, /proc/empulse, T, 200 * gasmix_power_ratio, 300 * gasmix_power_ratio, check_tick = TRUE)
+
+	//Reality distortion
 	for(var/mob/M in GLOB.player_list)
 		if(M.get_virtual_z_level() == get_virtual_z_level())
 			SEND_SOUND(M, 'sound/magic/charge.ogg')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the supermatter explodes, an EMP will be released with a minimum size of 40,60

## Why It's Good For The Game

More stuff to happen when the supermatter explodes, the entire station will be taken offline for a short amount of time and the power grid will actually be damaged. Will drain the power from batteries, so power generation from solars will need to be set up.
Currently the SM explosion is just a tiny little explosion which is usually of the minimum size doing almost nothing.

IPCs will fear the supermatter and will either have to run as far away from the SM as they can get, or stay somewhere where they can get repaired. Technology will be in ruins and the station will be back to the stone age.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/169353492-d5325635-df38-423a-9936-9f2b212163aa.png)

## Changelog
:cl:
add: The supermatter explosion will now create a relatively large EMP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
