### PR TITLE
Tune-ups to Supermatter radiation

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -14,7 +14,6 @@
 
 #define OXYGEN_TRANSMIT_MODIFIER 1.5   //Higher == Bigger bonus to power generation.
 #define PLASMA_TRANSMIT_MODIFIER 4
-#define BZ_TRANSMIT_MODIFIER -2
 
 #define N2O_HEAT_RESISTANCE 6          //Higher == Gas makes the crystal more resistant against heat damage.
 
@@ -33,7 +32,7 @@
 #define TRITIUM_RADIOACTIVITY_MODIFIER 3  //Higher == Crystal spews out more radiation
 #define BZ_RADIOACTIVITY_MODIFIER 5
 #define PLUOXIUM_RADIOACTIVITY_MODIFIER -2
-#define PLUOXIUM_HEAT_RESISTANCE 3
+#define PLUOXIUM_HEAT_RESISTANCE 1.5
 
 #define THERMAL_RELEASE_MODIFIER 5         //Higher == less heat released during reaction, not to be confused with the above values
 #define PLASMA_RELEASE_MODIFIER 750        //Higher == less plasma released by reaction
@@ -119,8 +118,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/tritiumcomp = 0
 	var/bzcomp = 0
 	var/n2ocomp = 0
-
-	var/pluoxiumbonus = 0
 
 	var/combined_gas = 0
 	var/gasmix_power_ratio = 0
@@ -403,17 +400,12 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		n2ocomp = max(removed.get_moles(GAS_NITROUS)/combined_gas, 0)
 		n2comp = max(removed.get_moles(GAS_N2)/combined_gas, 0)
 
-		if(pluoxiumcomp >= 15)
-			pluoxiumbonus = 1	//Just to be safe I don't want to remove pluoxium
-		else
-			pluoxiumbonus = 0
-
 		gasmix_power_ratio = min(max(plasmacomp + o2comp + co2comp + tritiumcomp + bzcomp - pluoxiumcomp - n2comp, 0), 1)
 
-		dynamic_heat_modifier = max((plasmacomp * PLASMA_HEAT_PENALTY) + (o2comp * OXYGEN_HEAT_PENALTY) + (co2comp * CO2_HEAT_PENALTY) + (tritiumcomp * TRITIUM_HEAT_PENALTY) + ((pluoxiumcomp * PLUOXIUM_HEAT_PENALTY) * pluoxiumbonus) + (n2comp * NITROGEN_HEAT_PENALTY) + (bzcomp * BZ_HEAT_PENALTY), 0.5)
-		dynamic_heat_resistance = max((n2ocomp * N2O_HEAT_RESISTANCE) + ((pluoxiumcomp * PLUOXIUM_HEAT_RESISTANCE) * pluoxiumbonus), 1)
+		dynamic_heat_modifier = max((plasmacomp * PLASMA_HEAT_PENALTY) + (o2comp * OXYGEN_HEAT_PENALTY) + (co2comp * CO2_HEAT_PENALTY) + (tritiumcomp * TRITIUM_HEAT_PENALTY) + (pluoxiumcomp * PLUOXIUM_HEAT_PENALTY) + (n2comp * NITROGEN_HEAT_PENALTY) + (bzcomp * BZ_HEAT_PENALTY), 0.5)
+		dynamic_heat_resistance = max((n2ocomp * N2O_HEAT_RESISTANCE) + (pluoxiumcomp * PLUOXIUM_HEAT_RESISTANCE), 1)
 
-		power_transmission_bonus = max((plasmacomp * PLASMA_TRANSMIT_MODIFIER) + (o2comp * OXYGEN_TRANSMIT_MODIFIER), 0)
+		power_transmission_bonus = 1 + max((plasmacomp * PLASMA_TRANSMIT_MODIFIER) + (o2comp * OXYGEN_TRANSMIT_MODIFIER), 0)
 
 		//more moles of gases are harder to heat than fewer, so let's scale heat damage around them
 		mole_heat_penalty = max(combined_gas / MOLE_HEAT_PENALTY, 0.25)
@@ -443,7 +435,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			power = clamp((removed.return_temperature() * temp_factor / T0C) * gasmix_power_ratio + power, 0, SUPERMATTER_MAXIMUM_ENERGY) //Total laser power plus an overload
 
 		if(prob(50))
-			last_rads = power * (1 + (tritiumcomp * TRITIUM_RADIOACTIVITY_MODIFIER) + ((pluoxiumcomp * PLUOXIUM_RADIOACTIVITY_MODIFIER) * pluoxiumbonus) * (power_transmission_bonus/(10-(bzcomp * BZ_RADIOACTIVITY_MODIFIER)))) // Rad Modifiers BZ(500%), Tritium(300%), and Pluoxium(-200%)
+			last_rads = power * max(0, power_transmission_bonus * (1 + (tritiumcomp * TRITIUM_RADIOACTIVITY_MODIFIER) + (pluoxiumcomp * PLUOXIUM_RADIOACTIVITY_MODIFIER) + (bzcomp * BZ_RADIOACTIVITY_MODIFIER))) // Rad Modifiers BZ(500%), Tritium(300%), and Pluoxium(-200%)
 			radiation_pulse(src, last_rads)
 		if(bzcomp >= 0.4 && prob(30 * bzcomp))
 			src.fire_nuclear_particle()		// Start to emit radballs at a maximum of 30% chance per tick
