### PR TITLE
Use defib HUD for changeling fakedeath

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -192,13 +192,15 @@
 		holder.pixel_y = I.Height() - world.icon_size
 		if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 			holder.icon_state = "hudxeno"
-		else if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
+		else if(stat == DEAD)
 			if(tod)
 				var/tdelta = round(world.time - timeofdeath)
 				if(tdelta < (DEFIB_TIME_LIMIT * 10))
 					holder.icon_state = "huddefib"
 					return
 			holder.icon_state = "huddead"
+		else if(HAS_TRAIT(src, TRAIT_FAKEDEATH))
+			holder.icon_state = "huddefib"
 		else
 			switch(virus_threat)
 				if(DISEASE_PANDEMIC)


### PR DESCRIPTION
## About The Pull Request

Fixes #7146 

- When using the Reviving Stasis ability, changelings will display on medhuds has revivable via defibrillation instead of dead.

## Why It's Good For The Game

It's very obvious a changeling has used Reviving Stasis if you have a medhud, because no one just drops straight into no-defib death.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/178090137-2fca03d2-7828-43ca-b666-9270ba6304dd.png)

</details>

## Changelog
:cl:
tweak: All fakedeaths show a defib icon on medhuds instead of a skull
/:cl: