### PR TITLE
Mobs with Jaunt type movement can't Strip anymore

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -47,6 +47,9 @@
 	if(over != user)
 		return
 
+	if(isrevenant(user))
+		return
+
 	// Cyborgs buckle people by dragging them onto them, unless in combat mode.
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/cyborg_user = user

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -47,8 +47,11 @@
 	if(over != user)
 		return
 
-	if(isrevenant(user))
-		return
+	// Mobs that can walk through walls cannot strip.
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.incorporeal_move)
+			return
 
 	// Cyborgs buckle people by dragging them onto them, unless in combat mode.
 	if(iscyborg(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #7173
Pretty clear

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

An invisible antagonist capable of passing through walls should not have the ability to stripe, it's simple!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I've tested it!
I didn't feel it was necessary to record it because it was simple enough,.
</details>

## Changelog
:cl:
tweak: Mobs with jaunt type movement can't strip anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
