### PR TITLE
Ports the button to exempt a player from playtime limitations

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -47,16 +47,6 @@
 			to_chat(usr, "<span class='danger'>ERROR: Mob not found.</span>")
 			return
 		cmd_show_exp_panel(M.client)
-
-	else if(href_list["toggleexempt"])
-		if(!check_rights(R_ADMIN))
-			return
-		var/client/C = locate(href_list["toggleexempt"]) in GLOB.clients
-		if(!C)
-			to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>")
-			return
-		toggle_exempt_status(C)
-
 	else if(href_list["makeAntag"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -50,7 +50,7 @@
 	data["livingTime"] = play_records[EXP_TYPE_LIVING]
 	data["ghostTime"] = play_records[EXP_TYPE_GHOST]
 
-	data["isAdmin"] = check_rights(R_ADMIN)
+	data["isAdmin"] = check_rights(R_ADMIN, show_msg = FALSE)
 
 	return data
 

--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -75,13 +75,11 @@
 				to_chat(usr, "<span class='danger'>ERROR: Insufficient admin rights.</span>", confidential = TRUE)
 				return TRUE
 
-			var/client/owner_client = locate(owner) in GLOB.clients
-
-			if(!owner_client)
+			if(QDELETED(owner))
 				to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>", confidential = TRUE)
 				return TRUE
 
-			viewer_admin_datum.toggle_exempt_status(owner_client)
+			viewer_admin_datum.toggle_exempt_status(owner)
 			return TRUE
 
 #undef JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED

--- a/code/modules/jobs/job_report.dm
+++ b/code/modules/jobs/job_report.dm
@@ -64,7 +64,7 @@
 			if(!check_rights(R_ADMIN))
 				message_admins("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin rights.")
 				log_admin("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin rights.")
-				to_chat(usr, "<span class='danger'>ERROR: Insufficient admin rights.</span>", confidential = TRUE)
+				to_chat(usr, "<span class='danger'>ERROR: Insufficient admin rights.</span>")
 				return TRUE
 
 			var/datum/admins/viewer_admin_datum = GLOB.admin_datums[usr.ckey]
@@ -72,11 +72,11 @@
 			if(!viewer_admin_datum)
 				message_admins("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin datum for their ckey.")
 				log_admin("[ADMIN_LOOKUPFLW(usr)] attempted to toggle job playtime exempt status without admin datum for their ckey.")
-				to_chat(usr, "<span class='danger'>ERROR: Insufficient admin rights.</span>", confidential = TRUE)
+				to_chat(usr, "<span class='danger'>ERROR: Insufficient admin rights.</span>")
 				return TRUE
 
 			if(QDELETED(owner))
-				to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>", confidential = TRUE)
+				to_chat(usr, "<span class='danger'>ERROR: Client not found.</span>")
 				return TRUE
 
 			viewer_admin_datum.toggle_exempt_status(owner)

--- a/tgui/packages/tgui/interfaces/TrackedPlaytime.js
+++ b/tgui/packages/tgui/interfaces/TrackedPlaytime.js
@@ -1,6 +1,6 @@
 import { sortBy } from "common/collections";
 import { useBackend } from "../backend";
-import { Box, Flex, ProgressBar, Section, Table } from "../components";
+import { Box, Button, Flex, ProgressBar, Section, Table } from "../components";
 import { Window } from "../layouts";
 
 const JOB_REPORT_MENU_FAIL_REASON_TRACKING_DISABLED = 1;
@@ -46,11 +46,13 @@ const PlaytimeSection = props => {
 };
 
 export const TrackedPlaytime = (props, context) => {
-  const { data } = useBackend(context);
+  const { act, data } = useBackend(context);
   const {
     failReason,
     jobPlaytimes,
     specialPlaytimes,
+    exemptStatus,
+    isAdmin,
     livingTime,
     ghostTime,
   } = data;
@@ -75,8 +77,18 @@ export const TrackedPlaytime = (props, context) => {
                 }}
               />
             </Section>
-            <Section title="Jobs">
-              <PlaytimeSection playtimes={jobPlaytimes} />
+            <Section
+              title="Jobs"
+              buttons={!!isAdmin && (
+                <Button.Checkbox
+                  checked={!!exemptStatus}
+                  onClick={() => act("toggle_exempt")}>
+                  Job Playtime Exempt
+                </Button.Checkbox>
+              )}>
+              <PlaytimeSection
+                playtimes={jobPlaytimes}
+              />
             </Section>
             <Section title="Special">
               <PlaytimeSection playtimes={specialPlaytimes} />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/56799
- https://github.com/tgstation/tgstation/pull/56951
- https://github.com/tgstation/tgstation/pull/57443

Apparently in the switch to TGUI for the playtime menu, a feature was removed. It was readded 5 months later, but the relevant PRs were missed when porting it to our codebase.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Adds a convenient administrative tool that was, in fact, previously removed, presumably as an oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure

### This PR has not been tested.

Playtime tracking requires a DB setup. As I do not have one, I was unable to test the code.

<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

N/A

</details>

## Changelog
:cl: KubeRoot, Timberpoes
admin: Re-added the button to the player playtime panel that lets admins toggle a player's job playtime exemption status.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
