### PR TITLE
Facehuggers now work on corpses

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -193,7 +193,7 @@
 	attached = FALSE
 
 /obj/item/clothing/mask/facehugger/proc/Impregnate(mob/living/target)
-	if(!target || target.stat == DEAD) //was taken off or something
+	if(!target) //was taken off or something
 		return
 
 	if(iscarbon(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes facehuggers work on dead players to invalidate the metagame-y strategy of suicide/succumbing early. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Metagaming antags bad.
Was requested on the forums [here](https://forums.beestation13.com/t/xenomorphs/18933?u=ruko) (There's some relevant back and forth discussion in the thread)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/178847377-fc33ae82-48d6-46b0-a46b-dd4725566df7.png)

</details>

## Changelog
:cl:
tweak: facehuggers now work on dead crew members. Suicide is not badass, it's metagaming. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
