### PR TITLE
Revert "Players who suicide or cryo are not elegible for Antagonist roles for 5 minutes"

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -445,8 +445,8 @@
 		return candidates
 
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		if(COOLDOWN_FINISHED(G, creation_time) || G.started_as_observer) // Prevents people who have just died from becoming Antagonists
-			candidates += G
+		candidates += G
+
 	return pollCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, flashwindow, candidates, req_hours)
 
 /proc/pollCandidates(Question, jobbanType, datum/game_mode/gametypeCheck, be_special_flag = 0, poll_time = 300, ignore_category = null, flashwindow = TRUE, list/group = null, req_hours = 0)

--- a/code/controllers/configuration/entries/game_tweaks.dm
+++ b/code/controllers/configuration/entries/game_tweaks.dm
@@ -19,7 +19,3 @@
 /datum/config_entry/number/brig_timer_preset_long
 	config_entry_value = 5
 	min_val = 1
-
-/datum/config_entry/number/cooldown_antag_time
-	config_entry_value = 0
-	min_val = 0

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -60,9 +60,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	// of the mob
 	var/deadchat_name
 	var/datum/orbit_menu/orbit_menu
-	var/static/cooldown_time
-	COOLDOWN_DECLARE(creation_time)
-
 
 /mob/dead/observer/Initialize(mapload)
 	set_invisibility(GLOB.observer_default_invisibility)
@@ -151,10 +148,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	grant_all_languages()
 	show_data_huds()
 	data_huds_on = 1
-
-	if(!cooldown_time) //so we only need to grab the config for this once.
-		cooldown_time = CONFIG_GET(number/cooldown_antag_time) MINUTES
-	COOLDOWN_START(src, creation_time , cooldown_time)
 
 	AddComponent(/datum/component/tracking_beacon, "ghost", null, null, TRUE, "#9e4d91", TRUE, TRUE)
 

--- a/config/gameplay_tweaks.txt
+++ b/config/gameplay_tweaks.txt
@@ -9,6 +9,3 @@ BRIG_TIMER_MAX 20
 BRIG_TIMER_PRESET_SHORT 5
 BRIG_TIMER_PRESET_MED 10
 BRIG_TIMER_PRESET_LONG 15
-
-# Time to wait after becoming a Ghost to qualify for antagonist, In minutes.
-COOLDOWN_ANTAG_TIME 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
closes #7228
reverts my change that forced people to wait 5 minutes after ghosting
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it has a few bugs, making many antagonists not as effective as they were before.
I might have all fixes today, but just in case I would suggest reverting it until is done and fully tested
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>



</details>

## Changelog
:cl:
del: Temporarily reverts the cooldown to become an antagonist after ghosting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
