### PR TITLE
Revert "Chemical Synthesizer rework #6281", but nerfs the plumbing with extreme delay instead (+plumbing investigate log)

### DIFF
--- a/code/__DEFINES/plumbing.dm
+++ b/code/__DEFINES/plumbing.dm
@@ -6,4 +6,5 @@
 
 #define DUCT_LAYER_DEFAULT THIRD_DUCT_LAYER
 
-#define MACHINE_REAGENT_TRANSFER 10 //the default max plumbing machinery transfers
+#define MACHINE_REAGENT_TRANSFER 1 //the default max plumbing machinery transfers
+#define MACHINE_PROCESS_COUNT_MAX 5 //if count reaches 5, process chem.

--- a/code/__DEFINES/plumbing.dm
+++ b/code/__DEFINES/plumbing.dm
@@ -7,4 +7,4 @@
 #define DUCT_LAYER_DEFAULT THIRD_DUCT_LAYER
 
 #define MACHINE_REAGENT_TRANSFER 1 //the default max plumbing machinery transfers
-#define MACHINE_PROCESS_COUNT_MAX 5 //if count reaches 5, process chem.
+#define MACHINE_PROCESS_COUNT_MAX 4 //if count reaches 4, process chem.

--- a/code/__DEFINES/plumbing.dm
+++ b/code/__DEFINES/plumbing.dm
@@ -6,5 +6,5 @@
 
 #define DUCT_LAYER_DEFAULT THIRD_DUCT_LAYER
 
-#define MACHINE_REAGENT_TRANSFER 1 //the default max plumbing machinery transfers
-#define MACHINE_PROCESS_COUNT_MAX 4 //if count reaches 4, process chem.
+#define MACHINE_REAGENT_TRANSFER  1 //the default max plumbing machinery transfers
+#define MACHINE_PROCESS_COUNT_MAX 2 //if count reaches 4, process chem.

--- a/code/__DEFINES/plumbing.dm
+++ b/code/__DEFINES/plumbing.dm
@@ -7,4 +7,4 @@
 #define DUCT_LAYER_DEFAULT THIRD_DUCT_LAYER
 
 #define MACHINE_REAGENT_TRANSFER  1 //the default max plumbing machinery transfers
-#define MACHINE_PROCESS_COUNT_MAX 2 //if count reaches 4, process chem.
+#define MACHINE_PROCESS_COUNT_MAX 2 //if count reaches 2, process chem.

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -15,7 +15,7 @@
 	var/active = FALSE
 	///if TRUE connects will spin with the parent object visually and codually, so you can have it work in any direction. FALSE if you want it to be static
 	var/turn_connects = TRUE
-	///
+	///if it reaches MACHINE_PROCESS_COUNT_MAX in `process_delay_check()` proc, processes the chemical transfer.
 	var/process_count = 0
 
 /datum/component/plumbing/Initialize(start=TRUE, _turn_connects=TRUE) //turn_connects for wheter or not we spin with the object to change our pipes

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -36,7 +36,7 @@
 	if(use_overlays)
 		create_overlays()
 
-/datum/component/plumbing/process_delay_check()
+/datum/component/plumbing/proc/process_delay_check()
 	if(process_count < MACHINE_PROCESS_COUNT_MAX)
 		process_count++
 		return FALSE

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -42,7 +42,7 @@
 		return FALSE
 	else
 		process_count = 0
-	//plumbing machine will only work for every 5 ticks
+	//plumbing machine will only work for every MACHINE_PROCESS_COUNT_MAX counts
 	return TRUE
 
 /datum/component/plumbing/process()
@@ -231,3 +231,8 @@
 /datum/component/plumbing/tank
 	demand_connects = WEST
 	supply_connects = EAST
+
+/datum/component/plumbing/tank/process_delay_check()
+	//tank processes 2x faster
+	process_count++
+	. = ..()

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -46,9 +46,9 @@
 	return TRUE
 
 /datum/component/plumbing/process()
+	if(!demand_connects || !reagents)		// This actually shouldn't happen, but better safe than sorry
+		return PROCESS_KILL
 	if(process_delay_check())
-		if(!demand_connects || !reagents)		// This actually shouldn't happen, but better safe than sorry
-			return PROCESS_KILL
 		if(reagents.total_volume < reagents.maximum_volume)
 			for(var/D in GLOB.cardinals)
 				if(D & demand_connects)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -234,5 +234,5 @@
 
 /datum/component/plumbing/tank/process_delay_check()
 	//tank processes 2x faster
-	process_count++
-	. = ..()
+	. = ..()+..()
+	// FALSE+TRUE will become TRUE

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -141,8 +141,6 @@
 	new /obj/item/construction/plumbing(src)
 	new	/obj/item/plunger(src)
 	new	/obj/item/plunger(src)
-	new /obj/item/rcd_ammo(src)
-	new /obj/item/rcd_ammo(src)
 
 /obj/structure/closet/secure_closet/chemical/heisenberg //contains one of each beaker, syringe etc.
 	name = "advanced chemical closet"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -18,8 +18,7 @@
 		/obj/item/storage/box/rxglasses = 1,
 		/obj/item/stack/ducts/fifty = 4,
 		/obj/item/construction/plumbing = 2,
-		/obj/item/plunger = 2,
-		/obj/item/rcd_ammo = 4)
+		/obj/item/plunger = 2)
 	generate_items_inside(items_inside,src)
 
 /obj/structure/closet/secure_closet/medical2

--- a/code/modules/plumbing/plumbers/bottle_dispenser.dm
+++ b/code/modules/plumbing/plumbers/bottle_dispenser.dm
@@ -41,6 +41,11 @@
 			stored_bottles -= AM
 			AM.forceMove(drop_location())
 
+			var/list/chem_names = list()
+			for(var/datum/reagent/R in AM.reagents.reagent_list)
+				chem_names += "[R.name] [R.volume]u"
+			investigate_log("a factory medicine [bottle_name] has been created. chem list: [english_list(chem_names)]", INVESTIGATE_ITEMS)
+			log_game("a factory medicine [bottle_name] has been created. chem list: [english_list(chem_names)]")
 
 /obj/machinery/plumbing/bottle_dispenser/ui_state(mob/user)
 	return GLOB.default_state

--- a/code/modules/plumbing/plumbers/patch_dispenser.dm
+++ b/code/modules/plumbing/plumbers/patch_dispenser.dm
@@ -43,6 +43,11 @@
 			stored_patches -= AM
 			AM.forceMove(drop_location())
 
+			var/list/chem_names = list()
+			for(var/datum/reagent/R in AM.reagents.reagent_list)
+				chem_names += "[R.name] [R.volume]u"
+			investigate_log("a factory medicine [patch_name] has been created. chem list: [english_list(chem_names)]", INVESTIGATE_ITEMS)
+			log_game("a factory medicine [patch_name] has been created. chem list: [english_list(chem_names)]")
 
 /obj/machinery/plumbing/patch_dispenser/ui_state(mob/user)
 	return GLOB.default_state

--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -67,6 +67,12 @@
 			stored_pills -= AM
 			AM.forceMove(drop_location())
 
+			var/list/chem_names = list()
+			for(var/datum/reagent/R in AM.reagents.reagent_list)
+				chem_names += "[R.name] [R.volume]u"
+			investigate_log("a factory medicine [pill_name] has been created. chem list: [english_list(chem_names)]", INVESTIGATE_ITEMS)
+			log_game("a factory medicine [pill_name] has been created. chem list: [english_list(chem_names)]")
+
 /obj/machinery/plumbing/pill_press/ui_assets(mob/user)
 	return list(
 		get_asset_datum(/datum/asset/spritesheet/simple/pills),

--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -12,17 +12,13 @@
 	///Amount we produce for every process. Ideally keep under 5 since thats currently the standard duct capacity
 	var/amount = 1
 	///The maximum we can produce for every process
-	buffer = 5
+	buffer = 1
 	///I track them here because I have no idea how I'd make tgui loop like that
-	var/static/list/possible_amounts = list(0,1,2,3,4,5)
+	var/static/list/possible_amounts = list(0,1)
 	///The reagent we are producing. We are a typepath, but are also typecast because there's several occations where we need to use initial.
 	var/datum/reagent/reagent_id = null
 	///reagent overlay. its the colored pipe thingies. we track this because overlays.Cut() is bad
 	var/image/r_overlay
-	///The amount of reagent dispensable before requiring a refill from a compressed matter cartridge.
-	var/volume_left = 0
-	///The maximum amount of precursor in a synthesizer.
-	var/max_volume = 1000
 	///straight up copied from chem dispenser. Being a subtype would be extremely tedious and making it global would restrict potential subtypes using different dispensable_reagents
 	var/list/dispensable_reagents = list(
 		/datum/reagent/aluminium,
@@ -65,34 +61,7 @@
 		return
 	if(reagents.total_volume >= amount*delta_time*0.5) //otherwise we get leftovers, and we need this to be precise
 		return
-	if(volume_left < amount) //Empty
-		return
 	reagents.add_reagent(reagent_id, amount*delta_time*0.5)
-	volume_left = max(volume_left - amount*delta_time*0.5, 0)
-
-/obj/machinery/plumbing/synthesizer/attackby(obj/item/O, mob/user, params)
-	if(!istype(O, /obj/item/rcd_ammo))
-		return ..()
-	var/obj/item/rcd_ammo/R = O
-	if(!R.ammoamt)
-		to_chat(user, "<span class='warning'>The [R.name] doesn't have any reagent left!</span>")
-		return ..()
-	var/added_volume = -volume_left //For the difference calculation
-	volume_left = min(volume_left+R.ammoamt*10, src.max_volume) //400 per cartridge
-	added_volume = added_volume+volume_left
-	R.ammoamt -= added_volume/10
-	if(R.ammoamt <= 0) //Emptied
-		to_chat(user, "<span class='notice'>You refill the chemical synthesizer with the [R.name], emptying it completely!</span>")
-		qdel(R)
-		return
-	if(added_volume == 0) //No change
-		to_chat(user, "<span class='notice'>The chemical synthesizer is full!</span>")
-		return
-	to_chat(user, "<span class='notice'>You refill the chemical synthesizer with the [R.name], leaving [R.ammoamt*10] units in it.</span>")
-
-/obj/machinery/plumbing/synthesizer/examine(mob/user)
-	. = ..()
-	. += "<span class='notice'>A display says it currently holds [volume_left] units of precursor before requiring a refill.</span>"
 
 /obj/machinery/plumbing/synthesizer/ui_state(mob/user)
 	return GLOB.default_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Reverts #6281
* And nerfs the plumbing that it processes chem at a miserable rate instead
chem will be processed about 1u per 5 seconds (approximately)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the gamer chemists bypass the nerf through input gates by manual chem injection, eventually they can make synth factory anyways.
reverts the nerf so that they can make a factory anyways, but chem processing is now at a miserable speed than before so you need to manage medical resources.

Plus, I really don't like examining every chem synthesizer and filling it with a cartridge. It's not the right way to nerf it.


Note: the chem process delay can be even slower than this if it makes a lot of medicines still.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
https://youtu.be/pskFb0-bFBE

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/180318093-78f9f8da-ecac-4aeb-b149-e4da92f2d5d7.png)
`[2022-07-21 21:26:40.176] GAME: a factory medicine factory bottle has been created. chem list: Bromine, Copper, Phosphorus, Lithium and Potassium`

Investigate log

</details>


## Changelog
:cl:
tweak: reverts "Chemical Synthesizer rework #6281" that you need compressed matter cartridges to charge synthesizers
balance: Chem synthesizer only can produce 1u of a chemical
balance: plumbing now processes chemical transference by 1u per 3 seconds (approximately)
add: Plumbing tank can pull chemicals at a double speed than other plumbing machines do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
