### PR TITLE
Grenade lances no longer transfer their grenade into the other person.

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -127,7 +127,6 @@
 		return
 	if(ISWIELDED(src))
 		user.say("[war_cry]", forced="spear warcry")
-		explosive.forceMove(AM)
 		explosive.prime(lanced_by=user)
 		qdel(src)
 


### PR DESCRIPTION
…han the other person

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Grenade lances will now have the grenade explode inside the lance, rather than inside the person being attacked.
This means that if you have a small explosive that will only kill the person on the grenade tile and injure the person on the other, you will be the one who dies instead.
This makes them essentially the same as just using a grenade with a 0 second cooldown.

## Why It's Good For The Game

Grenade lances are an instant-kill cheese weapon and allow a non-relevant character to kill a more relevent character based on the fact that not all players in a round are equally important.
They are now the same as just detonating a grenade in your hand with a signaller.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/179703955-7da56c66-51fc-4a29-a11f-91886cadcdc7.png)

(Explosion happened on my tile)

## Changelog
:cl:
balance: Grenade lances will no longer explode the grenade inside the attacked person, but instead inside of the lance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
