### PR TITLE
Fixes rubber autorifles not taking in lethal mags.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -100,8 +100,9 @@
 	w_class = WEIGHT_CLASS_BULKY
 	full_auto = TRUE
 
-/obj/item/gun/ballistic/automatic/wt550/rubber_loaded
-	mag_type = /obj/item/ammo_box/magazine/wt550m9/rubber
+/obj/item/gun/ballistic/automatic/wt550/rubber_loaded/Initialize(mapload)
+	magazine = new /obj/item/ammo_box/magazine/wt550m9/rubber(src)
+	. = ..()
 
 /obj/item/gun/ballistic/automatic/mini_uzi
 	name = "\improper Type U3 Uzi"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows CorgStation autorifles to take in regular ammo.

## Why It's Good For The Game

The guns in the armoury on corgstation do not accept lethal wt550 ammo cartridges.

## Testing Photographs and Procedure

Not been tested, but this is how riot toy guns work.

## Changelog
:cl:
fix: Fixes corgstation autorifles not accepting lethal mags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
