### PR TITLE
Subsystems are no longer allowed to sleep within fire()

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -63,6 +63,7 @@
 //fire() seems more suitable. This is the procedure that gets called every 'wait' deciseconds.
 //Sleeping in here prevents future fires until returned.
 /datum/controller/subsystem/proc/fire(resumed = 0)
+	SHOULD_NOT_SLEEP(TRUE)
 	flags |= SS_NO_FIRE
 	CRASH("Subsystem [src]([type]) does not fire() but did not set the SS_NO_FIRE flag. Please add the SS_NO_FIRE flag to any subsystem that doesn't fire so it doesn't get added to the processing list and waste cpu.")
 

--- a/code/controllers/subsystem/adjacent_air.dm
+++ b/code/controllers/subsystem/adjacent_air.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(adjacent_air)
 
 /datum/controller/subsystem/adjacent_air/Initialize()
 	while(length(queue) || length(disable_queue))
-		fire(mc_check = FALSE)
+		fire()
 		CHECK_TICK
 	return ..()
 

--- a/code/controllers/subsystem/adjacent_air.dm
+++ b/code/controllers/subsystem/adjacent_air.dm
@@ -15,11 +15,12 @@ SUBSYSTEM_DEF(adjacent_air)
 #endif
 
 /datum/controller/subsystem/adjacent_air/Initialize()
-	while(length(queue))
+	while(length(queue) || length(disable_queue))
 		fire(mc_check = FALSE)
+		CHECK_TICK
 	return ..()
 
-/datum/controller/subsystem/adjacent_air/fire(resumed = FALSE, mc_check = TRUE)
+/datum/controller/subsystem/adjacent_air/fire(resumed = FALSE)
 	if(SSair.thread_running())
 		pause()
 		return
@@ -33,11 +34,8 @@ SUBSYSTEM_DEF(adjacent_air)
 
 		terf.ImmediateDisableAdjacency(arg)
 
-		if(mc_check)
-			if(MC_TICK_CHECK)
-				return
-		else
-			CHECK_TICK
+		if(MC_TICK_CHECK)
+			return
 
 	var/list/queue = src.queue
 
@@ -47,8 +45,5 @@ SUBSYSTEM_DEF(adjacent_air)
 
 		currT.ImmediateCalculateAdjacentTurfs()
 
-		if(mc_check)
-			if(MC_TICK_CHECK)
-				break
-		else
-			CHECK_TICK
+		if(MC_TICK_CHECK)
+			break

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -465,9 +465,15 @@ SUBSYSTEM_DEF(air)
 /datum/controller/subsystem/air/proc/unpause_z(z_level)
 	var/list/turfs_to_reinit = block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level))
 	for(var/turf/T as anything in turfs_to_reinit)
-		T.Initalize_Atmos()
-		CHECK_TICK
+		//We can skip enabling space turfs
+		if(!isspaceturf(T))
+			T.Initalize_Atmos()
+		//High priority, as we don't want to freeze the server, but we also don't want this to take too long
+		//as it will freeze other subsystems during intense atmos hours
+		CHECK_TICK_HIGH_PRIORITY
 	LAZYREMOVE(paused_z_levels, z_level)
+	if(!length(paused_z_levels))
+		SSair.can_fire = TRUE
 
 /datum/controller/subsystem/air/proc/setup_allturfs()
 	var/list/turfs_to_init = block(locate(1, 1, 1), locate(world.maxx, world.maxy, world.maxz))

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -464,6 +464,7 @@ SUBSYSTEM_DEF(air)
 
 /datum/controller/subsystem/air/proc/unpause_z(z_level)
 	var/list/turfs_to_reinit = block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level))
+	SSair.can_fire = FALSE
 	for(var/turf/T as anything in turfs_to_reinit)
 		//We can skip enabling space turfs
 		if(!isspaceturf(T))

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -28,9 +28,9 @@ SUBSYSTEM_DEF(ambience)
 		var/ambi_fx = pick(current_area.ambientsounds)
 		var/ambi_music = pick(current_area.ambientmusic)
 
-		play_ambience_music(client_iterator.mob, ambi_music, current_area)
+		INVOKE_ASYNC(src, .proc/play_ambience_music, client_iterator.mob, ambi_music, current_area)
 
-		play_ambience_effects(client_iterator.mob, ambi_fx, current_area)
+		INVOKE_ASYNC(src, .proc/play_ambience_effects, client_iterator.mob, ambi_fx, current_area)
 
 		ambience_listening_clients[client_iterator] = world.time + rand(current_area.min_ambience_cooldown, current_area.max_ambience_cooldown)
 

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -17,5 +17,5 @@ SUBSYSTEM_DEF(autotransfer)
 
 /datum/controller/subsystem/autotransfer/fire()
 	if(REALTIMEOFDAY > targettime)
-		SSvote.initiate_vote("transfer", null)
+		INVOKE_ASYNC(SSvote, /datum/controller/subsystem/vote.proc/initiate_vote, "transfer", null)
 		targettime = targettime + CONFIG_GET(number/vote_autotransfer_interval)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -35,6 +35,7 @@ SUBSYSTEM_DEF(lighting)
 	return ..()
 
 /datum/controller/subsystem/lighting/fire(resumed, init_tick_checks)
