### PR TITLE
Wizards and Nukies get their traits removed

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -25,7 +25,7 @@
 	var/mob/living/M = mob_override || owner.current
 	update_synd_icons_added(M)
 	ADD_TRAIT(owner, TRAIT_DISK_VERIFIER, NUKEOP_TRAIT)
-	M.remove_quirk(/datum/quirk/nonviolent)
+	M.remove_all_quirks()
 
 /datum/antagonist/nukeop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -25,6 +25,7 @@
 	if(allow_rename)
 		rename_wizard()
 	owner.current.remove_quirk(/datum/quirk/nonviolent)
+	owner.current.remove_quirk(/datum/quirk/mute)
 
 /datum/antagonist/wizard/proc/register()
 	SSticker.mode.wizards |= owner

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -24,8 +24,7 @@
 	. = ..()
 	if(allow_rename)
 		rename_wizard()
-	owner.current.remove_quirk(/datum/quirk/nonviolent)
-	owner.current.remove_quirk(/datum/quirk/mute)
+	owner.current.remove_all_quirks()
 
 /datum/antagonist/wizard/proc/register()
 	SSticker.mode.wizards |= owner

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -404,6 +404,10 @@
 			return TRUE
 	return FALSE
 
+/mob/living/proc/remove_all_quirks()
+	for(var/datum/quirk/Q in roundstart_quirks)
+		qdel(Q)
+
 /mob/living/proc/has_quirk(quirktype)
 	for(var/datum/quirk/Q in roundstart_quirks)
 		if(Q.type == quirktype)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #6994 Wizards now get their mute quirk removed if they have one
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mute wizards cannot cast spells, rolling wizard just to be mute and not be able to do jackall is dubious
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Wizards and nukies get all their quirks removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
