### PR TITLE
Voice of God stun reduction and tweaks

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -1,7 +1,7 @@
-#define COOLDOWN_STUN 1
-#define COOLDOWN_DAMAGE 1
-#define COOLDOWN_MEME 1
-#define COOLDOWN_NONE 1
+#define COOLDOWN_STUN 2 MINUTES
+#define COOLDOWN_DAMAGE 1 MINUTES
+#define COOLDOWN_MEME 30 SECONDS
+#define COOLDOWN_NONE 10 SECONDS
 
 /obj/item/organ/vocal_cords //organs that are activated through speech with the :x/MODE_KEY_VOCALCORDS channel
 	name = "vocal cords"

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -163,9 +163,9 @@
 		//Chaplains are very good at speaking with the voice of god
 		if(user.mind.assigned_role == "Chaplain")
 			power_multiplier *= 2
-		//Command staff has authority
-		if(user.mind.assigned_role in GLOB.command_positions)
-			power_multiplier *= 1.4
+		//Curators are very good at speaking in other languages, but not as good as Chaplain with this one
+		if(user.mind.assigned_role == "Curator")
+			power_multiplier *= 1.5
 		//Why are you speaking
 		if(user.mind.assigned_role == "Mime")
 			power_multiplier *= 0.5
@@ -261,20 +261,20 @@
 		cooldown = COOLDOWN_STUN
 		for(var/V in listeners)
 			var/mob/living/L = V
-			L.Stun(60 * power_multiplier)
+			L.Stun(1 SECONDS * power_multiplier)
 
 	//KNOCKDOWN
 	else if(findtext(message, knockdown_words))
 		cooldown = COOLDOWN_STUN
 		for(var/V in listeners)
 			var/mob/living/L = V
-			L.Paralyze(60 * power_multiplier)
+			L.Knockdown(4 SECONDS * power_multiplier)
 
 	//SLEEP
 	else if((findtext(message, sleep_words)))
 		cooldown = COOLDOWN_STUN
 		for(var/mob/living/carbon/C in listeners)
-			C.Sleeping(40 * power_multiplier)
+			C.Sleeping(1 SECONDS * power_multiplier)
 
 	//VOMIT
 	else if((findtext(message, vomit_words)))
@@ -286,9 +286,7 @@
 	else if((findtext(message, silence_words)))
 		cooldown = COOLDOWN_STUN
 		for(var/mob/living/carbon/C in listeners)
-			if(user.mind && (user.mind.assigned_role == "Curator" || user.mind.assigned_role == "Mime"))
-				power_multiplier *= 3
-			C.silent += (10 * power_multiplier)
+			C.silent += (10 SECONDS * power_multiplier)
 
 	//HALLUCINATE
 	else if((findtext(message, hallucinate_words)))

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -268,7 +268,7 @@
 		cooldown = COOLDOWN_STUN
 		for(var/V in listeners)
 			var/mob/living/L = V
-			L.Knockdown(4 SECONDS * power_multiplier)
+			L.Knockdown(2 SECONDS * power_multiplier)
 
 	//SLEEP
 	else if((findtext(message, sleep_words)))

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -278,7 +278,7 @@
 
 	//VOMIT
 	else if((findtext(message, vomit_words)))
-		cooldown = COOLDOWN_STUN
+		cooldown = COOLDOWN_DAMAGE
 		for(var/mob/living/carbon/C in listeners)
 			C.vomit(10 * power_multiplier, stun = FALSE, distance = power_multiplier)
 

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -1,7 +1,7 @@
-#define COOLDOWN_STUN 1200
-#define COOLDOWN_DAMAGE 600
-#define COOLDOWN_MEME 300
-#define COOLDOWN_NONE 100
+#define COOLDOWN_STUN 1
+#define COOLDOWN_DAMAGE 1
+#define COOLDOWN_MEME 1
+#define COOLDOWN_NONE 1
 
 /obj/item/organ/vocal_cords //organs that are activated through speech with the :x/MODE_KEY_VOCALCORDS channel
 	name = "vocal cords"
@@ -280,7 +280,7 @@
 	else if((findtext(message, vomit_words)))
 		cooldown = COOLDOWN_STUN
 		for(var/mob/living/carbon/C in listeners)
-			C.vomit(10 * power_multiplier, distance = power_multiplier)
+			C.vomit(10 * power_multiplier, stun = FALSE, distance = power_multiplier)
 
 	//SILENCE
 	else if((findtext(message, silence_words)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I made voice of god much easier to obtain and, by extension, share with crew. This has had an immediately negative effect as brought to my attention via a player report. Hardstuns on the voice of god are pretty busted, so this reduces most of them substantially. 

Base duration of the follow commands have been adjusted: 
* Stun: 12 seconds -> 2 seconds
* Sleep: 8 seconds -> 2 seconds
* Paralyze -> 12 seconds -> 4 seconds and also changed to a knockdown
* Silence: 2 seconds -> 20 seconds
* Vomit: Does not stun, now has 1 minute "damage" cooldown instead of 2 minute "stun" cooldown

The following Multipliers have been adjusted:
* Command staff no longer receieves any special bonus for using voice of god
* Curator now receives a 50% bonus to all words instead of just silence
* Mime has lost their bonus for silence command, and all other words are still half power

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I made a 12 second stun with almost no chance to fail more easily obtainable. I feel the consequences of this don't need to be explained further. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/172916176-befc0482-470d-4633-851f-35d0d3c639aa.png)

![image](https://user-images.githubusercontent.com/9547572/172916219-398d2927-0b95-4767-9dda-329cd6d4038b.png)

![image](https://user-images.githubusercontent.com/9547572/172916259-b5483acd-a149-4814-99db-bb69dd4dd088.png)

### And one with curator for power bonus visibility
![image](https://user-images.githubusercontent.com/9547572/172916426-8185b7ce-bcde-4ea4-9b48-4ec8f1b2a5dc.png)


</details>

## Changelog
:cl:
balance: Voice of God stuns have been reduced substantially. 
tweak: Due to language proficiency, the curator now gets a bonus when using the voice of God, but it is weaker than the one the chaplain already got.
tweak: Command staff and mimes no longer receive any positive bonus multipliers when utilizing the voice of god.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
