### PR TITLE
Removes the redundant species ID from limb names

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -77,7 +77,7 @@
 /obj/item/bodypart/Initialize(mapload)
 	..()
 	name = "[parse_zone(body_zone)]"
-	desc += "\n<span class='notice'>It is a [limb_id] [parse_zone(body_zone)]."
+	desc += "\n<span class='notice'>It is a [limb_id] [parse_zone(body_zone)].</span>"
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")
 	update_icon_dropped()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -77,6 +77,7 @@
 /obj/item/bodypart/Initialize(mapload)
 	..()
 	name = "[parse_zone(body_zone)]"
+	desc += "\n<span class='notice'>It is a [limb_id] [parse_zone(body_zone)]."
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")
 	update_icon_dropped()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -77,7 +77,6 @@
 /obj/item/bodypart/Initialize(mapload)
 	..()
 	name = "[parse_zone(body_zone)]"
-	desc += "\n<span class='notice'>It is a [limb_id] [parse_zone(body_zone)].</span>"
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")
 	update_icon_dropped()
@@ -93,6 +92,8 @@
 		. += "<span class='warning'>This limb has [brute_dam > 30 ? "severe" : "minor"] bruising.</span>"
 	if(burn_dam > DAMAGE_PRECISION)
 		. += "<span class='warning'>This limb has [burn_dam > 30 ? "severe" : "minor"] burns.</span>"
+	if(limb_id)
+		. += "<span class='notice'>It is a [limb_id] [parse_zone(body_zone)].</span>"
 
 /obj/item/bodypart/blob_act()
 	take_damage(max_damage)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -76,7 +76,7 @@
 
 /obj/item/bodypart/Initialize(mapload)
 	..()
-	name = "[limb_id] [parse_zone(body_zone)]"
+	name = "[parse_zone(body_zone)]"
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")
 	update_icon_dropped()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.

Removes `limb_id` from the name of limbs; "human chest" becomes "chest"

It moves them to examine, as I'd rather not completely remove this.
![image](https://user-images.githubusercontent.com/83819203/170889430-e21f6a13-96b1-4bdf-8b57-84d4d02b823e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A lot of people find this annoying. Additionally this really sucks from a sentence structure perspective. This looks a lot cleaner, in my personal opinion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
spellcheck: Removed the redundant species name from limb names, moves it to description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
