### PR TITLE
Updates optical ecto-scanners

### DIFF
--- a/code/datums/components/team_monitor.dm
+++ b/code/datums/components/team_monitor.dm
@@ -225,10 +225,10 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 //===========
 
 /datum/component/team_monitor/proc/show_hud(mob/target)
-	updating = target
 	//Our hud is disabled
-	if(!hud_visible)
+	if(!hud_visible || !target)
 		return
+	updating = target
 	//Start processing to update in weird situations
 	START_PROCESSING(SSprocessing, src)
 	//Register parent signal
@@ -251,6 +251,8 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 	updating = null
 	//Stop processing
 	STOP_PROCESSING(SSprocessing, src)
+	if(!target)
+		return
 	//UnRegister parent signal
 	UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 	//Remove our arrows

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -17,6 +17,7 @@
 	var/list/icon/current = list() //the current hud icons
 	var/vision_correction = 0 //does wearing these glasses correct some of our vision defects?
 	var/glass_colour_type //colors your vision when worn
+	var/force_glass_colour = FALSE	//Should the user be forced to see the colour?
 
 /obj/item/clothing/glasses/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is stabbing \the [src] into [user.p_their()] eyes! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -304,8 +305,9 @@
 	icon_state = "bustin-g"
 	item_state = "bustin-g"
 	flash_protect = 1
-	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
+	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/green
+	force_glass_colour = TRUE
 
 /obj/item/clothing/glasses/welding/ghostbuster/ComponentInitialize()
 	. = ..()
@@ -313,8 +315,12 @@
 
 /obj/item/clothing/glasses/welding/ghostbuster/visor_toggling()
 	..()
-	var/datum/component/team_monitor/ghost_vision = GetComponent(/datum/component/team_monitor)
-	ghost_vision.toggle_hud(!ghost_vision.hud_visible, usr)
+	if(iscarbon(loc))
+		var/mob/living/carbon/C = loc
+		if(C.glasses != src)
+			return
+		var/datum/component/team_monitor/ghost_vision = GetComponent(/datum/component/team_monitor)
+		ghost_vision.toggle_hud(!ghost_vision.hud_visible, C)
 
 /obj/item/clothing/glasses/blindfold
 	name = "blindfold"
@@ -499,7 +505,7 @@
 
 
 /mob/living/carbon/human/proc/update_glasses_color(obj/item/clothing/glasses/G, glasses_equipped)
-	if(client && client.prefs.uses_glasses_colour && glasses_equipped)
+	if(((client && client.prefs.uses_glasses_colour) || force_glass_colour) && glasses_equipped)
 		add_client_colour(G.glass_colour_type)
 	else
 		remove_client_colour(G.glass_colour_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Optical ecto scanners now always have the green tint when worn.
Optical ecto scanners no longer work when in a pocket.
Updates the team monitor component to handle being equipped while deactive properly.

## Why It's Good For The Game

Fixes a bug, gives them the green overlay all the time.

## Testing Photographs and Procedure

Turns out there are quite a bit more problems outside of what I am fixing, tested this a bunch and discovered a ton of issues with the team monitor component when it comes to equipping toggleable hud items.

Seemed to work fine after testing.

## Changelog
:cl:
fix: Optical ecto-scanners no longer work if toggled in your pocket.
tweak: Optical ecto-scanners now have a flash protect of 2 while down
tweak: Optical ecto-scanners now have a green tint when worn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
