### PR TITLE
Fix RCL icon not updating after refilling an empty RCL

### DIFF
--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -55,6 +55,7 @@
 			else
 				loaded = W //W.loc is src at this point.
 				loaded.max_amount = max_amount //We store a lot.
+				update_icon()
 				return
 
 		if(loaded.amount < max_amount)


### PR DESCRIPTION
## About The Pull Request

RCL didn't update its icon after being refilled from an empty state

## Why It's Good For The Game

Bug bad

## Changelog
:cl:
fix: Update RCL icon on refill
/:cl: