### PR TITLE
Vampire Blood Fix + Vampire Bat speed-up

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -138,4 +138,4 @@
 	invocation = "Squeak!"
 	charge_max = 50
 	cooldown_min = 50
-	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/vampire

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -36,3 +36,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 
+
+/mob/living/simple_animal/hostile/retaliate/bat/vampire
+	desc = "A rare breed of bat which roosts in spaceships.\nLooks a little... bloody."
+	speed = -1.5

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -149,6 +149,8 @@
 		restore()
 
 /obj/shapeshift_holder/proc/restore(death=FALSE)
+	if(!stored) //somehow this proc is getting called twice and it runtimes on the second pass because stored has been hit with qdel()
+		return FALSE
 	restoring = TRUE
 	qdel(slink)
 	stored.forceMove(get_turf(src))
@@ -158,12 +160,14 @@
 	if(death)
 		stored.death()
 	else if(source.convert_damage)
+		var/original_blood_volume = stored.blood_volume
 		stored.revive(full_heal = TRUE)
 
 		var/damage_percent = (shape.maxHealth - shape.health)/shape.maxHealth;
 		var/damapply = stored.maxHealth * damage_percent
 
 		stored.apply_damage(damapply, source.convert_damage_type, forced = TRUE)
+		stored.blood_volume = original_blood_volume
 	qdel(shape)
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Closes #6752
* Resolves a minor runtime
* Speeds up bat form for vampires

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Vampires being able to negate their primary mechanic is bad
* Runtimes are bad
* Bat form has only 15 HP and is an extremely risky form change to use. Having somewhat increased movement speed makes it a more viable get-away tool instead of purely for ventcrawling. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/171413527-caf65174-a263-4d5a-bad8-55f67abc3c3f.png)

https://user-images.githubusercontent.com/9547572/171413769-f2417fc0-2709-484c-a8bd-b1998369f8d7.mp4

</details>

## Changelog
:cl:
fix: Vampire bat transformation no longer resets blood volume for vampires
balance: Vampire bat form is now faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
