### PR TITLE
No more infinite free slabs

### DIFF
--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -61,10 +61,12 @@
 	..()
 	playsound(src, 'sound/machines/click.ogg', 50)
 	if(occupant)
-		if(!iscarbon(occupant) || HAS_TRAIT(occupant, TRAIT_POWERHUNGRY))
+		var/mob/living/L = occupant
+		if(!iscarbon(L) || HAS_TRAIT(L, TRAIT_POWERHUNGRY) || !(MOB_ORGANIC in L?.mob_biotypes))
 			occupant.forceMove(drop_location())
 			occupant = null
 			return
+
 		to_chat(occupant, "<span class='notice'>You enter [src]</span>")
 		addtimer(CALLBACK(src, .proc/start_extracting), 20, TIMER_OVERRIDE|TIMER_UNIQUE)
 		update_icon()

--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -184,7 +184,6 @@
 		if(C.type_of_meat)
 			// Someone changed component rating high enough so it requires negative amount of nutrients to create a meat slab
 			if(nutrient_to_meat < 0)
-				message_admins("[src] requires negative amount of nutrients to create a slab. Exploding it to avoid crash") // no need to actually explode it but i want to punish whoever tries to do it
 				occupant.forceMove(drop_location())
 				occupant = null
 				explosion(loc, 0, 1, 2, 3, TRUE)

--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -61,7 +61,7 @@
 	..()
 	playsound(src, 'sound/machines/click.ogg', 50)
 	if(occupant)
-		if(!iscarbon(occupant) || HAS_TRAIT(L, TRAIT_POWERHUNGRY))
+		if(!iscarbon(occupant) || HAS_TRAIT(occupant, TRAIT_POWERHUNGRY))
 			occupant.forceMove(drop_location())
 			occupant = null
 			return

--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -61,7 +61,7 @@
 	..()
 	playsound(src, 'sound/machines/click.ogg', 50)
 	if(occupant)
-		if(!iscarbon(occupant))
+		if(!iscarbon(occupant) || HAS_TRAIT(L, TRAIT_POWERHUNGRY))
 			occupant.forceMove(drop_location())
 			occupant = null
 			return
@@ -182,6 +182,14 @@
 	if(occupant && iscarbon(occupant))
 		var/mob/living/carbon/C = occupant
 		if(C.type_of_meat)
+			// Someone changed component rating high enough so it requires negative amount of nutrients to create a meat slab
+			if(nutrient_to_meat < 0)
+				message_admins("[src] requires negative amount of nutrients to create a slab. Exploding it to avoid crash") // no need to actually explode it but i want to punish whoever tries to do it
+				occupant.forceMove(drop_location())
+				occupant = null
+				explosion(loc, 0, 1, 2, 3, TRUE)
+				qdel(src)
+				return
 			if(nutrients >= nutrient_to_meat * 2)
 				C.put_in_hands(new /obj/item/reagent_containers/food/snacks/cookie (), TRUE)
 			while(nutrients >= nutrient_to_meat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #7107 
FIxes #7123

- Makes it so mobs that use electricity instead of nutrients (IPC, ethereals) can't use lipid extractor
- Created a failsafe in case admin tries to tweak component rating of the lipid extractor high enough that it uses negative amount of nutrients to create a slab by exploding the machine (server crashing adminbus bad)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Infinite free slabs bad. Fixes good
Server crashing bad. failsafes good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
1. Be IPC/ethereal
2. Try to enter the lipid extractor
3. You can't
4. Be a fat human
5. Try to enter the lipid extractor
6. machine sucks the fat out of you

⁠
1. Tweak component rating of lipid extractor to 20
2. Insert fat human inside
3. Machine will explode

## Changelog
:cl:
fix: IPCs and ethereals now can't use the lipid extractor
admin: created a failsafe to avoid admins crashing the server using lipid extractor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
