### PR TITLE
Add radiation to the Supermatter Monitor

### DIFF
--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -73,6 +73,7 @@
 		data["active"] = TRUE
 		data["SM_integrity"] = active.get_integrity()
 		data["SM_power"] = active.power
+		data["SM_radiation"] = active.last_rads
 		data["SM_ambienttemp"] = air.return_temperature()
 		data["SM_ambientpressure"] = air.return_pressure()
 		//data["SM_EPR"] = round((air.total_moles / air.group_multiplier) / 23.1, 0.01)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -133,6 +133,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 
 	var/matter_power = 0
+	var/last_rads = 0
 
 	//Temporary values so that we can optimize this
 	//How much the bullets damage should be multiplied by when it is added to the internal variables
@@ -442,7 +443,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			power = clamp((removed.return_temperature() * temp_factor / T0C) * gasmix_power_ratio + power, 0, SUPERMATTER_MAXIMUM_ENERGY) //Total laser power plus an overload
 
 		if(prob(50))
-			radiation_pulse(src, power * (1 + (tritiumcomp * TRITIUM_RADIOACTIVITY_MODIFIER) + ((pluoxiumcomp * PLUOXIUM_RADIOACTIVITY_MODIFIER) * pluoxiumbonus) * (power_transmission_bonus/(10-(bzcomp * BZ_RADIOACTIVITY_MODIFIER))))) // Rad Modifiers BZ(500%), Tritium(300%), and Pluoxium(-200%)
+			last_rads = power * (1 + (tritiumcomp * TRITIUM_RADIOACTIVITY_MODIFIER) + ((pluoxiumcomp * PLUOXIUM_RADIOACTIVITY_MODIFIER) * pluoxiumbonus) * (power_transmission_bonus/(10-(bzcomp * BZ_RADIOACTIVITY_MODIFIER)))) // Rad Modifiers BZ(500%), Tritium(300%), and Pluoxium(-200%)
+			radiation_pulse(src, last_rads)
 		if(bzcomp >= 0.4 && prob(30 * bzcomp))
 			src.fire_nuclear_particle()		// Start to emit radballs at a maximum of 30% chance per tick
 

--- a/tgui/packages/tgui/interfaces/NtosSupermatterMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosSupermatterMonitor.js
@@ -28,6 +28,7 @@ export const NtosSupermatterMonitorContent = (props, context) => {
     SM_power,
     SM_ambienttemp,
     SM_ambientpressure,
+    SM_radiation,
   } = data;
   if (!active) {
     return (
@@ -64,6 +65,23 @@ export const NtosSupermatterMonitorContent = (props, context) => {
                   bad: [7000, Infinity],
                 }}>
                 {toFixed(SM_power) + ' MeV/cm3'}
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item label="Radiation">
+              <ProgressBar
+                value={SM_radiation}
+                minValue={0}
+                maxValue={7000}
+                ranges={{
+                  // The threshold where enough radiation gets to the
+                  // collectors to start generating power. Experimentally
+                  // determined, because radiation waves are inscrutable.
+                  grey: [-Infinity, 320],
+                  good: [320, 5000],
+                  average: [5000, 7000],
+                  bad: [7000, Infinity],
+                }}>
+                {toFixed(SM_radiation) + ' Sv/h'}
               </ProgressBar>
             </LabeledList.Item>
             <LabeledList.Item label="Temperature">


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This displays the intensity of the last radiation pulse released by the SM. A surface reading of the code makes it seem like this will be the same as power, but it turns out not to be - there is a formula that tweaks the rads produced, but more importantly the power decay happens _after_ the rads are calculated, so the displayed power value is post-decay whereas the rads (and the effect on waste gas production) is _pre-decay_. When the SM is on fire, these two values can diverge significantly (see screenshots.)

(Note that this does *not* give accurate dose information for living mobs, because the SM has additional code with a different formula that applies *extra* rads to livings things.)

Adding this info provides more insight into the SM, allowing for better control and designs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
At the low end, it provides a yardstick for how many rads you need before you get any power out of the collectors. At the high end, it shows how radiation levels can diverge significantly from displayed power in emergency situations. It provides more insight into one of the most complicated and hard-to-understand systems in the game (2nd only to fusion IMO).

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<details>

 ![rads-quiet](https://user-images.githubusercontent.com/459704/169932882-d71bafe4-892d-4f2c-8865-85fa171a66f5.png)
 ![rads-co2](https://user-images.githubusercontent.com/459704/169932987-843bfa51-03bd-4bbb-be8f-d50effda7349.png)
 ![rads-fire](https://user-images.githubusercontent.com/459704/169933018-1c66cc51-f607-49b5-a864-0dbd812cdb5f.png)
</details>

## Changelog
:cl:
add: Added radiation to the Supermatter Monitor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
