### PR TITLE
changes automute logic back to old timing logic(purly logic not code)

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -155,8 +155,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(COOLDOWN_FINISHED(src, total_count_reset))
 		total_message_count = 0 //reset the count if it's been more than 5 seconds since the last message.
 
+	if(!total_message_count) //so we don't reset it every single message
+		COOLDOWN_START(src, total_count_reset, 5 SECONDS)
 	total_message_count++
-	COOLDOWN_START(src, total_count_reset, 5 SECONDS)
 
 	if(total_message_count >= SPAM_TRIGGER_AUTOMUTE)
 		to_chat(src, "<span class='userdanger'>You have exceeded the spam filter limit for too many messages. An auto-mute was applied. Make an adminhelp ticket if you think this was in error.</span>")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		return FALSE
 
 	if(COOLDOWN_FINISHED(src, total_count_reset))
-		total_message_count = 0 //reset the count if it's been more than 5 seconds since the last message.
+		total_message_count = 0 //reset the count if it's been more than 5 seconds since the first message
 
 	if(!total_message_count) //so we don't reset it every single message
 		COOLDOWN_START(src, total_count_reset, 5 SECONDS)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -143,9 +143,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
  *
  * Handles checking for people sending messages too fast.
  *
- * This is defined as sending SPAM_TRIGGER_AUTOMUTE (10) messages within 5 seconds of eachother, which gets you auto-muted.
+ * This is defined as sending SPAM_TRIGGER_AUTOMUTE (10) messages within 5 seconds, which gets you auto-muted.
  *
- * You will be warned if you send SPAM_TRIGGER_WARNING(5) messages withing 5 seconds of eachother to hopefully prevent false positives.
+ * You will be warned if you send SPAM_TRIGGER_WARNING(5) messages withing 5 seconds to hopefully prevent false positives.
  *
  */
 /client/proc/handle_spam_prevention(message, mute_type)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -154,9 +154,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	if(COOLDOWN_FINISHED(src, total_count_reset))
 		total_message_count = 0 //reset the count if it's been more than 5 seconds since the first message
+		COOLDOWN_START(src, total_count_reset, 5 SECONDS) //inside this if so we don't reset it every single message
 
-	if(!total_message_count) //so we don't reset it every single message
-		COOLDOWN_START(src, total_count_reset, 5 SECONDS)
 	total_message_count++
 
 	if(total_message_count >= SPAM_TRIGGER_AUTOMUTE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This simply changes a single check so that the cooldown starts only form the first message and not gets started on every message so now the filter acutally does again work you can write 5 messages withing 5 seconds and not you can write 5 messages and then have to wait 5 seconds before you can write again unless you want to get warned/muted etc.
Also no need to give bigger spam range anymore cause this basically makes it behave like before the refactor (in terms of timing behavior not bugs etc.)
alternative to https://github.com/BeeStation/BeeStation-Hornet/pull/6929
I put it as alternative because this basically will restore basic behavior in terms of how often you can write in a 5 seconds before warning/mute that was before the rework and those values worked fine before but the rework made it basically you can write 5 messsages and have to wait for 5 seconds in between else you get warned/muted.

## Why It's Good For The Game

The spam protection refactor is great but at least i think that if it resets the timer every time it just becomes fustrating

## Changelog
:cl:
tweak: makes spam protection work around messages per timeframe instead of you have to wait so long before you can message again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
