### PR TITLE
Removes duplicate uranium in darkpurple warping

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/warping.dm
+++ b/code/modules/research/xenobiology/crossbreeding/warping.dm
@@ -342,7 +342,7 @@ put up a rune with bluespace effects, lots of those runes are fluff or act as a 
 	desc = "To gain something you must sacrifice something else in return."
 	var/static/list/materials = list(/obj/item/stack/sheet/iron, /obj/item/stack/sheet/glass, /obj/item/stack/sheet/mineral/silver,
 									/obj/item/stack/sheet/mineral/gold, /obj/item/stack/sheet/mineral/diamond, /obj/item/stack/sheet/mineral/uranium,
-									/obj/item/stack/sheet/mineral/titanium, /obj/item/stack/sheet/mineral/copper, /obj/item/stack/sheet/mineral/uranium,
+									/obj/item/stack/sheet/mineral/titanium, /obj/item/stack/sheet/mineral/copper,
 									/obj/item/stack/ore/bluespace_crystal/refined)
 
 /obj/effect/warped_rune/darkpurplespace/do_effect(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes issue #7101.
Removes the duplicate uranium material in the material list that resulted in skewed odds towards uranium. Now all materials have an equal chance of spawning from a warping dark purple rune.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

The warping dark purple extract was biased in favor of uranium (had a 20% chance while all other materials had a 10% chance), which can make it confusing or frustrating for players who were seeking materials other than uranium. This fixes that by making the odds for getting any material equal (11% chance of any material).

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Setup and completion of two tests running on my local server</summary>

![Plasma Test p1](https://user-images.githubusercontent.com/13326182/174924569-0e40c1bf-2ace-4bd9-a5d3-57e07f6b9f9b.png)
Setup of the test

![Plasma Test p2](https://user-images.githubusercontent.com/13326182/174924542-c7404104-7708-492e-b9a9-7337fd819023.png)
Test Result 1

![Plasma Test p3](https://user-images.githubusercontent.com/13326182/174924549-331445b0-4b72-4bf9-a338-7bbc08f5c910.png)
Test Result 2

</details>

## Changelog
:cl:
fixed: changed the odds of the dark purple warping rune to no longer be biased towards uranium
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
