### PR TITLE
Adjusts VV dropdown perms

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -38,8 +38,6 @@
 /datum/proc/vv_do_topic(list/href_list)
 	if(!usr || !usr.client || !usr.client.holder || !check_rights(NONE))
 		return FALSE			//This is VV, not to be called by anything else.
-	if(href_list[VV_HK_MODIFY_TRAITS])
-		usr.client.holder.modify_traits(src)
 	return TRUE
 
 /datum/proc/vv_get_header()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1071,20 +1071,27 @@
 							valid_id = TRUE
 						if(!valid_id)
 							to_chat(usr, "<span class='warning'>A reagent with that ID doesn't exist!</span>")
+				
 				if("Choose from a list")
 					chosen_id = input(usr, "Choose a reagent to add.", "Choose a reagent.") as null|anything in subtypesof(/datum/reagent)
+				
 				if("I'm feeling lucky")
 					chosen_id = pick(subtypesof(/datum/reagent))
+
 			if(chosen_id)
 				var/amount = input(usr, "Choose the amount to add.", "Choose the amount.", reagents.maximum_volume) as num
+
 				if(amount)
 					reagents.add_reagent(chosen_id, amount)
 					log_admin("[key_name(usr)] has added [amount] units of [chosen_id] to [src]")
 					message_admins("<span class='notice'>[key_name(usr)] has added [amount] units of [chosen_id] to [src]</span>")
+
 	if(href_list[VV_HK_TRIGGER_EXPLOSION] && check_rights(R_FUN))
 		usr.client.cmd_admin_explosion(src)
+
 	if(href_list[VV_HK_TRIGGER_EMP] && check_rights(R_FUN))
 		usr.client.cmd_admin_emp(src)
+
 	if(href_list[VV_HK_MODIFY_TRANSFORM] && check_rights(R_VAREDIT))
 		var/result = input(usr, "Choose the transformation to apply","Transform Mod") as null|anything in list("Scale","Translate","Rotate")
 		var/matrix/M = transform
@@ -1103,13 +1110,16 @@
 				var/angle = input(usr, "Choose angle to rotate","Transform Mod") as null|num
 				if(!isnull(angle))
 					transform = M.Turn(angle)
-	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
+
+	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_ADMIN))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text
 		if(newname)
 			vv_auto_rename(newname)
-	if(href_list[VV_HK_ADD_AI])
-		if(!check_rights(R_VAREDIT))
-			return
+
+	if(href_list[VV_HK_MODIFY_TRAITS] && check_rights(R_VAREDIT))
+		usr.client.holder.modify_traits(src)
+
+	if(href_list[VV_HK_ADD_AI] && check_rights(R_VAREDIT))
 		var/result = input(usr, "Choose the AI controller to apply to this atom WARNING: Not all AI works on all atoms.", "AI controller") as null|anything in subtypesof(/datum/ai_controller)
 		if(!result)
 			return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -650,6 +650,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	set category = "Fun"
 	set name = "Give Disease"
 	set desc = "Gives a Disease to a mob."
+
 	if(!istype(T))
 		to_chat(src, "<span class='notice'>You can only give a disease to a mob of type /mob/living.</span>")
 		return

--- a/code/modules/admin/view_variables/mark_datum.dm
+++ b/code/modules/admin/view_variables/mark_datum.dm
@@ -12,7 +12,7 @@
 	set category = "Debug"
 	set name = "Mark Object"
 
-	if(check_rights(R_VAREDIT))
+	if(!check_rights(R_VAREDIT))
 		return
 	mark_datum(D)
 

--- a/code/modules/admin/view_variables/mark_datum.dm
+++ b/code/modules/admin/view_variables/mark_datum.dm
@@ -11,6 +11,9 @@
 /client/proc/mark_datum_mapview(datum/D as mob|obj|turf|area in view(view))
 	set category = "Debug"
 	set name = "Mark Object"
+
+	if(check_rights(R_VAREDIT))
+		return
 	mark_datum(D)
 
 /datum/admins/proc/handle_marked_del(datum/source)

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -25,32 +25,33 @@
 				modify_variables(target, target_var, 0)
 			if(href_list[VV_HK_BASIC_MASSEDIT])
 				cmd_mass_modify_object_variables(target, target_var)
-	if(check_rights(R_ADMIN, FALSE))
-		if(href_list[VV_HK_EXPOSE])
-			var/value = vv_get_value(VV_CLIENT)
-			if (value["class"] != VV_CLIENT)
-				return
-			var/client/C = value["value"]
-			if (!C)
-				return
-			if(!target)
-				to_chat(usr, "<span class='warning'>The object you tried to expose to [C] no longer exists (nulled or hard-deled)</span>")
-				return
-			message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;datumrefresh=[REF(target)]'>VV window</a>")
-			log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [target]")
-			to_chat(C, "[holder.fakekey ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
-			C.debug_variables(target)
-	if(check_rights(R_DEBUG))
-		if(href_list[VV_HK_DELETE])
-			usr.client.admin_delete(target)
-			if (isturf(src))	// show the turf that took its place
-				usr.client.debug_variables(src)
-				return
 
-	if(href_list[VV_HK_MARK])
+	if(check_rights(R_DEBUG) && href_list[VV_HK_EXPOSE])
+		var/value = vv_get_value(VV_CLIENT)
+		if(value["class"] != VV_CLIENT)
+			return
+		var/client/C = value["value"]
+		if(!C)
+			return
+		if(!target)
+			to_chat(usr, "<span class='warning'>The object you tried to expose to [C] no longer exists (nulled or hard-deled)</span>")
+			return
+		message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='?_src_=vars;datumrefresh=[REF(target)]'>VV window</a>")
+		log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [target]")
+		to_chat(C, "[holder.fakekey ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
+		C.debug_variables(target)
+
+	if(check_rights(R_DEBUG) && href_list[VV_HK_DELETE])
+		usr.client.admin_delete(target)
+		if(isturf(src))	// show the turf that took its place
+			usr.client.debug_variables(src)
+			return
+
+	if(href_list[VV_HK_MARK] && check_rights(R_VAREDIT))
 		usr.client.mark_datum(target)
+
 	if(href_list[VV_HK_ADDCOMPONENT])
-		if(!check_rights(NONE))
+		if(!check_rights(R_VAREDIT))
 			return
 		var/list/names = list()
 		var/list/componentsubtypes = sortList(subtypesof(/datum/component), /proc/cmp_typepaths_asc)
@@ -77,12 +78,12 @@
 			target._AddElement(arglist(lst))
 		log_admin("[key_name(usr)] has added [result] [datumname] to [key_name(src)].")
 		message_admins("<span class='notice'>[key_name_admin(usr)] has added [result] [datumname] to [key_name_admin(src)].</span>")
-	if(href_list[VV_HK_MODIFY_GREYSCALE])
-		if(!check_rights(NONE))
-			return
+
+	if(href_list[VV_HK_MODIFY_GREYSCALE] && check_rights(NONE))
 		var/datum/greyscale_modify_menu/menu = new(target, usr, SSgreyscale.configurations)
 		menu.Unlock()
 		menu.ui_interact(usr)
+
 	if(href_list[VV_HK_CALLPROC])
 		usr.client.callproc_datum(target)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -898,19 +898,18 @@
 					else
 						to_chat(usr, "Only humans can be augmented.")
 		admin_ticket_log("[key_name_admin(usr)] has modified the bodyparts of [src]")
+	
 	if(href_list[VV_HK_MAKE_AI])
 		if(!check_rights(R_SPAWN))
 			return
 		if(alert("Confirm mob type change?",,"Transform","Cancel") != "Transform")
 			return
 		usr.client.holder.Topic("vv_override", list("makeai"=href_list[VV_HK_TARGET]))
-	if(href_list[VV_HK_MODIFY_ORGANS])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_MODIFY_ORGANS] && check_rights(R_FUN|R_DEBUG))
 		usr.client.manipulate_organs(src)
-	if(href_list[VV_HK_MARTIAL_ART])
-		if(!check_rights(NONE))
-			return
+
+	if(href_list[VV_HK_MARTIAL_ART] && check_rights(R_FUN))
 		var/list/artpaths = subtypesof(/datum/martial_art)
 		var/list/artnames = list()
 		for(var/i in artpaths)
@@ -928,9 +927,8 @@
 			MA.teach(src)
 			log_admin("[key_name(usr)] has taught [MA] to [key_name(src)].")
 			message_admins("<span class='notice'>[key_name_admin(usr)] has taught [MA] to [key_name_admin(src)].</span>")
-	if(href_list[VV_HK_GIVE_TRAUMA])
-		if(!check_rights(NONE))
-			return
+
+	if(href_list[VV_HK_GIVE_TRAUMA] && check_rights(R_FUN|R_DEBUG))
 		var/list/traumas = subtypesof(/datum/brain_trauma)
 		var/result = input(usr, "Choose the brain trauma to apply","Traumatize") as null|anything in traumas
 		if(!usr)
