### PR TITLE
Client color applies to items in inventory slots

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1107,7 +1107,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 				M.client.screen -= src
 			layer = initial(layer)
 			plane = initial(plane)
-			appearance_flags &= ~NO_CLIENT_COLOR
 			dropped(M)
 	return ..()
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -326,7 +326,6 @@
 			client.screen -= I
 		I.layer = initial(I.layer)
 		I.plane = initial(I.plane)
-		I.appearance_flags &= ~NO_CLIENT_COLOR
 		if(!no_move && !(I.item_flags & DROPDEL))	//item may be moved/qdel'd immedietely, don't bother moving it
 			if (isnull(newloc))
 				I.moveToNullspace()

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -50,7 +50,6 @@
 	I.forceMove(src)
 	I.layer = ABOVE_HUD_LAYER
 	I.plane = ABOVE_HUD_PLANE
-	I.appearance_flags |= NO_CLIENT_COLOR
 	var/not_handled = FALSE
 	switch(slot)
 		if(ITEM_SLOT_BACK)


### PR DESCRIPTION
## About The Pull Request

Fixes #6673

- Makes client colors apply to items in inventory slots

## Why It's Good For The Game

Makes monochromacy have less color, this is good, because seeing color for items in your toolbelt, ID or inventory slots is strange when in your hands or other locations the item lacks color.

Also works for the only other client color which applies with the cursed heart, turning everything blood-red.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/178092868-4922a1bb-c73a-428d-a4b9-4ebd10176be6.png)

![image](https://user-images.githubusercontent.com/10366817/178093260-7979c804-3eaf-4931-818c-fa6b2dfcced0.png)

</details>

## Changelog
:cl:
tweak: Monochromacy quirk and cursed heart blood-red client colors now apply to inventory slots
/:cl: