### PR TITLE
Amplification module key, Debug Encryption Key

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -160,7 +160,10 @@
 	independent = TRUE
 	amplification = TRUE
 
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_EXPLORATION = 1, RADIO_CHANNEL_AI_PRIVATE=1, RADIO_CHANNEL_CENTCOM = 1, RADIO_CHANNEL_SYNDICATE = 1)
+/obj/item/encryptionkey/debug/Initialize(mapload)
+	. = ..()
+	for(var/each in GLOB.radiochannels)
+		channels |= list("[each]" = 1)
 
 /obj/item/encryptionkey/ai //ported from NT, this goes 'inside' the AI.
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_EXPLORATION = 1, RADIO_CHANNEL_AI_PRIVATE = 1)
@@ -173,5 +176,5 @@
 	name = "box of high responsible keys"
 
 /obj/item/storage/box/command_keys/PopulateContents()
-	for(var/i in 1 to 5)
+	for(var/i in 1 to 2)
 		new /obj/item/encryptionkey/amplification(src)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -7,6 +7,7 @@
 	var/translate_binary = FALSE
 	var/syndie = FALSE
 	var/independent = FALSE
+	var/amplification = FALSE
 	var/list/channels = list()
 
 /obj/item/encryptionkey/Initialize(mapload)
@@ -33,6 +34,10 @@
 	name = "binary translator key"
 	icon_state = "bin_cypherkey"
 	translate_binary = TRUE
+
+/obj/item/encryptionkey/amplification
+	name = "amplification module key"
+	amplification = TRUE
 
 /obj/item/encryptionkey/headset_sec
 	name = "security radio encryption key"
@@ -145,8 +150,29 @@
 	independent = TRUE
 	channels = list(RADIO_CHANNEL_CENTCOM = 1)
 
+/obj/item/encryptionkey/debug
+	name = "\improper omni radio encryption key"
+	icon_state = "cent_cypherkey"
+	translate_binary = TRUE
+	syndie = TRUE
+	independent = TRUE
+	loud = TRUE
+
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_EXPLORATION = 1, RADIO_CHANNEL_AI_PRIVATE=1, RADIO_CHANNEL_CENTCOM = 1, RADIO_CHANNEL_SYNDICATE = 1)
+
 /obj/item/encryptionkey/ai //ported from NT, this goes 'inside' the AI.
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_EXPLORATION = 1, RADIO_CHANNEL_AI_PRIVATE = 1)
 
 /obj/item/encryptionkey/secbot
 	channels = list(RADIO_CHANNEL_AI_PRIVATE = 1, RADIO_CHANNEL_SECURITY = 1)
+
+
+/obj/item/storage/box/command_keys // HoP toys
+	name = "box of high responsible keys"
+
+/obj/item/storage/box/command_keys/PopulateContents()
+	new /obj/item/encryptionkey/amplification(src)
+	new /obj/item/encryptionkey/amplification(src)
+	new /obj/item/encryptionkey/amplification(src)
+	new /obj/item/encryptionkey/headset_com(src)
+	new /obj/item/encryptionkey/headset_com(src)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -37,7 +37,7 @@
 
 /obj/item/encryptionkey/amplification
 	name = "amplification module key"
-	desc = "An amplification module key for a radio headset. It will allow the key applied radioset talk loudly."
+	desc = "An amplification module key for a radio headset. It will enable the \"Loud mode\" ability on any headset it is inserted into."
 	amplification = TRUE
 
 /obj/item/encryptionkey/headset_sec

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -37,6 +37,7 @@
 
 /obj/item/encryptionkey/amplification
 	name = "amplification module key"
+	desc = "An amplification module key for a radio headset. It will allow the key applied radioset talk loudly."
 	amplification = TRUE
 
 /obj/item/encryptionkey/headset_sec
@@ -152,11 +153,12 @@
 
 /obj/item/encryptionkey/debug
 	name = "\improper omni radio encryption key"
+	desc = "a god-like key of omni-presence to eavesdrop anything they would want to hear."
 	icon_state = "cent_cypherkey"
 	translate_binary = TRUE
 	syndie = TRUE
 	independent = TRUE
-	loud = TRUE
+	amplification = TRUE
 
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_EXPLORATION = 1, RADIO_CHANNEL_AI_PRIVATE=1, RADIO_CHANNEL_CENTCOM = 1, RADIO_CHANNEL_SYNDICATE = 1)
 
@@ -171,8 +173,5 @@
 	name = "box of high responsible keys"
 
 /obj/item/storage/box/command_keys/PopulateContents()
-	new /obj/item/encryptionkey/amplification(src)
-	new /obj/item/encryptionkey/amplification(src)
-	new /obj/item/encryptionkey/amplification(src)
-	new /obj/item/encryptionkey/headset_com(src)
-	new /obj/item/encryptionkey/headset_com(src)
+	for(var/i in 1 to 5)
+		new /obj/item/encryptionkey/amplification(src)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -153,7 +153,7 @@
 
 /obj/item/encryptionkey/debug
 	name = "\improper omni radio encryption key"
-	desc = "a god-like key of omni-presence to eavesdrop anything they would want to hear."
+	desc = "A god-like key of omni-presence to eavesdrop anything you would want to hear."
 	icon_state = "cent_cypherkey"
 	translate_binary = TRUE
 	syndie = TRUE

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -173,7 +173,7 @@
 
 
 /obj/item/storage/box/command_keys // heads toys
-	name = "box of high responsible keys"
+	name = "box of amplification keys"
 
 /obj/item/storage/box/command_keys/PopulateContents()
 	for(var/i in 1 to 2)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -172,7 +172,7 @@
 	channels = list(RADIO_CHANNEL_AI_PRIVATE = 1, RADIO_CHANNEL_SECURITY = 1)
 
 
-/obj/item/storage/box/command_keys // HoP toys
+/obj/item/storage/box/command_keys // heads toys
 	name = "box of high responsible keys"
 
 /obj/item/storage/box/command_keys/PopulateContents()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -348,7 +348,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			syndie = TRUE
 		if (keyslot2.independent)
 			independent = TRUE
-		if (keyslot2.loud)
+		if (keyslot2.amplification)
 			command = TRUE
 
 	for(var/ch_name in channels)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -348,6 +348,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 			syndie = TRUE
 		if (keyslot2.independent)
 			independent = TRUE
+		if (keyslot2.loud)
+			command = TRUE
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -59,6 +59,7 @@
 	translate_binary = FALSE
 	syndie = FALSE
 	independent = FALSE
+	command = initial(command)
 
 	if(keyslot)
 		for(var/ch_name in keyslot.channels)
@@ -71,6 +72,11 @@
 			syndie = TRUE
 		if(keyslot.independent)
 			independent = TRUE
+		if(keyslot.loud)
+			command = TRUE
+
+	if(!command)
+		use_command = FALSE
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -72,7 +72,7 @@
 			syndie = TRUE
 		if(keyslot.independent)
 			independent = TRUE
-		if(keyslot.loud)
+		if(keyslot.amplification)
 			command = TRUE
 
 	if(!command)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -37,6 +37,7 @@
 	new /obj/item/card/id/departmental_budget/eng(src)
 	new /obj/item/storage/bag/construction(src)
 	new /obj/item/construction/rcd/loaded(src)
+	new /obj/item/storage/box/command_keys(src)
 	new /obj/item/rcd_ammo/large(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -109,6 +109,7 @@
 	new /obj/item/reagent_containers/food/drinks/bottle/synthflesh(src)
 	new /obj/item/card/id/departmental_budget/med(src)
 	new /obj/item/extrapolator(src)
+	new /obj/item/storage/box/command_keys(src)
 	new /obj/item/storage/lockbox/medal/med(src)
 
 /obj/structure/closet/secure_closet/animal

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -32,4 +32,5 @@
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 	new /obj/item/storage/photo_album/RD(src)
+	new /obj/item/storage/box/command_keys(src)
 	new /obj/item/card/id/departmental_budget/sci(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -35,6 +35,7 @@
 	new /obj/item/storage/belt/sabre(src)
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/storage/photo_album/Captain(src)
+	new /obj/item/storage/box/command_keys(src)
 	new /obj/item/card/id/departmental_budget/civ(src)
 
 /obj/structure/closet/secure_closet/hop
@@ -67,8 +68,8 @@
 	new /obj/item/door_remote/civillian(src)
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
 	new /obj/item/storage/photo_album/HoP(src)
-	new /obj/item/card/id/departmental_budget/srv(src)
 	new /obj/item/storage/box/command_keys(src)
+	new /obj/item/card/id/departmental_budget/srv(src)
 
 /obj/structure/closet/secure_closet/brig_phys
 	name = "\proper brig physician's locker"
@@ -127,6 +128,7 @@
 	new /obj/item/pinpointer/nuke(src)
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
 	new /obj/item/storage/photo_album/HoS(src)
+	new /obj/item/storage/box/command_keys(src)
 	new /obj/item/card/id/departmental_budget/sec(src)
 
 /obj/structure/closet/secure_closet/warden

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -68,6 +68,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
 	new /obj/item/storage/photo_album/HoP(src)
 	new /obj/item/card/id/departmental_budget/srv(src)
+	new /obj/item/storage/box/command_keys(src)
 
 /obj/structure/closet/secure_closet/brig_phys
 	name = "\proper brig physician's locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds two new keys: Amplification module key, Omni radio encryption key.
Amplification: Allows the radioset(or pAI, cyborg) to talk loudly.
Omni radio encryption key: Debug key. allows everything to you.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows Cyborgs/pAIs loud mode feature.
Admin convenience while they're dealing with something ICly.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![image](https://user-images.githubusercontent.com/87972842/177040293-2a53d7e4-0e6e-4586-9f4b-4e542d966fbe.png)
![image](https://user-images.githubusercontent.com/87972842/177040315-ed9509c5-4d91-4a0a-865a-d9fcad0576ed.png)

Borg can talk in loudmode.

![image](https://user-images.githubusercontent.com/87972842/177040325-ff0e0206-d28d-40a2-a49b-db6f83e4b131.png)

pAI works too. (but they can't turn on/off this while they are not in holo-mod)



![image](https://user-images.githubusercontent.com/87972842/177040388-47f3e6e0-86be-4a26-9fcd-4a35f053a134.png)

normal crews radioset works too.



if the amp key's out, the radioset loses the loud mode and forcefully turned off.

</details>

## Changelog
:cl:
refactor: Amplification module key feature(that allows loud mode) to radio code.
add: New key: Amplification module key. It allows you to talk in loud mode through your radio. Useful to Cyborgs and pAIs.
add: New key: Omni radio encryption key. a debug key for admins. Allows you to do everything that related to radio feature.
add: Box of amplification keys to heads' locker. (contains 2 amplification module keys) Give a key to your trustful crew, and make them after you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
