### PR TITLE
Morph TGUI & refactor + icon2base64 fixes from TG

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -1669,6 +1669,7 @@
 #include "code\modules\antagonists\magic_servant\servant.dm"
 #include "code\modules\antagonists\morph\morph.dm"
 #include "code\modules\antagonists\morph\morph_antag.dm"
+#include "code\modules\antagonists\morph\morph_stomach.dm"
 #include "code\modules\antagonists\nightmare\nightmare.dm"
 #include "code\modules\antagonists\ninja\ninja.dm"
 #include "code\modules\antagonists\nukeop\clownop.dm"

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1158,9 +1158,6 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 		alpha += 25
 		obj_flags &= ~FROZEN
 
-/// Save file used in icon2base64. Used for converting icons to base64.
-GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of icons for the browser output
-
 /// Generate a filename for this asset
 /// The same asset will always lead to the same asset name
 /// (Generated names do not include file extention.)
@@ -1175,10 +1172,14 @@ GLOBAL_DATUM_INIT(dummySave, /savefile, new("tmp/dummySave.sav")) //Cache of ico
 /proc/icon2base64(icon/icon)
 	if (!isicon(icon))
 		return FALSE
-	WRITE_FILE(GLOB.dummySave["dummy"], icon)
-	var/iconData = GLOB.dummySave.ExportText("dummy")
+	var/savefile/dummySave = new("tmp/dummySave.sav")
+	WRITE_FILE(dummySave["dummy"], icon)
+	var/iconData = dummySave.ExportText("dummy")
 	var/list/partial = splittext(iconData, "{")
-	return replacetext(copytext_char(partial[2], 3, -5), "\n", "")
+	. = replacetext(copytext_char(partial[2], 3, -5), "\n", "") //if cleanup fails we want to still return the correct base64
+	dummySave.Unlock()
+	dummySave = null
+	fdel("tmp/dummySave.sav") //if you get the idea to try and make this more optimized, make sure to still call unlock on the savefile after every write to unlock it.
 
 /proc/icon2html(thing, target, icon_state, dir = SOUTH, frame = 1, moving = FALSE, sourceonly = FALSE)
 	if (!thing)

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -55,107 +55,37 @@
 
 	mobchatspan = "blob"
 	discovery_points = 2000
+	var/datum/morph_stomach/morph_stomach
+	var/datum/action/innate/morph_stomach/stomach_action
 
 /mob/living/simple_animal/hostile/morph/Initialize(mapload)
-	var/datum/action/innate/morph/stomach/S = new
-	S.Grant(src)
+	morph_stomach = new(src)
+	stomach_action = new(morph_stomach)
+	stomach_action.Grant(src)
 	. = ..()
 
-/datum/action/innate/morph/stomach
-	name = "Stomach Contents"
-	button_icon_state = "morph"
+/mob/living/simple_animal/hostile/morph/Destroy()
+	QDEL_NULL(morph_stomach)
+	QDEL_NULL(stomach_action)
+	. = ..()
 
-/datum/action/innate/morph/stomach/Activate()
-	var/mob/living/simple_animal/hostile/morph/M = owner
-	M.manipulate(M)
+/mob/living/simple_animal/hostile/morph/proc/RemoveContents(atom/movable/A, throwatom_required = FALSE)
+	A.forceMove(loc)
+	morph_stomach.favorites -= REF(A)
+	if(throwatom == A && !throwatom_required)
+		throwatom = null
 
-/mob/living/simple_animal/hostile/morph/proc/manipulate(var/mob/living/simple_animal/hostile/morph/M)
-	var/list/choices = list()
-	var/list/mobfunctions = list("Drop", "Digest", "Disguise as", "Throw", "Strip")
-	var/list/itemfunctions = list("Use", "Throw", "Drop", "Use and Throw", "Digest", "Disguise as")
-	for(var/atom/movable/A in contents)
-		choices += A
-	var/atom/movable/target = input(src,"What do you wish to use") in null|choices
-	if(isliving(target))
-		var/mob/living/L = target
-		var/action = input(src,"What do you wish to do with [L]") in null|mobfunctions
-		switch(action)
-			if("Drop")
-				if(throwatom == L)
-					throwatom = null
-				L.forceMove(loc)
-				visible_message("<span class='warning'>[src] spits [L] out!</span>")
-				playsound(src, 'sound/effects/splat.ogg', 50, 1)
-			if("Digest")
-				if(throwatom == L)
-					throwatom = null
-				to_chat(src, "<span class ='danger'> You begin digesting [L]</span>")
-				if(do_mob(src, src, L.maxHealth))
-					for(var/atom/movable/AM in L.contents)
-						src.contents += AM
-					L.dust()
-					adjustHealth(-(L.maxHealth / 2))
-					to_chat(src, "<span class ='danger'> You digest [L], restoring some health</span>")
-					playsound(src, 'sound/effects/splat.ogg', 50, 1)
-			if("Disguise as")
-				ShiftClickOn(L)
-			if("Throw")
-				if(throwatom)
-					to_chat(src, "<span class ='danger'> You are already preparing to throw [throwatom]</span>")
-				else
-					throwatom = L
-					to_chat(src, "<span class ='danger'> You prepare to throw [L]</span>")
-			if("Strip")
-				to_chat(src, "<span class ='danger'> You start removing [L]'s possessions</span>")
-				if(do_mob(src, L, 30))
-					for(var/atom/movable/AM in L.contents)
-						src.contents += AM
-					to_chat(src, "<span class ='danger'> You place [L]'s possessions into your stomach</span>")
-	else if(isitem(target))
-		var/obj/item/I = target
-		var/action = input(src,"What do you wish to do with [I]") in null|itemfunctions
-		switch(action)
-			if("Drop")
-				if(throwatom == I)
-					throwatom = null
-				I.forceMove(loc)
-				visible_message("<span class='warning'>[src] spits [I] out!</span>")
-				playsound(src, 'sound/effects/splat.ogg', 50, 1)
-			if("Disguise as")
-				ShiftClickOn(I)
-			if("Throw")
-				if(throwatom)
-					to_chat(src, "<span class ='danger'> You are already preparing to throw [throwatom]</span>")
-				else
-					throwatom = I
-					to_chat(src, "<span class ='danger'> You prepare to throw [I]</span>")
-			if("Use")
-				I.attack_self(src)
-			if("Use and Throw")
-				if(throwatom)
-					to_chat(src, "<span class ='danger'> You are already preparing to throw [throwatom]</span>")
-				else
-					throwatom = I
-					to_chat(src, "<span class ='danger'> You prepare to throw [I]</span>")
-					I.attack_self(src)
-			if("Digest")
-				if(throwatom == I)
-					throwatom = null
-				if((I.resistance_flags & UNACIDABLE) || (I.resistance_flags & ACID_PROOF) || (I.resistance_flags & INDESTRUCTIBLE))
-					to_chat(src, "<span class ='danger'>[I] cannot be digested.</span>")
-				else
-					playsound(src, 'sound/items/welder.ogg', 150, 1)
-					qdel(I)
-					to_chat(src, "<span class ='danger'>You digest [I].</span>")
-
+/mob/living/simple_animal/hostile/morph/proc/AddContents(atom/movable/A)
+	A.forceMove(src)
 
 /mob/living/simple_animal/hostile/morph/ClickOn(atom/A)
 	if(throwatom)
-		throwatom.forceMove(loc)
+		RemoveContents(throwatom, TRUE)
 		throwatom.safe_throw_at(A, throwatom.throw_range, throwatom.throw_speed, src, null, null, null, move_force)
 		visible_message("<span class='warning'>[src] spits [throwatom] at [A]!</span>")
 		throwatom = null
 		playsound(src, 'sound/effects/splat.ogg', 50, 1)
+		morph_stomach.ui_update()
 	. = ..()
 
 
@@ -190,25 +120,22 @@
 		return FALSE
 	if(A && A.loc != src)
 		visible_message("<span class='warning'>[src] swallows [A] whole!</span>")
-		A.forceMove(src)
+		AddContents(A)
+		morph_stomach.ui_update()
 		return TRUE
 	return FALSE
 
 /mob/living/simple_animal/hostile/morph/ShiftClickOn(atom/movable/A)
 	if(morph_time <= world.time && !stat)
 		if(A == src)
-			restore()
+			restore(TRUE)
 			return
 		if(allowed(A))
 			assume(A)
 	else
 		to_chat(src, "<span class='warning'>Your chameleon skin is still repairing itself!</span>")
-		..()
 
 /mob/living/simple_animal/hostile/morph/proc/assume(atom/movable/target)
-	if(morphed)
-		to_chat(src, "<span class='warning'>You must restore to your original form first!</span>")
-		return
 	morphed = TRUE
 	form = target
 
@@ -238,9 +165,10 @@
 	med_hud_set_status() //we're an object honest
 	return
 
-/mob/living/simple_animal/hostile/morph/proc/restore()
+/mob/living/simple_animal/hostile/morph/proc/restore(var/intentional = FALSE)
 	if(!morphed)
