### PR TITLE
Reduces the amount of money cargo gets for coffins

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -27,7 +27,7 @@
 	exclude_types = list()
 
 /datum/export/large/crate/coffin
-	cost = 100 //50 wood costs 2000, makes 10 coffins, makes 1000 back. No free money allowed, considering they can be easlily stacked with disposal loops. Additionally you still get 600 credits from the box + manifest either way, for a total of 1600 back.
+	cost = 140 //50 wood costs 1700, makes 10 coffins, makes 1400 back. No free money allowed, considering they can be easlily stacked with disposal loops. Additionally you still get 600 credits from the box + manifest either way, for a total of 2000 back. Total of 300 profit for wasting your time building coffins.
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -27,7 +27,7 @@
 	exclude_types = list()
 
 /datum/export/large/crate/coffin
-	cost = 250//50 wooden crates cost 2000 points, and you can make 10 coffins in seconds with those planks. Each coffin selling for 250 means you can make a net gain of 500 points for wasting your time making coffins.
+	cost = 200 //50 wood costs 2000, makes 10 coffins, makes 2000 back. No free money allowed, considering they can be easlily stacked with disposal loops
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -27,7 +27,7 @@
 	exclude_types = list()
 
 /datum/export/large/crate/coffin
-	cost = 200 //50 wood costs 2000, makes 10 coffins, makes 2000 back. No free money allowed, considering they can be easlily stacked with disposal loops
+	cost = 100 //50 wood costs 2000, makes 10 coffins, makes 1000 back. No free money allowed, considering they can be easlily stacked with disposal loops. Additionally you still get 600 credits from the box + manifest either way, for a total of 1600 back.
 	unit_name = "coffin"
 	export_types = list(/obj/structure/closet/crate/coffin)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Getting free money from cargo is not a great concept, especially when crates can be stacked via disposals and only take up 1 turf on the shuttle. This can get out of hand really quickly with enough money spent on wood.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
This is a 1 line value change, is this really necessary?
<summary>Screenshots&Videos</summary>
I'll put some later I guess?
</details>

## Changelog
:cl: mc_meiler
tweak: Coffins now sell for 140 instead of 250 credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
