### PR TITLE
[TGUI] Upgrades terser to 5.14.2

### DIFF
--- a/tgui/package.json
+++ b/tgui/package.json
@@ -48,7 +48,7 @@
     "sass": "^1.37.5",
     "sass-loader": "^11.1.1",
     "style-loader": "^2.0.0",
-    "terser-webpack-plugin": "^5.1.4",
+    "terser-webpack-plugin": "^5.3.3",
     "typescript": "^4.3.5",
     "url-loader": "^4.1.1",
     "webpack": "^5.50.0",
@@ -57,7 +57,8 @@
   },
   "resolutions": {
     "ajv": "^6.12.3",
-    "minimist": "^1.2.6"
+    "minimist": "^1.2.6",
+    "terser": "^5.14.2"
   },
   "packageManager": "yarn@3.1.1"
 }

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -1630,10 +1630,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/gen-mapping@npm:^0.3.0":
+  version: 0.3.2
+  resolution: "@jridgewell/gen-mapping@npm:0.3.2"
+  dependencies:
+    "@jridgewell/set-array": ^1.0.1
+    "@jridgewell/sourcemap-codec": ^1.4.10
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 1832707a1c476afebe4d0fbbd4b9434fdb51a4c3e009ab1e9938648e21b7a97049fa6009393bdf05cab7504108413441df26d8a3c12193996e65493a4efb6882
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.0.5
   resolution: "@jridgewell/resolve-uri@npm:3.0.5"
   checksum: 1ee652b693da7979ac4007926cc3f0a32b657ffeb913e111f44e5b67153d94a2f28a1d560101cc0cf8087625468293a69a00f634a2914e1a6d0817ba2039a913
+  languageName: node
+  linkType: hard
+
+"@jridgewell/set-array@npm:^1.0.1":
+  version: 1.1.2
+  resolution: "@jridgewell/set-array@npm:1.1.2"
+  checksum: 69a84d5980385f396ff60a175f7177af0b8da4ddb81824cb7016a9ef914eee9806c72b6b65942003c63f7983d4f39a5c6c27185bbca88eb4690b62075602e28e
+  languageName: node
+  linkType: hard
+
+"@jridgewell/source-map@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@jridgewell/source-map@npm:0.3.2"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.0
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 1b83f0eb944e77b70559a394d5d3b3f98a81fcc186946aceb3ef42d036762b52ef71493c6c0a3b7c1d2f08785f53ba2df1277fe629a06e6109588ff4cdcf7482
   languageName: node
   linkType: hard
 
@@ -1651,6 +1679,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: ab8bce84bbbc8c34f3ba8325ed926f8f2d3098983c10442a80c55764c4eb6e47d5b92d8ff20a0dd868c3e76a3535651fd8a0138182c290dbfc8396195685c37b
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.7, @jridgewell/trace-mapping@npm:^0.3.9":
+  version: 0.3.14
+  resolution: "@jridgewell/trace-mapping@npm:0.3.14"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: b9537b9630ffb631aef9651a085fe361881cde1772cd482c257fe3c78c8fd5388d681f504a9c9fe1081b1c05e8f75edf55ee10fdb58d92bbaa8dbf6a7bd6b18c
   languageName: node
   linkType: hard
 
@@ -2291,6 +2329,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: e0f79409d68923fbf1aa6d4166f3eedc47955320d25c89a20cc822e6ba7c48c5963d5bc657bc242d68f7a4ac9faf96eef033e8f73656da6c640d4219935fdfd0
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.5.0":
+  version: 8.8.0
+  resolution: "acorn@npm:8.8.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 7270ca82b242eafe5687a11fea6e088c960af712683756abf0791b68855ea9cace3057bd5e998ffcef50c944810c1e0ca1da526d02b32110e13c722aa959afdc
   languageName: node
   linkType: hard
 
@@ -7447,7 +7494,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.7.3, source-map@npm:~0.7.2":
+"source-map@npm:^0.7.3":
   version: 0.7.3
   resolution: "source-map@npm:0.7.3"
   checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
@@ -7759,7 +7806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser-webpack-plugin@npm:^5.1.3, terser-webpack-plugin@npm:^5.1.4":
+"terser-webpack-plugin@npm:^5.1.3":
   version: 5.3.1
   resolution: "terser-webpack-plugin@npm:5.3.1"
   dependencies:
@@ -7781,21 +7828,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser@npm:^5.7.2":
-  version: 5.10.0
-  resolution: "terser@npm:5.10.0"
+"terser-webpack-plugin@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "terser-webpack-plugin@npm:5.3.3"
   dependencies:
-    commander: ^2.20.0
-    source-map: ~0.7.2
-    source-map-support: ~0.5.20
+    "@jridgewell/trace-mapping": ^0.3.7
+    jest-worker: ^27.4.5
+    schema-utils: ^3.1.1
+    serialize-javascript: ^6.0.0
+    terser: ^5.7.2
   peerDependencies:
-    acorn: ^8.5.0
+    webpack: ^5.1.0
   peerDependenciesMeta:
-    acorn:
+    "@swc/core":
       optional: true
+    esbuild:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 4b8d508d8a0f6e604addb286975f1fa670f8c3964a67abc03a7cfcfd4cdeca4b07dda6655e1c4425427fb62e4d2b0ca59d84f1b2cd83262ff73616d5d3ccdeb5
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.14.2":
+  version: 5.14.2
+  resolution: "terser@npm:5.14.2"
+  dependencies:
+    "@jridgewell/source-map": ^0.3.2
+    acorn: ^8.5.0
+    commander: ^2.20.0
+    source-map-support: ~0.5.20
   bin:
     terser: bin/terser
-  checksum: 1080faeb6d5cd155bb39d9cc41d20a590eafc9869560d5285f255f6858604dcd135311e344188a106f87fedb12d096ad3799cfc2e65acd470b85d468b1c7bd4c
+  checksum: cabb50a640d6c2cfb351e4f43dc7bf7436f649755bb83eb78b2cacda426d5e0979bd44e6f92d713f3ca0f0866e322739b9ced888ebbce6508ad872d08de74fcc
   languageName: node
   linkType: hard
 
@@ -7909,7 +7974,7 @@ __metadata:
     sass: ^1.37.5
     sass-loader: ^11.1.1
     style-loader: ^2.0.0
-    terser-webpack-plugin: ^5.1.4
+    terser-webpack-plugin: ^5.3.3
     typescript: ^4.3.5
     url-loader: ^4.1.1
     webpack: ^5.50.0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Updates the resolution for `terser-webpack-plugin` and `terser` to force a minimum version of 5.14.2.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Testing procedure:

1. Fully clean the build environment using juke
2. Rebuild TGUI and run the linter/tests
3. Build DM and launch a new server
4. Verify that TG-chat loads
5. Spawn as captain and interact with different TGUI menus

<details>
<summary>Build + inline tests</summary>

```node
❯ ../tools/build/build clean-all
Using system-wide Node v16.16.0
:: Juke Build version 0.8.1
=> Starting 'tgui-clean'
=> Finished 'tgui-clean' in 0.041s
=> Starting 'clean'
=> Finished 'clean' in 0s
=> Starting 'clean-all'
:: Cleaning up data/logs
:: Cleaning up global yarn cache
➤ YN0000: Done in 0s 17ms
=> Finished 'clean-all' in 0.3s
=> Done in 0.343s

repo/tgui on  terser-upgrade [!⇣] via  v16.16.0
❯ ../tools/build/build tgui tgui-lint tgui-test
Using system-wide Node v16.16.0
:: Juke Build version 0.8.1
=> Starting 'yarn'
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 448ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 4 packages were already cached, 854 had to be fetched
➤ YN0000: └ Completed in 25s 423ms
➤ YN0000: ┌ Link step
➤ YN0000: │ ESM support for PnP uses the experimental loader API and is therefore experimental
➤ YN0000: └ Completed in 0s 538ms
➤ YN0000: Done with warnings in 26s 520ms
=> Finished 'yarn' in 26.901s
=> Starting 'tgui'
=> Starting 'tgui-test'
=> Starting 'tgui-eslint'
=> Starting 'tgui-tsc'
 PASS  packages/common/collections.spec.ts
 PASS  packages/common/react.spec.ts

Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.03 s
Ran all test suites.
=> Finished 'tgui-test' in 2.285s
=> Finished 'tgui-tsc' in 2.903s
=> Finished 'tgui-eslint' in 10.468s
assets by path *.js 1.47 MiB
  asset tgui.bundle.js 1.03 MiB [emitted] [minimized] (name: tgui)
  asset tgui-panel.bundle.js 444 KiB [emitted] [minimized] (name: tgui-panel)
assets by path *.css 296 KiB
  asset tgui.bundle.css 193 KiB [emitted] (name: tgui)
  asset tgui-panel.bundle.css 103 KiB [emitted] (name: tgui-panel)
Entrypoint tgui 1.22 MiB = tgui.bundle.css 193 KiB tgui.bundle.js 1.03 MiB
Entrypoint tgui-panel 547 KiB = tgui-panel.bundle.css 103 KiB tgui-panel.bundle.js 444 KiB
2022-07-22 12:12:33: webpack 5.69.0 compiled successfully in 15604 ms
=> Finished 'tgui' in 17.671s
=> Done in 44.632s
```
</details>

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/26130695/180610347-baf861e9-42ea-4602-aead-9ff540d872e6.png)
![image](https://user-images.githubusercontent.com/26130695/180610375-7a2301d3-114e-4cf2-bb33-b8f03c5d0ace.png)
![image](https://user-images.githubusercontent.com/26130695/180610393-1e2f7bd9-bebe-433a-809f-8d982205ece6.png)
![image](https://user-images.githubusercontent.com/26130695/180610408-605301b9-d330-4298-b075-3038ee371c7c.png)
![image](https://user-images.githubusercontent.com/26130695/180610417-b4aa0466-702e-4898-904e-1d9f16a04209.png)
![image](https://user-images.githubusercontent.com/26130695/180610441-9e2e1e72-80f2-4126-9667-9fd8530f9838.png)
![image](https://user-images.githubusercontent.com/26130695/180610482-3757d543-697a-4858-b442-6d7044778f3f.png)

</details>

## Changelog
:cl:
server: Upgrades the TGUI dependency terser to 5.14.2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
