### PR TITLE
Latejoin window no longer shows improper "Command" category to Cargo/Civilian jobs

### DIFF
--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_INIT(science_positions, list(
 
 
 GLOBAL_LIST_INIT(supply_positions, list(
+	"Head of Personnel",
 	"Quartermaster",
 	"Cargo Technician",
 	"Shaft Miner"))

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -382,6 +382,19 @@
 */
 
 /mob/dead/new_player/proc/LateChoices()
+	var/static/list/department_order = list(
+		"Command" = "#ddddff",
+		"Engineering" = "#ffeeaa",
+		"Supply"= "#d7b088",
+		"Silicon" = "#ccffcc",
+		"Civilian"= "#bbe291",
+		"Gimmick" = "#dddddd",
+		"Medical" = "#c1e1ec",
+		"Science" = "#ffddff",
+		"Security" = "#ffdddd"
+	)
+	var/static/list/department_list = list(GLOB.command_positions) + list(GLOB.engineering_positions) + list(GLOB.supply_positions) + list(GLOB.nonhuman_positions - "pAI") + list(GLOB.civilian_positions) + list(GLOB.gimmick_positions) + list(GLOB.medical_positions) + list(GLOB.science_positions) + list(GLOB.security_positions)
+
 	var/list/dat = list("<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]</div>")
 	if(SSjob.prioritized_jobs.len > 0)
 		dat+="<div class='priority' style='text-align:center'>Jobs in Green have been prioritized by the Head of Personnel.<br>Please consider joining the game as that role.</div>"
@@ -397,10 +410,10 @@
 			SSjob.prioritized_jobs -= prioritized_job
 	dat += "<table><tr><td valign='top'>"
 	var/column_counter = 0
-	for(var/list/category in list(GLOB.command_positions) + list(GLOB.engineering_positions) + list(GLOB.supply_positions) + list(GLOB.nonhuman_positions - "pAI") + list(GLOB.civilian_positions) + list(GLOB.gimmick_positions) + list(GLOB.medical_positions) + list(GLOB.science_positions) + list(GLOB.security_positions))
-		var/cat_color = SSjob.name_occupations[category[1]].selection_color //use the color of the first job in the category (the department head) as the category color
+	for(var/list/category in department_list)
+		var/cat_color = department_order[department_order[column_counter+1]] //use the color of the first job in the category (the department head) as the category color
 		dat += "<fieldset style='width: 185px; border: 2px solid [cat_color]; display: inline'>"
-		dat += "<legend align='center' style='color: [cat_color]'>[SSjob.name_occupations[category[1]].exp_type_department]</legend>"
+		dat += "<legend align='center' style='color: [cat_color]'>[department_order[column_counter+1]]</legend>"
 		var/list/dept_dat = list()
 		for(var/job in category)
 			var/datum/job/job_datum = SSjob.name_occupations[job]

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -382,7 +382,7 @@
 */
 
 /mob/dead/new_player/proc/LateChoices()
-	var/static/list/department_order = list(
+	var/static/list/department_order = list( // department order and its dept color
 		"Command" = "#ddddff",
 		"Engineering" = "#ffeeaa",
 		"Supply"= "#d7b088",
@@ -411,7 +411,7 @@
 	dat += "<table><tr><td valign='top'>"
 	var/column_counter = 0
 	for(var/list/category in department_list)
-		var/cat_color = department_order[department_order[column_counter+1]] //use the color of the first job in the category (the department head) as the category color
+		var/cat_color = department_order[department_order[column_counter+1]] // color from `department_order`
 		dat += "<fieldset style='width: 185px; border: 2px solid [cat_color]; display: inline'>"
 		dat += "<legend align='center' style='color: [cat_color]'>[department_order[column_counter+1]]</legend>"
 		var/list/dept_dat = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Latejoin window no longer shows improper "Command" category to Cargo/Civilian jobs.
If HoP is among a non-commander roles, it always showed the whole category as Command category, and HoP's department is actually Command in the code.
So, I kept HoP as commander department, while I changed more precisely latejoin window.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/178163865-abac4b4a-1221-415c-9e53-c8052d1c7a24.png)

</details>

## Changelog
:cl:
fix: Latejoin now shows Head of Personnel job to Civilian and Cargo categories both along with Command category.
fix: When HoP job is in a non-command category, it showed the category as Command. (i.e. Supply as Command) now they're consistently showing proper categories even if HoP is there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
