### PR TITLE
Ripley drilling now causes sparks when drilling robots

### DIFF
--- a/code/game/mecha/equipment/tools/mining_tools.dm
+++ b/code/game/mecha/equipment/tools/mining_tools.dm
@@ -127,12 +127,17 @@
 		var/obj/item/bodypart/target_part = target.get_bodypart(ran_zone(BODY_ZONE_CHEST))
 		target.apply_damage(10, BRUTE, BODY_ZONE_CHEST, target.run_armor_check(target_part, "melee"))
 
-		//blood splatters
-		var/splatter_dir = get_dir(chassis, target)
-		if(isalien(target))
-			new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target.drop_location(), splatter_dir)
+		//blood splatters and sparks
+		if(issilicon(target)  || isbot(target) || isswarmer(target) || !IS_ORGANIC_LIMB(target_part))
+			do_sparks(rand(1, 3), FALSE, target.drop_location())
 		else
-			new /obj/effect/temp_visual/dir_setting/bloodsplatter(target.drop_location(), splatter_dir)
+			var/splatter_dir = get_dir(chassis, target)
+		
+			if(isalien(target))
+				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target.drop_location(), splatter_dir)
+			else
+				new /obj/effect/temp_visual/dir_setting/bloodsplatter(target.drop_location(), splatter_dir)
+
 
 		//organs go everywhere
 		if(target_part && prob(10 * drill_level))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

currently, drilling anything other than xenos with a ripley produces blood splash effect, even on IPCs and cyborgs.
this PR changes that so when you drill an IPC, cyborg, AI, swarmer or a bot, you cause sparks instead of blood.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bleeding cyborgs ruined my immersion, 0/10
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Untitled](https://user-images.githubusercontent.com/42618382/173050581-a73868ab-1001-43c1-b30e-44e7817d179a.png)

</details>

## Changelog
:cl:
tweak: ripley drill now causes sparks when dilling IPCs, cyborgs, active AIs, bots or swarmers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
