### PR TITLE
Fixes alt click not opening labcoat's inventory

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -139,6 +139,7 @@
 #define COMSIG_CLICK_SHIFT "shift_click"						//! from base of atom/ShiftClick(): (/mob)
 #define COMSIG_CLICK_CTRL "ctrl_click"							//! from base of atom/CtrlClickOn(): (/mob)
 #define COMSIG_CLICK_ALT "alt_click"							//! from base of atom/AltClick(): (/mob)
+	#define COMPONENT_INTERCEPT_ALT 1
 #define COMSIG_CLICK_CTRL_SHIFT "ctrl_shift_click"				//! from base of atom/CtrlShiftClick(/mob)
 #define COMSIG_MOUSEDROP_ONTO "mousedrop_onto"					//! from base of atom/MouseDrop(): (/atom/over, /mob/user)
 	#define COMPONENT_NO_MOUSEDROP 1

--- a/code/datums/ai/dog/dog_controller.dm
+++ b/code/datums/ai/dog/dog_controller.dm
@@ -180,6 +180,7 @@
 	if(!istype(clicker) || !blackboard[BB_DOG_FRIENDS][WEAKREF(clicker)])
 		return
 	INVOKE_ASYNC(src, .proc/command_radial, clicker)
+	return COMPONENT_INTERCEPT_ALT
 
 /// Show the command radial menu
 /datum/ai_controller/dog/proc/command_radial(mob/living/clicker)

--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -71,6 +71,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 	toggletracking(user)
 	ui_update()
+	return COMPONENT_INTERCEPT_ALT
 
 ///Toggles the tracking for the gps
 /datum/component/gps/item/proc/toggletracking(mob/user)

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -110,6 +110,7 @@
 	if(!can_be_rotated.Invoke(user, rotation) || !can_user_rotate.Invoke(user, rotation))
 		return
 	BaseRot(user, rotation)
+	return COMPONENT_INTERCEPT_ALT
 
 /datum/component/simple_rotation/proc/WrenchRot(datum/source, obj/item/I, mob/living/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -828,22 +828,23 @@
 	if(locked)
 		var/atom/host = parent
 		host.balloon_alert(user, "[host] is locked.")
-		return
+		return COMPONENT_INTERCEPT_ALT
 
 	var/atom/A = parent
 	if(!quickdraw)
 		A.add_fingerprint(user)
 		user_show_to_mob(user)
 		playsound(A, "rustle", 50, 1, -5)
-		return
+		return COMPONENT_INTERCEPT_ALT
 
 	if(user.incapacitated())
 		return
 
 	var/obj/item/to_remove = locate() in real_location()
 	if(!to_remove)
-		return
+		return COMPONENT_INTERCEPT_ALT
 	INVOKE_ASYNC(src, .proc/attempt_put_in_hands, to_remove, user)
+	return COMPONENT_INTERCEPT_ALT
 
 ///attempt to put an item from contents into the users hands
 /datum/component/storage/proc/attempt_put_in_hands(obj/item/to_remove, mob/user)

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -94,11 +94,7 @@
 //Toggle exosuits for different aesthetic styles (hoodies, suit jacket buttons, etc)
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
-	if(SEND_SIGNAL(src, COMSIG_CLICK_ALT, user))
-		return
-	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
-		return
-	else
+	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
 		suit_toggle(user)
 
 /obj/item/clothing/suit/toggle/ui_action_click()

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -94,6 +94,8 @@
 //Toggle exosuits for different aesthetic styles (hoodies, suit jacket buttons, etc)
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
+	if(SEND_SIGNAL(src, COMSIG_CLICK_ALT, user))
+		return
 	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 	else
@@ -102,7 +104,9 @@
 /obj/item/clothing/suit/toggle/ui_action_click()
 	suit_toggle()
 
-/obj/item/clothing/suit/toggle/proc/suit_toggle()
+/obj/item/clothing/suit/toggle/verb/suit_toggle()
+	set name = "Toggle Suit Style"
+	set category = "Object"
 	set src in usr
 
 	if(!can_use(usr))

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -95,7 +95,6 @@
 
 /obj/item/clothing/suit/toggle/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
-		suit_toggle(user)
 
 /obj/item/clothing/suit/toggle/ui_action_click()
 	suit_toggle()

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -72,6 +72,7 @@
 	source.balloon_alert(user, "Clicked the alternate button.")
 	playsound(source, get_sfx("terminal_type"), 25, FALSE)
 	alt.set_output(COMPONENT_SIGNAL)
+	return COMPONENT_INTERCEPT_ALT
 
 /obj/item/circuit_component/controller/proc/send_right_signal(atom/source, mob/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #3016
Alt click on a labcoat will no longer toggle the labcoat style, but will instead open the inventory.
To change the style, the toggle suit style verb can be used instead which is located on the context menu, or in the object tab of the stat panel.
![image](https://user-images.githubusercontent.com/26465327/172249210-d0c44b76-79c6-4913-be54-9543843817d5.png)

## Why It's Good For The Game

Makes it much easier to access items that are stored within a lab coat, due to conflicting key binds suit style adjustment have been moved to the object tab of the stat panel.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/172249240-ea20ebcf-ee4a-4ba5-861c-f48e70a46776.png)

![image](https://user-images.githubusercontent.com/26465327/172249340-6a745ef3-0fa6-4190-b8ca-895e3c6d3076.png)

## Changelog
:cl:
tweak: Alt clicking on suits that contain embedded storage (pockets) will now open the inventory instead of adjusting the style of that article of clothing. Adjusting the style can be done through the context menu or the stat panel under the object tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
