### PR TITLE
Security level change is now handled by signals

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -12,6 +12,7 @@
 #define COMSIG_GLOB_MOB_DEATH "!mob_death"						//! mob died somewhere : (mob , gibbed)
 #define COMSIG_GLOB_LIVING_SAY_SPECIAL "!say_special"			//! global living say plug - use sparingly: (mob/speaker , message)
 #define COMSIG_GLOB_CARBON_THROW_THING	"!throw_thing"			//! a person somewhere has thrown something : (mob/living/carbon/carbon_thrower, target)
+#define COMSIG_GLOB_SECURITY_ALERT_CHANGE "!alert_change"		//! security level was changed : (new_alert)
 /// called by datum/cinematic/play() : (datum/cinematic/new_cinematic)
 #define COMSIG_GLOB_PLAY_CINEMATIC "!play_cinematic"
 	#define COMPONENT_GLOB_BLOCK_CINEMATIC 1

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -68,6 +68,15 @@
 	//doors only block while dense though so we have to use the proc
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
+	if(red_alert_access)
+		RegisterSignal(SSdcs, COMSIG_GLOB_SECURITY_ALERT_CHANGE, .proc/handle_alert)
+
+/obj/machinery/door/proc/handle_alert(datum/source, new_alert)
+	SIGNAL_HANDLER
+	if(new_alert <= SEC_LEVEL_RED )
+		visible_message("<span class='notice'>[src] whirs as it automatically lifts access requirements!</span>")
+		playsound(src, 'sound/machines/boltsup.ogg', 50, TRUE)
+
 
 /obj/machinery/door/proc/set_init_door_layer()
 	if(density)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -73,7 +73,7 @@
 
 /obj/machinery/door/proc/handle_alert(datum/source, new_alert)
 	SIGNAL_HANDLER
-	if(new_alert <= SEC_LEVEL_RED )
+	if(new_alert >= SEC_LEVEL_RED)
 		visible_message("<span class='notice'>[src] whirs as it automatically lifts access requirements!</span>")
 		playsound(src, 'sound/machines/boltsup.ogg', 50, TRUE)
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -64,6 +64,12 @@
 	update_icon()
 	myarea = get_area(src)
 	LAZYADD(myarea.firealarms, src)
+	RegisterSignal(SSdcs, COMSIG_GLOB_SECURITY_ALERT_CHANGE, .proc/handle_alert)
+
+/obj/machinery/firealarm/proc/handle_alert(datum/source, new_alert)
+	SIGNAL_HANDLER
+	if(is_station_level(z))
+		update_icon()
 
 /obj/machinery/firealarm/Destroy()
 	myarea.firereset(src)

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -18,71 +18,50 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 			level = SEC_LEVEL_DELTA
 
 	//Will not be announced if you try to set to the same level as it already is
-	if(level >= SEC_LEVEL_GREEN && level <= SEC_LEVEL_DELTA && level != GLOB.security_level)
-		switch(level)
-			if(SEC_LEVEL_GREEN)
-				minor_announce(CONFIG_GET(string/alert_green), "Attention! Security level lowered to green:")
-				if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
-					if(GLOB.security_level >= SEC_LEVEL_RED)
-						SSshuttle.emergency.modTimer(4)
-					else
-						SSshuttle.emergency.modTimer(2)
-				GLOB.security_level = SEC_LEVEL_GREEN
-				for(var/obj/machinery/firealarm/FA in GLOB.machines)
-					if(is_station_level(FA.z))
-						FA.update_icon()
-			if(SEC_LEVEL_BLUE)
-				if(GLOB.security_level < SEC_LEVEL_BLUE)
-					minor_announce(CONFIG_GET(string/alert_blue_upto), "Attention! Security level elevated to blue:",1)
-					if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
-						SSshuttle.emergency.modTimer(0.5)
+	if(level < SEC_LEVEL_GREEN || level > SEC_LEVEL_DELTA || level == GLOB.security_level)
+		return
+	switch(level)
+		if(SEC_LEVEL_GREEN)
+			minor_announce(CONFIG_GET(string/alert_green), "Attention! Security level lowered to green:")
+			if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+				if(GLOB.security_level >= SEC_LEVEL_RED)
+					SSshuttle.emergency.modTimer(4)
 				else
-					minor_announce(CONFIG_GET(string/alert_blue_downto), "Attention! Security level lowered to blue:")
-					if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
-						SSshuttle.emergency.modTimer(2)
-				GLOB.security_level = SEC_LEVEL_BLUE
-				for(var/obj/machinery/firealarm/FA in GLOB.machines)
-					if(is_station_level(FA.z))
-						FA.update_icon()
-			if(SEC_LEVEL_RED)
-				if(GLOB.security_level < SEC_LEVEL_RED)
-					minor_announce(CONFIG_GET(string/alert_red_upto), "Attention! Code red!",1)
-					if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
-						if(GLOB.security_level == SEC_LEVEL_GREEN)
-							SSshuttle.emergency.modTimer(0.25)
-						else
-							SSshuttle.emergency.modTimer(0.5)
-				else
-					minor_announce(CONFIG_GET(string/alert_red_downto), "Attention! Code red!")
-				GLOB.security_level = SEC_LEVEL_RED
+					SSshuttle.emergency.modTimer(2)
 
-				for(var/obj/machinery/firealarm/FA in GLOB.machines)
-					if(is_station_level(FA.z))
-						FA.update_icon()
-				for(var/obj/machinery/computer/shuttle_flight/pod/pod in GLOB.machines)
-					pod.admin_controlled = 0
-			if(SEC_LEVEL_DELTA)
-				minor_announce(CONFIG_GET(string/alert_delta), "Attention! Delta security level reached!",1)
+		if(SEC_LEVEL_BLUE)
+			if(GLOB.security_level < SEC_LEVEL_BLUE)
+				minor_announce(CONFIG_GET(string/alert_blue_upto), "Attention! Security level elevated to blue:",1)
+				if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+					SSshuttle.emergency.modTimer(0.5)
+			else
+				minor_announce(CONFIG_GET(string/alert_blue_downto), "Attention! Security level lowered to blue:")
+				if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+					SSshuttle.emergency.modTimer(2)
+
+		if(SEC_LEVEL_RED)
+			if(GLOB.security_level < SEC_LEVEL_RED)
+				minor_announce(CONFIG_GET(string/alert_red_upto), "Attention! Code red!",1)
 				if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
 					if(GLOB.security_level == SEC_LEVEL_GREEN)
 						SSshuttle.emergency.modTimer(0.25)
-					else if(GLOB.security_level == SEC_LEVEL_BLUE)
+					else
 						SSshuttle.emergency.modTimer(0.5)
-				GLOB.security_level = SEC_LEVEL_DELTA
-				for(var/obj/machinery/firealarm/FA in GLOB.machines)
-					if(is_station_level(FA.z))
-						FA.update_icon()
-				for(var/obj/machinery/computer/shuttle_flight/pod/pod in GLOB.machines)
-					pod.admin_controlled = 0
-		if(level >= SEC_LEVEL_RED)
-			for(var/obj/machinery/door/D in GLOB.machines)
-				if(D.red_alert_access)
-					D.visible_message("<span class='notice'>[D] whirs as it automatically lifts access requirements!</span>")
-					playsound(D, 'sound/machines/boltsup.ogg', 50, TRUE)
-		SSblackbox.record_feedback("tally", "security_level_changes", 1, get_security_level())
-		SSnightshift.check_nightshift()
-	else
-		return
+			else
+				minor_announce(CONFIG_GET(string/alert_red_downto), "Attention! Code red!")
+
+		if(SEC_LEVEL_DELTA)
+			minor_announce(CONFIG_GET(string/alert_delta), "Attention! Delta security level reached!",1)
+			if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
+				if(GLOB.security_level == SEC_LEVEL_GREEN)
+					SSshuttle.emergency.modTimer(0.25)
+				else if(GLOB.security_level == SEC_LEVEL_BLUE)
+					SSshuttle.emergency.modTimer(0.5)
+
+	GLOB.security_level = level
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_SECURITY_ALERT_CHANGE, level)
+	SSblackbox.record_feedback("tally", "security_level_changes", 1, get_security_level())
+	SSnightshift.check_nightshift()
 
 /proc/get_security_level()
 	switch(GLOB.security_level)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -603,7 +603,7 @@
 
 /obj/machinery/computer/shuttle_flight/pod
 	name = "pod control computer"
-	admin_controlled = 1
+	admin_controlled = TRUE
 	recall_docking_port_id = "null"
 	request_shuttle_message = "Override Escape"
 	possible_destinations = "pod_asteroid"
@@ -612,6 +612,15 @@
 	light_color = LIGHT_COLOR_BLUE
 	density = FALSE
 	clockwork = TRUE //it'd look weird
+
+/obj/machinery/computer/shuttle_flight/pod/Initialize()
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_SECURITY_ALERT_CHANGE, .proc/handle_alert)
+
+/obj/machinery/computer/shuttle_flight/pod/proc/handle_alert(datum/source, new_alert)
+	SIGNAL_HANDLER
+	admin_controlled = (new_alert > SEC_LEVEL_RED)
+
 
 /obj/machinery/computer/shuttle_flight/pod/update_icon()
 	return

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -619,7 +619,7 @@
 
 /obj/machinery/computer/shuttle_flight/pod/proc/handle_alert(datum/source, new_alert)
 	SIGNAL_HANDLER
-	admin_controlled = (new_alert <= SEC_LEVEL_RED) // admin_controlled is FALSE if its red or delta
+	admin_controlled = (new_alert < SEC_LEVEL_RED) // admin_controlled is FALSE if its red or delta
 
 /obj/machinery/computer/shuttle_flight/pod/update_icon()
 	return

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -619,8 +619,7 @@
 
 /obj/machinery/computer/shuttle_flight/pod/proc/handle_alert(datum/source, new_alert)
 	SIGNAL_HANDLER
-	admin_controlled = (new_alert > SEC_LEVEL_RED)
-
+	admin_controlled = (new_alert <= SEC_LEVEL_RED) // admin_controlled is FALSE is its red or delta
 
 /obj/machinery/computer/shuttle_flight/pod/update_icon()
 	return

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -619,7 +619,7 @@
 
 /obj/machinery/computer/shuttle_flight/pod/proc/handle_alert(datum/source, new_alert)
 	SIGNAL_HANDLER
-	admin_controlled = (new_alert <= SEC_LEVEL_RED) // admin_controlled is FALSE is its red or delta
+	admin_controlled = (new_alert <= SEC_LEVEL_RED) // admin_controlled is FALSE if its red or delta
 
 /obj/machinery/computer/shuttle_flight/pod/update_icon()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so security alert changes are handled by signal instead of just looping multiple times
Also changes set_security_level() code so it has early return instead of entire code being in if statement
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Closes #6757 
## Why It's Good For The Game
Requested by @PowerfulBacon 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

1. Change security level to blue
2. Fire alarm light turns blue
3. Change security level to green
4. Fire alarm light turns green


## Changelog
:cl:
code: set_security_level() now uses signals instead of multiple loops
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
