### PR TITLE
More Metacoins for BYOND Members

### DIFF
--- a/code/__DEFINES/metacoin.dm
+++ b/code/__DEFINES/metacoin.dm
@@ -8,3 +8,5 @@
 #define METACOIN_NOTSURVIVE_REWARD       10
 /// Rewarded when you are alive and active for 10 minutes
 #define METACOIN_TENMINUTELIVING_REWARD  4
+/// Rewarded for being a BYOND Member
+#define METACOIN_BYONDMEMBERSHIP         40

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -15,9 +15,6 @@
 		if(is_content_unlocked())
 			inc_metabalance(METACOIN_BYONDMEMBERSHIP, reason="You're a BYOND Member!")
 
-
-
-
 /client/proc/process_greentext()
 	src.give_award(/datum/award/achievement/misc/greentext, src.mob)
 

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -12,6 +12,11 @@
 				inc_metabalance(METACOIN_ESCAPE_REWARD, reason="Survived the shift.")
 		else
 			inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
+		if(is_content_unlocked())
+			inc_metabalance(METACOIN_BYONDMEMBERSHIP, reason="You're a BYOND Member!")
+
+
+
 
 /client/proc/process_greentext()
 	src.give_award(/datum/award/achievement/misc/greentext, src.mob)


### PR DESCRIPTION
## About The Pull Request

Gives BYOND Members more metacoins per round, its that simple really

## Why It's Good For The Game

I've noticed the BYOND monthly goal not being met year after year, and I realised that there isnt much to motivate people to help support BYOND via membership, This should hopefully help with that. (We can also adjust this to include donators too maybe?)

## Testing Photographs and Procedure

Couldnt get metacoins to work on a generic dream-daemon without a database, and I'm not re-setting up my server enviroment to test this, but in theory it should work, hopefully...


## Changelog
:cl:
tweak: BYOND Members now gain extra metacoins at round-end
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
