### PR TITLE
Blobs can no longer destroy indestructible items.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -266,7 +266,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return 1
 
 /obj/item/blob_act(obj/structure/blob/B)
-	if(B && B.loc == loc)
+	if(B && B.loc == loc && !(resistance_flags & INDESTRUCTIBLE))
 		qdel(src)
 
 /obj/item/ComponentInitialize()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -266,7 +266,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return 1
 
 /obj/item/blob_act(obj/structure/blob/B)
-	if(B && B.loc == loc && !(resistance_flags & INDESTRUCTIBLE))
+	if(B.loc == loc && !(resistance_flags & INDESTRUCTIBLE))
 		qdel(src)
 
 /obj/item/ComponentInitialize()

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -114,11 +114,11 @@
 				toggle_power()
 			stability -= rand(10,20)
 
-/obj/machinery/power/am_control_unit/blob_act()
+/obj/machinery/power/am_control_unit/blob_act(obj/structure/blob/B)
 	stability -= 20
 	if(prob(100-stability))//Might infect the rest of the machine
 		for(var/obj/machinery/am_shielding/AMS in linked_shielding)
-			AMS.blob_act()
+			AMS.blob_act(B)
 		qdel(src)
 		return
 	check_stability()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #5326

Blobs can no longer destroy items that are indestructible.

## Why It's Good For The Game

Blobs will no longer be able to break things that are marked as indestructible.
Blobs can still break the self destruct, as it is specifically coded to be able to be broken by the blob so that the blob can counter the SD if they spawn in the vault.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/172247361-fa16545a-6496-4f10-bc27-659a2bfb8d84.png)

Didn't eat gun

![image](https://user-images.githubusercontent.com/26465327/172247388-03ad4859-65e3-408b-99a8-4c559fb5ccce.png)

Ate a clipboard

## Changelog
:cl:
fix: Blobs can no longer destroy indestructible items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
