### PR TITLE
Document and refactor the current situation with WIRE_IDSCAN.

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -46,7 +46,7 @@
 		if(WIRE_OPEN) // Pulse to open door (only works not emagged and ID wire is cut or no access is required).
 			if(A.obj_flags & EMAGGED)
 				return
-			if(!A.requiresID() || A.check_access(null))
+			if(A.id_scan_hacked() || A.check_access(null))
 				if(A.density)
 					INVOKE_ASYNC(A, /obj/machinery/door/airlock.proc/open)
 				else

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -6,7 +6,7 @@
 	canAIControl - 1 if the AI can control the airlock, 0 if not (then check canAIHack to see if it can hack in)
 	canAIHack - 1 if the AI can hack into the airlock to recover control, 0 if not. Also returns 0 if the AI does not *need* to hack it.
 	hasPower - 1 if the main or backup power are functioning, 0 if not.
-	requiresIDs - 1 if the airlock is requiring IDs, 0 if not
+	id_scan_hacked - Whether the AI has disabled the ID scanner, or the wire has been cut.
 	isAllPowerCut - 1 if the main and backup power both have cut wires.
 	regainMainPower - handles the effect of main power coming back on.
 	loseMainPower - handles the effect of main power going offline. Usually (if one isn't already running) spawn a thread to count down how long it will be offline - counting down won't happen if main power was completely cut along with backup power, though, the thread will just sleep.
@@ -234,7 +234,8 @@
 			cyclelinkairlock()
 
 /obj/machinery/door/airlock/check_access_ntnet(datum/netdata/data)
-	return !requiresID() || ..()
+	// Cutting WIRE_IDSCAN grants remote access
+	return id_scan_hacked() || ..()
 
 /obj/machinery/door/airlock/ntnet_receive(datum/netdata/data)
 	// Check if the airlock is powered and can accept control packets.
@@ -456,8 +457,8 @@
 		return TRUE
 	return ((!secondsMainPowerLost || !secondsBackupPowerLost) && !(stat & NOPOWER))
 
-/obj/machinery/door/airlock/requiresID()
-	return !(wires.is_cut(WIRE_IDSCAN) || aiDisabledIdScanner)
+/obj/machinery/door/airlock/id_scan_hacked()
+	return wires.is_cut(WIRE_IDSCAN) || aiDisabledIdScanner
 
 /obj/machinery/door/airlock/proc/isAllPowerCut()
 	if(protected_door)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -174,7 +174,7 @@
 	// But if we *have* cut the wire, this eventually falls through to attack_hand(), which calls try_to_activate_door(),
 	// which will fail because the door won't work if the wire is cut! Catch-22.
 	// Basically, TK won't work unless the door is all-access.
-	if(!id_scan_hacked() && !allowed(null))
+	if(!id_scan_hacked() && !allowed())
 		return
 	..()
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -141,19 +141,26 @@
 	if(istype(mover) && (mover.pass_flags & PASSGLASS))
 		return !opacity
 
-/obj/machinery/door/proc/bumpopen(mob/user)
-	if(operating)
-		return
+/// Helper method for bumpopen() and try_to_activate_door(). Don't override.
+/obj/machinery/door/proc/activate_door_base(mob/user, can_close_door)
 	add_fingerprint(user)
-	if(!src.requiresID())
-		user = null
-
-	if(density && !(obj_flags & EMAGGED))
-		if(allowed(user))
+	if(operating || (obj_flags & EMAGGED))
+		return
+	// Cutting WIRE_IDSCAN disables normal entry
+	if(!id_scan_hacked() && allowed(user))
+		if(density)
 			open()
 		else
-			do_animate("deny")
-	return
+			if(!can_close_door)
+				return FALSE
+			close()
+		return TRUE
+	if(density)
+		do_animate("deny")
+
+/// Handles a door getting "bumped" by a mob/living.
+/obj/machinery/door/proc/bumpopen(mob/user)
+	activate_door_base(user, FALSE)
 
 /obj/machinery/door/attack_hand(mob/user)
 	. = ..()
@@ -162,24 +169,18 @@
 	return try_to_activate_door(null, user)
 
 /obj/machinery/door/attack_tk(mob/user)
-	if(requiresID() && !allowed(null))
+	// allowed(null) will always return false, unless the door is all-access.
+	// So unless we've cut the id-scan wire, TK won't go through at all - not even showing an animation.
+	// But if we *have* cut the wire, this eventually falls through to attack_hand(), which calls try_to_activate_door(),
+	// which will fail because the door won't work if the wire is cut! Catch-22.
+	// Basically, TK won't work unless the door is all-access.
+	if(!id_scan_hacked() && !allowed(null))
 		return
 	..()
 
+/// Handles door activation via clicks, through attackby().
 /obj/machinery/door/proc/try_to_activate_door(obj/item/I, mob/user)
-	add_fingerprint(user)
-	if(operating || (obj_flags & EMAGGED))
-		return
-	if(!requiresID())
-		user = null //so allowed(user) always succeeds
-	if(allowed(user))
-		if(density)
-			open()
-		else
-			close()
-		return TRUE
-	if(density)
-		do_animate("deny")
+	return activate_door_base(user, TRUE)
 
 /obj/machinery/door/allowed(mob/M)
 	if(emergency)
@@ -383,8 +384,10 @@
 /obj/machinery/door/proc/autoclose_in(wait)
 	addtimer(CALLBACK(src, .proc/autoclose), wait, TIMER_UNIQUE | TIMER_NO_HASH_WAIT | TIMER_OVERRIDE)
 
-/obj/machinery/door/proc/requiresID()
-	return 1
+/// Is the ID Scan wire cut, or has the AI disabled it?
+/// This has a variety of non-uniform effects - it doesn't simply grant access.
+/obj/machinery/door/proc/id_scan_hacked()
+	return FALSE
 
 /obj/machinery/door/proc/hasPower()
 	return !(stat & NOPOWER)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -95,10 +95,8 @@
 	if( operating || !density )
 		return
 	add_fingerprint(user)
-	if(!requiresID())
-		user = null
-
-	if(allowed(user))
+	// Cutting WIRE_IDSCAN disables normal entry... or it would, if we could hack windowdoors.
+	if(!id_scan_hacked() && allowed(user))
 		open_and_close()
 	else
 		do_animate("deny")
@@ -320,7 +318,8 @@
 			flick("[base_state]deny", src)
 
 /obj/machinery/door/window/check_access_ntnet(datum/netdata/data)
-	return !requiresID() || ..()
+	// Cutting WIRE_IDSCAN grants remote access... or it would, if we could hack windowdoors.
+	return id_scan_hacked() || ..()
 
 /obj/machinery/door/window/ntnet_receive(datum/netdata/data)
 	// Check if the airlock is powered.

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -187,7 +187,8 @@
 	else if(istype(target, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/A = target
 
-		if((!A.requiresID() || A.allowed(user)) && A.hasPower()) //This is to prevent stupid shit like hitting a door with an arm blade, the door opening because you have acces and still getting a "the airlocks motors resist our efforts to force it" message, power requirement is so this doesn't stop unpowered doors from being pried open if you have access
+		if((A.id_scan_hacked() || A.allowed(user)) && A.hasPower()) //This is to prevent stupid shit like hitting a door with an arm blade, the door opening because you have access and still getting a "the airlocks motors resist our efforts to force it" message, power requirement is so this doesn't stop unpowered doors from being pried open if you have access.
+			//Note that because the id_scan_hacked() check is the opposite from how it works in the actual opening check, a powered + id_scan_hacked airlock will prevent lings from forcing the door with arm blades, while also blocking regular access. Also, the entire premise of the comment/logic above is flawed, since you can only use arm blades on a door with HARM intent (due to this being afterattack()), and that prevents you from interacting normally.
 			return
 		if(A.locked)
 			to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -1,5 +1,6 @@
 
-//returns TRUE if this mob has sufficient access to use this object
+///returns TRUE if this mob has sufficient access to use this object.
+///Note that this will return FALSE when passed null, unless the door doesn't require any access.
 /obj/proc/allowed(mob/M)
 	//check if it doesn't require any access at all
 	if(src.check_access(null))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is the alternative to #6919.

This changes the name `RequiresID()` to `id_scan_hacked()` (with opposite boolean meaning), and refactors one pair of functions for consistency.

It very carefully contains **no** behavior changes, instead documenting the strange and sometimes downright buggy behavior arising from the current status quo.

Current behaviors documented. All of these are triggered by cutting WIRE_IDSCAN or if the AI disables id scanning, which collectively is known as `id_scan_hacked`:
- `id_scan_hacked` causes the airlock to not function (it won't open via normal bumping/clicking).
- `id_scan_hacked` allows **all** door remotes to open the door, i.e. all-access. Yes, this is the opposite of the above.
- The code sets up both of those for windowdoors too, except it won't work because you can't hack them.
- `id_scan_hacked` allows airlocks to open/close when you pulse WIRE_OPEN. (It'll also work if it's a naturally all-access door, like when emergency is set.)
- `id_scan_hacked` is involved in ensuring that TK doesn't work on doors. At all. _Unless_ the door is naturally all-access.
- A powered + `id_scan_hacked` airlock will prevent a changeling from using their arm-blades to open the door. In general, a powered door will prevent a changeling from using their arm-blades, but if it's also `id_scan_hacked` they may be unable to get through normally as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's better to have the current state of things documented, rather than relying on strange and ill-understood side-effects. Clearly, the poor naming has already gotten past contributors into trouble.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
I tested each of the above behaviors, both with and without this change. They all function as documented, despite how strange some of them are.

## Changelog
:cl:
refactor: document behavior around airlocks and the id scan wire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
