### PR TITLE
Removes an unused Variable left by the mail PR

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -37,7 +37,6 @@ SUBSYSTEM_DEF(economy)
 	dep_cards = SSeconomy.dep_cards
 
 /datum/controller/subsystem/economy/fire(resumed = 0)
-	var/delta_time = wait / (5 MINUTES)
 	for(var/A in bank_accounts)
 		var/datum/bank_account/B = A
 		B.payday(1)


### PR DESCRIPTION
## About The Pull Request

This PR removes an unused variable I forgot when releasing the Mail PR, while it's inherently not bad, it's a bad practice to keep it around.

## Why It's Good For The Game

It clogs the compiler with a warning for an unused variable, thus it's bad to keep it around.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![immagine](https://user-images.githubusercontent.com/75247747/177134196-16b76a30-6fad-49b2-9580-ed398326cb6d.png)

This is effectively gone with this PR.

</details>

## Changelog
:cl:
del: Removed an unused variable I kept in the Mail PR by accident.
/:cl:
