### PR TITLE
Speeds up blob spores (again) and fixes some runtimes in the moveloop

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -439,14 +439,14 @@
 	var/target_turf
 
 /datum/move_loop/has_target/jps/hostile/recalculate_path()
-	if(!COOLDOWN_FINISHED(src, repath_cooldown) || repath_active)
+	if(!COOLDOWN_FINISHED(src, repath_cooldown) || repath_active || QDELETED(src))
 		return
 	repath_active = TRUE
 	COOLDOWN_START(src, repath_cooldown, repath_delay)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_JPS_REPATH)
 	movement_path = get_path_to(moving, target, max_path_length, minimum_distance, id, simulated_only, avoid, skip_first)
 	// Implementing pathfinding fallback solution
-	if(!length(movement_path))
+	if(!length(movement_path) && !QDELETED(src))
 		var/ln = get_dist(moving, target)
 		var/turf/target_new = target
 		var/found_blocker

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -105,7 +105,6 @@
 	del_on_death = TRUE
 	deathmessage = "explodes into a cloud of gas!"
 	gold_core_spawnable = HOSTILE_SPAWN
-	move_to_delay = 6
 	var/death_cloud_size = 1 //size of cloud produced from a dying spore
 	var/mob/living/carbon/human/oldguy
 	var/is_zombie = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR speeds up blob spores again they originally where slowed down because the original implementation of the movement solution using sleep kinda messed up timings and they felt to fast but now with the moveloop that issue is way less prevelent and now they feel way to slow. Also i discovered a runtime that can happen during qdeleted of the jps_hostile moveloop if the loop gets qdeleted while it recalculates the path (this can easily happen especially because the proc in question is beeing called async)

## Why It's Good For The Game

small tweaks faster spores (back to original speed) and maybe a runtime fix

</details>

## Changelog
:cl:
balance: changes the movement delay of blob spores back to the default for hostiles
fix: fixes a possible runtime in jps hostile while it gets qdeleted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
