### PR TITLE
Fixes a posibrain bug

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -104,8 +104,8 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		return
 	if(brainmob.suiciding) //clear suicide status if the old occupant suicided.
 		brainmob.set_suicide(FALSE)
-	GLOB.posi_key_list += user.ckey
-	transfer_personality(user)
+	if(transfer_personality(user))
+		GLOB.posi_key_list += user.ckey
 
 /obj/item/mmi/posibrain/transfer_identity(mob/living/carbon/C)
 	name = "[initial(name)] ([C])"


### PR DESCRIPTION
getting added to the posi key list even when you can't take the posi sucks

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since the 1 posibrain/round system got added, there's been a bug where attempting to join a posi at the same time as someone else will lead to only one person getting put in the posi, but both people getting added to the posi_key_list. This means that the person that didn't get the posi couldn't get into any further posis, despite never successfully taking a posi in that round.

This fixes that by checking to see if transfer_personality returns true before adding someone to the posi key list.

## Why It's Good For The Game

Bugs bad.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Tested with a posibrain, properly limited the ckey to 1/round without causing issues when you didn't get put into the brain.

</details>

## Changelog
:cl:
fix: Failing to get put into a posibrain won't lock you out of other posibrains anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
