### PR TITLE
Adds being British as a negative quirk.

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -13,6 +13,7 @@
 #define PINEAPPLE	(1<<12)
 #define BREAKFAST	(1<<13)
 #define CLOTH 		(1<<14)
+#define BEANS		(1<<15)
 
 #define DRINK_BAD   1
 #define DRINK_NICE	2

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -20,8 +20,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	quirk_blacklist = list(
 		list("Blind","Nearsighted"),
 		list("Jolly","Depression","Apathetic","Hypersensitive"),
-		list("Ageusia","Vegetarian","Deviant Tastes"),
-		list("Ananas Affinity","Ananas Aversion"),
+		list("British","Ageusia","Vegetarian","Deviant Tastes"),
+		list("British","Ananas Affinity","Ananas Aversion"),
 		list("Alcohol Tolerance","Light Drinker"),
 		list("Social Anxiety","Mute"),
 	)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -676,17 +676,26 @@
 	name = "British"
 	desc = "You're British"
 	value = -1
-	gain_text = "<span class='danger'>You are now British.</span>"
-	lose_text = "<span class='notice'>You are no longer British.</span>"
-	medical_record_text = "Patient suffers from being British"
+	gain_text = "<span class='danger'>Ye feel like a reet prat like, innit?.</span>"
+	lose_text = "<span class='notice'>You no longer feel like being rude and sassy.</span>"
 
 /datum/quirk/british/add()
-	var/mob/living/carbon/H = quirk_holder
+	var/mob/living/carbon/human/H = quirk_holder
 	RegisterSignal(H, COMSIG_MOB_SAY, .proc/handle_speech)
+	var/datum/species/species = H.dna.species
+	var/liked = species.liked_food
+	species.liked_food = /obj/item/reagent_containers/food/snacks/canned/beans
+	species.disliked_food = liked
+
+/datum/quirk/british/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	UnregisterSignal(H, COMSIG_MOB_SAY)
+	var/datum/species/species = H.dna.species
+	species.liked_food = initial(species.liked_food)
+	species.disliked_food = initial(species.disliked_food)
 
 /datum/quirk/british/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER
-
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
 		message = " [message]"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -671,3 +671,18 @@
 /datum/quirk/phobia/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.cure_trauma_type(/datum/brain_trauma/mild/phobia, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/british
+	name = "British"
+	desc = "You're British"
+	value = -1
+	gain_text = "<span class='danger'>You are now British.</span>"
+	lose_text = "<span class='notice'>You are no longer British.</span>"
+	medical_record_text = "Patient suffers from being British"
+
+/datum/quirk/british/add()
+	var/mob/living/carbon/H = quirk_holder
+	if(!H.has_dna())
+		return
+	H.dna.add_mutation(CHAV)
+

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -684,7 +684,7 @@
 	RegisterSignal(H, COMSIG_MOB_SAY, .proc/handle_speech)
 	var/datum/species/species = H.dna.species
 	var/liked = species.liked_food
-	species.liked_food = /obj/item/reagent_containers/food/snacks/canned/beans
+	species.liked_food = BEANS
 	species.disliked_food = liked
 
 /datum/quirk/british/remove()

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -682,7 +682,37 @@
 
 /datum/quirk/british/add()
 	var/mob/living/carbon/H = quirk_holder
-	if(!H.has_dna())
-		return
-	H.dna.add_mutation(CHAV)
+	RegisterSignal(H, COMSIG_MOB_SAY, .proc/handle_speech)
+
+/datum/quirk/british/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message[1] != "*")
+		message = " [message]"
+		var/list/whole_words = strings(BRIISH_TALK_FILE, "words")
+		var/list/british_sounds = strings(BRIISH_TALK_FILE, "sounds")
+		var/list/british_appends = strings(BRIISH_TALK_FILE, "appends")
+
+		for(var/key in whole_words)
+			var/value = whole_words[key]
+			if(islist(value))
+				value = pick(value)
+
+			message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
+			message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
+			message = replacetextEx(message, " [key]", " [value]")
+
+		for(var/key in british_sounds)
+			var/value = british_sounds[key]
+			if(islist(value))
+				value = pick(value)
+
+			message = replacetextEx(message, "[uppertext(key)]", "[uppertext(value)]")
+			message = replacetextEx(message, "[capitalize(key)]", "[capitalize(value)]")
+			message = replacetextEx(message, "[key]", "[value]")
+
+		if(prob(8))
+			message += pick(british_appends)
+	speech_args[SPEECH_MESSAGE] = trim(message)
 

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -608,7 +608,7 @@
 	list_reagents = list(/datum/reagent/consumable/nutriment = 10)
 	filling_color = "#B22222"
 	tastes = list("beans" = 1)
-	foodtype = VEGETABLES
+	foodtype = VEGETABLES | BEANS
 
 /obj/item/reagent_containers/food/snacks/canned/peaches
 	name = "canned peaches"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now select to be British as a negative quirk.

By the way, someone please come up with funnier messages for gaining/losing this quirk, I couldn't think of anything.

## Why It's Good For The Game

I got this in one round as a mutation after getting cloned, and this is honestly the funniest shit that I have seen in my 4 years of playing this game. The reason why I added it as a negative quirk is because it makes your speech partially unintelligible at times.

So, saying: 
"Captain, I need a new ID from the Head of Personnel, a traitor stole it, and security isn't doing anything about it"
gets turned into
"Queen, MAN need a new BBM PIN from 'he Head of Badmannel, a roadman s'ole i', and like copperz isn'' doin' any'hin' 'bou' i'"

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/82319489/170844852-d3b0e69b-5cb3-47fc-8a75-51ea83d2f17d.png)

</details>

## Changelog
:cl: EvilDragonfiend Ancopper
add: Added being British as a negative quirk.
/:cl:
