### PR TITLE
Bibles are now small

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -40,6 +40,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/mob/affecting = null
 	var/deity_name = "Christ"
 	force_string = "holy"
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/book/bible/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes Bibles a small item instead of a normal item

This affects all variants of the item, including the syndicate one, but I don't really see any major negative consequences of this. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Several null rod options are too large to store in a bag, and there is at least one player who likes to store these options on their back and forego having a bag entirely, but this means they have nowhere to put the bible because it is too large to keep anywhere but in a bag. 

While holy books tend to have many many pages, they are often printed in pocket sizes for mobility as well, so I don't believe this is immersion breaking. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9547572/179277626-6ee12a01-0e19-4bf6-9236-c08513542857.png)

</details>

## Changelog
:cl:
tweak: Bibles are now small items and can fit in pockets. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
