### PR TITLE
Fixes move-upwards and move-downwards

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -207,6 +207,13 @@ GLOBAL_LIST_EMPTY(station_turfs)
 			travel_z(user, below, FALSE)
 
 /turf/proc/travel_z(mob/user, turf/target, upwards = TRUE)
+	if(!target)
+		to_chat(user, "<span class='warning'>There is nothing in that direction!</span>")
+		return
+	//Check if we can travel in that direction
+	if((upwards && !target.allow_z_travel) || (!upwards && !allow_z_travel))
+		to_chat(user, "<span class='warning'>Something is blocking you!</span>")
+		return
 	user.visible_message("<span class='notice'>[user] begins floating [upwards ? "upwards" : "downwards"]!</span>", "<span class='notice'>You begin floating [upwards ? "upwards" : "downwards"].")
 	var/matrix/M = user.transform
 	//Animation is inverted due to immediately resetting user vars.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Move upwards and move downwards now have a check to see if the movement is valid before performing the animation.

## Why It's Good For The Game

This will prevent people from glitching out their character by using the move up and move down verb, which means less people need to be gibbed.

## Testing Photographs and Procedure

Tested firstly but encountered a runtime.
Currently writing this PR while loading the game, so in the present tense the next part of the test doesn't exist yet, however as I write this the present becomes the past and the future becomes the present which becomes the past causing the test to exist, a screenshot of that test will be, is and has been provided below.

![image](https://user-images.githubusercontent.com/26465327/170843177-1fd9425d-e382-4bfa-8cb3-49be5b64699c.png)


## Changelog
:cl:
fix: Move upwards and move downwards no longer animate if there is nowhere to move in that direction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