+	SHOULD_NOT_SLEEP(FALSE)	//Can sleep from init
 	MC_SPLIT_TICK_INIT(3)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -50,7 +50,7 @@ SUBSYSTEM_DEF(lighting)
 
 		if(init_tick_checks)
 			if(TICK_CHECK)
-				return
+				break
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
@@ -67,7 +67,7 @@ SUBSYSTEM_DEF(lighting)
 		C.needs_update = FALSE
 		if(init_tick_checks)
 			if(TICK_CHECK)
-				return
+				break
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
@@ -88,7 +88,7 @@ SUBSYSTEM_DEF(lighting)
 		O.needs_update = FALSE
 		if(init_tick_checks)
 			if(TICK_CHECK)
-				return
+				break
 		else if (MC_TICK_CHECK)
 			break
 	if (i)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -30,12 +30,13 @@ SUBSYSTEM_DEF(lighting)
 		create_all_lighting_objects()
 		initialized = TRUE
 
-	fire(FALSE, TRUE)
+	while(length(GLOB.lighting_update_lights) || length(GLOB.lighting_update_corners) || length(GLOB.lighting_update_objects))
+		fire(FALSE, TRUE)
+		CHECK_TICK
 
 	return ..()
 
 /datum/controller/subsystem/lighting/fire(resumed, init_tick_checks)
-	SHOULD_NOT_SLEEP(FALSE)	//Can sleep from init
 	MC_SPLIT_TICK_INIT(3)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
@@ -48,7 +49,8 @@ SUBSYSTEM_DEF(lighting)
 		L.needs_update = LIGHTING_NO_UPDATE
 
 		if(init_tick_checks)
-			CHECK_TICK
+			if(TICK_CHECK)
+				return
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
@@ -64,7 +66,8 @@ SUBSYSTEM_DEF(lighting)
 		C.update_objects()
 		C.needs_update = FALSE
 		if(init_tick_checks)
-			CHECK_TICK
+			if(TICK_CHECK)
+				return
 		else if (MC_TICK_CHECK)
 			break
 	if (i)
@@ -84,7 +87,8 @@ SUBSYSTEM_DEF(lighting)
 		O.update()
 		O.needs_update = FALSE
 		if(init_tick_checks)
-			CHECK_TICK
+			if(TICK_CHECK)
+				return
 		else if (MC_TICK_CHECK)
 			break
 	if (i)

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(mobs)
 					break
 				var/msg = "[ADMIN_LOOKUPFLW(M)] was found to have no .loc with an attached client, if the cause is unknown it would be wise to ask how this was accomplished."
 				message_admins(msg)
-				send2tgs_adminless_only("Mob", msg, R_ADMIN)
+				INVOKE_ASYNC(GLOBAL_PROC, send2tgs_adminless_only, "Mob", msg, R_ADMIN)
 				log_game("[key_name(M)] was found to have no .loc with an attached client.")
 
 			// This is a temporary error tracker to make sure we've caught everything

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(mobs)
 					break
 				var/msg = "[ADMIN_LOOKUPFLW(M)] was found to have no .loc with an attached client, if the cause is unknown it would be wise to ask how this was accomplished."
 				message_admins(msg)
-				INVOKE_ASYNC(GLOBAL_PROC, send2tgs_adminless_only, "Mob", msg, R_ADMIN)
+				INVOKE_ASYNC(GLOBAL_PROC, /proc/send2tgs_adminless_only, "Mob", msg, R_ADMIN)
 				log_game("[key_name(M)] was found to have no .loc with an attached client.")
 
 			// This is a temporary error tracker to make sure we've caught everything

--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -10,6 +10,8 @@ SUBSYSTEM_DEF(nightshift)
 
 	var/high_security_mode = FALSE
 
+	var/list/processing = list()
+
 /datum/controller/subsystem/nightshift/Initialize()
 	if(!CONFIG_GET(flag/enable_night_shifts))
 		can_fire = FALSE
@@ -31,7 +33,7 @@ SUBSYSTEM_DEF(nightshift)
 	if(!SSmapping.config.allow_night_lighting)
 		if(night_time)
 			night_time = FALSE
-			update_nightshift(night_time, FALSE)
+			INVOKE_ASYNC(src, .proc/update_nightshift, night_time, FALSE)
 		return
 	if(high_security_mode != emergency)
 		high_security_mode = emergency
@@ -44,7 +46,8 @@ SUBSYSTEM_DEF(nightshift)
 	if(emergency)
 		night_time = FALSE
 	if(nightshift_active != night_time)
-		update_nightshift(night_time, announcing)
+		//Would do it in fire() but it has an update rate of 60 seconds
+		INVOKE_ASYNC(src, .proc/update_nightshift, night_time, announcing)
 
 /datum/controller/subsystem/nightshift/proc/update_nightshift(active, announce = TRUE)
 	nightshift_active = active

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -30,7 +30,7 @@ SUBSYSTEM_DEF(overlays)
 	queue = SSoverlays.queue
 
 
-/datum/controller/subsystem/overlays/fire(resumed = FALSE, mc_check = TRUE)
+/datum/controller/subsystem/overlays/fire(resumed = FALSE)
 	var/list/queue = src.queue
 	var/static/count = 0
 	if (count)
@@ -46,11 +46,8 @@ SUBSYSTEM_DEF(overlays)
 			COMPILE_OVERLAYS(A)
 			STAT_STOP_STOPWATCH
 			STAT_LOG_ENTRY(stats, A.type)
-		if(mc_check)
-			if(MC_TICK_CHECK)
-				break
-		else
-			CHECK_TICK
+		if(MC_TICK_CHECK)
+			break
 
 	if (count)
 		queue.Cut(1,count+1)

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(overlays)
 
 /datum/controller/subsystem/overlays/Initialize()
 	initialized = TRUE
-	fire(mc_check = FALSE)
+	fire()
 	return ..()
 
 

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -50,5 +50,6 @@ SUBSYSTEM_DEF(processing)
   * If you override this do not call parent, as it will return PROCESS_KILL. This is done to prevent objects that dont override process() from staying in the processing list
   */
 /datum/proc/process(delta_time)
+	SHOULD_NOT_SLEEP(TRUE)
 	set waitfor = FALSE
 	return PROCESS_KILL

--- a/code/controllers/subsystem/processing/processing.dm
+++ b/code/controllers/subsystem/processing/processing.dm
@@ -50,6 +50,5 @@ SUBSYSTEM_DEF(processing)
   * If you override this do not call parent, as it will return PROCESS_KILL. This is done to prevent objects that dont override process() from staying in the processing list
   */
 /datum/proc/process(delta_time)
-	SHOULD_NOT_SLEEP(TRUE)
 	set waitfor = FALSE
 	return PROCESS_KILL

