### PR TITLE
Fixes an issue with xeno infection HUDs

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -112,6 +112,7 @@ Des: Removes all infected images from the alien.
 			var/searchfor = "infected"
 			if(findtext(I.icon_state, searchfor, 1, length(searchfor) + 1))
 				qdel(I)
+				client.images -= I
 	return
 
 /mob/living/carbon/alien/canBeHandcuffed()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -111,8 +111,8 @@ Des: Removes all infected images from the alien.
 		for(var/image/I in client.images)
 			var/searchfor = "infected"
 			if(findtext(I.icon_state, searchfor, 1, length(searchfor) + 1))
-				qdel(I)
 				client.images -= I
+				qdel(I)
 	return
 
 /mob/living/carbon/alien/canBeHandcuffed()

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -136,4 +136,5 @@ Des: Removes all images from the mob infected by this embryo
 			for(var/image/I in alien.client.images)
 				var/searchfor = "infected"
 				if(I.loc == owner && findtext(I.icon_state, searchfor, 1, length(searchfor) + 1))
+					alien.client.images -= I
 					qdel(I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes an issue where the infection hud for a person would not be removed if their larva was removed (e.g. through surgery/dismemberment/other reasons).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This makes sure xenos can see if someone has had their larva removed, which should happen fairly often if medical's competent.
closes #7297

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/179449072-98db46cf-de11-45cd-a10e-3a6ac196f01f.png)
Dismembered an infected corpse, and their infection icon got removed.
</details>

## Changelog
:cl:
fix: Fixes xeno infection images sticking around after a larva's been removed from a person.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
