### PR TITLE
Fix dank-pocket recipe having no category

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -327,7 +327,7 @@
 	result = /obj/item/reagent_containers/food/snacks/donkpocket
 	subcategory = CAT_PASTRY
 
-/datum/crafting_recipe/donkpocket/dank
+/datum/crafting_recipe/food/donkpocket/dank
 	time = 15
 	name = "Dank-pocket"
 	reqs = list(


### PR DESCRIPTION
## About The Pull Request

Fixes #7237

- Fixes dank-pocket having no category, causing a duplicate Pastries subcategory to appear and dank-pockets to be ordered last

## Why It's Good For The Game

No more duplicate categories plus they're ordered correctly

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/178140070-bd13f702-9619-4bcf-ad34-0f3c3a9b3d55.png)

</details>

## Changelog
:cl:
fix: Duplicate pastries category in crafting menu
fix: Dank-pockets are ordered correctly in the crafting menu
/:cl: