### PR TITLE
AI relayed speech holopad job transmission uses ID-based job instead of manifest

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -933,12 +933,12 @@
 	var/hrefpart = "<a href='?src=[REF(src)];track=[html_encode(namepart)]'>"
 	var/jobpart = "Unknown"
 
-	if (iscarbon(speaker))
-		var/mob/living/carbon/S = speaker
-		if(S.job)
-			jobpart = "[S.job]"
-	else
-		jobpart = "Unknown"
+	if (ishuman(speaker))
+		var/mob/living/carbon/human/S = speaker
+		if(S.wear_id)
+			var/obj/item/card/id/I = S.wear_id.GetID()
+			if(I)
+				jobpart = "[I.assignment]"
 
 	var/rendered = "<i><span class='game say'>[start]<span class='name'>[hrefpart][namepart] ([jobpart])</a> </span><span class='message'>[treated_message]</span></span></i>"
 


### PR DESCRIPTION
## About The Pull Request

Closes #7166 

- Changes the job displayed when relaying holopad speech to AI from the manifest assignment of the player to the one shown on their ID
- Removes redundant else cases (the variable is always defined as Unknown initially)

## Why It's Good For The Game

Previously, if the player was not on the manifest properly (say, an explo recovered VIP) or changed their ID in any way other than HoP's office (ex: changeling) it would show the old job. This is very bad, since it can meta-ly reveal a changeling by the job transmitted. Now it instead uses the job shown the ID, which is much more consistent with other AI-transmitted speech/radio.

## Testing Photographs and Procedure

1. Spawn in as a player character
2. Obtain an alternate ID
3. Put on the ID
4. Stand near holopad
5. Reconstruct in player-panel as another mob without deleting the old one
6. Make yourself an AI
7. Go to the holopad
8. Call `say` proc on the now soulless body wearing alternate ID
9. See result

<details>
<summary>Screenshots&Videos</summary>

**Before**

![image](https://user-images.githubusercontent.com/10366817/177916959-8f1511f9-c203-4998-9762-85b196fb1f81.png)

Shows Unknown since the player is not actually on the manifest as anything (since now the manifest only contains myself as Station Engineer, not this soulless body)

**After**

![image](https://user-images.githubusercontent.com/10366817/177916975-412188e2-ee9c-4336-b1c7-adfe93fff26b.png)

Spawned as Station Engineer, now shows Chemist due to ID - if this were a real, souled player, it would have previously said Station Engineer despite the ID showing Chemist.

</details>

## Changelog
:cl:
fix: Fixes holopad AI message relay using job from crew manifest instead of worn ID
/:cl:
