### PR TITLE
Fixes bug preventing shuttles from landing in the same custom location multiple times.

### DIFF
--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_docking.dm
@@ -174,6 +174,7 @@
 		my_port.dheight = shuttle_port.dheight
 		my_port.dwidth = shuttle_port.dwidth
 		my_port.hidden = shuttle_port.hidden
+		my_port.delete_after = TRUE
 	my_port.setDir(the_eye.dir)
 	my_port.forceMove(locate(eyeobj.x, eyeobj.y, eyeobj.z))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When selecting a custom location to dock at, shuttles can now land in previous locations used as a custom docking location. Static docks like the white ship home are still restricted for custom docking.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugs bad, removes weird restriction that you cannot dock in the same place twice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Docking in the same location twice</summary>




https://user-images.githubusercontent.com/51838176/176942642-da76985a-9285-4300-932f-7510575aee27.mp4




</details>

## Changelog
:cl:
fix: shuttles can now land in the same custom location multiple times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
