### PR TITLE
Vending machine stock display now uses product_path as key for retrieving stock

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -715,7 +715,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 				.["user"]["department"] = "No Department"
 	.["stock"] = list()
 	for (var/datum/data/vending_product/R in product_records + coin_records + hidden_records)
-		.["stock"][R.name] = R.amount
+		.["stock"]["[replacetext(replacetext("[R.product_path]", "/obj/item/", ""), "/", "-")]"] = R.amount
 	.["extended_inventory"] = extended_inventory
 
 /obj/machinery/vending/ui_act(action, params)

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -134,7 +134,7 @@ export const Vending = (props, context) => {
                 key={product.name}
                 custom={custom}
                 product={product}
-                productStock={data.stock[product.name]} />
+                productStock={data.stock[product.path]} />
             ))}
           </Table>
         </Section>


### PR DESCRIPTION
## About The Pull Request

Fixes #7205

- Vending machines now send stock data to TGUI using the path as the key instead of the name, fixing issues with duplicate names

## Why It's Good For The Game

Fixes improper stock displays when two items have the same name but different paths

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/178089376-2fc43e2b-0bf8-48fd-98b2-87fa19a9bbf4.png)
![image](https://user-images.githubusercontent.com/10366817/178089391-d9fb85f8-9353-4355-96f0-5a2119171edd.png)

</details>

## Changelog
:cl:
fix: Vending machines showing wrong stock if there is an item with the same name but different type path
/:cl:
