### PR TITLE
Tweaks to Technophile Sect

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -137,9 +137,9 @@
 	tgui_icon = "robot"
 	alignment = ALIGNMENT_NEUT
 	desired_items = list(/obj/item/stock_parts/cell = "with battery charge")
-	rites_list = list(/datum/religion_rites/synthconversion, /datum/religion_rites/machine_blessing)
+	rites_list = list(/datum/religion_rites/synthconversion, /datum/religion_rites/machine_blessing, /datum/religion_rites/machine_implantation)
 	altar_icon_state = "convertaltar-blue"
-	max_favor = 2500
+	max_favor = 5000
 
 /datum/religion_sect/technophile/sect_bless(mob/living/target, mob/living/chap)
 	if(iscyborg(target))
@@ -193,7 +193,7 @@
 	if(the_cell.charge < 300)
 		to_chat(chap,"<span class='notice'>[GLOB.deity] does not accept pity amounts of power.</span>")
 		return
-	adjust_favor(round(the_cell.charge/300), chap)
+	adjust_favor(round(the_cell.charge/100), chap)
 	to_chat(chap, "<span class='notice'>You offer [the_cell]'s power to [GLOB.deity], pleasing them.</span>")
 	qdel(I)
 	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -144,7 +144,7 @@
 
 /datum/religion_rites/machine_implantation
 	name = "Machine Implantation"
-	desc = "Apply a provided upgrade to your body. Place a cybernetic item on the altar, then buckle a someone to implant them, otherwise it will implant you."
+	desc = "Apply a provided upgrade to your body. Place a cybernetic item on the altar, then buckle someone to implant them, otherwise it will implant you."
 	ritual_length = 30 SECONDS
 	ritual_invocations = list("Lend us your power ...",
 						"... We call upon you, grant us this upgrade ...",

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -176,7 +176,7 @@
 		CRASH("[name]'s perform_rite had a movable atom that has somehow turned into a non-movable!")
 	var/atom/movable/movable_reltool = religious_tool
 	var/mob/living/carbon/human/rite_target
-	if(!movable_reltool.buckled_mobs?.len)
+	if(!length(movable_reltool.buckled_mobs))
 		rite_target = user
 	else
 		for(var/buckled in movable_reltool.buckled_mobs)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -121,9 +121,9 @@
 	desc = "Receive a blessing from the machine god to further your ascension."
 	ritual_length = 5 SECONDS
 	ritual_invocations =list( "Let your will power our forges.",
-							"...Help us in our great conquest!")
+							"... Help us in our great conquest!")
 	invoke_msg = "The end of flesh is near!"
-	favor_cost = 2000
+	favor_cost = 800
 
 /datum/religion_rites/machine_blessing/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	..()
@@ -134,9 +134,65 @@
 					/obj/item/organ/cyberimp/eyes/hud/medical,
 					/obj/item/organ/cyberimp/mouth/breathing_tube,
 					/obj/item/organ/cyberimp/chest/thrusters,
+					/obj/item/organ/cyberimp/chest/nutriment,
+					/obj/item/organ/cyberimp/arm/toolset,
+					/obj/item/organ/wings/cybernetic,
 					/obj/item/organ/eyes/robotic/glow)
 	new blessing(altar_turf)
 	return TRUE
+
+
+/datum/religion_rites/machine_implantation
+	name = "Machine Implantation"
+	desc = "Apply a provided upgrade to your body. Place a cybernetic item on the altar, then buckle a someone to implant them, otherwise it will implant you."
+	ritual_length = 30 SECONDS
+	ritual_invocations = list("Lend us your power ...",
+						"... We call upon you, grant us this upgrade ...",
+						"... Complete us, joining man and machine ...")
+	invoke_msg = "... Let the mechanical parts, Merge!!"
+	favor_cost = 1000
+	var/obj/item/organ/chosen_implant
+
+/datum/religion_rites/machine_implantation/perform_rite(mob/living/user, atom/religious_tool)
+	for(var/obj/item/organ/organ in get_turf(religious_tool))
+		chosen_implant = organ
+	if(!chosen_implant)
+		to_chat(user, "<span class='warning'>This rite requires cybernetics for implantation.</span>")
+		return FALSE
+	if(!ismovable(religious_tool))
+		to_chat(user,"<span class='warning'>This rite requires a religious device that individuals can be buckled to.</span>")
+		return FALSE
+	var/atom/movable/movable_reltool = religious_tool
+	if(!movable_reltool)
+		return FALSE
+	if(LAZYLEN(movable_reltool.buckled_mobs))
+		to_chat(user,"<span class='warning'>You're going to merge the implant with the one buckled on [movable_reltool].</span>")
+	else
+		if(!movable_reltool.can_buckle) //yes, if you have somehow managed to have someone buckled to something that now cannot buckle, we will still let you perform the rite!
+			to_chat(user,"<span class='warning'>This rite requires a religious device that individuals can be buckled to.</span>")
+			return FALSE
+	to_chat(user,"<span class='warning'>You're going to merge the implant into yourself with this ritual.</span>")
+	return ..()
+
+/datum/religion_rites/machine_implantation/invoke_effect(mob/living/user, atom/religious_tool)
+	..()
+	if(!ismovable(religious_tool))
+		CRASH("[name]'s perform_rite had a movable atom that has somehow turned into a non-movable!")
+	var/atom/movable/movable_reltool = religious_tool
+	var/mob/living/carbon/human/rite_target
+	if(!movable_reltool?.buckled_mobs?.len)
+		rite_target = user
+	else
+		for(var/buckled in movable_reltool.buckled_mobs)
+			if(ishuman(buckled))
+				rite_target = buckled
+				break
+	if(!rite_target)
+		return FALSE
+	chosen_implant.Insert(rite_target)
+	rite_target.visible_message("<span class='notice'>[chosen_implant] has been merged into [rite_target] by the rite of [name]!</span>")
+	return TRUE
+
 
 /**** Ever-Burning Candle sect ****/
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -154,8 +154,7 @@
 	var/obj/item/organ/chosen_implant
 
 /datum/religion_rites/machine_implantation/perform_rite(mob/living/user, atom/religious_tool)
-	for(var/obj/item/organ/organ in get_turf(religious_tool))
-		chosen_implant = organ
+	chosen_implant = locate() in get_turf(religious_tool)
 	if(!chosen_implant)
 		to_chat(user, "<span class='warning'>This rite requires cybernetics for implantation.</span>")
 		return FALSE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -162,14 +162,11 @@
 		to_chat(user,"<span class='warning'>This rite requires a religious device that individuals can be buckled to.</span>")
 		return FALSE
 	var/atom/movable/movable_reltool = religious_tool
-	if(!movable_reltool)
-		return FALSE
-	if(LAZYLEN(movable_reltool.buckled_mobs))
+	if(length(movable_reltool.buckled_mobs))
 		to_chat(user,"<span class='warning'>You're going to merge the implant with the one buckled on [movable_reltool].</span>")
-	else
-		if(!movable_reltool.can_buckle) //yes, if you have somehow managed to have someone buckled to something that now cannot buckle, we will still let you perform the rite!
-			to_chat(user,"<span class='warning'>This rite requires a religious device that individuals can be buckled to.</span>")
-			return FALSE
+	else if(!movable_reltool.can_buckle) //yes, if you have somehow managed to have someone buckled to something that now cannot buckle, we will still let you perform the rite!
+		to_chat(user,"<span class='warning'>This rite requires a religious device that individuals can be buckled to.</span>")
+		return FALSE
 	to_chat(user,"<span class='warning'>You're going to merge the implant into yourself with this ritual.</span>")
 	return ..()
 
@@ -179,7 +176,7 @@
 		CRASH("[name]'s perform_rite had a movable atom that has somehow turned into a non-movable!")
 	var/atom/movable/movable_reltool = religious_tool
 	var/mob/living/carbon/human/rite_target
-	if(!movable_reltool?.buckled_mobs?.len)
+	if(!movable_reltool.buckled_mobs?.len)
 		rite_target = user
 	else
 		for(var/buckled in movable_reltool.buckled_mobs)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -187,9 +187,11 @@
 				rite_target = buckled
 				break
 	if(!rite_target)
+		chosen_implant = null
 		return FALSE
 	chosen_implant.Insert(rite_target)
 	rite_target.visible_message("<span class='notice'>[chosen_implant] has been merged into [rite_target] by the rite of [name]!</span>")
+	chosen_implant = null
 	return TRUE
 
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -118,7 +118,7 @@
 
 /datum/religion_rites/machine_blessing
 	name = "Receive Blessing"
-	desc = "Receive a blessing from the machine god to further your ascension."
+	desc = "Receive a random blessing from the machine god to further your ascension."
 	ritual_length = 5 SECONDS
 	ritual_invocations =list( "Let your will power our forges.",
 							"... Help us in our great conquest!")

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -75,7 +75,7 @@
 						"... We call upon you, in the face of adversity ...",
 						"... to complete us, removing that which is undesirable ...")
 	invoke_msg = "... Arise, our champion! Become that which your soul craves, live in the world as your true form!!"
-	favor_cost = 1000
+	favor_cost = 1800
 
 /datum/religion_rites/synthconversion/perform_rite(mob/living/user, atom/religious_tool)
 	if(!ismovable(religious_tool))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After receiving input in-game over LOOC from multiple chaplains, I've taken things into consideration and adjusted the rite costs and favor gained from power cells

I've also added a rite to implant organs to whoever is buckled/or yourself if nobody is buckled, high favor cost alongside having to spend 800 favor anyway to get an implant in the first place.

## Why It's Good For The Game

Now it wont take 20+ fully charged bluespace power cells to do things!
So no more raiding R&D for the mats and getting into fights over using up all their iron and bluespace crystals
And now tech-cults can be self evolving without having to raid medbay for tools or surgical tables, although it still costs a lot of favor to do any implantations

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/17776299/180332723-6cd6aef7-1f7e-4a40-984f-2dda59c3f5ed.png)

</details>

## Changelog
:cl:
add: Added a new rite to the Technophile Sect - Machine Implantation - Add cybernetics to your followers with ease!
tweak: Technophile Sect favor is gained a little easier and rite costs have been lowered a little
tweak: Tech Sect Machine Blessing rite now has a chance to create nutriment, toolset, and wing implants

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
