### PR TITLE
Small-ish xenomorph refactor, hunter and sentinel rebalance

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -87,6 +87,8 @@
 
 /mob/living/carbon/RangedAttack(atom/A, mouseparams)
 	. = ..()
+	if(!dna)
+		return
 	for(var/datum/mutation/HM as() in dna.mutations)
 		HM.on_ranged_attack(A, mouseparams)
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -261,7 +261,7 @@
 	config_entry_value = list(			//DEFAULTS
 	/mob/living/simple_animal = 1,
 	/mob/living/silicon/pai = 1,
-	/mob/living/carbon/alien/humanoid/hunter = -1,
+	/mob/living/carbon/alien/humanoid/hunter = -0.5,
 	/mob/living/carbon/alien/humanoid/royal/praetorian = 1,
 	/mob/living/carbon/alien/humanoid/royal/queen = 3
 	)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -91,7 +91,7 @@ Proc: AddInfectionImages()
 Des: Gives the client of the alien an image on each infected mob.
 ----------------------------------------*/
 /mob/living/carbon/alien/proc/AddInfectionImages()
-	if(client)
+	if(!client)
 		return
 	for(var/i in GLOB.mob_living_list)
 		var/mob/living/L = i

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -11,29 +11,23 @@
 	initial_language_holder = /datum/language_holder/alien
 	bubble_icon = "alien"
 	type_of_meat = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
-
-	var/has_fine_manipulation = 0
-	var/move_delay_add = 0 // movement delay to add
-
 	status_flags = CANUNCONSCIOUS|CANPUSH
-
-	var/heat_protection = 0.5
-	var/leaping = 0
 	gib_type = /obj/effect/decal/cleanable/xenoblood/xgibs
 	unique_name = 1
-
 	mobchatspan = "alienmobsay"
+
 	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|queen)( \\(\\d+\\))?")
+	var/heat_protection = 0.5
+	var/leaping = FALSE
+	var/has_fine_manipulation = FALSE
+	var/move_delay_add = 0 // movement delay to add
 
 /mob/living/carbon/alien/Initialize(mapload)
 	add_verb(/mob/living/proc/mob_sleep)
 	add_verb(/mob/living/proc/lay_down)
-
 	create_bodyparts() //initialize bodyparts
-
 	create_internal_organs()
-
-	. = ..()
+	return ..()
 
 /mob/living/carbon/alien/create_internal_organs()
 	internal_organs += new /obj/item/organ/brain/alien
@@ -42,7 +36,7 @@
 	internal_organs += new /obj/item/organ/eyes/night_vision/alien
 	internal_organs += new /obj/item/organ/liver/alien
 	internal_organs += new /obj/item/organ/ears
-	..()
+	return ..()
 
 /mob/living/carbon/alien/assess_threat(judgment_criteria, lasercolor = "", datum/callback/weaponcheck=null) // beepsky won't hunt aliums
 	return -10
@@ -54,8 +48,8 @@
 	var/loc_temp = get_temperature(environment)
 
 	// Aliens are now weak to fire.
-
 	//After then, it reacts to the surrounding atmosphere based on your thermal protection
+
 	if(!on_fire) // If you're on fire, ignore local air temperature
 		if(loc_temp > bodytemperature)
 			//Place is hotter than we are
@@ -82,7 +76,7 @@
 		clear_alert("alien_fire")
 
 /mob/living/carbon/alien/reagent_check(datum/reagent/R) //can metabolize all reagents
-	return 0
+	return FALSE
 
 /mob/living/carbon/alien/IsAdvancedToolUser()
 	return has_fine_manipulation
@@ -97,15 +91,15 @@ Proc: AddInfectionImages()
 Des: Gives the client of the alien an image on each infected mob.
 ----------------------------------------*/
 /mob/living/carbon/alien/proc/AddInfectionImages()
-	if (client)
-		for (var/i in GLOB.mob_living_list)
-			var/mob/living/L = i
-			if(HAS_TRAIT(L, TRAIT_XENO_HOST))
-				var/obj/item/organ/body_egg/alien_embryo/A = L.getorgan(/obj/item/organ/body_egg/alien_embryo)
-				if(A)
-					var/I = image('icons/mob/alien.dmi', loc = L, icon_state = "infected[A.stage]")
-					client.images += I
-	return
+	if(client)
+		return
+	for(var/i in GLOB.mob_living_list)
+		var/mob/living/L = i
+		if(HAS_TRAIT(L, TRAIT_XENO_HOST))
+			var/obj/item/organ/body_egg/alien_embryo/A = L.getorgan(/obj/item/organ/body_egg/alien_embryo)
+			if(A)
+				var/I = image('icons/mob/alien.dmi', loc = L, icon_state = "infected[A.stage]")
+				client.images += I
 
 
 /*----------------------------------------
@@ -113,7 +107,7 @@ Proc: RemoveInfectionImages()
 Des: Removes all infected images from the alien.
 ----------------------------------------*/
 /mob/living/carbon/alien/proc/RemoveInfectionImages()
-	if (client)
+	if(client)
 		for(var/image/I in client.images)
 			var/searchfor = "infected"
 			if(findtext(I.icon_state, searchfor, 1, length(searchfor) + 1))
@@ -121,7 +115,7 @@ Des: Removes all infected images from the alien.
 	return
 
 /mob/living/carbon/alien/canBeHandcuffed()
-	return 1
+	return TRUE
 
 /mob/living/carbon/alien/get_standard_pixel_y_offset(lying = 0)
 	return initial(pixel_y)

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -18,8 +18,7 @@ In all, this is a lot like the monkey code. /N
 		return
 
 	switch(M.a_intent)
-
-		if ("help")
+		if("help")
 			if(M == src && check_self_for_injuries())
 				return
 			set_resting(FALSE)
@@ -31,15 +30,15 @@ In all, this is a lot like the monkey code. /N
 			AdjustSleeping(-100)
 			visible_message("<span class='notice'>[M.name] nuzzles [src] trying to wake [p_them()] up!</span>")
 
-		if ("grab")
+		if("grab")
 			grabbedby(M)
 
 		else
-			if(health > 0)
+			if(health > 1)
 				M.do_attack_animation(src, ATTACK_EFFECT_BITE)
 				playsound(loc, 'sound/weapons/bite.ogg', 50, 1, -1)
-				visible_message("<span class='danger'>[M.name] bites [src]!</span>", \
-						"<span class='userdanger'>[M.name] bites you!</span>", null, COMBAT_MESSAGE_RANGE)
+				visible_message("<span class='danger'>[M.name] playfully bites [src]!</span>", \
+						"<span class='userdanger'>[M.name] playfully bites you!</span>", null, COMBAT_MESSAGE_RANGE)
 				adjustBruteLoss(1)
 				log_combat(M, src, "attacked")
 				updatehealth()
@@ -50,76 +49,57 @@ In all, this is a lot like the monkey code. /N
 /mob/living/carbon/alien/attack_larva(mob/living/carbon/alien/larva/L)
 	return attack_alien(L)
 
-
-/mob/living/carbon/alien/attack_hand(mob/living/carbon/human/M)
-	if(..())	//to allow surgery to return properly.
-		return 0
-
-	switch(M.a_intent)
-		if("help")
-			help_shake_act(M)
-		if("grab")
-			grabbedby(M)
-		if ("harm")
-			if(HAS_TRAIT(M, TRAIT_PACIFISM))
-				to_chat(M, "<span class='notice'>You don't want to hurt [src]!</span>")
-				return 0
-			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
-			return 1
-		if("disarm")
-			M.do_attack_animation(src, ATTACK_EFFECT_DISARM)
-			return 1
-	return 0
-
-
 /mob/living/carbon/alien/attack_paw(mob/living/carbon/monkey/M)
-	if(..())
-		if (stat != DEAD)
-			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
-			apply_damage(rand(3), BRUTE, affecting)
+	if(!..())
+		return
+	if(stat != DEAD)
+		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
+		apply_damage(rand(3), BRUTE, affecting)
 
 
 /mob/living/carbon/alien/attack_animal(mob/living/simple_animal/M)
-	. = ..()
-	if(.)
-		var/damage = M.melee_damage
-		switch(M.melee_damage_type)
-			if(BRUTE)
-				adjustBruteLoss(damage)
-			if(BURN)
-				adjustFireLoss(damage)
-			if(TOX)
-				adjustToxLoss(damage)
-			if(OXY)
-				adjustOxyLoss(damage)
-			if(CLONE)
-				adjustCloneLoss(damage)
-			if(STAMINA)
-				adjustStaminaLoss(damage)
+	if(!..())
+		return
+	var/damage = M.melee_damage
+	switch(M.melee_damage_type)
+		if(BRUTE)
+			adjustBruteLoss(damage)
+		if(BURN)
+			adjustFireLoss(damage)
+		if(TOX)
+			adjustToxLoss(damage)
+		if(OXY)
+			adjustOxyLoss(damage)
+		if(CLONE)
+			adjustCloneLoss(damage)
+		if(STAMINA)
+			adjustStaminaLoss(damage)
 
 /mob/living/carbon/alien/attack_slime(mob/living/simple_animal/slime/M)
-	if(..()) //successful slime attack
-		var/damage = rand(20)
-		if(M.is_adult)
-			damage = rand(30)
-		if(M.transformeffects & SLIME_EFFECT_RED)
-			damage *= 1.1
-		adjustBruteLoss(damage)
-		log_combat(M, src, "attacked")
-		updatehealth()
+	if(!..())
+		return //gotta be a successful slime attack
+	var/damage = rand(20)
+	if(M.is_adult)
+		damage = rand(30)
+	if(M.transformeffects & SLIME_EFFECT_RED)
+		damage *= 1.1
+	adjustBruteLoss(damage)
+	log_combat(M, src, "attacked")
+	updatehealth()
 
 /mob/living/carbon/alien/ex_act(severity, target, origin)
 	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))
 		return
-	..()
+	. = ..()
 	if(QDELETED(src))
 		return
-	switch (severity)
-		if (EXPLODE_DEVASTATE)
+
+	switch(severity)
+		if(EXPLODE_DEVASTATE)
 			gib()
 			return
 
-		if (EXPLODE_HEAVY)
+		if(EXPLODE_HEAVY)
 			take_overall_damage(60, 60)
 			adjustEarDamage(30,120)
 
@@ -130,7 +110,7 @@ In all, this is a lot like the monkey code. /N
 			adjustEarDamage(15,60)
 
 /mob/living/carbon/alien/soundbang_act(intensity = 1, stun_pwr = 20, damage_pwr = 5, deafen_pwr = 15)
-	return 0
+	return FALSE
 
 /mob/living/carbon/alien/acid_act(acidpwr, acid_volume)
-	return 0//aliens are immune to acid.
+	return FALSE//aliens are immune to acid.

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -56,6 +56,30 @@ In all, this is a lot like the monkey code. /N
 		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 		apply_damage(rand(3), BRUTE, affecting)
 
+/mob/living/carbon/alien/attack_hand(mob/living/carbon/human/M)
+	if(..())	//to allow surgery to return properly.
+		return
+
+	switch(M.a_intent)
+		if("harm", "disarm") //harm and disarm will do the same, I doubt trying to shove a xeno would go well for you
+			if(HAS_TRAIT(M, TRAIT_PACIFISM))
+				to_chat(M, "<span class='notice'>You don't want to hurt [src]!</span>")
+				return
+			playsound(loc, "punch", 25, 1, -1)
+			visible_message("<span class='danger'>[M] punches [src]!</span>", \
+					"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
+			var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
+			apply_damage(M.dna.species.punchdamage, BRUTE, affecting)
+			log_combat(M, src, "attacked")
+			M.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
+
+		if("help")
+			M.visible_message("<span class='notice'>[M] hugs [src] to make [src.p_them()] feel better!</span>", \
+								"<span class='notice'>You hug [src] to make [src.p_them()] feel better!</span>")
+			playsound(M.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+
+		if("grab")
+			grabbedby(M)
 
 /mob/living/carbon/alien/attack_animal(mob/living/simple_animal/M)
 	if(!..())

--- a/code/modules/mob/living/carbon/alien/damage_procs.dm
+++ b/code/modules/mob/living/carbon/alien/damage_procs.dm
@@ -1,13 +1,13 @@
 
 /mob/living/carbon/alien/getToxLoss()
-	return 0
+	return FALSE
 
 /mob/living/carbon/alien/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE) //alien immune to tox damage
 	return FALSE
 
 //aliens are immune to stamina damage.
 /mob/living/carbon/alien/adjustStaminaLoss(amount, updating_health = 1, forced = FALSE)
-	return
+	return FALSE
 
 /mob/living/carbon/alien/setStaminaLoss(amount, updating_health = 1)
-	return
+	return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -9,22 +9,20 @@ Doesn't work on other aliens/AI.*/
 /obj/effect/proc_holder/alien
 	name = "Alien Power"
 	panel = "Alien"
-	var/plasma_cost = 0
-	var/check_turf = FALSE
-	has_action = TRUE
 	base_action = /datum/action/spell_action/alien
 	action_icon = 'icons/mob/actions/actions_xeno.dmi'
-	action_icon_state = "spell_default"
 	action_background_icon_state = "bg_alien"
+	var/plasma_cost = 0
+	var/check_turf = FALSE
 
 /obj/effect/proc_holder/alien/Click()
 	if(!iscarbon(usr))
-		return 1
+		return FALSE
 	var/mob/living/carbon/user = usr
 	if(cost_check(check_turf,user))
 		if(fire(user) && user) // Second check to prevent runtimes when evolving
 			user.adjustPlasma(-plasma_cost)
-	return 1
+	return TRUE
 
 /obj/effect/proc_holder/alien/on_gain(mob/living/carbon/user)
 	return
@@ -33,7 +31,7 @@ Doesn't work on other aliens/AI.*/
 	return
 
 /obj/effect/proc_holder/alien/fire(mob/living/carbon/user)
-	return 1
+	return TRUE
 
 /obj/effect/proc_holder/alien/get_panel_text()
 	. = ..()
@@ -73,10 +71,10 @@ Doesn't work on other aliens/AI.*/
 /obj/effect/proc_holder/alien/plant/fire(mob/living/carbon/user)
 	if(locate(/obj/structure/alien/weeds/node) in get_turf(user))
 		to_chat(user, "There's already a weed node here.")
-		return 0
+		return FALSE
 	user.visible_message("<span class='alertalien'>[user] has planted some alien weeds!</span>")
-	new/obj/structure/alien/weeds/node(user.loc)
-	return 1
+	new/obj/structure/alien/weeds/node(get_turf(user))
+	return TRUE
 
 /obj/effect/proc_holder/alien/whisper
 	name = "Whisper"
@@ -86,30 +84,28 @@ Doesn't work on other aliens/AI.*/
 
 /obj/effect/proc_holder/alien/whisper/fire(mob/living/carbon/user)
 	var/list/options = list()
-	for(var/mob/living/Ms in oview(user))
-		options += Ms
+	for(var/mob/living/L in oview(user))
+		options += L
 	var/mob/living/M = input("Select who to whisper to:","Whisper to?",null) as null|mob in sortNames(options)
 	if(!M)
-		return 0
+		return FALSE
 	var/msg = stripped_input(usr, "Message:", "Alien Whisper")
-	if(msg)
-		log_directed_talk(user, M, msg, LOG_SAY, tag="alien whisper")
-		to_chat(M, "<span class='noticealien'>You hear a strange, alien voice in your head.</span>[msg]")
-		to_chat(user, "<span class='noticealien'>You said: \"[msg]\" to [M]</span>")
-		for(var/ded in GLOB.dead_mob_list)
-			if(!isobserver(ded))
-				continue
-			var/follow_link_user = FOLLOW_LINK(ded, user)
-			var/follow_link_whispee = FOLLOW_LINK(ded, M)
-			to_chat(ded, "[follow_link_user] <span class='name'>[user]</span> <span class='alertalien'>Alien Whisper --> </span> [follow_link_whispee] <span class='name'>[M]</span> <span class='noticealien'>[msg]</span>")
-	else
-		return 0
-	return 1
+	if(!msg)
+		return FALSE
+	log_directed_talk(user, M, msg, LOG_SAY, tag="alien whisper")
+	to_chat(M, "<span class='noticealien'>You hear a strange, alien voice in your head.</span>[msg]")
+	to_chat(user, "<span class='noticealien'>You said: \"[msg]\" to [M]</span>")
+	for(var/ded in GLOB.dead_mob_list)
+		if(!isobserver(ded))
+			continue
+		var/follow_link_user = FOLLOW_LINK(ded, user)
+		var/follow_link_whispee = FOLLOW_LINK(ded, M)
+		to_chat(ded, "[follow_link_user] <span class='name'>[user]</span> <span class='alertalien'>Alien Whisper --> </span> [follow_link_whispee] <span class='name'>[M]</span> <span class='noticealien'>[msg]</span>")
+	return TRUE
 
 /obj/effect/proc_holder/alien/transfer
 	name = "Transfer Plasma"
 	desc = "Transfer Plasma to another alien."
-	plasma_cost = 0
 	action_icon_state = "alien_transfer"
 
 /obj/effect/proc_holder/alien/transfer/fire(mob/living/carbon/user)
@@ -121,16 +117,19 @@ Doesn't work on other aliens/AI.*/
 	if(!M)
 		return 0
 	var/amount = input("Amount:", "Transfer Plasma to [M]") as num
-	if (amount)
-		amount = min(abs(round(amount)), user.getPlasma())
-		if (get_dist(user,M) <= 1)
-			M.adjustPlasma(amount)
-			user.adjustPlasma(-amount)
-			to_chat(M, "<span class='noticealien'>[user] has transferred [amount] plasma to you.</span>")
-			to_chat(user, "<span class='noticealien'>You transfer [amount] plasma to [M]</span>")
-		else
-			to_chat(user, "<span class='noticealien'>You need to be closer!</span>")
-	return
+	amount = min(abs(round(amount)), user.getPlasma())
+	if(!amount)
+		return FALSE
+
+	if(!get_dist(user,M) <= 1)
+		to_chat(user, "<span class='noticealien'>You need to be closer!</span>")
+		return FALSE
+
+	M.adjustPlasma(amount)
+	user.adjustPlasma(-amount)
+	to_chat(M, "<span class='noticealien'>[user] has transferred [amount] plasma to you.</span>")
+	to_chat(user, "<span class='noticealien'>You transfer [amount] plasma to [M]</span>")
+	return TRUE
 
 /obj/effect/proc_holder/alien/acid
 	name = "Corrosive Acid"
@@ -231,18 +230,18 @@ Doesn't work on other aliens/AI.*/
 	remove_ranged_ability()
 
 /obj/effect/proc_holder/alien/neurotoxin/add_ranged_ability(mob/living/user,msg,forced)
-	..()
+	. = ..()
 	if(isalienadult(user))
 		var/mob/living/carbon/alien/humanoid/A = user
-		A.drooling = 1
+		A.drooling = TRUE
 		A.update_icons()
 
 /obj/effect/proc_holder/alien/neurotoxin/remove_ranged_ability(msg)
 	if(isalienadult(ranged_ability_user))
 		var/mob/living/carbon/alien/humanoid/A = ranged_ability_user
-		A.drooling = 0
+		A.drooling = FALSE
 		A.update_icons()
-	..()
+	return ..()
 
 /obj/effect/proc_holder/alien/resin
 	name = "Secrete Resin"
@@ -267,31 +266,29 @@ Doesn't work on other aliens/AI.*/
 	var/choice = input("Choose what you wish to shape.","Resin building") as null|anything in structures
 	if(!choice)
 		return FALSE
-	if (!cost_check(check_turf,user))
+	if(!cost_check(check_turf,user))
 		return FALSE
-	to_chat(user, "<span class='notice'>You shape a [choice].</span>")
-	user.visible_message("<span class='notice'>[user] vomits up a thick purple substance and begins to shape it.</span>")
+	user.visible_message("<span class='notice'>[user] vomits up a thick purple substance and begins to shape it.</span>", "<span class='notice'>You shape a [choice].</span>")
 
 	choice = structures[choice]
-	new choice(user.loc)
+	new choice(get_turf(user))
 	return TRUE
 
 /obj/effect/proc_holder/alien/sneak
 	name = "Sneak"
 	desc = "Blend into the shadows to stalk your prey."
 	active = 0
-
 	action_icon_state = "alien_sneak"
 
 /obj/effect/proc_holder/alien/sneak/fire(mob/living/carbon/alien/humanoid/user)
 	if(!active)
 		user.alpha = 75 //Still easy to see in lit areas with bright tiles, almost invisible on resin.
-		user.sneaking = 1
+		user.sneaking = TRUE
 		active = 1
 		to_chat(user, "<span class='noticealien'>You blend into the shadows.</span>")
 	else
 		user.alpha = initial(user.alpha)
-		user.sneaking = 0
+		user.sneaking = FALSE
 		active = 0
 		to_chat(user, "<span class='noticealien'>You reveal yourself!</span>")
 
@@ -299,21 +296,21 @@ Doesn't work on other aliens/AI.*/
 /mob/living/carbon/proc/getPlasma()
 	var/obj/item/organ/alien/plasmavessel/vessel = getorgan(/obj/item/organ/alien/plasmavessel)
 	if(!vessel)
-		return 0
+		return FALSE
 	return vessel.storedPlasma
 
 
 /mob/living/carbon/proc/adjustPlasma(amount)
 	var/obj/item/organ/alien/plasmavessel/vessel = getorgan(/obj/item/organ/alien/plasmavessel)
 	if(!vessel)
-		return 0
+		return FALSE
 	vessel.storedPlasma = max(vessel.storedPlasma + amount,0)
 	vessel.storedPlasma = min(vessel.storedPlasma, vessel.max_plasma) //upper limit of max_plasma, lower limit of 0
 	for(var/X in abilities)
 		var/obj/effect/proc_holder/alien/APH = X
 		if(APH.has_action)
 			APH.action.UpdateButtonIcon()
-	return 1
+	return TRUE
 
 /mob/living/carbon/alien/adjustPlasma(amount)
 	. = ..()
@@ -322,6 +319,5 @@ Doesn't work on other aliens/AI.*/
 /mob/living/carbon/proc/usePlasma(amount)
 	if(getPlasma() >= amount)
 		adjustPlasma(-amount)
-		return 1
-
-	return 0
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -13,31 +13,30 @@
 	internal_organs += new /obj/item/organ/alien/plasmavessel/large
 	internal_organs += new /obj/item/organ/alien/resinspinner
 	internal_organs += new /obj/item/organ/alien/acid
-	..()
+	return ..()
 
 /obj/effect/proc_holder/alien/evolve
 	name = "Evolve to Praetorian"
 	desc = "Praetorian"
 	plasma_cost = 500
-
 	action_icon_state = "alien_evolve_drone"
 
 /obj/effect/proc_holder/alien/evolve/fire(mob/living/carbon/alien/humanoid/user)
 	var/obj/item/organ/alien/hivenode/node = user.getorgan(/obj/item/organ/alien/hivenode)
 	if(!node) //Players are Murphy's Law. We may not expect there to ever be a living xeno with no hivenode, but they _WILL_ make it happen.
 		to_chat(user, "<span class='danger'>Without the hivemind, you can't possibly hold the responsibility of leadership!</span>")
-		return 0
+		return FALSE
 	if(node.recent_queen_death)
 		to_chat(user, "<span class='danger'>Your thoughts are still too scattered to take up the position of leadership.</span>")
-		return 0
+		return FALSE
 
 	if(!isturf(user.loc))
 		to_chat(user, "<span class='notice'>You can't evolve here!</span>")
-		return 0
-	if(!get_alien_type(/mob/living/carbon/alien/humanoid/royal))
-		var/mob/living/carbon/alien/humanoid/royal/praetorian/new_xeno = new (user.loc)
+		return FALSE
+	if(!get_alien_type_in_hive(/mob/living/carbon/alien/humanoid/royal))
+		var/mob/living/carbon/alien/humanoid/royal/praetorian/new_xeno = new(user.loc)
 		user.alien_evolve(new_xeno)
-		return 1
+		return TRUE
 	else
 		to_chat(user, "<span class='notice'>We already have a living royal!</span>")
-		return 0
+		return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -4,29 +4,27 @@
 	maxHealth = 125
 	health = 125
 	icon_state = "alienh"
-	var/atom/movable/screen/leap_icon = null
+	var/atom/movable/screen/leap_icon
 
 /mob/living/carbon/alien/humanoid/hunter/create_internal_organs()
 	internal_organs += new /obj/item/organ/alien/plasmavessel/small
-	..()
+	return ..()
 
 //Hunter verbs
 
-/mob/living/carbon/alien/humanoid/hunter/proc/toggle_leap(message = 1)
+/mob/living/carbon/alien/humanoid/hunter/proc/toggle_leap(message = TRUE)
 	leap_on_click = !leap_on_click
-	leap_icon.icon_state = "leap_[leap_on_click ? "on":"off"]"
+	leap_icon.icon_state = "leap_[leap_on_click ? "on" : "off"]"
 	update_icons()
 	if(message)
-		to_chat(src, "<span class='noticealien'>You will now [leap_on_click ? "leap at":"slash at"] enemies!</span>")
-	else
-		return
+		to_chat(src, "<span class='noticealien'>You will now [leap_on_click ? "leap at" : "slash at"] enemies!</span>")
 
 /mob/living/carbon/alien/humanoid/hunter/ClickOn(atom/A, params)
 	face_atom(A)
 	if(leap_on_click)
 		leap_at(A)
 	else
-		..()
+		return ..()
 
 #define MAX_ALIEN_LEAP_DIST 7
 
@@ -34,7 +32,7 @@
 	if((mobility_flags & (MOBILITY_MOVE | MOBILITY_STAND)) != (MOBILITY_MOVE | MOBILITY_STAND) || leaping)
 		return
 
-	if(pounce_cooldown > world.time)
+	if(!(COOLDOWN_FINISHED(src, pounce_cooldown)))
 		to_chat(src, "<span class='alertalien'>You are too fatigued to pounce right now!</span>")
 		return
 
@@ -43,23 +41,23 @@
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return
 
-	else //Maybe uses plasma in the future, although that wouldn't make any sense...
-		leaping = 1
-		weather_immunities += "lava"
-		update_icons()
-		throw_at(A, MAX_ALIEN_LEAP_DIST, 1, src, FALSE, TRUE, callback = CALLBACK(src, .proc/leap_end))
+	leaping = TRUE
+	weather_immunities += "lava"
+	update_icons()
+	throw_at(A, MAX_ALIEN_LEAP_DIST, 1, src, FALSE, TRUE, callback = CALLBACK(src, .proc/leap_end))
+
+#undef MAX_ALIEN_LEAP_DIST
 
 /mob/living/carbon/alien/humanoid/hunter/proc/leap_end()
-	leaping = 0
+	leaping = FALSE
 	weather_immunities -= "lava"
 	update_icons()
 
 /mob/living/carbon/alien/humanoid/hunter/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-
 	if(!leaping)
 		return ..()
 
-	pounce_cooldown = world.time + pounce_cooldown_time
+	COOLDOWN_START(src, pounce_cooldown, 30)
 	if(hit_atom)
 		if(isliving(hit_atom))
 			var/mob/living/L = hit_atom
@@ -72,11 +70,11 @@
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
 				L.Paralyze(100)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
-				step_towards(src,L)
+				step_towards(src, L)
 			else
 				Paralyze(40, 1, 1)
 
-			toggle_leap(0)
+			toggle_leap(FALSE)
 		else if(hit_atom.density && !hit_atom.CanPass(src))
 			visible_message("<span class ='danger'>[src] smashes into [hit_atom]!</span>", "<span class ='alertalien'>[src] smashes into [hit_atom]!</span>")
 			Paralyze(40, 1, 1)
@@ -86,10 +84,7 @@
 			update_icons()
 			update_mobility()
 
-
 /mob/living/carbon/alien/humanoid/float(on)
 	if(leaping)
 		return
-	..()
-
-
+	return ..()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/hunter
 	name = "alien hunter"
 	caste = "h"
-	maxHealth = 125
-	health = 125
+	maxHealth = 200
+	health = 200
 	icon_state = "alienh"
 	var/atom/movable/screen/leap_icon
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/praetorian.dm
@@ -16,27 +16,26 @@
 	internal_organs += new /obj/item/organ/alien/resinspinner
 	internal_organs += new /obj/item/organ/alien/acid
 	internal_organs += new /obj/item/organ/alien/neurotoxin
-	..()
+	return ..()
 
 /obj/effect/proc_holder/alien/royal/praetorian/evolve
 	name = "Evolve"
 	desc = "Produce an internal egg sac capable of spawning children. Only one queen can exist at a time. Costs 500 Plasma."
 	plasma_cost = 500
-
 	action_icon_state = "alien_evolve_praetorian"
 
 /obj/effect/proc_holder/alien/royal/praetorian/evolve/fire(mob/living/carbon/alien/humanoid/user)
 	var/obj/item/organ/alien/hivenode/node = user.getorgan(/obj/item/organ/alien/hivenode)
 	if(!node) //Just in case this particular Praetorian gets violated and kept by the RD as a replacement for Lamarr.
 		to_chat(user, "<span class='danger'>Without the hivemind, you would be unfit to rule as queen!</span>")
-		return 0
+		return FALSE
 	if(node.recent_queen_death)
 		to_chat(user, "<span class='danger'>You are still too burdened with guilt to evolve into a queen.</span>")
-		return 0
-	if(!get_alien_type(/mob/living/carbon/alien/humanoid/royal/queen))
-		var/mob/living/carbon/alien/humanoid/royal/queen/new_xeno = new (user.loc)
+		return FALSE
+	if(!get_alien_type_in_hive(/mob/living/carbon/alien/humanoid/royal/queen))
+		var/mob/living/carbon/alien/humanoid/royal/queen/new_xeno = new(user.loc)
 		user.alien_evolve(new_xeno)
-		return 1
+		return TRUE
 	else
 		to_chat(user, "<span class='notice'>We already have an alive queen.</span>")
-		return 0
+		return FALSE

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/sentinel
 	name = "alien sentinel"
 	caste = "s"
-	maxHealth = 150
-	health = 150
+	maxHealth = 225
+	health = 225
 	icon_state = "aliens"
 
 /mob/living/carbon/alien/humanoid/sentinel/Initialize(mapload)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -13,4 +13,4 @@
 	internal_organs += new /obj/item/organ/alien/plasmavessel
 	internal_organs += new /obj/item/organ/alien/acid
 	internal_organs += new /obj/item/organ/alien/neurotoxin
-	..()
+	return ..()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -4,20 +4,19 @@
 	pass_flags = PASSTABLE
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
-	limb_destroyer = 1
+	limb_destroyer = TRUE
 	hud_type = /datum/hud/alien
-	var/caste = ""
-	var/alt_icon = 'icons/mob/alienleap.dmi' //used to switch between the two alien icon files.
-	var/leap_on_click = 0
-	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 30
-	var/custom_pixel_x_offset = 0 //for admin fuckery.
-	var/custom_pixel_y_offset = 0
-	var/sneaking = 0 //For sneaky-sneaky mode and appropriate slowdown
-	var/drooling = 0 //For Neurotoxic spit overlays
 	deathsound = 'sound/voice/hiss6.ogg'
 	bodyparts = list(/obj/item/bodypart/chest/alien, /obj/item/bodypart/head/alien, /obj/item/bodypart/l_arm/alien,
-					 /obj/item/bodypart/r_arm/alien, /obj/item/bodypart/r_leg/alien, /obj/item/bodypart/l_leg/alien)
+					/obj/item/bodypart/r_arm/alien, /obj/item/bodypart/r_leg/alien, /obj/item/bodypart/l_leg/alien)
+	var/caste = ""
+	var/alt_icon = 'icons/mob/alienleap.dmi' //used to switch between the two alien icon files.
+	var/leap_on_click = FALSE
+	COOLDOWN_DECLARE(pounce_cooldown)
+	var/custom_pixel_x_offset = 0 //for admin fuckery.
+	var/custom_pixel_y_offset = 0
+	var/sneaking = FALSE //For sneaky-sneaky mode and appropriate slowdown
+	var/drooling = FALSE //For Neurotoxic spit overlays
 
 GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	/datum/strippable_item/hand/left,
@@ -65,10 +64,10 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 
 /mob/living/carbon/alien/humanoid/alien_evolve(mob/living/carbon/alien/humanoid/new_xeno)
 	drop_all_held_items()
-	..()
+	return ..()
 
 //For alien evolution/promotion/queen finder procs. Checks for an active alien of that type
-/proc/get_alien_type(var/alienpath)
+/proc/get_alien_type_in_hive(datum/alienpath)
 	for(var/mob/living/carbon/alien/humanoid/A in GLOB.alive_mob_list)
 		if(!istype(A, alienpath))
 			continue
@@ -77,8 +76,7 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 		return A
 	return FALSE
 
-
 /mob/living/carbon/alien/humanoid/check_breath(datum/gas_mixture/breath)
 	if(breath && breath.total_moles() > 0 && !sneaking)
 		playsound(get_turf(src), pick('sound/voice/lowHiss2.ogg', 'sound/voice/lowHiss3.ogg', 'sound/voice/lowHiss4.ogg'), 50, 0, -5)
-	..()
+	return ..()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -1,5 +1,3 @@
-
-
 /mob/living/carbon/alien/humanoid/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
 	if(user.a_intent == INTENT_HARM)
 		..(user, 1)
@@ -13,41 +11,9 @@
 		playsound(loc, "punch", 25, 1, -1)
 		visible_message("<span class='danger'>[user] [hitverb] [src]!</span>", \
 		"<span class='userdanger'>[user] [hitverb] you!</span>", null, COMBAT_MESSAGE_RANGE)
-		return 1
-
-/mob/living/carbon/alien/humanoid/attack_hand(mob/living/carbon/human/M)
-	if(..())
-		switch(M.a_intent)
-			if ("harm")
-				playsound(loc, "punch", 25, 1, -1)
-				visible_message("<span class='danger'>[M] punches [src]!</span>", \
-						"<span class='userdanger'>[M] punches you!</span>", null, COMBAT_MESSAGE_RANGE)
-				var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
-				apply_damage(M.dna.species.punchdamage, BRUTE, affecting)
-				log_combat(M, src, "attacked")
-
-			if ("disarm")
-				if (!(mobility_flags & MOBILITY_STAND))
-					if (prob(5))
-						Unconscious(40)
-						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-						log_combat(M, src, "pushed")
-						visible_message("<span class='danger'>[M] pushed [src] down!</span>", \
-							"<span class='userdanger'>[M] pushed you down!</span>")
-					else
-						if (prob(50))
-							dropItemToGround(get_active_held_item())
-							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-							visible_message("<span class='danger'>[M] disarms [src]!</span>", \
-							"<span class='userdanger'>[M] disarms you!</span>", null, COMBAT_MESSAGE_RANGE)
-						else
-							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-							visible_message("<span class='danger'>[M] fails to disarm [src]!</span>",\
-								"<span class='userdanger'>[M] fails to disarm you!</span>", null, COMBAT_MESSAGE_RANGE)
-
-
+		return TRUE
 
 /mob/living/carbon/alien/humanoid/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
 	if(!no_effect && !visual_effect_icon)
 		visual_effect_icon = ATTACK_EFFECT_CLAW
-	..()
+	return ..()

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -1,13 +1,11 @@
-
-
 /mob/living/carbon/alien/humanoid/proc/adjust_body_temperature(current, loc_temp, boost)
 	var/temperature = current
 	var/difference = abs(current-loc_temp)	//get difference
 	var/increments// = difference/10			//find how many increments apart they are
 	if(difference > 50)
-		increments = difference/5
+		increments = difference * 0.2
 	else
-		increments = difference/10
+		increments = difference * 0.1
 	var/change = increments*boost	// Get the amount to change by (x per increment)
 	var/temp_change
 	if(current < loc_temp)

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -135,7 +135,7 @@
 
 /obj/effect/proc_holder/alien/royal/queen/promote/fire(mob/living/carbon/alien/user)
 	var/obj/item/queenpromote/prom
-	if(get_alien_type(/mob/living/carbon/alien/humanoid/royal/praetorian/))
+	if(get_alien_type_in_hive(/mob/living/carbon/alien/humanoid/royal/praetorian/))
 		to_chat(user, "<span class='noticealien'>You already have a Praetorian!</span>")
 		return 0
 	else
@@ -167,7 +167,7 @@
 	if(!isalienadult(M) || isalienroyal(M))
 		to_chat(user, "<span class='noticealien'>You may only use this with your adult, non-royal children!</span>")
 		return
-	if(get_alien_type(/mob/living/carbon/alien/humanoid/royal/praetorian/))
+	if(get_alien_type_in_hive(/mob/living/carbon/alien/humanoid/royal/praetorian/))
 		to_chat(user, "<span class='noticealien'>You already have a Praetorian!</span>")
 		return
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/alien/Life()
 	findQueen()
-	return..()
+	return ..()
 
 /mob/living/carbon/alien/check_breath(datum/gas_mixture/breath)
 	if(status_flags & GODMODE)
@@ -15,9 +15,9 @@
 	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*breath.return_temperature())/BREATH_VOLUME
 
 	//Partial pressure of the toxins in our breath
-	var/Toxins_pp = (breath.get_moles(GAS_PLASMA)/breath.total_moles())*breath_pressure
+	var/toxins_pp = (breath.get_moles(GAS_PLASMA)/breath.total_moles())*breath_pressure
 
-	if(Toxins_pp > tox_detect_threshold) // Detect toxins in air
+	if(toxins_pp > tox_detect_threshold) // Detect toxins in air
 		adjustPlasma(breath.get_moles(GAS_PLASMA)*250)
 		throw_alert("alien_tox", /atom/movable/screen/alert/alien_tox)
 

--- a/code/modules/mob/living/carbon/alien/login.dm
+++ b/code/modules/mob/living/carbon/alien/login.dm
@@ -1,4 +1,3 @@
 /mob/living/carbon/alien/Login()
-	..()
+	. = ..()
 	AddInfectionImages()
-	return

--- a/code/modules/mob/living/carbon/alien/logout.dm
+++ b/code/modules/mob/living/carbon/alien/logout.dm
@@ -1,4 +1,3 @@
 /mob/living/carbon/alien/Logout()
 	..()
 	RemoveInfectionImages()
-	return

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -14,21 +14,19 @@
 	return ..()
 
 /obj/item/organ/alien/Insert(mob/living/carbon/M, special = 0)
-	..()
+	. = ..()
 	for(var/obj/effect/proc_holder/alien/P in alien_powers)
 		M.AddAbility(P)
-
 
 /obj/item/organ/alien/Remove(mob/living/carbon/M, special = 0)
 	for(var/obj/effect/proc_holder/alien/P in alien_powers)
 		M.RemoveAbility(P)
-	..()
+	return ..()
 
 /obj/item/organ/alien/prepare_eat()
 	var/obj/S = ..()
 	S.reagents.add_reagent(/datum/reagent/toxin/acid, 10)
 	return S
-
 
 /obj/item/organ/alien/plasmavessel
 	name = "plasma vessel"
@@ -92,16 +90,18 @@
 		owner.adjustPlasma(plasma_rate * 0.1)
 
 /obj/item/organ/alien/plasmavessel/Insert(mob/living/carbon/M, special = 0)
-	..()
-	if(isalien(M))
-		var/mob/living/carbon/alien/A = M
-		A.updatePlasmaDisplay()
+	. = ..()
+	if(!isalien(M))
+		return
+	var/mob/living/carbon/alien/A = M
+	A.updatePlasmaDisplay()
 
 /obj/item/organ/alien/plasmavessel/Remove(mob/living/carbon/M, special = 0)
-	..()
-	if(isalien(M))
-		var/mob/living/carbon/alien/A = M
-		A.updatePlasmaDisplay()
+	. = ..()
+	if(!isalien(M))
+		return
+	var/mob/living/carbon/alien/A = M
+	A.updatePlasmaDisplay()
 
 #define QUEEN_DEATH_DEBUFF_DURATION 2400
 
@@ -111,18 +111,18 @@
 	zone = BODY_ZONE_HEAD
 	slot = "hivenode"
 	w_class = WEIGHT_CLASS_TINY
-	var/recent_queen_death = 0 //Indicates if the queen died recently, aliens are heavily weakened while this is active.
 	alien_powers = list(/obj/effect/proc_holder/alien/whisper)
+	var/recent_queen_death = 0 //Indicates if the queen died recently, aliens are heavily weakened while this is active.
 
 /obj/item/organ/alien/hivenode/Insert(mob/living/carbon/M, special = 0)
-	..()
 	M.faction |= ROLE_ALIEN
 	ADD_TRAIT(M, TRAIT_XENO_IMMUNE, "xeno immune")
+	return ..()
 
 /obj/item/organ/alien/hivenode/Remove(mob/living/carbon/M, special = 0)
 	M.faction -= ROLE_ALIEN
 	REMOVE_TRAIT(M, TRAIT_XENO_IMMUNE, "xeno immune")
-	..()
+	return ..()
 
 //When the alien queen dies, all aliens suffer a penalty as punishment for failing to protect her.
 /obj/item/organ/alien/hivenode/proc/queen_death()
@@ -143,7 +143,7 @@
 	owner.confused += 30
 	owner.stuttering += 30
 
-	recent_queen_death = 1
+	recent_queen_death = TRUE
 	owner.throw_alert("alien_noqueen", /atom/movable/screen/alert/alien_vulnerable)
 	addtimer(CALLBACK(src, .proc/clear_queen_death), QUEEN_DEATH_DEBUFF_DURATION)
 
@@ -151,7 +151,7 @@
 /obj/item/organ/alien/hivenode/proc/clear_queen_death()
 	if(QDELETED(src)) //In case the node is deleted
 		return
-	recent_queen_death = 0
+	recent_queen_death = FALSE
 	if(!owner) //In case the xeno is butchered or subjected to surgery after death.
 		return
 	to_chat(owner, "<span class='noticealien'>The pain of the queen's death is easing. You begin to hear the hivemind again.</span>")

--- a/code/modules/mob/living/carbon/alien/say.dm
+++ b/code/modules/mob/living/carbon/alien/say.dm
@@ -1,5 +1,5 @@
 /mob/living/proc/alien_talk(message, shown_name = real_name)
-	src.log_talk(message, LOG_SAY)
+	log_talk(message, LOG_SAY)
 	message = trim(message)
 	if(!message)
 		return
@@ -15,7 +15,7 @@
 
 /mob/living/carbon/alien/humanoid/royal/queen/alien_talk(message, shown_name = name)
 	shown_name = "<FONT size = 3>[shown_name]</FONT>"
-	..(message, shown_name)
+	return ..(message, shown_name)
 
 /mob/living/carbon/hivecheck()
 	var/obj/item/organ/alien/hivenode/N = getorgan(/obj/item/organ/alien/hivenode)

--- a/code/modules/mob/living/carbon/alien/screen.dm
+++ b/code/modules/mob/living/carbon/alien/screen.dm
@@ -1,33 +1,35 @@
 
 /mob/living/carbon/alien/proc/updatePlasmaDisplay()
-	if(hud_used) //clientless aliens
-		hud_used.alien_plasma_display.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='magenta'>[round(getPlasma())]</font></div>")
+	if(!hud_used) //clientless aliens
+		return
+	hud_used.alien_plasma_display.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='magenta'>[round(getPlasma())]</font></div>")
 
 /mob/living/carbon/alien/larva/updatePlasmaDisplay()
 	return
 
 /mob/living/carbon/alien/proc/findQueen()
-	if(hud_used)
-		hud_used.alien_queen_finder.cut_overlays()
-		var/mob/queen = get_alien_type(/mob/living/carbon/alien/humanoid/royal/queen)
-		if(!queen)
-			return
-		var/turf/Q = get_turf(queen)
-		var/turf/A = get_turf(src)
-		if(Q.get_virtual_z_level() != A.get_virtual_z_level()) //The queen is on a different Z level, we cannot sense that far.
-			return
-		var/Qdir = get_dir(src, Q)
-		var/Qdist = get_dist(src, Q)
-		var/finder_icon = "finder_center" //Overlay showed when adjacent to or on top of the queen!
-		switch(Qdist)
-			if(2 to 7)
-				finder_icon = "finder_near"
-			if(8 to 20)
-				finder_icon = "finder_med"
-			if(21 to INFINITY)
-				finder_icon = "finder_far"
-		var/image/finder_eye = image('icons/mob/screen_alien.dmi', finder_icon, dir = Qdir)
-		hud_used.alien_queen_finder.add_overlay(finder_eye)
+	if(!hud_used)
+		return
+	hud_used.alien_queen_finder.cut_overlays()
+	var/mob/queen = get_alien_type_in_hive(/mob/living/carbon/alien/humanoid/royal/queen)
+	if(!queen)
+		return
+	var/turf/Q = get_turf(queen)
+	var/turf/A = get_turf(src)
+	if(Q.get_virtual_z_level() != A.get_virtual_z_level()) //The queen is on a different Z level, we cannot sense that far.
+		return
+	var/Qdir = get_dir(src, Q)
+	var/Qdist = get_dist(src, Q)
+	var/finder_icon = "finder_center" //Overlay showed when adjacent to or on top of the queen!
+	switch(Qdist)
+		if(2 to 7)
+			finder_icon = "finder_near"
+		if(8 to 20)
+			finder_icon = "finder_med"
+		if(21 to INFINITY)
+			finder_icon = "finder_far"
+	var/image/finder_eye = image('icons/mob/screen_alien.dmi', finder_icon, dir = Qdir)
+	hud_used.alien_queen_finder.add_overlay(finder_eye)
 
 /mob/living/carbon/alien/humanoid/royal/queen/findQueen()
 	return //Queen already knows where she is. Hopefully.

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -8,7 +8,7 @@
 	var/bursting = FALSE
 
 /obj/item/organ/body_egg/alien_embryo/on_find(mob/living/finder)
-	..()
+	. = ..()
 	if(stage < 4)
 		to_chat(finder, "It's small and weak, barely the size of a foetus.")
 	else

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -240,7 +240,7 @@
 
 	icon_state = "[initial(icon_state)]_dead"
 	item_state = "facehugger_inactive"
-	stat == DEAD
+	stat = DEAD
 
 	visible_message("<span class='danger'>[src] curls up into a ball!</span>")
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -23,11 +23,9 @@
 	max_integrity = 100
 
 	var/stat = CONSCIOUS //UNCONSCIOUS is the idle state in this case
-
 	var/sterile = FALSE
 	var/real = TRUE //0 for the toy, 1 for real. Sure I could istype, but fuck that.
 	var/strength = 5
-
 	var/attached = 0
 
 /obj/item/clothing/mask/facehugger/Initialize(mapload)
@@ -39,7 +37,7 @@
 
 /obj/item/clothing/mask/facehugger/lamarr
 	name = "Lamarr"
-	sterile = 1
+	sterile = TRUE
 
 /obj/item/clothing/mask/facehugger/dead
 	icon_state = "facehugger_dead"
@@ -52,7 +50,7 @@
 	stat = DEAD
 
 /obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
-	..()
+	. = ..()
 	if(obj_integrity < 90)
 		Die()
 
@@ -67,10 +65,10 @@
 	if((stat == CONSCIOUS && !sterile) && !isalien(user))
 		if(Leap(user))
 			return
-	. = ..()
+	return ..()
 
 /obj/item/clothing/mask/facehugger/attack(mob/living/M, mob/user)
-	..()
+	. = ..()
 	if(user.transferItemToLoc(src, get_turf(M)))
 		Leap(M)
 
@@ -79,11 +77,11 @@
 	if(!real)//So that giant red text about probisci doesn't show up.
 		return
 	switch(stat)
-		if(DEAD,UNCONSCIOUS)
+		if(DEAD, UNCONSCIOUS)
 			. += "<span class='boldannounce'>[src] is not moving.</span>"
 		if(CONSCIOUS)
 			. += "<span class='boldannounce'>[src] seems to be active!</span>"
-	if (sterile)
+	if(sterile)
 		. += "<span class='boldannounce'>It looks like the proboscis has been removed.</span>"
 
 
@@ -98,17 +96,16 @@
 	SIGNAL_HANDLER
 
 	HasProximity(target)
-	return
 
 /obj/item/clothing/mask/facehugger/on_found(mob/finder)
 	if(stat == CONSCIOUS)
 		return HasProximity(finder)
-	return 0
+	return FALSE
 
 /obj/item/clothing/mask/facehugger/HasProximity(atom/movable/AM as mob|obj)
 	if(CanHug(AM) && Adjacent(AM))
 		return Leap(AM)
-	return 0
+	return FALSE
 
 /obj/item/clothing/mask/facehugger/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, quickstart = TRUE)
 	if(!..())
@@ -122,7 +119,7 @@
 		icon_state = "[initial(icon_state)]"
 
 /obj/item/clothing/mask/facehugger/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	..()
+	. = ..()
 	if(stat == CONSCIOUS)
 		icon_state = "[initial(icon_state)]"
 		Leap(hit_atom)
@@ -130,20 +127,15 @@
 /obj/item/clothing/mask/facehugger/proc/valid_to_attach(mob/living/M)
 	// valid targets: carbons except aliens and devils
 	// facehugger state early exit checks
-	if(stat != CONSCIOUS)
-		return FALSE
-	if(attached)
+	if(stat != CONSCIOUS || attached)
 		return FALSE
 	if(iscarbon(M))
 		// disallowed carbons
 		if(isalien(M) || isdevil(M))
 			return FALSE
 		var/mob/living/carbon/target = M
-		// gotta have a head to be implanted (no changelings or sentient plants)
-		if(!target.get_bodypart(BODY_ZONE_HEAD))
-			return FALSE
-		// gotta be able to have the xeno implanted
-		if(HAS_TRAIT(target, TRAIT_XENO_IMMUNE))
+		// gotta have a head to be implanted (no changelings or sentient plants), gotta be able to have the xeno implanted
+		if(!target.get_bodypart(BODY_ZONE_HEAD) || HAS_TRAIT(target, TRAIT_XENO_IMMUNE))
 			return FALSE
 		// carbon, has head, not alien or devil, has no hivenode or embryo: valid
 		return TRUE
@@ -185,10 +177,9 @@
 	if(!valid_to_attach(M))
 		return
 	// early returns and validity checks done: attach.
-	attached++
+	attached = TRUE
 	//ensure we detach once we no longer need to be attached
 	addtimer(CALLBACK(src, .proc/detach), MAX_IMPREGNATION_TIME)
-
 
 	if(!sterile)
 		M.take_bodypart_damage(strength,0) //done here so that humans in helmets take damage
@@ -199,7 +190,7 @@
 	addtimer(CALLBACK(src, .proc/Impregnate, M), rand(MIN_IMPREGNATION_TIME, MAX_IMPREGNATION_TIME))
 
 /obj/item/clothing/mask/facehugger/proc/detach()
-	attached = 0
+	attached = FALSE
 
 /obj/item/clothing/mask/facehugger/proc/Impregnate(mob/living/target)
 	if(!target || target.stat == DEAD) //was taken off or something
@@ -249,28 +240,24 @@
 
 	icon_state = "[initial(icon_state)]_dead"
 	item_state = "facehugger_inactive"
-	stat = DEAD
+	stat == DEAD
 
 	visible_message("<span class='danger'>[src] curls up into a ball!</span>")
 
 /proc/CanHug(mob/living/M)
-	if(!istype(M))
-		return 0
-	if(M.stat == DEAD)
-		return 0
-	if(M.getorgan(/obj/item/organ/alien/hivenode))
-		return 0
+	if(!istype(M) || M.stat == DEAD || M.getorgan(/obj/item/organ/alien/hivenode))
+		return FALSE
 
 	if(ismonkey(M))
-		return 1
+		return TRUE
 
 	var/mob/living/carbon/C = M
 	if(ishuman(C) && !(ITEM_SLOT_MASK in C.dna.species.no_equip))
 		var/mob/living/carbon/human/H = C
 		if(H.is_mouth_covered(head_only = 1))
-			return 0
-		return 1
-	return 0
+			return FALSE
+		return TRUE
+	return FALSE
 
 #undef MIN_ACTIVE_TIME
 #undef MAX_ACTIVE_TIME

--- a/code/modules/mob/living/carbon/alien/update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/update_icons.dm
@@ -1,6 +1,3 @@
-
-
-
 /mob/living/carbon/alien/update_damage_overlays() //aliens don't have damage overlays.
 	return
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -56,7 +56,7 @@
 	var/bloodcrawl = 0 //0 No blood crawling, BLOODCRAWL for bloodcrawling, BLOODCRAWL_EAT for crawling+mob devour
 	var/holder = null //The holder for blood crawling
 	var/ventcrawler = 0 //0 No vent crawling, 1 vent crawling in the nude, 2 vent crawling always
-	var/limb_destroyer = 0 //1 Sets AI behavior that allows mobs to target and dismember limbs with their basic attack.
+	var/limb_destroyer = FALSE //1 Sets AI behavior that allows mobs to target and dismember limbs with their basic attack.
 
 	var/mob_size = MOB_SIZE_HUMAN
 	var/list/mob_biotypes = list(MOB_ORGANIC)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -292,7 +292,7 @@
 	minbodytemp = 0
 	mob_size = MOB_SIZE_TINY
 	movement_type = FLYING
-	limb_destroyer = 1
+	limb_destroyer = TRUE
 	speak_emote = list("states")
 	bubble_icon = "syndibot"
 	gold_core_spawnable = HOSTILE_SPAWN

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -396,7 +396,7 @@
 
 
 /mob/proc/reagent_check(datum/reagent/R) // utilized in the species code
-	return 1
+	return TRUE
 
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Refactors a bunch of random xeno code a bit, fixes xenos runtiming literally every time they click something out of their range
- Reworked intents. You can hug xenos, grab them with grab intent and punch them on disarm/harm intent.
- Hunter slowed down by 50%
- Hunter health 125 => 200
- Sentinel health 150 => 225

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Hunter is not fun to fight when that fast. This keeps them still considerably faster than a regular crew memeber, but at a more sane level. Sentinel hp buffed so they actually have some use and are not just an inferior hunter.

Code being better is also nice.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

It's a lot of changes, so it's kinda tough to test. Might wanna do a test merge first. I did check the move speed and basic xeno abilities work, though.

</details>

## Changelog
:cl:
balance: slowed down hunters while buffing hunter's and sentinels' health
refactor: refactored some xeno code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
