### PR TITLE
Dead people don't get their mood changed.

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -198,6 +198,9 @@
 /datum/component/mood/proc/setSanity(amount, minimum=SANITY_INSANE, maximum=SANITY_GREAT)
 	var/mob/living/owner = parent
 
+	if(owner.stat == DEAD) // deadman can't feel mood
+		return
+
 	if(amount == sanity)
 		return
 	// If we're out of the acceptable minimum-maximum range move back towards it in steps of 0.5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A PR that makes people's moodlet is not changed anymore when they're dead.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Being dead for a long time and revived at an insane mood level is annoying, and it doesn't make sense since dead people can't feel.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/179024065-f4f7ddde-d6f4-4774-aab1-1ca0c132ab34.png)

current live (dead man goes insane)
died in the best condition, spending a few minutes checking their mood.



![image](https://user-images.githubusercontent.com/87972842/179024603-be21a8e0-0e38-44fa-b6ab-04b2b1e7f5a1.png)

this PR (dead man is still peaceful)
died in the best condition, spending a few minutes checking their mood.
It's pretty fine.

</details>

## Changelog
:cl:
balance: People's mood is no longer changed/adjusted when they're dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
