### PR TITLE
Flash Rebalance

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -257,7 +257,7 @@
 				M.Paralyze(70 * flash_proportion)
 			else if(flash_proportion > 0)
 				M.Knockdown(70 * flash_proportion)
-			M.confused = max(M.confused, 40)
+			M.confused = max(M.confused, 70)
 
 		else if(user)
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -253,6 +253,8 @@
 				to_chat(M, "<span class='userdanger'>You are blinded by [src]!</span>")
 			//Will be 0 if the user has no stmaina loss, will be 1 if they are in stamcrit
 			var/flash_proportion = CLAMP01(M.getStaminaLoss() / (M.maxHealth - M.crit_threshold))
+			if (!(M.mobility_flags & MOBILITY_STAND))
+				flash_proportion = 1
 			if(flash_proportion > 0.4)
 				M.Paralyze(70 * flash_proportion)
 			else if(flash_proportion > 0)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -259,7 +259,7 @@
 				M.Paralyze(70 * flash_proportion)
 			else if(flash_proportion > 0)
 				M.Knockdown(70 * flash_proportion)
-			M.confused = max(M.confused, 7)
+			M.confused = max(M.confused, 4)
 
 		else if(user)
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -257,7 +257,7 @@
 				M.Paralyze(70 * flash_proportion)
 			else if(flash_proportion > 0)
 				M.Knockdown(70 * flash_proportion)
-			M.confused = max(M.confused, 70 * (1 - flash_proportion))
+			M.confused = max(M.confused, 40)
 
 		else if(user)
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -251,7 +251,13 @@
 				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
 			else
 				to_chat(M, "<span class='userdanger'>You are blinded by [src]!</span>")
-			M.Paralyze(70)
+			//Will be 0 if the user has no stmaina loss, will be 1 if they are in stamcrit
+			var/flash_proportion = CLAMP01(M.getStaminaLoss() / (M.maxHealth - M.crit_threshold))
+			if(flash_proportion > 0.4)
+				M.Paralyze(70 * flash_proportion)
+			else if(flash_proportion > 0)
+				M.Knockdown(70 * flash_proportion)
+			M.confused = max(M.confused, 70 * (1 - flash_proportion))
 
 		else if(user)
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -259,7 +259,7 @@
 				M.Paralyze(70 * flash_proportion)
 			else if(flash_proportion > 0)
 				M.Knockdown(70 * flash_proportion)
-			M.confused = max(M.confused, 70)
+			M.confused = max(M.confused, 7)
 
 		else if(user)
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Flashes now have new mechanics, that interact with other mechanics such as stunning.

Flashes now:
 - Blind for 2.5 seconds (No changes)
 - Confuse for 7 seconds
 - If the mob has less than 40 stamina damage, they will get knocked down for the proportion of stamina damage they have * 7.
 - If the mob has more than 40 stamina damage, they will get paralysed for the proportion of stamina damage they have * 7.
 - If the target is lying down, they will be paralysed for the full 7 seconds, even if they have no stun damage.

## Why It's Good For The Game

Currently flashes are a hard win with a hard counter. After these changes they will now interact with other combat mechanics like stunning more.

If a target is just up and running around as normal, they will be confused for 7 seconds. This will make it a lot harder for them to fight, especially when you factor in the blindness, however it will not put them out of the fight.
If a target has less than 40% stamina damage, they will be knocked down but will still be able to attack and use their weapons. Again, this makes them a lot easier to fight but doesn't completely put them out.
If a target has more than 40% stamina damage, then the flash will paralyse them, causing them to drop their weapons and be unable to fight. If they don't have flash protection, then this is a good end to a fight assuming you are fighting with non-lethal weaponry in the first place.
If the target is lying down, they get the full paralysis, to make it possible to uncuff, flash and then leave a prisoner in the cell.

Another advantage of this strategy is simply flashing + smashing is no longer a guaranteed, effective and instantly victorious strategy. In order to get the most effectiveness out of a flash, you need to pair it with other forms of non-lethal stamina combat which limits their effectiveness in kill oriented combat scenarios.

While they are most effective when paired with other tools, they are not completely useless alone and will cause confusion, making them easier to hit with other weapons.

## Testing Photographs and Procedure

Will do testing after this round

![image](https://user-images.githubusercontent.com/26465327/179731574-c63c7b72-8ccd-45f8-a9f5-065c12a22475.png)

![image](https://user-images.githubusercontent.com/26465327/179731619-038ddb65-1c85-4b38-9398-993a6555c33d.png)


## Changelog
:cl:
balance: Flashes now cause confusion instead of paralysis if a target has no stamina damage.
balance: Flashes will cause knockdown with the length of the knockdown proportional to the target's stamina damage if they have less than 40% stamina damage.
balance: Flashes will cause paralysis with the length of the paralysis proportional to the target's stamina damage if they have more than 40% stamina damage.
balance: Flashes will paralyse for 7 seconds if a target is lying down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
