### PR TITLE
Making light floor/tiles breakable by lighteater

### DIFF
--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -16,6 +16,8 @@
 /turf/open/floor/light/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>There's a <b>small crack</b> on the edge of it.</span>"
+	if(broken)
+		. += "<span class='notice'>It seems to be completely broken.</span>"
 
 /turf/open/floor/light/Initialize(mapload)
 	. = ..()
@@ -55,6 +57,8 @@
 /turf/open/floor/light/attack_hand(mob/user)
 	. = ..()
 	if(.)
+		return
+	if(broken)
 		return
 	if(!can_modify_colour)
 		return

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -238,5 +238,14 @@
 			playsound(src, 'sound/machines/terminal_eject.ogg', 50, TRUE)
 	..()
 
+/turf/open/floor/light/lighteater_act(obj/item/light_eater/light_eater)
+	. = ..()
+	if(!light_range || !light_power || !light_on)
+		return
+	if(light_eater)
+		visible_message("<span class='danger'>The light bulb of [src] is disintegrated by [light_eater]!</span>")
+	break_tile()
+	playsound(src, 'sound/items/welder.ogg', 50, 1)
+
 #undef HEART_SPECIAL_SHADOWIFY
 #undef HEART_RESPAWN_THRESHHOLD


### PR DESCRIPTION
## About The Pull Request

Closes #7158 (Maybe?, talks about cheesing nightmares with these, if energy thing wanted can try to do that)

Adds `lighteater_act` to light floors/tiles (the thingies shown in Screenshots&Videos) so lighteaters from nightmares break them and disable their light.

Also small fix so said tiles can't just be activated again after being broken. And also a small description for when they are broken.

(I also thought about them needing energy but that would need conversion to a machine instead of being a tile (if i understood that code correctly), if wanted i can try that though)

## Why It's Good For The Game

Removes a counter against nightmares who can't do much against it except to always carry a crowbar with them or need to cycle through all the lights of the tile

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/53494785/177435992-3399bbb7-e9d4-4a0b-85fc-996cb2653083.mp4

</details>

## Changelog
:cl:
add: Nightmares can now break light floor/tiles with their lighteater
add: small description for when the tiles are broken
fix: said light floor/tiles can't be turned back on anymore after being broken
/:cl: