### PR TITLE
Simplifies cooldown defines

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -58,6 +58,15 @@
 /*
  * Cooldown system based on storing world.time on a variable, plus the cooldown time.
  * Better performance over timer cooldowns, lower control. Same functionality.
+ *
+ * var/cooldown_timer
+ *
+ * 	/proc/activate()
+ * 		if(!IS_COOLDOWN_FINISHED(cooldown_timer))
+ * 			return "Thing is on cooldown!"
+ * 		COOLDOWN_START(cooldown_timer, 5 SECONDS)
+ * 		return "Thing was activated, you can use again in 5 seconds!"
+ *
 */
 
 #define COOLDOWN_START(cd_var, cd_time) (cd_var = world.time + (cd_time))

--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -69,11 +69,14 @@
  *
 */
 
+//Takes in a variable and the cooldown length, stores the world time that the cooldown will be completed
 #define COOLDOWN_START(cd_var, cd_time) (cd_var = world.time + (cd_time))
 
 //Returns true if the cooldown has run its course, false otherwise
 #define IS_COOLDOWN_FINISHED(cd_var) (cd_var < world.time)
 
+//Resets a cooldown's completion time to 0, instantly finishing it
 #define COOLDOWN_RESET(cd_var) cd_var = 0
 
+//Returns the amount of time left on the cooldown in seconds
 #define COOLDOWN_TIMELEFT(cd_var) (max(0, cd_var - world.time))

--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -60,15 +60,11 @@
  * Better performance over timer cooldowns, lower control. Same functionality.
 */
 
-#define COOLDOWN_DECLARE(cd_index) var/##cd_index = 0
-
-#define COOLDOWN_STATIC_DECLARE(cd_index) var/static/##cd_index = 0
-
-#define COOLDOWN_START(cd_source, cd_index, cd_time) (cd_source.cd_index = world.time + (cd_time))
+#define COOLDOWN_START(cd_var, cd_time) (cd_var = world.time + (cd_time))
 
 //Returns true if the cooldown has run its course, false otherwise
-#define COOLDOWN_FINISHED(cd_source, cd_index) (cd_source.cd_index < world.time)
+#define IS_COOLDOWN_FINISHED(cd_var) (cd_var < world.time)
 
-#define COOLDOWN_RESET(cd_source, cd_index) cd_source.cd_index = 0
+#define COOLDOWN_RESET(cd_var) cd_var = 0
 
-#define COOLDOWN_TIMELEFT(cd_source, cd_index) (max(0, cd_source.cd_index - world.time))
+#define COOLDOWN_TIMELEFT(cd_var) (max(0, cd_var - world.time))

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -445,7 +445,7 @@
 		return candidates
 
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		if(COOLDOWN_FINISHED(G, creation_time) || G.started_as_observer) // Prevents people who have just died from becoming Antagonists
+		if(IS_COOLDOWN_FINISHED(G.creation_time) || G.started_as_observer) // Prevents people who have just died from becoming Antagonists
 			candidates += G
 	return pollCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, flashwindow, candidates, req_hours)
 

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -367,10 +367,10 @@
 
 //Returns FALSE if the recalculation failed, TRUE otherwise
 /datum/move_loop/has_target/jps/proc/recalculate_path()
-	if(!IS_COOLDOWN_FINISHED(src, repath_cooldown) || repath_active)
+	if(!IS_COOLDOWN_FINISHED(repath_cooldown) || repath_active)
 		return
 	repath_active = TRUE
-	COOLDOWN_START(src, repath_cooldown, repath_delay)
+	COOLDOWN_START(repath_cooldown, repath_delay)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_JPS_REPATH)
 	movement_path = get_path_to(moving, target, max_path_length, minimum_distance, id, simulated_only, avoid, skip_first)
 	repath_active = FALSE
@@ -457,10 +457,10 @@
 	var/target_turf
 
 /datum/move_loop/has_target/jps/hostile/recalculate_path()
-	if(!IS_COOLDOWN_FINISHED(src, repath_cooldown) || repath_active || QDELETED(src))
+	if(!IS_COOLDOWN_FINISHED(repath_cooldown) || repath_active || QDELETED(src))
 		return
 	repath_active = TRUE
-	COOLDOWN_START(src, repath_cooldown, repath_delay)
+	COOLDOWN_START(repath_cooldown, repath_delay)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_JPS_REPATH)
 	movement_path = get_path_to(moving, target, max_path_length, minimum_distance, id, simulated_only, avoid, skip_first)
 	// Implementing pathfinding fallback solution

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -332,7 +332,7 @@
 	///TRUE if a repath proc is currently running to ensure that only one can be called and finishes at a time
 	var/repath_active
 	///Cooldown for repathing, prevents spam
-	COOLDOWN_DECLARE(repath_cooldown)
+	var/repath_cooldown
 
 /datum/move_loop/has_target/jps/setup(delay, timeout, atom/chasing, repath_delay, max_path_length, minimum_distance, obj/item/card/id/id, simulated_only, turf/avoid, skip_first)
 	. = ..()
@@ -367,7 +367,7 @@
 
 //Returns FALSE if the recalculation failed, TRUE otherwise
 /datum/move_loop/has_target/jps/proc/recalculate_path()
-	if(!COOLDOWN_FINISHED(src, repath_cooldown) || repath_active)
+	if(!IS_COOLDOWN_FINISHED(src, repath_cooldown) || repath_active)
 		return
 	repath_active = TRUE
 	COOLDOWN_START(src, repath_cooldown, repath_delay)
@@ -457,7 +457,7 @@
 	var/target_turf
 
 /datum/move_loop/has_target/jps/hostile/recalculate_path()
-	if(!COOLDOWN_FINISHED(src, repath_cooldown) || repath_active || QDELETED(src))
+	if(!IS_COOLDOWN_FINISHED(src, repath_cooldown) || repath_active || QDELETED(src))
 		return
 	repath_active = TRUE
 	COOLDOWN_START(src, repath_cooldown, repath_delay)

--- a/code/controllers/subsystem/processing/ai_controllers.dm
+++ b/code/controllers/subsystem/processing/ai_controllers.dm
@@ -24,10 +24,10 @@ SUBSYSTEM_DEF(ai_controllers)
 
 /datum/controller/subsystem/ai_controllers/fire(resumed)
 	for(var/datum/ai_controller/ai_controller as anything in active_ai_controllers)
-		if(!IS_COOLDOWN_FINISHED(ai_controller, failed_planning_cooldown))
+		if(!IS_COOLDOWN_FINISHED(ai_controller.failed_planning_cooldown))
 			continue
 
 		if(!LAZYLEN(ai_controller.current_behaviors))
 			ai_controller.SelectBehaviors(wait * 0.1)
 			if(!LAZYLEN(ai_controller.current_behaviors)) //Still no plan
-				COOLDOWN_START(ai_controller, failed_planning_cooldown, AI_FAILED_PLANNING_COOLDOWN)
+				COOLDOWN_START(ai_controller.failed_planning_cooldown, AI_FAILED_PLANNING_COOLDOWN)

--- a/code/controllers/subsystem/processing/ai_controllers.dm
+++ b/code/controllers/subsystem/processing/ai_controllers.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(ai_controllers)
 
 /datum/controller/subsystem/ai_controllers/fire(resumed)
 	for(var/datum/ai_controller/ai_controller as anything in active_ai_controllers)
-		if(!COOLDOWN_FINISHED(ai_controller, failed_planning_cooldown))
+		if(!IS_COOLDOWN_FINISHED(ai_controller, failed_planning_cooldown))
 			continue
 
 		if(!LAZYLEN(ai_controller.current_behaviors))

--- a/code/controllers/subsystem/processing/orbits.dm
+++ b/code/controllers/subsystem/processing/orbits.dm
@@ -114,9 +114,9 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 		for(var/datum/tgui/tgui as() in open_orbital_maps)
 			tgui.send_update()
 	//Check creating objectives / missions.
-	if(next_objective_time < world.time && length(possible_objectives) < 6)
+	if(IS_COOLDOWN_FINISHED(next_objective_time) && length(possible_objectives) < 6)
 		create_objective()
-		next_objective_time = world.time + rand(30 SECONDS, 5 MINUTES)
+		COOLDOWN_START(next_objective_time, rand(30 SECONDS, 5 MINUTES))
 	//Check space ruin count
 	if(ruin_levels < 2 && prob(5))
 		new /datum/orbital_object/z_linked/beacon/ruin/spaceruin()

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -525,7 +525,7 @@
 	button_icon_state = "deploy_box"
 	///The type of closet this action spawns.
 	var/boxtype = /obj/structure/closet/cardboard/agent
-	COOLDOWN_DECLARE(box_cooldown)
+	var/box_cooldown
 
 ///Handles opening and closing the box.
 /datum/action/item_action/agent_box/Trigger()
@@ -541,7 +541,7 @@
 	if(!isturf(owner.loc)) //Don't let the player use this to escape mechs/welded closets.
 		to_chat(owner, "<span class = 'notice'>You need more space to activate this implant.</span>")
 		return
-	if(!COOLDOWN_FINISHED(src, box_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, box_cooldown))
 		return
 	COOLDOWN_START(src, box_cooldown, 10 SECONDS)
 	var/box = new boxtype(owner.drop_location())

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -541,9 +541,9 @@
 	if(!isturf(owner.loc)) //Don't let the player use this to escape mechs/welded closets.
 		to_chat(owner, "<span class = 'notice'>You need more space to activate this implant.</span>")
 		return
-	if(!IS_COOLDOWN_FINISHED(src, box_cooldown))
+	if(!IS_COOLDOWN_FINISHED(box_cooldown))
 		return
-	COOLDOWN_START(src, box_cooldown, 10 SECONDS)
+	COOLDOWN_START(box_cooldown, 10 SECONDS)
 	var/box = new boxtype(owner.drop_location())
 	owner.forceMove(box)
 	owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -179,7 +179,7 @@ multiple modular subtrees with behaviors
 ///This is where you decide what actions are taken by the AI.
 /datum/ai_controller/proc/SelectBehaviors(delta_time)
 	SHOULD_NOT_SLEEP(TRUE) //Fuck you don't sleep in procs like this.
-	if(!IS_COOLDOWN_FINISHED(src, failed_planning_cooldown))
+	if(!IS_COOLDOWN_FINISHED(failed_planning_cooldown))
 		return FALSE
 
 	LAZYINITLIST(current_behaviors)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -28,7 +28,7 @@ multiple modular subtrees with behaviors
 	///distance to give up on target
 	var/max_target_distance = 14
 	///Cooldown for new plans, to prevent AI from going nuts if it can't think of new plans and looping on end
-	COOLDOWN_DECLARE(failed_planning_cooldown)
+	var/failed_planning_cooldown
 	///All subtrees this AI has available, will run them in order, so make sure they're in the order you want them to run. On initialization of this type, it will start as a typepath(s) and get converted to references of ai_subtrees found in SSai_controllers when init_subtrees() is called
 	var/list/planning_subtrees
 
@@ -36,7 +36,7 @@ multiple modular subtrees with behaviors
 	///Reference to the movement datum we use. Is a type on initialize but becomes a ref afterwards.
 	var/datum/ai_movement/ai_movement = /datum/ai_movement/dumb
 	///Cooldown until next movement
-	COOLDOWN_DECLARE(movement_cooldown)
+	var/movement_cooldown
 	///Delay between movements. This is on the controller so we can keep the movement datum singleton
 	var/movement_delay = 0.1 SECONDS
 
@@ -179,7 +179,7 @@ multiple modular subtrees with behaviors
 ///This is where you decide what actions are taken by the AI.
 /datum/ai_controller/proc/SelectBehaviors(delta_time)
 	SHOULD_NOT_SLEEP(TRUE) //Fuck you don't sleep in procs like this.
-	if(!COOLDOWN_FINISHED(src, failed_planning_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, failed_planning_cooldown))
 		return FALSE
 
 	LAZYINITLIST(current_behaviors)

--- a/code/datums/ai/dog/dog_controller.dm
+++ b/code/datums/ai/dog/dog_controller.dm
@@ -61,7 +61,7 @@
 		return
 
 	// if we were just ordered to heel, chill out for a bit
-	if(!IS_COOLDOWN_FINISHED(src, heel_cooldown))
+	if(!IS_COOLDOWN_FINISHED(heel_cooldown))
 		return
 
 	// if we're just ditzing around carrying something, occasionally print a message so people know we have something
@@ -84,7 +84,7 @@
 	SIGNAL_HANDLER
 	if(blackboard[BB_FETCH_TARGET] || blackboard[BB_FETCH_DELIVER_TO] || blackboard[BB_DOG_PLAYING_DEAD]) // we're already busy
 		return
-	if(!IS_COOLDOWN_FINISHED(src, heel_cooldown))
+	if(!IS_COOLDOWN_FINISHED(heel_cooldown))
 		return
 	if(!can_see(pawn, carbon_thrower, length=AI_DOG_VISION_RANGE))
 		return
@@ -175,7 +175,7 @@
 /datum/ai_controller/dog/proc/check_altclicked(datum/source, mob/living/clicker)
 	SIGNAL_HANDLER
 
-	if(!IS_COOLDOWN_FINISHED(src, command_cooldown))
+	if(!IS_COOLDOWN_FINISHED(command_cooldown))
 		return
 	if(!istype(clicker) || !blackboard[BB_DOG_FRIENDS][WEAKREF(clicker)])
 		return
@@ -209,7 +209,7 @@
 	if(!blackboard[BB_DOG_FRIENDS][WEAKREF(speaker)])
 		return
 
-	if(!IS_COOLDOWN_FINISHED(src, command_cooldown))
+	if(!IS_COOLDOWN_FINISHED(command_cooldown))
 		return
 
 	var/mob/living/living_pawn = pawn
@@ -235,14 +235,14 @@
 
 /// Whether we got here via radial menu or a verbal command, this is where we actually process what our new command will be
 /datum/ai_controller/dog/proc/set_command_mode(mob/commander, command)
-	COOLDOWN_START(src, command_cooldown, AI_DOG_COMMAND_COOLDOWN)
+	COOLDOWN_START(command_cooldown, AI_DOG_COMMAND_COOLDOWN)
 
 	switch(command)
 		// heel: stop what you're doing, relax and try not to do anything for a little bit
 		if(COMMAND_HEEL)
 			pawn.visible_message("<span class='notice'>[pawn]'s ears prick up at [commander]'s command, and [pawn.p_they()] sit[pawn.p_s()] down obediently, awaiting further orders.</span>")
 			blackboard[BB_DOG_ORDER_MODE] = DOG_COMMAND_NONE
-			COOLDOWN_START(src, heel_cooldown, AI_DOG_HEEL_DURATION)
+			COOLDOWN_START(heel_cooldown, AI_DOG_HEEL_DURATION)
 			CancelActions()
 		// fetch: whatever the commander points to, try and bring it back
 		if(COMMAND_FETCH)
@@ -265,14 +265,14 @@
 	if(IS_DEAD_OR_INCAP(living_pawn))
 		return
 
-	if(!IS_COOLDOWN_FINISHED(src, command_cooldown))
+	if(!IS_COOLDOWN_FINISHED(command_cooldown))
 		return
 	if(pointed_movable == pawn || blackboard[BB_FETCH_TARGET] || !istype(pointed_movable) || blackboard[BB_DOG_ORDER_MODE] == DOG_COMMAND_NONE) // busy or no command
 		return
 	if(!can_see(pawn, pointing_friend, length=AI_DOG_VISION_RANGE) || !can_see(pawn, pointed_movable, length=AI_DOG_VISION_RANGE))
 		return
 
-	COOLDOWN_START(src, command_cooldown, AI_DOG_COMMAND_COOLDOWN)
+	COOLDOWN_START(command_cooldown, AI_DOG_COMMAND_COOLDOWN)
 
 	switch(blackboard[BB_DOG_ORDER_MODE])
 		if(DOG_COMMAND_FETCH)

--- a/code/datums/ai/dog/dog_controller.dm
+++ b/code/datums/ai/dog/dog_controller.dm
@@ -11,8 +11,8 @@
 	ai_movement = /datum/ai_movement/jps
 	planning_subtrees = list(/datum/ai_planning_subtree/dog)
 
-	COOLDOWN_DECLARE(heel_cooldown)
-	COOLDOWN_DECLARE(command_cooldown)
+	var/heel_cooldown
+	var/command_cooldown
 
 
 /datum/ai_controller/dog/process(delta_time)
@@ -61,7 +61,7 @@
 		return
 
 	// if we were just ordered to heel, chill out for a bit
-	if(!COOLDOWN_FINISHED(src, heel_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, heel_cooldown))
 		return
 
 	// if we're just ditzing around carrying something, occasionally print a message so people know we have something
@@ -84,7 +84,7 @@
 	SIGNAL_HANDLER
 	if(blackboard[BB_FETCH_TARGET] || blackboard[BB_FETCH_DELIVER_TO] || blackboard[BB_DOG_PLAYING_DEAD]) // we're already busy
 		return
-	if(!COOLDOWN_FINISHED(src, heel_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, heel_cooldown))
 		return
 	if(!can_see(pawn, carbon_thrower, length=AI_DOG_VISION_RANGE))
 		return
@@ -175,7 +175,7 @@
 /datum/ai_controller/dog/proc/check_altclicked(datum/source, mob/living/clicker)
 	SIGNAL_HANDLER
 
-	if(!COOLDOWN_FINISHED(src, command_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, command_cooldown))
 		return
 	if(!istype(clicker) || !blackboard[BB_DOG_FRIENDS][WEAKREF(clicker)])
 		return
@@ -209,7 +209,7 @@
 	if(!blackboard[BB_DOG_FRIENDS][WEAKREF(speaker)])
 		return
 
-	if(!COOLDOWN_FINISHED(src, command_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, command_cooldown))
 		return
 
 	var/mob/living/living_pawn = pawn
@@ -265,7 +265,7 @@
 	if(IS_DEAD_OR_INCAP(living_pawn))
 		return
 
-	if(!COOLDOWN_FINISHED(src, command_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, command_cooldown))
 		return
 	if(pointed_movable == pawn || blackboard[BB_FETCH_TARGET] || !istype(pointed_movable) || blackboard[BB_DOG_ORDER_MODE] == DOG_COMMAND_NONE) // busy or no command
 		return

--- a/code/datums/ai/dog/dog_subtrees.dm
+++ b/code/datums/ai/dog/dog_subtrees.dm
@@ -6,12 +6,12 @@
 	var/mob/living/living_pawn = controller.pawn
 
 	// occasionally reset our ignore list
-	if(IS_COOLDOWN_FINISHED(src, reset_ignore_cooldown) && length(controller.blackboard[BB_FETCH_IGNORE_LIST]))
-		COOLDOWN_START(src, reset_ignore_cooldown, AI_FETCH_IGNORE_DURATION)
+	if(IS_COOLDOWN_FINISHED(reset_ignore_cooldown) && length(controller.blackboard[BB_FETCH_IGNORE_LIST]))
+		COOLDOWN_START(reset_ignore_cooldown, AI_FETCH_IGNORE_DURATION)
 		controller.blackboard[BB_FETCH_IGNORE_LIST] = list()
 
 	// if we were just ordered to heel, chill out for a bit
-	if(!IS_COOLDOWN_FINISHED(src, heel_cooldown))
+	if(!IS_COOLDOWN_FINISHED(heel_cooldown))
 		return
 
 	// if we're not already carrying something and we have a fetch target (and we're not already doing something with it), see if we can eat/equip it

--- a/code/datums/ai/dog/dog_subtrees.dm
+++ b/code/datums/ai/dog/dog_subtrees.dm
@@ -1,17 +1,17 @@
 /datum/ai_planning_subtree/dog
-	COOLDOWN_DECLARE(heel_cooldown)
-	COOLDOWN_DECLARE(reset_ignore_cooldown)
+	var/heel_cooldown
+	var/reset_ignore_cooldown
 
 /datum/ai_planning_subtree/dog/SelectBehaviors(datum/ai_controller/dog/controller, delta_time)
 	var/mob/living/living_pawn = controller.pawn
 
 	// occasionally reset our ignore list
-	if(COOLDOWN_FINISHED(src, reset_ignore_cooldown) && length(controller.blackboard[BB_FETCH_IGNORE_LIST]))
+	if(IS_COOLDOWN_FINISHED(src, reset_ignore_cooldown) && length(controller.blackboard[BB_FETCH_IGNORE_LIST]))
 		COOLDOWN_START(src, reset_ignore_cooldown, AI_FETCH_IGNORE_DURATION)
 		controller.blackboard[BB_FETCH_IGNORE_LIST] = list()
 
 	// if we were just ordered to heel, chill out for a bit
-	if(!COOLDOWN_FINISHED(src, heel_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, heel_cooldown))
 		return
 
 	// if we're not already carrying something and we have a fetch target (and we're not already doing something with it), see if we can eat/equip it

--- a/code/datums/components/aiming.dm
+++ b/code/datums/components/aiming.dm
@@ -30,9 +30,9 @@
 /datum/component/aiming/proc/aim(mob/user, mob/target)
 	if(QDELETED(user) || QDELETED(target)) // We lost the user or target somehow
 		return
-	if(!IS_COOLDOWN_FINISHED(src, aiming_cooldown) || src.target || user == target) // No double-aiming
+	if(!IS_COOLDOWN_FINISHED(aiming_cooldown) || src.target || user == target) // No double-aiming
 		return
-	COOLDOWN_START(src, aiming_cooldown, 5 SECONDS)
+	COOLDOWN_START(aiming_cooldown, 5 SECONDS)
 	src.user = user
 	src.target = target
 	user.visible_message("<span class='warning'>[user] points [parent] at [target]!</span>")
@@ -97,7 +97,7 @@ Methods to alert the aimer about events (Surrendering/equipping an item/dropping
 // Called when the target mob equips something
 /datum/component/aiming/proc/on_equip(mob/M, obj/item/I, slot)
 	SIGNAL_HANDLER
-	if(I != target.get_active_held_item() || !IS_COOLDOWN_FINISHED(src, notification_cooldown)) // Checks to make sure the item was actually equipped to the target's hands
+	if(I != target.get_active_held_item() || !IS_COOLDOWN_FINISHED(notification_cooldown)) // Checks to make sure the item was actually equipped to the target's hands
 		return
 	if(istype(I, /obj/item/gun))
 		target.balloon_alert(user, "[target] equipped a gun!")
@@ -105,7 +105,7 @@ Methods to alert the aimer about events (Surrendering/equipping an item/dropping
 		target.balloon_alert(user, "[target] equipped something!")
 	SEND_SOUND(user, 'sound/machines/chime.ogg')
 	new /obj/effect/temp_visual/aiming/suspect_alert(get_turf(target))
-	COOLDOWN_START(src, notification_cooldown, 5 SECONDS)
+	COOLDOWN_START(notification_cooldown, 5 SECONDS)
 
 // Called when the target mob drops something
 /datum/component/aiming/proc/on_drop(mob/M, obj/item/I, loc)
@@ -173,14 +173,14 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 		stop_aiming()
 		return
 	if(choice != CANCEL && choice != FIRE) // Handling voiceline cooldowns and mimes
-		if(!IS_COOLDOWN_FINISHED(src, voiceline_cooldown))
+		if(!IS_COOLDOWN_FINISHED(voiceline_cooldown))
 			to_chat(user, "<span class = 'warning'>You've already given a command recently!</span>")
 			show_ui(user, target, choice)
 			return
 		if(user.mind.assigned_role == "Mime")
 			user.visible_message("<span class='warning'>[user] waves [parent] around menacingly!</span>")
 			show_ui(user, target, choice)
-			COOLDOWN_START(src, voiceline_cooldown, 2 SECONDS)
+			COOLDOWN_START(voiceline_cooldown, 2 SECONDS)
 			return
 	switch(choice)
 		if(CANCEL) //first off, are they telling us to stop aiming?
@@ -196,7 +196,7 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 		if(DROP_TO_FLOOR)
 			user.say(pick("On the ground! Now!", "Lie down and place your hands behind your head!", "Get down on the ground!"), forced = "Weapon aiming")
 	aim_react(target)
-	COOLDOWN_START(src, voiceline_cooldown, 2 SECONDS)
+	COOLDOWN_START(voiceline_cooldown, 2 SECONDS)
 	show_ui(user, target, choice)
 
 /datum/component/aiming/proc/fire()

--- a/code/datums/components/aiming.dm
+++ b/code/datums/components/aiming.dm
@@ -17,9 +17,9 @@
 	var/obj/item/target_held = null
 	var/datum/radial_menu/persistent/choice_menu // Radial menu for the user
 	var/datum/radial_menu/persistent/choice_menu_target // Radial menu for the target
-	COOLDOWN_DECLARE(aiming_cooldown) // 5 second cooldown so you can't spam aiming for faster bullets
-	COOLDOWN_DECLARE(voiceline_cooldown) // 2 seconds, prevents spamming commands
-	COOLDOWN_DECLARE(notification_cooldown) // 5 seconds, prevents spamming the equip notification/sound
+	var/aiming_cooldown // 5 second cooldown so you can't spam aiming for faster bullets
+	var/voiceline_cooldown // 2 seconds, prevents spamming commands
+	var/notification_cooldown // 5 seconds, prevents spamming the equip notification/sound
 
 /datum/component/aiming/Initialize(source)
 	if(!istype(parent, /obj/item))
@@ -30,7 +30,7 @@
 /datum/component/aiming/proc/aim(mob/user, mob/target)
 	if(QDELETED(user) || QDELETED(target)) // We lost the user or target somehow
 		return
-	if(!COOLDOWN_FINISHED(src, aiming_cooldown) || src.target || user == target) // No double-aiming
+	if(!IS_COOLDOWN_FINISHED(src, aiming_cooldown) || src.target || user == target) // No double-aiming
 		return
 	COOLDOWN_START(src, aiming_cooldown, 5 SECONDS)
 	src.user = user
@@ -97,7 +97,7 @@ Methods to alert the aimer about events (Surrendering/equipping an item/dropping
 // Called when the target mob equips something
 /datum/component/aiming/proc/on_equip(mob/M, obj/item/I, slot)
 	SIGNAL_HANDLER
-	if(I != target.get_active_held_item() || !COOLDOWN_FINISHED(src, notification_cooldown)) // Checks to make sure the item was actually equipped to the target's hands
+	if(I != target.get_active_held_item() || !IS_COOLDOWN_FINISHED(src, notification_cooldown)) // Checks to make sure the item was actually equipped to the target's hands
 		return
 	if(istype(I, /obj/item/gun))
 		target.balloon_alert(user, "[target] equipped a gun!")
@@ -173,7 +173,7 @@ AIMING_DROP_WEAPON means they selected the "drop your weapon" command
 		stop_aiming()
 		return
 	if(choice != CANCEL && choice != FIRE) // Handling voiceline cooldowns and mimes
-		if(!COOLDOWN_FINISHED(src, voiceline_cooldown))
+		if(!IS_COOLDOWN_FINISHED(src, voiceline_cooldown))
 			to_chat(user, "<span class = 'warning'>You've already given a command recently!</span>")
 			show_ui(user, target, choice)
 			return

--- a/code/datums/components/beetlejuice.dm
+++ b/code/datums/components/beetlejuice.dm
@@ -45,8 +45,8 @@
 			occurrences++
 		R.next = 1
 
-		if(!first_heard[speaker] || (first_heard[speaker] + max_delay < world.time))
-			first_heard[speaker] = world.time
+		if(!first_heard[speaker] || IS_COOLDOWN_FINISHED(first_heard[speaker]))
+			COOLDOWN_START(first_heard[speaker], max_delay)
 			count[speaker] = 0
 		count[speaker] += occurrences
 		if(count[speaker] >= min_count)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -64,8 +64,8 @@
 
 		H.apply_damage(damage, BRUTE, picked_def_zone)
 
-		if(IS_COOLDOWN_FINISHED(src, caltrop_cooldown))
-			COOLDOWN_START(src, caltrop_cooldown, 1 SECONDS) //cooldown to avoid message spam.
+		if(IS_COOLDOWN_FINISHED(caltrop_cooldown))
+			COOLDOWN_START(caltrop_cooldown, 1 SECONDS) //cooldown to avoid message spam.
 			if(!H.incapacitated(ignore_restraints = TRUE))
 				H.visible_message("<span class='danger'>[H] steps on [A].</span>", \
 						"<span class='userdanger'>You step on [A]!</span>")

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -3,7 +3,7 @@
 	var/max_damage
 	var/probability
 	var/flags
-	COOLDOWN_DECLARE(caltrop_cooldown)
+	var/caltrop_cooldown
 	///given to connect_loc to listen for something moving over target
 	var/static/list/crossed_connections = list(
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
@@ -64,7 +64,7 @@
 
 		H.apply_damage(damage, BRUTE, picked_def_zone)
 
-		if(COOLDOWN_FINISHED(src, caltrop_cooldown))
+		if(IS_COOLDOWN_FINISHED(src, caltrop_cooldown))
 			COOLDOWN_START(src, caltrop_cooldown, 1 SECONDS) //cooldown to avoid message spam.
 			if(!H.incapacitated(ignore_restraints = TRUE))
 				H.visible_message("<span class='danger'>[H] steps on [A].</span>", \

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -413,7 +413,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	var/telethreshold = 15
 	var/burnheal = FALSE
 	var/turf/open/location_return = null
-	COOLDOWN_DECLARE(teleport_cooldown)
+	var/teleport_cooldown
 	threshold_desc = "<b>Resistance 6:</b> The disease acts on a smaller scale, resetting burnt tissue back to a state of health.<br>\
 					<b>Transmission 8:</b> The disease becomes more active, activating in a smaller temperature range."
 
@@ -442,7 +442,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 			if(burnheal)
 				M.heal_overall_damage(0, 1.5 * power) //no required_status checks here, this does all bodyparts equally
 
-			if(COOLDOWN_FINISHED(src, teleport_cooldown) && (M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT || M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT))
+			if(IS_COOLDOWN_FINISHED(src, teleport_cooldown) && (M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT || M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT))
 				location_return = get_turf(M)	//sets up return point
 				to_chat(M, "<span class='warning'>The lukewarm temperature makes you feel strange!</span>")
 				COOLDOWN_START(src, teleport_cooldown, (TELEPORT_COOLDOWN * 5) + (rand(1, 300) * 10))
@@ -459,7 +459,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 						M.adjust_fire_stacks(-10)
 					location_return = null
 					COOLDOWN_START(src, teleport_cooldown, TELEPORT_COOLDOWN)
-			if(COOLDOWN_FINISHED(src, teleport_cooldown))
+			if(IS_COOLDOWN_FINISHED(src, teleport_cooldown))
 				location_return = null
 		else
 			if(prob(7))
@@ -690,7 +690,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 				bloodpoints += 1
 			else
 				bloodpoints += max(0, grabbedblood)
-			for(var/I in 1 to power)//power doesnt increase efficiency, just usage. 
+			for(var/I in 1 to power)//power doesnt increase efficiency, just usage.
 				if(bloodpoints > 0)
 					if(ishuman(M))
 						var/mob/living/carbon/human/H = M
@@ -703,7 +703,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 					else if(bruteheal && M.getBruteLoss())
 						bloodpoints -= 1
 						M.heal_overall_damage(2, required_status = BODYTYPE_ORGANIC)
-					if(prob(60) && !M.stat) 
+					if(prob(60) && !M.stat)
 						bloodpoints -- //you cant just accumulate blood and keep it as a battery of healing. the quicker the symptom is, the faster your bloodpoints decay
 				else if(prob(20) && M.blood_volume >= BLOOD_VOLUME_BAD)//the virus continues to extract blood if you dont have any stored up. higher probability due to BP value
 					M.blood_volume = (M.blood_volume - 1)
@@ -716,7 +716,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	REMOVE_TRAIT(A.affected_mob, TRAIT_DRINKSBLOOD, DISEASE_TRAIT)
 	if(bloodtypearchive && ishuman(A.affected_mob))
 		var/mob/living/carbon/human/H = A.affected_mob
-		H.dna.blood_type = bloodtypearchive 
+		H.dna.blood_type = bloodtypearchive
 
 /datum/symptom/vampirism/proc/succ(mob/living/carbon/M) //you dont need the blood reagent to suck blood. however, you need to have blood, or at least a shared blood reagent, for most of the other uses
 	var/gainedpoints = 0
@@ -754,7 +754,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 						playsound(T, 'sound/effects/splat.ogg', 50, 1)
 						bloodpoints -= 2
 						return 0
-					else 
+					else
 						var/todir = get_dir(H, bloodbag)
 						var/targetloc = bloodbag.loc
 						var/dist = get_dist(H, bloodbag)
@@ -772,8 +772,8 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 								bloodpoints -= 2
 								bloodbag.visible_message("<span class='warning'>A current of blood pushes [bloodbag.name] towards [H.name]'s corpse!</span>")
 								playsound(bloodbag.loc, 'sound/magic/exit_blood.ogg', 25, 1)
-								return 0 
-			else 
+								return 0
+			else
 				var/list/candidates = list()
 				for(var/mob/living/carbon/human/C in ohearers(min(bloodpoints/4, possibledist), H))
 					if(NOBLOOD in C.dna.species.species_traits)
@@ -788,7 +788,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 						candidates[prospect] += (3 - get_dist(candidate, H)) * 2
 						candidates[prospect] += round(candidate.blood_volume / 150)
 				bloodbag = pickweight(candidates) //dont return here
-	
+
 	if(bloodpoints >= maxbloodpoints)
 		return 0
 	if(ishuman(M) && aggression) //first, try to suck those the host is actively grabbing
@@ -839,7 +839,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 			playsound(M.loc, 'sound/magic/exit_blood.ogg', 50, 1)
 			M.visible_message("<span class='warning'>Blood flows from the floor into [M.name]!</span>", "<span class='warning'>You consume the errant blood</span>")
 		return CLAMP(gainedpoints, 0, maxbloodpoints - bloodpoints)
-	if(ishuman(M) && aggression)//finally, attack mobs touching the host. 
+	if(ishuman(M) && aggression)//finally, attack mobs touching the host.
 		var/mob/living/carbon/human/H = M
 		for(var/mob/living/carbon/human/C in ohearers(1, H))
 			if(NOBLOOD in C.dna.species.species_traits)
@@ -892,7 +892,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 /datum/symptom/parasite/proc/isslimetarget(var/mob/living/carbon/M)
 	if(isslimeperson(M) || isluminescent(M) || isjellyperson(M) || isoozeling(M) || isstargazer(M))
 		return TRUE
-	else 
+	else
 		return FALSE
 
 /datum/symptom/parasite/Activate(datum/disease/advance/A)
@@ -900,7 +900,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 		return
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
-		if(1, 2)	
+		if(1, 2)
 			to_chat(M, "<span class='warning'>[pick("You feel something crawling in your veins!", "You feel an unpleasant throbbing.", "You hear something squishy in your ear.")]</span>")
 		if(3 to 5)
 			var/slowdown = 0
@@ -926,12 +926,12 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 			if(((M.getToxLoss() > (LAZYLEN(grubs) * (30/power))) || isslimetarget(M)) && prob(10 * power) && (LAZYLEN(grubs) < power * 2))
 				var/mob/living/simple_animal/hostile/redgrub/grub = new(src)// add new grubs if there's enough toxin for them
 				grub.food = 10
-				grubs += grub 
+				grubs += grub
 				grub.togglehibernation()
 				grub.grubdisease = list(A)
 			if(prob(LAZYLEN(grubs) * (6/power)))// so you know its working. power lowers this so it doesnt spam you at high grub counts
 				to_chat(M, "<span class='warning'>You feel something squirming inside of you!</span>")
-			M.add_movespeed_modifier(MOVESPEED_ID_GRUB_VIRUS_SLOWDOWN, override = TRUE, multiplicative_slowdown = max(slowdown - 0.5, 0)) 
+			M.add_movespeed_modifier(MOVESPEED_ID_GRUB_VIRUS_SLOWDOWN, override = TRUE, multiplicative_slowdown = max(slowdown - 0.5, 0))
 
 /datum/symptom/parasite/End(datum/disease/advance/A)
 	. = ..()
@@ -974,7 +974,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	prefixes = list("Gray ", "Amped ", "Nervous ")
 	var/clearcc = FALSE
 	threshold_desc = "<b>Resistance 8:</b>The virus causes an even greater rate of nutriment loss, able to cause starvation, but its energy gain greatly increases<br>\
-					<b>Stage Speed 8:</b>The virus causes extreme nervousness and paranoia, resulting in occasional hallucinations, and extreme restlessness, but greater overall energy and the ability to shake off stuns faster." 
+					<b>Stage Speed 8:</b>The virus causes extreme nervousness and paranoia, resulting in occasional hallucinations, and extreme restlessness, but greater overall energy and the ability to shake off stuns faster."
 
 /datum/symptom/jitters/severityset(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -442,14 +442,14 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 			if(burnheal)
 				M.heal_overall_damage(0, 1.5 * power) //no required_status checks here, this does all bodyparts equally
 
-			if(IS_COOLDOWN_FINISHED(src, teleport_cooldown) && (M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT || M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT))
+			if(IS_COOLDOWN_FINISHED(teleport_cooldown) && (M.bodytemperature < BODYTEMP_HEAT_DAMAGE_LIMIT || M.bodytemperature > BODYTEMP_COLD_DAMAGE_LIMIT))
 				location_return = get_turf(M)	//sets up return point
 				to_chat(M, "<span class='warning'>The lukewarm temperature makes you feel strange!</span>")
-				COOLDOWN_START(src, teleport_cooldown, (TELEPORT_COOLDOWN * 5) + (rand(1, 300) * 10))
+				COOLDOWN_START(teleport_cooldown, (TELEPORT_COOLDOWN * 5) + (rand(1, 300) * 10))
 			if(location_return)
 				if(location_return.z != M.loc.z)
 					location_return = null
-					COOLDOWN_RESET(src, teleport_cooldown)
+					COOLDOWN_RESET(teleport_cooldown)
 				else if(((M.bodytemperature > BODYTEMP_HEAT_DAMAGE_LIMIT + telethreshold  && !HAS_TRAIT(M, TRAIT_RESISTHEAT)) || (M.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT - telethreshold  && !HAS_TRAIT(M, TRAIT_RESISTCOLD)) || (burnheal && M.getFireLoss() > 60 + telethreshold)))
 					do_sparks(5, FALSE, M)
 					to_chat(M, "<span class='userdanger'>The change in temperature shocks you back to a previous spatial state!</span>")
@@ -458,8 +458,8 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 					if(burnheal)
 						M.adjust_fire_stacks(-10)
 					location_return = null
-					COOLDOWN_START(src, teleport_cooldown, TELEPORT_COOLDOWN)
-			if(IS_COOLDOWN_FINISHED(src, teleport_cooldown))
+					COOLDOWN_START(teleport_cooldown, TELEPORT_COOLDOWN)
+			if(IS_COOLDOWN_FINISHED(teleport_cooldown))
 				location_return = null
 		else
 			if(prob(7))

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -9,14 +9,14 @@
 	show_in_report = TRUE
 	report_message = "Your station has won the grand prize of the annual station charity event. Free snacks will be delivered to the bar every now and then."
 	trait_processes = TRUE
-	COOLDOWN_DECLARE(party_cooldown)
+	var/party_cooldown
 
 /datum/station_trait/lucky_winner/on_round_start()
 	. = ..()
 	COOLDOWN_START(src, party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))
 
 /datum/station_trait/lucky_winner/process(delta_time)
-	if(!COOLDOWN_FINISHED(src, party_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, party_cooldown))
 		return
 
 	COOLDOWN_START(src, party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -13,13 +13,13 @@
 
 /datum/station_trait/lucky_winner/on_round_start()
 	. = ..()
-	COOLDOWN_START(src, party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))
+	COOLDOWN_START(party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))
 
 /datum/station_trait/lucky_winner/process(delta_time)
-	if(!IS_COOLDOWN_FINISHED(src, party_cooldown))
+	if(!IS_COOLDOWN_FINISHED(party_cooldown))
 		return
 
-	COOLDOWN_START(src, party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))
+	COOLDOWN_START(party_cooldown, rand(PARTY_COOLDOWN_LENGTH_MIN, PARTY_COOLDOWN_LENGTH_MAX))
 
 	var/area/area_to_spawn_in = pick(GLOB.bar_areas)
 	var/turf/T = get_safe_random_station_turfs(area_to_spawn_in)

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -26,7 +26,7 @@
 		LAZYADD(owner.status_effects, src)
 	if(duration != -1)
 		duration = world.time + duration
-	tick_interval = world.time + tick_interval
+	COOLDOWN_START(tick_interval, tick_interval)
 	if(alert_type)
 		var/atom/movable/screen/alert/status_effect/A = owner.throw_alert(id, alert_type)
 		A.attached_effect = src //so the alert can reference us, if it needs to
@@ -49,9 +49,9 @@
 	if(!owner)
 		qdel(src)
 		return
-	if(tick_interval < world.time)
+	if(IS_COOLDOWN_FINISHED(tick_interval))
 		tick()
-		tick_interval = world.time + initial(tick_interval)
+		START_COOLDOWN(tick_interval, initial(tick_interval))
 	if(duration != -1 && duration < world.time)
 		qdel(src)
 

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -51,7 +51,7 @@
 		return
 	if(IS_COOLDOWN_FINISHED(tick_interval))
 		tick()
-		START_COOLDOWN(tick_interval, initial(tick_interval))
+		COOLDOWN_START(tick_interval, initial(tick_interval))
 	if(duration != -1 && duration < world.time)
 		qdel(src)
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -340,6 +340,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/proc/ModifyFiredoors(opening)
 	if(firedoors)
 		firedoors_last_closed_on = world.time
+		COOLDOWN_START(firedoors_last_closed_on, 10 SECONDS)
 		for(var/FD in firedoors)
 			var/obj/machinery/door/firedoor/D = FD
 			var/cont = !D.welded
@@ -433,7 +434,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   * If 100 ticks has elapsed, toggle all the firedoors closed again
   */
 /area/process()
-	if(firedoors_last_closed_on + 100 < world.time)	//every 10 seconds
+	if(IS_COOLDOWN_FINISHED(firedoors_last_closed_on))	//every 10 seconds
 		ModifyFiredoors(FALSE)
 
 /**

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -24,7 +24,7 @@
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute(population)
 	. = ..()
-	COOLDOWN_START(src, autotraitor_cooldown_check, autotraitor_cooldown)
+	COOLDOWN_START(autotraitor_cooldown_check, autotraitor_cooldown)
 	var/num_traitors = get_antag_cap(population) * (scaled_times + 1)
 	for (var/i = 1 to num_traitors)
 		var/mob/M = pick_n_take(candidates)
@@ -34,8 +34,8 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/traitor/rule_process()
-	if (IS_COOLDOWN_FINISHED(src, autotraitor_cooldown_check))
-		COOLDOWN_START(src, autotraitor_cooldown_check, autotraitor_cooldown)
+	if (IS_COOLDOWN_FINISHED(autotraitor_cooldown_check))
+		COOLDOWN_START(autotraitor_cooldown_check, autotraitor_cooldown)
 		log_game("DYNAMIC: Checking if we can turn someone into a traitor.")
 		mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -20,7 +20,7 @@
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	antag_cap = list("denominator" = 24)
 	var/autotraitor_cooldown = (15 MINUTES)
-	COOLDOWN_DECLARE(autotraitor_cooldown_check)
+	var/autotraitor_cooldown_check
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute(population)
 	. = ..()
@@ -34,7 +34,7 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/traitor/rule_process()
-	if (COOLDOWN_FINISHED(src, autotraitor_cooldown_check))
+	if (IS_COOLDOWN_FINISHED(src, autotraitor_cooldown_check))
 		COOLDOWN_START(src, autotraitor_cooldown_check, autotraitor_cooldown)
 		log_game("DYNAMIC: Checking if we can turn someone into a traitor.")
 		mode.picking_specific_rule(/datum/dynamic_ruleset/midround/autotraitor)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -165,7 +165,7 @@
 		if ("messageAssociates")
 			if (!authenticated_as_non_silicon_captain(usr))
 				return
-			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
+			if (!IS_COOLDOWN_FINISHED(src, important_action_cooldown))
 				return
 
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
@@ -221,7 +221,7 @@
 		if ("requestNukeCodes")
 			if (!authenticated_as_non_silicon_captain(usr))
 				return
-			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
+			if (!IS_COOLDOWN_FINISHED(src, important_action_cooldown))
 				return
 			var/reason = trim(html_encode(params["reason"]), MAX_MESSAGE_LEN)
 			nuke_request(reason, usr)
@@ -245,7 +245,7 @@
 				return
 			if (!can_send_messages_to_other_sectors(usr))
 				return
-			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
+			if (!IS_COOLDOWN_FINISHED(src, important_action_cooldown))
 				return
 
 			var/message = trim(html_encode(params["message"]), MAX_MESSAGE_LEN)
@@ -360,7 +360,7 @@
 		data["canSendToSectors"] = FALSE
 		data["canSetAlertLevel"] = FALSE
 		data["canToggleEmergencyAccess"] = FALSE
-		data["importantActionReady"] = COOLDOWN_FINISHED(src, important_action_cooldown)
+		data["importantActionReady"] = IS_COOLDOWN_FINISHED(src, important_action_cooldown)
 		data["shuttleCalled"] = FALSE
 		data["shuttleLastCalled"] = FALSE
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -19,7 +19,7 @@
 	var/authenticated = 0
 
 	/// Cooldown for important actions, such as messaging CentCom or other sectors
-	COOLDOWN_DECLARE(static/important_action_cooldown)
+	var/static/important_action_cooldown
 
 	/// The current state of the UI
 	var/state = STATE_MESSAGES
@@ -165,7 +165,7 @@
 		if ("messageAssociates")
 			if (!authenticated_as_non_silicon_captain(usr))
 				return
-			if (!IS_COOLDOWN_FINISHED(src, important_action_cooldown))
+			if (!IS_COOLDOWN_FINISHED(important_action_cooldown))
 				return
 
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
@@ -182,7 +182,7 @@
 			var/associates = emagged ? "the Syndicate": "CentCom"
 			usr.log_talk(message, LOG_SAY, tag = "message to [associates]")
 			deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.real_name]</span> has messaged [associates], \"[message]\" at <span class='name'>[get_area_name(usr, TRUE)]</span>.</span>", usr)
-			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
+			COOLDOWN_START(important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 			. = TRUE
 		if ("purchaseShuttle")
 			var/can_buy_shuttles_or_fail_reason = can_buy_shuttles(usr)
@@ -221,7 +221,7 @@
 		if ("requestNukeCodes")
 			if (!authenticated_as_non_silicon_captain(usr))
 				return
-			if (!IS_COOLDOWN_FINISHED(src, important_action_cooldown))
+			if (!IS_COOLDOWN_FINISHED(important_action_cooldown))
 				return
 			var/reason = trim(html_encode(params["reason"]), MAX_MESSAGE_LEN)
 			nuke_request(reason, usr)
@@ -229,7 +229,7 @@
 			usr.log_message("has requested the nuclear codes from CentCom with reason \"[reason]\"", LOG_SAY)
 			priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self-Destruct Codes Requested", SSstation.announcer.get_rand_report_sound())
 			playsound(src, 'sound/machines/terminal_prompt.ogg', 50, FALSE)
-			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
+			COOLDOWN_START(important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 			. = TRUE
 		if ("restoreBackupRoutingData")
 			if (!authenticated_as_non_silicon_captain(usr))
@@ -245,7 +245,7 @@
 				return
 			if (!can_send_messages_to_other_sectors(usr))
 				return
-			if (!IS_COOLDOWN_FINISHED(src, important_action_cooldown))
+			if (!IS_COOLDOWN_FINISHED(important_action_cooldown))
 				return
 
 			var/message = trim(html_encode(params["message"]), MAX_MESSAGE_LEN)
@@ -260,7 +260,7 @@
 			message_admins("[ADMIN_LOOKUPFLW(usr)] has sent a message to the other server.")
 			deadchat_broadcast("<span class='deadsay bold'>[usr.real_name] has sent an outgoing message to the other station(s).</span>", usr)
 
-			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
+			COOLDOWN_START(important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 			. = TRUE
 		if ("setState")
 			if (!authenticated(usr))
@@ -360,7 +360,7 @@
 		data["canSendToSectors"] = FALSE
 		data["canSetAlertLevel"] = FALSE
 		data["canToggleEmergencyAccess"] = FALSE
-		data["importantActionReady"] = IS_COOLDOWN_FINISHED(src, important_action_cooldown)
+		data["importantActionReady"] = IS_COOLDOWN_FINISHED(important_action_cooldown)
 		data["shuttleCalled"] = FALSE
 		data["shuttleLastCalled"] = FALSE
 
@@ -530,7 +530,7 @@
 /// Override the cooldown for special actions
 /// Used in places such as CentCom messaging back so that the crew can answer right away
 /obj/machinery/computer/communications/proc/override_cooldown()
-	COOLDOWN_RESET(src, important_action_cooldown)
+	COOLDOWN_RESET(important_action_cooldown)
 
 /obj/machinery/computer/communications/proc/add_message(datum/comm_message/new_message)
 	LAZYADD(messages, new_message)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -73,7 +73,7 @@
 	var/obj/machinery/door/airlock/closeOther
 	var/justzap = FALSE
 	var/obj/item/electronics/airlock/electronics
-	COOLDOWN_DECLARE(shockCooldown) //Prevents multiple shocks from happening
+	var/shockCooldown //Prevents multiple shocks from happening
 	var/obj/item/doorCharge/charge //If applied, causes an explosion upon opening the door
 	var/obj/item/note //Any papers pinned to the airlock
 	var/detonated = FALSE
@@ -519,7 +519,7 @@
 /obj/machinery/door/airlock/proc/shock(mob/user, prb)
 	if(!hasPower())		// unpowered, no shock
 		return FALSE
-	if(!COOLDOWN_FINISHED(src, shockCooldown))
+	if(!IS_COOLDOWN_FINISHED(src, shockCooldown))
 		return FALSE	//Already shocked someone recently?
 	if(!prob(prb))
 		return FALSE //you lucked out, no shock for you

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -519,14 +519,14 @@
 /obj/machinery/door/airlock/proc/shock(mob/user, prb)
 	if(!hasPower())		// unpowered, no shock
 		return FALSE
-	if(!IS_COOLDOWN_FINISHED(src, shockCooldown))
+	if(!IS_COOLDOWN_FINISHED(shockCooldown))
 		return FALSE	//Already shocked someone recently?
 	if(!prob(prb))
 		return FALSE //you lucked out, no shock for you
 	do_sparks(5, TRUE, src)
 	var/check_range = TRUE
 	if(electrocute_mob(user, get_area(src), src, 1, check_range))
-		COOLDOWN_START(src, shockCooldown, 1 SECONDS)
+		COOLDOWN_START(shockCooldown, 1 SECONDS)
 		return TRUE
 	else
 		return FALSE

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -5,11 +5,11 @@
 	icon_state = "implant"
 	activated = 1
 	var/obj/machinery/abductor/pad/home
-	COOLDOWN_DECLARE(abductor_implant_cooldown)
+	var/abductor_implant_cooldown
 
 /obj/item/implant/abductor/activate()
 	. = ..()
-	if(!COOLDOWN_FINISHED(src, abductor_implant_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, abductor_implant_cooldown))
 		to_chat(imp_in, "<span class='warning'>You must wait [COOLDOWN_TIMELEFT(src, abductor_implant_cooldown)*0.1] seconds to use [src] again!</span>")
 		return
 

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -9,12 +9,12 @@
 
 /obj/item/implant/abductor/activate()
 	. = ..()
-	if(!IS_COOLDOWN_FINISHED(src, abductor_implant_cooldown))
-		to_chat(imp_in, "<span class='warning'>You must wait [COOLDOWN_TIMELEFT(src, abductor_implant_cooldown)*0.1] seconds to use [src] again!</span>")
+	if(!IS_COOLDOWN_FINISHED(abductor_implant_cooldown))
+		to_chat(imp_in, "<span class='warning'>You must wait [COOLDOWN_TIMELEFT(abductor_implant_cooldown)*0.1] seconds to use [src] again!</span>")
 		return
 
 	home.Retrieve(imp_in,1)
-	COOLDOWN_START(src, abductor_implant_cooldown, 60 SECONDS)
+	COOLDOWN_START(abductor_implant_cooldown, 60 SECONDS)
 
 /obj/item/implant/abductor/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	if(..())

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -273,10 +273,10 @@
 		if(R.total_volume < 100)
 			to_chat(user, "<span class='warning'>You need at least 100 units of water to use the resin launcher!</span>")
 			return
-		if(!IS_COOLDOWN_FINISHED(src, resin_cooldown))
+		if(!IS_COOLDOWN_FINISHED(resin_cooldown))
 			to_chat(user, "<span class='warning'>Resin launcher is still recharging...</span>")
 			return
-		COOLDOWN_START(src, resin_cooldown, 10 SECONDS)
+		COOLDOWN_START(resin_cooldown, 10 SECONDS)
 		R.remove_any(100)
 		var/obj/effect/resin_container/resin = new (get_turf(src))
 		log_game("[key_name(user)] used Resin Launcher at [AREACOORD(user)].")

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -218,7 +218,7 @@
 	var/obj/item/watertank/tank
 	var/nozzle_mode = 0
 	var/metal_synthesis_cooldown = 0
-	COOLDOWN_DECLARE(resin_cooldown)
+	var/resin_cooldown
 
 /obj/item/extinguisher/mini/nozzle/Initialize(mapload)
 	. = ..()
@@ -273,7 +273,7 @@
 		if(R.total_volume < 100)
 			to_chat(user, "<span class='warning'>You need at least 100 units of water to use the resin launcher!</span>")
 			return
-		if(!COOLDOWN_FINISHED(src, resin_cooldown))
+		if(!IS_COOLDOWN_FINISHED(src, resin_cooldown))
 			to_chat(user, "<span class='warning'>Resin launcher is still recharging...</span>")
 			return
 		COOLDOWN_START(src, resin_cooldown, 10 SECONDS)

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -114,10 +114,10 @@
 	armour_penetration = 12
 	attack_verb = list("attacked", "slashed", "cut", "torn", "gored")
 	clockwork_hint = "Targets will be struck with a powerful electromagnetic pulse while on Reebe."
-	COOLDOWN_DECLARE(emp_cooldown)
+	var/emp_cooldown
 
 /obj/item/clockwork/weapon/brass_sword/hit_effect(mob/living/target, mob/living/user, thrown)
-	if(!COOLDOWN_FINISHED(src, emp_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, emp_cooldown))
 		return
 	COOLDOWN_START(src, emp_cooldown, 30 SECONDS)
 
@@ -131,7 +131,7 @@
 	..()
 	if(!(istype(O, /obj/mecha) && is_reebe(user.z)))
 		return
-	if(!COOLDOWN_FINISHED(src, emp_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, emp_cooldown))
 		return
 	COOLDOWN_START(src, emp_cooldown, 20 SECONDS)
 

--- a/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
+++ b/code/modules/antagonists/clock_cult/items/clockwork_weapon.dm
@@ -117,9 +117,9 @@
 	var/emp_cooldown
 
 /obj/item/clockwork/weapon/brass_sword/hit_effect(mob/living/target, mob/living/user, thrown)
-	if(!IS_COOLDOWN_FINISHED(src, emp_cooldown))
+	if(!IS_COOLDOWN_FINISHED(emp_cooldown))
 		return
-	COOLDOWN_START(src, emp_cooldown, 30 SECONDS)
+	COOLDOWN_START(emp_cooldown, 30 SECONDS)
 
 	target.emp_act(EMP_LIGHT)
 	new /obj/effect/temp_visual/emp/pulse(target.loc)
@@ -131,9 +131,9 @@
 	..()
 	if(!(istype(O, /obj/mecha) && is_reebe(user.z)))
 		return
-	if(!IS_COOLDOWN_FINISHED(src, emp_cooldown))
+	if(!IS_COOLDOWN_FINISHED(emp_cooldown))
 		return
-	COOLDOWN_START(src, emp_cooldown, 20 SECONDS)
+	COOLDOWN_START(emp_cooldown, 20 SECONDS)
 
 	var/obj/mecha/target = O
 	target.emp_act(EMP_HEAVY)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -36,7 +36,7 @@
 	var/proper_bomb = TRUE //Please
 	var/obj/effect/countdown/nuclearbomb/countdown
 	var/sound/countdown_music = null
-	COOLDOWN_DECLARE(arm_cooldown)
+	var/arm_cooldown
 
 /obj/machinery/nuclearbomb/Initialize(mapload)
 	. = ..()
@@ -400,7 +400,7 @@
 				playsound(src, 'sound/machines/nuke/angry_beep.ogg', 50, FALSE)
 		if("arm")
 			if(auth && yes_code && !safety && !exploded)
-				if(!COOLDOWN_FINISHED(src, arm_cooldown))
+				if(!COOLDOWN_FINISHED(arm_cooldown))
 					return
 				playsound(src, 'sound/machines/nuke/confirm_beep.ogg', 50, FALSE)
 				set_active()
@@ -463,7 +463,7 @@
 			S.switch_mode_to(initial(S.mode))
 			S.alert = FALSE
 		countdown.stop()
-	COOLDOWN_START(src, arm_cooldown, ARM_ACTION_COOLDOWN)
+	COOLDOWN_START(arm_cooldown, ARM_ACTION_COOLDOWN)
 	update_icon()
 
 /obj/machinery/nuclearbomb/proc/get_time_left()
@@ -657,7 +657,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	var/last_disk_move
 	var/process_tick = 0
 	investigate_flags = ADMIN_INVESTIGATE_TARGET
-	COOLDOWN_DECLARE(weight_increase_cooldown)
+	var/weight_increase_cooldown
 
 /obj/item/disk/nuclear/Initialize(mapload)
 	. = ..()
@@ -689,11 +689,11 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 
-		if(COOLDOWN_FINISHED(src, weight_increase_cooldown) && last_disk_move < world.time - (5 MINUTES) && world.time > (30 MINUTES))
+		if(COOLDOWN_FINISHED(weight_increase_cooldown) && last_disk_move < world.time - (5 MINUTES) && world.time > (30 MINUTES))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 5
-				COOLDOWN_START(src, weight_increase_cooldown, (5 MINUTES))
+				COOLDOWN_START(weight_increase_cooldown, (5 MINUTES))
 				message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 				if(disk_comfort_level >= 2 && (process_tick % 30) == 0)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -400,7 +400,7 @@
 				playsound(src, 'sound/machines/nuke/angry_beep.ogg', 50, FALSE)
 		if("arm")
 			if(auth && yes_code && !safety && !exploded)
-				if(!COOLDOWN_FINISHED(arm_cooldown))
+				if(!IS_COOLDOWN_FINISHED(arm_cooldown))
 					return
 				playsound(src, 'sound/machines/nuke/confirm_beep.ogg', 50, FALSE)
 				set_active()
@@ -689,7 +689,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 			if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 				disk_comfort_level++
 
-		if(COOLDOWN_FINISHED(weight_increase_cooldown) && last_disk_move < world.time - (5 MINUTES) && world.time > (30 MINUTES))
+		if(IS_COOLDOWN_FINISHED(weight_increase_cooldown) && last_disk_move < world.time - (5 MINUTES) && world.time > (30 MINUTES))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 5

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -156,7 +156,7 @@
 
 
 		if("express_add")//Generate Supply Order first
-			if(!COOLDOWN_FINISHED(src, order_cooldown))
+			if(!IS_COOLDOWN_FINISHED(src, order_cooldown))
 				return
 			if(usingBeacon && !(beacon && (isturf(beacon.loc) || ismob(beacon.loc))))
 				return

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -156,7 +156,7 @@
 
 
 		if("express_add")//Generate Supply Order first
-			if(!IS_COOLDOWN_FINISHED(src, order_cooldown))
+			if(!IS_COOLDOWN_FINISHED(order_cooldown))
 				return
 			if(usingBeacon && !(beacon && (isturf(beacon.loc) || ismob(beacon.loc))))
 				return
@@ -201,7 +201,7 @@
 							LZ = pick(empty_turfs)
 					if (SO.pack.get_cost() <= points_to_check && LZ)//we need to call the cost check again because of the CHECK_TICK call
 						new /obj/effect/pod_landingzone(LZ, podType, SO)
-						COOLDOWN_START(src, order_cooldown, ORDER_COOLDOWN)
+						COOLDOWN_START(order_cooldown, ORDER_COOLDOWN)
 						D.adjust_money(-SO.pack.get_cost())
 						. = TRUE
 						update_icon()
@@ -221,7 +221,7 @@
 							var/LZ = pick(empty_turfs)
 							LAZYREMOVE(empty_turfs, LZ)
 							new /obj/effect/pod_landingzone(LZ, podType, SO)
-							COOLDOWN_START(src, order_cooldown, ORDER_COOLDOWN/2)
+							COOLDOWN_START(order_cooldown, ORDER_COOLDOWN/2)
 							. = TRUE
 							update_icon()
 							CHECK_TICK

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -180,7 +180,7 @@
 				say("The supply shuttle has been loaned to CentCom.")
 				. = TRUE
 		if("add")
-			if(!IS_COOLDOWN_FINISHED(src, order_cooldown))
+			if(!IS_COOLDOWN_FINISHED(order_cooldown))
 				return
 			var/id = text2path(params["id"])
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -19,7 +19,7 @@
 	var/obj/item/radio/headset/radio
 	/// var that tracks message cooldown
 	var/message_cooldown
-	COOLDOWN_DECLARE(order_cooldown)
+	var/order_cooldown
 
 	light_color = "#E2853D"//orange
 
@@ -180,7 +180,7 @@
 				say("The supply shuttle has been loaned to CentCom.")
 				. = TRUE
 		if("add")
-			if(!COOLDOWN_FINISHED(src, order_cooldown))
+			if(!IS_COOLDOWN_FINISHED(src, order_cooldown))
 				return
 			var/id = text2path(params["id"])
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -22,7 +22,7 @@
 	/// How many messages sent in the last 10 seconds
 	var/total_message_count = 0
 	/// Next tick to reset the total message counter
-	COOLDOWN_DECLARE(total_count_reset)
+	var/total_count_reset
 	var/externalreplyamount = 0
 	var/cryo_warned = -3000//when was the last time we warned them about not cryoing without an ahelp, set to -5 minutes so that rounstart cryo still warns
 	var/staff_check_rate = 0 //when was the last time they checked online staff

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -152,9 +152,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(!(CONFIG_GET(flag/automute_on)))
 		return FALSE
 
-	if(IS_COOLDOWN_FINISHED(src, total_count_reset))
+	if(IS_COOLDOWN_FINISHED(total_count_reset))
 		total_message_count = 0 //reset the count if it's been more than 5 seconds since the first message
-		COOLDOWN_START(src, total_count_reset, 5 SECONDS) //inside this if so we don't reset it every single message
+		COOLDOWN_START(total_count_reset, 5 SECONDS) //inside this if so we don't reset it every single message
 
 	total_message_count++
 

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(!(CONFIG_GET(flag/automute_on)))
 		return FALSE
 
-	if(COOLDOWN_FINISHED(src, total_count_reset))
+	if(IS_COOLDOWN_FINISHED(src, total_count_reset))
 		total_message_count = 0 //reset the count if it's been more than 5 seconds since the first message
 		COOLDOWN_START(src, total_count_reset, 5 SECONDS) //inside this if so we don't reset it every single message
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -111,7 +111,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		else
 			linked.power_usage = list(AREA_USAGE_LEN)
 
-	COOLDOWN_START(src, holodeck_cooldown, HOLODECK_CD)
+	COOLDOWN_START(holodeck_cooldown, HOLODECK_CD)
 	generate_program_list()
 	load_program(offline_program,TRUE)
 
@@ -193,7 +193,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		map_id = offline_program
 		force = TRUE
 
-	if (!force && (!IS_COOLDOWN_FINISHED(src, holodeck_cooldown) || spawning_simulation))
+	if (!force && (!IS_COOLDOWN_FINISHED(holodeck_cooldown) || spawning_simulation))
 		say("ERROR. Recalibrating projection apparatus.")
 		return
 
@@ -201,7 +201,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		return
 
 	if (add_delay)
-		COOLDOWN_START(src, holodeck_cooldown, (damaged ? HOLODECK_CD + HOLODECK_DMG_CD : HOLODECK_CD))
+		COOLDOWN_START(holodeck_cooldown, (damaged ? HOLODECK_CD + HOLODECK_DMG_CD : HOLODECK_CD))
 		if (damaged && floorcheck())
 			damaged = FALSE
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -77,7 +77,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 	var/damaged = FALSE
 
 	//creates the timer that determines if another program can be manually loaded
-	COOLDOWN_DECLARE(holodeck_cooldown)
+	var/holodeck_cooldown
 
 /obj/machinery/computer/holodeck/Initialize(mapload)
 	..()
@@ -193,7 +193,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 		map_id = offline_program
 		force = TRUE
 
-	if (!force && (!COOLDOWN_FINISHED(src, holodeck_cooldown) || spawning_simulation))
+	if (!force && (!IS_COOLDOWN_FINISHED(src, holodeck_cooldown) || spawning_simulation))
 		say("ERROR. Recalibrating projection apparatus.")
 		return
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -289,7 +289,7 @@
 		return
 
 	if(wisp.loc == src)
-		if(COOLDOWN_FINISHED(wisp,wisp_tired))
+		if(IS_COOLDOWN_FINISHED(wisp,wisp_tired))
 			to_chat(user, "<span class='notice'>You release the wisp. It begins to bob around your head.</span>")
 			icon_state = "lantern"
 			wisp.orbit(user, 20)
@@ -333,7 +333,7 @@
 	var/obj/item/wisp_lantern/home
 	var/sight_flags = SEE_MOBS
 	var/lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-	COOLDOWN_DECLARE(wisp_tired)
+	var/wisp_tired
 	var/time
 
 /obj/effect/wisp/orbit(atom/thing, radius, clockwise, rotation_speed, rotation_segments, pre_rotation, lockinorbit)
@@ -1217,7 +1217,7 @@
 
 /obj/item/hierophant_club/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(user.mind.martial_art.no_guns) 
+	if(user.mind.martial_art.no_guns)
 		to_chat(user, "<span class='warning'>To use this weapon would bring dishonor to the clan.</span>")
 		return
 	var/turf/T = get_turf(target)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -289,7 +289,7 @@
 		return
 
 	if(wisp.loc == src)
-		if(IS_COOLDOWN_FINISHED(wisp,wisp_tired))
+		if(IS_COOLDOWN_FINISHED(wisp.wisp_tired))
 			to_chat(user, "<span class='notice'>You release the wisp. It begins to bob around your head.</span>")
 			icon_state = "lantern"
 			wisp.orbit(user, 20)
@@ -367,7 +367,7 @@
 	. = ..()
 	if(home)
 		src.forceMove(home)
-		COOLDOWN_START(src,wisp_tired, 5 MINUTES)
+		COOLDOWN_START(wisp_tired, 5 MINUTES)
 		home.icon_state = "lantern-blue"
 		set_light_on(FALSE)
 	else

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -61,7 +61,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	var/deadchat_name
 	var/datum/orbit_menu/orbit_menu
 	var/static/cooldown_time
-	COOLDOWN_DECLARE(creation_time)
+	var/creation_time
 
 
 /mob/dead/observer/Initialize(mapload)
@@ -154,7 +154,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 	if(!cooldown_time) //so we only need to grab the config for this once.
 		cooldown_time = CONFIG_GET(number/cooldown_antag_time) MINUTES
-	COOLDOWN_START(src, creation_time , cooldown_time)
+	COOLDOWN_START(creation_time, cooldown_time)
 
 	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE)
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -32,7 +32,7 @@
 	if((mobility_flags & (MOBILITY_MOVE | MOBILITY_STAND)) != (MOBILITY_MOVE | MOBILITY_STAND) || leaping)
 		return
 
-	if(!(IS_COOLDOWN_FINISHED(src, pounce_cooldown)))
+	if(!(IS_COOLDOWN_FINISHED(pounce_cooldown)))
 		to_chat(src, "<span class='alertalien'>You are too fatigued to pounce right now!</span>")
 		return
 
@@ -57,7 +57,7 @@
 	if(!leaping)
 		return ..()
 
-	COOLDOWN_START(src, pounce_cooldown, 30)
+	COOLDOWN_START(pounce_cooldown, 30)
 	if(hit_atom)
 		if(isliving(hit_atom))
 			var/mob/living/L = hit_atom

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -32,7 +32,7 @@
 	if((mobility_flags & (MOBILITY_MOVE | MOBILITY_STAND)) != (MOBILITY_MOVE | MOBILITY_STAND) || leaping)
 		return
 
-	if(!(COOLDOWN_FINISHED(src, pounce_cooldown)))
+	if(!(IS_COOLDOWN_FINISHED(src, pounce_cooldown)))
 		to_chat(src, "<span class='alertalien'>You are too fatigued to pounce right now!</span>")
 		return
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -12,7 +12,7 @@
 	var/caste = ""
 	var/alt_icon = 'icons/mob/alienleap.dmi' //used to switch between the two alien icon files.
 	var/leap_on_click = FALSE
-	COOLDOWN_DECLARE(pounce_cooldown)
+	var/pounce_cooldown
 	var/custom_pixel_x_offset = 0 //for admin fuckery.
 	var/custom_pixel_y_offset = 0
 	var/sneaking = FALSE //For sneaky-sneaky mode and appropriate slowdown

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -236,12 +236,12 @@ GLOBAL_VAR(medibot_unique_id_gen)
 
 	if(assess_patient(H))
 		last_found = world.time
-		if((last_newpatient_speak + 300) < world.time) //Don't spam these messages!
+		if(IS_COOLDOWN_FINISHED(last_newpatient_speak)) //Don't spam these messages!
 			var/list/messagevoice = list("Hey, [H.name]! Hold on, I'm coming." = 'sound/voice/medbot/coming.ogg',"Wait [H.name]! I want to help!" = 'sound/voice/medbot/help.ogg',"[H.name], you appear to be injured!" = 'sound/voice/medbot/injured.ogg')
 			var/message = pick(messagevoice)
 			speak(message)
 			playsound(src, messagevoice[message], 50, 0)
-			last_newpatient_speak = world.time
+			COOLDOWN_START(last_newpatient_speak, 30 SECONDS)
 		return H
 	else
 		return

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -130,11 +130,11 @@
 /mob/living/simple_animal/hostile/carp/megacarp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
 	if(.)
-		regen_cooldown = world.time + REGENERATION_DELAY
+		COOLDOWN_START(regen_cooldown, REGENERATION_DELAY)
 
 /mob/living/simple_animal/hostile/carp/megacarp/Life()
 	. = ..()
-	if(regen_cooldown < world.time)
+	if(IS_COOLDOWN_FINISHED(regen_cooldown))
 		heal_overall_damage(4)
 
 /mob/living/simple_animal/hostile/carp/cayenne

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -180,7 +180,7 @@ Difficulty: Hard
 
 	if(IS_COOLDOWN_FINISHED(chaser_cooldown)) //if chasers are off cooldown, fire some!
 		var/obj/effect/temp_visual/hierophant/chaser/C = new /obj/effect/temp_visual/hierophant/chaser(loc, src, target, chaser_speed, FALSE)
-		START_COOLDOWN(chaser_cooldown, initial(chaser_cooldown))
+		COOLDOWN_START(chaser_cooldown, initial(chaser_cooldown))
 		if((prob(anger_modifier) || target.Adjacent(src)) && target != src)
 			var/obj/effect/temp_visual/hierophant/chaser/OC = new(loc, src, target, chaser_speed * 1.5, FALSE)
 			OC.moving = 4

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -163,7 +163,7 @@ Difficulty: Hard
 			possibilities += "cross_blast_spam"
 		if(get_dist(src, target) > 2)
 			possibilities += "blink_spam"
-		if(chaser_cooldown < world.time)
+		if(IS_COOLDOWN_FINISHED(chaser_cooldown))
 			if(prob(anger_modifier * 2))
 				possibilities = list("chaser_swarm")
 			else
@@ -178,9 +178,9 @@ Difficulty: Hard
 					chaser_swarm(blink_counter, target_slowness, cross_counter)
 			return
 
-	if(chaser_cooldown < world.time) //if chasers are off cooldown, fire some!
+	if(IS_COOLDOWN_FINISHED(chaser_cooldown)) //if chasers are off cooldown, fire some!
 		var/obj/effect/temp_visual/hierophant/chaser/C = new /obj/effect/temp_visual/hierophant/chaser(loc, src, target, chaser_speed, FALSE)
-		chaser_cooldown = world.time + initial(chaser_cooldown)
+		START_COOLDOWN(chaser_cooldown, initial(chaser_cooldown))
 		if((prob(anger_modifier) || target.Adjacent(src)) && target != src)
 			var/obj/effect/temp_visual/hierophant/chaser/OC = new(loc, src, target, chaser_speed * 1.5, FALSE)
 			OC.moving = 4
@@ -262,7 +262,7 @@ Difficulty: Hard
 		C.moving = 3
 		C.moving_dir = pick_n_take(cardinal_copy)
 		SLEEP_CHECK_DEATH(8 + target_slowness)
-	chaser_cooldown = world.time + initial(chaser_cooldown)
+	COOLDOWN_START(chaser_cooldown, initial(chaser_cooldown))
 	animate(src, color = oldcolor, time = 8)
 	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
 	SLEEP_CHECK_DEATH(8)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -98,8 +98,8 @@
 	. = ..()
 	if(!.) //Checks if they are dead as a rock.
 		return
-	if(health < maxHealth * 0.5 && rand_tent < world.time)
-		rand_tent = world.time + 30
+	if(health < maxHealth * 0.5 && IS_COOLDOWN_FINISHED(rand_tent))
+		COOLDOWN_START(rand_tent, 3 SECONDS)
 		var/tentacle_amount = 5
 		if(health < maxHealth * 0.25)
 			tentacle_amount = 10

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -54,11 +54,11 @@
 
 /mob/living/simple_animal/hostile/retaliate/clown/Life()
 	. = ..()
-	if(banana_time && banana_time < world.time)
+	if(banana_time && IS_COOLDOWN_FINISHED(banana_time))
 		var/turf/T = get_turf(src)
 		var/list/adjacent =  T.GetAtmosAdjacentTurfs(1)
 		new banana_type(pick(adjacent))
-		banana_time = world.time + rand(30,60)
+		COOLDOWN_START(banana_time, rand(30, 60))
 
 /mob/living/simple_animal/hostile/retaliate/clown/AttackingTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -62,17 +62,14 @@
 
 /mob/living/simple_animal/hostile/wizard/handle_automated_action()
 	. = ..()
-	if(target && next_cast < world.time)
+	if(target && IS_COOLDOWN_FINISHED(next_cast))
 		if((get_dir(src,target) in list(SOUTH,EAST,WEST,NORTH)) && fireball.cast_check(0,src)) //Lined up for fireball
 			src.setDir(get_dir(src,target))
 			fireball.perform(list(target), user = src)
-			next_cast = world.time + 10 //One spell per second
-			return .
+			START_COOLDOWN(next_cast, 1 SECONDS) //One spell per second
 		if(mm.cast_check(0,src))
 			mm.choose_targets(src)
-			next_cast = world.time + 10
-			return .
+			START_COOLDOWN(next_cast, 1 SECONDS)
 		if(blink.cast_check(0,src)) //Spam Blink when you can
 			blink.choose_targets(src)
-			next_cast = world.time + 10
-			return .
+			START_COOLDOWN(next_cast, 1 SECONDS)

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -66,10 +66,10 @@
 		if((get_dir(src,target) in list(SOUTH,EAST,WEST,NORTH)) && fireball.cast_check(0,src)) //Lined up for fireball
 			src.setDir(get_dir(src,target))
 			fireball.perform(list(target), user = src)
-			START_COOLDOWN(next_cast, 1 SECONDS) //One spell per second
+			COOLDOWN_START(next_cast, 1 SECONDS) //One spell per second
 		if(mm.cast_check(0,src))
 			mm.choose_targets(src)
-			START_COOLDOWN(next_cast, 1 SECONDS)
+			COOLDOWN_START(next_cast, 1 SECONDS)
 		if(blink.cast_check(0,src)) //Spam Blink when you can
 			blink.choose_targets(src)
-			START_COOLDOWN(next_cast, 1 SECONDS)
+			COOLDOWN_START(next_cast, 1 SECONDS)

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -41,7 +41,7 @@
 	if(Target.buckled_mobs?.len && (locate(/mob/living/simple_animal/slime) in Target.buckled_mobs))
 		slime_on_target = 1
 
-	if(Target.get_virtual_z_level() == src.get_virtual_z_level() && IS_COOLDOWN_FINISHED(attack_cooldown)  && get_dist(Target, src) <= 1)
+	if(Target.get_virtual_z_level() == src.get_virtual_z_level() && IS_COOLDOWN_FINISHED(src) <= 1)
 		if(!slime_on_target && CanFeedon(Target))
 			if(!Target.client || prob(20))
 				Feedon(Target)

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -41,7 +41,7 @@
 	if(Target.buckled_mobs?.len && (locate(/mob/living/simple_animal/slime) in Target.buckled_mobs))
 		slime_on_target = 1
 
-	if(Target.get_virtual_z_level() == src.get_virtual_z_level() && attack_cooldown < world.time && get_dist(Target, src) <= 1)
+	if(Target.get_virtual_z_level() == src.get_virtual_z_level() && IS_COOLDOWN_FINISHED(attack_cooldown)  && get_dist(Target, src) <= 1)
 		if(!slime_on_target && CanFeedon(Target))
 			if(!Target.client || prob(20))
 				Feedon(Target)
@@ -50,7 +50,7 @@
 				return
 		if((attacked || rabid) && Adjacent(Target))
 			Target.attack_slime(src)
-			attack_cooldown = world.time + attack_cooldown_time
+			COOLDOWN_START(attack_cooldown, attack_cooldown_time)
 	else if(src in viewers(7, Target))
 		if((transformeffects & SLIME_EFFECT_BLUESPACE) && powerlevel >= 5)
 			do_teleport(src, get_turf(Target), asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -232,10 +232,10 @@
 				probab = 95
 		if(prob(probab))
 			if(istype(O, /obj/structure/window) || istype(O, /obj/structure/grille))
-				if(attack_cooldown < world.time && nutrition <= get_hunger_nutrition())
+				if(IS_COOLDOWN_FINISHED(attack_cooldown) && nutrition <= get_hunger_nutrition())
 					if (is_adult || prob(5))
 						O.attack_slime(src)
-						attack_cooldown = world.time + attack_cooldown_time
+						COOLDOWN_START(attack_cooldown, attack_cooldown_time)
 
 /mob/living/simple_animal/slime/Process_Spacemove(movement_dir = 0)
 	return 2

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -221,9 +221,9 @@
 	return locate(selected) in GLOB.carbon_list //currently we dont have a list of humanoids so this'll have to do
 
 /datum/computer_file/program/radar/lifeline/scan()
-	if(!IS_COOLDOWN_FINISHED(src, last_scan))
+	if(!IS_COOLDOWN_FINISHED(last_scan))
 		return
-	COOLDOWN_START(src, last_scan, SCAN_COOLDOWN)
+	COOLDOWN_START(last_scan, SCAN_COOLDOWN)
 	objects = list()
 	for(var/i in GLOB.carbon_list)
 		var/mob/living/carbon/human/humanoid = i
@@ -278,9 +278,9 @@
 	return locate(selected) in GLOB.poi_list
 
 /datum/computer_file/program/radar/fission360/scan()
-	if(!IS_COOLDOWN_FINISHED(src, last_scan))
+	if(!IS_COOLDOWN_FINISHED(last_scan))
 		return
-	COOLDOWN_START(src, last_scan, SCAN_COOLDOWN)
+	COOLDOWN_START(last_scan, SCAN_COOLDOWN)
 	objects = list()
 	for(var/i in GLOB.nuke_list)
 		var/obj/machinery/nuclearbomb/nuke = i

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -24,7 +24,7 @@
 	var/arrowstyle = "ntosradarpointer.png"
 	///Used by the tgui interface, themed for NT or Syndicate colors.
 	var/pointercolor = "green"
-	COOLDOWN_DECLARE(last_scan)
+	var/last_scan
 
 /datum/computer_file/program/radar/run_program(mob/living/user)
 	. = ..()
@@ -221,7 +221,7 @@
 	return locate(selected) in GLOB.carbon_list //currently we dont have a list of humanoids so this'll have to do
 
 /datum/computer_file/program/radar/lifeline/scan()
-	if(!COOLDOWN_FINISHED(src, last_scan))
+	if(!IS_COOLDOWN_FINISHED(src, last_scan))
 		return
 	COOLDOWN_START(src, last_scan, SCAN_COOLDOWN)
 	objects = list()
@@ -278,7 +278,7 @@
 	return locate(selected) in GLOB.poi_list
 
 /datum/computer_file/program/radar/fission360/scan()
-	if(!COOLDOWN_FINISHED(src, last_scan))
+	if(!IS_COOLDOWN_FINISHED(src, last_scan))
 		return
 	COOLDOWN_START(src, last_scan, SCAN_COOLDOWN)
 	objects = list()

--- a/code/modules/power/singularity/anomaly.dm
+++ b/code/modules/power/singularity/anomaly.dm
@@ -17,7 +17,7 @@
 
 
 /obj/anomaly/proc/dissipate(delta_time)
-	if(!dissipate && !IS_COOLDOWN_FINISHED(src, RESTART_DISSIPATE))
+	if(!dissipate && !IS_COOLDOWN_FINISHED(RESTART_DISSIPATE))
 		return
 	time_since_last_dissipiation += delta_time
 
@@ -30,9 +30,9 @@
 /obj/anomaly/bullet_act(obj/item/projectile/energy/accelerated_particle/P, def_zone, piercing_hit = FALSE)
 	if(istype(P))
 		if(P.stop_dissipate) //if we get hit by the weak version we won't dissipate nor gain energy
-			COOLDOWN_START(src, RESTART_DISSIPATE, conistant_energy_cooldown)
+			COOLDOWN_START(RESTART_DISSIPATE, conistant_energy_cooldown)
 		else
-			COOLDOWN_RESET(src, RESTART_DISSIPATE) //if we get hit by another type of particle we start the normal process again immidiatly
+			COOLDOWN_RESET(RESTART_DISSIPATE) //if we get hit by another type of particle we start the normal process again immidiatly
 			energy += P.energy
 	else
 		return ..() //highly doubt that anything else could hit this but just in case

--- a/code/modules/power/singularity/anomaly.dm
+++ b/code/modules/power/singularity/anomaly.dm
@@ -13,11 +13,11 @@
 	var/time_since_last_dissipiation = 0
 	/// How long until we start to dissipate/gain energy again after beeing hit by a /obj/item/projectile/energy/accelerated_particle/weak
 	var/conistant_energy_cooldown = 10 SECONDS
-	COOLDOWN_DECLARE(RESTART_DISSIPATE)
+	var/RESTART_DISSIPATE
 
 
 /obj/anomaly/proc/dissipate(delta_time)
-	if(!dissipate && !COOLDOWN_FINISHED(src, RESTART_DISSIPATE))
+	if(!dissipate && !IS_COOLDOWN_FINISHED(src, RESTART_DISSIPATE))
 		return
 	time_since_last_dissipiation += delta_time
 

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -42,7 +42,7 @@ field_generator power level display
 	var/list/obj/machinery/field/containment/fields
 	var/list/obj/machinery/field/generator/connected_gens
 	var/clean_up = 0
-	COOLDOWN_STATIC_DECLARE(loose_message_cooldown)
+	var/static/loose_message_cooldown
 
 /obj/machinery/field/generator/Initialize(mapload)
 	. = ..()
@@ -334,7 +334,7 @@ field_generator power level display
 	loose_message(dist) //we forward the distance of the furtest away generator
 
 /obj/machinery/field/generator/proc/loose_message(dist)
-	if(COOLDOWN_FINISHED(src, loose_message_cooldown))
+	if(IS_COOLDOWN_FINISHED(src, loose_message_cooldown))
 		COOLDOWN_START(src, loose_message_cooldown, 5 SECONDS) //this cooldown is shared between all field generators
 		var/obj/anomaly/a = locate(/obj/anomaly) in oview(dist, src)
 		var/turf/T = get_turf(src)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -334,8 +334,8 @@ field_generator power level display
 	loose_message(dist) //we forward the distance of the furtest away generator
 
 /obj/machinery/field/generator/proc/loose_message(dist)
-	if(IS_COOLDOWN_FINISHED(src, loose_message_cooldown))
-		COOLDOWN_START(src, loose_message_cooldown, 5 SECONDS) //this cooldown is shared between all field generators
+	if(IS_COOLDOWN_FINISHED(loose_message_cooldown))
+		COOLDOWN_START(loose_message_cooldown, 5 SECONDS) //this cooldown is shared between all field generators
 		var/obj/anomaly/a = locate(/obj/anomaly) in oview(dist, src)
 		var/turf/T = get_turf(src)
 		if(a)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -348,14 +348,14 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else
 		soundloop.mid_sounds = list('sound/machines/sm/loops/calm.ogg' = 1)
 
-	if(last_accent_sound < world.time && prob(20))
+	if(IS_COOLDOWN_FINISHED(last_accent_sound) && prob(20))
 		var/aggression = min(((damage / 800) * (power / 2500)), 1.0) * 100
 		if(damage >= 300)
 			playsound(src, "smdelam", max(50, aggression), FALSE, 10)
 		else
 			playsound(src, "smcalm", max(50, aggression), FALSE, 10)
 		var/next_sound = round((100 - aggression) * 5)
-		last_accent_sound = world.time + max(SUPERMATTER_ACCENT_SOUND_MIN_COOLDOWN, next_sound)
+		COOLDOWN_START(last_accent_sound, max(SUPERMATTER_ACCENT_SOUND_MIN_COOLDOWN, next_sound))
 
 	//Ok, get the air from the turf
 	var/datum/gas_mixture/env = T.return_air()

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -96,7 +96,7 @@
 
 
 /obj/anomaly/energy_ball/proc/handle_energy(delta_time)
-	if(!IS_COOLDOWN_FINISHED(src, RESTART_DISSIPATE))
+	if(!IS_COOLDOWN_FINISHED(RESTART_DISSIPATE))
 		return
 	if(energy >= energy_to_raise)
 		energy_to_lower = energy_to_raise - 20

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -96,7 +96,7 @@
 
 
 /obj/anomaly/energy_ball/proc/handle_energy(delta_time)
-	if(!COOLDOWN_FINISHED(src, RESTART_DISSIPATE))
+	if(!IS_COOLDOWN_FINISHED(src, RESTART_DISSIPATE))
 		return
 	if(energy >= energy_to_raise)
 		energy_to_lower = energy_to_raise - 20

--- a/code/modules/projectiles/guns/energy/laser_gatling.dm
+++ b/code/modules/projectiles/guns/energy/laser_gatling.dm
@@ -157,8 +157,8 @@
 /obj/item/gun/energy/minigun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(ammo_pack)
 		if(obj_flags & EMAGGED)
-			if(cooldown < world.time)
-				cooldown = world.time + 50
+			if(IS_COOLDOWN_FINISHED(cooldown))
+				COOLDOWN_START(cooldown, 5 SECONDS)
 				playsound(get_turf(src), 'sound/weapons/heavyminigunstart.ogg', 50, 0, 0)
 				slowdown = 5
 				sleep(15)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -181,9 +181,9 @@
 	flushing = TRUE
 	flushAnimation()
 	sleep(10)
-	if(last_sound < world.time + 1)
+	if(IS_COOLDOWN_FINISHED(last_sound))
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, FALSE, FALSE)
-		last_sound = world.time
+		COOLDOWN_START(last_sound, 1)
 	sleep(5)
 	if(QDELETED(src))
 		return

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -38,7 +38,7 @@
 	flick("outlet-open", src)
 	if(IS_COOLDOWN_FINISHED(start_eject))
 		start_eject = world.time
-		START_COOLDOWN(start_eject, 3 SECONDS)
+		COOLDOWN_START(start_eject, 3 SECONDS)
 		playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
 		addtimer(CALLBACK(src, .proc/expel_holder, H, TRUE), 20)
 	else

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -36,8 +36,9 @@
 /obj/structure/disposaloutlet/proc/expel(obj/structure/disposalholder/H)
 	H.active = FALSE
 	flick("outlet-open", src)
-	if((start_eject + 30) < world.time)
+	if(IS_COOLDOWN_FINISHED(start_eject))
 		start_eject = world.time
+		START_COOLDOWN(start_eject, 3 SECONDS)
 		playsound(src, 'sound/machines/warning-buzzer.ogg', 50, 0, 0)
 		addtimer(CALLBACK(src, .proc/expel_holder, H, TRUE), 20)
 	else

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -248,9 +248,9 @@
 	var/spread_cooldown = 0
 
 /datum/nanite_program/spreading/active_effect()
-	if(spread_cooldown < world.time)
+	if(IS_COOLDOWN_FINISHED(spread_cooldown))
 		return
-	spread_cooldown = world.time + 50
+	START_COOLDOWN(spread_cooldown, 5 SECONDS)
 	var/list/mob/living/target_hosts = list()
 	for(var/mob/living/L in ohearers(5, host_mob))
 		if(!prob(25))

--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -250,7 +250,7 @@
 /datum/nanite_program/spreading/active_effect()
 	if(IS_COOLDOWN_FINISHED(spread_cooldown))
 		return
-	START_COOLDOWN(spread_cooldown, 5 SECONDS)
+	COOLDOWN_START(spread_cooldown, 5 SECONDS)
 	var/list/mob/living/target_hosts = list()
 	for(var/mob/living/L in ohearers(5, host_mob))
 		if(!prob(25))

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -229,13 +229,14 @@ Slimecrossing Items
 	list_reagents = list(/datum/reagent/consumable/nutriment/stabilized = 10, /datum/reagent/consumable/nutriment = 2) //Won't make you fat. Will make you question your sanity.
 
 /obj/item/reagent_containers/food/snacks/rationpack/checkLiked(fraction, mob/M)	//Nobody likes rationpacks. Nobody.
-	if(last_check_time + 50 < world.time)
+	if(IS_COOLDOWN_FINISHED(last_check_time))
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.mind && !HAS_TRAIT(H, TRAIT_AGEUSIA))
 				to_chat(H,"<span class='notice'>That didn't taste very good...</span>") //No disgust, though. It's just not good tasting.
 				SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "gross_food", /datum/mood_event/gross_food)
 				last_check_time = world.time
+				COOLDOWN_START(last_check_time, 5 SECONDS)
 				return
 	..()
 

--- a/code/modules/research/xenobiology/crossbreeding/gentle.dm
+++ b/code/modules/research/xenobiology/crossbreeding/gentle.dm
@@ -6,7 +6,7 @@
 	icon_state = "gentle"
 	var/extract_type
 	var/obj/item/slime_extract/extract
-	COOLDOWN_DECLARE(use_cooldown)
+	var/use_cooldown
 	var/cooldown = 5 //This is in seconds
 
 /obj/item/slimecross/gentle/Initialize(mapload)
@@ -23,14 +23,14 @@
 /obj/item/slimecross/gentle/attack_self(mob/living/carbon/user)
 	if(user.incapacitated() || !iscarbon(user))
 		return
-	if(!COOLDOWN_FINISHED(src, use_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, use_cooldown))
 		return
 	COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR))
 
 /obj/item/slimecross/gentle/AltClick(mob/living/carbon/user, obj/item/I)
 	if(user.incapacitated() || !iscarbon(user))
 		return
-	if(!COOLDOWN_FINISHED(src, use_cooldown))
+	if(!IS_COOLDOWN_FINISHED(src, use_cooldown))
 		return
 	COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR))
 

--- a/code/modules/research/xenobiology/crossbreeding/gentle.dm
+++ b/code/modules/research/xenobiology/crossbreeding/gentle.dm
@@ -23,16 +23,16 @@
 /obj/item/slimecross/gentle/attack_self(mob/living/carbon/user)
 	if(user.incapacitated() || !iscarbon(user))
 		return
-	if(!IS_COOLDOWN_FINISHED(src, use_cooldown))
+	if(!IS_COOLDOWN_FINISHED(use_cooldown))
 		return
-	COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR))
+	COOLDOWN_START(use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MINOR))
 
 /obj/item/slimecross/gentle/AltClick(mob/living/carbon/user, obj/item/I)
 	if(user.incapacitated() || !iscarbon(user))
 		return
-	if(!IS_COOLDOWN_FINISHED(src, use_cooldown))
+	if(!IS_COOLDOWN_FINISHED(use_cooldown))
 		return
-	COOLDOWN_START(src, use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR))
+	COOLDOWN_START(use_cooldown, extract.activate(user, user.dna.species, SLIME_ACTIVATE_MAJOR))
 
 /obj/item/slimecross/gentle/grey
 	extract_type = /obj/item/slime_extract/grey

--- a/code/modules/shuttle/shuttle_creation/shuttle_creator_eye.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator_eye.dm
@@ -23,7 +23,7 @@
 	var/initial = initial(sprint)
 	var/max_sprint = 50
 
-	if(cooldown && cooldown < world.timeofday) // 3 seconds
+	if(cooldown && IS_COOLDOWN_FINISHED(cooldown)) // 3 seconds
 		sprint = initial
 
 	for(var/i = 0; i < max(sprint, initial); i += 20)
@@ -31,7 +31,7 @@
 		if(step && can_move_to(step))
 			setLoc(step)
 
-	cooldown = world.timeofday + 5
+	COOLDOWN_START(cooldown, 5)
 	if(acceleration)
 		sprint = min(sprint + 0.5, max_sprint)
 	else

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -301,9 +301,9 @@
 	else if (payees[AM] > 0)
 		for(var/obj/I in counted_money)
 			qdel(I)
-		if(!check_times[AM] || check_times[AM] < world.time) //Let's not spam the message
+		if(!check_times[AM] || IS_COOLDOWN_FINISHED(check_times[AM])) //Let's not spam the message
 			say("<span class='robot'>$[payees[AM]] received, [AM]. You need $[threshold-payees[AM]] more.</span>")
-			check_times[AM] = world.time + LUXURY_MESSAGE_COOLDOWN
+			START_COOLDOWN(check_times[AM], LUXURY_MESSAGE_COOLDOWN)
 		return ..()
 	else
 		return ..()

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -303,7 +303,7 @@
 			qdel(I)
 		if(!check_times[AM] || IS_COOLDOWN_FINISHED(check_times[AM])) //Let's not spam the message
 			say("<span class='robot'>$[payees[AM]] received, [AM]. You need $[threshold-payees[AM]] more.</span>")
-			START_COOLDOWN(check_times[AM], LUXURY_MESSAGE_COOLDOWN)
+			COOLDOWN_START(check_times[AM], LUXURY_MESSAGE_COOLDOWN)
 		return ..()
 	else
 		return ..()

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -61,9 +61,9 @@
 
 /obj/vehicle/ridden/driver_move(mob/user, direction)
 	if(key_type && !is_key(inserted_key))
-		if(message_cooldown < world.time)
+		if(IS_COOLDOWN_FINISHED(message_cooldown))
 			to_chat(user, "<span class='warning'>[src] has no key inserted!</span>")
-			message_cooldown = world.time + 5 SECONDS
+			COOLDOWN_START(message_cooldown, 5 SECONDS)
 		return FALSE
 	if(legs_required)
 		var/how_many_legs = user.get_num_legs()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -780,9 +780,9 @@ GLOBAL_LIST_EMPTY(vending_products)
 				var/datum/bank_account/D = SSeconomy.get_dep_account(payment_department)
 				if(D)
 					D.adjust_money(price_to_use)
-			if(last_shopper != REF(usr) || purchase_message_cooldown < world.time)
+			if(last_shopper != REF(usr) || IS_COOLDOWN_FINISHED(purchase_message_cooldown))
 				say("Thank you for shopping with [src]!")
-				purchase_message_cooldown = world.time + 5 SECONDS
+				COOLDOWN_START(purchase_message_cooldown, 5 SECONDS)
 				//This is not the best practice, but it's safe enough here since the chances of two people using a machine with the same ref in 5 seconds is fuck low
 				last_shopper = REF(usr)
 			use_power(5)
@@ -1035,9 +1035,9 @@ GLOBAL_LIST_EMPTY(vending_products)
 						S.forceMove(drop_location())
 						loaded_items--
 						use_power(5)
-						if(last_shopper != REF(usr) || purchase_message_cooldown < world.time)
+						if(last_shopper != REF(usr) || IS_COOLDOWN_FINISHED(purchase_message_cooldown))
 							say("Thank you for buying local and purchasing [S]!")
-							purchase_message_cooldown = world.time + 5 SECONDS
+							COOLDOWN_START(purchase_message_cooldown, 5 SECONDS)
 							last_shopper = REF(usr)
 						vend_ready = TRUE
 						return TRUE

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -69,7 +69,7 @@
 	if(.)
 		return
 
-	if(!IS_COOLDOWN_FINISHED(src, next_sound))
+	if(!IS_COOLDOWN_FINISHED(next_sound))
 		return
 
 	var/sound_to_play = options_map[current_option]
@@ -78,4 +78,4 @@
 
 	playsound(src, sound_to_play, volume.input_value, FALSE, frequency = frequency.input_value)
 
-	COOLDOWN_START(src, next_sound, sound_cooldown)
+	COOLDOWN_START(next_sound, sound_cooldown)

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -19,7 +19,7 @@
 
 	var/list/options_map
 
-	COOLDOWN_DECLARE(next_sound)
+	var/next_sound
 
 /obj/item/circuit_component/soundemitter/get_ui_notices()
 	. = ..()
@@ -69,7 +69,7 @@
 	if(.)
 		return
 
-	if(!COOLDOWN_FINISHED(src, next_sound))
+	if(!IS_COOLDOWN_FINISHED(src, next_sound))
 		return
 
 	var/sound_to_play = options_map[current_option]

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -15,7 +15,7 @@
 	/// The cooldown for this component of how often it can send speech messages.
 	var/speech_cooldown = 1 SECONDS
 
-	COOLDOWN_DECLARE(next_speech)
+	var/next_speech
 
 /obj/item/circuit_component/speech/get_ui_notices()
 	. = ..()
@@ -41,7 +41,7 @@
 	if(!COMPONENT_TRIGGERED_BY(trigger, port))
 		return
 
-	if(!COOLDOWN_FINISHED(src, next_speech))
+	if(!IS_COOLDOWN_FINISHED(src, next_speech))
 		return
 
 	if(message.input_value)

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -41,7 +41,7 @@
 	if(!COMPONENT_TRIGGERED_BY(trigger, port))
 		return
 
-	if(!IS_COOLDOWN_FINISHED(src, next_speech))
+	if(!IS_COOLDOWN_FINISHED(next_speech))
 		return
 
 	if(message.input_value)
@@ -51,4 +51,4 @@
 			shell.say(message.input_value)
 		else
 			say(message.input_value)
-		COOLDOWN_START(src, next_speech, speech_cooldown)
+		COOLDOWN_START(next_speech, speech_cooldown)

--- a/code/modules/wiremod/shell/drone.dm
+++ b/code/modules/wiremod/shell/drone.dm
@@ -35,10 +35,10 @@
 	var/datum/port/input/west
 
 	// Done like this so that travelling diagonally is more simple
-	COOLDOWN_DECLARE(north_delay)
-	COOLDOWN_DECLARE(east_delay)
-	COOLDOWN_DECLARE(south_delay)
-	COOLDOWN_DECLARE(west_delay)
+	var/north_delay
+	var/east_delay
+	var/south_delay
+	var/west_delay
 
 	/// Delay between each movement
 	var/move_delay = 0.2 SECONDS
@@ -61,16 +61,16 @@
 
 	var/direction
 
-	if(COMPONENT_TRIGGERED_BY(north, port) && COOLDOWN_FINISHED(src, north_delay))
+	if(COMPONENT_TRIGGERED_BY(north, port) && IS_COOLDOWN_FINISHED(src, north_delay))
 		direction = NORTH
 		COOLDOWN_START(src, north_delay, move_delay)
-	else if(COMPONENT_TRIGGERED_BY(east, port) && COOLDOWN_FINISHED(src, east_delay))
+	else if(COMPONENT_TRIGGERED_BY(east, port) && IS_COOLDOWN_FINISHED(src, east_delay))
 		direction = EAST
 		COOLDOWN_START(src, east_delay, move_delay)
-	else if(COMPONENT_TRIGGERED_BY(south, port) && COOLDOWN_FINISHED(src, south_delay))
+	else if(COMPONENT_TRIGGERED_BY(south, port) && IS_COOLDOWN_FINISHED(src, south_delay))
 		direction = SOUTH
 		COOLDOWN_START(src, south_delay, move_delay)
-	else if(COMPONENT_TRIGGERED_BY(west, port) && COOLDOWN_FINISHED(src, west_delay))
+	else if(COMPONENT_TRIGGERED_BY(west, port) && IS_COOLDOWN_FINISHED(src, west_delay))
 		direction = WEST
 		COOLDOWN_START(src, west_delay, move_delay)
 

--- a/code/modules/wiremod/shell/drone.dm
+++ b/code/modules/wiremod/shell/drone.dm
@@ -61,18 +61,18 @@
 
 	var/direction
 
-	if(COMPONENT_TRIGGERED_BY(north, port) && IS_COOLDOWN_FINISHED(src, north_delay))
+	if(COMPONENT_TRIGGERED_BY(north, port) && IS_COOLDOWN_FINISHED(north_delay))
 		direction = NORTH
-		COOLDOWN_START(src, north_delay, move_delay)
-	else if(COMPONENT_TRIGGERED_BY(east, port) && IS_COOLDOWN_FINISHED(src, east_delay))
+		COOLDOWN_START(north_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(east, port) && IS_COOLDOWN_FINISHED(east_delay))
 		direction = EAST
-		COOLDOWN_START(src, east_delay, move_delay)
-	else if(COMPONENT_TRIGGERED_BY(south, port) && IS_COOLDOWN_FINISHED(src, south_delay))
+		COOLDOWN_START(east_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(south, port) && IS_COOLDOWN_FINISHED(south_delay))
 		direction = SOUTH
-		COOLDOWN_START(src, south_delay, move_delay)
-	else if(COMPONENT_TRIGGERED_BY(west, port) && IS_COOLDOWN_FINISHED(src, west_delay))
+		COOLDOWN_START(south_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(west, port) && IS_COOLDOWN_FINISHED(west_delay))
 		direction = WEST
-		COOLDOWN_START(src, west_delay, move_delay)
+		COOLDOWN_START(west_delay, move_delay)
 
 	if(!direction)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simplifies the cooldown defines. They are unnecessarilly complicated and over engineered. We really don't need a cooldown that just makes a variable for someone, it doesn't make the code easier to read and just introduces inconsistencies.

This adds some more cooldowns to the cooldown defines, but not all of them since its a lot of manual tedious work and doesn't really matter that much. (It's not worth the extra effort as the gain is almost nothing, code quality before and after is about the same with/without the defines.)

## Why It's Good For The Game

The cooldown timers should be more intuative and easy to use, an example comment has been added on how to use them.
You now provide cooldown timers with a variable, rather than an object and a variable name which adds some more simplicity to them.
Beautiful code is one that is simple to understand and isn't overcomplicated. The original implementation of these cooldown timers was overcomplicated and inelegant.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/178056994-ace1c7a3-44b4-4a0d-a187-31a7a2f78a18.png)

![image](https://user-images.githubusercontent.com/26465327/178057007-6c83fc81-1bdd-4d8a-a926-13d4ac88c249.png)

Can't spam this shit.

## Changelog
:cl:
code: Cooldown timer defines have been simplified. There should be no player-facing changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
