### PR TITLE
Incursionists don't get radio Uplinks anymore, getting Traitor-like uplinks instead

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -324,6 +324,8 @@
 	if (!implant)
 		. = uplink_loc
 		var/datum/component/uplink/U = uplink_loc.AddComponent(/datum/component/uplink, traitor_mob.key, TRUE, FALSE, gamemode, telecrystals)
+		if(src.has_antag_datum(/datum/antagonist/incursion))
+			U.uplink_flag = UPLINK_INCURSION
 		if(!U)
 			CRASH("Uplink creation failed.")
 		U.setup_unlock_code()

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -68,8 +68,9 @@
 	SSticker.mode.update_incursion_icons_removed(owner)
 
 /datum/antagonist/incursion/proc/finalize_incursion()
+	owner.equip_traitor("The Syndicate", FALSE, src, 15)
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE)
-	equip()
+
 
 /datum/antagonist/incursion/admin_add(datum/mind/new_owner,mob/admin)
 	//show list of possible brothers
@@ -89,22 +90,6 @@
 		message_admins("New incursion team created by [key_name_admin(admin)]")
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] and [key_name_admin(new_owner.current)] into blood brothers.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(new_owner.current)] into incursion traitor team.")
-
-/datum/antagonist/incursion/proc/equip(var/silent = FALSE)
-	var/obj/item/uplink/incursion/uplink = new(get_turf(owner.current), owner.key, 15)
-	var/where
-	if(ishuman(owner.current))		//if he's not a human, uplink will spawn under his feet
-		var/mob/living/carbon/human/H = owner.current
-		var/static/list/slots = list(
-			"in your backpack" = ITEM_SLOT_BACKPACK,
-			"in your left pocket" = ITEM_SLOT_LPOCKET,
-			"in your right pocket" = ITEM_SLOT_RPOCKET,
-			"in your hands" = ITEM_SLOT_HANDS
-		)
-		where = H.equip_in_one_of_slots(uplink, slots, FALSE)
-	to_chat(owner.current, "<span class='notice'><b>You have been equipped with a syndicate uplink located [where ? where : "at your feet"]. Activate the transponder in hand to access the market.</b></span>")
-	var/obj/item/implant/radio/syndicate/selfdestruct/syndio = new
-	syndio.implant(owner.current)
 
 /datum/team/incursion
 	name = "syndicate incursion force"

--- a/code/modules/uplink/uplink_devices.dm
+++ b/code/modules/uplink/uplink_devices.dm
@@ -34,14 +34,6 @@
 	hidden_uplink.name = "debug uplink"
 	hidden_uplink.debug = TRUE
 
-/obj/item/uplink/incursion
-	uplink_flag = UPLINK_INCURSION
-
-/obj/item/uplink/incursion/Initialize(mapload, owner, tc_amount = 20)
-	. = ..()
-	var/datum/component/uplink/hidden_uplink = GetComponent(/datum/component/uplink)
-	hidden_uplink.non_traitor_allowed = FALSE
-
 /obj/item/uplink/nuclear
 	uplink_flag = UPLINK_NUKE_OPS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what it says on the tin, Incursions get their uplinks in PDA/pen/radio instead of station bounced radio in their backpack.
closes #6784 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's harder to meta an incursion, headcoder requested this
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![Screenshot_1127](https://user-images.githubusercontent.com/53474257/175522043-356be3c3-e99d-43bf-a67b-9ad9e6d4a87a.png)

PDA Uplink, correct ammount of TC and unable to buy encryption key (UPLINK_INCURSION flag applied correctly)

## Changelog
:cl:
add: Incursionists now have traitor-like uplinks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
