### PR TITLE
Fixes chainsaws losing all force when dropped

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -257,7 +257,7 @@
 		parent_item.force -= sharpened_increase
 	if(force_multiplier)
 		parent_item.force /= force_multiplier
-	else if(!isnull(force_unwielded))
+	else if(force_unwielded)
 		parent_item.force = force_unwielded
 	if(!isnull(block_power_unwielded))
 		parent_item.block_power = block_power_unwielded

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -12,7 +12,7 @@
 	var/force_wielded 	 						    /// The force of the item when wielded
 	var/force_unwielded		 					    /// The force of the item when unwielded
 	var/block_power_wielded					     	/// The block power of the item when wielded
-	var/block_power_unwielded 				        /// The block power of the item when unwielded
+	var/block_power_unwielded = 0 				    /// The block power of the item when unwielded
 	var/wieldsound = FALSE 							/// Play sound when wielded
 	var/unwieldsound = FALSE 						/// Play sound when unwielded
 	var/attacksound = FALSE							/// Play sound on attack when wielded

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -8,18 +8,18 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS 		// Only one of the component can exist on an item
 	var/mob/wielder							/// The mob that is wielding us
 	var/wielded = FALSE 							/// Are we holding the two handed item properly
-	var/force_multiplier = 0						/// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
-	var/force_wielded = 0	 						/// The force of the item when wielded
-	var/force_unwielded = 0		 					/// The force of the item when unwielded
-	var/block_power_wielded = 0						/// The block power of the item when wielded
-	var/block_power_unwielded = 0					/// The block power of the item when unwielded
+	var/force_multiplier						    /// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
+	var/force_wielded 	 						    /// The force of the item when wielded
+	var/force_unwielded		 					    /// The force of the item when unwielded
+	var/block_power_wielded					     	/// The block power of the item when wielded
+	var/block_power_unwielded 				        /// The block power of the item when unwielded
 	var/wieldsound = FALSE 							/// Play sound when wielded
 	var/unwieldsound = FALSE 						/// Play sound when unwielded
 	var/attacksound = FALSE							/// Play sound on attack when wielded
 	var/require_twohands = FALSE					/// Does it have to be held in both hands
 	var/icon_wielded = FALSE						/// The icon that will be used when wielded
 	var/obj/item/offhand/offhand_item		/// Reference to the offhand created for the item
-	var/sharpened_increase = 0						/// The amount of increase recived from sharpening the item
+	var/sharpened_increase					/// The amount of increase recived from sharpening the item
 	var/unwield_on_swap								/// Allow swapping, unwield on swap
 	var/auto_wield									/// If true wielding will be performed when picked up
 	var/ignore_attack_self							/// If true will not unwield when attacking self.
@@ -199,13 +199,13 @@
 
 	// update item stats and name
 	var/obj/item/parent_item = parent
-	if(force_multiplier)
+	if(!isnull(force_multiplier))
 		parent_item.force *= force_multiplier
-	else if(force_wielded)
+	else if(!isnull(force_wielded))
 		parent_item.force = force_wielded
-	if(block_power_wielded)
+	if(!isnull(block_power_wielded))
 		parent_item.block_power = block_power_wielded
-	if(sharpened_increase)
+	if(!isnull(sharpened_increase))
 		parent_item.force += sharpened_increase
 	parent_item.name = "[parent_item.name] (Wielded)"
 	parent_item.update_icon()
@@ -253,13 +253,13 @@
 
 	// update item stats
 	var/obj/item/parent_item = parent
-	if(sharpened_increase)
+	if(!isnull(sharpened_increase))
 		parent_item.force -= sharpened_increase
-	if(force_multiplier)
+	if(!isnull(force_multiplier))
 		parent_item.force /= force_multiplier
-	else if(force_unwielded)
+	else if(!isnull(force_unwielded))
 		parent_item.force = force_unwielded
-	if(block_power_unwielded)
+	if(!isnull(block_power_unwielded))
 		parent_item.block_power = block_power_unwielded
 
 	// update the items name to remove the wielded status

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -259,7 +259,7 @@
 		parent_item.force /= force_multiplier
 	else if(force_unwielded)
 		parent_item.force = force_unwielded
-	if(!isnull(block_power_unwielded))
+	if(block_power_unwielded)
 		parent_item.block_power = block_power_unwielded
 
 	// update the items name to remove the wielded status

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -31,7 +31,7 @@
 /obj/item/chainsaw/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 30, 100, 0, 'sound/weapons/chainsawhit.ogg', TRUE)
-	AddComponent(/datum/component/two_handed, require_twohands=TRUE, block_power_unwielded=block_power, block_power_wielded=block_power,force_unwielded = force)
+	AddComponent(/datum/component/two_handed, require_twohands=TRUE, block_power_unwielded=block_power, block_power_wielded=block_power)
 
 /obj/item/chainsaw/suicide_act(mob/living/carbon/user)
 	if(on)

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -31,7 +31,7 @@
 /obj/item/chainsaw/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 30, 100, 0, 'sound/weapons/chainsawhit.ogg', TRUE)
-	AddComponent(/datum/component/two_handed, require_twohands=TRUE, block_power_unwielded=block_power, block_power_wielded=block_power)
+	AddComponent(/datum/component/two_handed, require_twohands=TRUE, block_power_unwielded=block_power, block_power_wielded=block_power,force_unwielded = force)
 
 /obj/item/chainsaw/suicide_act(mob/living/carbon/user)
 	if(on)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #7010  Chainsaws no longer become force 0 when dropped
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a bug
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Chainsaws no longer become useless when dropped
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
