### PR TITLE
Revert "Removes miasma, corpseflowers, and the rot component"

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -497,6 +497,7 @@
 #include "code\datums\components\religious_tool.dm"
 #include "code\datums\components\remote_materials.dm"
 #include "code\datums\components\riding.dm"
+#include "code\datums\components\rot.dm"
 #include "code\datums\components\rotation.dm"
 #include "code\datums\components\shell.dm"
 #include "code\datums\components\singularity.dm"

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -275,6 +275,7 @@
 #define GAS_BZ					"bz"
 #define GAS_STIMULUM			"stim"
 #define GAS_PLUOXIUM			"pluox"
+#define GAS_MIASMA				"miasma"
 
 #define GAS_FLAG_DANGEROUS		(1<<0)
 #define GAS_FLAG_BREATH_PROC	(1<<1)
@@ -321,6 +322,10 @@ GLOBAL_LIST_INIT(pipe_paint_colors, sortList(list(
 		"violet" = rgb(64,0,128),
 		"yellow" = rgb(255,198,0)
 )))
+
+//ROT MIASMA
+#define MIASMA_CORPSE_MOLES 0.02
+#define MIASMA_GIBS_MOLES 0.005
 
 //PIPENET UPDATE STATUS
 #define PIPENET_UPDATE_STATUS_DORMANT 0

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -33,6 +33,7 @@
 #define NOBLIUM_RESEARCH_AMOUNT				1000
 #define BZ_RESEARCH_SCALE					4
 #define BZ_RESEARCH_MAX_AMOUNT				400
+#define MIASMA_RESEARCH_AMOUNT				40
 #define STIMULUM_RESEARCH_AMOUNT			50
 //Plasma fusion properties
 #define FUSION_ENERGY_THRESHOLD				3e9 	//! Amount of energy it takes to start a fusion reaction

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -1,0 +1,66 @@
+/datum/component/rot
+	var/amount = 1
+
+/datum/component/rot/Initialize(new_amount)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	if(new_amount)
+		amount = new_amount
+
+	START_PROCESSING(SSprocessing, src)
+
+/datum/component/rot/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
+	return ..()
+
+/datum/component/rot/process(delta_time)
+	var/atom/A = parent
+
+	var/turf/open/T = get_turf(A)
+	if(!istype(T) || T.return_air().return_pressure() > (WARNING_HIGH_PRESSURE - 10))
+		return
+
+	var/datum/gas_mixture/stank = new
+	stank.set_moles(GAS_MIASMA, amount * delta_time)
+	stank.set_temperature(BODYTEMP_NORMAL) // otherwise we have gas below 2.7K which will break our lag generator
+	T.assume_air(stank)
+	T.air_update_turf()
+
+/datum/component/rot/corpse
+	amount = MIASMA_CORPSE_MOLES
+
+/datum/component/rot/corpse/Initialize()
+	if(!iscarbon(parent))
+		return COMPONENT_INCOMPATIBLE
+	. = ..()
+
+/datum/component/rot/corpse/process()
+	var/mob/living/carbon/C = parent
+	if(C == null) //can't delete what doesnt exist
+		return
+
+	if(C.stat != DEAD)
+		qdel(src)
+		return
+
+	// Wait a bit before decaying
+	if(world.time - C.timeofdeath < 2 MINUTES)
+		return
+
+	// Properly stored corpses shouldn't create miasma
+	if(istype(C.loc, /obj/structure/closet/crate/coffin)|| istype(C.loc, /obj/structure/closet/body_bag) || istype(C.loc, /obj/structure/bodycontainer))
+		return
+
+	// No decay if formaldehyde in corpse or when the corpse is charred
+	if(C.reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 15) || HAS_TRAIT(C, TRAIT_HUSK))
+		return
+
+	// Also no decay if corpse chilled or not organic/undead
+	if(C.bodytemperature <= T0C-10 || (!(MOB_ORGANIC in C.mob_biotypes) && !(MOB_UNDEAD in C.mob_biotypes)))
+		return
+
+	..()
+
+/datum/component/rot/gibs
+	amount = MIASMA_GIBS_MOLES

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -84,6 +84,7 @@
 	if(rename)
 		name = "rotting [initial(name)]"
 		desc += " They smell terrible."
+	AddComponent(/datum/component/rot/gibs)
 
 /obj/effect/decal/cleanable/blood/gibs/replace_decal(obj/effect/decal/cleanable/C)
 	return FALSE //Never fail to place us

--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -119,3 +119,11 @@
 	fusion_power = 10
 	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 1000 // it is VERY stable
 	oxidation_rate = 8
+
+/datum/gas/miasma
+	id = GAS_MIASMA
+	specific_heat = 20
+	fusion_power = 50
+	name = "Miasma"
+	gas_overlay = "miasma"
+	moles_visible = MOLES_GAS_VISIBLE * 60

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -548,6 +548,32 @@
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 			air.set_temperature(max(((air.return_temperature()*old_heat_capacity - energy_taken)/new_heat_capacity),TCMB))
 
+
+/datum/gas_reaction/miaster	//dry heat sterilization: clears out pathogens in the air
+	priority = -10 //after all the heating from fires etc. is done
+	name = "Dry Heat Sterilization"
+	id = "sterilization"
+
+/datum/gas_reaction/miaster/init_reqs()
+	min_requirements = list(
+		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST+70,
+		GAS_MIASMA = MINIMUM_MOLE_COUNT
+	)
+
+/datum/gas_reaction/miaster/react(datum/gas_mixture/air, datum/holder)
+	// As the name says it, it needs to be dry
+	if(air.get_moles(GAS_H2O)/air.total_moles() > 0.1)
+		return
+
+	//Replace miasma with oxygen
+	var/cleaned_air = min(air.get_moles(GAS_MIASMA), 20 + (air.return_temperature() - FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 70) / 20)
+	air.adjust_moles(GAS_MIASMA, -cleaned_air)
+	air.adjust_moles(GAS_O2, cleaned_air)
+
+	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
+	air.set_temperature(air.return_temperature() + cleaned_air * 0.002)
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, cleaned_air*MIASMA_RESEARCH_AMOUNT)//Turns out the burning of miasma is kinda interesting to scientists
+
 /datum/gas_reaction/stim_ball
 	priority = 7
 	name ="Stimulum Energy Ball"

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -93,6 +93,7 @@
 		GAS_O2			= new/datum/tlv(16, 19, 40, 50), // Partial pressure, kpa
 		GAS_N2			= new/datum/tlv(-1, -1, 1000, 1000),
 		GAS_CO2	= new/datum/tlv(-1, -1, 5, 10),
+		GAS_MIASMA			= new/datum/tlv/(-1, -1, 15, 30),
 		GAS_PLASMA			= new/datum/tlv/dangerous,
 		GAS_NITROUS	= new/datum/tlv/dangerous,
 		GAS_BZ				= new/datum/tlv/dangerous,
@@ -111,6 +112,7 @@
 		GAS_O2			= new/datum/tlv/no_checks,
 		GAS_N2			= new/datum/tlv/no_checks,
 		GAS_CO2	= new/datum/tlv/no_checks,
+		GAS_MIASMA			= new/datum/tlv/no_checks,
 		GAS_PLASMA			= new/datum/tlv/no_checks,
 		GAS_NITROUS	= new/datum/tlv/no_checks,
 		GAS_BZ				= new/datum/tlv/no_checks,
@@ -129,6 +131,7 @@
 		GAS_O2			= new/datum/tlv(16, 19, 135, 140), // Partial pressure, kpa
 		GAS_N2			= new/datum/tlv(-1, -1, 1000, 1000),
 		GAS_CO2	= new/datum/tlv(-1, -1, 5, 10),
+		GAS_MIASMA			= new/datum/tlv/(-1, -1, 2, 5),
 		GAS_PLASMA			= new/datum/tlv/dangerous,
 		GAS_NITROUS	= new/datum/tlv/dangerous,
 		GAS_BZ				= new/datum/tlv/dangerous,
@@ -526,6 +529,7 @@
 					"power" = 1,
 					"set_filters" = list(
 						GAS_CO2,
+						GAS_MIASMA,
 						GAS_PLASMA,
 						GAS_H2O,
 						GAS_HYPERNOB,

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -255,7 +255,7 @@
 
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom/Initialize(mapload)
 	. = ..()
-	target_temperature = T0C-20
+	target_temperature = T0C-20 //Cold enough to prevent Miasma
 
 /obj/machinery/atmospherics/components/unary/thermomachine/heater
 	icon_state = "heater"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -54,6 +54,7 @@
 		"stimulum" = /obj/machinery/portable_atmospherics/canister/stimulum,
 		"pluoxium" = /obj/machinery/portable_atmospherics/canister/pluoxium,
 		"caution" = /obj/machinery/portable_atmospherics/canister,
+		"miasma" = /obj/machinery/portable_atmospherics/canister/miasma
 	)
 
 /obj/machinery/portable_atmospherics/canister/interact(mob/user)
@@ -82,6 +83,14 @@
 	gas_type = GAS_CO2
 	greyscale_config = /datum/greyscale_config/canister
 	greyscale_colors = "#4e4c48"
+
+/obj/machinery/portable_atmospherics/canister/miasma
+	name = "miasma canister"
+	desc = "Miasma. Makes you wish your nose was blocked."
+	gas_type = GAS_MIASMA
+	filled = 1
+	greyscale_config = /datum/greyscale_config/canister/double_stripe
+	greyscale_colors = "#009823#f7d5d3"
 
 /obj/machinery/portable_atmospherics/canister/nitrogen
 	name = "n2 canister"

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -144,6 +144,7 @@
 	worth += C.air_contents.get_moles(GAS_BZ)*4
 	worth += C.air_contents.get_moles(GAS_STIMULUM)*100
 	worth += C.air_contents.get_moles(GAS_HYPERNOB)*1000
+	worth += C.air_contents.get_moles(GAS_MIASMA)*10
 	worth += C.air_contents.get_moles(GAS_TRITIUM)*5
 	worth += C.air_contents.get_moles(GAS_PLUOXIUM)*5
 	return worth

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -14,7 +14,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy)
-	mutatelist = list(/obj/item/seeds/galaxythistle)
+	mutatelist = list(/obj/item/seeds/starthistle/corpse_flower, /obj/item/seeds/galaxythistle)
 
 /obj/item/seeds/starthistle/harvest(mob/user)
 	var/obj/machinery/hydroponics/parent = loc
@@ -27,6 +27,39 @@
 			harvestseeds.forceMove(output_loc)
 
 	parent.update_tray()
+
+// Corpse flower
+/obj/item/seeds/starthistle/corpse_flower
+	name = "pack of corpse flower seeds"
+	desc = "A species of plant that emits a horrible odor. The odor stops being produced in difficult atmospheric conditions."
+	icon_state = "seed-corpse-flower"
+	species = "corpse-flower"
+	plantname = "Corpse flower"
+	production = 2
+	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
+	genes = list()
+	mutatelist = list()
+
+/obj/item/seeds/starthistle/corpse_flower/pre_attack(obj/machinery/hydroponics/I)
+	if(istype(I, /obj/machinery/hydroponics))
+		if(!I.myseed)
+			START_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/seeds/starthistle/corpse_flower/process(delta_time)
+	var/obj/machinery/hydroponics/parent = loc
+	if(parent.age < maturation) // Start a little before it blooms
+		return
+
+	var/turf/open/T = get_turf(parent)
+	if(abs(ONE_ATMOSPHERE - T.return_air().return_pressure()) > (potency/10 + 10)) // clouds can begin showing at around 50-60 potency in standard atmos
+		return
+
+	var/datum/gas_mixture/stank = new
+	stank.set_moles(GAS_MIASMA, (yield + 6)*3.5*MIASMA_CORPSE_MOLES*delta_time) // this process is only being called about 2/7 as much as corpses so this is 12-32 times a corpses
+	stank.set_temperature(T20C) // without this the room would eventually freeze and miasma mining would be easier
+	T.assume_air(stank)
+	T.air_update_turf()
 
 //Galaxy Thistle
 /obj/item/seeds/galaxythistle

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -49,6 +49,7 @@
 
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
+		LoadComponent(/datum/component/rot/corpse)
 
 	//Updates the number of stored chemicals for changeling powers
 	if(hud_used?.lingchemdisplay && !isalien(src) && mind)
@@ -266,6 +267,48 @@
 	if(breath.get_moles(GAS_NITRYL))
 		var/nitryl_partialpressure = (breath.get_moles(GAS_NITRYL)/breath.total_moles())*breath_pressure
 		adjustFireLoss(nitryl_partialpressure/4)
