### PR TITLE
Fixes brain problems not equipping medicine properly.

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -78,7 +78,7 @@
 	if(where)
 		to_chat(quirk_holder, "<span class='boldnotice'>There is a bottle of mannitol [where]. You're going to need it.</span>")
 	else
-		to_chat(quirk_holder, "<span class='boldnotice'>You dropped your bottle of mannitol on the floor. better pick it up, you are going to need it.</span>")
+		to_chat(quirk_holder, "<span class='boldnotice'>You dropped your bottle of mannitol on the floor. Better pick it up, you are going to need it.</span>")
 
 /datum/quirk/deafness
 	name = "Deaf"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -78,7 +78,7 @@
 	if(where)
 		to_chat(quirk_holder, "<span class='boldnotice'>There is a bottle of mannitol [where]. You're going to need it.</span>")
 	else
-		to_chat(quirk_holder, "<span class='boldnotice'>You dropped your bottle of mannitol on the shuttle ride here and couldn't find it, it must have fallen into a bluespace pocket! You better find some more at chemistry and fast...</span>")
+		to_chat(quirk_holder, "<span class='boldnotice'>You dropped your bottle of mannitol on the floor. better pick it up, you are going to need it.</span>")
 
 /datum/quirk/deafness
 	name = "Deaf"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -72,17 +72,13 @@
 		"in your right pocket" = ITEM_SLOT_RPOCKET,
 		"in your backpack" = ITEM_SLOT_BACKPACK
 	)
-	var/slot = H.equip_in_one_of_slots(P, slots, FALSE)
-	if(slot)
-		var/list/slots = list(
-		ITEM_SLOT_LPOCKET = "in your left pocket",
-		ITEM_SLOT_RPOCKET = "in your right pocket",
-		ITEM_SLOT_BACKPACK = "in your backpack"
-		)
-		where = slots[slot]
+	where = H.equip_in_one_of_slots(P, slots, FALSE)
 
 /datum/quirk/brainproblems/post_add()
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a bottle of mannitol [where]. You're going to need it.</span>")
+	if(where)
+		to_chat(quirk_holder, "<span class='boldnotice'>There is a bottle of mannitol [where]. You're going to need it.</span>")
+	else
+		to_chat(quirk_holder, "<span class='boldnotice'>You dropped your bottle of mannitol on the shuttle ride here and couldn't find it, it must have fallen into a bluespace pocket! You better find some more at chemistry and fast...</span>")
 
 /datum/quirk/deafness
 	name = "Deaf"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -67,7 +67,12 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/storage/pill_bottle/mannitol/braintumor/P = new(get_turf(H))
 
-	var/slot = H.equip_in_one_of_slots(P, list(ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET, ITEM_SLOT_BACKPACK), FALSE)
+	var/list/slots = list(
+		"in your left pocket" = ITEM_SLOT_LPOCKET,
+		"in your right pocket" = ITEM_SLOT_RPOCKET,
+		"in your backpack" = ITEM_SLOT_BACKPACK
+	)
+	var/slot = H.equip_in_one_of_slots(P, slots, FALSE)
 	if(slot)
 		var/list/slots = list(
 		ITEM_SLOT_LPOCKET = "in your left pocket",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #4453
Changes the usage of equip_in_one_of_slots to be used how it is meant to be used.

## Why It's Good For The Game

Fixes a runtime error occured by improper use of the equip_in_one_of_slots  proc.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/172250383-6e908d9b-5fce-430c-b75f-a36feab8b6cb.png)

## Changelog
:cl:
fix: Fixes brain trauma quirk medicine spawning
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
