### PR TITLE
reworks random code generator (for nuke codes and technically pda antag uplinks)

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1227,12 +1227,17 @@ Increases delay as the server gets more overloaded, as sleeps aren't cheap and s
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
 
-/proc/random_nukecode()
-	var/val = rand(0, 99999)
-	var/str = "[val]"
-	while(length(str) < 5)
-		str = "0" + str
-	. = str
+/**
+ * random code generator (only numbers)
+ * Arguments
+ * n_length - length of the random code
+ *
+**/
+/proc/random_code(n_length = 0)
+	if(!n_length) //incase someone forgets to say how long they want the code to be
+		stack_trace("No code length forwarded as argument")
+	while(length(.) < n_length)
+		. += "[rand(0, 9)]" // we directly write into the return value (.) here
 
 /atom/proc/Shake(pixelshiftx = 15, pixelshifty = 15, duration = 250)
 	var/initialpixelx = pixel_x

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1229,6 +1229,7 @@ Increases delay as the server gets more overloaded, as sleeps aren't cheap and s
 
 /**
  * random code generator (only numbers)
+ * This returns a string
  * Arguments
  * n_length - length of the random code
  *

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -344,7 +344,7 @@
 
 /datum/component/uplink/proc/generate_code()
 	if(istype(parent,/obj/item/pda))
-		return "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
+		return "[random_code(3)] [pick(GLOB.phonetic_alphabet)]"
 	else if(istype(parent,/obj/item/radio))
 		return sanitize_frequency(rand(MIN_FREQ, MAX_FREQ), TRUE)
 	else if(istype(parent,/obj/item/pen))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1797,7 +1797,7 @@
 	else if(href_list["set_selfdestruct_code"])
 		if(!check_rights(R_ADMIN))
 			return
-		var/code = random_nukecode()
+		var/code = random_code(5)
 		for(var/obj/machinery/nuclearbomb/selfdestruct/SD in GLOB.nuke_list)
 			SD.r_code = code
 		message_admins("[key_name_admin(usr)] has set the self-destruct \

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -71,7 +71,7 @@
 
 /datum/antagonist/nukeop/proc/assign_nuke()
 	if(nuke_team && !nuke_team.tracked_nuke)
-		nuke_team.memorized_code = random_nukecode()
+		nuke_team.memorized_code = random_code(5)
 		var/obj/machinery/nuclearbomb/syndicate/nuke = locate() in GLOB.nuke_list
 		if(nuke)
 			nuke_team.tracked_nuke = nuke
@@ -241,7 +241,7 @@
 
 /datum/antagonist/nukeop/lone/assign_nuke()
 	if(nuke_team && !nuke_team.tracked_nuke)
-		nuke_team.memorized_code = random_nukecode()
+		nuke_team.memorized_code = random_code(5)
 		var/obj/machinery/nuclearbomb/selfdestruct/nuke = locate() in GLOB.nuke_list
 		if(nuke)
 			nuke_team.tracked_nuke = nuke

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -400,7 +400,7 @@
 	var/code
 	for(var/obj/machinery/nuclearbomb/beer/beernuke in GLOB.nuke_list)
 		if(beernuke.r_code == "ADMIN")
-			beernuke.r_code = random_nukecode()
+			beernuke.r_code = random_code(5)
 		code = beernuke.r_code
 	info = "important party info, DONT FORGET: <b>[code]</b>"
 

--- a/code/modules/requests/request_manager.dm
+++ b/code/modules/requests/request_manager.dm
@@ -189,7 +189,7 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 			if (request.req_type != REQUEST_NUKE)
 				to_chat(usr, "You cannot set the nuke code for a non-nuke-code-request request!")
 				return TRUE
-			var/code = random_nukecode()
+			var/code = random_code(5)
 			for(var/obj/machinery/nuclearbomb/selfdestruct/SD in GLOB.nuke_list)
 				SD.r_code = code
 			message_admins("[key_name_admin(usr)] has set the self-destruct code to \"[code]\".")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The original code relied on a random number from 0 to 99999 and then padded out any numbers that where missing in the front this just rewrites the code to not need that at all and also allows for variable code size we can have a code of 5 or 10 or what do i know 15 now the whole code is still only numbers trough(as a string).
Also the antag uplink for pda's will also use this code generator now so we can have codes that are not only from 100 to 999 plus a short text behind but have like 001 or 011 ALPHA etc.

## Why It's Good For The Game

Not much changes

## Changelog
:cl:
code: reworks nuke_code proc (now random_code proc) to not use padding and be able to accept variable code lengths
refactor: make the antag uplinke code (for pda uplinks at least) also use this proc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
