### PR TITLE
Ruko destroys meth

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -202,7 +202,7 @@
 	if(L.client)
 		L.client.give_award(/datum/award/achievement/misc/meth, L)
 	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
-	M.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING)) //Yes, this does not actually change movespeed. Required to pass github checks because I remove movespeed modifiers in on_mob_end_metabolize()
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING)) //Yes, this does not actually change movespeed. Required to pass github checks because I remove movespeed modifiers in on_mob_end_metabolize()
 	addiction_threshold = rand(0, 10) //Highly addictive substances are risky. You never know exactly when you'll be addicted
 	overdose_threshold = rand(10, 20)
 

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -202,6 +202,7 @@
 	if(L.client)
 		L.client.give_award(/datum/award/achievement/misc/meth, L)
 	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
+	M.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING)) //Yes, this does not actually change movespeed. Required to pass github checks because I remove movespeed modifiers in on_mob_end_metabolize()
 	addiction_threshold = rand(0, 10) //Highly addictive substances are risky. You never know exactly when you'll be addicted
 	overdose_threshold = rand(10, 20)
 
@@ -218,6 +219,7 @@
 	switch(current_cycle) //These all add together multiplicatively producing a gradually higher speed bonus
 		if(8)
 			to_chat(M, "<span class='notice'>You feel hyper.</span>")
+			M.remove_movespeed_modifier(type)
 			M.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.15, blacklisted_movetypes=(FLYING|FLOATING))
 		if(16)
 			to_chat(M, "<span class='notice'>You feel like you need to go faster.</span>")

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -13,6 +13,61 @@
 	M.reagents.remove_reagent(/datum/reagent/medicine/mannitol,3) //Mannitol doesn't mix well with drugs
 	..()
 
+/datum/reagent/drug/badminordrazine
+	name = "Badminordrazine"
+	color = "#A02020" //Hellish red for the underworld
+	description = "It's magic. We don't have to explain it."
+	chem_flags = CHEMICAL_NOT_SYNTH | CHEMICAL_RNG_FUN
+	taste_description = "badmins"
+
+/datum/reagent/drug/badminordrazine/on_mob_metabolize(mob/living/L)
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0.5, blacklisted_movetypes=(FLYING|FLOATING))
+	..()
+
+/datum/reagent/drug/badminordrazine/on_mob_end_metabolize(mob/living/L)
+	L.remove_movespeed_modifier(type)
+	..()
+	
+/datum/reagent/drug/badminordrazine/on_mob_life(mob/living/carbon/M)
+	var/effect_choice = rand(1,100)
+	if(!(current_cycle % 3)) //effect once every three ticks, since some of these are somewhat extreme. One effect for every 1.2u consumed
+		switch(effect_choice)
+			if(1 to 10)
+				M.confused = max(M.confused, 20)
+			if(11 to 20)
+				M.nutrition = pick(NUTRITION_LEVEL_STARVING, NUTRITION_LEVEL_FAT + 50)
+			if(21 to 30)
+				M.adjust_fire_stacks(5)
+				M.IgniteMob()
+			if(31 to 40)
+				M.Sleeping(60, 0) //lasts until next random effect
+			if(41 to 50)
+				M.bluespace_shuffle()
+			if(51 to 60)
+				var/turf/open/OT = get_turf(M)
+				OT.MakeSlippery(TURF_WET_LUBE, min_wet_time = 20 SECONDS, wet_time_to_add = 10 SECONDS)
+				M.slip(60)
+			if(61 to 70)
+				if(!M.getorgan(/obj/item/organ/ears/cat) && !M.getorgan(/obj/item/organ/tail/cat))
+					var/obj/item/organ/ears/cat/newears = new
+					var/obj/item/organ/tail/cat/newtail = new
+					newears.Insert(M)
+					newtail.Insert(M)
+					playsound(get_turf(M), 'sound/effects/meow1.ogg', 50, 1, -1)
+					to_chat(M, "<span class='userdanger'>You feel a bit feline.</span>")
+			if(71 to 80)
+				to_chat(M, "<span class='userdanger'>You feel that you have incurred the wrath of a god.</span>") //doesn't actually do anything, just ominous
+			if(81 to 90)
+				M.electrocute_act(rand(5,20), "Badminordrazine in their body", 1, 1)
+			if(91 to 95)
+				M.vomit()
+			if(96 to 100) // 50% chance of vomitting up an organ. High chance of being lethal
+				M.spew_organ()
+				M.vomit()
+				to_chat(M, "<span class='userdanger'>You feel something lumpy come up as you vomit.</span>")
+	..()
+	
+
 /datum/reagent/drug/space_drugs
 	name = "Space drugs"
 	description = "An illegal chemical compound used as drug."

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -202,8 +202,8 @@
 	if(L.client)
 		L.client.give_award(/datum/award/achievement/misc/meth, L)
 	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
-//	addiction_threshold = rand(0, 10) //Highly addictive substances are risky. You never know exactly when you'll be addicted
-//	overdose_threshold = rand(10, 20)
+	addiction_threshold = rand(0, 10) //Highly addictive substances are risky. You never know exactly when you'll be addicted
+	overdose_threshold = rand(10, 20)
 
 /datum/reagent/drug/methamphetamine/on_mob_end_metabolize(mob/living/L)
 	REMOVE_TRAIT(L, TRAIT_NOBLOCK, type)
@@ -213,8 +213,8 @@
 /datum/reagent/drug/methamphetamine/on_mob_life(mob/living/carbon/M)
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
-//	overdose_threshold -= metabolization_rate * 0.5 //Prevents indefinite microdosing
-//	addiction_threshold -= metabolization_rate * 0.5
+	overdose_threshold -= metabolization_rate * 0.5 //Prevents indefinite microdosing
+	addiction_threshold -= metabolization_rate * 0.5
 	switch(current_cycle) //These all add together multiplicatively producing a gradually higher speed bonus
 		if(8)
 			to_chat(M, "<span class='notice'>You feel hyper.</span>")

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -202,7 +202,6 @@
 	if(L.client)
 		L.client.give_award(/datum/award/achievement/misc/meth, L)
 	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
-	M.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING)) //Yes, this does not actually change movespeed. Required to pass github checks because I remove movespeed modifiers in on_mob_end_metabolize()
 	addiction_threshold = rand(0, 10) //Highly addictive substances are risky. You never know exactly when you'll be addicted
 	overdose_threshold = rand(10, 20)
 
@@ -219,7 +218,6 @@
 	switch(current_cycle) //These all add together multiplicatively producing a gradually higher speed bonus
 		if(8)
 			to_chat(M, "<span class='notice'>You feel hyper.</span>")
-			M.remove_movespeed_modifier(type)
 			M.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.15, blacklisted_movetypes=(FLYING|FLOATING))
 		if(16)
 			to_chat(M, "<span class='notice'>You feel like you need to go faster.</span>")

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -202,7 +202,7 @@
 	if(L.client)
 		L.client.give_award(/datum/award/achievement/misc/meth, L)
 	ADD_TRAIT(L, TRAIT_NOBLOCK, type)
-	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING)) //Yes, this does not actually change movespeed. Required to pass github checks because I remove movespeed modifiers in on_mob_end_metabolize()
+	M.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING)) //Yes, this does not actually change movespeed. Required to pass github checks because I remove movespeed modifiers in on_mob_end_metabolize()
 	addiction_threshold = rand(0, 10) //Highly addictive substances are risky. You never know exactly when you'll be addicted
 	overdose_threshold = rand(10, 20)
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -167,7 +167,7 @@
 	id = "methboom1"
 	required_temp = 380 //slightly above the meth mix time.
 	required_reagents = list(/datum/reagent/drug/methamphetamine = 1)
-	strengthdiv = 6
+	strengthdiv = 10
 	modifier = 1
 	mob_react = FALSE
 

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -11,11 +11,9 @@
 	user.Life()
 
 	TEST_ASSERT(user.reagents.has_reagent(meth), "User does not have meth in their system after consuming it")
-	TEST_ASSERT(user.has_movespeed_modifier(/datum/reagent/drug/methamphetamine), "User consumed meth, but did not gain movespeed modifier")
 
 	user.Life()
 	TEST_ASSERT(!user.reagents.has_reagent(meth), "User still has meth in their system when it should've finished metabolizing")
-	TEST_ASSERT(!user.has_movespeed_modifier(/datum/reagent/drug/methamphetamine), "User still has movespeed modifier despite not containing any more meth")
 
 /datum/unit_test/on_mob_end_metabolize/Destroy()
 	SSmobs.ignite()

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -3,17 +3,19 @@
 
 	var/mob/living/carbon/human/user = allocate(/mob/living/carbon/human)
 	var/obj/item/reagent_containers/pill/pill = allocate(/obj/item/reagent_containers/pill)
-	var/datum/reagent/drug/methamphetamine/meth = /datum/reagent/drug/methamphetamine
+	var/datum/reagent/drug/badminordrazine/badminordrazine = /datum/reagent/drug/badminordrazine
 
-	// Give them enough meth to be consumed in 2 metabolizations
-	pill.reagents.add_reagent(meth, initial(meth.metabolization_rate) * 1.9)
+	// Give them enough badminordrazine to be consumed in 2 metabolizations
+	pill.reagents.add_reagent(badminordrazine, initial(badminordrazine.metabolization_rate) * 1.9)
 	pill.attack(user, user)
 	user.Life()
 
-	TEST_ASSERT(user.reagents.has_reagent(meth), "User does not have meth in their system after consuming it")
+	TEST_ASSERT(user.reagents.has_reagent(badminordrazine), "User does not have badminordrazine in their system after consuming it")
+	TEST_ASSERT(user.has_movespeed_modifier(/datum/reagent/drug/badminordrazine), "User consumed badminordrazine, but did not gain movespeed modifier")
 
 	user.Life()
-	TEST_ASSERT(!user.reagents.has_reagent(meth), "User still has meth in their system when it should've finished metabolizing")
+	TEST_ASSERT(!user.reagents.has_reagent(badminordrazine), "User still has badminordrazine in their system when it should've finished metabolizing")
+	TEST_ASSERT(!user.has_movespeed_modifier(/datum/reagent/drug/badminordrazine), "User still has movespeed modifier despite not containing any more badminordrazine")
 
 /datum/unit_test/on_mob_end_metabolize/Destroy()
 	SSmobs.ignite()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Slows down the rate at which meth is metabolized, allowing for smaller doses to provide a longer effect period
* Makes the addiction side effects of meth non-lethal (No more toxin damage at stage 4)
* Makes the addiction side effects of meth less annoying (lower chance of forced emotes)
* Makes the addiction and overdose thresholds for meth dynamic
* Makes positive meth effects build over time instead of behaving like an instant combat-ready adrenal stim.
* Removes sleep immunity from meth
* Reduced the explosive power of meth to equal potassium/water - players wanting explosives should make dedicated explosive reagents for the biggest boom. 
* Makes all drugs (/datum/reagent/drug) purge Mannitol from the user's system (alternative to the idea presented in #7198).
* ~~Removes the run tests for meth increasing speed on_mob_metabolize() and on_mob_end_metabolize() since this behavior is being changed and meth is not guaranteed to affect speed.~~
* Implements Badminordrazine to take the place of meth in the above reagent tests. It also doubles as a new admin smite and floorpill chem. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Meth is the single most powerful reagent in the game, beaten only by nitroglycerin in terms of explosive power, and beaten by pretty much nothing in terms of being a combat stim. This makes the drug a more nuanced "jack of trades" choice when compared to other options. It remains powerful as a combat stim to those willing to brave the (now reduced) side effects of addiction and overdosing, especially if taken regularly or ahead of getting into an engagement. 

As for the mannitol part, I mostly agree with the points made in #7198, just not the execution. Being able to easily disregard the downside to something means the downside may as well not resist. My solution is less nuclear and doesn't totally prevent the use of mannitol while on drugs, but greatly diminishes its usefulness. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

100u meth explosion after the nerf, size (1, 2, 4, 0)
![image](https://user-images.githubusercontent.com/9547572/177674820-b521cef2-5ec5-4258-b4d5-688017216631.png)

Showing the dynamic overdose threshold taking effect after continuous microdosing:
![image](https://user-images.githubusercontent.com/9547572/177677448-d7b84a57-a135-4bb2-bcd9-0c5f71e60c3c.png)

</details>

## Changelog
:cl:
balance: All of meth's positive effects are now built over time, with movement speed being capped at 50 seconds and the stun resistance and stamina restoration effects having no cap, but starting low. Sleep immunity has been removed. 
balance: Meth explosions are now equal to potassium + water so that dedicated explosive reagents are worth making
tweak: Meth metabolizes 33% slower, so a smaller dose will last longer. 
tweak: Meth now has dynamic addiction and overdose thresholds instead of static ones. 
tweak: Meth's addiction side effects are now completely non-lethal and the forced emotes proc far less often as well.
tweak: All drugs purge mannitol from the user's system. Recovering from brain damaging drugs requires a sober period
add: Badminordrazine is a new reagent which can be used by staff for smites and also has a small chance of appearing in floor pills. It inflicts any of ten random effects every six seconds it is being processed. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
