### PR TITLE
Friendly ninjas are now admin only

### DIFF
--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -26,8 +26,7 @@
 
 /datum/antagonist/ninja/proc/addMemories()
 	antag_memory += "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!<br>"
-	antag_memory += "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by clicking the initialize UI button, to use abilities like stealth)!<br>"
-	antag_memory += "Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.<br>"
+	antag_memory += "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (initialize your suit by clicking the initialize UI button, to use abilities like stealth)!<br>"
 
 /datum/antagonist/ninja/proc/addObjectives(quantity = 3)
 	if(!give_objectives)
@@ -58,47 +57,23 @@
 				objectives += O
 				log_objective(owner, O.explanation_text)
 
-			if(3)	//protect/kill
+			if(3)	//kill
 				if(!possible_targets.len)	continue
 				var/index = rand(1,possible_targets.len)
 				var/datum/mind/M = possible_targets[index]
-				var/is_bad_guy = possible_targets[M]
 				possible_targets.Cut(index,index+1)
-
-				if(is_bad_guy ^ helping_station)			//kill (good-ninja + bad-guy or bad-ninja + good-guy)
-					var/datum/objective/assassinate/O = new /datum/objective/assassinate()
-					O.owner = owner
-					O.set_target(M)
-					O.explanation_text = "Slay \the [M.current.real_name], the [M.assigned_role]."
-					objectives += O
-					log_objective(owner, O.explanation_text)
-				else										//protect
-					var/datum/objective/protect/O = new /datum/objective/protect()
-					O.owner = owner
-					O.set_target(M)
-					O.explanation_text = "Protect \the [M.current.real_name], the [M.assigned_role], from harm."
-					objectives += O
-					log_objective(owner, O.explanation_text)
-			if(4)	//debrain/capture
-				if(!possible_targets.len)	continue
-				var/selected = rand(1,possible_targets.len)
-				var/datum/mind/M = possible_targets[selected]
-				var/is_bad_guy = possible_targets[M]
-				possible_targets.Cut(selected,selected+1)
-
-				if(is_bad_guy ^ helping_station)			//debrain (good-ninja + bad-guy or bad-ninja + good-guy)
-					var/datum/objective/debrain/O = new /datum/objective/debrain()
-					O.owner = owner
-					O.set_target(M)
-					O.explanation_text = "Steal the brain of [M.current.real_name]."
-					objectives += O
-					log_objective(owner, O.explanation_text)
-				else										//capture
-					var/datum/objective/capture/O = new /datum/objective/capture()
-					O.owner = owner
-					O.gen_amount_goal()
-					objectives += O
-					log_objective(owner, O.explanation_text)
+				var/datum/objective/assassinate/O = new /datum/objective/assassinate()
+				O.owner = owner
+				O.set_target(M)
+				O.explanation_text = "Slay \the [M.current.real_name], the [M.assigned_role]."
+				objectives += O
+				log_objective(owner, O.explanation_text)
+			if(4)	//capture
+				var/datum/objective/capture/O = new /datum/objective/capture()
+				O.owner = owner
+				O.gen_amount_goal()
+				objectives += O
+				log_objective(owner, O.explanation_text)
 			else
 				break
 	var/datum/objective/O = new /datum/objective/survive()
@@ -120,8 +95,7 @@
 /datum/antagonist/ninja/greet()
 	SEND_SOUND(owner.current, sound('sound/effects/ninja_greeting.ogg'))
 	to_chat(owner.current, "I am an elite mercenary assassin of the mighty Spider Clan. A <font color='red'><B>SPACE NINJA</B></font>!")
-	to_chat(owner.current, "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (//initialize your suit by right clicking on it, to use abilities like stealth)!")
-	to_chat(owner.current, "Officially, [helping_station?"Nanotrasen":"The Syndicate"] are my employer.")
+	to_chat(owner.current, "Surprise is my weapon. Shadows are my armor. Without them, I am nothing. (initialize your suit by right clicking on it, to use abilities like stealth)!")
 	owner.announce_objectives()
 	owner.current.client?.tgui_panel?.give_antagonist_popup("Ninja",
 		"Infiltrate the station and complete your assigned objectives.")
@@ -136,23 +110,14 @@
 
 /datum/antagonist/ninja/admin_add(datum/mind/new_owner,mob/admin)
 	var/adj
-	switch(input("What kind of ninja?", "Ninja") as null|anything in list("Random","Syndicate","Nanotrasen","No objectives"))
+	switch(input("What kind of ninja?", "Ninja") as null|anything in list("Random","No objectives"))
 		if("Random")
-			helping_station = pick(TRUE,FALSE)
 			adj = ""
-		if("Syndicate")
-			helping_station = FALSE
-			adj = "syndie"
-		if("Nanotrasen")
-			helping_station = TRUE
-			adj = "friendly"
 		if("No objectives")
 			give_objectives = FALSE
 			adj = "objectiveless"
 		else
 			return
-	if(helping_station)
-		can_elimination_hijack = ELIMINATION_PREVENT
 	new_owner.assigned_role = ROLE_NINJA
 	new_owner.special_role = ROLE_NINJA
 	new_owner.add_antag_datum(src)

--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -109,20 +109,11 @@
 	. = ..()
 
 /datum/antagonist/ninja/admin_add(datum/mind/new_owner,mob/admin)
-	var/adj
-	switch(input("What kind of ninja?", "Ninja") as null|anything in list("Random","No objectives"))
-		if("Random")
-			adj = ""
-		if("No objectives")
-			give_objectives = FALSE
-			adj = "objectiveless"
-		else
-			return
 	new_owner.assigned_role = ROLE_NINJA
 	new_owner.special_role = ROLE_NINJA
 	new_owner.add_antag_datum(src)
-	message_admins("[key_name_admin(admin)] has [adj] ninja'ed [key_name_admin(new_owner)].")
-	log_admin("[key_name(admin)] has [adj] ninja'ed [key_name(new_owner)].")
+	message_admins("[key_name_admin(admin)] has ninja'd [key_name_admin(new_owner)].")
+	log_admin("[key_name(admin)] has ninja'd [key_name(new_owner)].")
 
 /datum/antagonist/ninja/proc/update_ninja_icons_added(var/mob/living/carbon/human/ninja)
 	var/datum/atom_hud/antag/ninjahud = GLOB.huds[ANTAG_HUD_NINJA]

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -66,7 +66,6 @@ Contents:
 	var/mob/living/carbon/human/Ninja = create_space_ninja(spawn_loc)
 	Mind.transfer_to(Ninja)
 	var/datum/antagonist/ninja/ninjadatum = new
-	ninjadatum.helping_station = pick(TRUE,FALSE)
 	Mind.add_antag_datum(ninjadatum)
 
 	if(Ninja.mind != Mind)			//something has gone wrong!

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -22,12 +22,8 @@ Contents:
 	role_name = "space ninja"
 	minimum_required = 1
 
-	var/helping_station
 	var/spawn_loc
 	var/give_objectives = TRUE
-
-/datum/round_event/ghost_role/ninja/setup()
-	helping_station = rand(0,1)
 
 /datum/round_event/ghost_role/ninja/kill()
 	if(!success_spawn && control)
@@ -72,8 +68,8 @@ Contents:
 		CRASH("Ninja created with incorrect mind")
 
 	spawned_mobs += Ninja
-	message_admins("[ADMIN_LOOKUPFLW(Ninja)] has been made into a ninja by an event. They are employed by [ninjadatum.helping_station?"Nanotrasen":"The Syndicate"].")
-	log_game("[key_name(Ninja)] was spawned as a ninja by an event. They are employed by [ninjadatum.helping_station?"Nanotrasen":"The Syndicate"]")
+	message_admins("[ADMIN_LOOKUPFLW(Ninja)] has been made into a ninja by an event")
+	log_game("[key_name(Ninja)] was spawned as a ninja by an event.")
 
 	return SUCCESSFUL_SPAWN
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the possibility for randomly spawned ninjas to be Nanotrasen aligned, as this can frequently result in less than desirable gameplay circumstances.
Removes debrain objectives from ninjas because it fills the same role as assassination. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1) Having a friendly ninja join sec is pretty much the most oppressive thing that can possibly happen in a round to antagonists. 
2) Having unfriendly ninjas able to believably claim they are just there to help is equally problematic. 

This did not remove the ability for admins to explicitly create friendly ninjas should the need arise, and I would expect this would probably be done along with some sort of notification sent to the station so they have an advanced heads up. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![image](https://user-images.githubusercontent.com/9547572/172731742-2ab39fd1-9666-4fbf-ba07-c3659a5db989.png)

![image](https://user-images.githubusercontent.com/9547572/172731776-6e1b78f0-1745-4cb7-9a80-b67b62d55844.png)


## Changelog
:cl:
tweak: The spider clan has terminated its contracts with Nanotrasen. Ninjas will now work exclusively for the syndicate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
