### PR TITLE
Rework AI Alerts menu to use browser popups instead of raw IE

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -265,37 +265,38 @@
 	return tab_data
 
 /mob/living/silicon/ai/proc/update_ai_alerts()
-	if(alerts_popup && alerts_popup.resolve())
-		var/dat
-		for (var/cat in alarms)
-			dat += text("<B>[]</B><BR>\n", cat)
-			var/list/L = alarms[cat]
-			if (L.len)
-				for (var/alarm in L)
-					var/list/alm = L[alarm]
-					var/area/A = alm[1]
-					var/C = alm[2]
-					var/list/sources = alm[3]
-					dat += "<NOBR>"
-					if (C && istype(C, /list))
-						var/dat2 = ""
-						for (var/obj/machinery/camera/I in C)
-							dat2 += text("[]<A HREF=?src=[REF(src)];switchcamera=[REF(I)]>[]</A>", (dat2=="") ? "" : " | ", I.c_tag)
-						dat += text("-- [] ([])", A.name, (dat2!="") ? dat2 : "No Camera")
-					else if (C && istype(C, /obj/machinery/camera))
-						var/obj/machinery/camera/Ctmp = C
-						dat += text("-- [] (<A HREF=?src=[REF(src)];switchcamera=[REF(C)]>[]</A>)", A.name, Ctmp.c_tag)
-					else
-						dat += text("-- [] (No Camera)", A.name)
-					if (sources.len > 1)
-						dat += text("- [] sources", sources.len)
-					dat += "</NOBR><BR>\n"
-			else
-				dat += "-- All Systems Nominal<BR>\n"
-			dat += "<BR>\n"
-		var/datum/browser/popup = alerts_popup.resolve()
-		popup.set_content(dat)
-		popup.open()
+	if(!alerts_popup || !alerts_popup.resolve())
+		return
+	var/dat
+	for (var/cat in alarms)
+		dat += text("<B>[]</B><BR>\n", cat)
+		var/list/L = alarms[cat]
+		if (L.len)
+			for (var/alarm in L)
+				var/list/alm = L[alarm]
+				var/area/A = alm[1]
+				var/C = alm[2]
+				var/list/sources = alm[3]
+				dat += "<NOBR>"
+				if (C && istype(C, /list))
+					var/dat2 = ""
+					for (var/obj/machinery/camera/I in C)
+						dat2 += text("[]<A HREF=?src=[REF(src)];switchcamera=[REF(I)]>[]</A>", (dat2=="") ? "" : " | ", I.c_tag)
+					dat += text("-- [] ([])", A.name, (dat2!="") ? dat2 : "No Camera")
+				else if (C && istype(C, /obj/machinery/camera))
+					var/obj/machinery/camera/Ctmp = C
+					dat += text("-- [] (<A HREF=?src=[REF(src)];switchcamera=[REF(C)]>[]</A>)", A.name, Ctmp.c_tag)
+				else
+					dat += text("-- [] (No Camera)", A.name)
+				if (sources.len > 1)
+					dat += text("- [] sources", sources.len)
+				dat += "</NOBR><BR>\n"
+		else
+			dat += "-- All Systems Nominal<BR>\n"
+		dat += "<BR>\n"
+	var/datum/browser/popup = alerts_popup.resolve()
+	popup.set_content(dat)
+	popup.open()
 
 /mob/living/silicon/ai/proc/ai_alerts()
 	var/datum/browser/popup

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -38,7 +38,7 @@
 	var/can_be_carded = TRUE
 	var/alarms = list("Motion"=list(), "Fire"=list(), "Atmosphere"=list(), "Power"=list(), "Camera"=list(), "Burglar"=list())
 	var/datum/weakref/alerts_popup = null
-	var/icon/holo_icon//Default is assigned when AI is created.
+	var/icon/holo_icon //Default is assigned when AI is created.
 	var/obj/mecha/controlled_mech //For controlled_mech a mech, to determine whether to relaymove or use the AI eye.
 	var/radio_enabled = TRUE //Determins if a carded AI can speak with its built in radio or not.
 	radiomod = ";" //AIs will, by default, state their laws on the internal radio.


### PR DESCRIPTION
## About The Pull Request

Fixes #7143

- Refactors AI alert menu to use `/datum/browser` instead of a raw `src << browse()` call - this means it will use theming of most HTML-based popups instead of being an ugly white default IE theme box and makes it more consistent with other AI menus (robot control, manifest, etc)
- Fixes AI alerts menu randomly unfocusing the game
- Fixes AI alerts menu being unclosable when incapacitated or no longer in AI control

Also, not sure about possible hard-dels or the need for weakrefs in this - no one was available in the Discord that knew well enough at the time, so let me know if there's any problems with the design here and the `alerts_popup` var. I think it should be fine as it is - but if there's something I did that's unnecessary or could be done better let me know as this is only my second PR and the first one with any type of refactors.

## Why It's Good For The Game

You couldn't close the menu after your round as AI without closing the whole game, that was annoying. It also looks much better now and is more consistent with other menus (and also won't burn your eyes off).

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/177935032-bda3d202-1d0a-4d48-bae0-1bed2bd0c657.png)

Buttons work as expected to go to cameras.

Will auto-update when a new alert comes or is cleared without unfocusing the game sometimes.

Closing when your APC powers off does not cause unexpected errors or behavior.

Closing when no longer the AI player does not cause unexpected errors or behavior.

</details>

## Changelog
:cl:
tweak: AI alerts menu looks better and is more consistent with other AI menus
fix: AI alerts menu will no longer unfocus the game when updating
fix: AI alerts menu can now be closed as expected when unconscious or no longer in AI control
/:cl: