### PR TITLE
Votes display percentages, and map votes clearly state it's a chance.

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -117,7 +117,7 @@ SUBSYSTEM_DEF(vote)
 			var/votes = choices[choices[i]]
 			if(!votes)
 				votes = 0
-			text += "\n<b>[choices[i]]:</b> [votes] ([round((votes/total_votes), 0.01)*100]%"
+			text += "\n<b>[choices[i]]:</b> [votes] ([total_votes ? (round((votes/total_votes), 0.01)*100) : "0"]%"
 			if(mode == "map")
 				text += " chance)"
 			else

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -102,6 +102,10 @@ SUBSYSTEM_DEF(vote)
 	return .
 
 /datum/controller/subsystem/vote/proc/announce_result()
+	var/total_votes = 0
+	for(var/option in choices)
+		var/votes = choices[option]
+		total_votes += votes
 	var/list/winners = get_result()
 	var/text
 	if(winners.len > 0)
@@ -113,7 +117,11 @@ SUBSYSTEM_DEF(vote)
 			var/votes = choices[choices[i]]
 			if(!votes)
 				votes = 0
-			text += "\n<b>[choices[i]]:</b> [votes]"
+			text += "\n<b>[choices[i]]:</b> [votes] ([round((votes/total_votes), 0.01)*100]%"
+			if(mode == "map")
+				text += " chance)"
+			else
+				text += ")"
 		if(mode != "custom")
 			if(winners.len > 1)
 				text = "\n<b>Vote Tied Between:</b>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When vote results are being displayed to players, it now shows the percentage of players that chose each option
When it is a map vote, it specifically states it as a percentage chance, since several players are confused by our maps being drawn from a hat. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1) It was requested by @PowerfulBacon 
2) Confusing UI bad, clearly stating that a result is a percent chance is better. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/177018415-010db942-16d0-43df-bd66-5c87fdcd942f.png)

![image](https://user-images.githubusercontent.com/9547572/177018425-586b8ec2-961d-41a8-a90c-ba357004d56b.png)

![image](https://user-images.githubusercontent.com/9547572/177018431-098ce8d5-72f4-4593-a330-b359428469a3.png)

Testing the divide by zero:
![image](https://user-images.githubusercontent.com/9547572/177018648-2616dc76-6254-439f-b3f1-bd3cff8d5cca.png)

And yes, even though the snippet of code that divides by zero *shouldn't even run when total_votes is zero*, I still got that error and runtime if nobody votes regardless. A check for divide by zero is necessary. 

</details>

## Changelog
:cl:
tweak: Votes now display a percentage alongside the tally
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
