### PR TITLE
PDA is now automatically updated when it takes a card / ghost role spawns now have proper HUDs, card names

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -10,6 +10,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 #define PDA_SCANNER_HALOGEN		4
 #define PDA_SCANNER_GAS			5
 #define PDA_SPAM_DELAY		    1 MINUTES
+#define PDA_TOGGLE_ON		    "On"
+#define PDA_TOGGLE_OFF		    "Off"
 
 /obj/item/pda
 	name = "\improper PDA"
@@ -74,6 +76,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/equipped = FALSE  //used here to determine if this is the first time its been picked up
 	var/allow_emojis = FALSE //if the pda can send emojis and actually have them parsed as such
 	var/sort_by_job = FALSE // If this is TRUE, will sort PDA list by job.
+	var/toggle_auto_update = PDA_TOGGLE_ON // If this is "On", automatically update PDA when taken a card, if no, it doesn't.
 
 	var/obj/item/card/id/id = null //Making it possible to slot an ID card into the PDA so it can function as both.
 	var/ownjob = null //related to above
@@ -233,7 +236,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += "<h2>PERSONAL DATA ASSISTANT v.1.2</h2>"
 				dat += "Owner: [owner], [ownjob]<br>"
 				dat += text("ID: <a href='?src=[REF(src)];choice=Authenticate'>[id ? "[id.registered_name], [id.assignment]" : "----------"]")
-				dat += text("<br><a href='?src=[REF(src)];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</A><br><br>")
+				dat += text("<br><a href='?src=[REF(src)];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</A><br>")
+				dat += text("<br><a href='?src=[REF(src)];choice=ToggleAutoUpdate'>Toggle auto-updating: \[[toggle_auto_update]\]</A><br><br>")
 
 				dat += "[station_time_timestamp()]<br>" //:[world.time / 100 % 6][world.time / 100 % 10]"
 				dat += "[time2text(world.realtime, "MMM DD")] [GLOB.year_integer+540]"
@@ -444,6 +448,13 @@ GLOBAL_LIST_EMPTY(PDAs)
 				id_check(U)
 			if("UpdateInfo")
 				update_pda()
+			if("ToggleAutoUpdate")
+				switch(toggle_auto_update)
+					if(PDA_TOGGLE_ON)
+						toggle_auto_update = PDA_TOGGLE_OFF
+					if(PDA_TOGGLE_OFF)
+						toggle_auto_update = PDA_TOGGLE_ON
+						update_pda()
 			if("Eject")//Ejects the cart, only done from hub.
 				eject_cart(U)
 				if(!silent)
@@ -974,7 +985,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if(!id_check(user, idcard))
 				return
 			to_chat(user, "<span class='notice'>You put the ID into \the [src]'s slot.</span>")
-			if(ownjob != id.assignment && !istype(id, /obj/item/card/id/syndicate)) // auto-update by inserting your card
+			if(((owner != id.registered_name) || (ownjob != id.assignment)) && (toggle_auto_update == PDA_TOGGLE_ON)) // auto-update by inserting your card
 				update_pda()
 			updateSelfDialog()//Update self dialog on success.
 
@@ -1198,3 +1209,5 @@ GLOBAL_LIST_EMPTY(PDAs)
 #undef PDA_SCANNER_HALOGEN
 #undef PDA_SCANNER_GAS
 #undef PDA_SPAM_DELAY
+#undef PDA_TOGGLE_ON
+#undef PDA_TOGGLE_OFF

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -443,13 +443,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if ("Authenticate")//Checks for ID
 				id_check(U)
 			if("UpdateInfo")
-				ownjob = id.assignment
-				if(istype(id, /obj/item/card/id/syndicate))
-					owner = id.registered_name
-				update_label()
-				if(!silent)
-					playsound(src, 'sound/machines/terminal_processing.ogg', 15, TRUE)
-					addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, src, 'sound/machines/terminal_success.ogg', 15, TRUE), 1.3 SECONDS)
+				update_pda()
 			if("Eject")//Ejects the cart, only done from hub.
 				eject_cart(U)
 				if(!silent)
@@ -645,6 +639,15 @@ GLOBAL_LIST_EMPTY(PDAs)
 			var/mob/living/carbon/human/H = loc
 			if(H.wear_id == src)
 				H.sec_hud_set_ID()
+
+/obj/item/pda/proc/update_pda()
+	ownjob = id.assignment
+	if(istype(id, /obj/item/card/id/syndicate))
+		owner = id.registered_name
+	update_label()
+	if(!silent)
+		playsound(src, 'sound/machines/terminal_processing.ogg', 15, TRUE)
+		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, src, 'sound/machines/terminal_success.ogg', 15, TRUE), 1.3 SECONDS)
 
 /obj/item/pda/proc/do_remove_id(mob/user)
 	if(!id)
@@ -971,9 +974,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 			if(!id_check(user, idcard))
 				return
 			to_chat(user, "<span class='notice'>You put the ID into \the [src]'s slot.</span>")
+			if(ownjob != id.assignment && !istype(id, /obj/item/card/id/syndicate)) // auto-update by inserting your card
+				update_pda()
 			updateSelfDialog()//Update self dialog on success.
 
 			return	//Return in case of failed check or when successful.
+
 		updateSelfDialog()//For the non-input related code.
 	else if(istype(C, /obj/item/paicard) && !pai)
 		if(!user.transferItemToLoc(C, src))

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -174,7 +174,7 @@
 	back = /obj/item/storage/backpack/satchel
 	r_pocket = /obj/item/pda/heads
 	l_hand = /obj/item/clipboard
-	id = /obj/item/card/id
+	id = /obj/item/card/id/centcom
 
 /datum/outfit/centcom_official/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
@@ -187,6 +187,7 @@
 
 	var/obj/item/card/id/W = H.wear_id
 	W.icon_state = "centcom"
+	W.access = list() // wipe access - they shouldn't get all centcom access.
 	W.access = get_centcom_access("CentCom Official")
 	W.access += ACCESS_WEAPONS
 	W.assignment = "CentCom Official"
@@ -343,6 +344,7 @@
 		return
 
 	var/obj/item/card/id/W = H.wear_id
+	W.access = list() //wipe access - they shouldn't get all centcom access.
 	W.access = get_centcom_access(name)
 	W.access += ACCESS_WEAPONS
 	W.assignment = name
@@ -430,7 +432,7 @@
 	suit_store = /obj/item/tank/internals/emergency_oxygen/double
 	belt = /obj/item/gun/ballistic/revolver/mateba
 	l_hand = /obj/item/gun/energy/pulse/loyalpin
-	id = /obj/item/card/id
+	id = /obj/item/card/id/centcom
 	ears = /obj/item/radio/headset/headset_cent/alt
 
 	backpack_contents = list(/obj/item/storage/box=1,\
@@ -454,6 +456,7 @@
 
 	var/obj/item/card/id/W = H.wear_id
 	W.icon_state = "centcom"
+	W.access = list() //wipe access first
 	W.access = get_all_accesses()//They get full station access.
 	W.access += get_centcom_access("Death Commando")//Let's add their alloted CentCom access.
 	W.assignment = "Death Commando"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -421,3 +421,11 @@
 	ears = /obj/item/radio/headset/headset_srv
 
 
+/datum/outfit/joker/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
+	var/obj/item/card/id/I = H.wear_id
+	I.assignment = "Joker"
+	I.registered_name = H.real_name
+	I.update_label()

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -236,7 +236,7 @@
 	r_pocket = /obj/item/lighter
 	l_pocket = /obj/item/ammo_box/a357
 	back = /obj/item/storage/backpack/satchel/leather
-	id = /obj/item/card/id
+	id = /obj/item/card/id/centcom
 
 /datum/outfit/centcom/commander/plasmaman
 	name = "CentCom Commander Plasmaman"
@@ -274,7 +274,7 @@
 	belt = /obj/item/gun/energy/pulse/pistol/m1911
 	r_pocket = /obj/item/lighter
 	back = /obj/item/storage/backpack/satchel/leather
-	id = /obj/item/card/id
+	id = /obj/item/card/id/centcom
 	r_hand = /obj/item/megaphone/command
 
 /datum/outfit/admiral/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -356,13 +356,13 @@
 	back = /obj/item/storage/backpack/satchel/leather
 	belt = /obj/item/gun/ballistic/revolver/mateba
 
-	id = /obj/item/card/id
+	id = /obj/item/card/id/silver
 
 /datum/outfit/soviet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
 		return
 
-	var/obj/item/card/id/W = H.wear_id
+	var/obj/item/card/id/silver/W = H.wear_id
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("Admiral")

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/vip_extraction.dm
@@ -87,6 +87,17 @@
 	back = /obj/item/storage/backpack
 	r_hand = /obj/item/gps
 
+/datum/outfit/vip_target/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
+	if(H.wear_id?.GetID())
+		var/obj/item/card/id/I = H.wear_id.GetID()
+		if(I)
+			I.registered_name = H.real_name
+			I.update_label()
+
+
 //=====================
 // Centcom Official (VIP)
 //=====================


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
HUD related tweaks/fix
* PDA is now automatically updated when it takes a card (if it's a syndicate card, manual update is needed)
* ghost role spawns now have proper HUDs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Seeing grey hud is bad
Seeing crews not updating their PDA is not good too. Unless they're syndicate, there would be no practical usage to not-update your PDA.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/178454038-5dec812f-b5c2-422c-8a49-cdae0627816d.png)

captain spare card automatically refreshes your PDA as captain

![image](https://user-images.githubusercontent.com/87972842/178454498-d5ba4b20-d99e-4b95-b54d-22f94180e3b3.png)

normal cards with no name/incorrect name are rejected. only captain's spare works.

-------------------

![image](https://user-images.githubusercontent.com/87972842/178454584-c26d68e2-e7f5-4e8d-9d33-8b3baed8e09a.png)

Otherwise, as long as the card has a name that is same to the PDA's registered name, it is automatically updated.


-------------------


![image](https://user-images.githubusercontent.com/87972842/179452408-6ddc03a1-3582-45ec-b4b6-89242b0562fe.png)
![image](https://user-images.githubusercontent.com/87972842/179452438-377e6285-4055-4ad6-8c74-fbdb60c34434.png)


as long as it's ON mode, it will automatically update your PDA.
chameleon PDA still should do manual update

-------------

(images deleted accidentally...)
syndicate cards are working well too

-------------------
![image](https://user-images.githubusercontent.com/87972842/178455114-069e452f-56fc-4d81-a0a6-73ed7cc6eb9f.png)
![image](https://user-images.githubusercontent.com/87972842/178455124-e05b09dc-8b14-4f1a-bae3-5d1afec70143.png)
![image](https://user-images.githubusercontent.com/87972842/178455137-cc9957b0-4948-445d-b22f-c0fc06f8850d.png)

ghost role spawns now properly shows correct HUDs.

--------------

![image](https://user-images.githubusercontent.com/87972842/178499295-b352d394-acc2-49ee-8094-679078445356.png)

ruin VIP gets their card named

</details>

## Changelog
:cl:
tweak: adjusted ghost role spawn character's ID card as it doesn't show grey hud icon. (CentCom commander, Official, etc)
tweak: PDA now has a clickable link to turn on/off PDA auto-update. As long as it's On, PDA is automatically updated when it takes a card (Chameleon PDA still should do a manual update when you change appearance.)
fix: Ruin VIP's card gets their owner's name now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
