### PR TITLE
Renames misleading float define

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -145,8 +145,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define AA_TARGET_SEE_APPEARANCE (1<<0)
 #define AA_MATCH_TARGET_OVERLAYS (1<<1)
 
-/// 33554431 (2^24 - 1) is the maximum value our bitflags can reach.
-#define MAX_BITFLAG_DIGITS 8
+/// Integer precision in 32 bit single-precision floating point numbers is lost beyond 24 bits
+#define MAX_BITFLAG_DIGITS 24
 
 //religious_tool flags
 #define RELIGION_TOOL_INVOKE (1<<0)

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define FLYING			(1<<1)
 #define VENTCRAWLING	(1<<2)
 #define FLOATING		(1<<3)
-#define PHASING		(1<<4)			//! When moving, will Bump()/Cross() everything, but won't be stopped.
+#define PHASING			(1<<4)			//! When moving, will Bump()/Cross() everything, but won't be stopped.
 #define THROWN			(1<<5) //! while an atom is being thrown
 
 //! ## Fire and Acid stuff, for resistance_flags
@@ -144,9 +144,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 //alternate appearance flags
 #define AA_TARGET_SEE_APPEARANCE (1<<0)
 #define AA_MATCH_TARGET_OVERLAYS (1<<1)
-
-/// Integer precision in 32 bit single-precision floating point numbers is lost beyond 24 bits
-#define MAX_BITFLAG_DIGITS 24
 
 //religious_tool flags
 #define RELIGION_TOOL_INVOKE (1<<0)

--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -2,13 +2,16 @@
 // This file is quadruple wrapped for your pleasure
 // (
 
-#define NUM_E 2.71828183
+#define NUM_E 2.718282
 
 #define PI						3.1416
 #define INFINITY				1e31	//closer then enough
 #define SYSTEM_TYPE_INFINITY					1.#INF //only for isinf check
 
 #define SHORT_REAL_LIMIT 16777216
+
+/// A 32 bit single-precision floating point number's mantissa gives us 7 significant digits
+#define SIGNIFICANT_PRECISION 7
 
 //"fancy" math for calculating time in ms from tick_usage percentage and the length of ticks
 //percent_of_tick_used * (ticklag * 100(to convert to ms)) / 100(percent ratio)

--- a/code/modules/admin/verbs/individual_logging.dm
+++ b/code/modules/admin/verbs/individual_logging.dm
@@ -68,5 +68,5 @@
 	if(selected_type == log_type && selected_src == log_src)
 		slabel = "<b>\[[label]\]</b>"
 	//This is necessary because num2text drops digits and rounds on big numbers. If more defines get added in the future it could break again.
-	log_type = num2text(log_type, MAX_BITFLAG_DIGITS)
+	log_type = num2text(log_type, SIGNIFICANT_PRECISION)
 	return "<a href='?_src_=holder;[HrefToken()];individuallog=[REF(M)];log_type=[log_type];log_src=[log_src]'>[slabel]</a>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames `MAX_BITFLAG_DIGITS` to `SIGNIFICANT_PRECISION`

Bitflag digits can go significantly beyond 7 in base 10 representation, albeit with some precision loss (which doesn't matter for flags). It also kind of makes it sounds like flags can't be shifted further than 7 from 0.

What the define is actually supposed to represent is the number of significant decimal digits that can be represented by the 24 bit mantissa, which is 7

## Changelog
:cl:
code: renames and clarifies misleading define
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
