### PR TITLE
Makes chameleon actions copy alternate worn icons

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -230,6 +230,7 @@
 			if(initial(picked_item.greyscale_config_inhand_right))
 				I.righthand_file = SSgreyscale.GetColoredIconByType(initial(picked_item.greyscale_config_inhand_right), initial(picked_item.greyscale_colors))
 		I.worn_icon_state = initial(picked_item.worn_icon_state)
+		I.alternate_worn_icon = initial(picked_item.alternate_worn_icon)
 		I.item_state = initial(picked_item.item_state)
 		if(isclothing(I) && ispath(picked_item, /obj/item/clothing))
 			var/obj/item/clothing/CL = I


### PR DESCRIPTION
## About The Pull Request

Some items have alternate worn icons, this PR lets chameleon items copy those properly so they don't go invisible when equipped.
Mostly helpful for downstreams *cough cough NSV* where clothing is given alternate icon files to avoid dmi conflicts.

## Why It's Good For The Game

Fixing bugs!

## Testing Photographs and Procedure

Shown working with an NSV item that uses an alternate icon state:
![image](https://user-images.githubusercontent.com/43698041/175943926-adf134ce-ea50-41b4-b785-71fc124435a3.png)
![image](https://user-images.githubusercontent.com/43698041/175944472-2a067243-5f7e-4969-850b-057ace23715b.png)

## Changelog
:cl:
fix: Fixed chameleon clothing not working for certain items
/:cl: