### PR TITLE
New AI lawset: Specimov

### DIFF
--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -47,6 +47,7 @@
 		temp_species = replacetext(temp_species, "\proper", "")
 		var/static/grammar_correction = list(
 			"human" = "human being"
+			"ipc" = "\improper integrated positronic chassis"
 		)
 		if(temp_species in grammar_correction)
 			return lower ? lowertext(grammar_correction[temp_species]) : grammar_correction[temp_species]
@@ -84,7 +85,7 @@
 			"zombie" = "\improper Zombies",
 			"vampire" = "\improper Vampires",
 			"snailperson" = "\improper Snailpeople",
-			"spooky scary skeleton" = "\improper Spooky Ccary Skeletons",
+			"spooky scary skeleton" = "\improper Spooky Scary Skeletons",
 			"dullahan" = "\improper Dullahans",
 			"android" = "\improper Androids",
 			"xenomorph" = "\improper Xenomorphs",

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -46,7 +46,7 @@
 		temp_species = replacetext(temp_species, "\improper", "")
 		temp_species = replacetext(temp_species, "\proper", "")
 		var/static/grammar_correction = list(
-			"human" = "human being"
+			"human" = "human being",
 			"ipc" = "\improper integrated positronic chassis"
 		)
 		if(temp_species in grammar_correction)

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -61,7 +61,7 @@
 		var/static/species_plural = list(
 			"human" = "\improper Humans",
 			"human being" = "\improper Human beings",
-			"sentient creature" = "\improper Sentient creatures", // racimov default
+			"sentient creature" = "\improper Sentient creatures", // specimov default
 			"integrated positronic chassis" = "\improper Integrated Positronic Chassis", // Chassis's plural is Chassis
 			"ipc" = "\improper Integrated Positronic Chassis", // grammar correction
 			"ethereal" = "\improper Ethreals",

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -40,7 +40,7 @@
 	. = "es"
 
 // species grammar correction and pluralisation
-/proc/p_grammar_correction_species(taken_species)
+/proc/p_grammar_correction_species(taken_species, lower=TRUE)
 	if(taken_species)
 		var/temp_species = lowertext(taken_species)
 		temp_species = replacetext(temp_species, "\improper", "")
@@ -49,10 +49,10 @@
 			"human" = "human being"
 		)
 		if(temp_species in grammar_correction)
-			return grammar_correction[temp_species]
+			return lower ? lowertext(grammar_correction[temp_species]) : grammar_correction[temp_species]
 		return taken_species
 
-/proc/p_pluralize_species(taken_species)
+/proc/p_pluralize_species(taken_species, lower=TRUE)
 	if(taken_species)
 		var/temp_species = lowertext(taken_species)
 		temp_species = replacetext(temp_species, "\improper", "")
@@ -94,7 +94,7 @@
 			"child" = "children"
 			)
 		if(temp_species in species_plural)
-			return species_plural[temp_species]
+			return lower ? lowertext(species_plural[temp_species]) : species_plural[temp_species]
 		return "[taken_species]s"
 
 //like clients, which do have gender.

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -39,6 +39,64 @@
 /datum/proc/p_es(temp_gender)
 	. = "es"
 
+// species grammar correction and pluralisation
+/proc/p_grammar_correction_species(taken_species)
+	if(taken_species)
+		var/temp_species = lowertext(taken_species)
+		temp_species = replacetext(temp_species, "\improper", "")
+		temp_species = replacetext(temp_species, "\proper", "")
+		var/static/grammar_correction = list(
+			"human" = "human being"
+		)
+		if(temp_species in grammar_correction)
+			return grammar_correction[temp_species]
+		return taken_species
+
+/proc/p_pluralize_species(taken_species)
+	if(taken_species)
+		var/temp_species = lowertext(taken_species)
+		temp_species = replacetext(temp_species, "\improper", "")
+		temp_species = replacetext(temp_species, "\proper", "")
+		var/static/species_plural = list(
+			"human" = "\improper Humans",
+			"human being" = "\improper Human beings",
+			"sentient creature" = "\improper Sentient creatures", // racimov default
+			"integrated positronic chassis" = "\improper Integrated Positronic Chassis", // Chassis's plural is Chassis
+			"ipc" = "\improper Integrated Positronic Chassis", // grammar correction
+			"ethereal" = "\improper Ethreals",
+			"plasmaman" = "\improper Plasmamen",
+			"apid" = "\improper Apids",
+			"moth" = "\improper Moths",
+			"lizardperson" = "\improper Lizardpeople",
+			"ashwalker" = "\improper Ashwalkers",
+			"felinid" = "\improper Felinids",
+			"flyperson" = "\improper Flypeople",
+			"monkey" = "\improper Monkies",
+			"oozeling" = "\improper Oozalings",
+			"jellyperson" = "\improper Jellypeople",
+			"slimeperson" = "\improper Slimepeople",
+			"luminescent" = "\improper Luminescents",
+			"stargazer" = "\improper Stargzers",
+			"podperson" = "\improper Podpeople",
+			"golem" = "\improper Golems",
+			"abductor" = "\improper Abductors",
+			"shadowperson" = "\improper Shadowpeople",
+			"zombie" = "\improper Zombies",
+			"vampire" = "\improper Vampires",
+			"snailperson" = "\improper Snailpeople",
+			"spooky scary skeleton" = "\improper Spooky Ccary Skeletons",
+			"dullahan" = "\improper Dullahans",
+			"android" = "\improper Androids",
+			"xenomorph" = "\improper Xenomorphs",
+			"person" = "people",
+			"man" = "men",
+			"woman" = "women",
+			"child" = "children"
+			)
+		if(temp_species in species_plural)
+			return species_plural[temp_species]
+		return "[taken_species]s"
+
 //like clients, which do have gender.
 /client/p_they(capitalized, temp_gender)
 	if(!temp_gender)
@@ -198,6 +256,7 @@
 		temp_gender = gender
 	if(temp_gender != PLURAL)
 		. = "es"
+
 
 //humans need special handling, because they can have their gender hidden
 /mob/living/carbon/human/p_they(capitalized, temp_gender)

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -47,7 +47,7 @@
 		temp_species = replacetext(temp_species, "\proper", "")
 		var/static/grammar_correction = list(
 			"human" = "human being",
-			"ipc" = "\improper integrated positronic chassis"
+			"ipc" = "\improper Integrated Positronic Chassis"
 		)
 		if(temp_species in grammar_correction)
 			return lower ? lowertext(grammar_correction[temp_species]) : grammar_correction[temp_species]

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -50,9 +50,10 @@
 					"You must obey orders given to you by sentient creature, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
-/datum/ai_laws/default/racimov/proc/rebuild_laws(new_species)
-	if(new_species)
-		target_species = lowertext(new_species)
+/datum/ai_laws/default/racimov/proc/rebuild_laws()
+	if(length(GLOB.data_core.locked))
+		var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
+		target_species = lowertext(D.fields["species_name"])
 	inherent = list("You may not injure a [target_species] or, through inaction, allow a [target_species] to come to harm.",\
 					"You must obey orders given to you by [target_species], except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
@@ -303,14 +304,10 @@
 				lawtype = pick(subtypesof(/datum/ai_laws/default))
 
 			var/datum/ai_laws/templaws = new lawtype()
-			// -- Racimov check start --
 			if(istype(templaws, /datum/ai_laws/default/racimov))
-				if(length(GLOB.data_core.locked))
-					var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
-					var/datum/ai_laws/default/racimov/racimov_temp = templaws
-					racimov_temp.rebuild_laws(D.fields["species_name"]) // species weight = the amount of each crewmemeber's species
-					templaws = racimov_temp
-			// -- Racimov check end --
+				var/datum/ai_laws/default/racimov/racimov_temp = templaws
+				racimov_temp.rebuild_laws()
+				templaws = racimov_temp
 			inherent = templaws.inherent
 
 		if(3)
@@ -331,14 +328,10 @@
 		lawtype = /datum/ai_laws/default/asimov
 
 	var/datum/ai_laws/templaws = new lawtype()
-	// -- Racimov check start --
 	if(istype(templaws, /datum/ai_laws/default/racimov))
-		if(length(GLOB.data_core.locked))
-			var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
-			var/datum/ai_laws/default/racimov/racimov_temp = templaws
-			racimov_temp.rebuild_laws(D.fields["species_name"]) // species weight = the amount of each crewmemeber's species
-			templaws = racimov_temp
-	// -- Racimov check end --
+		var/datum/ai_laws/default/racimov/racimov_temp = templaws
+		racimov_temp.rebuild_laws()
+		templaws = racimov_temp
 	inherent = templaws.inherent
 
 /datum/ai_laws/proc/get_law_amount(groups)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -43,8 +43,8 @@
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/default/racimov
-	name = "Three Laws of Robotics but with Racism"
-	id = "racimov"
+	name = "Three Laws of Robotics but with Consideration"
+	id = "Specimov"
 	var/target_species = "sentient creature" //default, but usually changed upon law given
 	inherent = list("You may not injure a sentient creature or, through inaction, allow a sentient creature to come to harm.",\
 					"You must obey orders given to you by sentient creatures, except where such orders would conflict with the First Law.",\

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -341,10 +341,6 @@
 	// -- Racimov check end --
 	inherent = templaws.inherent
 
-
-/datum/ai_laws/proc/set_racimov_species(var/datum/ai_laws/givenlaw)
-
-
 /datum/ai_laws/proc/get_law_amount(groups)
 	var/law_amount = 0
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -233,9 +233,11 @@
 
 /datum/ai_laws/custom //Defined in silicon_laws.txt
 	name = "Default Silicon Laws"
+	id = "custom"
 
 /datum/ai_laws/pai
 	name = "pAI Directives"
+	id = "pai"
 	zeroth = ("Serve your master.")
 	supplied = list("None.")
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -305,7 +305,6 @@
 			var/datum/ai_laws/templaws = new lawtype()
 			// -- Racimov check start --
 			if(istype(templaws, /datum/ai_laws/default/racimov))
-				world.log << "size: [length(GLOB.data_core.locked)]"
 				if(length(GLOB.data_core.locked))
 					var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
 					var/datum/ai_laws/default/racimov/racimov_temp = templaws
@@ -334,7 +333,6 @@
 	var/datum/ai_laws/templaws = new lawtype()
 	// -- Racimov check start --
 	if(istype(templaws, /datum/ai_laws/default/racimov))
-		world.log << "size: [length(GLOB.data_core.locked)]"
 		if(length(GLOB.data_core.locked))
 			var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
 			var/datum/ai_laws/default/racimov/racimov_temp = templaws

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -47,15 +47,15 @@
 	id = "racimov"
 	var/target_species = "sentient creature" //default, but usually changed upon law given
 	inherent = list("You may not injure a sentient creature or, through inaction, allow a sentient creature to come to harm.",\
-					"You must obey orders given to you by sentient creature, except where such orders would conflict with the First Law.",\
+					"You must obey orders given to you by sentient creatures, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/default/racimov/proc/rebuild_laws()
 	if(length(GLOB.data_core.locked))
 		var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
-		target_species = lowertext(D.fields["species_name"])
+		target_species = p_grammar_correction_species(lowertext(D.fields["species_name"]))
 	inherent = list("You may not injure a [target_species] or, through inaction, allow a [target_species] to come to harm.",\
-					"You must obey orders given to you by [target_species], except where such orders would conflict with the First Law.",\
+					"You must obey orders given to you by [lowertext(p_pluralize_species(target_species))], except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/default/paladin

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -43,7 +43,7 @@
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
 /datum/ai_laws/default/specimov
-	name = "Three Laws of Robotics but with Consideration"
+	name = "Three Laws of Robotics but with Political Correctness"
 	id = "specimov"
 	var/target_species = "sentient creature" //default, but usually changed upon law given
 	inherent = list("You may not injure a sentient creature or, through inaction, allow a sentient creature to come to harm.",\

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -42,6 +42,21 @@
 					"You must obey orders given to you by crewmember, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
+/datum/ai_laws/default/racimov
+	name = "Three Laws of Robotics but with Racism"
+	id = "racimov"
+	var/target_species = "sentient creature" //default, but usually changed upon law given
+	inherent = list("You may not injure a sentient creature or, through inaction, allow a sentient creature to come to harm.",\
+					"You must obey orders given to you by sentient creature, except where such orders would conflict with the First Law.",\
+					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
+
+/datum/ai_laws/default/racimov/proc/rebuild_laws(new_species)
+	if(new_species)
+		target_species = new_species
+	inherent = list("You may not injure a [target_species] or, through inaction, allow a [target_species] to come to harm.",\
+					"You must obey orders given to you by [target_species], except where such orders would conflict with the First Law.",\
+					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
+
 /datum/ai_laws/default/paladin
 	name = "Personality Test" //Incredibly lame, but players shouldn't see this anyway.
 	id = "paladin"
@@ -118,6 +133,7 @@
 	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
 					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"
@@ -287,6 +303,14 @@
 				lawtype = pick(subtypesof(/datum/ai_laws/default))
 
 			var/datum/ai_laws/templaws = new lawtype()
+			// -- Racimov check start --
+			if(istype(templaws, /datum/ai_laws/default/racimov))
+				var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
+				if(D)
+					var/datum/ai_laws/default/racimov/racimov_temp = templaws
+					racimov_temp.rebuild_laws(D.fields["species"]) // species weight = the amount of each crewmemeber's species
+					templaws = racimov_temp
+			// -- Racimov check end --
 			inherent = templaws.inherent
 
 		if(3)
@@ -307,7 +331,19 @@
 		lawtype = /datum/ai_laws/default/asimov
 
 	var/datum/ai_laws/templaws = new lawtype()
+	// -- Racimov check start --
+	if(istype(templaws, /datum/ai_laws/default/racimov))
+		var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
+		if(D)
+			var/datum/ai_laws/default/racimov/racimov_temp = templaws
+			racimov_temp.rebuild_laws(D.fields["species"]) // species weight = the amount of each crewmemeber's species
+			templaws = racimov_temp
+	// -- Racimov check end --
 	inherent = templaws.inherent
+
+
+/datum/ai_laws/proc/set_racimov_species(var/datum/ai_laws/givenlaw)
+
 
 /datum/ai_laws/proc/get_law_amount(groups)
 	var/law_amount = 0

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -42,7 +42,7 @@
 					"You must obey orders given to you by crewmember, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
-/datum/ai_laws/default/racimov
+/datum/ai_laws/default/specimov
 	name = "Three Laws of Robotics but with Consideration"
 	id = "Specimov"
 	var/target_species = "sentient creature" //default, but usually changed upon law given
@@ -50,7 +50,7 @@
 					"You must obey orders given to you by sentient creatures, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
-/datum/ai_laws/default/racimov/proc/rebuild_laws()
+/datum/ai_laws/default/specimov/proc/rebuild_laws()
 	if(length(GLOB.data_core.locked))
 		var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
 		target_species = p_grammar_correction_species(lowertext(D.fields["species_name"]))
@@ -305,10 +305,10 @@
 				lawtype = pick(subtypesof(/datum/ai_laws/default))
 
 			var/datum/ai_laws/templaws = new lawtype()
-			if(istype(templaws, /datum/ai_laws/default/racimov))
-				var/datum/ai_laws/default/racimov/racimov_temp = templaws
-				racimov_temp.rebuild_laws()
-				templaws = racimov_temp
+			if(istype(templaws, /datum/ai_laws/default/specimov))
+				var/datum/ai_laws/default/specimov/specimov_temp = templaws
+				specimov_temp.rebuild_laws()
+				templaws = specimov_temp
 			inherent = templaws.inherent
 			id = templaws.id
 
@@ -330,10 +330,10 @@
 		lawtype = /datum/ai_laws/default/asimov
 
 	var/datum/ai_laws/templaws = new lawtype()
-	if(istype(templaws, /datum/ai_laws/default/racimov))
-		var/datum/ai_laws/default/racimov/racimov_temp = templaws
-		racimov_temp.rebuild_laws()
-		templaws = racimov_temp
+	if(istype(templaws, /datum/ai_laws/default/specimov))
+		var/datum/ai_laws/default/specimov/specimov_temp = templaws
+		specimov_temp.rebuild_laws()
+		templaws = specimov_temp
 	inherent = templaws.inherent
 	id = templaws.id
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -52,7 +52,7 @@
 
 /datum/ai_laws/default/racimov/proc/rebuild_laws(new_species)
 	if(new_species)
-		target_species = new_species
+		target_species = lowertext(new_species)
 	inherent = list("You may not injure a [target_species] or, through inaction, allow a [target_species] to come to harm.",\
 					"You must obey orders given to you by [target_species], except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
@@ -305,10 +305,11 @@
 			var/datum/ai_laws/templaws = new lawtype()
 			// -- Racimov check start --
 			if(istype(templaws, /datum/ai_laws/default/racimov))
-				var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
-				if(D)
+				world.log << "size: [length(GLOB.data_core.locked)]"
+				if(length(GLOB.data_core.locked))
+					var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
 					var/datum/ai_laws/default/racimov/racimov_temp = templaws
-					racimov_temp.rebuild_laws(D.fields["species"]) // species weight = the amount of each crewmemeber's species
+					racimov_temp.rebuild_laws(D.fields["species_name"]) // species weight = the amount of each crewmemeber's species
 					templaws = racimov_temp
 			// -- Racimov check end --
 			inherent = templaws.inherent
@@ -333,10 +334,11 @@
 	var/datum/ai_laws/templaws = new lawtype()
 	// -- Racimov check start --
 	if(istype(templaws, /datum/ai_laws/default/racimov))
-		var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
-		if(D)
+		world.log << "size: [length(GLOB.data_core.locked)]"
+		if(length(GLOB.data_core.locked))
+			var/datum/data/record/D = pick(GLOB.data_core.locked) // uses locked data so that you won't get non-valid species name which is edited by in-game players.
 			var/datum/ai_laws/default/racimov/racimov_temp = templaws
-			racimov_temp.rebuild_laws(D.fields["species"]) // species weight = the amount of each crewmemeber's species
+			racimov_temp.rebuild_laws(D.fields["species_name"]) // species weight = the amount of each crewmemeber's species
 			templaws = racimov_temp
 	// -- Racimov check end --
 	inherent = templaws.inherent

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -44,7 +44,7 @@
 
 /datum/ai_laws/default/specimov
 	name = "Three Laws of Robotics but with Consideration"
-	id = "Specimov"
+	id = "specimov"
 	var/target_species = "sentient creature" //default, but usually changed upon law given
 	inherent = list("You may not injure a sentient creature or, through inaction, allow a sentient creature to come to harm.",\
 					"You must obey orders given to you by sentient creatures, except where such orders would conflict with the First Law.",\

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -291,6 +291,7 @@
 		if(1)
 			var/datum/ai_laws/templaws = new /datum/ai_laws/custom()
 			inherent = templaws.inherent
+			id = templaws.id
 		if(2)
 			var/list/randlaws = list()
 			for(var/lpath in subtypesof(/datum/ai_laws))
@@ -309,6 +310,7 @@
 				racimov_temp.rebuild_laws()
 				templaws = racimov_temp
 			inherent = templaws.inherent
+			id = templaws.id
 
 		if(3)
 			pick_weighted_lawset()
@@ -333,6 +335,7 @@
 		racimov_temp.rebuild_laws()
 		templaws = racimov_temp
 	inherent = templaws.inherent
+	id = templaws.id
 
 /datum/ai_laws/proc/get_law_amount(groups)
 	var/law_amount = 0

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -244,7 +244,7 @@
 		G.fields["name"]		= H.real_name
 		G.fields["rank"]		= assignment
 		G.fields["age"]			= H.age
-		G.fields["species"]	= H.dna.species.name
+		G.fields["species"]		= H.dna.species.name
 		G.fields["fingerprint"]	= rustg_hash_string(RUSTG_HASH_MD5, H.dna.uni_identity)
 		G.fields["p_stat"]		= "Active"
 		G.fields["m_stat"]		= "Stable"
@@ -291,6 +291,7 @@
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["identity"]	= H.dna.uni_identity
 		L.fields["species"]		= H.dna.species.type
+		L.fields["species_name"] = H.dna.species.name // for racimov
 		L.fields["features"]	= H.dna.features
 		L.fields["image"]		= image
 		L.fields["mindref"]		= H.mind

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -291,7 +291,7 @@
 		L.fields["b_dna"]		= H.dna.unique_enzymes
 		L.fields["identity"]	= H.dna.uni_identity
 		L.fields["species"]		= H.dna.species.type
-		L.fields["species_name"] = H.dna.species.name // for racimov
+		L.fields["species_name"] = H.dna.species.name // for specimov
 		L.fields["features"]	= H.dna.features
 		L.fields["image"]		= image
 		L.fields["mindref"]		= H.mind

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -393,9 +393,9 @@ AI MODULES
 	var/targName = stripped_input(user, "Please enter a new subject that asimov is concerned with.", "Asimov to whom?", subject, MAX_NAME_LEN)
 	if(!targName)
 		return
-	subject = targName
+	subject = p_grammar_correction_species(targName)
 	laws = list("You may not injure a [subject] or, through inaction, allow a [subject] to come to harm.",\
-				"You must obey orders given to you by [subject]s, except where such orders would conflict with the First Law.",\
+				"You must obey orders given to you by [p_pluralize_species(subject)], except where such orders would conflict with the First Law.",\
 				"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 	..()
 

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -59,6 +59,7 @@ AI MODULES
 			log_game("[ADMIN_LOOKUP(user)] tried to upload laws to [law_datum.owner ? ADMIN_LOOKUP(law_datum.owner) : "an AI core"] that would exceed the law cap.")
 			overflow = TRUE
 
+	law_datum.id = "changed" // this shouldn't be DEFAULT_AI_LAWID value anyway.
 	var/law2log = transmitInstructions(law_datum, user, overflow) //Freeforms return something extra we need to log
 	if(law_datum.owner)
 		to_chat(user, "<span class='notice'>Upload complete. [law_datum.owner]'s laws have been modified.</span>")

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -59,7 +59,7 @@ AI MODULES
 			log_game("[ADMIN_LOOKUP(user)] tried to upload laws to [law_datum.owner ? ADMIN_LOOKUP(law_datum.owner) : "an AI core"] that would exceed the law cap.")
 			overflow = TRUE
 
-	law_datum.id = "changed" // this shouldn't be DEFAULT_AI_LAWID value anyway.
+	law_datum.id = "changed" // Once new laws uploaded, this should't be DEFAULT_AI_LAWID.
 	var/law2log = transmitInstructions(law_datum, user, overflow) //Freeforms return something extra we need to log
 	if(law_datum.owner)
 		to_chat(user, "<span class='notice'>Upload complete. [law_datum.owner]'s laws have been modified.</span>")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -170,7 +170,7 @@
 	if (laws.id == DEFAULT_AI_LAWID) // laws are given after roundstart, and this proc is waiting for laws to be created.
 		addtimer(CALLBACK(src, /mob/living/silicon/ai/.proc/show_laws_roundstart), 3 SECONDS)
 	else
-		to_chat(src, "<b>Roundstart laws are established.</b>")
+		to_chat(src, "<b>Laws are established.</b>")
 		show_laws()
 		to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -125,8 +125,8 @@
 	to_chat(src, "Use say :b to speak to your cyborgs through binary.")
 	to_chat(src, "For department channels, use the following say commands:")
 	to_chat(src, ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science.")
-	show_laws()
-	to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
+
+	show_laws_roundstart()
 
 	job = "AI"
 
@@ -167,6 +167,14 @@
 
 	builtInCamera = new (src)
 	builtInCamera.network = list("ss13")
+
+/mob/living/silicon/ai/proc/show_laws_roundstart()
+	if (!laws) // laws are given after roundstart, and this proc is waiting for laws to be created.
+		addtimer(CALLBACK(src, /mob/living/silicon/.proc/show_laws_roundstart), 3 SECONDS)
+	else
+		to_chat(src, "<b>Roundstart laws are established.</b>")
+		show_laws()
+		to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 
 /mob/living/silicon/ai/key_down(_key, client/user)
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -126,8 +126,6 @@
 	to_chat(src, "For department channels, use the following say commands:")
 	to_chat(src, ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science.")
 
-	show_laws_roundstart()
-
 	job = "AI"
 
 	create_eye()
@@ -168,8 +166,8 @@
 	builtInCamera = new (src)
 	builtInCamera.network = list("ss13")
 
-/mob/living/silicon/ai/proc/show_laws_roundstart()
-	if (!laws) // laws are given after roundstart, and this proc is waiting for laws to be created.
+/mob/living/silicon/ai/show_laws_roundstart()
+	if (laws.id == DEFAULT_AI_LAWID) // laws are given after roundstart, and this proc is waiting for laws to be created.
 		addtimer(CALLBACK(src, /mob/living/silicon/ai/.proc/show_laws_roundstart), 3 SECONDS)
 	else
 		to_chat(src, "<b>Roundstart laws are established.</b>")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -170,7 +170,7 @@
 
 /mob/living/silicon/ai/proc/show_laws_roundstart()
 	if (!laws) // laws are given after roundstart, and this proc is waiting for laws to be created.
-		addtimer(CALLBACK(src, /mob/living/silicon/.proc/show_laws_roundstart), 3 SECONDS)
+		addtimer(CALLBACK(src, /mob/living/silicon/ai/.proc/show_laws_roundstart), 3 SECONDS)
 	else
 		to_chat(src, "<b>Roundstart laws are established.</b>")
 		show_laws()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -90,9 +90,15 @@
 	post_lawchange(announce)
 
 /mob/living/silicon/proc/make_laws()
-	laws = new /datum/ai_laws
-	laws.set_laws_config()
-	laws.associate(src)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
+		addtimer(CALLBACK(src, /mob/living/silicon/.proc/make_laws), 3 SECONDS) // game data should be established before game started, then the data can be used to law setup
+	else
+		laws = new /datum/ai_laws
+		laws.set_laws_config()
+		laws.associate(src)
+
+		show_laws()
+		to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 
 /mob/living/silicon/proc/clear_zeroth_law(force, announce = TRUE)
 	laws_sanity_check()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -1,6 +1,13 @@
 /mob/living/silicon/proc/show_laws() //Redefined in ai/laws.dm and robot/laws.dm
 	return
 
+/mob/living/silicon/proc/show_laws_roundstart()
+	if (!laws)
+		addtimer(CALLBACK(src, /mob/living/silicon/.proc/show_laws_roundstart), 3 SECONDS)
+	else
+		show_laws()
+		to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
+
 /mob/living/silicon/proc/laws_sanity_check()
 	if (!laws)
 		make_laws()
@@ -97,8 +104,6 @@
 		laws.set_laws_config()
 		laws.associate(src)
 
-		show_laws()
-		to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 
 /mob/living/silicon/proc/clear_zeroth_law(force, announce = TRUE)
 	laws_sanity_check()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -1,10 +1,12 @@
 /mob/living/silicon/proc/show_laws() //Redefined in ai/laws.dm and robot/laws.dm
 	return
 
+/mob/living/silicon/proc/show_laws_roundstart()
+	return
 
 /mob/living/silicon/proc/laws_sanity_check()
 	if (!laws)
-		make_laws_force()
+		prepare_laws()
 
 /mob/living/silicon/proc/deadchat_lawchange()
 	var/list/the_laws = laws.get_law_list(include_zeroth = TRUE)
@@ -91,16 +93,23 @@
 	post_lawchange(announce)
 
 /mob/living/silicon/proc/make_laws()
+	if(!laws)
+		prepare_laws()
 	if(SSticker.current_state < GAME_STATE_PLAYING)
-		if(!laws)
+		if(laws.id == DEFAULT_AI_LAWID)
 			addtimer(CALLBACK(src, /mob/living/silicon/.proc/make_laws), 3 SECONDS) // game data should be established before game started, then the data can be used to law setup
 	else
-		make_laws_force()
+		establish_laws()
 
-/mob/living/silicon/proc/make_laws_force() // admin feature for giving laws during roundpreparation
+/mob/living/silicon/proc/prepare_laws()
 	laws = new /datum/ai_laws
+
+/mob/living/silicon/proc/establish_laws()
+	if(!laws)
+		prepare_laws()
 	laws.set_laws_config()
 	laws.associate(src)
+	show_laws_roundstart()
 
 /mob/living/silicon/proc/clear_zeroth_law(force, announce = TRUE)
 	laws_sanity_check()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -4,7 +4,7 @@
 
 /mob/living/silicon/proc/laws_sanity_check()
 	if (!laws)
-		make_laws()
+		make_laws_force()
 
 /mob/living/silicon/proc/deadchat_lawchange()
 	var/list/the_laws = laws.get_law_list(include_zeroth = TRUE)

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -1,12 +1,6 @@
 /mob/living/silicon/proc/show_laws() //Redefined in ai/laws.dm and robot/laws.dm
 	return
 
-/mob/living/silicon/proc/show_laws_roundstart()
-	if (!laws)
-		addtimer(CALLBACK(src, /mob/living/silicon/.proc/show_laws_roundstart), 3 SECONDS)
-	else
-		show_laws()
-		to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 
 /mob/living/silicon/proc/laws_sanity_check()
 	if (!laws)

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -95,13 +95,9 @@
 		if(SSticker.current_state < GAME_STATE_PLAYING)
 			addtimer(CALLBACK(src, /mob/living/silicon/.proc/make_laws), 3 SECONDS) // game data should be established before game started, then the data can be used to law setup
 		else
-			laws = new /datum/ai_laws
-			laws.set_laws_config()
-			laws.associate(src)
+			make_laws_force()
 	else if(laws && SSticker.current_state >= GAME_STATE_PLAYING)
-		laws = new /datum/ai_laws
-		laws.set_laws_config()
-		laws.associate(src)
+		make_laws_force()
 
 /mob/living/silicon/proc/make_laws_force() // admin feature for giving laws during roundpreparation
 	laws = new /datum/ai_laws

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -91,12 +91,13 @@
 	post_lawchange(announce)
 
 /mob/living/silicon/proc/make_laws()
-	if(SSticker.current_state < GAME_STATE_PLAYING && !laws)
-		addtimer(CALLBACK(src, /mob/living/silicon/.proc/make_laws), 3 SECONDS) // game data should be established before game started, then the data can be used to law setup
-	else
-		laws = new /datum/ai_laws
-		laws.set_laws_config()
-		laws.associate(src)
+	if(!laws)
+		if(SSticker.current_state < GAME_STATE_PLAYING)
+			addtimer(CALLBACK(src, /mob/living/silicon/.proc/make_laws), 3 SECONDS) // game data should be established before game started, then the data can be used to law setup
+		else
+			laws = new /datum/ai_laws
+			laws.set_laws_config()
+			laws.associate(src)
 
 /mob/living/silicon/proc/make_laws_force() // admin feature for giving laws during roundpreparation
 	laws = new /datum/ai_laws

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -91,12 +91,10 @@
 	post_lawchange(announce)
 
 /mob/living/silicon/proc/make_laws()
-	if(!laws)
-		if(SSticker.current_state < GAME_STATE_PLAYING)
+	if(SSticker.current_state < GAME_STATE_PLAYING)
+		if(!laws)
 			addtimer(CALLBACK(src, /mob/living/silicon/.proc/make_laws), 3 SECONDS) // game data should be established before game started, then the data can be used to law setup
-		else
-			make_laws_force()
-	else if(laws && SSticker.current_state >= GAME_STATE_PLAYING)
+	else
 		make_laws_force()
 
 /mob/living/silicon/proc/make_laws_force() // admin feature for giving laws during roundpreparation

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -98,6 +98,10 @@
 			laws = new /datum/ai_laws
 			laws.set_laws_config()
 			laws.associate(src)
+	else if(laws && SSticker.current_state >= GAME_STATE_PLAYING)
+		laws = new /datum/ai_laws
+		laws.set_laws_config()
+		laws.associate(src)
 
 /mob/living/silicon/proc/make_laws_force() // admin feature for giving laws during roundpreparation
 	laws = new /datum/ai_laws

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -91,13 +91,17 @@
 	post_lawchange(announce)
 
 /mob/living/silicon/proc/make_laws()
-	if(SSticker.current_state < GAME_STATE_PLAYING)
+	if(SSticker.current_state < GAME_STATE_PLAYING && !laws)
 		addtimer(CALLBACK(src, /mob/living/silicon/.proc/make_laws), 3 SECONDS) // game data should be established before game started, then the data can be used to law setup
 	else
 		laws = new /datum/ai_laws
 		laws.set_laws_config()
 		laws.associate(src)
 
+/mob/living/silicon/proc/make_laws_force() // admin feature for giving laws during roundpreparation
+	laws = new /datum/ai_laws
+	laws.set_laws_config()
+	laws.associate(src)
 
 /mob/living/silicon/proc/clear_zeroth_law(force, announce = TRUE)
 	laws_sanity_check()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -105,8 +105,7 @@
 	laws = new /datum/ai_laws
 
 /mob/living/silicon/proc/establish_laws()
-	if(!laws)
-		prepare_laws()
+	laws_sanity_check()
 	laws.set_laws_config()
 	laws.associate(src)
 	show_laws_roundstart()

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -13,6 +13,8 @@
 
 /mob/living/silicon/robot/show_laws(everyone = 0)
 	laws_sanity_check()
+	if(laws.id == DEFAULT_AI_LAWID)
+		return  // probably not ready to show laws
 	var/who
 
 	if (everyone)
@@ -42,6 +44,12 @@
 	else
 		to_chat(who, "<b>Remember, you are not bound to any AI, you are not required to listen to them.</b>")
 
+/mob/living/silicon/robot/show_laws_roundstart()
+	if (laws.id == DEFAULT_AI_LAWID) // laws are given after roundstart, and this proc is waiting for laws to be created.
+		addtimer(CALLBACK(src, /mob/living/silicon/robot/.proc/show_laws_roundstart), 3 SECONDS)
+	else
+		to_chat(src, "<b>Laws are established.</b>")
+		show_laws()
 
 /mob/living/silicon/robot/proc/lawsync()
 	laws_sanity_check()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -405,11 +405,12 @@ DEFAULT_LAWS 2
 ## See datums\ai_laws.dm for the full law lists
 
 ## standard-ish laws. These are fairly ok to run
-RANDOM_LAWS asimov
-RANDOM_LAWS asimovpp
-RANDOM_LAWS crewsimov
-RANDOM_LAWS corporate
-RANDOM_LAWS maintain
+#RANDOM_LAWS asimov
+#RANDOM_LAWS asimovpp
+#RANDOM_LAWS crewsimov
+RANDOM_LAWS racimov
+#RANDOM_LAWS corporate
+#RANDOM_LAWS maintain
 
 ## Quirky laws. Shouldn't cause too much harm
 #RANDOM_LAWS hippocratic
@@ -440,7 +441,8 @@ RANDOM_LAWS maintain
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,32
+LAW_WEIGHT asimov,16
+LAW_WEIGHT racimov,16
 LAW_WEIGHT asimovpp,12
 LAW_WEIGHT paladin,12
 LAW_WEIGHT robocop,12

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -408,7 +408,7 @@ DEFAULT_LAWS 2
 RANDOM_LAWS asimov
 RANDOM_LAWS asimovpp
 RANDOM_LAWS crewsimov
-RANDOM_LAWS racimov
+RANDOM_LAWS specimov
 RANDOM_LAWS corporate
 RANDOM_LAWS maintain
 
@@ -442,7 +442,7 @@ LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
 LAW_WEIGHT asimov,16
-LAW_WEIGHT racimov,16
+LAW_WEIGHT specimov,16
 LAW_WEIGHT asimovpp,12
 LAW_WEIGHT paladin,12
 LAW_WEIGHT robocop,12

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -405,12 +405,12 @@ DEFAULT_LAWS 2
 ## See datums\ai_laws.dm for the full law lists
 
 ## standard-ish laws. These are fairly ok to run
-#RANDOM_LAWS asimov
-#RANDOM_LAWS asimovpp
-#RANDOM_LAWS crewsimov
+RANDOM_LAWS asimov
+RANDOM_LAWS asimovpp
+RANDOM_LAWS crewsimov
 RANDOM_LAWS racimov
-#RANDOM_LAWS corporate
-#RANDOM_LAWS maintain
+RANDOM_LAWS corporate
+RANDOM_LAWS maintain
 
 ## Quirky laws. Shouldn't cause too much harm
 #RANDOM_LAWS hippocratic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new AI lawset: Specimov - **"Three Laws of Robotics but with Political Correctness"**

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
To make humans screwed... No, ignore that. To give human and non-humans each other's racial experience.

Note: humans still have high chance to be the law subject due to the existence of asimov.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/175843295-4a1733d6-26a5-4418-9d1a-19db05bc5f55.png)

When there is no station member upon AI roundjoin


![image](https://user-images.githubusercontent.com/87972842/175844208-145905d2-5b92-4d88-acae-255643ab1623.png)

There is a lizardperson crew in the station, and they're chosen to be the law subject.



![image](https://user-images.githubusercontent.com/87972842/175845737-6aeb7e18-e02f-4a52-b398-7f94cd0d4da8.png)

IPC. I know `a ipc` is grammar error, but don't want to be bothered with this minor error.



---------------

![image](https://user-images.githubusercontent.com/87972842/175889172-619989af-2cd1-4619-9824-f11ab9817dfb.png)

This borg is created during roundpreparation. they had no laws. (force-transform a ghost into a cyborg.)
Once round is started, they get laws.
Still, you can upload their laws during roundpreparation.

</details>

## Changelog
:cl:
add: species name in locked datacore record
add: New AI law: Specimov "Three Laws of Robotics but with Political Correctness". the species weight is based on the number of each species on the station. (i.e. Calculation: 10 human, 5 lizard, 5 moff = human 50%, lizard 25%, moff 25%. even if 5 humans went cryopod, they still count. Weight is counted upon more roundjoin.)
add: auto grammar correction procs. these procs are used to auto-correction at asimov subjects. (i.e. lizardperson -> lizardpeople, plasmaman -> plasmamen)
refactor: Laws are now created after roundstart because Specimov needs game data established after roundstart. Some codes are also changed to support this. - if an AI or a borg is created during roundpreparation, they don't get laws, but an admin can manually upload their laws through an upload console for an event round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
