### PR TITLE
Fixes lighteater

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -805,6 +805,9 @@
 /atom/proc/lighteater_act(obj/item/light_eater/light_eater)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src,COMSIG_ATOM_LIGHTEATER_ACT)
+	for(var/datum/light_source/light_source in light_sources)
+		if(light_source.source_atom != src)
+			light_source.source_atom.lighteater_act(light_eater)
 
 /**
   * Respond to the eminence clicking on our atom

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -186,15 +186,19 @@
 		return
 	AM.lighteater_act(src)
 
+/atom/movable/lighteater_act(obj/item/light_eater/light_eater)
+	..()
+	for(var/datum/component/overlay_lighting/light_source in affected_dynamic_lights)
+		if(light_source.parent != src)
+			var/atom/A = light_source.parent
+			A.lighteater_act(light_eater)
+
 /mob/living/lighteater_act(obj/item/light_eater/light_eater)
 	..()
 	if(on_fire)
 		ExtinguishMob()
 		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
-	for(var/obj/item/O in src)
-		if(O.light_range && O.light_power)
-			O.lighteater_act(light_eater)
-	if(pulling && pulling.light_range)
+	if(pulling)
 		pulling.lighteater_act(light_eater)
 
 /mob/living/carbon/human/lighteater_act(obj/item/light_eater/light_eater)
@@ -209,29 +213,30 @@
 		to_chat(src, "<span class='danger'>Your headlamp is fried! You'll need a human to help replace it.</span>")
 
 /obj/structure/bonfire/lighteater_act(obj/item/light_eater/light_eater)
-	..()
 	if(burning)
 		extinguish()
 		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
-
-/obj/item/pda/lighteater_act(obj/item/light_eater/light_eater)
 	..()
-	if(!light_range || !light_power)
-		return
-	set_light_on(FALSE)
-	light_power = 0
-	shorted = TRUE
-	update_icon()
-	visible_message("<span class='danger'>The light in [src] shorts out!</span>")
 
 /obj/item/lighteater_act(obj/item/light_eater/light_eater)
 	..()
-	if(!light_range || !light_power)
+	if(!light_range || !light_power || !light_on)
 		return
 	if(light_eater)
 		visible_message("<span class='danger'>[src] is disintegrated by [light_eater]!</span>")
 	burn()
 	playsound(src, 'sound/items/welder.ogg', 50, 1)
+
+
+/obj/item/pda/lighteater_act(obj/item/light_eater/light_eater)
+	if(light_range && light_power && light_on)
+		//Eject the ID card
+		if(id)
+			id.forceMove(get_turf(src))
+			id = null
+			update_icon()
+			playsound(src, 'sound/machines/terminal_eject.ogg', 50, TRUE)
+	..()
 
 #undef HEART_SPECIAL_SHADOWIFY
 #undef HEART_RESPAWN_THRESHHOLD

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -14,10 +14,6 @@
 	else
 		camera_mode_on(user)
 
-/obj/item/camera/siliconcam/lighteater_act(obj/item/light_eater/light_eater)
-	..()
-	return
-
 /obj/item/camera/siliconcam/burn()
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The ligheater act now works by checking for lights attached to an atom and applying itself to them. This means that processing time doesn't need to be wasted searching in the contents for things with lights, since we can just see what lights are being emitted by a parent atom and what their source atom is.
Lighteater also checks for light_on, so that movable lights that are turned off will not be broken by the lighteater.

## Why It's Good For The Game

Fixes 2 bugs wtih the lighteater:
1. The lighteater couldn't break gunlights or most recursive lights
2. The lighteater would break movable lights even if the light was off.

## Testing Photographs and Procedure

Tested it by hitting a PDA with light off, didn't break.
Hit a PDA with light on, PDA broke and ID dropped to the floor.
Hit a HOS with gunlight on, energy gun with seclight on and PDA light on and all broke as expected.

## Changelog
:cl:
fix: The lighteater will now break gunlights and flashlights attached to things.
fix: The lighteater will no longer break PDAs that do not have their light turned on.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