@@ -944,15 +942,13 @@
 		if(BT)
 			log_admin("[key_name(usr)] has traumatized [key_name(src)] with [BT.name]")
 			message_admins("<span class='notice'>[key_name_admin(usr)] has traumatized [key_name_admin(src)] with [BT.name].</span>")
-	if(href_list[VV_HK_CURE_TRAUMA])
-		if(!check_rights(NONE))
-			return
+
+	if(href_list[VV_HK_CURE_TRAUMA] && check_rights(R_FUN|R_DEBUG))
 		cure_all_traumas(TRAUMA_RESILIENCE_ABSOLUTE)
 		log_admin("[key_name(usr)] has cured all traumas from [key_name(src)].")
 		message_admins("<span class='notice'>[key_name_admin(usr)] has cured all traumas from [key_name_admin(src)].</span>")
-	if(href_list[VV_HK_HALLUCINATION])
-		if(!check_rights(NONE))
-			return
+
+	if(href_list[VV_HK_HALLUCINATION] && check_rights(R_FUN))
 		var/list/hallucinations = subtypesof(/datum/hallucination)
 		var/result = input(usr, "Choose the hallucination to apply","Send Hallucination") as null|anything in hallucinations
 		if(!usr)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1140,53 +1140,40 @@
 
 /mob/vv_do_topic(list/href_list)
 	. = ..()
-	if(href_list[VV_HK_REGEN_ICONS])
-		if(!check_rights(NONE))
-			return
+	if(href_list[VV_HK_REGEN_ICONS] && check_rights(R_ADMIN))
 		regenerate_icons()
-	if(href_list[VV_HK_PLAYER_PANEL])
-		if(!check_rights(NONE))
-			return
+
+	if(href_list[VV_HK_PLAYER_PANEL] && check_rights(R_ADMIN))
 		usr.client.holder.show_player_panel(src)
-	if(href_list[VV_HK_GODMODE])
-		if(!check_rights(R_ADMIN))
-			return
+	
+	if(href_list[VV_HK_GODMODE] && check_rights(R_FUN))
 		usr.client.cmd_admin_godmode(src)
-	if(href_list[VV_HK_GIVE_SPELL])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_GIVE_SPELL] && check_rights(R_FUN))
 		usr.client.give_spell(src)
-	if(href_list[VV_HK_REMOVE_SPELL])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_REMOVE_SPELL] && check_rights(R_FUN))
 		usr.client.remove_spell(src)
-	if(href_list[VV_HK_GIVE_DISEASE])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_GIVE_DISEASE] && check_rights(R_FUN))
 		usr.client.give_disease(src)
-	if(href_list[VV_HK_GIB])
-		if(!check_rights(R_FUN))
-			return
+	
+	if(href_list[VV_HK_GIB] && check_rights(R_FUN))
 		usr.client.cmd_admin_gib(src)
-	if(href_list[VV_HK_BUILDMODE])
-		if(!check_rights(R_BUILD))
-			return
+	
+	if(href_list[VV_HK_BUILDMODE] && check_rights(R_BUILD))
 		togglebuildmode(src)
-	if(href_list[VV_HK_DROP_ALL])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_DROP_ALL] && check_rights(R_FUN))
 		usr.client.cmd_admin_drop_everything(src)
-	if(href_list[VV_HK_DIRECT_CONTROL])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_DIRECT_CONTROL] && check_rights(R_ADMIN))
 		usr.client.cmd_assume_direct_control(src)
-	if(href_list[VV_HK_GIVE_DIRECT_CONTROL])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_GIVE_DIRECT_CONTROL] && check_rights(R_ADMIN))
 		usr.client.cmd_give_direct_control(src)
-	if(href_list[VV_HK_OFFER_GHOSTS])
-		if(!check_rights(NONE))
-			return
+	
+	if(href_list[VV_HK_OFFER_GHOSTS] && check_rights(R_ADMIN))
 		offer_control(src)
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Restricts most of the VV dropdown options to outside Moderators' perms.
- Allows moderators to rename mobs.
- Some misc code cleanup to make it more readable.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mod perms being tighter for adminbus, but better for actually adminning good good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

https://cdn.discordapp.com/attachments/838856888435212308/1000096040445280427/2022-07-22_19-29-20.mp4

</details>

## Changelog
:cl:
admin: Moderators' bus perms have been toned down, but they can now rename improperly named characters/mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
