### PR TITLE
Fixes multi-z jaunting and reduces gravity message frequency

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -166,7 +166,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		if(!user.has_gravity(src) || (user.movement_type & FLYING))
 			check_z_travel(user)
 			return
-		else
+		else if(allow_z_travel)
 			to_chat(user, "<span class='warning'>You can't float up and down when there is gravity!</span>")
 	. = ..()
 	if(SEND_SIGNAL(user, COMSIG_MOB_ATTACK_HAND_TURF, src) & COMPONENT_NO_ATTACK_HAND)
@@ -211,26 +211,23 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		to_chat(user, "<span class='warning'>There is nothing in that direction!</span>")
 		return
 	//Check if we can travel in that direction
-	if((upwards && !target.allow_z_travel) || (!upwards && !allow_z_travel))
+	var/mob/living/L = user
+	var/jaunting = isliving(user) && L.incorporeal_move
+
+	if(!jaunting && ((upwards && !target.allow_z_travel) || (!upwards && !allow_z_travel)))
 		to_chat(user, "<span class='warning'>Something is blocking you!</span>")
 		return
 	user.visible_message("<span class='notice'>[user] begins floating [upwards ? "upwards" : "downwards"]!</span>", "<span class='notice'>You begin floating [upwards ? "upwards" : "downwards"].")
 	var/matrix/M = user.transform
 	//Animation is inverted due to immediately resetting user vars.
-	animate(user, 30, pixel_y = upwards ? -64 : 64, transform = matrix() * (upwards ? 0.7 : 1.3))
+	animate(user, 30, pixel_y = upwards ? 32 : -32, transform = matrix() * (upwards ? 1.3 : 0.7))
 	user.pixel_y = 0
 	user.transform = M
 	if(!do_after(user, 30, FALSE, get_turf(user)))
 		animate(user, 0, flags = ANIMATION_END_NOW)
 		return
-	if(isliving(user))
-		var/mob/living/L = user
-		if(L.incorporeal_move) // Allow most jaunting
-			user.client?.Process_Incorpmove(upwards ? UP : DOWN)
-			return
-	// You can push off of or land on the floor, but not go through it
-	if((upwards && !target.allow_z_travel) || (!upwards && !allow_z_travel))
-		to_chat(user, "<span class='warning'>Something is blocking you!</span>")
+	if(jaunting) // Allow most jaunting
+		user.client?.Process_Incorpmove(upwards ? UP : DOWN)
 		return
 	var/atom/movable/AM
 	if(user.pulling)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Fixes incorporeal mobs being unable to traverse ceilings/floors
- Removes a redundant "something is blocking you" check
- Makes the message about not being able to move up and down in gravity only appear on space and open turfs as it did originally
- A couple people requested I flip the animation around and make it a bit smaller. I don't care that much so I'll revert this part if asked.

## Why It's Good For The Game
- Revenants get sad when they have to use stairs and elevators to get around.
- Getting that message all the time when misclicking is in fact kind of annoying

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![revenantup](https://user-images.githubusercontent.com/17987483/175801442-102cc7da-a0d2-4f42-bc4e-b416c3c12116.png)

</details>

## Changelog
:cl:
fix: Incorporeal mobs can traverse Z levels through the floor/ceiling
tweak: Warnings about being unable to Z travel in gravity will only appear on space or openspace
tweak: Reverses animation direction for Z travel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
