### PR TITLE
[Debug] Disable ruin generation

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -46,6 +46,8 @@
 /datum/config_entry/number/minimal_access_threshold	//If the number of players is larger than this threshold, minimal access will be turned on.
 	min_val = 0
 
+/datum/config_entry/flag/exploration_disable		//Debugging flag to disable exploration. This flag is a quick and dirty removal and shouldn't be used permanently.
+
 /datum/config_entry/flag/jobs_have_minimal_access	//determines whether jobs use minimal access or expanded access.
 
 /datum/config_entry/flag/assistants_have_maint_access

--- a/code/controllers/subsystem/processing/orbits.dm
+++ b/code/controllers/subsystem/processing/orbits.dm
@@ -99,6 +99,9 @@ PROCESSING_SUBSYSTEM_DEF(orbits)
 	//Create initial ruins
 	for(var/i in 1 to initial_space_ruins)
 		new /datum/orbital_object/z_linked/beacon/ruin/spaceruin()
+	//Quick and dirty way to disable asteroid & ruin generation.
+	if(CONFIG_GET(flag/exploration_disable))
+		return
 	for(var/i in 1 to initial_objective_beacons)
 		new /datum/orbital_object/z_linked/beacon/ruin()
 	//Create asteroid belt

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -28,6 +28,12 @@
 	)
 	biohazard = 20//who knows what you'll find out there that could have nasties on it...
 
+/datum/job/exploration/New()
+	. = ..()
+	if(CONFIG_GET(flag/exploration_disable))
+		total_positions = 0
+		spawn_positions = 0
+
 /datum/job/exploration/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source)
 	if(outfit_override)
 		return ..()

--- a/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/beacon.dm
+++ b/code/modules/shuttle/super_cruise/orbital_map_components/orbital_objects/beacon.dm
@@ -112,6 +112,12 @@
 	var/datum/space_level/assigned_space_level = SSzclear.get_free_z_level()
 	linked_z_level = list(assigned_space_level)
 	assigned_space_level.orbital_body = src
+	//Quick and dirty way to disable asteroid & ruin generation.
+	if(CONFIG_GET(flag/exploration_disable))
+		//Place plasma randomly lol
+		for(var/i in 1 to 30)
+			new /obj/item/stack/ore/plasma(locate(rand(1, world.maxx), rand(1, world.maxy), assigned_space_level.z_value), rand(1, 10))
+		return
 	generate_asteroids(world.maxx / 2, world.maxy / 2, assigned_space_level.z_value, 120, -0.4, 40)
 
 /datum/orbital_object/z_linked/beacon/ruin/stranded_shuttle/post_map_setup()

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_computer.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_computer.dm
@@ -22,6 +22,9 @@ GLOBAL_LIST_EMPTY(objective_computers)
 	return GLOB.default_state
 
 /obj/machinery/computer/objective/ui_interact(mob/user, datum/tgui/ui)
+	if(CONFIG_GET(flag/exploration_disable))
+		to_chat(user, "<span class='warning'>Objectives has been temporarilly disabled for debugging purposes. They will be returned soon. We apologise for any inconvenience caused.</span>")
+		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Objective")
@@ -55,6 +58,11 @@ GLOBAL_LIST_EMPTY(objective_computers)
 	. = ..()
 	if(.)
 		return
+
+	if(CONFIG_GET(flag/exploration_disable))
+		to_chat(usr, "<span class='warning'>Objectives has been temporarilly disabled for debugging purposes. They will be returned soon. We apologise for any inconvenience caused.</span>")
+		return
+
 	if(action != "assign")
 		return
 	var/obj_id = params["id"]

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_computer.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_computer.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(objective_computers)
 
 /obj/machinery/computer/objective/ui_interact(mob/user, datum/tgui/ui)
 	if(CONFIG_GET(flag/exploration_disable))
-		to_chat(user, "<span class='warning'>Objectives has been temporarilly disabled for debugging purposes. They will be returned soon. We apologise for any inconvenience caused.</span>")
+		to_chat(usr, "<span class='warning'>Nanotrasen is not offering objectives in this sector. We apologise for the inconvenience and they will return soon.</span>")
 		return
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
@@ -60,7 +60,7 @@ GLOBAL_LIST_EMPTY(objective_computers)
 		return
 
 	if(CONFIG_GET(flag/exploration_disable))
-		to_chat(usr, "<span class='warning'>Objectives has been temporarilly disabled for debugging purposes. They will be returned soon. We apologise for any inconvenience caused.</span>")
+		to_chat(usr, "<span class='warning'>Nanotrasen is not offering objectives in this sector. We apologise for the inconvenience and they will return soon.</span>")
 		return
 
 	if(action != "assign")

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/asteroid_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/asteroid_generator.dm
@@ -3,6 +3,9 @@
 //if this number is negative, asteroids will be smaller.
 //if this number is positive asteroids will be larger and more likely
 /proc/generate_asteroids(center_x, center_y, center_z, max_radius, weight_offset = 0, scale = 65)
+	if(CONFIG_GET(flag/exploration_disable))
+		message_admins("Unable to generate ruin: Exploration has been disabled on this server.")
+		return
 	var/datum/space_level/space_level = SSmapping.get_level(center_z)
 	space_level.generating = TRUE
 	_generate_asteroids(center_x, center_y, center_z, max_radius, weight_offset, scale)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/exoplanets/exoplanet_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/exoplanets/exoplanet_generator.dm
@@ -1,4 +1,7 @@
 /proc/generate_exoplanet(center_z)
+	if(CONFIG_GET(flag/exploration_disable))
+		message_admins("Unable to generate ruin: Exploration has been disabled on this server.")
+		return
 	var/datum/space_level/space_level = SSmapping.get_level(center_z)
 	space_level.generating = TRUE
 	_generate_exoplanet(center_z, new /datum/exoplanet_biome/lavaland)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_generator.dm
@@ -17,6 +17,9 @@
  * can go past the border. No attachment points can be generated past the border.
  */
 /proc/generate_space_ruin(center_x, center_y, center_z, border_x, border_y, datum/orbital_objective/linked_objective, forced_decoration, datum/ruin_event/ruin_event)
+	if(CONFIG_GET(flag/exploration_disable))
+		message_admins("Unable to generate ruin: Exploration has been disabled on this server.")
+		return
 	var/datum/space_level/space_level = SSmapping.get_level(center_z)
 	space_level.generating = TRUE
 	_generate_space_ruin(center_x, center_y, center_z, border_x, border_y, linked_objective, forced_decoration, ruin_event)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -631,3 +631,6 @@ SPARE_ENFORCE_COC
 
 ## Uncomment to disable local bans, effectively enforcing only global bans
 DISABLE_LOCAL_BANS
+
+## Debugging flag to disable exploration and ruin generation. This is for testing purposes
+EXPLORATION_DISABLE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a flag to disable ruin generation.
The current working theory for the lag spikes is that the generation process allows the map placement to use up basically all the tick during generation at high-CPU load.
This will allow us to confirm that the theory is false if it happens while this is merged. We can't prove that the theory is true with this, since it happens at seemingly random intervals, but its a good starting point.

If this is the case, the next thing to do is to find out why this has only started happening *relatively* recently in the past few months, and why this never happened in the years prior.

My current working theory is:
This could be due to the atom subsystem port from TG introducing some new assumptions that mapload will not be running during the game?

## Why It's Good For The Game

For debugging purposes.

## Testing Photographs and Procedure
I launched game.

![image](https://user-images.githubusercontent.com/26465327/180042315-51fa4dc3-6642-4072-9e81-4ed246c960ca.png)

Didnt spawn as explo.

![image](https://user-images.githubusercontent.com/26465327/180042350-b87d1e89-43dc-43f5-8012-6a026309b51f.png)

Only space ruins spawn

![image](https://user-images.githubusercontent.com/26465327/180042402-4d448cb7-2211-4f9e-8370-255adeb86223.png)

soz

## Changelog
:cl:
del: Temporarilly disabled ruin generation and exploration crew for testing purposes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
