### PR TITLE
Add health HUD / red vignette to simplemobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -82,10 +82,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	elite_owner.chosen_attack = chosen_attack_num
 	to_chat(elite_owner, chosen_message)
 
-/mob/living/simple_animal/hostile/asteroid/elite/updatehealth()
-	. = ..()
-	update_health_hud()
-
 /mob/living/simple_animal/hostile/asteroid/elite/update_health_hud()
 	if(hud_used)
 		var/severity = 0

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -142,26 +142,13 @@
 	update_health_hud()
 
 /mob/living/simple_animal/update_health_hud()
-	if(hud_used)
-		var/severity = 0
-		var/healthpercent = (health / maxHealth) * 100
-		switch(healthpercent)
-			if(80 to 99)
-				severity = 1
-			if(60 to 80)
-				severity = 2
-			if(40 to 60)
-				severity = 3
-			if(20 to 40)
-				severity = 4
-			if(1 to 20)
-				severity = 5
-			else
-				severity = 0
-		if(severity > 0)
-			overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
-		else
-			clear_fullscreen("brute")
+	if(!hud_used)
+		return
+	var/severity = 6 - (CLAMP(FLOOR((health / maxHealth) * 5, 1), 0, 5) + 1)
+	if(severity > 0)
+		overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
+	else
+		clear_fullscreen("brute")
 
 /mob/living/simple_animal/update_stat()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -144,7 +144,7 @@
 /mob/living/simple_animal/update_health_hud()
 	if(!hud_used)
 		return
-	var/severity = 6 - (CLAMP(FLOOR((health / maxHealth) * 5, 1), 0, 5) + 1)
+	var/severity = 7 - CLAMP(FLOOR((health / maxHealth) * 5, 1), 0, 5)
 	if(severity > 0)
 		overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
 	else

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -139,6 +139,29 @@
 /mob/living/simple_animal/updatehealth()
 	..()
 	health = CLAMP(health, 0, maxHealth)
+	update_health_hud()
+
+/mob/living/simple_animal/update_health_hud()
+	if(hud_used)
+		var/severity = 0
+		var/healthpercent = (health / maxHealth) * 100
+		switch(healthpercent)
+			if(80 to 99)
+				severity = 1
+			if(60 to 80)
+				severity = 2
+			if(40 to 60)
+				severity = 3
+			if(20 to 40)
+				severity = 4
+			if(1 to 20)
+				severity = 5
+			else
+				severity = 0
+		if(severity > 0)
+			overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
+		else
+			clear_fullscreen("brute")
 
 /mob/living/simple_animal/update_stat()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -144,7 +144,7 @@
 /mob/living/simple_animal/update_health_hud()
 	if(!hud_used)
 		return
-	var/severity = 7 - CLAMP(FLOOR((health / maxHealth) * 5, 1), 0, 5)
+	var/severity = 5 - CLAMP(FLOOR((health / maxHealth) * 5, 1), 0, 5)
 	if(severity > 0)
 		overlay_fullscreen("brute", /atom/movable/screen/fullscreen/brute, severity)
 	else

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -172,7 +172,6 @@
 		if(health <= 0)
 			mod += 2
 	add_movespeed_modifier(MOVESPEED_ID_SLIME_HEALTHMOD, TRUE, 100, multiplicative_slowdown = mod, override = TRUE)
-	update_health_hud()
 
 /mob/living/simple_animal/slime/update_health_hud()
 	if(hud_used)


### PR DESCRIPTION
## About The Pull Request

- Adds red brute/burn outline to all simplemobs (`/mob/living/simple_animal`) when they lose health - similar to slimes and lavaland elite's existing overlays.

## Why It's Good For The Game

As it is now, controlled simplemobs only way of knowing their own health is by looking at the Status panel. This is really unintuitive and can lead to premature death due to not noticing damage being taken.

This outline makes it much clearer to the player they are taking damage without requiring much in terms of HUD icons.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

**Test of new code on birdboat with damage**
![image](https://user-images.githubusercontent.com/10366817/177949787-e1f3ba86-90d0-4c0d-ba6b-eddb273dccf4.png)

**Test of new code on birdboat without damage**
![image](https://user-images.githubusercontent.com/10366817/177951101-a593124a-386a-4af8-b636-caa1b0bc0844.png)

**Existing slime HUD works as originally made due to override**
![image](https://user-images.githubusercontent.com/10366817/177949740-f2b66745-6470-4e3c-a35f-bcaae4099f8d.png)

**Existing lavaland elite HUD works as originally made**
![image](https://user-images.githubusercontent.com/10366817/177949750-a5bd6058-66a0-4a19-8362-bab24d36c0ce.png)

**Test of new code on space dragon (the main reason I even made this, they're simplemobs so it's really hard to tell your health)**
![image](https://user-images.githubusercontent.com/10366817/177949761-d18ccd46-84f8-4f6c-be82-4010c0d770fd.png)


</details>

## Changelog
:cl:
add: Brute damage HUD overlay (red vignette) for all simplemobs
/:cl:
