### PR TITLE
Fix: Belt overlay not updating on dumping items

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -879,6 +879,7 @@
 	if(user.active_storage) //refresh the HUD to show the transfered contents
 		user.active_storage.close(user)
 		user.active_storage.show_to(user)
+	src_object.update_icon()
 	return TRUE
 
 ///Get the best place to dump the items contained in the source storage item?


### PR DESCRIPTION
## About The Pull Request

Just adds `src_object.update_icon()` to `component_storage_contents_dump_act()` so the overlays of `src_object` update after dumping.
Fixes #6794 

## Why It's Good For The Game

Fixing bugs is good.

## Testing Photographs and Procedure

<details>
<summary>Videos</summary>

**Before**:

https://user-images.githubusercontent.com/53494785/169409578-55d14ebc-f753-461d-9825-a7a2294802a9.mp4

**After**:

https://user-images.githubusercontent.com/53494785/169409667-b7459d36-9df8-4921-9071-7a1dbd2fbec7.mp4


</details>

## Changelog
:cl:
fix: Belt overlay not updating on dumping items
/:cl: