### PR TITLE
Allow invisible mobs to hear speech in range

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -236,7 +236,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/eavesdrop_range = 0
 	if(message_mods[WHISPER_MODE]) //If we're whispering
 		eavesdrop_range = EAVESDROP_EXTRA_RANGE
-	var/list/listening = get_hearers_in_view(message_range+eavesdrop_range, source)
+	var/list/listening = get_hearers_in_view(message_range+eavesdrop_range, source, SEE_INVISIBLE_OBSERVER)
 	var/list/the_dead = list()
 	for(var/mob/M as() in GLOB.player_list)
 		if(!M)				//yogs
@@ -244,11 +244,14 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(M.stat != DEAD) //not dead, not important
 			continue
 		if(!M.client || !client) //client is so that ghosts don't have to listen to mice
+			listening -= M // remove (added by SEE_INVISIBLE_OBSERVER)
 			continue
 		if(get_dist(M, src) > 7 || M.get_virtual_z_level() != get_virtual_z_level()) //they're out of range of normal hearing
 			if(eavesdrop_range && !(M.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
+				listening -= M // remove (added by SEE_INVISIBLE_OBSERVER)
 				continue
 			if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+				listening -= M // remove (added by SEE_INVISIBLE_OBSERVER)
 				continue
 		listening |= M
 		the_dead[M] = TRUE


### PR DESCRIPTION
## About The Pull Request

Addon to #6587
Fixes #7240
Fixes #7053
Fixes #7220

- Fixes invisible mobs being unable to hear speech (AI with surveillance upgrade, revenant)

## Why It's Good For The Game

Invisible mobs not being able to hear speech is bad

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

**AI Eye speech**
![image](https://user-images.githubusercontent.com/10366817/178137946-44e8df8f-a091-4255-9d9a-b51445b38984.png)

**AI eye speech (out of range)**
![image](https://user-images.githubusercontent.com/10366817/178137951-853f9a26-8078-49a5-85f6-451d816eef6f.png)

**Revenant**
![image](https://user-images.githubusercontent.com/10366817/178137965-469b766a-8b1a-4449-a9ee-58b538971959.png)

Tested ghost speech as well, it's unaffected by this and still obeys user preference including range preference.
</details>

## Changelog
:cl:
fix: Invisible mobs can now hear speech (includes revenant, AI eye with surveillance upgrade)
/:cl:
