### PR TITLE
new crew objective for R&D, viro, geneticist, heads

### DIFF
--- a/code/modules/crew_objectives/civilian_objectives.dm
+++ b/code/modules/crew_objectives/civilian_objectives.dm
@@ -1,5 +1,5 @@
 /*				CIVILIAN OBJECTIVES			*/
-
+// botanist plant -------------------------------------------------------
 /datum/objective/crew/druglordbot //ported from old Hippie with adjustments
 	var/targetchem = "none"
 	var/datum/reagent/chempath
@@ -29,6 +29,7 @@
 	else
 		return ..()
 
+// cook food delivery -------------------------------------------------------
 /datum/objective/crew/foodhoard
 	var/datum/crafting_recipe/food/targetfood
 	var/obj/item/reagent_containers/food/foodpath
@@ -54,6 +55,7 @@
 	else
 		return ..()
 
+// bartender -------------------------------------------------------
 /datum/objective/crew/responsibility
 	explanation_text = "Make sure nobody dies with alcohol poisoning."
 	jobs = "bartender"
@@ -65,6 +67,7 @@
 				return ..()
 	return TRUE
 
+// clean station -------------------------------------------------------
 /datum/objective/crew/clean //ported from old Hippie
 	var/list/areas = list()
 	var/hardmode = FALSE
@@ -106,6 +109,7 @@
 			return ..()
 	return TRUE
 
+// mice catcher -------------------------------------------------------
 /datum/objective/crew/exterminator
 	explanation_text = "Ensure that there are no more than (Yell on github, this objective broke) living mice on the station when the round ends."
 	jobs = "janitor"
@@ -128,6 +132,7 @@
 		return TRUE
 	return ..()
 
+// key holder -------------------------------------------------------
 /datum/objective/crew/lostkeys
 	explanation_text = "Don't lose the janicart keys. Have them with you when the shift ends."
 	jobs = "janitor"
@@ -137,6 +142,7 @@
 		return TRUE
 	return ..()
 
+// clown slip prank -------------------------------------------------------
 /datum/objective/crew/slipster //ported from old Hippie with adjustments
 	explanation_text = "Slip at least (Yell on GitHub if you see this) different people with your PDA, and have it on you at the end of the shift."
 	jobs = "clown"
@@ -161,6 +167,7 @@
 	else
 		return ..()
 
+// clown shoes steal prank -------------------------------------------------------
 /datum/objective/crew/shoethief
 	explanation_text = "Steal at least (Yell on github, this objective broke) pairs of shoes, and have them in your bag at the end of the shift. Bonus points if they are stolen from crewmembers instead of ClothesMates."
 	jobs = "clown"
@@ -184,6 +191,7 @@
 		return TRUE
 	return ..()
 
+// mime does mime -------------------------------------------------------
 /datum/objective/crew/vow //ported from old Hippie
 	explanation_text = "Never break your vow of silence."
 	jobs = "mime"
@@ -195,6 +203,7 @@
 			return ..()
 	return TRUE
 
+// mime has nothing -------------------------------------------------------
 /datum/objective/crew/nothingreallymatterstome
 	explanation_text = "Have a Bottle of Nothing with you at the end of the shift."
 	jobs = "mime"
@@ -204,6 +213,7 @@
 		return TRUE
 	return ..()
 
+// chaplain nullrod -------------------------------------------------------
 /datum/objective/crew/nullrod
 	explanation_text = "Don't lose your nullrod. You can still transform it into another item."
 	jobs = "chaplain"
@@ -215,6 +225,7 @@
 				return TRUE
 	return ..()
 
+// curator curating -------------------------------------------------------
 /datum/objective/crew/reporter //ported from old hippie
 	var/charcount = 100
 	explanation_text = "Publish at least (Yo something broke) articles containing at least (Report this on GitHub) characters."
@@ -243,6 +254,7 @@
 	else
 		return ..()
 
+// assistant grubby  -------------------------------------------------------
 /datum/objective/crew/pwrgame //ported from Goon with adjustments
 	var/obj/item/clothing/targettidegarb
 	explanation_text = "Get your grubby hands on a (Dear god something broke. Report this on GitHub)."
@@ -267,6 +279,7 @@
 				return TRUE
 	return ..()
 
+// assistant got job -------------------------------------------------------
 /datum/objective/crew/promotion //ported from Goon
 	explanation_text = "Have a non-assistant ID registered to you at the end of the shift."
 	jobs = "assistant"
@@ -280,6 +293,7 @@
 				return TRUE
 	return ..()
 
+// lawyer's responsibility -------------------------------------------------------
 /datum/objective/crew/justicecrew
 	explanation_text = "Ensure there are no members of security in the prison wing when the shift ends."
 	jobs = "lawyer"

--- a/code/modules/crew_objectives/command_objectives.dm
+++ b/code/modules/crew_objectives/command_objectives.dm
@@ -1,5 +1,5 @@
 /*				COMMAND OBJECTIVES				*/
-
+// Captain's hat -------------------------------------------------------
 /datum/objective/crew/caphat //Ported from Goon
 	explanation_text = "Don't lose your hat."
 	jobs = "captain"
@@ -10,6 +10,7 @@
 	else
 		return ..()
 
+// Captain's nuke disk -------------------------------------------------------
 /datum/objective/crew/datfukkendisk //Ported from old Hippie
 	explanation_text = "Defend the nuclear authentication disk at all costs, and be the one to personally deliver it to CentCom."
 	jobs = "captain" //give this to other heads at your own risk.
@@ -20,6 +21,7 @@
 	else
 		return ..()
 
+// Captain's end -------------------------------------------------------
 /datum/objective/crew/downwiththestation
 	explanation_text = "Go down with your station. Do not leave on the shuttle or an escape pod. Instead, stay on the bridge."
 	jobs = "captain"
@@ -30,6 +32,7 @@
 			return TRUE
 	return ..()
 
+// HoP Ian -------------------------------------------------------
 /datum/objective/crew/ian //Ported from old Hippie
 	explanation_text = "Defend Ian at all costs, and ensure he gets delivered to CentCom at the end of the shift."
 	jobs = "headofpersonnel"
@@ -38,5 +41,20 @@
 	if(owner?.current)
 		for(var/mob/living/simple_animal/pet/dog/corgi/Ian/goodboy in GLOB.mob_list)
 			if(goodboy.stat != DEAD && SSshuttle.emergency.shuttle_areas[get_area(goodboy)])
+				return TRUE
+	return ..()
+
+// All heads duty (except HoS) -------------------------------------------------------
+/datum/objective/crew/headsduty //Ported from old Hippie
+	explanation_text = "Success the station goal."
+	jobs = "captain,headofpersonnel,chiefengineer,chiefmedicalofficer,researchdirector"
+	// HoS can't actually do the station goal work. Let's exclude them from this duty.
+
+/datum/objective/crew/headsduty/check_completion()
+	var/datum/game_mode/dynamic/mode = SSticker.mode
+	if(mode.station_goals.len)
+		for(var/V in mode.station_goals)
+			var/datum/station_goal/G = V
+			if(G.check_completion())
 				return TRUE
 	return ..()

--- a/code/modules/crew_objectives/command_objectives.dm
+++ b/code/modules/crew_objectives/command_objectives.dm
@@ -45,7 +45,7 @@
 	return ..()
 
 // All heads duty (except HoS) -------------------------------------------------------
-/datum/objective/crew/headsduty //Ported from old Hippie
+/datum/objective/crew/headsduty
 	explanation_text = "Success the station goal."
 	jobs = "captain,headofpersonnel,chiefengineer,chiefmedicalofficer,researchdirector"
 	// HoS can't actually do the station goal work. Let's exclude them from this duty.

--- a/code/modules/crew_objectives/engineering_objectives.dm
+++ b/code/modules/crew_objectives/engineering_objectives.dm
@@ -1,5 +1,5 @@
 /*				ENGINEERING OBJECTIVES				*/
-
+// engineer SM integrity -------------------------------------------------------
 /datum/objective/crew/integrity //ported from old Hippie
 	explanation_text = "Ensure the station's integrity rating is at least (Something broke, yell on GitHub)% when the shift ends."
 	jobs = "chiefengineer,stationengineer"
@@ -22,6 +22,7 @@
 	else
 		return ..()
 
+// CE poly -------------------------------------------------------
 /datum/objective/crew/poly
 	explanation_text = "Make sure Poly keeps his headset, and stays alive until the end of the shift."
 	jobs = "chiefengineer"

--- a/code/modules/crew_objectives/medical_objectives.dm
+++ b/code/modules/crew_objectives/medical_objectives.dm
@@ -90,10 +90,10 @@
 	var/realperson = 0
 	var/hadvaccine = 0
 	for(var/mob/living/carbon/human/H in GLOB.mob_list)
-		if(H.mind)
+		if(H.mind && H.mind.assigned_role)
 			realperson++
 		if(length(H.disease_resistances))
 			hadvaccine++
-	if(round(realperson/2) <= hadvaccine)
+	if(realperson/2 <= hadvaccine) //don't have to round(realperson)
 		return TRUE
 	return ..()

--- a/code/modules/crew_objectives/medical_objectives.dm
+++ b/code/modules/crew_objectives/medical_objectives.dm
@@ -83,13 +83,17 @@
 		return ..()
 
 /datum/objective/crew/noinfections
-	explanation_text = "Make sure there are no crew members with harmful diseases at the end of the shift."
+	explanation_text = "Let more than half crew members have a vaccine of any diesease at the end of the shift."
 	jobs = "virologist"
 
 /datum/objective/crew/noinfections/check_completion()
+	var/realperson = 0
+	var/hadvaccine = 0
 	for(var/mob/living/carbon/human/H in GLOB.mob_list)
-		if(!H.stat == DEAD)
-			if((H.z in SSmapping.levels_by_trait(ZTRAIT_STATION)) || SSshuttle.emergency.shuttle_areas[get_area(H)])
-				if(H.check_virus() == 2) //Harmful viruses only
-					return ..()
-	return TRUE
+		if(H.mind)
+			realperson++
+		if(length(H.disease_resistances))
+			hadvaccine++
+	if(round(realperson/2) <= hadvaccine)
+		return TRUE
+	return ..()

--- a/code/modules/crew_objectives/medical_objectives.dm
+++ b/code/modules/crew_objectives/medical_objectives.dm
@@ -1,8 +1,8 @@
 /*				MEDICAL OBJECTIVES				*/
-
+// Clean body medbay -------------------------------------------------------
 /datum/objective/crew/morgue //Ported from old Hippie
 	explanation_text = "Ensure the Medbay has been cleaned of any corpses when the shift ends."
-	jobs = "chiefmedicalofficer,geneticist,medicaldoctor"
+	jobs = "chiefmedicalofficer,medicaldoctor"
 
 /datum/objective/crew/morgue/check_completion()
 	var/list/medical_areas = typecacheof(list(/area/medical/cryo, /area/medical/genetics/cloning, /area/medical/exam_room,
@@ -14,6 +14,7 @@
 			return ..()
 	return TRUE
 
+// Clean body station (paramedic) -------------------------------------------------------
 /datum/objective/crew/emtmorgue
 	explanation_text = "Ensure that no corpses remain outside of Medbay when the shift ends."
 	jobs = "paramedic"
@@ -28,6 +29,7 @@
 			return ..()
 	return TRUE
 
+// chemist Chem eat -------------------------------------------------------
 /datum/objective/crew/chems //Ported from old Hippie
 	var/targetchem = "none"
 	var/datum/reagent/chempath
@@ -51,6 +53,7 @@
 				return TRUE
 	return ..()
 
+// chemist drug maker -------------------------------------------------------
 /datum/objective/crew/druglordchem //ported from old Hippie with adjustments
 	var/targetchem = "none"
 	var/datum/reagent/chempath
@@ -82,11 +85,43 @@
 	else
 		return ..()
 
-/datum/objective/crew/noinfections
-	explanation_text = "Let more than half crew members have a vaccine of any diesease at the end of the shift."
-	jobs = "virologist"
+// geneticist mutation give -------------------------------------------------------
+/datum/objective/crew/crewmutant
+	explanation_text = "Let more than one third crew members have a mutation at least at the end of the shift."
+	jobs = "chiefmedicalofficer,geneticist"
 
-/datum/objective/crew/noinfections/check_completion()
+/datum/objective/crew/crewmutant/check_completion()
+	var/realperson = 0
+	var/hadmutation = 0
+	for(var/mob/living/carbon/human/H in GLOB.mob_list)
+		if(H.mind && H.mind.assigned_role)
+			realperson++
+		if(length(H.dna.mutations))
+			hadmutation++
+	if(realperson/3 <= hadmutation) //don't have to `round(realperson/2)`
+		return TRUE
+	return ..()
+
+// geneticist self enhancement
+/datum/objective/crew/selfmutant
+	explanation_text = "Have yourself enhanced by spending more than 50 genetic stability when the shift ends."
+	jobs = "geneticist"
+
+/datum/objective/crew/selfmutant/check_completion()
+	if(owner.current)
+		if(ishuman(owner.current)) // in case that your body is fucked (i.e. corgified)
+			var/mob/living/carbon/human/you = owner.current
+			var/datum/dna/yourdna = you.dna
+			if(yourdna.stability <= 50)
+				return TRUE
+	return ..()
+
+// virologist Vaccine -------------------------------------------------------
+/datum/objective/crew/vaccine
+	explanation_text = "Let more than half crew members have a vaccine of any diesease at the end of the shift."
+	jobs = "chiefmedicalofficer,virologist"
+
+/datum/objective/crew/vaccine/check_completion()
 	var/realperson = 0
 	var/hadvaccine = 0
 	for(var/mob/living/carbon/human/H in GLOB.mob_list)
@@ -94,6 +129,6 @@
 			realperson++
 		if(length(H.disease_resistances))
 			hadvaccine++
-	if(realperson/2 <= hadvaccine) //don't have to round(realperson)
+	if(realperson/2 <= hadvaccine) //don't have to `round(realperson/2)`
 		return TRUE
 	return ..()

--- a/code/modules/crew_objectives/science_objectives.dm
+++ b/code/modules/crew_objectives/science_objectives.dm
@@ -56,7 +56,7 @@
 
 /datum/objective/crew/xenoslime/New()
 	. = ..()
-	target_amount = rand(33,66)
+	target_amount = rand(33,60)
 	update_explanation_text()
 
 /datum/objective/crew/xenoslime/update_explanation_text()

--- a/code/modules/crew_objectives/science_objectives.dm
+++ b/code/modules/crew_objectives/science_objectives.dm
@@ -1,27 +1,43 @@
 /*				SCIENCE OBJECTIVES				*/
 
-/datum/objective/crew/cyborgs //Ported from old Hippie
-	explanation_text = "Ensure there are at least (Yell on GitHub, something broke) functioning cyborgs when the shift ends."
+/datum/objective/crew/botmaker //Ported from old Hippie
+	explanation_text = "Ensure there are at least (Yell on GitHub, something broke) functioning bots when the shift ends. The roundstarting ones don't count."
 	jobs = "researchdirector,roboticist"
+	var/static/roundstartcount
 
-/datum/objective/crew/cyborgs/New()
+/datum/objective/crew/botmaker/New()
 	. = ..()
-	target_amount = rand(3,10)
+	target_amount = rand(4,16)
+	if(isnull(roundstartcount))
+		roundstartcount = 0
+		for(var/mob/living/simple_animal/bot/B in GLOB.alive_mob_list)
+			roundstartcount++
+	target_amount += roundstartcount
 	update_explanation_text()
 
-/datum/objective/crew/cyborgs/update_explanation_text()
+/datum/objective/crew/botmaker/update_explanation_text()
 	. = ..()
-	explanation_text = "Ensure there are at least [target_amount] functioning cyborgs when the shift ends."
+	explanation_text = "Ensure there are at least [target_amount-roundstartcount] functioning bots when the shift ends. The roundstarting ones don't count."
 
-/datum/objective/crew/cyborgs/check_completion()
-	var/borgcount = target_amount
-	for(var/mob/living/silicon/robot/R in GLOB.alive_mob_list)
-		if(!(R.stat == DEAD))
-			borgcount--
-	if(borgcount <= 0)
+
+/datum/objective/crew/botmaker/check_completion()
+	var/botcount = target_amount
+	for(var/mob/living/simple_animal/bot/B in GLOB.alive_mob_list)
+		if(!(B.stat == DEAD))
+			botcount--
+		if(botcount <= 0)
+			return TRUE
+	return ..()
+
+/datum/objective/crew/servertech //Ported from old Hippie
+	explanation_text = "reach the 4 tech tier from the station R&D server when the shift ends."
+	jobs = "researchdirector,scientist,explorationcrew"
+
+/datum/objective/crew/servertech/check_completion()
+	var/datum/techweb/stored_research = SSresearch.science_tech
+	if(stored_research.current_tier >= 4)
 		return TRUE
-	else
-		return ..()
+	return ..()
 
 //TODO: make the research objective work with techwebs
 /*

--- a/code/modules/crew_objectives/science_objectives.dm
+++ b/code/modules/crew_objectives/science_objectives.dm
@@ -1,13 +1,14 @@
 /*				SCIENCE OBJECTIVES				*/
 
-/datum/objective/crew/botmaker //Ported from old Hippie
+// Roboticst Botmaker -------------------------------------------------------
+/datum/objective/crew/botmaker
 	explanation_text = "Ensure there are at least (Yell on GitHub, something broke) functioning bots when the shift ends. The roundstarting ones don't count."
 	jobs = "researchdirector,roboticist"
 	var/static/roundstartcount
 
 /datum/objective/crew/botmaker/New()
 	. = ..()
-	target_amount = rand(7,16)
+	target_amount = rand(7,18)
 	if(isnull(roundstartcount))
 		roundstartcount = 0
 		for(var/mob/living/simple_animal/bot/B in GLOB.alive_mob_list)
@@ -19,7 +20,6 @@
 	. = ..()
 	explanation_text = "Ensure there are at least [target_amount-roundstartcount] functioning bots when the shift ends. The roundstarting ones don't count."
 
-
 /datum/objective/crew/botmaker/check_completion()
 	var/botcount = target_amount
 	for(var/mob/living/simple_animal/bot/B in GLOB.alive_mob_list)
@@ -29,14 +29,80 @@
 			return TRUE
 	return ..()
 
-/datum/objective/crew/servertech //Ported from old Hippie
-	explanation_text = "reach the 4 tech tier from the station R&D server when the shift ends."
-	jobs = "researchdirector,scientist,explorationcrew"
+// scientist Tech research -------------------------------------------------------
+/datum/objective/crew/servertech
+	explanation_text = "reach 'val' tech tier from the station R&D server when the shift ends."
+	jobs = "researchdirector,scientist"
+	target_amount = 5
+
+/datum/objective/crew/servertech/New()
+	. = ..()
+	update_explanation_text()
+
+/datum/objective/crew/servertech/update_explanation_text()
+	. = ..()
+	explanation_text = "reach [target_amount] tech tier from the station R&D server when the shift ends."
 
 /datum/objective/crew/servertech/check_completion()
 	var/datum/techweb/stored_research = SSresearch.science_tech
-	if(stored_research.current_tier >= 4)
+	if(stored_research.current_tier >= target_amount)
 		return TRUE
+	return ..()
+
+// scientist Xeno slime -------------------------------------------------------
+/datum/objective/crew/xenoslime
+	explanation_text = "have 'val' living slimes in the xenobiology lab when the shift ends."
+	jobs = "researchdirector,scientist"
+
+/datum/objective/crew/xenoslime/New()
+	. = ..()
+	target_amount = rand(33,66)
+	update_explanation_text()
+
+/datum/objective/crew/xenoslime/update_explanation_text()
+	. = ..()
+	explanation_text = "have [target_amount] living slimes in the xenobiology lab when the shift ends."
+
+/datum/objective/crew/xenoslime/check_completion()
+	var/list/xenobio_area = typecacheof(list(/area/science/xenobiology))
+	var/slimecount = target_amount
+	for(var/mob/living/simple_animal/slime/S in GLOB.alive_mob_list)
+		var/area/A = get_area(S)
+		if(S.stat != DEAD && is_station_level(S.z) && is_type_in_typecache(A, xenobio_area))
+			slimecount--
+		if(slimecount <= 0)
+			return TRUE
+	return ..()
+
+// R&D nanites -------------------------------------------------------
+/datum/objective/crew/scinanites
+	explanation_text = "Let more than one third station crews have nanites."
+	jobs = "researchdirector,scientist,roboticist"
+
+/datum/objective/crew/scinanites/check_completion()
+	var/realperson = 0
+	var/hadnanites = 0
+	for(var/mob/living/carbon/human/H in GLOB.mob_list)
+		if(H.mind && H.mind.assigned_role)
+			realperson++
+		if(SEND_SIGNAL(H, COMSIG_HAS_NANITES))
+			hadnanites++
+	if(realperson/3 <= hadnanites) //don't have to `round(realperson/3)`
+		return TRUE
+	return ..()
+
+// Exploration crew Lost tech -------------------------------------------------------
+/datum/objective/crew/losttech
+	explanation_text = "have a lost technology disk from explorative ruins when the shift ends."
+	jobs = "explorationcrew"
+
+/datum/objective/crew/losttech/check_completion()
+	if(owner.current)
+		if(owner.current.contents)
+			for(var/obj/item/disk/tech_disk/research/D in owner.current.get_contents())
+				var/objpath = D.type
+				if(objpath in subtypesof(/obj/item/disk/tech_disk/research))
+					return TRUE
 	return ..()
 
 //TODO: make the research objective work with techwebs

--- a/code/modules/crew_objectives/science_objectives.dm
+++ b/code/modules/crew_objectives/science_objectives.dm
@@ -7,7 +7,7 @@
 
 /datum/objective/crew/botmaker/New()
 	. = ..()
-	target_amount = rand(4,16)
+	target_amount = rand(7,16)
 	if(isnull(roundstartcount))
 		roundstartcount = 0
 		for(var/mob/living/simple_animal/bot/B in GLOB.alive_mob_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
new crew objectives
* Roboticis+RD: Need to make 7~18 bots. roundstarting ones don't count.
* Scientist+RD: need to research to tier 5
* Scientist+RD: need to have 33~60 living slmes in xeno lab
* Scentist+Robo+RD: 1/3 crew members should have nanites
* explo crew: have a ruin tech disk when a shift ends
* virologist+CMO: let half crew members have a vaccine of any disease
* geneticist+CMO: let 1/3 crew members have a mutation at least
* geneticist: spend more than 50 genetic stability
* genetics: no longer need to clean medbay corpse
* all heads(except for HoS): success the station goal
* and remove old ones

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
R&D's crew objective has been bullshit and actually not valid to complete.
virologist's is buggy and always success, so replaced it with another version
change geneticist's objective to their real deal 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://user-images.githubusercontent.com/87972842/171627334-8c9d7bf2-d723-4249-93d5-7992816e838b.png)
![image](https://user-images.githubusercontent.com/87972842/171752520-6554f256-cd78-409e-8a2f-2609de8fe6f1.png)

</details>

## Changelog
:cl:
refactor: put some comments to separate code slabs in the objective one.
del: Old roboticist objective is gone. (make sure 3-8 functional borgs exist)
add: New crew objective for Roboticist and RD (Make 7-18 functional bots. Roundstarting ones don't count)
add: New crew objective for Scientist and RD (Reach 5 tech tier.)
add: New crew objective for Scientist and RD (Have 33~60 living slimes in xeno lab)
add: New crew objective for Scientist, Roboticist and RD (have one third crews have nanites)
add: New crew objective for Exploration crew (have a ruin tech disk when a shift ends)
add: New crew objective for geneticist and CMO (have one third crews have a mutation)
add: New crew objective for geneticist only (spend 50 genetic stability)
tweak: Geneticist doesn't get medbay corpse clean objective anymore.
add: New crew objective for all heads except for HoS (success the station goal)
del: Old virologist objective (don't let crew member infected with harmful virus)
add: New virologist objective (More than half crew members should have a vaccine of any disease)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