--- a/code/controllers/subsystem/profiler.dm
+++ b/code/controllers/subsystem/profiler.dm
@@ -62,7 +62,6 @@ SUBSYSTEM_DEF(profiler)
 	var/current_sendmaps_data = world.Profile(PROFILE_REFRESH, type = "sendmaps", format="json")
 #endif
 	fetch_cost = MC_AVERAGE(fetch_cost, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
-	CHECK_TICK
 
 	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
 		stack_trace("Warning, profiling stopped manually before dump.")

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -99,7 +99,7 @@ SUBSYSTEM_DEF(shuttle)
 			mobile.Remove(thing)
 			continue
 		var/obj/docking_port/mobile/P = thing
-		P.check()
+		INVOKE_ASYNC(P, /obj/docking_port/mobile.proc/check)
 	for(var/thing in transit)
 		var/obj/docking_port/stationary/transit/T = thing
 		if(!T.owner)

--- a/code/controllers/subsystem/stat.dm
+++ b/code/controllers/subsystem/stat.dm
@@ -22,7 +22,6 @@ SUBSYSTEM_DEF(stat)
 	//cache for sanic speed (lists are references anyways)
 	var/list/currentrun = src.currentrun
 	var/list/currentrun_listed = src.currentrun_listed
-	var/list/icon_requests = src.icon_requests
 	var/list/currentrun_aftericon = src.currentrun_aftericon
 
 	while(currentrun.len)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -507,7 +507,7 @@ SUBSYSTEM_DEF(ticker)
 		for (var/mob/dead/new_player/NP in queued_players)
 			to_chat(NP, "<span class='userdanger'>The alive players limit has been released!<br><a href='?src=[REF(NP)];late_join=override'>[html_encode(">>Join Game<<")]</a></span>")
 			SEND_SOUND(NP, sound('sound/misc/notice1.ogg'))
-			INVOKE_ASYNC(NP, /mob/dead/new_player./LateChoices)
+			INVOKE_ASYNC(NP, /mob/dead/new_player.proc/LateChoices)
 		queued_players.len = 0
 		queue_delay = 0
 		return
@@ -522,7 +522,7 @@ SUBSYSTEM_DEF(ticker)
 				if(next_in_line && next_in_line.client)
 					to_chat(next_in_line, "<span class='userdanger'>A slot has opened! You have approximately 20 seconds to join. <a href='?src=[REF(next_in_line)];late_join=override'>\>\>Join Game\<\<</a></span>")
 					SEND_SOUND(next_in_line, sound('sound/misc/notice1.ogg'))
-					INVOKE_ASYNC(next_in_line, /mob/dead/new_player./LateChoices)
+					INVOKE_ASYNC(next_in_line, /mob/dead/new_player.proc/LateChoices)
 					return
 				queued_players -= next_in_line //Client disconnected, remove he
 			queue_delay = 0 //No vacancy: restart timer

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -159,7 +159,7 @@ SUBSYSTEM_DEF(vote)
 					SSshuttle.emergencyNoRecall = TRUE //Prevent Recall.
 					var/obj/machinery/computer/communications/C = locate() in GLOB.machines
 					if(C)
-						INVOKE_ASYNC(C, /obj/machinery/computer/communications.post_status, "shuttle")
+						INVOKE_ASYNC(C, /obj/machinery/computer/communications.proc/post_status, "shuttle")
 	if(restart)
 		var/active_admins = FALSE
 		for(var/client/C in GLOB.admins+GLOB.deadmins)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -155,11 +155,11 @@ SUBSYSTEM_DEF(vote)
 				SSmapping.map_voted = TRUE
 			if("transfer")
 				if(. == "Initiate Crew Transfer")
-					INVOKE_ASYNC(SSshuttle, /datum/controller/subsystem/shuttle.proc/requestEvac, null, "Crew Transfer Requested.")
+					INVOKE_ASYNC(SSshuttle, /datum/controller/subsystem/shuttle/proc/requestEvac, null, "Crew Transfer Requested.")
 					SSshuttle.emergencyNoRecall = TRUE //Prevent Recall.
 					var/obj/machinery/computer/communications/C = locate() in GLOB.machines
 					if(C)
-						INVOKE_ASYNC(C, /obj/machinery/computer/communications.proc/post_status, "shuttle")
+						INVOKE_ASYNC(C, /obj/machinery/computer/communications/proc/post_status, "shuttle")
 	if(restart)
 		var/active_admins = FALSE
 		for(var/client/C in GLOB.admins+GLOB.deadmins)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -257,8 +257,8 @@ SUBSYSTEM_DEF(vote)
 			V.Grant(C.mob)
 			generated_actions += V
 
-			if(popup)
-				C?.mob?.vote() // automatically popup the vote
+			if(popup && C?.mob)
+				INVOKE_ASYNC(C.mob, /mob.verb/vote) // automatically popup the vote
 
 		return 1
 	return 0

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -92,7 +92,7 @@ SUBSYSTEM_DEF(vote)
 				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
 	. = list()
 	if(mode == "map")
-		. += pickweight(choices) //map is chosen by drawing votes from a hat, instead of automatically going to map with the most votes. 
+		. += pickweight(choices) //map is chosen by drawing votes from a hat, instead of automatically going to map with the most votes.
 		return .
 	//get all options with that many votes and return them in a list
 	if(greatest_votes)
@@ -155,11 +155,11 @@ SUBSYSTEM_DEF(vote)
 				SSmapping.map_voted = TRUE
 			if("transfer")
 				if(. == "Initiate Crew Transfer")
-					SSshuttle.requestEvac(null, "Crew Transfer Requested.")
+					INVOKE_ASYNC(SSshuttle, /datum/controller/subsystem/shuttle.proc/requestEvac, null, "Crew Transfer Requested.")
 					SSshuttle.emergencyNoRecall = TRUE //Prevent Recall.
 					var/obj/machinery/computer/communications/C = locate() in GLOB.machines
 					if(C)
-						C.post_status("shuttle")
+						INVOKE_ASYNC(C, /obj/machinery/computer/communications.post_status, "shuttle")
 	if(restart)
 		var/active_admins = FALSE
 		for(var/client/C in GLOB.admins+GLOB.deadmins)

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -78,9 +78,11 @@
 					controller.cycleClose(door)
 		else
 			controller.onlyClose(door)
-		sleep(20)
-		busy = FALSE
-		update_icon()
+		addtimer(CALLBACK(src, .proc/clear_busy), 2 SECONDS)
+
+/obj/machinery/doorButtons/access_button/proc/clear_busy()
+	busy = FALSE
+	update_icon()
 
 /obj/machinery/doorButtons/access_button/update_icon()
 	if(stat & NOPOWER)

--- a/code/modules/antagonists/clock_cult/clockwork_massive.dm
+++ b/code/modules/antagonists/clock_cult/clockwork_massive.dm
@@ -33,6 +33,12 @@ GLOBAL_LIST_INIT(clockwork_portals, list())
 		return
 	destroyed = TRUE
 	hierophant_message("The Ark has been destroyed, Reebe is becomming unstable!", null, "<span class='large_brass'>")
+	INVOKE_ASYNC(src, .proc/attackers_escape)
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
+	INVOKE_ASYNC(src, .proc/explode_reebe)
+
+/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/attackers_escape()
 	for(var/mob/living/M in GLOB.player_list)
 		if(!is_reebe(M.z))
 			continue
@@ -44,9 +50,6 @@ GLOBAL_LIST_INIT(clockwork_portals, list())
 		to_chat(M, "<span class='reallybig hypnophrase'>Your mind is distorted by the distant sound of a thousand screams before suddenly everything falls silent.</span>")
 		to_chat(M, "<span class='hypnophrase'>The only thing you remember is suddenly feeling warm and safe.</span>")
 		M.forceMove(safe_place)
-	STOP_PROCESSING(SSobj, src)
-	. = ..()
-	INVOKE_ASYNC(src, .proc/explode_reebe)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/proc/explode_reebe()
 	for(var/i in 1 to 30)
@@ -66,6 +69,9 @@ GLOBAL_LIST_INIT(clockwork_portals, list())
 		to_chat(world, pick(phase_messages))
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/deconstruct(disassembled = TRUE)
+	INVOKE_ASYNC(src, .proc/async_destruction, disassembled)
+
+/obj/structure/destructible/clockwork/massive/celestial_gateway/proc/async_destruction(disassembled)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(!disassembled)
 			resistance_flags |= INDESTRUCTIBLE
@@ -80,11 +86,11 @@ GLOBAL_LIST_INIT(clockwork_portals, list())
 			sound_to_playing_players('sound/effects/explosion_distant.ogg', volume = 50)
 			for(var/obj/effect/portal/wormhole/clockcult/CC in GLOB.all_wormholes)
 				qdel(CC)
+			qdel(src)
 			SSshuttle.clearHostileEnvironment(src)
 			set_security_level(SEC_LEVEL_RED)
 			sleep(300)
 			SSticker.force_ending = TRUE
-	qdel(src)
 
 /obj/structure/destructible/clockwork/massive/celestial_gateway/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
 	. = ..()

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -86,33 +86,40 @@
 		insistinga++
 
 	else
-		chargesa--
 		insistinga = 0
-		var/wish = input("You want...","Wish") as null|anything in sortList(list("Power","Wealth","Immortality","Peace"))
-		switch(wish)
-			if("Power")
-				to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
-				to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
-				user.dna.add_mutation(LASEREYES)
-				user.dna.add_mutation(SPACEMUT)
-				user.dna.add_mutation(XRAY)
-				user.set_species(/datum/species/shadow)
-			if("Wealth")
-				to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
-				to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
-				new /obj/structure/closet/syndicate/resources/everything(loc)
-				user.set_species(/datum/species/shadow)
-			if("Immortality")
-				to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
-				to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
-				user.add_verb(/mob/living/carbon/proc/immortality)
-				user.set_species(/datum/species/shadow)
-			if("Peace")
-				to_chat(user, "<B>Whatever alien sentience that the Wish Granter possesses is satisfied with your wish. There is a distant wailing as the last of the Faithless begin to die, then silence.</B>")
-				to_chat(user, "You feel as if you just narrowly avoided a terrible fate...")
-				for(var/mob/living/simple_animal/hostile/faithless/F in GLOB.mob_living_list)
-					F.death()
+		INVOKE_ASYNC(src, .proc/grant_power)
 
+/obj/machinery/wish_granter_dark/proc/grant_power()
+	var/wish = input("You want...","Wish") as null|anything in sortList(list("Power","Wealth","Immortality","Peace"))
+
+	if(chargesa <= 0)
+		to_chat(user, "The Wish Granter lies silent.")
+		return
+
+	chargesa--
+	switch(wish)
+		if("Power")
+			to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
+			to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
+			user.dna.add_mutation(LASEREYES)
+			user.dna.add_mutation(SPACEMUT)
+			user.dna.add_mutation(XRAY)
+			user.set_species(/datum/species/shadow)
+		if("Wealth")
+			to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
+			to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
+			new /obj/structure/closet/syndicate/resources/everything(loc)
+			user.set_species(/datum/species/shadow)
+		if("Immortality")
+			to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
+			to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
+			user.add_verb(/mob/living/carbon/proc/immortality)
+			user.set_species(/datum/species/shadow)
+		if("Peace")
+			to_chat(user, "<B>Whatever alien sentience that the Wish Granter possesses is satisfied with your wish. There is a distant wailing as the last of the Faithless begin to die, then silence.</B>")
+			to_chat(user, "You feel as if you just narrowly avoided a terrible fate...")
+			for(var/mob/living/simple_animal/hostile/faithless/F in GLOB.mob_living_list)
+				F.death()
 
 ///////////////Meatgrinder//////////////
 

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -87,9 +87,9 @@
 
 	else
 		insistinga = 0
-		INVOKE_ASYNC(src, .proc/grant_power)
+		INVOKE_ASYNC(src, .proc/grant_power, user)
 
-/obj/machinery/wish_granter_dark/proc/grant_power()
+/obj/machinery/wish_granter_dark/proc/grant_power(mob/living/carbon/human/user)
 	var/wish = input("You want...","Wish") as null|anything in sortList(list("Power","Wealth","Immortality","Peace"))
 
 	if(chargesa <= 0)

--- a/code/modules/awaymissions/signpost.dm
+++ b/code/modules/awaymissions/signpost.dm
@@ -16,22 +16,22 @@
 	. = ..()
 	if(.)
 		return
-	INVOKE_ASYNC(src, .proc/perform_interaction)
+	INVOKE_ASYNC(src, .proc/perform_interaction, user)
 
-/obj/structure/signpost/proc/perform_interaction()
+/obj/structure/signpost/proc/perform_interaction(mob/user)
 	if(alert(question,name,"Yes","No") == "Yes" && Adjacent(user))
-	var/turf/T = find_safe_turf(zlevels=zlevels)
+		var/turf/T = find_safe_turf(zlevels=zlevels)
 
-	if(T)
-		var/atom/movable/AM = user.pulling
-		if(AM)
-			AM.forceMove(T)
-		user.forceMove(T)
-		if(AM)
-			user.start_pulling(AM)
-		to_chat(user, "<span class='notice'>You blink and find yourself in [get_area_name(T)].</span>")
-	else
-		to_chat(user, "Nothing happens. You feel that this is a bad sign.")
+		if(T)
+			var/atom/movable/AM = user.pulling
+			if(AM)
+				AM.forceMove(T)
+			user.forceMove(T)
+			if(AM)
+				user.start_pulling(AM)
+			to_chat(user, "<span class='notice'>You blink and find yourself in [get_area_name(T)].</span>")
+		else
+			to_chat(user, "Nothing happens. You feel that this is a bad sign.")
 
 /obj/structure/signpost/attackby(obj/item/W, mob/user, params)
 	return interact(user)

--- a/code/modules/awaymissions/signpost.dm
+++ b/code/modules/awaymissions/signpost.dm
@@ -16,19 +16,22 @@
 	. = ..()
 	if(.)
 		return
-	if(alert(question,name,"Yes","No") == "Yes" && Adjacent(user))
-		var/turf/T = find_safe_turf(zlevels=zlevels)
+	INVOKE_ASYNC(src, .proc/perform_interaction)
 
-		if(T)
-			var/atom/movable/AM = user.pulling
-			if(AM)
-				AM.forceMove(T)
-			user.forceMove(T)
-			if(AM)
-				user.start_pulling(AM)
-			to_chat(user, "<span class='notice'>You blink and find yourself in [get_area_name(T)].</span>")
-		else
-			to_chat(user, "Nothing happens. You feel that this is a bad sign.")
+/obj/structure/signpost/proc/perform_interaction()
+	if(alert(question,name,"Yes","No") == "Yes" && Adjacent(user))
+	var/turf/T = find_safe_turf(zlevels=zlevels)
+
+	if(T)
+		var/atom/movable/AM = user.pulling
+		if(AM)
+			AM.forceMove(T)
+		user.forceMove(T)
+		if(AM)
+			user.start_pulling(AM)
+		to_chat(user, "<span class='notice'>You blink and find yourself in [get_area_name(T)].</span>")
+	else
+		to_chat(user, "Nothing happens. You feel that this is a bad sign.")
 
 /obj/structure/signpost/attackby(obj/item/W, mob/user, params)
 	return interact(user)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -132,11 +132,11 @@
 
 /obj/machinery/shuttle_scrambler/interact(mob/user)
 	if(!active)
-		INVOKE_ASYNC(src, .proc/try_interaction)
+		INVOKE_ASYNC(src, .proc/try_interaction, user)
 	else
 		dump_loot(user)
 
-/obj/machinery/shuttle_scrambler/proc/try_interaction()
+/obj/machinery/shuttle_scrambler/proc/try_interaction(mob/user)
 	if(alert(user, "Turning the scrambler on will make the shuttle trackable by GPS. Are you sure you want to do it?", "Scrambler", "Yes", "Cancel") == "Cancel")
 		return
 	if(active || !user.canUseTopic(src, BE_CLOSE))

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -132,15 +132,18 @@
 
 /obj/machinery/shuttle_scrambler/interact(mob/user)
 	if(!active)
-		if(alert(user, "Turning the scrambler on will make the shuttle trackable by GPS. Are you sure you want to do it?", "Scrambler", "Yes", "Cancel") == "Cancel")
-			return
-		if(active || !user.canUseTopic(src, BE_CLOSE))
-			return
-		toggle_on(user)
-		update_icon()
-		send_notification()
+		INVOKE_ASYNC(src, .proc/try_interaction)
 	else
 		dump_loot(user)
+
+/obj/machinery/shuttle_scrambler/proc/try_interaction()
+	if(alert(user, "Turning the scrambler on will make the shuttle trackable by GPS. Are you sure you want to do it?", "Scrambler", "Yes", "Cancel") == "Cancel")
+		return
+	if(active || !user.canUseTopic(src, BE_CLOSE))
+		return
+	toggle_on(user)
+	update_icon()
+	send_notification()
 
 //interrupt_research
 /obj/machinery/shuttle_scrambler/proc/interrupt_research()

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -117,7 +117,9 @@
 		total_time += P.time
 	var/offset = prob(50) ? -2 : 2
 	animate(src, pixel_x = pixel_x + offset, time = 0.2, loop = (total_time / rating_speed)*5) //start shaking
-	sleep(total_time / rating_speed)
+	addtimer(CALLBACK(src, .proc/finish_processing), total_time / rating_speed)
+
+/obj/machinery/processor/proc/finish_processing()
 	for(var/atom/movable/O in src.contents)
 		var/datum/food_processor_process/P = select_recipe(O)
 		if (!P)

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -213,46 +213,49 @@
 		else
 			visible_message("<span class='danger'>[user] disturbs the [name] to no effect!</span>")
 	else
-		var/option = alert(user, "What action do you wish to perform?","Apiary","Remove a Honey Frame","Remove the Queen Bee", "Cancel")
-		if(!Adjacent(user))
-			return
-		switch(option)
-			if("Remove a Honey Frame")
-				if(!honey_frames.len)
-					to_chat(user, "<span class='warning'>There are no honey frames to remove!</span>")
-					return
+		INVOKE_ASYNC(src, .proc/perform_interaction)
 
-				var/obj/item/honey_frame/HF = pick_n_take(honey_frames)
-				if(HF)
-					if(!user.put_in_active_hand(HF))
-						HF.forceMove(drop_location())
-					visible_message("<span class='notice'>[user] removes a frame from the apiary.</span>")
+/obj/structure/beebox/proc/perform_interaction()
+	var/option = alert(user, "What action do you wish to perform?","Apiary","Remove a Honey Frame","Remove the Queen Bee", "Cancel")
+	if(!Adjacent(user))
+		return
+	switch(option)
+		if("Remove a Honey Frame")
+			if(!honey_frames.len)
+				to_chat(user, "<span class='warning'>There are no honey frames to remove!</span>")
+				return
 
-					var/amtH = HF.honeycomb_capacity
-					var/fallen = 0
-					while(honeycombs.len && amtH) //let's pretend you always grab the frame with the most honeycomb on it
-						var/obj/item/reagent_containers/honeycomb/HC = pick_n_take(honeycombs)
-						if(HC)
-							HC.forceMove(drop_location())
-							amtH--
-							fallen++
-					if(fallen)
-						var/multiple = fallen > 1
-						visible_message("<span class='notice'>[user] scrapes [multiple ? "[fallen]" : "a"] honeycomb[multiple ? "s" : ""] off of the frame.</span>")
+			var/obj/item/honey_frame/HF = pick_n_take(honey_frames)
+			if(HF)
+				if(!user.put_in_active_hand(HF))
+					HF.forceMove(drop_location())
+				visible_message("<span class='notice'>[user] removes a frame from the apiary.</span>")
 
-			if("Remove the Queen Bee")
-				if(!queen_bee || queen_bee.loc != src)
-					to_chat(user, "<span class='warning'>There is no queen bee to remove!</span>")
-					return
-				var/obj/item/queen_bee/QB = new()
-				queen_bee.forceMove(QB)
-				bees -= queen_bee
-				QB.queen = queen_bee
-				QB.name = queen_bee.name
-				if(!user.put_in_active_hand(QB))
-					QB.forceMove(drop_location())
-				visible_message("<span class='notice'>[user] removes the queen from the apiary.</span>")
-				queen_bee = null
+				var/amtH = HF.honeycomb_capacity
+				var/fallen = 0
+				while(honeycombs.len && amtH) //let's pretend you always grab the frame with the most honeycomb on it
+					var/obj/item/reagent_containers/honeycomb/HC = pick_n_take(honeycombs)
+					if(HC)
+						HC.forceMove(drop_location())
+						amtH--
+						fallen++
+				if(fallen)
+					var/multiple = fallen > 1
+					visible_message("<span class='notice'>[user] scrapes [multiple ? "[fallen]" : "a"] honeycomb[multiple ? "s" : ""] off of the frame.</span>")
+
+		if("Remove the Queen Bee")
+			if(!queen_bee || queen_bee.loc != src)
+				to_chat(user, "<span class='warning'>There is no queen bee to remove!</span>")
+				return
+			var/obj/item/queen_bee/QB = new()
+			queen_bee.forceMove(QB)
+			bees -= queen_bee
+			QB.queen = queen_bee
+			QB.name = queen_bee.name
+			if(!user.put_in_active_hand(QB))
+				QB.forceMove(drop_location())
+			visible_message("<span class='notice'>[user] removes the queen from the apiary.</span>")
+			queen_bee = null
 
 /obj/structure/beebox/deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/mineral/wood (loc, 20)

--- a/code/modules/hydroponics/beekeeping/beebox.dm
+++ b/code/modules/hydroponics/beekeeping/beebox.dm
@@ -213,9 +213,9 @@
 		else
 			visible_message("<span class='danger'>[user] disturbs the [name] to no effect!</span>")
 	else
-		INVOKE_ASYNC(src, .proc/perform_interaction)
+		INVOKE_ASYNC(src, .proc/perform_interaction, user)
 
-/obj/structure/beebox/proc/perform_interaction()
+/obj/structure/beebox/proc/perform_interaction(mob/user)
 	var/option = alert(user, "What action do you wish to perform?","Apiary","Remove a Honey Frame","Remove the Queen Bee", "Cancel")
 	if(!Adjacent(user))
 		return

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -152,7 +152,7 @@ GLOBAL_PROTECT(exp_to_update)
 			var/rolefound = FALSE
 			play_records[EXP_TYPE_LIVING] += minutes
 
-			process_ten_minute_living()
+			INVOKE_ASYNC(src, .proc/process_ten_minute_living)
 
 			if(announce_changes)
 				to_chat(src,"<span class='notice'>You got: [minutes] Living EXP!</span>")

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -211,11 +211,7 @@ GLOBAL_LIST_EMPTY(employmentCabinets)
 	new /obj/item/paper/contract/employment(src, employee)
 
 /obj/structure/filingcabinet/employment/interact(mob/user)
-	if(cooldown < world.time)
-		if(virgin)
-			fillCurrent()
-			virgin = 0
-		cooldown = world.time + 10 SECONDS
-	else
-		to_chat(user, "<span class='warning'>[src] is jammed, give it a few seconds.</span>")
+	if(virgin)
+		virgin = 0
+		fillCurrent()
 	..()

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -211,13 +211,11 @@ GLOBAL_LIST_EMPTY(employmentCabinets)
 	new /obj/item/paper/contract/employment(src, employee)
 
 /obj/structure/filingcabinet/employment/interact(mob/user)
-	if(!cooldown)
+	if(cooldown < world.time)
 		if(virgin)
 			fillCurrent()
 			virgin = 0
-		cooldown = 1
-		sleep(100) // prevents the devil from just instantly emptying the cabinet, ensuring an easy win.
-		cooldown = 0
+		cooldown = world.time + 10 SECONDS
 	else
 		to_chat(user, "<span class='warning'>[src] is jammed, give it a few seconds.</span>")
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

fixes https://github.com/BeeStation/BeeStation-Hornet/issues/7070
fixes https://github.com/BeeStation/BeeStation-Hornet/issues/7189 (I think)

## About The Pull Request

SSair.unpause_z was called by SSzclear, however it contained a CHECK_TICK. This introduced a CHECK_TICK into the master controller cycle, which would cause all subsystems to be frozen during high tick loads until that function could complete.

This updates the function to instead command the air subsystem to unpause the z-level during its fire() call. It now also runs off the MC_TICK_CHECK instead. If it takes a super long time to run for whatever reason, rather than freezing the entire MC, only atmos will be paused for some time.

We also ignore space turfs for atmos reactivation, since it uses a static atmosphere anyway so shouldn't ever contain gas even if the ChangeTurf retains the initial atmos state.

Subsystem fire calls are no longer allowed to sleep at all. This should prevent this ever happening in the future.

## Why It's Good For The Game

No more TICK_CHECK within the master process call chain. This should fix all subsystems suddenly freezing up during high server load.

## Testing Photographs and Procedure

<details>

![image](https://user-images.githubusercontent.com/26465327/179256322-2fc102b9-8075-463f-8a4d-9fd2761a3033.png)

Frozen subsystem

![image](https://user-images.githubusercontent.com/26465327/179256423-c79cec94-6d84-47b0-97e1-e96d4fc8a9f7.png)

Variables are fine

![image](https://user-images.githubusercontent.com/26465327/179256449-3cad90fc-8cf4-4563-b4f5-5cb8f8b6b40d.png)

Only runtime was fixed

![image](https://user-images.githubusercontent.com/26465327/179256523-37e91e17-ff7d-4461-9b50-db9b018dff15.png)

Unpausing triggers atmos updates

![image](https://user-images.githubusercontent.com/26465327/179256570-3ad9fa5b-f587-4f90-ba12-9bca14896af1.png)

Variables are fine

![image](https://user-images.githubusercontent.com/26465327/179256608-f194ccba-b1dc-48f2-9cd2-0d8290e106b8.png)

Still no relevant runtimes.

![image](https://user-images.githubusercontent.com/26465327/179256930-2bc468ed-0279-4d98-84ef-70023d0eae25.png)

Nightshift functionality still works.

![image](https://user-images.githubusercontent.com/26465327/179257035-93aecb69-3da7-4b92-9388-fd19911eb029.png)

Overlay functionality still works

![image](https://user-images.githubusercontent.com/26465327/179257646-a768ce0c-2740-43ed-ac2c-afbf70907d97.png)

Queued player joining works.

Shuttle call vote: ~~**failed**~~ Nevermind, this was because not enough time had passed in the round.

![image](https://user-images.githubusercontent.com/26465327/179260269-20e39599-7bca-47ef-a6d1-80d29f033e61.png)

Access buttons working

![image](https://user-images.githubusercontent.com/26465327/179260350-22501bed-075c-4300-9bd8-61259229e569.png)

Wishgranter Dark Working

![image](https://user-images.githubusercontent.com/26465327/179260398-c579849b-10c8-4bfc-9825-19da3f5e2662.png)

Salvation working

![image](https://user-images.githubusercontent.com/26465327/179260438-b8a29b9e-5ad4-4ed9-9971-0761e329a6f5.png)

Shuttle scrambler working

![image](https://user-images.githubusercontent.com/26465327/179260567-51606087-a717-4ad7-b4e7-6417d5ae1d6f.png)

Food processor working

![image](https://user-images.githubusercontent.com/26465327/179260622-e6b7815a-1707-4ecb-9878-e31dc47396ab.png)

Beebox works

</details>

**Haven't tested:**
Mobs having an invalid client being sent to TGS (No TGS setup on local)

## Changelog
:cl:
fix: Timers, orbit updates and other subsystem related processes will no longer freeze when a z-level is unpaused from atmospherics.
fix: Improved the performance of atmospheric unpausing by ignoring updates on space turfs.
code: Subsystems are no longer allowed to sleep during their fire process.
del: Removes the delay from getting employment contracts out of the lawyers office thing. (No player facing changes, this was bugged anyway)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
