### PR TITLE
Revenants can strip again, but it makes them vulnerable

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -47,10 +47,10 @@
 	if(over != user)
 		return
 
-	// Mobs that can walk through walls cannot strip.
+	// Mobs that can walk through walls cannot strip, except revenants which are handled later.
 	if(isliving(user))
 		var/mob/living/L = user
-		if(L.incorporeal_move)
+		if(L.incorporeal_move && !isrevenant(L))
 			return
 
 	// Cyborgs buckle people by dragging them onto them, unless in combat mode.
@@ -295,6 +295,9 @@
 
 /// A utility function for `/datum/strippable_item`s to start unequipping an item from a mob.
 /proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay)
+	if(isrevenant(user))
+		var/mob/living/simple_animal/revenant/ghostie = user
+		ghostie.reveal(max(item.strip_delay, 25)) //This stacks if a rev attempts to strip multiple items at once
 	if(!do_mob(user, source, strip_delay || item.strip_delay))
 		return FALSE
 

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -296,8 +296,10 @@
 /// A utility function for `/datum/strippable_item`s to start unequipping an item from a mob.
 /proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay)
 	if(isrevenant(user))
+		if(length(user.progressbars)) //Revenants can only strip one item at a time
+			return FALSE
 		var/mob/living/simple_animal/revenant/ghostie = user
-		ghostie.reveal(max(item.strip_delay, 25)) //This stacks if a rev attempts to strip multiple items at once
+		ghostie.reveal(max(item.strip_delay, 25))
 	if(!do_mob(user, source, strip_delay || item.strip_delay))
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Allows specifically revenants to strip people again, but doing so makes them visible for at least as long as the item would take to strip, even if the stripping is interrupted. 
* Revenants are unable to strip more than one item at a time. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was a really fun bug, as shown by the feedback when it was fixed in #7177. I definitely agree a counterbalance needed to be added for the ability to remain however, and so I've done that by making the revenant vulnerable while stripping and reducing their ability to fullstrip people who look away for just a moment. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Double checked and other mobs still can't strip during jaunts, no image to show since... there's nothing to show for this at all


### Revenant strip demonstration:
* Shoes take less time to strip than the minimum reveal time: so revenant stays revealed after stripping for a bit
* Carapace takes longer to strip than minimum reveal time: Revenant stays revealed just long enough to strip it
* Stripping is interrupted: Revenant stays revealed for the full duration they were committed to. 
* Revenant cannot strip multiple items at once
 
 ![8l4EqbKWFk](https://user-images.githubusercontent.com/9547572/179319648-e5520839-188b-4798-a9a4-898f0f8ded81.gif)

</details>

## Changelog
:cl:
add: Revenant stripping bug is now a feature! However, revenants are revealed while stripping items and can only strip one item at a time. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