@@ -476,10 +468,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			var/D = sqrt(1 / max(1, get_dist(l, src)))
 			l.hallucination += power * config_hallucination_power * D
 			l.hallucination = CLAMP(0, 200, l.hallucination)
-
-	for(var/mob/living/l in range(round((power / 100) ** 0.25), src))
-		var/rads = (power / 10) * sqrt( 1 / max(get_dist(l, src),1) )
-		l.rad_act(rads)
 
 	//Transitions between one function and another, one we use for the fast inital startup, the other is used to prevent errors with fusion temperatures.
 	//Use of the second function improves the power gain imparted by using co2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
First off, what this does _**NOT**_ do: It doesn't change how heat or power levels or gas production work, and it doesn't effect the most commonly used coolant gases (N2 and CO2) in any way.

What this _does_ is fix some very old bugs with SM radiation calculation, causing the amount of rads to differ from power, sometimes significantly, for the less-used gases.

Specifically, #785 added the current diversity of gasses to the SM, based on [TG's #45676](https://github.com/tgstation/tgstation/pull/45676). 11 days later, [#45676](https://github.com/tgstation/tgstation/pull/46040) fixed the off-by-100x bug that causes this to not work, but that never got ported to Bee.

Note that rather than directly fixing the mistake, I'm ripping out the `pluoxiumbonus` threshold test entirely. Hard cutoffs like that make control much harder to deal with; if any of the bonuses are too strong, they should be adjusted down, instead of having an arbitrary cutoff where they stop applying.

The rads formula was also messed up (bad parenthesis nesting), so that the power transmission multiplier only affected pluoxium. While fixing that, I also made the (previously useless) BZ rad bonus a regular bonus instead of the weird division thing it was; it's much easier to reason about and balance that way.

Lastly, I removed the weird loop that targets only living entities with extra radiation. In almost all cases, its effect could only reach 2 tiles, i.e. the area directly around the crystal and the walls. Now that pluoxium can reduce the SM radiation down to 0, it's very weird if you go into the SM chamber and your hair starts falling out due to rads you can't see with a Geiger counter or on the SM monitor.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes it actually worth using some of the other gasses, maybe. At the very least, it cleans up some buggy code. Pluoxium becomes viable as an "oh shit" gas, but because it nerfs power production so hard it can't be left in the core. It also means you have to deal with Pluox production aggressively in CO2 setups, or it will poison the output - which IMO is a good thing, since trying to do complicated things should be complicated.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
All testing was performed using the basic roundstart setup on Meta, straight-piped over all standard pumps. Both freezers were turned on and min-temp (73.15K).

I tested switching the filters from N2 to CO2+Pluoxium, i.e. forcing a fire by voiding the SM and then seeing how well it recovered. With everything pre-arranged perfectly (both freezers on, the filters set to both Pluox _and_ CO2), it is able to self-recover _just_ in time: One test got to 2% integrity, the other one 5%. This is slightly better than before, where it barely delaminates; most of the self-recovery comes from Pluoxium's ability to displace Oxygen and be a non-reactive gas, not because of the bonuses. Engineers not being on the ball, or an antagonist who sticks around (or does something besides this) can still easily get a delam.

<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots</summary>

Running an Oxygen/Nitrogen engine is possible on the roundstart setup, at least with no emitters! (Always was, this is not new, also not wise.) The new thing here is the difference between power and rads:
![eengine_oxygen](https://user-images.githubusercontent.com/459704/170477136-7207e34c-3e9c-4123-8475-103931187a87.png)

Add some tritium to make it extra spicy! When this inevitably catches fire, you can experience fusion in the SM chamber, which every engineer should do once in their life. (Again, the only new thing here is the amount of rads.)
![engine_trit](https://user-images.githubusercontent.com/459704/170474662-bb30cea5-ff40-41d5-aed8-e4fdbcf178a1.png)

Enough pluoxium will bring the radiation output down to 0. In this case, even though the emitters are running, it's safe to go into the SM chamber in a firesuit, or your jumpsuit if you don't mind freezing.
![engine-pluox](https://user-images.githubusercontent.com/459704/170475063-9437d428-7bdc-4b01-909b-4fe9bb423474.png)
</details>

## Changelog
:cl:
fix: Supermatter radiation code is fixed, can now vary significantly from power levels
fix: Pluoxium functions as the coolant it was meant to be, but nerfs power production
del: No more sneaky extra SM radiation that only targets living mobs, making it undetectable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
