### PR TITLE
Make cutting the IDSCAN wire allow all-access on airlocks

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -145,8 +145,6 @@
 	if(operating)
 		return
 	add_fingerprint(user)
-	if(!src.requiresID())
-		user = null
 
 	if(density && !(obj_flags & EMAGGED))
 		if(allowed(user))
@@ -162,7 +160,7 @@
 	return try_to_activate_door(null, user)
 
 /obj/machinery/door/attack_tk(mob/user)
-	if(requiresID() && !allowed(null))
+	if(!allowed(null))
 		return
 	..()
 
@@ -170,8 +168,6 @@
 	add_fingerprint(user)
 	if(operating || (obj_flags & EMAGGED))
 		return
-	if(!requiresID())
-		user = null //so allowed(user) always succeeds
 	if(allowed(user))
 		if(density)
 			open()
@@ -183,6 +179,8 @@
 
 /obj/machinery/door/allowed(mob/M)
 	if(emergency)
+		return TRUE
+	if(!requiresID())
 		return TRUE
 	if(unrestricted_side(M))
 		return TRUE

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -95,8 +95,6 @@
 	if( operating || !density )
 		return
 	add_fingerprint(user)
-	if(!requiresID())
-		user = null
 
 	if(allowed(user))
 		open_and_close()

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -187,7 +187,7 @@
 	else if(istype(target, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/A = target
 
-		if((!A.requiresID() || A.allowed(user)) && A.hasPower()) //This is to prevent stupid shit like hitting a door with an arm blade, the door opening because you have acces and still getting a "the airlocks motors resist our efforts to force it" message, power requirement is so this doesn't stop unpowered doors from being pried open if you have access
+		if(A.allowed(user) && A.hasPower()) //This is to prevent stupid shit like hitting a door with an arm blade, the door opening because you have acces and still getting a "the airlocks motors resist our efforts to force it" message, power requirement is so this doesn't stop unpowered doors from being pried open if you have access
 			return
 		if(A.locked)
 			to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix handling of RequiresID() by making it part of allowed()

This makes the behavior in line with the documented intent of the code: Cutting the ID wire so that RequiresID() is TRUE means that anyone can open the door.

The old action of nulling user did *not* accomplish this, despite comments to the contrary. Instead, it caused the door to be locked to everyone. This was actually documented on the wiki, because it was like this for so many years.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The primary reason is code cleanliness: The current state is extremely confusing, and if we don't do this, instead we should do some extreme renaming/documenting to make the current state more clear.
Secondary is that it's clearly the original dev intent, and it also makes ID Scan on airlocks work the same as ID Scan on other machines/devices, where it *does* grant all-access.
It also adds more depth to stealth-antag: Right now there's no way to set up an airlock so you have easy access to it without it being obvious that's something's wrong. With this, you can cut the ID Scan wire and replace the cover and it won't be obvious what you did, unless someone without access tries to walk through and realizes that they shouldn't be able to.
The behavior it eliminates is a clumsy and easily fixed way of blocking the airlock, and there's already plenty of ways to do that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
Doesn't fit well in a short video, but as the CE I verified the correct wire with blueprints, cut it, and then checked that I could get through after dropping my ID (and that other doors wouldn't let me through). Mending the wire returned the behavior to normal.

## Changelog
:cl:
tweak: Cutting ID Scan on an airlock grants access instead of blocking it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
