### PR TITLE
Fixes conjugation for plural gender limb examines

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -172,7 +172,7 @@
 
 	for(var/obj/item/bodypart/BP as() in bodyparts)
 		if(BP.limb_id != (dna.species.examine_limb_id ? dna.species.examine_limb_id : dna.species.id))
-			msg += "<span class='info'>[t_He] has \an [BP.name].</span>\n"
+			msg += "<span class='info'>[t_He] [t_has] \an [BP.name].</span>\n"
 
 	var/list/harm_descriptors = dna?.species.get_harm_descriptors()
 	var/brute_msg = harm_descriptors?["brute"]

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1623,7 +1623,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(!affecting) //Something went wrong. Maybe the limb is missing?
 		affecting = H.bodyparts[1]
 
-	hit_area = affecting.name
+	hit_area = parse_zone(affecting.body_zone)
 	var/def_zone = affecting.body_zone
 
 	var/armor_block = H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area]!</span>", "<span class='warning'>Your armor has softened a hit to your [hit_area]!</span>",I.armour_penetration)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -76,7 +76,7 @@
 
 /obj/item/bodypart/Initialize(mapload)
 	..()
-	name = "[parse_zone(body_zone)]"
+	name = "[limb_id] [parse_zone(body_zone)]"
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")
 	update_icon_dropped()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a conjugation error seen in #6959 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix bug.
closes #6959 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Binary Gender Check](https://user-images.githubusercontent.com/68963748/171479168-3ba73291-fafb-40af-aa2f-68f5915f47a0.png)

Working for binary genders.

![Plural Gender Check](https://user-images.githubusercontent.com/68963748/171479266-30f36376-e7df-4a0d-b326-130955efde58.png)

Working for plural gender.

![Limb naming works properly](https://user-images.githubusercontent.com/68963748/171487416-1cb071f3-4e8d-465e-b4a4-bb68f00a7c9a.png)

Limb names got messed up. Now robotic limbs are acknowledged properly.

![Attack messages ignore species limb type](https://user-images.githubusercontent.com/68963748/171487456-3e7f99b3-73e6-4b26-be37-5c2478df182d.png)

Attack messages specify the zone instead of body part.

</details>

## Changelog
:cl: DatBoiTim
fix: Fixed a conjugation issue for examining unknowns or plural gendered mobs with special limbs
fix: Prosthetic Limbs showing up as right/left arm/leg in examine instead of robotic right/left arm/leg
fix: Attack messages now mention the zone affected rather than the name of the limb affected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
