### PR TITLE
EMP nerfs

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -201,7 +201,7 @@
 	if (!(. & EMP_PROTECT_SELF) && !(obj_flags & OBJ_EMPED))
 		obj_flags |= OBJ_EMPED
 		update_icon()
-		addtimer(CALLBACK(src, .proc/emp_reset), rand(0, 200 / severity))
+		addtimer(CALLBACK(src, .proc/emp_reset), rand(1, 200 / severity))
 		playsound(src, 'sound/machines/capacitor_discharge.ogg', 60, TRUE)
 
 /obj/item/melee/baton/proc/emp_reset()

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -201,7 +201,7 @@
 	if (!(. & EMP_PROTECT_SELF) && !(obj_flags & OBJ_EMPED))
 		obj_flags |= OBJ_EMPED
 		update_icon()
-		addtimer(CALLBACK(src, .proc/emp_reset), rand(1200 / severity, 600 / severity))
+		addtimer(CALLBACK(src, .proc/emp_reset), rand(0, 200 / severity))
 		playsound(src, 'sound/machines/capacitor_discharge.ogg', 60, TRUE)
 
 /obj/item/melee/baton/proc/emp_reset()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -4,14 +4,14 @@
 	desc = "A basic energy-based gun."
 	icon = 'icons/obj/guns/energy.dmi'
 	///What type of power cell this uses
-	var/obj/item/stock_parts/cell/cell 
+	var/obj/item/stock_parts/cell/cell
 	var/cell_type = /obj/item/stock_parts/cell
 	/// how much charge the cell will have, if we want the gun to have some abnormal charge level without making a new battery.
 	var/gun_charge
 	var/modifystate = 0
 	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
 	///The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
-	var/select = 1 
+	var/select = 1
 	///Can it be charged in a recharger?
 	var/can_charge = TRUE
 	///Do we handle overlays with base update_icon()?
@@ -19,23 +19,23 @@
 	var/charge_sections = 4
 	ammo_x_offset = 2
 	///if this gun uses a stateful charge bar for more detail
-	var/shaded_charge = FALSE 
+	var/shaded_charge = FALSE
 	/// stores the gun's previous ammo "ratio" to see if it needs an updated icon
-	var/old_ratio = 0 
+	var/old_ratio = 0
 	var/selfcharge = 0
 	var/charge_timer = 0
 	var/charge_delay = 8
 	///whether the gun's cell drains the cyborg user's cell to recharge
-	var/use_cyborg_cell = FALSE 
+	var/use_cyborg_cell = FALSE
 	///set to true so the gun is given an empty cell
-	var/dead_cell = FALSE 
+	var/dead_cell = FALSE
 
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()
 	if(!(. & EMP_PROTECT_CONTENTS))
 		obj_flags |= OBJ_EMPED
 		update_icon()
-		addtimer(CALLBACK(src, .proc/emp_reset), rand(600 / severity, 300 / severity))
+		addtimer(CALLBACK(src, .proc/emp_reset), rand(0, 200 / severity))
 		playsound(src, 'sound/machines/capacitor_discharge.ogg', 60, TRUE)
 
 /obj/item/gun/energy/proc/emp_reset()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -35,7 +35,7 @@
 	if(!(. & EMP_PROTECT_CONTENTS))
 		obj_flags |= OBJ_EMPED
 		update_icon()
-		addtimer(CALLBACK(src, .proc/emp_reset), rand(0, 200 / severity))
+		addtimer(CALLBACK(src, .proc/emp_reset), rand(1, 200 / severity))
 		playsound(src, 'sound/machines/capacitor_discharge.ogg', 60, TRUE)
 
 /obj/item/gun/energy/proc/emp_reset()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The time that EMPs disable guns and stun batons for has been updated:
Light EMP: 0 to 10 seconds
Heavy EMP: 0 to 20 seconds

## Why It's Good For The Game

A single EMP can make any member of security unable to fight back for a very long time. This makes EMP temporarilly disable them during a fight, so that you can get a short upper hand however the other person can fight back after at most 20 seconds rather than 2 minutes.
A lot of complaints that this required the use of shotgun meta, so this should make it so you can still fight against someone with EMPs with the user of regular weapons.

## Testing Photographs and Procedure


https://user-images.githubusercontent.com/26465327/172069399-f7f1091a-2ece-4921-8462-a07448306c20.mp4



## Changelog
:cl:
balance: Light EMPs will disable energy weapons and batons for 0-10 seconds as opposed to 30-60 seconds.
balance: Heavy EMPs will disable energy weapons and batons for 0-20 seconds as opposed to 60-120 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
