### PR TITLE
Fixes duplication bug that allows to obtain infinite glass and cable by disassembling and reassembling Disco Tiles

### DIFF
--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -21,6 +21,7 @@
 		to_chat(user, "<span class='warning'>You need one iron sheet to finish the light tile!</span>")
 		return
 	new /obj/item/stack/tile/light(user.drop_location(), null, TRUE, user)
+	qdel(src)
 	to_chat(user, "<span class='notice'>You make a light tile.</span>")
 	use(1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #7206
Now, when assembling a Disco Tile, the wired tile disappears after being used.

## Why It's Good For The Game

We don't want infinite glass and cable coil!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Before: 

https://user-images.githubusercontent.com/45698448/177639819-a50cb2ca-898c-4258-8ee9-7fd24cca6788.mp4

After:


https://user-images.githubusercontent.com/45698448/177639957-a6e57932-b46d-45cc-b25b-33e1de55d1aa.mp4



</details>

## Changelog
:cl:
fix: Fixed being able to get infinite glass and wires disassembling Disco Tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
