### PR TITLE
Mixing meth and mannitol now makes a brand new chem, Methnitol 

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -148,6 +148,7 @@
 		/datum/reagent/drug/aranesp,\
 		/datum/reagent/drug/krokodil,\
 		/datum/reagent/drug/methamphetamine,\
+		/datum/chemical_reaction/methnitol,\
 		/datum/reagent/teslium,\
 		/datum/reagent/toxin/anacea,\
 		/datum/reagent/pax)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -570,3 +570,118 @@
 		M.Jitter(4)
 		M.Dizzy(4)
 	..()
+
+
+/datum/reagent/drug/methnitol
+	name = "methnitol"
+	description = "All the ups of mixing meth and mannitol, at a steep cost of a Soul crushing addiction. If overdosed the subject will move randomly, laugh randomly, drop items and suffer from Toxin and severe Brain damage. If addicted the subject will constantly jitter and drool, before becoming dizzy and losing motor control and eventually suffer heavy toxin damage, assuming their brain isn't mush potatoes or completeley senile at this point..."
+	reagent_state = LIQUID
+	color = "#c5adf2"
+	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY | CHEMICAL_GOAL_CHEMIST_DRUG | CHEMICAL_GOAL_CHEMIST_BLOODSTREAM
+	overdose_threshold = 15
+	addiction_threshold = 5.1 //more than 5 units, and you'll descend hell.
+	metabolization_rate = 0.7 * REAGENTS_METABOLISM
+
+/datum/reagent/drug/methnitol/on_mob_metabolize(mob/living/L)
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.5, blacklisted_movetypes=(FLYING|FLOATING))
+	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
+
+/datum/reagent/drug/methnitol/on_mob_end_metabolize(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
+	REMOVE_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
+	L.remove_movespeed_modifier(type)
+	..()
+
+/datum/reagent/drug/methnitol/on_mob_life(mob/living/carbon/M)
+	var/high_message = pick("You feel hyper, yet focused.", "You feel like you need to go faster, yet concentrated.", "You feel like you can run the world, yet be knowledgable.")
+	if(prob(5))
+		to_chat(M, "<span class='notice'>[high_message]</span>")
+	M.AdjustStun(-40, FALSE)
+	M.AdjustKnockdown(-40, FALSE)
+	M.AdjustUnconscious(-40, FALSE)
+	M.AdjustParalyzed(-40, FALSE)
+	M.AdjustImmobilized(-40, FALSE)
+	M.adjustStaminaLoss(-40, 0)
+	M.drowsyness = max(0,M.drowsyness-30)
+	M.Jitter(2)
+	//M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1)
+	if(prob(5))
+		M.emote(pick("twitch", "shiver"))
+	..()
+	. = 1
+
+/datum/reagent/drug/methnitol/overdose_start(mob/living/M)
+	to_chat(M, "<span class='userdanger'>You feel like you're losing neurons by the second!</span>")
+	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overdose, name)
+
+/datum/reagent/drug/methnitol/overdose_process(mob/living/M)
+	if((M.mobility_flags & MOBILITY_MOVE) && !ismovableatom(M.loc))
+		for(var/i in 1 to 4)
+			step(M, pick(GLOB.cardinals))
+	if(prob(11))
+		M.visible_message("<span class='danger'>[M] stumbles around in a panic.</span>", \
+									"<span class='userdanger'>You have a panic attack!</span>")
+		M.confused += (rand(6,8))
+		M.jitteriness += (rand(6,8))
+	if(prob(22))
+		M.emote("laugh")
+	if(prob(33))
+		M.visible_message("<span class='danger'>[M]'s hands flip out and flail everywhere!</span>")
+		M.drop_all_held_items()
+
+	..()
+	M.adjustToxLoss(1, 0)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, pick(1, 1.2, 1.4, 1.6, 1.8, 2)) //oh, do you think you're safe?
+	M.confused = (2)
+	. = 1
+
+/datum/reagent/drug/methnitol/addiction_act_stage1(mob/living/M)
+	M.Jitter(5)
+	if(prob(20))
+		M.emote(pick("twitch","drool","moan"))
+	if(prob(1))
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
+	..()
+
+/datum/reagent/drug/methnitol/addiction_act_stage2(mob/living/M)
+	M.Jitter(10)
+	M.Dizzy(10)
+	if(prob(30))
+		M.emote(pick("twitch","drool","moan"))
+	if(prob(5))
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.4)
+	..()
+
+/datum/reagent/drug/methnitol/addiction_act_stage3(mob/living/M)
+	if((M.mobility_flags & MOBILITY_MOVE) && !ismovableatom(M.loc))
+		for(var/i = 0, i < 4, i++)
+			step(M, pick(GLOB.cardinals))
+	M.Jitter(15)
+	M.Dizzy(15)
+	M.adjustToxLoss(2, 0)
+	if(prob(40))
+		M.emote(pick("twitch","drool","moan"))
+	if(prob(10))
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.8)
+	..()
+
+/datum/reagent/drug/methnitol/addiction_act_stage4(mob/living/carbon/human/M)
+	if((M.mobility_flags & MOBILITY_MOVE) && !ismovableatom(M.loc))
+		for(var/i = 0, i < 8, i++)
+			step(M, pick(GLOB.cardinals))
+	M.Jitter(20)
+	M.Dizzy(20)
+	M.adjustToxLoss(5, 0)
+	M.hallucination = min(max(0, M.hallucination + 5), 60)
+	if(prob(50))
+		M.emote(pick("twitch","drool","moan","laugh","frown"))
+	if(prob(15))
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2)
+	if(prob(5))
+		to_chat(M, "<span class='notice'>You forget for a moment what you were doing.</span>")
+		M.Stun(20)
+	..()
+	. = 1
+
+

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -28,6 +28,12 @@
 	required_reagents = list(/datum/reagent/medicine/ephedrine = 1, /datum/reagent/iodine = 1, /datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1)
 	required_temp = 374
 
+/datum/chemical_reaction/methnitol
+	name = /datum/reagent/drug/methnitol
+	id = /datum/reagent/drug/methnitol
+	results = list(/datum/reagent/drug/methnitol = 2)
+	required_reagents = list(/datum/reagent/drug/methamphetamine = 1, /datum/reagent/medicine/mannitol = 1)
+
 /datum/chemical_reaction/bath_salts
 	name = /datum/reagent/drug/bath_salts
 	id = /datum/reagent/drug/bath_salts


### PR DESCRIPTION
## About The Pull Request

Makes mixing meth and mannitol synthesize a brand new drug, Methnitol, while it is the bridge between abusing massive amount of methamphetamines and mannitol, this new drug packs it all in one chem, at the cost of a dramatic addiction and a soulcrushing overdose.

## Why It's Good For The Game

This aims to address at the current meta for chemists where they make pills of 9u meth + as much mannitol as they can pack for good measure. This makes the mix not only more dangerous, but also more tricky and limited to use.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![immagine](https://user-images.githubusercontent.com/75247747/177210722-2f632d92-a853-4e6a-ab6d-d2b956125294.png)

![immagine](https://user-images.githubusercontent.com/75247747/177210753-d83b8d94-7c5a-4bb9-9611-338bacb613f1.png)

</details>

## Changelog
:cl:
add: Added a brand new chem, Methnitol, a mix of 1:1 of meth and mannitol
/:cl:

