### PR TITLE
No more Xray Malf AI metagame

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -162,7 +162,7 @@
 	// Cameras that get here are moving, and are likely attached to some moving atom such as cyborgs.
 	last_camera_turf = get_turf(cam_location)
 
-	if(active_camera.isXRay())
+	if(active_camera.isXRay(TRUE))	//ignore_malf_upgrades = TRUE
 		visible_turfs += RANGE_TURFS(active_camera.view_range, cam_location)
 	else
 		for(var/turf/T in view(active_camera.view_range, cam_location))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Camera consoles can no longer use malf AI xray.

## Why It's Good For The Game

Metagaming is not cool.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
No analyzer.

![image](https://user-images.githubusercontent.com/34888552/178853675-f75ec28e-e886-4d76-bd8f-2805287732a2.png)

Yes analyzer.

![image](https://user-images.githubusercontent.com/34888552/178853795-4c1bdeea-2582-422e-85dc-a6f8e4ddaf3b.png)

Both images were taken after the AI installed upgrades.

</details>


## Changelog
:cl:
fix: Camera consoles can no longer be used to metagame a malf AI installing x-ray upgrades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
