### PR TITLE
Lag-proofing nightmares

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -335,8 +335,7 @@
 //ED209's ignore monkeys
 #define JUDGE_IGNOREMONKEYS	(1<<4)
 
-#define SHADOW_SPECIES_LIGHT_THRESHOLD 0.2
-
+#define SHADOW_SPECIES_LIGHT_THRESHOLD 0.25
 // Offsets defines
 
 #define OFFSET_UNIFORM "uniform"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1099,7 +1099,6 @@
 	else
 		return ..()
 
-
 /obj/machinery/door/airlock/try_to_weld(obj/item/weldingtool/W, mob/user)
 	if(!operating && density)
 		if(user.a_intent != INTENT_HELP)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -902,7 +902,7 @@
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
 	if(!issilicon(user) && !IsAdminGhost(user))
-		if(isElectrified())
+		if(isElectrified() && C?.siemens_coefficient)
 			if(shock(user, 75))
 				return
 	add_fingerprint(user)
@@ -1073,7 +1073,7 @@
 		note = C
 		update_icon()
 	else if(HAS_TRAIT(C, TRAIT_DOOR_PRYER) && user.a_intent != INTENT_HARM)
-		if(isElectrified())
+		if(isElectrified() && C?.siemens_coefficient)
 			shock(user,100)
 
 		if(locked) 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1072,6 +1072,32 @@
 		user.visible_message("<span class='notice'>[user] pins [C] to [src].</span>", "<span class='notice'>You pin [C] to [src].</span>")
 		note = C
 		update_icon()
+	else if(istype(C, /obj/item/light_eater))
+		if(isElectrified())
+			shock(user,100)//it's like sticking a forck in a power socket
+			return
+
+		if(!density)//already open
+			return
+
+		if(locked)
+			to_chat(user, "<span class='warning'>The bolts are down, it won't budge!</span>")
+			return
+
+		if(welded)
+			to_chat(user, "<span class='warning'>It's welded, it won't budge!</span>")
+			return
+
+		var/time_to_open = 5
+		if(hasPower() && !prying_so_hard)
+			time_to_open = 50
+			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
+			prying_so_hard = TRUE
+			if(do_after(user, time_to_open, TRUE, src))
+				open(2)
+				if(density && !open(2))
+					to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
+			prying_so_hard = FALSE
 	else
 		return ..()
 
@@ -1136,7 +1162,7 @@
 		to_chat(user, "<span class='warning'>The airlock's motors resist your efforts to force it!</span>")
 	else if(locked)
 		to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")
-	else if( !welded && !operating)
+	else if(!welded && !operating)
 		if(istype(I, /obj/item/fireaxe)) //being fireaxe'd
 			var/obj/item/fireaxe/F = I
 			if(F && !ISWIELDED(F))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1072,7 +1072,7 @@
 		user.visible_message("<span class='notice'>[user] pins [C] to [src].</span>", "<span class='notice'>You pin [C] to [src].</span>")
 		note = C
 		update_icon()
-	else if(HAS_TRAIT(C, TRAIT_DOOR_PRYER))
+	else if(HAS_TRAIT(C, TRAIT_DOOR_PRYER) && user.a_intent != INTENT_HARM)
 		if(isElectrified())
 			shock(user,100)
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1072,15 +1072,11 @@
 		user.visible_message("<span class='notice'>[user] pins [C] to [src].</span>", "<span class='notice'>You pin [C] to [src].</span>")
 		note = C
 		update_icon()
-	else if(istype(C, /obj/item/light_eater))
+	else if(HAS_TRAIT(C, TRAIT_DOOR_PRYER))
 		if(isElectrified())
-			shock(user,100)//it's like sticking a forck in a power socket
-			return
+			shock(user,100)
 
-		if(!density)//already open
-			return
-
-		if(locked)
+		if(locked) 
 			to_chat(user, "<span class='warning'>The bolts are down, it won't budge!</span>")
 			return
 
@@ -1089,15 +1085,17 @@
 			return
 
 		var/time_to_open = 5
-		if(hasPower() && !prying_so_hard)
+		if(hasPower() && !prying_so_hard && density)
 			time_to_open = 50
-			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
+			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
 			prying_so_hard = TRUE
+			to_chat(user, "<span class='warning'>You begin prying open the airlock...</span>")
 			if(do_after(user, time_to_open, TRUE, src))
-				open(2)
-				if(density && !open(2))
+				if(!open(2) && density)
 					to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
 			prying_so_hard = FALSE
+		if(!hasPower())
+			INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
 	else
 		return ..()
 
@@ -1169,33 +1167,6 @@
 				to_chat(user, "<span class='warning'>You need to be wielding the fire axe to do that!</span>")
 				return
 		INVOKE_ASYNC(src, (density ? .proc/open : .proc/close), 2)
-
-	if(HAS_TRAIT(I, TRAIT_DOOR_PRYER))
-		if(isElectrified())
-			shock(user,100)//it's like sticking a forck in a power socket
-			return
-
-		if(!density)//already open
-			return
-
-		if(locked)
-			to_chat(user, "<span class='warning'>The bolts are down, it won't budge!</span>")
-			return
-
-		if(welded)
-			to_chat(user, "<span class='warning'>It's welded, it won't budge!</span>")
-			return
-
-		var/time_to_open = 5
-		if(hasPower() && !prying_so_hard)
-			time_to_open = 50
-			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE) //is it aliens or just the CE being a dick?
-			prying_so_hard = TRUE
-			if(do_after(user, time_to_open, TRUE, src))
-				open(2)
-				if(density && !open(2))
-					to_chat(user, "<span class='warning'>Despite your attempts, [src] refuses to open.</span>")
-			prying_so_hard = FALSE
 
 
 /obj/machinery/door/airlock/open(forced=0)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -649,6 +649,7 @@
 /obj/item/nullrod/armblade/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
+//	ADD_TRAIT(src, TRAIT_DOOR_PRYER, INNATE_TRAIT)	//uncomment if you want chaplains to have AA as a null rod option. The armblade will behave even more like a changeling one then!
 	AddComponent(/datum/component/butchering, 80, 70)
 
 /obj/item/nullrod/armblade/tentacle

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -166,6 +166,7 @@
 /obj/item/melee/arm_blade/Initialize(mapload,silent,synthetic)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
+	ADD_TRAIT(src, TRAIT_DOOR_PRYER, INNATE_TRAIT)
 	if(ismob(loc) && !silent)
 		loc.visible_message("<span class='warning'>A grotesque blade forms around [loc.name]\'s arm!</span>", "<span class='warning'>Our arm twists and mutates, transforming it into a deadly blade.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
 	if(synthetic)
@@ -183,27 +184,6 @@
 	else if(istype(target, /obj/machinery/computer))
 		var/obj/machinery/computer/C = target
 		C.attack_alien(user) //muh copypasta
-
-	else if(istype(target, /obj/machinery/door/airlock))
-		var/obj/machinery/door/airlock/A = target
-
-		if((A.id_scan_hacked() || A.allowed(user)) && A.hasPower()) //This is to prevent stupid shit like hitting a door with an arm blade, the door opening because you have access and still getting a "the airlocks motors resist our efforts to force it" message, power requirement is so this doesn't stop unpowered doors from being pried open if you have access.
-			//Note that because the id_scan_hacked() check is the opposite from how it works in the actual opening check, a powered + id_scan_hacked airlock will prevent lings from forcing the door with arm blades, while also blocking regular access. Also, the entire premise of the comment/logic above is flawed, since you can only use arm blades on a door with HARM intent (due to this being afterattack()), and that prevents you from interacting normally.
-			return
-		if(A.locked)
-			to_chat(user, "<span class='warning'>The airlock's bolts prevent it from being forced!</span>")
-			return
-
-		if(A.hasPower())
-			user.visible_message("<span class='warning'>[user] jams [src] into the airlock and starts prying it open!</span>", "<span class='warning'>We start forcing the [A] open.</span>", \
-			"<span class='italics'>You hear a metal screeching sound.</span>")
-			playsound(A, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
-			if(!do_after(user, 100, target = A))
-				return
-		//user.say("Heeeeeeeeeerrre's Johnny!")
-		user.visible_message("<span class='warning'>[user] forces the airlock to open with [user.p_their()] [src]!</span>", "<span class='warning'>We force the [A] to open.</span>", \
-		"<span class='italics'>You hear a metal screeching sound.</span>")
-		A.open(2)
 
 /obj/item/melee/arm_blade/dropped(mob/user)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -178,6 +178,7 @@
 /obj/item/light_eater/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
+	ADD_TRAIT(src, TRAIT_DOOR_PRYER, HAND_REPLACEMENT_TRAIT)
 	AddComponent(/datum/component/butchering, 80, 70)
 
 /obj/item/light_eater/afterattack(atom/movable/AM, mob/user, proximity)

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -178,7 +178,7 @@
 /obj/item/light_eater/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
-	ADD_TRAIT(src, TRAIT_DOOR_PRYER, HAND_REPLACEMENT_TRAIT)
+	ADD_TRAIT(src, TRAIT_DOOR_PRYER, INNATE_TRAIT)
 	AddComponent(/datum/component/butchering, 80, 70)
 
 /obj/item/light_eater/afterattack(atom/movable/AM, mob/user, proximity)

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -50,15 +50,19 @@
 	if(isspaceturf(newLoc))
 		to_chat(user, "<span class='warning'>It really would not be wise to go into space.</span>")
 		return
+	var/light_amount = newLoc.get_lumcount()
+	if(light_amount > SHADOW_SPECIES_LIGHT_THRESHOLD && is_blocked_turf(newLoc))
+		to_chat(user, "<span class='warning'>It wouldn't be wise to move here while incorporeal, I may become trapped.</span>")
+		return
 	forceMove(newLoc)
 	check_light_level()
 
 /obj/effect/dummy/phased_mob/shadow/proc/check_light_level()
 	var/turf/T = get_turf(src)
 	var/light_amount = T.get_lumcount()
-	if(light_amount > 0.2) // jaunt ends
+	if(light_amount > SHADOW_SPECIES_LIGHT_THRESHOLD) // jaunt ends
 		end_jaunt(TRUE)
-	else if (light_amount < 0.2 && (!QDELETED(jaunter))) //heal in the dark
+	else if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD && (!QDELETED(jaunter))) //heal in the dark
 		jaunter.heal_overall_damage(1,1, 0, BODYTYPE_ORGANIC)
 
 /obj/effect/dummy/phased_mob/shadow/proc/end_jaunt(forced = FALSE)

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -50,8 +50,7 @@
 	if(isspaceturf(newLoc))
 		to_chat(user, "<span class='warning'>It really would not be wise to go into space.</span>")
 		return
-	var/light_amount = newLoc.get_lumcount()
-	if(light_amount > SHADOW_SPECIES_LIGHT_THRESHOLD && is_blocked_turf(newLoc))
+	if(newLoc.get_lumcount() > SHADOW_SPECIES_LIGHT_THRESHOLD && is_blocked_turf(newLoc))
 		to_chat(user, "<span class='warning'>It wouldn't be wise to move here while incorporeal, I may become trapped.</span>")
 		return
 	forceMove(newLoc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Adjusts the light threshold at which Nightmares and Shadowpeople take damage from 0.2 to 0.25. This allows both races to stand directly adjacent to a space tile without being exposed or taking damage. This is not enough of a change for any other practical difference: A functional APC still produces enough light to damage/expose, for instance, and being in space itself also does.
* The code that prevented nightmares from spacing themselves while jaunted now actually works because of the above. 
* Prevents the nightmare jaunt from allowing movement into well lit, dense objects in order to make it substantially harder to accidentally trap oneself in any number of possible positions that prevent movement and ultimately result in an accidental death. 
* Changes how `TRAIT_DOOR_PRYER` functions so that it works when applied to something that is not a crowbar, 
* Applies the `TRAIT_DOOR_PRYER` to the light eater and for consistency, also to changeling armblades which have lost their snowflake door prying code. 

**Some implications of these changes**
* The code that *should* have prevented nightmares from spacing themselves (which more or less guarantees the death of the nightmare currently) was non-functional because of how it works: Nightmares were prevented from jaunting directly into a spaced tile... but being adjacent to a spaced tile while jaunted would expose you to enough light to rematerialize, completely preventing the check from ever being made.
* By preventing a nightmare from jaunting into solid tiles which are exposed to light, they have been made substantially less capable of assaulting well-lit areas, as they can no longer enter completely lit areas through a wall or other solid objects. 
* Being able pry open airlocks, jaunt and heal inside of space-adjacent walls, and being able to intentionally space oneself and re-enter the station through an exterior airlock should make up for this
* You can still be helplessly trapped in a bad location if someone walks up to you with a light on while you're sandwiched between impassable tiles, so there will still need to be a degree of awareness when facing people with lights. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Accidentally spacing or otherwise trapping yourself in a situation you have no way out of is one of the biggest killers of nightmares. This almost completely prevents accidental deaths at the hands of the nightmare player. 
* While this wasn't the intent or focus of the PR, it does also serves to curb some of the extremely aggressive nightmare playstyles by making it more difficult to assault well-lit areas without warning.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

### Jaunting

Trying to space myself while jaunted:
![image](https://user-images.githubusercontent.com/9547572/178193681-f56ca662-2a01-449a-9d2e-d07017d8b3af.png)
![image](https://user-images.githubusercontent.com/9547572/178193646-f3911ded-0ef1-4887-88d7-d1e00307d790.png)

Spacing myself when materialized (This does harm and prevent jaunting):
![image](https://user-images.githubusercontent.com/9547572/178193672-f20d804f-1c8f-48a4-80d6-f5c58abe4af3.png)
![image](https://user-images.githubusercontent.com/9547572/178193725-b52a99d0-4598-46db-b566-fca5ce7f6ddf.png)

Trying to enter a well lit, dense tile while jaunted (moving up):
![image](https://user-images.githubusercontent.com/9547572/178194674-853ba97b-c2be-48e5-b21b-8da7edc9a619.png)
![image](https://user-images.githubusercontent.com/9547572/178194687-c0c2ce1f-331d-4af5-8181-d875e3913543.png)
![image](https://user-images.githubusercontent.com/9547572/178194394-d4c008f9-dc33-4652-b368-4cfb9be049e4.png)

Trying to enter a well lit, but open area from a wall that is dark enough to stay hidden:
![image](https://user-images.githubusercontent.com/9547572/178194872-32966685-1694-43f7-bda6-7dd9cdf41b25.png)
![image](https://user-images.githubusercontent.com/9547572/178194762-2a0e05b7-49e9-4a2c-a250-d65cdb90b0ee.png)

### Door prying and Jaws of life
Jaws of life are the only other item that currently makes use of `TRAIT_DOOR_PRYER`

Prying from non-harm intent
![image](https://user-images.githubusercontent.com/9547572/178193490-0dde4395-8255-415d-90d0-938d1dba4041.png)
![image](https://user-images.githubusercontent.com/9547572/178193527-5b1c3c35-de94-415c-a862-1f6dec20a466.png)
![image](https://user-images.githubusercontent.com/9547572/178193514-5a37a261-679e-45f8-bee1-2ec791d6eedb.png)

Attacking from harm intent:
![image](https://user-images.githubusercontent.com/9547572/178193596-ae85799d-86a3-4d7b-8d35-57db2449ce21.png)
![image](https://user-images.githubusercontent.com/9547572/178193616-e497a08b-43d1-4d20-ab99-42f6c744b40a.png)



Testing Jaws of Life to ensure they still work:
![image](https://user-images.githubusercontent.com/9547572/178194027-b62a4fd9-34c3-4ce7-a773-0c3fd27d041f.png)

In wire mode on an airlock:
![image](https://user-images.githubusercontent.com/9547572/178194096-f2f7561d-a586-489f-8084-0904f43f7f52.png)

Testing Siemen's Coefficient check (There is no item that currently utilizes this):
![image](https://user-images.githubusercontent.com/9547572/179229344-d7c1f4d8-89d6-440a-aeee-06a66edabdf2.png)
![image](https://user-images.githubusercontent.com/9547572/179229371-df454288-2dad-4876-9ded-f9b0a0ab4cf6.png)

Same door, pried without insulation on the armblade:
![image](https://user-images.githubusercontent.com/9547572/179230005-7bbb652b-d334-4049-bfc7-0212e1261c16.png)



</details>

## Changelog
:cl:
fix: Nightmares can no longer accidentally space themselves while jaunted. Rematerializing manually will allow entry into space, which is bright enough to harm and prevent further jaunting
tweak: Nightmares are no longer exposed or harmed when adjacent to space tiles
tweak: Nightmares can no longer enter solid tiles which are bright enough to force rematerialization
add: Light eater can now force doors open, even if they are powered (But not if bolted or welded)
balance: Nightmares are less capable of entering well-lit areas, but are even more slippery than before now that they can reliably re-enter the station from space if they're fast enough and can afford the harm it causes. Nightmares should be almost incapable of killing themselves via lag or accidental mishaps as well now.
code: Due to code shuffling of door prying, changeling armblades now require non-harm intent to open doors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
