### PR TITLE
fixes TGUI 'Colored names' option for custom job colours + minor fix to PDA painter

### DIFF
--- a/code/__HELPERS/jobs.dm
+++ b/code/__HELPERS/jobs.dm
@@ -32,7 +32,7 @@
 		// R&D
 		"Science (Custom)" = "rawscience",
 		"Research Director" = "rd",
-		"Science" = "sci",
+		"Scientist" = "sci",
 		"Roboticist" = "roboticist",
 		"Exploration Crew" = "exploration",
 		// Engineering

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -107,6 +107,18 @@ const formatHighContrast = inputHtml => {
     "stagemagician",
     "psychiatrist",
     "vip",
+    "king",
+    "rawcommand",
+    "rawservice",
+    "rawcargo",
+    "rawscience",
+    "rawmedical",
+    "rawengineering",
+    "rawsecurity",
+    "rawcentcom",
+    "syndicate",
+    "notcentcom",
+    "unassigned",
   ];
   const spanRegex = new RegExp('(<span[\\w| |\t|=]*[\'|"][\\w| ]*)(?:' + replacementNodes.join('|') + ')([\'|"]>)', 'gi');
   return inputHtml.replace(spanRegex, '$1$2');


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes TGUI 'Colored names' option for custom job colours.
even if this option is disabled, custom jobs are still showing their colours at the chat.
also, minor bug fix that "Scientist" option isn't valid in PDA painter.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://user-images.githubusercontent.com/87972842/180348371-cc0c4f87-8a2b-4621-8bf2-1fd745702a89.png)
![image](https://user-images.githubusercontent.com/87972842/180348381-ce9f6171-6d56-4965-8fc9-6ed928c8a905.png)

</details>

## Changelog
:cl:
fix: TGUI chat 'Colored names' option no longer shows colored names when it's disabled.
fix: Scientist selection in PDA painter no longer gives a non-painted ID card
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
