### PR TITLE
Removes a line i forgot to remove in the moveloop PR

### DIFF
--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -343,8 +343,6 @@ field_generator power level display
 			investigate_log("has <font color='red'>failed</font> whilst a [a.name] exists at [AREACOORD(T)].", INVESTIGATE_ENGINES)
 			notify_ghosts("IT'S LOOSE", source = src, action = NOTIFY_ORBIT, flashwindow = FALSE, ghost_sound = 'sound/machines/warning-buzzer.ogg', header = "IT'S LOOSE", notify_volume = 75)
 
-/obj/machinery/field/generator/tesla_act()
-
 /obj/machinery/field/generator/proc/block_singularity_if_active()
 	SIGNAL_HANDLER
 	if(active)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Appearantly while i was working on logging tesla/singu i tried one approach of using tesla act so i setup a proper overwrite for the proc but i stashed that idea because the field generator is actually blacklisted from tesla act anyways so this overwrite did nothing in the first place and would have just quietly returned but because there was a blacklist for the tesla_zap proc for this object anyways it didn't even reach this point.

## Why It's Good For The Game

Concept work i forgot to remove in the final product whops

## Testing Photographs and Procedure
Now i did not really test this in terms aside compiling however this won't have any effect since this can litterally not be called in the first place as /obj/machinery/field/generator is in the blacklisted_tesla_types var list in the tesla_zap proc so it never got even zapped in the first place means the tesla_act proc never got called so the overwrite did nothing either.

</details>

## Changelog
:cl:
code: removes concept code i forgot about
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