-		to_chat(src, "<span class='warning'>You're already in your normal form!</span>")
+		if(intentional)
+			to_chat(src, "<span class='warning'>You're already in your normal form!</span>")
 		return
 	morphed = FALSE
 	form = null
@@ -275,9 +203,10 @@
 
 /mob/living/simple_animal/hostile/morph/proc/barf_contents()
 	for(var/atom/movable/AM in src)
-		AM.forceMove(loc)
+		RemoveContents(AM)
 		if(prob(90))
 			step(AM, pick(GLOB.alldirs))
+	morph_stomach.ui_update()
 
 /mob/living/simple_animal/hostile/morph/wabbajack_act(mob/living/new_mob)
 	barf_contents()

--- a/code/modules/antagonists/morph/morph_stomach.dm
+++ b/code/modules/antagonists/morph/morph_stomach.dm
@@ -1,0 +1,155 @@
+/datum/morph_stomach
+	var/name = "morph stomach"
+	var/mob/living/simple_animal/hostile/morph/morph
+	var/list/base64_cache = list()
+	var/list/favorites = list()
+
+/datum/morph_stomach/New(my_morph)
+	. = ..()
+	morph = my_morph
+
+/datum/morph_stomach/Destroy()
+	morph = null
+	. = ..()
+
+/datum/morph_stomach/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/morph_stomach/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, morph, ui)
+	if(!ui)
+		ui = new(user, src, "Morph")
+		ui.open()
+
+/datum/morph_stomach/ui_data(mob/user)
+	var/list/data = list()
+	var/list/data_contents = list()
+	var/list/data_living = list()
+	var/list/data_items = list()
+	for(var/atom/movable/A in morph.contents)
+		if(!isliving(A) && !isitem(A))
+			continue
+		var/list/element = list()
+		element["living"] = isliving(A)
+		element["name"] = A.name
+		element["id"] = REF(A)
+		element["favorite"] = favorites.Find(element["id"])
+		element["digestable"] = TRUE
+		var/base64 = null
+		var/icon_state_temp = A.icon_state
+		if(icon_state_temp == "" || icon_state_temp == null)
+			if("[A.icon]" == "icons/mob/human.dmi")
+				icon_state_temp = "ghost"
+		if(icon_state_temp != "" && icon_state_temp != null)
+			var/icon_key = "[A.icon]-[icon_state_temp]"
+			if(base64_cache[icon_key] != null)
+				base64 = base64_cache[icon_key]
+			else
+				base64 = icon2base64(icon(A.icon, icon_state_temp, frame=1, dir=SOUTH))
+				base64_cache[icon_key] = base64
+			element["img"] = base64
+		if(isliving(A))
+			data_living[element["id"]] = element
+		else if(isitem(A))
+			var/obj/item/I = A
+			element["digestable"] = !(I.resistance_flags & UNACIDABLE) && !(I.resistance_flags & ACID_PROOF) && !(I.resistance_flags & INDESTRUCTIBLE)
+			data_items[element["id"]] = element
+	data_contents["living"] = data_living
+	data_contents["items"] = data_items
+	data["contents"] = data_contents
+	data["throw_ref"] = REF(morph.throwatom)
+	return data
+
+/datum/morph_stomach/ui_act(action, params)
+	if(..())
+		return
+	var/ref = params["id"]
+	var/atom/movable/target = null
+	for(var/atom/movable/A in morph.contents)
+		if(REF(A) == ref)
+			target = A
+			break
+	if(target == null || (!isliving(target) && !isitem(target)))
+		return
+	switch(action)
+		if("drop")
+			morph.RemoveContents(target)
+			morph.visible_message("<span class='warning'>[morph] spits [target] out!</span>")
+			playsound(morph, 'sound/effects/splat.ogg', 50, 1)
+			return TRUE
+		if("disguise")
+			morph.ShiftClickOn(target)
+			return FALSE
+		if("throw")
+			morph.throwatom = target
+			to_chat(morph, "<span class='danger'>You prepare to throw [target]</span>")
+			return TRUE
+		if("unthrow")
+			morph.throwatom = null
+			return TRUE
+		if("favorite")
+			if(favorites.Find(ref))
+				favorites -= ref
+			else
+				favorites += ref
+			return TRUE
+	if(isliving(target))
+		var/mob/living/L = target
+		switch(action)
+			if("digest")
+				if(morph.throwatom == L)
+					morph.throwatom = null
+				to_chat(morph, "<span class='danger'>You begin digesting [L]</span>")
+				if(do_mob(morph, morph, L.maxHealth))
+					if(ishuman(L) || ismonkey(L) || isalienadult(L) || istype(L, /mob/living/simple_animal/pet/dog) || istype(L, /mob/living/simple_animal/parrot))
+						var/list/turfs_to_throw = view(2, morph)
+						for(var/obj/item/I in L.contents)
+							L.dropItemToGround(I, TRUE)
+							if(QDELING(I))
+								continue //skip it
+							I.throw_at(pick(turfs_to_throw), 3, 1, spin = FALSE)
+							I.pixel_x = rand(-10, 10)
+							I.pixel_y = rand(-10, 10)
+					morph.RemoveContents(L)
+					L.dust()
+					morph.adjustHealth(-(L.maxHealth / 2))
+					to_chat(morph, "<span class='danger'>You digest [L], restoring some health</span>")
+					playsound(morph, 'sound/effects/splat.ogg', 50, 1)
+					return TRUE
+	else if(isitem(target))
+		var/obj/item/I = target
+		switch(action)
+			if("use")
+				I.attack_self(morph)
+			if("usethrow")
+				morph.throwatom = I
+				to_chat(morph, "<span class='danger'> You prepare to throw [I]</span>")
+				I.attack_self(morph)
+				return TRUE
+			if("digest")
+				if(morph.throwatom == I)
+					morph.throwatom = null
+				if((I.resistance_flags & UNACIDABLE) || (I.resistance_flags & ACID_PROOF) || (I.resistance_flags & INDESTRUCTIBLE))
+					to_chat(morph, "<span class='danger'>[I] cannot be digested.</span>")
+				else
+					playsound(morph, 'sound/items/welder.ogg', 150, 1)
+					qdel(I)
+					to_chat(morph, "<span class='danger'>You digest [I].</span>")
+					return TRUE
+
+/datum/action/innate/morph_stomach
+	name = "Stomach Contents"
+	icon_icon = 'icons/mob/animal.dmi'
+	button_icon_state = "morph"
+	var/datum/morph_stomach/morph_stomach
+
+/datum/action/innate/morph_stomach/New(our_target)
+	. = ..()
+	button.name = name
+	if(istype(our_target, /datum/morph_stomach))
+		morph_stomach = our_target
+	else
+		CRASH("morph_stomach action created with non stomach")
+
+/datum/action/innate/morph_stomach/Activate()
+	morph_stomach.ui_interact(owner)

--- a/tgui/packages/tgui/interfaces/Morph.js
+++ b/tgui/packages/tgui/interfaces/Morph.js
@@ -4,7 +4,7 @@ import { Box, Button, Section, Tabs, LabeledList } from '../components';
 
 export const Morph = (props, context) => {
   return (
-    <Window width={650} height={650}>
+    <Window theme="generic" width={650} height={650}>
       <Window.Content scrollable>
         <MorphContents />
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/Morph.js
+++ b/tgui/packages/tgui/interfaces/Morph.js
@@ -35,10 +35,12 @@ const MorphContents = (props, context) => {
       </Tabs>
       <LabeledList>
         {tab === 'favorites' ? (
-          favorites.map((A) => <MorphItem throw_ref={data.throw_ref} {...A} />)
+          favorites.map((A) => (
+            <MorphItem key={A.id} throw_ref={data.throw_ref} {...A} />
+          ))
         ) : data.contents[tab] ? (
           Object.values(data.contents[tab]).map((A) => (
-            <MorphItem throw_ref={data.throw_ref} {...A} />
+            <MorphItem key={A.id} throw_ref={data.throw_ref} {...A} />
           ))
         ) : (
           <span>

--- a/tgui/packages/tgui/interfaces/Morph.js
+++ b/tgui/packages/tgui/interfaces/Morph.js
@@ -1,0 +1,118 @@
+import { useBackend, useSharedState } from '../backend';
+import { Window } from '../layouts';
+import { Box, Button, Section, Tabs, LabeledList } from '../components';
+
+export const Morph = (props, context) => {
+  return (
+    <Window width={650} height={650}>
+      <Window.Content scrollable>
+        <MorphContents />
+      </Window.Content>
+    </Window>
+  );
+};
+
+const MorphContents = (props, context) => {
+  const { data } = useBackend(context);
+  const [tab, setTab] = useSharedState(context, 'tab', 'living');
+  const favorites = Object.values(data.contents.living)
+    .concat(Object.values(data.contents.items))
+    .filter((A) => A.favorite);
+  return (
+    <Section title="Morph Stomach">
+      <Tabs>
+        <Tabs.Tab selected={tab === 'living'} onClick={() => setTab('living')}>
+          Mobs ({Object.keys(data.contents.living).length})
+        </Tabs.Tab>
+        <Tabs.Tab selected={tab === 'items'} onClick={() => setTab('items')}>
+          Items ({Object.keys(data.contents.items).length})
+        </Tabs.Tab>
+        <Tabs.Tab
+          selected={tab === 'favorites'}
+          onClick={() => setTab('favorites')}>
+          Favorites ({favorites.length})
+        </Tabs.Tab>
+      </Tabs>
+      <LabeledList>
+        {tab === 'favorites' ? (
+          favorites.map((A) => <MorphItem throw_ref={data.throw_ref} {...A} />)
+        ) : data.contents[tab] ? (
+          Object.values(data.contents[tab]).map((A) => (
+            <MorphItem throw_ref={data.throw_ref} {...A} />
+          ))
+        ) : (
+          <span>
+            <strong>Your stomach is empty!</strong>
+          </span>
+        )}
+      </LabeledList>
+    </Section>
+  );
+};
+
+const MorphItem = (
+  { name, id, img, living, favorite, digestable, throw_ref },
+  context
+) => {
+  return (
+    <LabeledList.Item
+      label={
+        <>
+          {img ? (
+            <img
+              src={`data:image/jpeg;base64,${img}`}
+              style={{
+                'vertical-align': 'middle',
+                'horizontal-align': 'middle',
+              }}
+            />
+          ) : null}
+          <span title={name}>
+            {name.length > 26 ? name.substring(0, 24) + '...' : name}
+          </span>
+        </>
+      }>
+      <MorphItemButtons {...{ id, living, favorite, digestable, throw_ref }} />
+    </LabeledList.Item>
+  );
+};
+
+const MorphItemButtons = (
+  { id, living, favorite, digestable, throw_ref },
+  context
+) => {
+  const { act } = useBackend(context);
+  return (
+    <>
+      <Button
+        color={favorite ? 'yellow' : null}
+        icon={favorite ? 'star' : 'star-o'}
+        onClick={() => act('favorite', { id: id })}
+      />
+      <Button
+        content="Disguise As"
+        onClick={() => act('disguise', { id: id })}
+      />
+      <Button content="Drop" onClick={() => act('drop', { id: id })} />
+      <Button
+        content="Digest"
+        disabled={!digestable}
+        onClick={() => act('digest', { id: id })}
+      />
+      <Button
+        content={throw_ref === id ? 'Unthrow' : 'Throw'}
+        onClick={() => act(throw_ref === id ? 'unthrow' : 'throw', { id: id })}
+      />
+      {living ? null : (
+        <>
+          <Button content="Use" onClick={() => act('use', { id: id })} />
+          <Button
+            content="Use and Throw"
+            disabled={throw_ref === id}
+            onClick={() => act('usethrow', { id: id })}
+          />
+        </>
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

- Removed extra examine on disguise call
- Setting a new target for throwing works if you already have one
- No longer spams restore text when attacking
- Can disguise as something else without morphing back
- Removed strip button as it was extremely buggy and morphs can strip by dropping instead
- Digesting now removes mobs before dusting
- Stomach contents action now has an icon
- Refactor drop/pick up code
- Added new persistent auto-updating morph UI with favorites system

Ports https://github.com/tgstation/tgstation/pull/56320

## Why It's Good For The Game

Old morph menu bad no tgui, now good tgui and also morph is less buggy and way more usable

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/182038057-be55dff2-de94-4f4e-9a79-80188a7edc79.png)

Changes since this video: Digest no longer adds contents to morph, instead it drops it around the player the same as battle royale does

https://user-images.githubusercontent.com/10366817/180356418-322dcd60-4698-40ad-8023-3cf7bcb21261.mp4

</details>

## Changelog
:cl:
add: Persistent auto-updating Morph UI with favorites system
refactor: Morph stomach contents now uses TGUI
fix: Morph menu HUD icon is no longer invisible
fix: Rapid attacking as morph no longer spams your chat with messages
del: Removed morph Strip button in favor of regular stripping as it was extremely buggy
tweak: Digesting a mob as morph now drops it before dusting it
tweak: Digesting a mob with items no longer "strips" it first, instead the items are dropped onto the ground around the morph
tweak: Morph can now morph into other things without going back to its normal form
tweak: You can now remove your throw target as morph
code: Fixed issue with icon2base64
/:cl:
