### PR TITLE
Adds unused HoP suit to HoP locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -49,6 +49,8 @@
 	new /obj/item/storage/lockbox/medal/service(src)
 	new /obj/item/clothing/under/rank/civilian/head_of_personnel(src)
 	new /obj/item/clothing/under/rank/civilian/head_of_personnel/skirt(src)
+	new /obj/item/clothing/under/rank/civilian/head_of_personnel/alt(src)
+	new /obj/item/clothing/under/rank/civilian/head_of_personnel/alt/skirt(src)
 	new /obj/item/clothing/head/hopcap(src)
 	new /obj/item/cartridge/hop(src)
 	new /obj/item/radio/headset/heads/hop(src)

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -79,15 +79,15 @@
 	fitted = FEMALE_UNIFORM_TOP
 	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 
-/obj/item/clothing/under/rank/civilian/head_of_personnel/suit
-	name = "head of personnel's suit"
+/obj/item/clothing/under/rank/civilian/head_of_personnel/alt
+	name = "head of personnel's teal jumpsuit"
 	desc = "A teal suit and yellow necktie. An authoritative yet tacky ensemble."
 	icon_state = "teal_suit"
 	item_state = "g_suit"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/rank/civilian/head_of_personnel/suit/skirt
-	name = "head of personnel's suit"
+/obj/item/clothing/under/rank/civilian/head_of_personnel/alt/skirt
+	name = "head of personnel's teal jumpskirt"
 	desc = "A teal suit and yellow necktie. An authoritative yet tacky ensemble."
 	icon_state = "teal_suit_skirt"
 	item_state = "g_suit"

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -88,7 +88,7 @@
 
 /obj/item/clothing/under/rank/civilian/head_of_personnel/alt/skirt
 	name = "head of personnel's teal jumpskirt"
-	desc = "A teal suit and yellow necktie. An authoritative yet tacky ensemble."
+	desc = "A teal skirt and yellow necktie. An authoritative yet tacky ensemble."
 	icon_state = "teal_suit_skirt"
 	item_state = "g_suit"
 	can_adjust = FALSE

--- a/tools/UpdatePaths/clothingunderrepath.txt
+++ b/tools/UpdatePaths/clothingunderrepath.txt
@@ -122,8 +122,8 @@
 /obj/item/clothing/under/lawyer/black/female : /obj/item/clothing/under/suit/black/female
 /obj/item/clothing/under/rank/head_of_personnel : /obj/item/clothing/under/rank/civilian/head_of_personnel
 /obj/item/clothing/under/rank/head_of_personnel/skirt : /obj/item/clothing/under/rank/civilian/head_of_personnel/skirt
-/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit : /obj/item/clothing/under/rank/civilian/head_of_personnel/suit
-/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit/skirt : /obj/item/clothing/under/rank/civilian/head_of_personnel/suit/skirt
+/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit : /obj/item/clothing/under/rank/civilian/head_of_personnel/alt
+/obj/item/clothing/under/gimmick/rank/head_of_personnel/suit/skirt : /obj/item/clothing/under/rank/civilian/head_of_personnel/alt/skirt
 
 /obj/item/clothing/under/rank/cargo : /obj/item/clothing/under/rank/cargo/qm
 /obj/item/clothing/under/rank/cargo/skirt : /obj/item/clothing/under/rank/cargo/qm/skirt


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds HoP's teal jumpsuit and jumpskirt to the HoP's locker, which is currently unused in the game.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Alternative drip for HoP players.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![dreamseeker_HYNaK32q2s](https://user-images.githubusercontent.com/66234359/173247824-76cb1a56-cd04-412e-9088-66537684fee9.png)

</details>

## Changelog
:cl: Hardly
add: Head of Personnel's teal jumpsuit and jumpskirt now spawn in HoP's locker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
