### PR TITLE
Removes the ability to make romerol in virology

### DIFF
--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -121,6 +121,9 @@ Bonus
 					  <b>Stealth 5:</b> The symptom remains hidden until active."
 
 
+/datum/symptom/flesh_death/severityset(datum/disease/advance/A)
+	. = ..()
+
 /datum/symptom/flesh_death/Start(datum/disease/advance/A)
 	if(!..())
 		return

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -117,14 +117,9 @@ Bonus
 	prefixes = list("Necrotic ", "Necro")
 	suffixes = list(" Rot")
 	var/chems = FALSE
-	var/zombie = FALSE
 	threshold_desc = "<b>Stage Speed 7:</b> Synthesizes Heparin and Lipolicide inside the host, causing increased bleeding and hunger.<br>\
 					  <b>Stealth 5:</b> The symptom remains hidden until active."
 
-/datum/symptom/flesh_death/severityset(datum/disease/advance/A)
-	. = ..()
-	if((A.stealth >= 2) && (A.stage_rate >= 12))
-		bodies = list("Zombie")
 
 /datum/symptom/flesh_death/Start(datum/disease/advance/A)
 	if(!..())
@@ -133,8 +128,6 @@ Bonus
 		suppress_warning = TRUE
 	if(A.stage_rate >= 7) //bleeding and hunger
 		chems = TRUE
-	if((A.stealth >= 2) && (A.stage_rate >= 12))
-		zombie = TRUE
 
 /datum/symptom/flesh_death/Activate(datum/disease/advance/A)
 	if(!..())
@@ -156,21 +149,8 @@ Bonus
 /datum/symptom/flesh_death/proc/Flesh_death(mob/living/M, datum/disease/advance/A)
 	var/get_damage = rand(6,10)
 	if(MOB_UNDEAD in M.mob_biotypes)
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			var/S = H.dna.species
-			if(zombie && istype(S, /datum/species/zombie/infectious) && !istype(S, /datum/species/zombie/infectious/fast))
-				H.set_species(/datum/species/zombie/infectious/fast)
-				to_chat(M, "<span class='warning'>Your extraneous flesh sloughs off, giving you a boost of speed at the cost of a bit of padding!</span>")
-			else if(prob(base_message_chance))
-				to_chat(M, "<span class='warning'>Your body slowly decays... luckily, you're already dead!</span>")
 		return //this symptom wont work on the undead.
 	M.take_overall_damage(brute = get_damage, required_status = BODYTYPE_ORGANIC)
 	if(chems)
 		M.reagents.add_reagent_list(list(/datum/reagent/toxin/heparin = 2, /datum/reagent/toxin/lipolicide = 2))
-	if(zombie)
-		if(ishuman(A.affected_mob))
-			if(!A.affected_mob.getorganslot(ORGAN_SLOT_ZOMBIE))
-				var/obj/item/organ/zombie_infection/ZI = new()
-				ZI.Insert(M)
 	return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the hidden and undocumented effects of Autophagocytosis Necrosis. Specifically it removes the ability for non-uplink antags to trigger zombie outbreaks. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was previously "balanced" by being relatively unknown, but this has gradually become less and less true. 

Overpowered features kept secret for the sake of balance so that only those who wrote the code, code dive, or are told about it by one of the prior two types of people is garbage design. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

Var editted for quicker testing. Virus behaves as you would expect. 
![image](https://user-images.githubusercontent.com/9547572/177045809-2440ab10-3a21-4862-bb49-17c63dc2db44.png)

![image](https://user-images.githubusercontent.com/9547572/177045825-a58f82c4-213c-40b7-9026-f2dc71caa0f4.png)

</details>

## Changelog
:cl:
del: Removed undocumented and very powerful effect from viral symptom Autophagocytosis Necrosis. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
