### PR TITLE
Removes bluespace polycrystals

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -35,7 +35,7 @@
 /area/ruin/space/has_grav/hilbertresearchfacility)
 "h" = (
 /obj/structure/table/glass,
-/obj/item/stack/sheet/bluespace_crystal{
+/obj/item/stack/ore/bluespace_crystal/refined{
 	amount = 37
 	},
 /turf/open/floor/plasteel/grimy{

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -106,7 +106,7 @@
 	color = "#506bc7"
 	greyscale_colors = "#506bc7"
 	categories = list(MAT_CATEGORY_ORE = TRUE)
-	sheet_type = /obj/item/stack/sheet/bluespace_crystal
+	sheet_type = /obj/item/stack/ore/bluespace_crystal/refined
 
 ///Honks and slips
 /datum/material/bananium

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -9,7 +9,7 @@
 	materials = list(/datum/material/bluespace=MINERAL_MATERIAL_AMOUNT)
 	points = 50
 	var/blink_range = 8 // The teleport range when crushed/thrown at someone.
-	refined_type = /obj/item/stack/sheet/bluespace_crystal
+	refined_type = /obj/item/stack/ore/bluespace_crystal/refined
 	grind_results = list(/datum/reagent/bluespace = 20)
 	scan_state = "rock_BScrystal"
 
@@ -56,45 +56,11 @@
 	refined_type = null
 	grind_results = list(/datum/reagent/bluespace = 10, /datum/reagent/silicon = 20)
 
-//Polycrystals, aka stacks
-/obj/item/stack/sheet/bluespace_crystal
-	name = "bluespace polycrystal"
-	icon = 'icons/obj/telescience.dmi'
-	icon_state = "polycrystal"
-	item_state = "sheet-polycrystal"
-	singular_name = "bluespace polycrystal"
-	desc = "A stable polycrystal, made of fused-together bluespace crystals. You could probably break one off."
-	materials = list(/datum/material/bluespace=MINERAL_MATERIAL_AMOUNT)
-	attack_verb = list("bluespace polybashed", "bluespace polybattered", "bluespace polybludgeoned", "bluespace polythrashed", "bluespace polysmashed")
-	novariants = TRUE
-	grind_results = list(/datum/reagent/bluespace = 20)
-	point_value = 30
-	merge_type = /obj/item/stack/sheet/bluespace_crystal
-	var/crystal_type = /obj/item/stack/ore/bluespace_crystal/refined
-
-/obj/item/stack/sheet/bluespace_crystal/fifty
+/obj/item/stack/ore/bluespace_crystal/refined/fifty
 	amount = 50
 
-/obj/item/stack/sheet/bluespace_crystal/twenty
+/obj/item/stack/ore/bluespace_crystal/refined/twenty
 	amount = 20
 
-/obj/item/stack/sheet/bluespace_crystal/five
+/obj/item/stack/ore/bluespace_crystal/refined/five
 	amount = 5
-
-/obj/item/stack/sheet/bluespace_crystal/attack_self(mob/user)// to prevent the construction menu from ever happening
-	to_chat(user, "<span class='warning'>You cannot crush the polycrystal in-hand, try breaking one off.</span>")
-
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/item/stack/sheet/bluespace_crystal/attack_hand(mob/user)
-	if(user.get_inactive_held_item() == src)
-		if(zero_amount())
-			return
-		var/BC = new crystal_type(src)
-		user.put_in_hands(BC)
-		use(1)
-		if(!amount)
-			to_chat(user, "<span class='notice'>You break the final crystal off.</span>")
-		else
-			to_chat(user, "<span class='notice'>You break off a crystal.</span>")
-	else
-		..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1230,7 +1230,7 @@
 		/obj/item/stack/sheet/mineral/uranium=50,\
 		/obj/item/stack/sheet/mineral/plasma=50,\
 		/obj/item/stack/sheet/mineral/diamond=50,\
-		/obj/item/stack/sheet/bluespace_crystal=50,\
+		/obj/item/stack/ore/bluespace_crystal/refined=50,\
 		/obj/item/stack/sheet/mineral/bananium=50,\
 		/obj/item/stack/sheet/plastic/fifty=1,\
 		/obj/item/stack/sheet/runed_metal/fifty=1,\

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -107,7 +107,7 @@
 	/obj/item/stack/sheet/mineral/titanium,
 	/obj/item/stack/sheet/mineral/plastitanium,
 	/obj/item/stack/rods,
-	/obj/item/stack/sheet/bluespace_crystal,
+	/obj/item/stack/ore/bluespace_crystal/refined,
 	/obj/item/stack/sheet/mineral/abductor,
 	/obj/item/stack/sheet/plastic,
 	/obj/item/stack/sheet/mineral/wood,

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -70,7 +70,7 @@
 /datum/export/stack/bscrystal
 	cost = 300
 	message = "of bluespace crystals"
-	export_types = list(/obj/item/stack/sheet/bluespace_crystal)
+	export_types = list(/obj/item/stack/ore/bluespace_crystal)
 
 /datum/export/stack/wood
 	cost = 30

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -119,7 +119,7 @@ Charged extracts:
 	effect_desc = "Makes a bluespace polycrystal."
 
 /obj/item/slimecross/charged/bluespace/do_effect(mob/user)
-	new /obj/item/stack/sheet/bluespace_crystal(get_turf(user), 10)
+	new /obj/item/stack/ore/bluespace_crystal/refined(get_turf(user), 10)
 	user.visible_message("<span class='notice'>[src] produces several sheets of polycrystal!</span>")
 	..()
 

--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -54,7 +54,7 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 ///runes can also be deleted by bluespace crystals relatively fast as an alternative to cleaning them.
 /obj/effect/warped_rune/attackby(obj/item/used_item, mob/user)
 	. = ..()
-	if(!istype(used_item,/obj/item/stack/sheet/bluespace_crystal) && !istype(used_item,/obj/item/stack/ore/bluespace_crystal))
+	if(!istype(used_item,/obj/item/stack/ore/bluespace_crystal))
 		return
 
 	var/obj/item/stack/space_crystal = used_item
@@ -343,7 +343,7 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 	var/static/list/materials = list(/obj/item/stack/sheet/iron, /obj/item/stack/sheet/glass, /obj/item/stack/sheet/mineral/silver,
 									/obj/item/stack/sheet/mineral/gold, /obj/item/stack/sheet/mineral/diamond, /obj/item/stack/sheet/mineral/uranium,
 									/obj/item/stack/sheet/mineral/titanium, /obj/item/stack/sheet/mineral/copper, /obj/item/stack/sheet/mineral/uranium,
-									/obj/item/stack/sheet/bluespace_crystal)
+									/obj/item/stack/ore/bluespace_crystal/refined)
 
 /obj/effect/warped_rune/darkpurplespace/do_effect(mob/user)
 	if(locate(/obj/item/stack/sheet/mineral/plasma) in rune_turf)

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -65,7 +65,7 @@
 		/obj/item/stack/sheet/mineral/plastitanium	= /datum/species/golem/plastitanium,
 		/obj/item/stack/sheet/mineral/abductor	    = /datum/species/golem/alloy,
 		/obj/item/stack/sheet/mineral/wood	        = /datum/species/golem/wood,
-		/obj/item/stack/sheet/bluespace_crystal	    = /datum/species/golem/bluespace,
+		/obj/item/stack/ore/bluespace_crystal	    = /datum/species/golem/bluespace,
 		/obj/item/stack/sheet/runed_metal	        = /datum/species/golem/runic,
 		/obj/item/stack/medical/gauze	            = /datum/species/golem/cloth,
 		/obj/item/stack/sheet/cotton/cloth			= /datum/species/golem/cloth,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes #2271

## About The Pull Request

Removes bluespace polycrystals and replaces them with refined bluespace crystals.

## Why It's Good For The Game

Bluespace polycrystals are incredibly confusing, you think you have a bluespace crystal but instead it is a version of the bluespace crystal that you have to attack with an empty hand in order to get a different type of bluespace crystal that works.
This completely removes bluespace polycrystals and just uses the bluespace crystals that work instead.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/172245940-d3b23dcd-edad-40fa-88ca-cc076a9340ec.png)

Tested and confirmed working with recipes.

Lathes now output refined bluespace crystals instead:
![image](https://user-images.githubusercontent.com/26465327/172246076-ba2bd7dd-60a5-4b91-a56c-2d81c3b2de6c.png)

Tested stack merging and ORM duplication glitches, none found.
![image](https://user-images.githubusercontent.com/26465327/172246234-54952ad7-19de-4e0c-9ae2-f74f51da1cae.png)

## Changelog
:cl:
tweak: Removes bluespace polycrystals and replaces anything that produces them with regular bluespace crystals.
balance: Stabilized metal crossbreed will no longer accept bluespace polycrystals crystals as input.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
