### PR TITLE
Adds the batong, a toy version of security batons

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -42,6 +42,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 		/obj/item/toy/clockwork_watch = 2,
 		/obj/item/toy/toy_dagger = 2,
 		/obj/item/toy/cog = 2,
+		/obj/item/toy/batong = 1,
 		/obj/item/toy/replica_fabricator = 1,
 		/obj/item/extendohand/acme = 1,
 		/obj/item/hot_potato/harmless/toy = 1,

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -16,7 +16,7 @@
 		/obj/item/gun/energy,
 		/obj/item/melee/baton,
 		/obj/item/ammo_box/magazine/recharge,
-		/obj/item/toy/batong
+		/obj/item/toy/batong,
 		/obj/item/modular_computer))
 
 /obj/machinery/recharger/RefreshParts()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -16,6 +16,7 @@
 		/obj/item/gun/energy,
 		/obj/item/melee/baton,
 		/obj/item/ammo_box/magazine/recharge,
+		/obj/item/toy/batong
 		/obj/item/modular_computer))
 
 /obj/machinery/recharger/RefreshParts()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -313,16 +313,16 @@
 /*
  * Batong
  */
- /obj/item/toy/batong
-	name = "batong"
-	desc = "Despite being a cheap plastic imitation of a stunbaton, it can still be charged."
-	icon = 'icons/obj/items_and_weapons.dmi'
-	icon_state = "stunbaton"
-	item_state = "baton"
-	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-	attack_verb = list("batonged", "stunned", "hit")
-	w_class = WEIGHT_CLASS_SMALL
+/obj/item/toy/batong
+    name = "batong"
+    desc = "Despite being a cheap plastic imitation of a stunbaton, it can still be charged."
+    icon = 'icons/obj/items_and_weapons.dmi'
+    icon_state = "stunbaton"
+    item_state = "baton"
+    lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
+    righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+    attack_verb = list("batonged", "stunned", "hit")
+    w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/toy/windupToolbox
 	name = "windup toolbox"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -23,6 +23,7 @@
  *		Clockwork Watches
  *		Toy Daggers
  *		Eldrich stuff
+ *		Batong
  */
 
 
@@ -308,6 +309,20 @@
 	attack_verb = list("pricked", "absorbed", "gored")
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
+	
+/*
+ * Batong
+ */
+ /obj/item/toy/batong
+	name = "batong"
+	desc = "Maybe the real charger was the friends we made along the way."
+	icon = 'icons/obj/toy.dmi'
+	icon_state = "baton"
+	item_state = "classic_baton"
+	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+	attack_verb = list("batonged", "stunned", "hit")
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/toy/windupToolbox
 	name = "windup toolbox"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -315,10 +315,10 @@
  */
  /obj/item/toy/batong
 	name = "batong"
-	desc = "Despite it being a cheap plastic imitation of a baton, it can still be charged."
+	desc = "Despite being a cheap plastic imitation of a stunbaton, it can still be charged."
 	icon = 'icons/obj/toy.dmi'
-	icon_state = "baton"
-	item_state = "classic_baton"
+	icon_state = "stunbaton"
+	item_state = "baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	attack_verb = list("batonged", "stunned", "hit")

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -316,7 +316,7 @@
  /obj/item/toy/batong
 	name = "batong"
 	desc = "Despite being a cheap plastic imitation of a stunbaton, it can still be charged."
-	icon = 'icons/obj/toy.dmi'
+	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "stunbaton"
 	item_state = "baton"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -314,15 +314,15 @@
  * Batong
  */
 /obj/item/toy/batong
-    name = "batong"
-    desc = "Despite being a cheap plastic imitation of a stunbaton, it can still be charged."
-    icon = 'icons/obj/items_and_weapons.dmi'
-    icon_state = "stunbaton"
-    item_state = "baton"
-    lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
-    righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
-    attack_verb = list("batonged", "stunned", "hit")
-    w_class = WEIGHT_CLASS_SMALL
+	name = "batong"
+	desc = "Despite being a cheap plastic imitation of a stunbaton, it can still be charged."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "stunbaton"
+	item_state = "baton"
+	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
+	attack_verb = list("batonged", "stunned", "hit")
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/toy/windupToolbox
 	name = "windup toolbox"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -315,7 +315,7 @@
  */
  /obj/item/toy/batong
 	name = "batong"
-	desc = "Maybe the real charger was the friends we made along the way."
+	desc = "Despite it being a cheap plastic imitation of a baton, it can still be charged."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "baton"
 	item_state = "classic_baton"


### PR DESCRIPTION
## About The Pull Request
As said above, the batong has the same sprites as a normal baton and can even be inserted into a charger (though it won't do anything). Also included in arcade prizes and thus cargo toy crates.

## Why It's Good For The Game
More toy variety is always good, plus it can be used to play pranks like with lasertag guns.

## Testing Photographs and Procedure
![34634653723457](https://user-images.githubusercontent.com/101019561/177623916-afb11e2d-bb2c-4de6-bcbf-d35d40919dc8.png)
![745874257564576542457](https://user-images.githubusercontent.com/101019561/177624014-f2cb9f29-1dbb-4a93-bdbc-a83c5b82e897.png)

## Changelog
:cl:
add: Adds a new chargable toy batong
/:cl:
