### PR TITLE
Fixes handling of 0.1 damage

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -9,7 +9,7 @@
 	if((resistance_flags & INDESTRUCTIBLE) || obj_integrity <= 0)
 		return
 	damage_amount = run_obj_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
-	if(damage_amount <= DAMAGE_PRECISION)
+	if(damage_amount < DAMAGE_PRECISION)
 		return
 	. = damage_amount
 	var/old_integ = obj_integrity

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -503,7 +503,7 @@
 
 /mob/living/carbon/update_stamina(extend_stam_crit = FALSE)
 	var/stam = getStaminaLoss()
-	if(stam > DAMAGE_PRECISION && (maxHealth - stam) <= crit_threshold && !stat && !HAS_TRAIT(src, TRAIT_NOSTAMCRIT))
+	if(stam >= DAMAGE_PRECISION && (maxHealth - stam) <= crit_threshold && !stat && !HAS_TRAIT(src, TRAIT_NOSTAMCRIT))
 		if(extend_stam_crit || !stam_paralyzed)
 			enter_stamcrit()
 	else if(stam_paralyzed)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -211,7 +211,7 @@
 		parts -= picked
 	if(updating_health)
 		updatehealth()
-		update_stamina(stamina > DAMAGE_PRECISION)
+		update_stamina(stamina >= DAMAGE_PRECISION)
 	if(update)
 		update_damage_overlays()
 
@@ -244,4 +244,4 @@
 		updatehealth()
 	if(update)
 		update_damage_overlays()
-	update_stamina(stamina > DAMAGE_PRECISION)
+	update_stamina(stamina >= DAMAGE_PRECISION)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -306,7 +306,7 @@
 	//Find how many bodyparts we have with stamina damage
 	if(stam_regen)
 		for(var/obj/item/bodypart/BP as() in bodyparts)
-			if(BP.stamina_dam > DAMAGE_PRECISION)
+			if(BP.stamina_dam >= DAMAGE_PRECISION)
 				bodyparts_with_stam++
 				total_stamina_loss += BP.stamina_dam * BP.stam_damage_coeff
 		//Force bodyparts to heal if we have more than 120 stamina damage (6 seconds)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -256,7 +256,7 @@
 	adjustStaminaLoss(stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina(stamina > DAMAGE_PRECISION)
+		update_stamina(stamina >= DAMAGE_PRECISION)
 
 // heal MANY bodyparts, in random order
 /mob/living/proc/heal_overall_damage(brute = 0, burn = 0, stamina = 0, required_status, updating_health = TRUE)
@@ -274,7 +274,7 @@
 	adjustStaminaLoss(stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina(stamina > DAMAGE_PRECISION)
+		update_stamina(stamina >= DAMAGE_PRECISION)
 
 //heal up to amount damage, in a given order
 /mob/living/proc/heal_ordered_damage(amount, list/damage_types)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -88,9 +88,9 @@
 
 /obj/item/bodypart/examine(mob/user)
 	. = ..()
-	if(brute_dam > DAMAGE_PRECISION)
+	if(brute_dam >= DAMAGE_PRECISION)
 		. += "<span class='warning'>This limb has [brute_dam > 30 ? "severe" : "minor"] bruising.</span>"
-	if(burn_dam > DAMAGE_PRECISION)
+	if(burn_dam >= DAMAGE_PRECISION)
 		. += "<span class='warning'>This limb has [burn_dam > 30 ? "severe" : "minor"] burns.</span>"
 	if(limb_id)
 		. += "<span class='notice'>It is a [limb_id] [parse_zone(body_zone)].</span>"
@@ -150,7 +150,7 @@
 		I.forceMove(T)
 
 /obj/item/bodypart/proc/consider_processing()
-	if(stamina_dam > DAMAGE_PRECISION)
+	if(stamina_dam >= DAMAGE_PRECISION)
 		. = TRUE
 	//else if.. else if.. so on.
 	else
@@ -159,7 +159,7 @@
 
 //Return TRUE to get whatever mob this is in to update health.
 /obj/item/bodypart/proc/on_life(stam_regen)
-	if(stamina_dam > DAMAGE_PRECISION && stam_regen)					//DO NOT update health here, it'll be done in the carbon's life.
+	if(stamina_dam >= DAMAGE_PRECISION && stam_regen)					//DO NOT update health here, it'll be done in the carbon's life.
 		heal_damage(0, 0, stam_regen, null, FALSE)
 		. |= BODYPART_LIFE_UPDATE_HEALTH
 
@@ -212,7 +212,7 @@
 
 	if(owner && updating_health)
 		owner.updatehealth()
-		if(stamina > DAMAGE_PRECISION)
+		if(stamina >= DAMAGE_PRECISION)
 			owner.update_stamina(TRUE)
 			owner.stam_regen_start_time = max(owner.stam_regen_start_time, world.time + STAMINA_REGEN_BLOCK_TIME)
 	consider_processing()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #5569
Due to a logic error, limbs would only heal stamina damage if they had more than 0.1 points of damage rather than more than or equal to 0.1 points of stamina damage.
Actually fixes a few logic arrows that means that 0.1 damage wasn't considered damage, despite 0.1 being the minimum amount of damage that can be applied.

## Why It's Good For The Game

Recieving 0.1 stamina damage to a limb will no longer cause the health doll to display stamina damage permanently.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/172251421-672dfc16-5a42-4563-a35e-817db6c62e71.png)
![image](https://user-images.githubusercontent.com/26465327/172252025-885f64d2-8909-4a62-8bc4-04418cf9c4a6.png)



## Changelog
:cl:
fix: Taking the minimum amount of stamina damage will now properly heal.
fix: Fixes a few miscalculations of minimum damage, meaning that 0.1 damage should properly update the health hud and display on examine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
