### PR TITLE
New SPAM Cartridge + cartridge spam tweak

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -676,7 +676,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		t = Gibberish(t, TRUE)
 	return t
 
-/obj/item/pda/proc/send_pda_message(mob/living/user, list/obj/item/pda/targets, everyone, var/multi_delay=0)
+/obj/item/pda/proc/send_pda_message(mob/living/user, list/obj/item/pda/targets, everyone, multi_delay=0)
 	var/message = msg_input(user)
 	if(!message || !targets.len)
 		return
@@ -783,11 +783,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 	update_icon()
 	add_overlay(icon_alert)
 
-/obj/item/pda/proc/send_to_all(mob/living/U, var/multi_delay)
+/obj/item/pda/proc/send_to_all(mob/living/U, multi_delay)
 	if (last_everyone && world.time < (last_everyone + PDA_SPAM_DELAY*multi_delay))
 		to_chat(U,"<span class='warning'>Send To All function is still on cooldown. Enabled in [(last_everyone + PDA_SPAM_DELAY*multi_delay - world.time)/10] seconds.")
 		return
-	send_pda_message(U,get_viewable_pdas(), TRUE, multi_delay=multi_delay)
+	if(multi_delay)
+		send_pda_message(U,get_viewable_pdas(), TRUE, multi_delay=multi_delay)
 
 /obj/item/pda/proc/create_message(mob/living/U, obj/item/pda/P)
 	send_pda_message(U,list(P))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -786,10 +786,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 /obj/item/pda/proc/send_to_all(mob/living/U, var/multi_delay)
 	if (last_everyone && world.time < (last_everyone + PDA_SPAM_DELAY*multi_delay))
 		to_chat(U,"<span class='warning'>Send To All function is still on cooldown. Enabled in [(last_everyone + PDA_SPAM_DELAY*multi_delay - world.time)/10] seconds.")
-		world.log << world.time
-		world.log << multi_delay
-		world.log << PDA_SPAM_DELAY
-		world.log << PDA_SPAM_DELAY*multi_delay
 		return
 	send_pda_message(U,get_viewable_pdas(), TRUE, multi_delay=multi_delay)
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -788,7 +788,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(U,"<span class='warning'>Send To All function is still on cooldown. Enabled in [(last_everyone + PDA_SPAM_DELAY*multi_delay - world.time)/10] seconds.")
 		return
 	if(multi_delay)
-		send_pda_message(U,get_viewable_pdas(), TRUE, multi_delay=multi_delay)
+		send_pda_message(U,get_viewable_pdas(), TRUE, multi_delay)
 
 /obj/item/pda/proc/create_message(mob/living/U, obj/item/pda/P)
 	send_pda_message(U,list(P))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 #define PDA_SCANNER_REAGENT		3
 #define PDA_SCANNER_HALOGEN		4
 #define PDA_SCANNER_GAS			5
-#define PDA_SPAM_DELAY		    2 MINUTES
+#define PDA_SPAM_DELAY		    1 MINUTES
 
 /obj/item/pda
 	name = "\improper PDA"
@@ -345,7 +345,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "</ul>"
 				if (count == 0)
 					dat += "None detected.<br>"
-				else if(cartridge && cartridge.spam_enabled)
+				else if(cartridge && cartridge.spam_delay)
 					dat += "<a href='byond://?src=[REF(src)];choice=MessageAll'>Send To All</a>"
 
 			if(21)
@@ -575,8 +575,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 				sort_by_job = !sort_by_job
 
 			if("MessageAll")
-				if(cartridge?.spam_enabled)
-					send_to_all(U)
+				if(cartridge?.spam_delay)
+					send_to_all(U, cartridge?.spam_delay)
 
 			if("cart")
 				if(cartridge)
@@ -676,11 +676,11 @@ GLOBAL_LIST_EMPTY(PDAs)
 		t = Gibberish(t, TRUE)
 	return t
 
-/obj/item/pda/proc/send_message(mob/living/user, list/obj/item/pda/targets, everyone)
+/obj/item/pda/proc/send_pda_message(mob/living/user, list/obj/item/pda/targets, everyone, var/multi_delay=0)
 	var/message = msg_input(user)
 	if(!message || !targets.len)
 		return
-	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + PDA_SPAM_DELAY))
+	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < (last_everyone + PDA_SPAM_DELAY*multi_delay)))
 		return
 	if(prob(1))
 		message += "\nSent from my PDA"
@@ -783,14 +783,18 @@ GLOBAL_LIST_EMPTY(PDAs)
 	update_icon()
 	add_overlay(icon_alert)
 
-/obj/item/pda/proc/send_to_all(mob/living/U)
-	if (last_everyone && world.time < last_everyone + PDA_SPAM_DELAY)
-		to_chat(U,"<span class='warning'>Send To All function is still on cooldown.")
+/obj/item/pda/proc/send_to_all(mob/living/U, var/multi_delay)
+	if (last_everyone && world.time < (last_everyone + PDA_SPAM_DELAY*multi_delay))
+		to_chat(U,"<span class='warning'>Send To All function is still on cooldown. Enabled in [(last_everyone + PDA_SPAM_DELAY*multi_delay - world.time)/10] seconds.")
+		world.log << world.time
+		world.log << multi_delay
+		world.log << PDA_SPAM_DELAY
+		world.log << PDA_SPAM_DELAY*multi_delay
 		return
-	send_message(U,get_viewable_pdas(), TRUE)
+	send_pda_message(U,get_viewable_pdas(), TRUE, multi_delay=multi_delay)
 
 /obj/item/pda/proc/create_message(mob/living/U, obj/item/pda/P)
-	send_message(U,list(P))
+	send_pda_message(U,list(P))
 
 /obj/item/pda/AltClick(mob/user)
 	if(id)

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -252,16 +252,6 @@
 	default_cartridge = /obj/item/cartridge/medical
 	icon_state = "pda-genetics"
 
-/obj/item/pda/unlicensed
-	name = "unlicensed PDA"
-	desc = "A shitty knockoff of a portable microcomputer by Thinktronic Systems, LTD. Complete with a cracked operating system."
-	note = "Error: Unlicensed OS. Please contact your supervisor."
-	icon_state = "pda-knockoff"
-	icon_alert = "pda-r-wide"
-	icon_pai = "pai-overlay-wide"
-	icon_inactive_pai = "pai-off-overlay-wide"
-	inserted_item = /obj/item/pen/charcoal
-
 /obj/item/pda/celebrity
 	name = "fancy PDA"
 	default_cartridge = /obj/item/cartridge/annoyance //so they can send messages to everyone and be generally obnoxious
@@ -270,3 +260,14 @@
 	note = "Congratulations, you have chosen the Thinktronic 5230 LRP Series Personal Data Assistant Golden Edition!"
 	icon_state = "pda-gold"
 	ttone = "ch-CHING"
+
+/obj/item/pda/unlicensed
+	name = "unlicensed PDA"
+	default_cartridge = /obj/item/cartridge/annoyance/lesser
+	desc = "A shitty knockoff of a portable microcomputer by Thinktronic Systems, LTD. Complete with a cracked operating system."
+	note = "Error: Unlicensed OS. Please contact your supervisor."
+	icon_state = "pda-knockoff"
+	icon_alert = "pda-r-wide"
+	icon_pai = "pai-overlay-wide"
+	icon_inactive_pai = "pai-off-overlay-wide"
+	inserted_item = /obj/item/pen/charcoal

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -32,7 +32,7 @@
 	var/remote_door_id = ""
 
 	var/bot_access_flags = 0 //Bit flags. Selection: SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT | FIRE_BOT
-	var/spam_enabled = 0 //Enables "Send to All" Option
+	var/spam_delay = 0 //Enables "Send to All" Option. 1=1 min, 2=2mins, 3=3mins.
 
 	var/obj/item/pda/host_pda = null
 	var/menu
@@ -102,12 +102,13 @@
 	name = "\improper P.R.O.V.E. cartridge"
 	icon_state = "cart-prove"
 	access = CART_SECURITY
-	spam_enabled = 1
+	spam_delay = 2.5
 
 /obj/item/cartridge/curator
 	name = "\improper Lib-Tweet cartridge"
 	icon_state = "cart-cur"
 	access = CART_NEWSCASTER
+	spam_delay = 3.5
 
 /obj/item/cartridge/roboticist
 	name = "\improper B.O.O.P. Remote Control cartridge"
@@ -183,7 +184,7 @@
 	icon_state = "cart-cap"
 	access = ~(CART_CLOWN | CART_MIME | CART_REMOTE_DOOR)
 	bot_access_flags = SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT | FIRE_BOT
-	spam_enabled = 1
+	spam_delay = 2
 
 /obj/item/cartridge/captain/Initialize(mapload)
 	. = ..()
@@ -192,7 +193,12 @@
 /obj/item/cartridge/annoyance //the only purpose of this cartridge is to allow the VIP to be annoying
 	name = "\improper TWIT cartridge"
 	icon_state = "cart-twit"
-	spam_enabled = 1
+	spam_delay = 1.5
+
+/obj/item/cartridge/annoyance/lesser //HoP can give you this
+	name = "\improper FACEBUCKS cartridge"
+	icon_state = "cart-signal"
+	spam_delay = 5
 
 /obj/item/cartridge/proc/post_status(command, data1, data2)
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -198,7 +198,7 @@
 /obj/item/cartridge/annoyance/lesser //HoP can give you this
 	name = "\improper FACEBUCKS cartridge"
 	icon_state = "cart-signal" // might need a new sprite
-	spam_delay = 4
+	spam_delay = 5
 
 /obj/item/cartridge/proc/post_status(command, data1, data2)
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -32,7 +32,7 @@
 	var/remote_door_id = ""
 
 	var/bot_access_flags = 0 //Bit flags. Selection: SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT | FIRE_BOT
-	var/spam_delay = 0 //Enables "Send to All" Option. 1=1 min, 2=2mins, 3=3mins.
+	var/spam_delay = 0 //Enables "Send to All" Option. 1=1 min, 2=2mins, 2.5=2 min 30 seconds
 
 	var/obj/item/pda/host_pda = null
 	var/menu
@@ -197,8 +197,8 @@
 
 /obj/item/cartridge/annoyance/lesser //HoP can give you this
 	name = "\improper FACEBUCKS cartridge"
-	icon_state = "cart-signal"
-	spam_delay = 5
+	icon_state = "cart-signal" // might need a new sprite
+	spam_delay = 4
 
 /obj/item/cartridge/proc/post_status(command, data1, data2)
 

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -13,8 +13,8 @@
 					/obj/item/cartridge/signal/toxins = 10,
 					/obj/item/pda/heads = 10,
 					/obj/item/cartridge/captain = 3,
-					/obj/item/cartridge/quartermaster = 10,
-					/obj/item/cartridge/annoyance/lesser = 3)
+					/obj/item/cartridge/quartermaster = 10)
+	premium = list(/obj/item/cartridge/annoyance/lesser = 3)
 	refill_canister = /obj/item/vending_refill/cart
 	default_price = 50
 	extra_price = 100

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -13,7 +13,8 @@
 					/obj/item/cartridge/signal/toxins = 10,
 					/obj/item/pda/heads = 10,
 					/obj/item/cartridge/captain = 3,
-					/obj/item/cartridge/quartermaster = 10)
+					/obj/item/cartridge/quartermaster = 10,
+					/obj/item/cartridge/annoyance/lesser = 3)
 	refill_canister = /obj/item/vending_refill/cart
 	default_price = 50
 	extra_price = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a new cartridge.
Tweaks cartridge spam system.

## Why It's Good For The Game
new feature good

Captain: The standard one.
Laywer: They're already obnoxious than VIP. gives 30 seconds nurf.
Curator: Nobody actually reads a newsfeed. Let's allow them to spam in a long cooldown time than lawyers'.
VIP: They actually don't onboard a station well, but they are so special. 30 seconds buff.
FACEBUCKS: Stealing PROVE/Value-PAK cartridge isn't a good idea in general, and HoP would not want to give them to a person in general. This one is quite lesser and you'll hardly see their spam. 3 cartridges are available from HoP cartridge vendor.  It's questionable why it's more expensive than Value-PAK.
Barber/Stage Magician: They actually can't RP well because their office room is somewhere in maints. Let's allow them to advertise something.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://user-images.githubusercontent.com/87972842/173383693-205fc051-f6f7-4e86-9b60-e693f3e78484.png)

When you change cartridges with different cooldown time. PDA remembers when messages were sent.

--------------
![image](https://user-images.githubusercontent.com/87972842/173385874-714e1b1f-2396-41bd-90fe-5839d3049e9b.png)


</details>

## Changelog
:cl:
refactor: spam_enabled variable is spam_delay, 1 means 1 minute, 2 means 2 minutes.
refactor: send_message proc in PDA.dm is now send_pda_message to prevent any confusion from TGUI send_message.
add: Spam cartridges have now delay multiplyer based on its type.
add: Value-PAK cartridge (Captain) multiply is *2. (2 minutes)
add: P.R.O.V.E cartridge (Lawyer) multiply is *2.5. (2 min 30 seconds)
add: Lib-Tweet (Curator) now can spam, and its multiply is *3.5
add: TWIT cartridge (VIP) delay multiply is *1.5
add: FACEBUCKS cartridge (generic) is newly added, and its multiply is *5. can be purchased from HoP cartridge vendor with 100 credits.
add: Send all message function tells you how much time you should wait to send another.
add: Unlicensed PDA (Barber, Stage Magician) is now loaded with FACEBUCKS cartridge. Barber and Stage Magician can advertise themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