+
+	//MIASMA
+	if(breath.get_moles(GAS_MIASMA))
+		var/miasma_partialpressure = (breath.get_moles(GAS_MIASMA)/breath.total_moles())*breath_pressure
+
+		if(prob(1 * miasma_partialpressure))
+			var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(2,3)
+			miasma_disease.name = "Unknown"
+			ForceContractDisease(miasma_disease, TRUE, TRUE)
+
+		//Miasma side effects
+		switch(miasma_partialpressure)
+			if(0.25 to 5)
+				// At lower pp, give out a little warning
+				SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+				if(prob(5))
+					to_chat(src, "<span class='notice'>There is an unpleasant smell in the air.</span>")
+			if(5 to 20)
+				//At somewhat higher pp, warning becomes more obvious
+				if(prob(15))
+					to_chat(src, "<span class='warning'>You smell something horribly decayed inside this room.</span>")
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/bad_smell)
+			if(15 to 30)
+				//Small chance to vomit. By now, people have internals on anyway
+				if(prob(5))
+					to_chat(src, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+					vomit()
+			if(30 to INFINITY)
+				//Higher chance to vomit. Let the horror start
+				if(prob(25))
+					to_chat(src, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+					vomit()
+			else
+				SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+
+
+	//Clear all moods if no miasma at all
+	else
+		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "smell")
+
 
 	//BREATH TEMPERATURE
 	handle_breath_temperature(breath)

--- a/code/modules/mob/living/simple_animal/bot/atmosbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/atmosbot.dm
@@ -15,6 +15,7 @@
 #define ATMOSBOT_VENT_AIR 2
 #define ATMOSBOT_SCRUB_TOXINS 3
 #define ATMOSBOT_TEMPERATURE_CONTROL 4
+#define ATMOSBOT_SPRAY_MIASMA 5
 
 //Floorbot
 /mob/living/simple_animal/bot/atmosbot
@@ -55,6 +56,7 @@
 		GAS_BZ = 1,
 		GAS_CO2 = 1,
 		GAS_HYPERNOB = 1,
+		GAS_MIASMA = 1,
 		GAS_NITROUS = 1,
 		GAS_NITRYL = 1,
 		GAS_PLASMA = 1,
@@ -193,7 +195,7 @@
 	if(pressure_delta > 0)
 		var/transfer_moles = pressure_delta*environment.return_volume()/(T20C * R_IDEAL_GAS_EQUATION)
 		if(emagged == 2)
-			environment.adjust_moles(GAS_CO2, transfer_moles)
+			environment.adjust_moles(GAS_MIASMA, transfer_moles)
 		else
 			environment.adjust_moles(GAS_N2, transfer_moles * 0.7885)
 			environment.adjust_moles(GAS_O2, transfer_moles * 0.2115)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/alien_artifact.dm
@@ -397,6 +397,7 @@ GLOBAL_LIST_EMPTY(destabliization_exits)
 	var/static/list/valid_outputs = list(
 		/datum/gas/bz = 3,
 		/datum/gas/hypernoblium = 1,
+		/datum/gas/miasma = 3,
 		/datum/gas/plasma = 3,
 		/datum/gas/tritium = 2,
 		/datum/gas/nitryl = 1

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -265,6 +265,54 @@
 			H.reagents.add_reagent(/datum/reagent/stimulum, max(0, 5 - existing))
 		breath.adjust_moles(GAS_STIMULUM, -gas_breathed)
 
+	// Miasma
+		if (breath.get_moles(GAS_MIASMA))
+			var/miasma_pp = PP(breath,GAS_MIASMA)
+			if(miasma_pp > MINIMUM_MOLES_DELTA_TO_MOVE)
+
+				//Miasma sickness
+				if(prob(0.05 * miasma_pp))
+					var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(TRUE, 2, 3)
+					miasma_disease.name = "Unknown"
+					miasma_disease.try_infect(owner)
+
+				// Miasma side effects
+				switch(miasma_pp)
+					if(1 to 5)
+						// At lower pp, give out a little warning
+						SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
+						if(prob(5))
+							to_chat(owner, "<span class='notice'>There is an unpleasant smell in the air.</span>")
+					if(6 to 15)
+						//At somewhat higher pp, warning becomes more obvious
+						if(prob(15))
+							to_chat(owner, "<span class='warning'>You smell something horribly decayed inside this room.</span>")
+							SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/bad_smell)
+					if(16 to 30)
+						//Small chance to vomit. By now, people have internals on anyway
+						if(prob(5))
+							to_chat(owner, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+							SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+							owner.vomit()
+					if(31 to INFINITY)
+						//Higher chance to vomit. Let the horror start
+						if(prob(15))
+							to_chat(owner, "<span class='warning'>The stench of rotting carcasses is unbearable!</span>")
+							SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "smell", /datum/mood_event/disgust/nauseating_stench)
+							owner.vomit()
+					else
+						SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
+
+				// In a full miasma atmosphere with 101.34 pKa, about 10 disgust per breath, is pretty low compared to threshholds
+				// Then again, this is a purely hypothetical scenario and hardly reachable
+				owner.adjust_disgust(0.1 * miasma_pp)
+
+				breath.adjust_moles(GAS_MIASMA, -gas_breathed)
+
+		// Clear out moods when no miasma at all
+		else
+			SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
+
 		handle_breath_temperature(breath, H)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The original PR was merged with very little justification.

The main reason hinged on its impact on server performance through the Life() proc, but the author did not provide any evidence to support this claim (such as profiler tests), nor have I personally heard any anecdotal evidence other than from Kapu themselves about lag caused by miasma.

The only other concern of note was regarding the economy issues caused by miasma farms. I don't believe this is a real issue, considering that the actual frequency with which miasma farms are built is incredibly low, in part due to their potential illegality by creating a workplace hazard, contravening space law, as well as the skills required in multiple departments to procure and sell the gas.

I am open to potentially adding a diminishing returns system to the sale of miasma if the maintainers are adamant this is a real issue (it's not), but I personally see it as unnecessary.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Pending

</details>

## Changelog
:cl: MCterra
add: re-adds miasma, corpseflowers and rot to the game
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
