### PR TITLE
Robo console shows all non emagged/syndie borgs to AIs

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -59,6 +59,7 @@
 			module = R.module ? "[R.module.name] Module" : "No Module Detected",
 			synchronization = R.connected_ai,
 			emagged =  R.emagged,
+			can_user_act = R.connected_ai == user || !isAI(user),
 			ref = REF(R)
 		)
 		data["cyborgs"] += list(cyborg_data)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -14,7 +14,7 @@
 	if(!istype(R))
 		return
 	if(isAI(user))
-		if(R.connected_ai != user)
+		if(R.emagged == TRUE)
 			return
 	if(iscyborg(user))
 		if(R != user)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -122,7 +122,7 @@
 		ResetModule()
 		return
 
-	SetEmagged(1)
+	SetEmagged(TRUE)
 	SetStun(60) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
 	lawupdate = FALSE
 	connected_ai = null

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -70,16 +70,16 @@ const Cyborgs = (props, context) => {
             )}
             <Button.Confirm
               icon={cyborg.locked_down ? 'unlock' : 'lock'}
-              color={cyborg.locked_down ? 'good' : 'default'}
+              color={cyborg.can_user_act ? (cyborg.locked_down ? 'good' : 'default') : 'grey'}
               content={cyborg.locked_down ? "Release" : "Lockdown"}
-              onClick={() => act('stopbot', {
+              onClick={() => cyborg.can_user_act && act('stopbot', {
                 ref: cyborg.ref,
               })} />
             <Button.Confirm
               icon="bomb"
               content="Detonate"
-              color="bad"
-              onClick={() => act('killbot', {
+              color={cyborg.can_user_act ? 'bad' : 'grey'}
+              onClick={() => cyborg.can_user_act && act('killbot', {
                 ref: cyborg.ref,
               })} />
           </>


### PR DESCRIPTION
## About The Pull Request

Fixes: #6877

As title says.

## Why It's Good For The Game

It makes no sense that every crewmember can see every borgo (linked or not linked, emagged or not) but AIs can't. It gets super annoying when you latejoin as AI, see a borg running around and you don't know what's going on.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: AIs can now see all non emagged/syndie borgs on the robo console
/:cl: