### PR TITLE
Makes Brain Tumor quirk less harsh

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -277,6 +277,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_EMPATH			"empath"
 #define TRAIT_FRIENDLY			"friendly"
 #define TRAIT_GRABWEAKNESS		"grab_weakness"
+#define TRAIT_BRAIN_TUMOR		"brain_tumor"
 
 ///Trait applied to turfs when an atmos holosign is placed on them. It will stop firedoors from closing.
 #define TRAIT_FIREDOOR_STOP "firedoor_stop"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -222,3 +222,9 @@
 /datum/mood_event/feline_mania
 	description = "<span class='nicegreen'>I'M SO HECKIN CUTE OMIGOSH!</span>\n"
 	mood_change = 5
+
+/datum/mood_event/brain_tumor_mannitol
+	description = "<span class='nicegreen'>Mannitol makes my brain calm down.</span>\n"
+	mood_change = 0
+	timeout = 30 SECONDS
+

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -228,3 +228,6 @@
 	mood_change = 0
 	timeout = 30 SECONDS
 
+/datum/mood_event/brain_tumor_mannitol/New(mob/M, param)
+	timeout = rand(30,60) SECONDS // makes the timing unreliable on your mood
+	..()

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -65,6 +65,8 @@
 /datum/quirk/brainproblems/on_process(delta_time)
 	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol) && prob(80))
 		quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
+	else
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
 	var/obj/item/organ/brain/B = quirk_holder.getorgan(/obj/item/organ/brain)
 	if(B)
 		if(B.damage>BRAIN_DAMAGE_MILD-1 && !notified)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -66,8 +66,6 @@
 	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol))
 		if(prob(80))
 			quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
-	else
-		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
 	var/obj/item/organ/brain/B = quirk_holder.getorgan(/obj/item/organ/brain)
 	if(B)
 		if(B.damage>BRAIN_DAMAGE_MILD-1 && !notified)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -53,6 +53,7 @@
 /datum/quirk/brainproblems
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Thankfully, you start with a bottle of mannitol pills."
+	mob_trait = TRAIT_BRAIN_TUMOR
 	value = -3
 	gain_text = "<span class='danger'>You feel smooth.</span>"
 	lose_text = "<span class='notice'>You feel wrinkled again.</span>"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -60,9 +60,21 @@
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
 	process = TRUE
 	var/where = "at your feet"
+	var/notified = FALSE
 
 /datum/quirk/brainproblems/on_process(delta_time)
-	quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2 * delta_time)
+	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol) && prob(80))
+		quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
+	var/obj/item/organ/brain/B = quirk_holder.getorgan(/obj/item/organ/brain)
+	if(B)
+		if(B.damage>BRAIN_DAMAGE_MILD-1 && !notified)
+			to_chat(quirk_holder, "<span class='danger'>You sense your brain is getting beyond your control...</span>")
+			notified = TRUE
+		if(B.damage<1 && notified)
+			to_chat(quirk_holder, "<span class='notice'>You feel your brain is quite well.</span>")
+			notified = FALSE
+
+
 
 /datum/quirk/brainproblems/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -63,8 +63,9 @@
 	var/notified = FALSE
 
 /datum/quirk/brainproblems/on_process(delta_time)
-	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol) && prob(80))
-		quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
+	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol))
+		if(prob(80))
+			quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
 	else
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
 	var/obj/item/organ/brain/B = quirk_holder.getorgan(/obj/item/organ/brain)

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -490,7 +490,7 @@
 	desc = "Generously supplied by your Nanotrasen health insurance to treat that pesky tumor in your brain."
 
 /obj/item/storage/pill_bottle/mannitol/braintumor/PopulateContents()
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/mannitol/braintumor(src)
 
 /obj/item/storage/pill_bottle/stimulant

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -490,7 +490,7 @@
 	desc = "Generously supplied by your Nanotrasen health insurance to treat that pesky tumor in your brain."
 
 /obj/item/storage/pill_bottle/mannitol/braintumor/PopulateContents()
-	for(var/i in 1 to 7)
+	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/mannitol/braintumor(src)
 
 /obj/item/storage/pill_bottle/stimulant

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,6 +1,8 @@
 /mob/living/carbon/proc/handle_dreams()
 	if(prob(10) && !dreaming)
 		dream()
+	if(HAS_TRAIT(src, TRAIT_BRAIN_TUMOR))
+		adjustOrganLoss(ORGAN_SLOT_BRAIN, -1)
 
 /mob/living/carbon/proc/dream()
 	set waitfor = FALSE

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -2,7 +2,7 @@
 	if(prob(10) && !dreaming)
 		dream()
 	if(HAS_TRAIT(src, TRAIT_BRAIN_TUMOR))
-		adjustOrganLoss(ORGAN_SLOT_BRAIN, -1)
+		adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.3)
 
 /mob/living/carbon/proc/dream()
 	set waitfor = FALSE

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,8 +1,6 @@
 /mob/living/carbon/proc/handle_dreams()
 	if(prob(10) && !dreaming)
 		dream()
-	if(HAS_TRAIT(src, TRAIT_BRAIN_TUMOR))
-		adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.3)
 
 /mob/living/carbon/proc/dream()
 	set waitfor = FALSE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -964,17 +964,18 @@
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY | CHEMICAL_GOAL_CHEMIST_BLOODSTREAM | CHEMICAL_GOAL_BOTANIST_HARVEST
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
-	if(HAS_TRAIT(src, TRAIT_BRAIN_TUMOR))
-		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1*REM)
-		overdose_threshold = 35
-	else
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR)) // to brain tumor quirker
+		if(!overdosed) // don't merge this condition into the `if` above.
+			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5*REM)
+			overdose_threshold = 35
+	else // to ordinary people
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
 	..()
 
-
-/datum/reagent/medicine/mannitol/overdose_process(mob/living/M)
-	if(HAS_TRAIT(src, TRAIT_BRAIN_TUMOR))
-		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1.01*REM) // intentional
+/datum/reagent/medicine/mannitol/overdose_process(mob/living/carbon/C)
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
+		if(prob(10))
+			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1*REM)
 	..()
 
 /datum/reagent/medicine/neurine

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -963,11 +963,16 @@
 	color = "#A0A0A0" //mannitol is light grey, neurine is lighter grey"
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY | CHEMICAL_GOAL_CHEMIST_BLOODSTREAM | CHEMICAL_GOAL_BOTANIST_HARVEST
 
+/datum/reagent/medicine/mannitol/on_mob_add(mob/living/carbon/C)
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
+		overdose_threshold = 35 // special overdose to brain tumor quirker
+	..()
+
+
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
 	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR)) // to brain tumor quirker
 		if(!overdosed) // don't merge this condition into the `if` above.
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5*REM)
-			overdose_threshold = 35 // Brain tumor people have special overdose
 	else // to ordinary people
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -971,7 +971,8 @@
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
 	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR)) // to brain tumor quirker
-		if(!overdosed) // don't merge this condition into the `if` above.
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
+		if(!overdosed)
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5*REM)
 	else // to ordinary people
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
@@ -983,6 +984,13 @@
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1*REM)
 	..()
 
+/datum/reagent/medicine/amphetamine/on_mob_end_metabolize(mob/living/carbon/C)
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
+		// re-send the mood signal. to make the time measure unreliable but within an estimation.
+		SEND_SIGNAL(C, COMSIG_CLEAR_MOOD_EVENT, "brain_tumor")
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
+		// this is not a fail removal. it's re-applying, because the mood timeout is random.
+	..()
 /datum/reagent/medicine/neurine
 	name = "Neurine"
 	description = "Reacts with neural tissue, helping reform damaged connections. Can cure minor traumas."

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -965,6 +965,7 @@
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
 	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR)) // to brain tumor quirker
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
 		if(!overdosed) // don't merge this condition into the `if` above.
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5*REM)
 			overdose_threshold = 35

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -964,7 +964,17 @@
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY | CHEMICAL_GOAL_CHEMIST_BLOODSTREAM | CHEMICAL_GOAL_BOTANIST_HARVEST
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
-	C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
+	if(HAS_TRAIT(src, TRAIT_BRAIN_TUMOR))
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1*REM)
+		overdose_threshold = 35
+	else
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
+	..()
+
+
+/datum/reagent/medicine/mannitol/overdose_process(mob/living/M)
+	if(HAS_TRAIT(src, TRAIT_BRAIN_TUMOR))
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1.01*REM) // intentional
 	..()
 
 /datum/reagent/medicine/neurine

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -963,12 +963,16 @@
 	color = "#A0A0A0" //mannitol is light grey, neurine is lighter grey"
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY | CHEMICAL_GOAL_CHEMIST_BLOODSTREAM | CHEMICAL_GOAL_BOTANIST_HARVEST
 
+/datum/reagent/mannitol/on_mob_add(mob/living/carbon/C)
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
+		overdose_threshold = 35 // Brain tumor people have special overdose
+	..()
+
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
 	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR)) // to brain tumor quirker
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
 		if(!overdosed) // don't merge this condition into the `if` above.
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5*REM)
-			overdose_threshold = 35
 	else // to ordinary people
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -963,16 +963,11 @@
 	color = "#A0A0A0" //mannitol is light grey, neurine is lighter grey"
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY | CHEMICAL_GOAL_CHEMIST_BLOODSTREAM | CHEMICAL_GOAL_BOTANIST_HARVEST
 
-/datum/reagent/mannitol/on_mob_add(mob/living/carbon/C)
-	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
-		overdose_threshold = 35 // Brain tumor people have special overdose
-	..()
-
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
 	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR)) // to brain tumor quirker
-		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
 		if(!overdosed) // don't merge this condition into the `if` above.
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5*REM)
+			overdose_threshold = 35 // Brain tumor people have special overdose
 	else // to ordinary people
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -984,13 +984,6 @@
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1*REM)
 	..()
 
-/datum/reagent/medicine/mannitol/on_mob_end_metabolize(mob/living/carbon/C)
-	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
-		// re-send the mood signal. to make the time measure unreliable but within an estimation.
-		SEND_SIGNAL(C, COMSIG_CLEAR_MOOD_EVENT, "brain_tumor")
-		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
-		// this is not a fail removal. it's re-applying, because the mood timeout is random.
-	..()
 
 /datum/reagent/medicine/neurine
 	name = "Neurine"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -984,13 +984,14 @@
 			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1*REM)
 	..()
 
-/datum/reagent/medicine/amphetamine/on_mob_end_metabolize(mob/living/carbon/C)
+/datum/reagent/medicine/mannitol/on_mob_end_metabolize(mob/living/carbon/C)
 	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
 		// re-send the mood signal. to make the time measure unreliable but within an estimation.
 		SEND_SIGNAL(C, COMSIG_CLEAR_MOOD_EVENT, "brain_tumor")
 		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
 		// this is not a fail removal. it's re-applying, because the mood timeout is random.
 	..()
+
 /datum/reagent/medicine/neurine
 	name = "Neurine"
 	description = "Reacts with neural tissue, helping reform damaged connections. Can cure minor traumas."

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -139,7 +139,7 @@
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/mannitol/braintumor //For the brain tumor quirk
-	list_reagents = list(/datum/reagent/medicine/mannitol = 20)
+	list_reagents = list(/datum/reagent/medicine/mannitol = 30)
 
 /obj/item/reagent_containers/pill/mutadone
 	name = "mutadone pill"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes Brain Tumor quirk less harsh, so that people would want to pick the quirk.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
a quirk that nobody actually can help you is stupid. It's even worse than Blind trait in many situations.
This PR makes Brain Tumor penalty less harsh, so that you can earn your time more to find a help to treat your tumor.
Because it's less harsh, I added more downside in return.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/177005649-aa85b52d-699e-4c7f-a80d-a348c9f45319.png)

mannitol overdose

![image](https://user-images.githubusercontent.com/87972842/177006267-beb3da69-8701-42e7-a3dc-f4439bee9858.png)

warning


![image](https://user-images.githubusercontent.com/87972842/177006474-4e07ab45-696a-4940-8abf-c07a8d83a3a6.png)

stable notice


![image](https://user-images.githubusercontent.com/87972842/177009683-ea205644-485e-4f75-89b3-3bd959e16d01.png)

Mood event
Brain Tumor quirker will have a +0 mood event when they eat mannitol. the message will persist for 30 seconds longer even if mannitol doesn't exist in your bloodstream.

</details>

## Changelog
:cl:
balance: Brain Tumor will deal 0.1 brain damage at 80% chance. (equals 0.08 damage) previously it was 0.2 damage.
balance: Brain Tumor will not deal brain damage when the quirker has mannitol in their bloodstream.
balance: Mannitol is less effective for Brain Tumor quirker. It only heals 0.5 brain damage and special overdose thresholds(35u). on overdose, it will heal only 0.1 brain damage at 10% chance. (equals 0.01 damage) Don't overdose them.
balance: Brain Tumor quirker now starts with 5 pills of 30u mannitol. Each pill keeps you for 150 seconds, in total 750 seconds.
add: Brain Tumor will warn you when you're about to be at a mild trauma threshold. It will notice you when your brain damage is at near zero.
add: Brain Tumor quirker will have a +0 mood event when they eat mannitol. the message will persist for 30~60 seconds longer even if mannitol doesn't exist in your bloodstream.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
