### PR TITLE
Wizarditis now behaves like Wizarditis

### DIFF
--- a/code/datums/diseases/advance/symptoms/wizarditis.dm
+++ b/code/datums/diseases/advance/symptoms/wizarditis.dm
@@ -100,10 +100,37 @@
 
 
 /datum/symptom/wizarditis/proc/teleport(datum/disease/advance/A)
-	var/turf/L = get_safe_random_station_turfs()
-	A.affected_mob.say("SCYAR NILA!")
-	do_teleport(A.affected_mob, L, channel = TELEPORT_CHANNEL_MAGIC)
-	playsound(get_turf(A.affected_mob), 'sound/weapons/zapbang.ogg', 50,1)
+	var/list/theareas = get_areas_in_range(80, A.affected_mob)
+	for(var/area/space/S in theareas)
+		theareas -= S
+
+	if(!theareas||!theareas.len)
+		return
+
+	var/area/thearea = pick(theareas)
+
+	var/list/L = list()
+	for(var/turf/T in get_area_turfs(thearea.type))
+		if(T.get_virtual_z_level() != A.affected_mob.get_virtual_z_level())
+			continue
+		if(T.name == "space")
+			continue
+		if(!T.density)
+			var/clear = 1
+			for(var/obj/O in T)
+				if(O.density)
+					clear = 0
+					break
+			if(clear)
+				L+=T
+
+	if(!L)
+		return
+
+	if(do_teleport(A.affected_mob, pick(L), channel = TELEPORT_CHANNEL_MAGIC, no_effects = TRUE))
+		A.affected_mob.say("SCYAR NILA [uppertext(thearea.name)]!", forced = "wizarditis teleport")
+		playsound(get_turf(A.affected_mob), 'sound/weapons/zapbang.ogg', 50,1)
+	return
 
 /datum/symptom/wizarditis/End(datum/disease/advance/A)
 	if(ishuman(A.affected_mob))

--- a/code/datums/diseases/advance/symptoms/wizarditis.dm
+++ b/code/datums/diseases/advance/symptoms/wizarditis.dm
@@ -113,7 +113,7 @@
 	for(var/turf/T in get_area_turfs(thearea.type))
 		if(T.get_virtual_z_level() != A.affected_mob.get_virtual_z_level())
 			continue
-		if(T.name == "space")
+		if(isgroundlessturf(T))
 			continue
 		if(!T.density)
 			var/clear = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the virus trait called wizarditis behave like the virus named wizarditis, instead of using its own unique teleportation code. Teleports now check exclusively for valid turfs from the same Z-level instead of only choosing areas on the station Z-level. 

Closes #7122 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lavaland Syndicate are ignoring server rules and abusing it, and the benefit to having a virus that specifically teleports you to the station is negligible at best. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/176920210-b403158f-b9fd-4f17-8580-6ba1b9b800e7.png)
![image](https://user-images.githubusercontent.com/9547572/176920360-37860352-895e-4273-b517-63fe619f1d8b.png)

</details>

## Changelog
:cl:
tweak: Wizarditis can no longer teleport across Z-levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
