### PR TITLE
Brain surgery term is now Brain Recalibration.

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3297,7 +3297,7 @@
 #include "code\modules\surgery\amputation.dm"
 #include "code\modules\surgery\anesthetic_machine.dm"
 #include "code\modules\surgery\blood_filter.dm"
-#include "code\modules\surgery\brain_surgery.dm"
+#include "code\modules\surgery\brain_recalibration.dm"
 #include "code\modules\surgery\cavity_implant.dm"
 #include "code\modules\surgery\core_removal.dm"
 #include "code\modules\surgery\coronary_bypass.dm"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -169,7 +169,7 @@
 #define BRAIN_TRAUMA_MAGIC /datum/brain_trauma/magic
 
 #define TRAUMA_RESILIENCE_BASIC 1      //! Curable with chems
-#define TRAUMA_RESILIENCE_SURGERY 2    //! Curable with brain surgery
+#define TRAUMA_RESILIENCE_SURGERY 2    //! Curable with brain recalibration
 #define TRAUMA_RESILIENCE_LOBOTOMY 3   //! Curable with lobotomy
 #define TRAUMA_RESILIENCE_MAGIC 4      //! Curable only with magic
 #define TRAUMA_RESILIENCE_ABSOLUTE 5   //! This is here to stay

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -1,5 +1,5 @@
 //Mild traumas are the most common; they are generally minor annoyances.
-//They can be cured with mannitol and patience, although brain surgery still works.
+//They can be cured with mannitol and patience, although brain recalibration still works.
 //Most of the old brain damage effects have been transferred to the dumbness trauma.
 
 /datum/brain_trauma/mild

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -256,7 +256,7 @@
 	gain_text = "<span class='warning'>You feel somewhat dazed.</span>"
 	lose_text = "<span class='notice'>You feel like a fog was lifted from your mind.</span>"
 
-/datum/brain_trauma/severe/hypnotic_stupor/on_lose() //hypnosis must be cleared separately, but brain surgery should get rid of both anyway
+/datum/brain_trauma/severe/hypnotic_stupor/on_lose() //hypnosis must be cleared separately, but brain recalibration should get rid of both anyway
 	..()
 	owner.remove_status_effect(/datum/status_effect/trance)
 

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -1,6 +1,6 @@
 //Severe traumas, when your brain gets abused way too much.
 //These range from very annoying to completely debilitating.
-//They cannot be cured with chemicals, and require brain surgery to solve.
+//They cannot be cured with chemicals, and require brain recalibration to solve.
 
 /datum/brain_trauma/severe
 	resilience = TRAUMA_RESILIENCE_SURGERY

--- a/code/modules/surgery/brain_recalibration.dm
+++ b/code/modules/surgery/brain_recalibration.dm
@@ -1,5 +1,5 @@
-/datum/surgery/brain_surgery
-	name = "brain surgery"
+/datum/surgery/brain_recalibration
+	name = "brain recalibration"
 	steps = list(
 	/datum/surgery_step/incise,
 	/datum/surgery_step/retract_skin,
@@ -17,7 +17,7 @@
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	time = 120 //long and complicated
 
-/datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/brain_recalibration/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
 	if(!B)
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
change wording. Brain Surgery into Brain Recalibration.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brain surgery is a term that is way too wide for all kinds of brain surgeries, but we all know it exactly means a certain surgery.
Now when we talk about 'brain surgery', it will be meant for all kinds of brain surgeries, rather than certain one.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/176987973-e99a07c4-fd9d-4e7b-afb2-a40ad921b704.png)


</details>

## Changelog
:cl:
refactor: rename/repath "brain_surgery.dm" and brain_surgery path into "brain_recalibration.dm"
tweak: the operation "Brain Surgery" has been reworded to "Brain Recalibration". When we say "brain surgery", now it would mean all kinds of brain surgeries.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
