### PR TITLE
Removes blood boil from blood cult entirely.

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -751,67 +751,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 		qdel(src)
 	else
 		visible_message("<span class='warning'>The air displaces atop [src], however nothing appears.</span>")
-
-//Rite of Boiling Blood: Deals extremely high amounts of damage to non-cultists nearby
-/obj/effect/rune/blood_boil
-	cultist_name = "Boil Blood"
-	cultist_desc = "boils the blood of non-believers who can see the rune, rapidly dealing extreme amounts of damage. Requires 3 invokers."
-	invocation = "Dedo ol'btoh!"
-	icon_state = "4"
-	color = RUNE_COLOR_BURNTORANGE
-	light_color = LIGHT_COLOR_LAVA
-	req_cultists = 3
-	invoke_damage = 10
-	construct_invoke = FALSE
-	var/tick_damage = 25
-	rune_in_use = FALSE
-
-/obj/effect/rune/blood_boil/do_invoke_glow()
-	return
-
-/obj/effect/rune/blood_boil/invoke(var/list/invokers)
-	if(rune_in_use)
-		return
-	..()
-	rune_in_use = TRUE
-	var/turf/T = get_turf(src)
-	visible_message("<span class='warning'>[src] turns a bright, glowing orange!</span>")
-	color = "#FC9B54"
-	set_light(6, 1, color)
-	for(var/mob/living/L in viewers(T))
-		if(!iscultist(L) && L.blood_volume)
-			var/atom/I = L.anti_magic_check(magic=FALSE,holy=TRUE,major = FALSE)
-			if(I)
-				if(isitem(I))
-					to_chat(L, "<span class='userdanger'>[I] suddenly burns hotly before returning to normal!</span>")
-				continue
-			to_chat(L, "<span class='cultlarge'>Your blood boils in your veins!</span>")
-	animate(src, color = "#FCB56D", time = 4)
-	sleep(4)
-	if(QDELETED(src))
-		return
-	do_area_burn(T, 0.5)
-	animate(src, color = "#FFDF80", time = 5)
-	sleep(5)
-	if(QDELETED(src))
-		return
-	do_area_burn(T, 1)
-	animate(src, color = "#FFFDF4", time = 6)
-	sleep(6)
-	if(QDELETED(src))
-		return
-	do_area_burn(T, 1.5)
-	new /obj/effect/hotspot(T)
-	qdel(src)
-
-/obj/effect/rune/blood_boil/proc/do_area_burn(turf/T, multiplier)
-	set_light(6, 1, color)
-	for(var/mob/living/L in viewers(T))
-		if(!iscultist(L) && L.blood_volume)
-			if(L.anti_magic_check(magic=FALSE,holy=TRUE,major = FALSE))
-				continue
-			L.take_overall_damage(tick_damage*multiplier, tick_damage*multiplier)
-
 //Rite of Spectral Manifestation: Summons a ghost on top of the rune as a cultist human with no items. User must stand on the rune at all times, and takes damage for each summoned ghost.
 /obj/effect/rune/manifest
 	cultist_name = "Spirit Realm"

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -751,6 +751,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		qdel(src)
 	else
 		visible_message("<span class='warning'>The air displaces atop [src], however nothing appears.</span>")
+
 //Rite of Spectral Manifestation: Summons a ghost on top of the rune as a cultist human with no items. User must stand on the rune at all times, and takes damage for each summoned ghost.
 /obj/effect/rune/manifest
 	cultist_name = "Spirit Realm"

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_netherworld.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_netherworld.dm
@@ -20,7 +20,6 @@
 		/obj/structure/spawner/nether = 0.3,
 		/obj/structure/destructible/cult/pylon = 2,
 		/obj/structure/destructible/cult/forge = 1,
-		/obj/effect/rune/blood_boil = 1,
 		/obj/effect/rune/empower = 1,
 		null = 140,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This removes the blood boil rune from the game entirely.
## Why It's Good For The Game
I think we can all agree that blood cult is quite overpowered in many aspects, and the blood boil rune is the one thing that should definitely get removed. Being able to instantly put 5-6 people who can see the rune into critical state with just THREE cultists is absolutely busted and it should not exist. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
It makes cult more balanced and more reliant on other methods, rather than a relatively easy to make instant crit weapon in a stalemate, for example.
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/77589317/174600861-b5a537a7-866e-4b75-89a5-57db9af12136.png)
Gone.
</details>

## Changelog
:cl:
del: Removed the blood boil rune permanently from the game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
