### PR TITLE
[TG PORT] Gets our Modular PCs (mostly) up to date with TG + small runtime fix

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2768,6 +2768,7 @@
 #include "code\modules\modular_computers\hardware\portable_disk.dm"
 #include "code\modules\modular_computers\hardware\printer.dm"
 #include "code\modules\modular_computers\hardware\recharger.dm"
+#include "code\modules\modular_computers\hardware\sensor_package.dm"
 #include "code\modules\modular_computers\NTNet\NTNRC\conversation.dm"
 #include "code\modules\ninja\__ninjaDefines.dm"
 #include "code\modules\ninja\energy_katana.dm"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -604,3 +604,9 @@
 #define COMSIG_MOVELOOP_POSTPROCESS "moveloop_postprocess"
 //from [/datum/move_loop/has_target/jps/recalculate_path] ():
 #define COMSIG_MOVELOOP_JPS_REPATH "moveloop_jps_repath"
+
+// /obj/machinery/power/supermatter_crystal signals
+/// from /obj/machinery/power/supermatter_crystal/process_atmos(); when the SM delam reaches the point of sounding alarms
+#define COMSIG_SUPERMATTER_DELAM_START_ALARM "sm_delam_start_alarm"
+/// from /obj/machinery/power/supermatter_crystal/process_atmos(); when the SM sounds an audible alarm
+#define COMSIG_SUPERMATTER_DELAM_ALARM "sm_delam_alarm"

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -54,11 +54,13 @@
 #define MC_HDD "HDD"
 #define MC_SDD "SDD"
 #define MC_CARD "CARD"
+#define MC_CARD2 "CARD2"
 #define MC_NET "NET"
 #define MC_PRINT "PRINT"
 #define MC_CELL "CELL"
 #define MC_CHARGE "CHARGE"
 #define MC_AI "AI"
+#define MC_SENSORS "SENSORS"
 
 //! ## NTNet stuff, for modular computers
 //!  **NTNet module-configuration values. Do not change these. If you need to add another use larger number (5..6..7 etc)**

--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -87,6 +87,12 @@
 #define PROGRAM_STATE_KILLED 0
 #define PROGRAM_STATE_BACKGROUND 1
 #define PROGRAM_STATE_ACTIVE 2
+//Program categories
+#define PROGRAM_CATEGORY_CREW "Crew"
+#define PROGRAM_CATEGORY_ENGI "Engineering"
+#define PROGRAM_CATEGORY_ROBO "Robotics"
+#define PROGRAM_CATEGORY_SUPL "Supply"
+#define PROGRAM_CATEGORY_MISC "Other"
 
 #define FIREDOOR_OPEN 1
 #define FIREDOOR_CLOSED 2

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -38,7 +38,10 @@
 		. += "<span class='notice'>- Recharging <b>[recharge_coeff*10]%</b> cell charge per cycle.</span>"
 		if(charging)
 			var/obj/item/stock_parts/cell/C = charging.get_cell()
-			. += "<span class='notice'>- \The [charging]'s cell is at <b>[C.percent()]%</b>.</span>"
+			if(C)
+				. += "<span class='notice'>- \The [charging]'s cell is at <b>[C.percent()]%</b>.</span>"
+			else
+				. += "<span class='notice'>- \The [charging] has no power cell installed.</span>"
 
 
 /obj/machinery/recharger/proc/setCharging(new_charging)

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -42,7 +42,7 @@
 	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
 	box = /obj/item/storage/box/engineer
 	pda_slot = ITEM_SLOT_LPOCKET
-	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
+	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced/atmos=1)
 
 /datum/outfit/job/atmospheric_technician/rig
 	name = "Atmospheric Technician (Hardsuit)"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -75,11 +75,8 @@
 		. = pda.owner
 	else if(istype(tablet))
 		var/obj/item/computer_hardware/card_slot/card_slot = tablet.all_components[MC_CARD]
-		if(card_slot && (card_slot.stored_card2 || card_slot.stored_card))
-			if(card_slot.stored_card2?.registered_name) //The second card is the one used for authorization in the ID changing program, so we prioritize it here for consistency
-				. = card_slot.stored_card2.registered_name
-			else if(card_slot.stored_card?.registered_name)
-				. = card_slot.stored_card.registered_name
+		if(card_slot?.stored_card)
+			. = card_slot.stored_card.registered_name
 	if(!.)
 		. = if_no_id	//to prevent null-names making the mob unclickable
 	return

--- a/code/modules/modular_computers/computers/_modular_computer_shared.dm
+++ b/code/modules/modular_computers/computers/_modular_computer_shared.dm
@@ -47,9 +47,9 @@
 	var/obj/item/computer_hardware/card_slot/card_slot2 = get_modular_computer_part(MC_CARD2)
 	var/multiple_slots = istype(card_slot) && istype(card_slot2)
 	if(card_slot)
-		if(card_slot.stored_card || card_slot2.stored_card)
-			var/obj/item/card/id/first_ID = card_slot.stored_card
-			var/obj/item/card/id/second_ID = card_slot2.stored_card
+		if(card_slot?.stored_card || card_slot2?.stored_card)
+			var/obj/item/card/id/first_ID = card_slot?.stored_card
+			var/obj/item/card/id/second_ID = card_slot2?.stored_card
 			var/multiple_cards = istype(first_ID) && istype(second_ID)
 			if(user_is_adjacent)
 				. += "It has [multiple_slots ? "two slots" : "a slot"] for identification cards installed[multiple_cards ? " which contain [first_ID] and [second_ID]" : ", one of which contains [first_ID ? first_ID : second_ID]"]."

--- a/code/modules/modular_computers/computers/_modular_computer_shared.dm
+++ b/code/modules/modular_computers/computers/_modular_computer_shared.dm
@@ -44,18 +44,20 @@
 			. += "It has a slot installed for an intelliCard."
 
 	var/obj/item/computer_hardware/card_slot/card_slot = get_modular_computer_part(MC_CARD)
+	var/obj/item/computer_hardware/card_slot/card_slot2 = get_modular_computer_part(MC_CARD2)
+	var/multiple_slots = istype(card_slot) && istype(card_slot2)
 	if(card_slot)
-		if(card_slot.stored_card || card_slot.stored_card2)
+		if(card_slot.stored_card || card_slot2.stored_card)
 			var/obj/item/card/id/first_ID = card_slot.stored_card
-			var/obj/item/card/id/second_ID = card_slot.stored_card2
+			var/obj/item/card/id/second_ID = card_slot2.stored_card
 			var/multiple_cards = istype(first_ID) && istype(second_ID)
 			if(user_is_adjacent)
-				. += "It has two slots for identification cards installed[multiple_cards ? " which contain [first_ID] and [second_ID]" : ", one of which contains [first_ID ? first_ID : second_ID]"]."
+				. += "It has [multiple_slots ? "two slots" : "a slot"] for identification cards installed[multiple_cards ? " which contain [first_ID] and [second_ID]" : ", one of which contains [first_ID ? first_ID : second_ID]"]."
 			else
-				. += "It has two slots for identification cards installed, [multiple_cards ? "both of which appear" : "and one of them appears"] to be occupied."
+				. += "It has [multiple_slots ? "two slots" : "a slot"] for identification cards installed, [multiple_cards ? "both of which appear" : "and one of them appears"] to be occupied."
 			. += "<span class='info'>Alt-click [src] to eject the identification card[multiple_cards ? "s":""].</span>"
 		else
-			. += "It has two slots installed for identification cards."
+			. += "It has [multiple_slots ? "two slots" : "a slot"] installed for identification cards."
 
 	var/obj/item/computer_hardware/printer/printer_slot = get_modular_computer_part(MC_PRINT)
 	if(printer_slot)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -247,6 +247,28 @@
 	handle_power(delta_time) // Handles all computer power interaction
 	//check_update_ui_need()
 
+/**
+  * Displays notification text alongside a soundbeep when requested to by a program.
+  *
+  * After checking tha the requesting program is allowed to send an alert, creates
+  * a visible message of the requested text alongside a soundbeep. This proc adds
+  * text to indicate that the message is coming from this device and the program
+  * on it, so the supplied text should be the exact message and ending punctuation.
+  *
+  * Arguments:
+  * The program calling this proc.
+  * The message that the program wishes to display.
+ */
+
+/obj/item/modular_computer/proc/alert_call(datum/computer_file/program/caller, alerttext, sound = 'sound/machines/twobeep_high.ogg')
+	if(!caller || !caller.alert_able || caller.alert_silenced || !alerttext) //Yeah, we're checking alert_able. No, you don't get to make alerts that the user can't silence.
+		return
+	playsound(src, sound, 50, TRUE)
+	visible_message("<span class='notice'>The [src] displays a [caller.filedesc] notification: [alerttext]</span>")
+	var/mob/living/holder = loc
+	if(istype(holder))
+		to_chat(holder, "[icon2html(src)] <span class='notice'>The [src] displays a [caller.filedesc] notification: [alerttext]</span>")
+
 // Function used by NanoUI's to obtain data for header. All relevant entries begin with "PC_"
 /obj/item/modular_computer/proc/get_header_data()
 	var/list/data = list()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -34,11 +34,12 @@
 	max_integrity = 100
 	armor = list("melee" = 0, "bullet" = 20, "laser" = 20, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0, "stamina" = 0)
 
-	// Important hardware (must be installed for computer to work)
-
-	// Optional hardware (improves functionality, but is not critical for computer to work)
-
-	var/list/all_components = list()						// List of "connection ports" in this computer and the components with which they are plugged
+	/// List of "connection ports" in this computer and the components with which they are plugged
+	var/list/all_components = list()
+	/// Lazy List of extra hardware slots that can be used modularly.
+	var/list/expansion_bays
+	/// Number of total expansion bays this computer has available.
+	var/max_bays = 0
 
 	var/list/idle_threads							// Idle programs on background. They still receive process calls but can't be interacted with.
 	var/obj/physical = null									// Object that represents our computer. It's used for Adjacent() and UI visibility checks.
@@ -74,9 +75,9 @@
 		return
 
 	if(user.canUseTopic(src, BE_CLOSE))
+		var/obj/item/computer_hardware/card_slot/card_slot2 = all_components[MC_CARD2]
 		var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-		if(card_slot)
-			card_slot.try_eject(null, user)
+		return (card_slot2?.try_eject(user) || card_slot?.try_eject(user)) //Try the secondary one first.
 
 // Gets IDs/access levels from card slot. Would be useful when/if PDAs would become modular PCs.
 /obj/item/modular_computer/GetAccess()
@@ -92,19 +93,25 @@
 	return ..()
 
 /obj/item/modular_computer/RemoveID()
+	var/obj/item/computer_hardware/card_slot/card_slot2 = all_components[MC_CARD2]
 	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-	if(!card_slot)
-		return
-	return card_slot.RemoveID()
+	return (card_slot2?.try_eject() || card_slot?.try_eject()) //Try the secondary one first.
 
 /obj/item/modular_computer/InsertID(obj/item/inserting_item)
 	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-	if(!card_slot)
+	var/obj/item/computer_hardware/card_slot/card_slot2 = all_components[MC_CARD2]
+	if(!(card_slot || card_slot2))
+		//to_chat(user, "<span class='warning'>There isn't anywhere you can fit a card into on this computer.</span>")
 		return FALSE
+
 	var/obj/item/card/inserting_id = inserting_item.RemoveID()
 	if(!inserting_id)
 		return FALSE
-	return card_slot.try_insert(inserting_id)
+
+	if((card_slot?.try_insert(inserting_id)) || (card_slot2?.try_insert(inserting_id)))
+		return TRUE
+	//to_chat(user, "<span class='warning'>This computer doesn't have an open card slot.</span>")
+	return FALSE
 
 /obj/item/modular_computer/MouseDrop(obj/over_object, src_location, over_location)
 	var/mob/M = usr

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -101,7 +101,6 @@
 	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
 	var/obj/item/computer_hardware/card_slot/card_slot2 = all_components[MC_CARD2]
 	if(!(card_slot || card_slot2))
-		//to_chat(user, "<span class='warning'>There isn't anywhere you can fit a card into on this computer.</span>")
 		return FALSE
 
 	var/obj/item/card/inserting_id = inserting_item.RemoveID()
@@ -110,7 +109,6 @@
 
 	if((card_slot?.try_insert(inserting_id)) || (card_slot2?.try_insert(inserting_id)))
 		return TRUE
-	//to_chat(user, "<span class='warning'>This computer doesn't have an open card slot.</span>")
 	return FALSE
 
 /obj/item/modular_computer/MouseDrop(obj/over_object, src_location, over_location)
@@ -365,6 +363,10 @@
 
 
 /obj/item/modular_computer/attackby(obj/item/W as obj, mob/user as mob)
+	// Check for ID first
+	if(istype(W, /obj/item/card/id) && InsertID(W))
+		return
+
 	// Insert items into the components
 	for(var/h in all_components)
 		var/obj/item/computer_hardware/H = all_components[h]

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -69,79 +69,14 @@
 	physical = null
 	return ..()
 
-
-/obj/item/modular_computer/proc/add_computer_verbs(var/path)
-	switch(path)
-		if(MC_CARD)
-			add_verb(/obj/item/modular_computer/proc/eject_id)
-		if(MC_SDD)
-			add_verb(/obj/item/modular_computer/proc/eject_disk)
-		if(MC_AI)
-			add_verb(/obj/item/modular_computer/proc/eject_card)
-
-/obj/item/modular_computer/proc/remove_computer_verbs(path)
-	switch(path)
-		if(MC_CARD)
-			remove_verb(/obj/item/modular_computer/proc/eject_id)
-		if(MC_SDD)
-			remove_verb(/obj/item/modular_computer/proc/eject_disk)
-		if(MC_AI)
-			remove_verb(/obj/item/modular_computer/proc/eject_card)
-
-// Eject ID card from computer, if it has ID slot with card inside.
-/obj/item/modular_computer/proc/eject_id()
-	set name = "Eject ID"
-	set category = "Object"
-	set src in view(1)
-
-	if(issilicon(usr))
-		return
-	var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-	if(usr.canUseTopic(src, BE_CLOSE))
-		card_slot.try_eject(null, usr)
-
-// Ejects an intellicard from a computer, if there's a slot and an intellicard inside.
-/obj/item/modular_computer/proc/eject_card()
-	set name = "Eject Intellicard"
-	set category = "Object"
-
-	if(issilicon(usr))
-		return
-	var/obj/item/computer_hardware/ai_slot/ai_slot = all_components[MC_AI]
-	if(usr.canUseTopic(src, BE_CLOSE))
-		ai_slot.try_eject(null, usr,1)
-
-
-// Ejects a data disk from a computer, if there's a slot and a disk inside.
-/obj/item/modular_computer/proc/eject_disk()
-	set name = "Eject Data Disk"
-	set category = "Object"
-
-	if(issilicon(usr))
-		return
-
-	if(usr.canUseTopic(src, BE_CLOSE))
-		var/obj/item/computer_hardware/hard_drive/portable/portable_drive = all_components[MC_SDD]
-		if(uninstall_component(portable_drive, usr))
-			portable_drive.verb_pickup()
-
 /obj/item/modular_computer/AltClick(mob/user)
 	if(issilicon(user))
 		return
 
 	if(user.canUseTopic(src, BE_CLOSE))
 		var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-		var/obj/item/computer_hardware/ai_slot/ai_slot = all_components[MC_AI]
-		var/obj/item/computer_hardware/hard_drive/portable/portable_drive = all_components[MC_SDD]
-		if(portable_drive)
-			if(uninstall_component(portable_drive, user))
-				portable_drive.verb_pickup()
-		else
-			if(card_slot && card_slot.try_eject(null, user))
-				return
-			if(ai_slot)
-				ai_slot.try_eject(null, user)
-
+		if(card_slot)
+			card_slot.try_eject(null, user)
 
 // Gets IDs/access levels from card slot. Would be useful when/if PDAs would become modular PCs.
 /obj/item/modular_computer/GetAccess()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -248,7 +248,7 @@
 /**
   * Displays notification text alongside a soundbeep when requested to by a program.
   *
-  * After checking tha the requesting program is allowed to send an alert, creates
+  * After checking that the requesting program is allowed to send an alert, creates
   * a visible message of the requested text alongside a soundbeep. This proc adds
   * text to indicate that the message is coming from this device and the program
   * on it, so the supplied text should be the exact message and ending punctuation.

--- a/code/modules/modular_computers/computers/item/computer_components.dm
+++ b/code/modules/modular_computers/computers/item/computer_components.dm
@@ -43,6 +43,7 @@
 	if(enabled && !use_power())
 		shutdown_computer()
 	update_icon()
+	return TRUE
 
 
 // Checks all hardware pieces to determine if name matches, if yes, returns the hardware piece, otherwise returns null

--- a/code/modules/modular_computers/computers/item/computer_components.dm
+++ b/code/modules/modular_computers/computers/item/computer_components.dm
@@ -6,6 +6,14 @@
 		to_chat(user, "<span class='warning'>This component is too large for \the [src]!</span>")
 		return FALSE
 
+	if(H.expansion_hw)
+		if(LAZYLEN(expansion_bays) >= max_bays)
+			to_chat(user, "<span class='warning'>All of the computer's expansion bays are filled.</span>")
+			return FALSE
+		if(LAZYACCESS(expansion_bays, H.device_type))
+			to_chat(user, "<span class='warning'>The computer immediately ejects /the [H] and flashes an error: \"Hardware Address Conflict\".</span>")
+			return FALSE
+
 	if(all_components[H.device_type])
 		to_chat(user, "<span class='warning'>This computer's hardware slot is already occupied by \the [all_components[H.device_type]].</span>")
 		return FALSE
@@ -20,6 +28,8 @@
 	if(user && !user.transferItemToLoc(H, src))
 		return FALSE
 
+	if(H.expansion_hw)
+		LAZYSET(expansion_bays, H.device_type, H)
 	all_components[H.device_type] = H
 
 	to_chat(user, "<span class='notice'>You install \the [H] into \the [src].</span>")
@@ -32,7 +42,9 @@
 /obj/item/modular_computer/proc/uninstall_component(obj/item/computer_hardware/H, mob/living/user = null)
 	if(H.holder != src) // Not our component at all.
 		return FALSE
+	if(H.expansion_hw)
 
+		LAZYREMOVE(expansion_bays, H.device_type)
 	all_components.Remove(H.device_type)
 
 	to_chat(user, "<span class='notice'>You remove \the [H] from \the [src].</span>")

--- a/code/modules/modular_computers/computers/item/computer_components.dm
+++ b/code/modules/modular_computers/computers/item/computer_components.dm
@@ -43,7 +43,6 @@
 	if(H.holder != src) // Not our component at all.
 		return FALSE
 	if(H.expansion_hw)
-
 		LAZYREMOVE(expansion_bays, H.device_type)
 	all_components.Remove(H.device_type)
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -76,6 +76,9 @@
 	var/obj/item/computer_hardware/ai_slot/intelliholder = all_components[MC_AI]
 	if(intelliholder?.stored_card)
 		data["removable_media"] += "intelliCard"
+	var/obj/item/computer_hardware/card_slot/secondarycardholder = all_components[MC_CARD2]
+	if(secondarycardholder?.stored_card)
+		data["removable_media"] += "secondary RFID card"
 
 	data["programs"] = list()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = all_components[MC_HDD]
@@ -207,13 +210,19 @@
 					var/obj/item/computer_hardware/ai_slot/intelliholder = all_components[MC_AI]
 					if(!intelliholder)
 						return
-					if(intelliholder.try_eject(0,user))
+					if(intelliholder.try_eject(user))
 						playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50)
 				if("ID")
 					var/obj/item/computer_hardware/card_slot/cardholder = all_components[MC_CARD]
 					if(!cardholder)
 						return
-					cardholder.try_eject(0, user)
+					cardholder.try_eject(user)
+				if("secondary RFID card")
+					var/obj/item/computer_hardware/card_slot/cardholder = all_components[MC_CARD2]
+					if(!cardholder)
+						return
+					cardholder.try_eject(user)
+
 
 		else
 			return

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -87,7 +87,7 @@
 		if(P in idle_threads)
 			running = 1
 
-		data["programs"] += list(list("name" = P.filename, "desc" = P.filedesc, "running" = running, "icon" = P.program_icon))
+		data["programs"] += list(list("name" = P.filename, "desc" = P.filedesc, "running" = running, "icon" = P.program_icon, "alert" = P.alert_pending))
 
 	data["has_light"] = has_light
 	data["light_on"] = light_on
@@ -154,6 +154,7 @@
 			if(P in idle_threads)
 				P.program_state = PROGRAM_STATE_ACTIVE
 				active_program = P
+				P.alert_pending = FALSE
 				idle_threads.Remove(P)
 				update_icon()
 				return
@@ -169,6 +170,7 @@
 				return
 			if(P.run_program(user))
 				active_program = P
+				P.alert_pending = FALSE
 				update_icon()
 			return TRUE
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -53,6 +53,30 @@
 /obj/item/modular_computer/ui_data(mob/user)
 	var/list/data = get_header_data()
 	data["device_theme"] = device_theme
+
+	data["login"] = list()
+	var/obj/item/computer_hardware/card_slot/cardholder = all_components[MC_CARD]
+	if(cardholder)
+		var/obj/item/card/id/stored_card = cardholder.GetID()
+		if(stored_card)
+			var/stored_name = stored_card.registered_name
+			var/stored_title = stored_card.assignment
+			if(!stored_name)
+				stored_name = "Unknown"
+			if(!stored_title)
+				stored_title = "Unknown"
+			data["login"] = list(
+				IDName = stored_name,
+				IDJob = stored_title,
+			)
+
+	data["removable_media"] = list()
+	if(all_components[MC_SDD])
+		data["removable_media"] += "removable storage disk"
+	var/obj/item/computer_hardware/ai_slot/intelliholder = all_components[MC_AI]
+	if(intelliholder?.stored_card)
+		data["removable_media"] += "intelliCard"
+
 	data["programs"] = list()
 	var/obj/item/computer_hardware/hard_drive/hard_drive = all_components[MC_HDD]
 	for(var/datum/computer_file/program/P in hard_drive.stored_files)
@@ -167,6 +191,30 @@
 			light_color = new_color
 			update_light()
 			return TRUE
+
+		if("PC_Eject_Disk")
+			var/param = params["name"]
+			var/mob/user = usr
+			switch(param)
+				if("removable storage disk")
+					var/obj/item/computer_hardware/hard_drive/portable/portable_drive = all_components[MC_SDD]
+					if(!portable_drive)
+						return
+					if(uninstall_component(portable_drive, usr))
+						user.put_in_hands(portable_drive)
+						playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50)
+				if("intelliCard")
+					var/obj/item/computer_hardware/ai_slot/intelliholder = all_components[MC_AI]
+					if(!intelliholder)
+						return
+					if(intelliholder.try_eject(0,user))
+						playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50)
+				if("ID")
+					var/obj/item/computer_hardware/card_slot/cardholder = all_components[MC_CARD]
+					if(!cardholder)
+						return
+					cardholder.try_eject(0, user)
+
 		else
 			return
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -87,7 +87,7 @@
 		if(P in idle_threads)
 			running = 1
 
-		data["programs"] += list(list("name" = P.filename, "desc" = P.filedesc, "running" = running))
+		data["programs"] += list(list("name" = P.filename, "desc" = P.filedesc, "running" = running, "icon" = P.program_icon))
 
 	data["has_light"] = has_light
 	data["light_on"] = light_on

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -11,6 +11,7 @@
 	hardware_flag = PROGRAM_LAPTOP
 	max_hardware_size = 2
 	w_class = WEIGHT_CLASS_NORMAL
+	max_bays = 4
 
 	// No running around with open laptops in hands.
 	item_flags = SLOWS_WHILE_IN_HAND

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -8,6 +8,7 @@
 	icon_state_unpowered = null
 	icon_state_menu = null
 	hardware_flag = 0
+	max_bays = 4
 
 	var/obj/machinery/modular_computer/machinery_computer = null
 

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -58,23 +58,5 @@
 	machinery_computer.update_icon()
 	return
 
-/obj/item/modular_computer/processor/add_computer_verbs(path)
-	switch(path)
-		if(MC_CARD)
-			machinery_computer.add_verb(/obj/machinery/modular_computer/proc/eject_id)
-		if(MC_SDD)
-			machinery_computer.add_verb(/obj/machinery/modular_computer/proc/eject_disk)
-		if(MC_AI)
-			machinery_computer.add_verb(/obj/machinery/modular_computer/proc/eject_card)
-
-/obj/item/modular_computer/processor/remove_computer_verbs(path)
-	switch(path)
-		if(MC_CARD)
-			machinery_computer.remove_verb(/obj/machinery/modular_computer/proc/eject_id)
-		if(MC_SDD)
-			machinery_computer.remove_verb(/obj/machinery/modular_computer/proc/eject_disk)
-		if(MC_AI)
-			machinery_computer.remove_verb(/obj/machinery/modular_computer/proc/eject_card)
-
 /obj/item/modular_computer/processor/attack_ghost(mob/user)
 	ui_interact(user)

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -61,3 +61,9 @@
 
 /obj/item/modular_computer/processor/attack_ghost(mob/user)
 	ui_interact(user)
+
+/obj/item/modular_computer/processor/alert_call(datum/computer_file/program/caller, alerttext)
+	if(!caller || !caller.alert_able || caller.alert_silenced || !alerttext)
+		return
+	playsound(src, 'sound/machines/twobeep_high.ogg', 50, TRUE)
+	machinery_computer.visible_message("<span class='notice'>The [src] displays a [caller.filedesc] notification: [alerttext]</span>")

--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -8,6 +8,7 @@
 	hardware_flag = PROGRAM_TABLET
 	max_hardware_size = 1
 	w_class = WEIGHT_CLASS_SMALL
+	max_bays = 3
 	steel_sheet_cost = 1
 	slot_flags = ITEM_SLOT_ID | ITEM_SLOT_BELT
 	has_light = TRUE //LED flashlight!

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -24,6 +24,8 @@
 	. = ..()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	hard_drive.store_file(new /datum/computer_file/program/budgetorders)
+	install_component(new /obj/item/computer_hardware/sensorpackage)
+	install_component(new /obj/item/computer_hardware/card_slot/secondary)
 
 /obj/item/modular_computer/tablet/preset/cargo/Initialize(mapload)
 	. = ..()
@@ -36,14 +38,9 @@
 	install_component(new /obj/item/computer_hardware/printer/mini)
 	hard_drive.store_file(new /datum/computer_file/program/bounty)
 
-/obj/item/modular_computer/tablet/preset/advanced/atmos/Initialize() //This will be defunct and will be replaced when NtOS PDAs are done
+/obj/item/modular_computer/tablet/preset/advanced/atmos/Initialize(mapload) //This will be defunct and will be replaced when NtOS PDAs are done
 	. = ..()
 	install_component(new /obj/item/computer_hardware/sensorpackage)
-
-/obj/item/modular_computer/tablet/preset/advanced/command/Initialize()
-	. = ..()
-	install_component(new /obj/item/computer_hardware/sensorpackage)
-	install_component(new /obj/item/computer_hardware/card_slot/secondary)
 
 /// Given by the syndicate as part of the contract uplink bundle - loads in the Contractor Uplink.
 /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink/Initialize(mapload)

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -31,9 +31,19 @@
 	install_component(new /obj/item/computer_hardware/processor_unit/small)
 	install_component(new /obj/item/computer_hardware/battery(src, /obj/item/stock_parts/cell/computer))
 	install_component(hard_drive)
+	install_component(new /obj/item/computer_hardware/card_slot)
 	install_component(new /obj/item/computer_hardware/network_card)
 	install_component(new /obj/item/computer_hardware/printer/mini)
 	hard_drive.store_file(new /datum/computer_file/program/bounty)
+
+/obj/item/modular_computer/tablet/preset/advanced/atmos/Initialize() //This will be defunct and will be replaced when NtOS PDAs are done
+	. = ..()
+	install_component(new /obj/item/computer_hardware/sensorpackage)
+
+/obj/item/modular_computer/tablet/preset/advanced/command/Initialize()
+	. = ..()
+	install_component(new /obj/item/computer_hardware/sensorpackage)
+	install_component(new /obj/item/computer_hardware/card_slot/secondary)
 
 /// Given by the syndicate as part of the contract uplink bundle - loads in the Contractor Uplink.
 /obj/item/modular_computer/tablet/syndicate_contract_uplink/preset/uplink/Initialize(mapload)

--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -1,6 +1,6 @@
 /obj/machinery/modular_computer/console/preset
 	// Can be changed to give devices specific hardware
-	var/_has_id_slot = FALSE
+	var/_has_second_id_slot = FALSE
 	var/_has_printer = FALSE
 	var/_has_battery = FALSE
 	var/_has_ai = FALSE
@@ -11,8 +11,9 @@
 		return
 	cpu.install_component(new /obj/item/computer_hardware/processor_unit)
 
-	if(_has_id_slot)
-		cpu.install_component(new /obj/item/computer_hardware/card_slot)
+	cpu.install_component(new /obj/item/computer_hardware/card_slot)
+	if(_has_second_id_slot)
+		cpu.install_component(new /obj/item/computer_hardware/card_slot/secondary)
 	if(_has_printer)
 		cpu.install_component(new /obj/item/computer_hardware/printer)
 	if(_has_battery)
@@ -56,7 +57,7 @@
 	console_department = "Command"
 	name = "command console"
 	desc = "A stationary computer. This one comes preloaded with command programs."
-	_has_id_slot = TRUE
+	_has_second_id_slot = TRUE
 	_has_printer = TRUE
 
 /obj/machinery/modular_computer/console/preset/command/install_programs()

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -74,30 +74,6 @@
 		add_overlay("bsod")
 		add_overlay("broken")
 
-// Eject ID card from computer, if it has ID slot with card inside.
-/obj/machinery/modular_computer/proc/eject_id()
-	set name = "Eject ID"
-	set category = "Object"
-
-	if(cpu)
-		cpu.eject_id()
-
-// Eject ID card from computer, if it has ID slot with card inside.
-/obj/machinery/modular_computer/proc/eject_disk()
-	set name = "Eject Data Disk"
-	set category = "Object"
-
-	if(cpu)
-		cpu.eject_disk()
-
-/obj/machinery/modular_computer/proc/eject_card()
-	set name = "Eject Intellicard"
-	set category = "Object"
-	set src in view(1)
-
-	if(cpu)
-		cpu.eject_card()
-
 /obj/machinery/modular_computer/AltClick(mob/user)
 	if(cpu)
 		cpu.AltClick(user)

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -113,7 +113,7 @@
 	update_icon()
 
 /obj/machinery/modular_computer/attackby(var/obj/item/W as obj, mob/user)
-	if(cpu && !(flags_1 & NODECONSTRUCT_1))
+	if(user.a_intent == INTENT_HELP && cpu && !(flags_1 & NODECONSTRUCT_1))
 		return cpu.attackby(W, user)
 	return ..()
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -19,6 +19,8 @@
 	var/tgui_id								// ID of TGUI interface
 	var/ui_style							// ID of custom TGUI style (optional)
 	var/ui_header = null					// Example: "something.gif" - a header image that will be rendered in computer's UI when this program is running at background. Images are taken from /icons/program_icons. Be careful not to use too large images!
+	/// Font Awesome icon to use as this program's icon in the modular computer main menu. Defaults to a basic program maximize window icon if not overridden.
+	var/program_icon = "window-maximize-o"
 
 /datum/computer_file/program/New(obj/item/modular_computer/comp = null)
 	..()

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -21,6 +21,12 @@
 	var/ui_header = null					// Example: "something.gif" - a header image that will be rendered in computer's UI when this program is running at background. Images are taken from /icons/program_icons. Be careful not to use too large images!
 	/// Font Awesome icon to use as this program's icon in the modular computer main menu. Defaults to a basic program maximize window icon if not overridden.
 	var/program_icon = "window-maximize-o"
+	/// Whether this program can send alerts while minimized or closed. Used to show a mute button per program in the file manager
+	var/alert_able = FALSE
+	/// Whether the user has muted this program's ability to send alerts.
+	var/alert_silenced = FALSE
+	/// Whether to highlight our program in the main screen. Intended for alerts, but loosely available for any need to notify of changed conditions. Think Windows task bar highlighting. Available even if alerts are muted.
+	var/alert_pending = FALSE
 
 /datum/computer_file/program/New(obj/item/modular_computer/comp = null)
 	..()

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -7,6 +7,8 @@
 	var/program_state = PROGRAM_STATE_KILLED// PROGRAM_STATE_KILLED or PROGRAM_STATE_BACKGROUND or PROGRAM_STATE_ACTIVE - specifies whether this program is running.
 	var/obj/item/modular_computer/computer	// Device that runs this program.
 	var/filedesc = "Unknown Program"		// User-friendly name of this program.
+	/// Category in the NTDownloader.
+	var/category = PROGRAM_CATEGORY_MISC
 	var/extended_desc = "N/A"				// Short description of this program's function.
 	var/program_icon_state = null			// Program-specific screen icon state
 	var/requires_ntnet = 0					// Set to 1 for program to require nonstop NTNet connection to run. If NTNet connection is lost program crashes.

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -66,10 +66,18 @@
 /datum/computer_file/program/proc/process_tick(delta_time)
 	return 1
 
-// Check if the user can run program. Only humans can operate computer. Automatically called in run_program()
-// User has to wear their ID for ID Scan to work.
-// Can also be called manually, with optional parameter being access_to_check to scan the user's ID
-/datum/computer_file/program/proc/can_run(mob/user, loud = 0, access_to_check, transfer = 0)
+/**
+  *Check if the user can run program. Only humans can operate computer. Automatically called in run_program()
+  *ID must be inserted into a card slot to be read. If the program is not currently installed (as is the case when
+  *NT Software Hub is checking available software), a list can be given to be used instead.
+  *Arguments:
+  *user is a ref of the mob using the device.
+  *loud is a bool deciding if this proc should use to_chats
+  *access_to_check is an access level that will be checked against the ID
+  *transfer, if TRUE and access_to_check is null, will tell this proc to use the program's transfer_access in place of access_to_check
+  *access can contain a list of access numbers to check against. If access is not empty, it will be used istead of checking any inserted ID.
+*/
+/datum/computer_file/program/proc/can_run(mob/user, loud = FALSE, access_to_check, transfer = FALSE, var/list/access)
 	// Defaults to required_access
 	if(!access_to_check)
 		if(transfer && transfer_access)
@@ -88,29 +96,24 @@
 	if(issilicon(user))
 		return 1
 
-	if(ishuman(user))
+	if(!length(access))
 		var/obj/item/card/id/D
 		var/obj/item/computer_hardware/card_slot/card_slot
-		if(computer && card_slot)
+		if(computer)
 			card_slot = computer.all_components[MC_CARD]
-			D = card_slot.GetID()
-		var/mob/living/carbon/human/h = user
-		var/obj/item/card/id/I = h.get_idcard(TRUE)
+			D = card_slot?.GetID()
 
-		if(!I && !D)
+		if(!D)
 			if(loud)
 				to_chat(user, "<span class='danger'>\The [computer] flashes an \"RFID Error - Unable to scan ID\" warning.</span>")
-			return 0
+			return FALSE
+		access = D.GetAccess()
 
-		if(I)
-			if(access_to_check in I.GetAccess())
-				return 1
-		else if(D)
-			if(access_to_check in D.GetAccess())
-				return 1
-		if(loud)
-			to_chat(user, "<span class='danger'>\The [computer] flashes an \"Access Denied\" warning.</span>")
-	return 0
+	if(access_to_check in access)
+		return TRUE
+	if(loud)
+		to_chat(user, "<span class='danger'>\The [computer] flashes an \"Access Denied\" warning.</span>")
+	return FALSE
 
 // This attempts to retrieve header data for UIs. If implementing completely new device of different type than existing ones
 // always include the device here in this proc. This proc basically relays the request to whatever is running the program.

--- a/code/modules/modular_computers/file_system/program_events.dm
+++ b/code/modules/modular_computers/file_system/program_events.dm
@@ -2,7 +2,7 @@
 // Always include a parent call when overriding an event.
 
 // Called when the ID card is removed from computer. ID is removed AFTER this proc.
-/datum/computer_file/program/proc/event_idremoved(background, slot)
+/datum/computer_file/program/proc/event_idremoved(background)
 	return
 
 // Called when the computer fails due to power loss. Override when program wants to specifically react to power loss.

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -49,7 +49,7 @@
 			if(computer.all_components[MC_AI])
 				var/obj/item/computer_hardware/ai_slot/ai_slot = computer.all_components[MC_AI]
 				if(ai_slot?.stored_card)
-					ai_slot.try_eject(0,usr)
+					ai_slot.try_eject(usr)
 					return TRUE
 
 /datum/computer_file/program/aidiag/process_tick()

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -9,8 +9,7 @@
 	transfer_access = ACCESS_HEADS
 	available_on_ntnet = TRUE
 	tgui_id = "NtosAiRestorer"
-
-
+	program_icon = "laptop-code"
 	/// Variable dictating if we are in the process of restoring the AI in the inserted intellicard
 	var/restoring = FALSE
 

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/aidiag
 	filename = "aidiag"
 	filedesc = "AI Integrity Restorer"
+	category = PROGRAM_CATEGORY_ROBO
 	program_icon_state = "generic"
 	extended_desc = "This program is capable of reconstructing damaged AI systems. Requires direct AI connection via intellicard slot."
 	size = 12

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -2,6 +2,7 @@
 	filename = "alarmmonitor"
 	filedesc = "Alarm Monitor"
 	ui_header = "alarm_green.gif"
+	category = PROGRAM_CATEGORY_ENGI
 	program_icon_state = "alert-green"
 	extended_desc = "This program provides visual interface for station's alarm system."
 	requires_ntnet = 1

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -8,9 +8,7 @@
 	network_destination = "alarm monitoring network"
 	size = 5
 	tgui_id = "NtosStationAlertConsole"
-
-
-
+	program_icon = "bell"
 	var/has_alert = 0
 
 /datum/computer_file/program/alarm_monitor/process_tick()

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/contract_uplink
 	filename = "contractor uplink"
 	filedesc = "Syndicate Contractor Uplink"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "assign"
 	extended_desc = "A standard, Syndicate issued system for handling important contracts while on the field."
 	size = 10

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -9,8 +9,7 @@
 	unsendable = 1
 	undeletable = 1
 	tgui_id = "SyndContractor"
-
-
+	program_icon = "tasks"
 	var/error = ""
 	var/info_screen = TRUE
 	var/assigned = FALSE

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/ntnet_dos
 	filename = "ntn_dos"
 	filedesc = "DoS Traffic Generator"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "hostile"
 	extended_desc = "This advanced script can perform denial of service attacks against NTNet quantum relays. The system administrator will probably notice this. Multiple devices can run this program together against same relay for increased effect"
 	size = 20

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -8,6 +8,7 @@
 	available_on_ntnet = FALSE
 	available_on_syndinet = TRUE
 	tgui_id = "NtosNetDos"
+	program_icon = "satellite-dish"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/revelation
 	filename = "revelation"
 	filedesc = "Revelation"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "hostile"
 	extended_desc = "This virus can destroy hard drive of system it is executed on. It may be obfuscated to look like another non-malicious program. Once armed, it will destroy the system upon next execution."
 	size = 13

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -8,9 +8,7 @@
 	available_on_ntnet = FALSE
 	available_on_syndinet = TRUE
 	tgui_id = "NtosRevelation"
-
-
-
+	program_icon = "magnet"
 	var/armed = 0
 
 /datum/computer_file/program/revelation/run_program(var/mob/living/user)

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -7,6 +7,7 @@
 	network_destination = "arcade network"
 	size = 6
 	tgui_id = "NtosArcade"
+	program_icon = "gamepad"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/arcade
 	filename = "arcade"
 	filedesc = "Nanotrasen Micro Arcade"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "arcade"
 	extended_desc = "This port of the classic game 'Outbomb Cuban Pete', redesigned to run on tablets, with thrilling graphics and chilling storytelling."
 	requires_ntnet = FALSE

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -6,6 +6,7 @@
 	network_destination = "atmos scan"
 	size = 4
 	tgui_id = "NtosAtmos"
+	program_icon = "thermometer-half"
 
 /datum/computer_file/program/atmosscan/run_program(mob/living/user)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -7,13 +7,20 @@
 	size = 4
 	tgui_id = "NtosAtmos"
 
+/datum/computer_file/program/atmosscan/run_program(mob/living/user)
+	. = ..()
+	if (!.)
+		return
+	if(!computer?.get_modular_computer_part(MC_SENSORS)) //Giving a clue to users why the program is spitting out zeros.
+		to_chat(user, "<span class='warning'>\The [computer] flashes an error: \"hardware\\sensorpackage\\startup.bin -- file not found\".</span>")
 
 
 /datum/computer_file/program/atmosscan/ui_data(mob/user)
 	var/list/data = get_header_data()
 	var/list/airlist = list()
 	var/turf/T = get_turf(ui_host())
-	if(T)
+	var/obj/item/computer_hardware/sensorpackage/sensors = computer?.get_modular_computer_part(MC_SENSORS)
+	if(T && sensors?.check_functionality())
 		var/datum/gas_mixture/environment = T.return_air()
 		var/pressure = environment.return_pressure()
 		var/total_moles = environment.total_moles()
@@ -25,6 +32,10 @@
 				if(gas_level > 0)
 					airlist += list(list("name" = "[GLOB.gas_data.names[id]]", "percentage" = round(gas_level*100, 0.01)))
 		data["AirData"] = airlist
+	else
+		data["AirPressure"] = 0
+		data["AirTemp"] = 0
+		data["AirData"] = list(list())
 	return data
 
 /datum/computer_file/program/atmosscan/ui_act(action, list/params)

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/atmosscan
 	filename = "atmosscan"
 	filedesc = "Atmospheric Scanner"
+	category = PROGRAM_CATEGORY_ENGI
 	program_icon_state = "air"
 	extended_desc = "A small built-in sensor reads out the atmospheric conditions around the device."
 	network_destination = "atmos scan"

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -9,6 +9,7 @@
 	network_destination = "cyborg remote monitoring"
 	size = 5
 	tgui_id = "NtosCyborgRemoteMonitor"
+	program_icon = "project-diagram"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/borg_monitor
 	filename = "cyborgmonitor"
 	filedesc = "Cyborg Remote Monitoring"
+	category = PROGRAM_CATEGORY_ROBO
 	ui_header = "borg_mon.gif"
 	program_icon_state = "generic"
 	extended_desc = "This program allows for remote monitoring of station cyborgs."

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/budgetorders
 	filename = "orderapp"
 	filedesc = "Nanotrasen Internal Requisition Network (NIRN)"
+	category = PROGRAM_CATEGORY_SUPL
 	program_icon_state = "request"
 	extended_desc = "A request network that utilizes the Nanotrasen Ordering network to purchase supplies using a department budget account."
 	requires_ntnet = TRUE

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -7,6 +7,7 @@
 	usage_flags = PROGRAM_LAPTOP | PROGRAM_TABLET
 	size = 20
 	tgui_id = "NtosCargo"
+	program_icon = "credit-card"
 	//Are you actually placing orders with it?
 	var/requestonly = TRUE
 	//Can the tablet see or buy illegal stuff?

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -9,6 +9,7 @@
 /datum/computer_file/program/card_mod
 	filename = "cardmod"
 	filedesc = "ID Card Modification"
+	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for programming employee ID cards to access parts of the station."
 	transfer_access = ACCESS_HEADS

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -15,6 +15,7 @@
 	requires_ntnet = 0
 	size = 8
 	tgui_id = "NtosCard"
+	program_icon = "id-card"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -100,17 +100,19 @@
 		return TRUE
 
 	var/obj/item/computer_hardware/card_slot/card_slot
+	var/obj/item/computer_hardware/card_slot/card_slot2
 	var/obj/item/computer_hardware/printer/printer
 	if(computer)
 		card_slot = computer.all_components[MC_CARD]
+		card_slot2 = computer.all_components[MC_CARD2]
 		printer = computer.all_components[MC_PRINT]
-		if(!card_slot)
+		if(!card_slot || !card_slot2)
 			return
 
 	var/mob/user = usr
-	var/obj/item/card/id/user_id_card = user.get_idcard(FALSE)
+	var/obj/item/card/id/user_id_card = card_slot.stored_card
 
-	var/obj/item/card/id/id_card = card_slot.stored_card
+	var/obj/item/card/id/target_id_card = card_slot2.stored_card
 
 	switch(action)
 		if("PRG_authenticate")
@@ -131,14 +133,14 @@
 				return
 			var/contents = {"<h4>Access Report</h4>
 						<u>Prepared By:</u> [user_id_card && user_id_card.registered_name ? user_id_card.registered_name : "Unknown"]<br>
-						<u>For:</u> [id_card.registered_name ? id_card.registered_name : "Unregistered"]<br>
+						<u>For:</u> [target_id_card.registered_name ? target_id_card.registered_name : "Unregistered"]<br>
 						<hr>
-						<u>Assignment:</u> [id_card.assignment]<br>
+						<u>Assignment:</u> [target_id_card.assignment]<br>
 						<u>Access:</u><br>
 						"}
 
 			var/known_access_rights = get_all_accesses()
-			for(var/A in id_card.access)
+			for(var/A in target_id_card.access)
 				if(A in known_access_rights)
 					contents += "  [get_access_desc(A)]"
 
@@ -150,45 +152,42 @@
 				computer.visible_message("<span class='notice'>\The [computer] prints out a paper.</span>")
 			return TRUE
 		if("PRG_eject")
-			if(!computer || !card_slot)
+			if(!computer || !card_slot2)
 				return
-			if(id_card)
-				GLOB.data_core.manifest_modify(id_card.registered_name, id_card.assignment, id_card.hud_state)
-				card_slot.try_eject(TRUE, user)
+			if(target_id_card)
+				GLOB.data_core.manifest_modify(target_id_card.registered_name, target_id_card.assignment, target_id_card.hud_state)
+				return card_slot2.try_eject(user)
 			else
 				var/obj/item/I = user.get_active_held_item()
 				if(istype(I, /obj/item/card/id))
-					if(!user.transferItemToLoc(I, computer))
-						return
-					card_slot.stored_card = I
-			playsound(computer, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
-			return TRUE
+					return card_slot2.try_insert(I)
+			return FALSE
 		if("PRG_terminate")
 			if(!computer || !authenticated)
 				return
 			if(minor)
-				if(!(id_card.assignment in head_subordinates) && id_card.assignment != JOB_NAME_ASSISTANT)
+				if(!(target_id_card.assignment in head_subordinates) && target_id_card.assignment != JOB_NAME_ASSISTANT)
 					return
 
-			id_card.access -= get_all_centcom_access() + get_all_accesses()
-			id_card.assignment = "Unassigned"
-			id_card.update_label()
-			log_id("[key_name(usr)] unassigned and stripped all access from [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+			target_id_card.access -= get_all_centcom_access() + get_all_accesses()
+			target_id_card.assignment = "Unassigned"
+			target_id_card.update_label()
+			log_id("[key_name(usr)] unassigned and stripped all access from [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_edit")
-			if(!computer || !authenticated || !id_card)
+			if(!computer || !authenticated || !target_id_card)
 				return
 			var/new_name = reject_bad_name(params["name"]) // if reject bad name fails, the edit will just not go through instead of discarding all input, as new_name would be blank.
 			if(!new_name)
 				return
-			log_id("[key_name(usr)] changed [id_card] name to '[new_name]', using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
-			id_card.registered_name = new_name
-			id_card.update_label()
+			log_id("[key_name(usr)] changed [target_id_card] name to '[new_name]', using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+			target_id_card.registered_name = new_name
+			target_id_card.update_label()
 			playsound(computer, "terminal_type", 50, FALSE)
 			return TRUE
 		if("PRG_assign")
-			if(!computer || !authenticated || !id_card)
+			if(!computer || !authenticated || !target_id_card)
 				return
 			var/target = params["assign_target"]
 			if(!target)
@@ -197,9 +196,9 @@
 			if(target == "Custom")
 				var/custom_name = reject_bad_name(params["custom_name"]) // if reject bad name fails, the edit will just not go through, as custom_name would be empty
 				if(custom_name)
-					log_id("[key_name(usr)] assigned a custom assignment '[custom_name]' to [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
-					id_card.assignment = custom_name
-					id_card.update_label()
+					log_id("[key_name(usr)] assigned a custom assignment '[custom_name]' to [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+					target_id_card.assignment = custom_name
+					target_id_card.update_label()
 			else
 				if(minor && !(target in head_subordinates))
 					return
@@ -217,11 +216,11 @@
 						to_chat(user, "<span class='warning'>No class exists for this job: [target].</span>")
 						return
 					new_access = job.get_access()
-				log_id("[key_name(usr)] changed [id_card] assignment to '[target]', overriding all previous access using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
-				id_card.access -= get_all_centcom_access() + get_all_accesses()
-				id_card.access |= new_access
-				id_card.assignment = target
-				id_card.update_label()
+				log_id("[key_name(usr)] changed [target_id_card] assignment to '[target]', overriding all previous access using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+				target_id_card.access -= get_all_centcom_access() + get_all_accesses()
+				target_id_card.access |= new_access
+				target_id_card.assignment = target
+				target_id_card.update_label()
 
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
@@ -230,26 +229,26 @@
 				return
 			var/access_type = text2num(params["access_target"])
 			if(access_type in (is_centcom ? get_all_centcom_access() : get_all_accesses()))
-				if(access_type in id_card.access)
-					id_card.access -= access_type
-					log_id("[key_name(usr)] removed [get_access_desc(access_type)] from [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+				if(access_type in target_id_card.access)
+					target_id_card.access -= access_type
+					log_id("[key_name(usr)] removed [get_access_desc(access_type)] from [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 				else
-					id_card.access |= access_type
-					log_id("[key_name(usr)] added [get_access_desc(access_type)] to [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+					target_id_card.access |= access_type
+					log_id("[key_name(usr)] added [get_access_desc(access_type)] to [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 				playsound(computer, "terminal_type", 50, FALSE)
 				return TRUE
 		if("PRG_grantall")
 			if(!computer || !authenticated || minor)
 				return
-			id_card.access |= (is_centcom ? get_all_centcom_access() : get_all_accesses())
-			log_id("[key_name(usr)] granted All Access to [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+			target_id_card.access |= (is_centcom ? get_all_centcom_access() : get_all_accesses())
+			log_id("[key_name(usr)] granted All Access to [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_denyall")
 			if(!computer || !authenticated || minor)
 				return
-			id_card.access.Cut()
-			log_id("[key_name(usr)] removed All Access from [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+			target_id_card.access.Cut()
+			log_id("[key_name(usr)] removed All Access from [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_grantregion")
@@ -258,8 +257,8 @@
 			var/region = text2num(params["region"])
 			if(isnull(region))
 				return
-			id_card.access |= get_region_accesses(region)
-			log_id("[key_name(usr)] granted [get_region_accesses_name(region)] regional access to [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+			target_id_card.access |= get_region_accesses(region)
+			log_id("[key_name(usr)] granted [get_region_accesses_name(region)] regional access to [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_denyregion")
@@ -268,8 +267,8 @@
 			var/region = text2num(params["region"])
 			if(isnull(region))
 				return
-			id_card.access -= get_region_accesses(region)
-			log_id("[key_name(usr)] removed [region] regional access from [id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
+			target_id_card.access -= get_region_accesses(region)
+			log_id("[key_name(usr)] removed [region] regional access from [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 
@@ -334,17 +333,17 @@
 /datum/computer_file/program/card_mod/ui_data(mob/user)
 	var/list/data = get_header_data()
 
-	var/obj/item/computer_hardware/card_slot/card_slot
+	var/obj/item/computer_hardware/card_slot/card_slot2
 	var/obj/item/computer_hardware/printer/printer
 
 	if(computer)
-		card_slot = computer.all_components[MC_CARD]
+		card_slot2 = computer.all_components[MC_CARD2]
 		printer = computer.all_components[MC_PRINT]
 
 	data["station_name"] = station_name()
 
 	if(computer)
-		data["have_id_slot"] = !!card_slot
+		data["have_id_slot"] = !!(card_slot2)
 		data["have_printer"] = !!printer
 	else
 		data["have_id_slot"] = FALSE
@@ -353,7 +352,7 @@
 	data["authenticated"] = authenticated
 
 	if(computer)
-		var/obj/item/card/id/id_card = card_slot.stored_card
+		var/obj/item/card/id/id_card = card_slot2.stored_card
 		data["has_id"] = !!id_card
 		data["id_name"] = id_card ? id_card.name : "-----"
 		if(id_card)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -335,32 +335,31 @@
 /datum/computer_file/program/card_mod/ui_data(mob/user)
 	var/list/data = get_header_data()
 
+	data["station_name"] = station_name()
+
 	var/obj/item/computer_hardware/card_slot/card_slot2
 	var/obj/item/computer_hardware/printer/printer
 
 	if(computer)
 		card_slot2 = computer.all_components[MC_CARD2]
 		printer = computer.all_components[MC_PRINT]
-
-	data["station_name"] = station_name()
-
-	if(computer)
 		data["have_id_slot"] = !!(card_slot2)
-		data["have_printer"] = !!printer
+		data["have_printer"] = !!(printer)
 	else
 		data["have_id_slot"] = FALSE
 		data["have_printer"] = FALSE
 
 	data["authenticated"] = authenticated
+	if(!card_slot2)
+		return data //We're just gonna error out on the js side at this point anyway
 
-	if(computer)
-		var/obj/item/card/id/id_card = card_slot2.stored_card
-		data["has_id"] = !!id_card
-		data["id_name"] = id_card ? id_card.name : "-----"
-		if(id_card)
-			data["id_rank"] = id_card.assignment ? id_card.assignment : "Unassigned"
-			data["id_owner"] = id_card.registered_name ? id_card.registered_name : "-----"
-			data["access_on_card"] = id_card.access
+	var/obj/item/card/id/id_card = card_slot2.stored_card
+	data["has_id"] = !!id_card
+	data["id_name"] = id_card ? id_card.name : "-----"
+	if(id_card)
+		data["id_rank"] = id_card.assignment ? id_card.assignment : "Unassigned"
+		data["id_owner"] = id_card.registered_name ? id_card.registered_name : "-----"
+		data["access_on_card"] = id_card.access
 
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/cargobounty.dm
+++ b/code/modules/modular_computers/file_system/programs/cargobounty.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/bounty
 	filename = "bounty"
 	filedesc = "Nanotrasen Bounty Hunter"
+	category = PROGRAM_CATEGORY_SUPL
 	program_icon_state = "bounty"
 	extended_desc = "A basic interface for supply personnel to check and claim bounties."
 	requires_ntnet = TRUE

--- a/code/modules/modular_computers/file_system/programs/cargobounty.dm
+++ b/code/modules/modular_computers/file_system/programs/cargobounty.dm
@@ -8,7 +8,8 @@
 	network_destination = "cargo claims interface"
 	size = 10
 	tgui_id = "NtosBountyConsole"
-	
+	program_icon = "tags"
+
 	///cooldown var for printing paper sheets.
 	var/printer_ready = 0
 	///The cargo account for grabbing the cargo account's credits.
@@ -43,12 +44,12 @@
 			"priority" = B.high_priority,
 			"bounty_ref" = REF(B)
 		))
-	
+
 	data["has_printer"] = printer ? TRUE : FALSE
 
 	data["stored_cash"] = cargocash.account_balance
 	data["bountydata"] = bountyinfo
-	
+
 	return data
 
 /datum/computer_file/program/bounty/ui_act(action,params)
@@ -64,7 +65,7 @@
 			var/obj/item/computer_hardware/printer/printer
 			if(computer)
 				printer = computer.all_components[MC_PRINT]
-			
+
 			if(printer)
 				if(!printer.print_type(/obj/item/paper/bounty_printout))
 					to_chat(usr, "<span class='notice'>Hardware error: Printer was unable to print the file. It may be out of paper.</span>")

--- a/code/modules/modular_computers/file_system/programs/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/configurator.dm
@@ -13,6 +13,7 @@
 	available_on_ntnet = 0
 	requires_ntnet = 0
 	tgui_id = "NtosConfiguration"
+	program_icon = "cog"
 
 	var/obj/item/modular_computer/movable = null
 

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -7,6 +7,7 @@
 	requires_ntnet = FALSE
 	size = 4
 	tgui_id = "NtosCrewManifest"
+	program_icon = "clipboard-list"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/crew_manifest
 	filename = "crewmani"
 	filedesc = "Crew Manifest"
+	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
 	transfer_access = ACCESS_HEADS

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -8,6 +8,7 @@
 	available_on_ntnet = FALSE
 	undeletable = TRUE
 	tgui_id = "NtosFileManager"
+	program_icon = "folder"
 
 	var/open_file
 	var/error

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -66,6 +66,13 @@
 			var/datum/computer_file/C = F.clone(FALSE)
 			HDD.store_file(C)
 			return TRUE
+		if("PRG_togglesilence")
+			if(!HDD)
+				return
+			var/datum/computer_file/program/binary = HDD.find_file_by_name(params["name"])
+			if(!binary || !istype(binary))
+				return
+			binary.alert_silenced = !binary.alert_silenced
 
 /datum/computer_file/program/filemanager/ui_data(mob/user)
 	var/list/data = get_header_data()
@@ -79,11 +86,19 @@
 	else
 		var/list/files = list()
 		for(var/datum/computer_file/F in HDD.stored_files)
+			var/noisy = FALSE
+			var/silenced = FALSE
+			var/datum/computer_file/program/binary = F
+			if(istype(binary))
+				noisy = binary.alert_able
+				silenced = binary.alert_silenced
 			files += list(list(
 				"name" = F.filename,
 				"type" = F.filetype,
 				"size" = F.size,
-				"undeletable" = F.undeletable
+				"undeletable" = F.undeletable,
+				"alert_able" = noisy,
+				"alert_silenced" = silenced
 			))
 		data["files"] = files
 		if(RHDD)

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -7,6 +7,7 @@
 	requires_ntnet = 0
 	size = 4
 	tgui_id = "NtosJobManager"
+	program_icon = "address-book"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/job_management
 	filename = "job_manage"
 	filedesc = "Job Manager"
+	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and changing job slot avalibility."
 	transfer_access = ACCESS_HEADS

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -57,14 +57,10 @@
 	if(..())
 		return
 
-	var/authed = FALSE
-	var/mob/user = usr
-	var/obj/item/card/id/user_id = user.get_idcard()
-	if(user_id)
-		if(ACCESS_CHANGE_IDS in user_id.access)
-			authed = TRUE
+	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
+	var/obj/item/card/id/user_id = card_slot?.stored_card
 
-	if(!authed)
+	if(!user_id || !(ACCESS_CHANGE_IDS in user_id.access))
 		return
 
 	switch(action)
@@ -112,10 +108,10 @@
 	var/list/data = get_header_data()
 
 	var/authed = FALSE
-	var/obj/item/card/id/user_id = user.get_idcard(FALSE)
-	if(user_id)
-		if(ACCESS_CHANGE_IDS in user_id.access)
-			authed = TRUE
+	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
+	var/obj/item/card/id/user_id = card_slot?.stored_card
+	if(user_id && (ACCESS_CHANGE_IDS in user_id.access))
+		authed = TRUE
 
 	data["authed"] = authed
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -150,7 +150,7 @@
 	for(var/A in main_repo)
 		var/datum/computer_file/program/P = A
 		// Only those programs our user can run will show in the list
-		if(!P.can_run(user,transfer = 1, access = access) || hard_drive.find_file_by_name(P.filename))
+		if(hard_drive.find_file_by_name(P.filename))
 			continue
 		all_entries.Add(list(list(
 			"filename" = P.filename,
@@ -158,6 +158,7 @@
 			"fileinfo" = P.extended_desc,
 			"compatibility" = check_compatibility(P),
 			"size" = P.size,
+			"access" = P.can_run(user,transfer = 1, access = access)
 		)))
 	data["hackedavailable"] = FALSE
 	if(emagged) // If we are running on emagged computer we have access to some "bonus" software
@@ -171,7 +172,9 @@
 				"filename" = P.filename,
 				"filedesc" = P.filedesc,
 				"fileinfo" = P.extended_desc,
+				"compatibility" = check_compatibility(P),
 				"size" = P.size,
+				"access" = TRUE,
 			)))
 		data["hacked_programs"] = hacked_programs
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -11,6 +11,7 @@
 	available_on_ntnet = 0
 	ui_header = "downloader_finished.gif"
 	tgui_id = "NtosNetDownloader"
+	program_icon = "download"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -24,6 +24,13 @@
 	var/emagged = FALSE
 	var/list/main_repo
 	var/list/antag_repo
+	var/list/show_categories = list(
+		PROGRAM_CATEGORY_CREW,
+		PROGRAM_CATEGORY_ENGI,
+		PROGRAM_CATEGORY_ROBO,
+		PROGRAM_CATEGORY_SUPL,
+		PROGRAM_CATEGORY_MISC,
+	)
 
 /datum/computer_file/program/ntnetdownload/run_program()
 	. = ..()
@@ -147,48 +154,38 @@
 	var/obj/item/computer_hardware/hard_drive/hard_drive = my_computer.all_components[MC_HDD]
 	data["disk_size"] = hard_drive.max_capacity
 	data["disk_used"] = hard_drive.used_capacity
-	var/list/all_entries[0]
-	for(var/A in main_repo)
-		var/datum/computer_file/program/P = A
-		// Only those programs our user can run will show in the list
-		if(hard_drive.find_file_by_name(P.filename))
-			continue
-		all_entries.Add(list(list(
+	data["emagged"] = emagged
+
+	var/list/repo = antag_repo | main_repo
+	var/list/program_categories = list()
+
+	for(var/I in repo)
+		var/datum/computer_file/program/P = I
+		if(!(P.category in program_categories))
+			program_categories.Add(P.category)
+		data["programs"] += list(list(
+			"icon" = P.program_icon,
 			"filename" = P.filename,
 			"filedesc" = P.filedesc,
 			"fileinfo" = P.extended_desc,
-			"compatibility" = check_compatibility(P),
+			"category" = P.category,
+			"installed" = !!hard_drive.find_file_by_name(P.filename),
+			"compatible" = check_compatibility(P),
 			"size" = P.size,
-			"access" = P.can_run(user,transfer = 1, access = access)
-		)))
-	data["hackedavailable"] = FALSE
-	if(emagged) // If we are running on emagged computer we have access to some "bonus" software
-		var/list/hacked_programs[0]
-		for(var/S in antag_repo)
-			var/datum/computer_file/program/P = S
-			if(hard_drive.find_file_by_name(P.filename))
-				continue
-			data["hackedavailable"] = TRUE
-			hacked_programs.Add(list(list(
-				"filename" = P.filename,
-				"filedesc" = P.filedesc,
-				"fileinfo" = P.extended_desc,
-				"compatibility" = check_compatibility(P),
-				"size" = P.size,
-				"access" = TRUE,
-			)))
-		data["hacked_programs"] = hacked_programs
+			"access" = emagged && P.available_on_syndinet ? TRUE : P.can_run(user,transfer = 1, access = access),
+			"verifiedsource" = P.available_on_ntnet,
+		))
 
-	data["downloadable_programs"] = all_entries
+	data["categories"] = show_categories & program_categories
 
 	return data
 
 /datum/computer_file/program/ntnetdownload/proc/check_compatibility(datum/computer_file/program/P)
 	var/hardflag = computer.hardware_flag
 
-	if(P && P.is_supported_by_hardware(hardflag,0))
-		return "Compatible"
-	return "Incompatible!"
+	if(P?.is_supported_by_hardware(hardflag,0))
+		return TRUE
+	return FALSE
 
 /datum/computer_file/program/ntnetdownload/kill_program(forced)
 	abort_file_download()

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -127,6 +127,8 @@
 
 	if(!istype(my_computer))
 		return
+	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
+	var/list/access = card_slot?.GetAccess()
 
 	var/list/data = get_header_data()
 
@@ -148,7 +150,7 @@
 	for(var/A in main_repo)
 		var/datum/computer_file/program/P = A
 		// Only those programs our user can run will show in the list
-		if(!P.can_run(user,transfer = 1) || hard_drive.find_file_by_name(P.filename))
+		if(!P.can_run(user,transfer = 1, access = access) || hard_drive.find_file_by_name(P.filename))
 			continue
 		all_entries.Add(list(list(
 			"filename" = P.filename,

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/ntnetmonitor
 	filename = "ntmonitor"
 	filedesc = "NTNet Diagnostics and Monitoring"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "comm_monitor"
 	extended_desc = "This program monitors stationwide NTNet network, provides access to logging systems, and allows for configuration changes"
 	size = 12

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -8,6 +8,7 @@
 	required_access = ACCESS_NETWORK	//NETWORK CONTROL IS A MORE SECURE PROGRAM.
 	available_on_ntnet = TRUE
 	tgui_id = "NtosNetMonitor"
+	program_icon = "network-wired"
 
 /datum/computer_file/program/ntnetmonitor/ui_act(action, params)
 	if(..())

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/chatclient
 	filename = "ntnrc_client"
 	filedesc = "Chat Client"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "command"
 	extended_desc = "This program allows communication over NTNRC network"
 	size = 8

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -10,9 +10,7 @@
 	ui_header = "ntnrc_idle.gif"
 	available_on_ntnet = 1
 	tgui_id = "NtosNetChat"
-
-
-
+	program_icon = "comment-alt"
 	var/last_message				// Used to generate the toolbar icon
 	var/username
 	var/active_channel

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -18,6 +18,7 @@
 	requires_ntnet = TRUE
 	size = 9
 	tgui_id = "NtosPortraitPrinter"
+	program_icon = "print"
 
 /datum/computer_file/program/portrait_printer/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -11,6 +11,7 @@
 /datum/computer_file/program/portrait_printer
 	filename = "PortraitPrinter"
 	filedesc = "Marlowe Treeby's Art Galaxy"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "dummy"
 	extended_desc = "This program connects to a Spinward Sector community art site for viewing and printing art."
 	transfer_access = ACCESS_LIBRARY

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -3,6 +3,7 @@
 /datum/computer_file/program/power_monitor
 	filename = "powermonitor"
 	filedesc = "Power Monitor"
+	category = PROGRAM_CATEGORY_ENGI
 	program_icon_state = "power_monitor"
 	extended_desc = "This program connects to sensors around the station to provide information about electrical systems"
 	ui_header = "power_norm.gif"

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -12,6 +12,7 @@
 	network_destination = "power monitoring system"
 	size = 9
 	tgui_id = "NtosPowerMonitor"
+	program_icon = "plug"
 
 
 

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -216,6 +216,7 @@
 	requires_ntnet = TRUE
 	transfer_access = ACCESS_MEDICAL
 	available_on_ntnet = TRUE
+	program_icon = "heartbeat"
 
 /datum/computer_file/program/radar/lifeline/find_atom()
 	return locate(selected) in GLOB.carbon_list //currently we dont have a list of humanoids so this'll have to do
@@ -271,6 +272,7 @@
 	available_on_ntnet = FALSE
 	available_on_syndinet = TRUE
 	tgui_id = "NtosRadarSyndicate"
+	program_icon = "bomb"
 	arrowstyle = "ntosradarpointerS.png"
 	pointercolor = "red"
 

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -3,6 +3,7 @@
 /datum/computer_file/program/radar //generic parent that handles most of the process
 	filename = "genericfinder"
 	filedesc = "debug_finder"
+	category = PROGRAM_CATEGORY_CREW
 	ui_header = "borg_mon.gif" //DEBUG -- new icon before PR
 	program_icon_state = "radarntos"
 	requires_ntnet = TRUE
@@ -265,6 +266,7 @@
 /datum/computer_file/program/radar/fission360
 	filename = "fission360"
 	filedesc = "Fission360"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "radarsyndicate"
 	extended_desc = "This program allows for tracking of nuclear authorization disks and warheads."
 	requires_ntnet = FALSE

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -9,8 +9,7 @@
 	network_destination = "robotics control network"
 	size = 12
 	tgui_id = "NtosRoboControl"
-
-
+	program_icon = "robot"
 	///Number of simple robots on-station.
 	var/botcount = 0
 	///Used to find the location of the user for the purposes of summoning robots.

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -80,7 +80,7 @@
 				return
 			if(id_card)
 				GLOB.data_core.manifest_modify(id_card.registered_name, id_card.assignment, id_card.hud_state)
-				card_slot.try_eject(TRUE, current_user)
+				card_slot.try_eject(current_user)
 			else
 				playsound(get_turf(ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
 	return

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -2,6 +2,7 @@
 /datum/computer_file/program/robocontrol
 	filename = "robocontrol"
 	filedesc = "Bot Remote Controller"
+	category = PROGRAM_CATEGORY_ROBO
 	program_icon_state = "robot"
 	extended_desc = "A remote controller used for giving basic commands to non-sentient robots."
 	transfer_access = ACCESS_ROBOTICS

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -10,6 +10,7 @@
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
 	size = 5
 	tgui_id = "NtosSecurEye"
+	program_icon = "eye"
 
 	var/list/network = list("ss13")
 	var/obj/machinery/camera/active_camera

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -3,6 +3,7 @@
 /datum/computer_file/program/secureye
 	filename = "secureye"
 	filedesc = "SecurEye"
+	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "generic"
 	extended_desc = "This program allows access to standard security camera networks."
 	requires_ntnet = TRUE

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -1,6 +1,7 @@
 /datum/computer_file/program/supermatter_monitor
 	filename = "smmonitor"
 	filedesc = "Supermatter Monitoring"
+	category = PROGRAM_CATEGORY_ENGI
 	ui_header = "smmon_0.gif"
 	program_icon_state = "smmon_0"
 	extended_desc = "This program connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -10,10 +10,15 @@
 	size = 5
 	tgui_id = "NtosSupermatterMonitor"
 	program_icon = "radiation"
+	alert_able = TRUE
 	var/last_status = SUPERMATTER_INACTIVE
 	var/list/supermatters
 	var/obj/machinery/power/supermatter_crystal/active		// Currently selected supermatter crystal.
 
+/datum/computer_file/program/supermatter_monitor/Destroy()
+	clear_signals()
+	active = null
+	return ..()
 
 /datum/computer_file/program/supermatter_monitor/process_tick()
 	..()
@@ -27,6 +32,8 @@
 
 /datum/computer_file/program/supermatter_monitor/run_program(mob/living/user)
 	. = ..(user)
+	if(!(active in GLOB.machines))
+		active = null
 	refresh()
 
 /datum/computer_file/program/supermatter_monitor/kill_program(forced = FALSE)
@@ -54,6 +61,58 @@
 	. = SUPERMATTER_INACTIVE
 	for(var/obj/machinery/power/supermatter_crystal/S in supermatters)
 		. = max(., S.get_status())
+
+/**
+  * Sets up the signal listener for Supermatter delaminations.
+  *
+  * Unregisters any old listners for SM delams, and then registers one for the SM refered
+  * to in the `active` variable. This proc is also used with no active SM to simply clear
+  * the signal and exit.
+ */
+/datum/computer_file/program/supermatter_monitor/proc/set_signals()
+	if(active)
+		RegisterSignal(active, COMSIG_SUPERMATTER_DELAM_ALARM, .proc/send_alert, override = TRUE)
+		RegisterSignal(active, COMSIG_SUPERMATTER_DELAM_START_ALARM, .proc/send_start_alert, override = TRUE)
+
+/**
+  * Removes the signal listener for Supermatter delaminations from the selected supermatter.
+  *
+  * Pretty much does what it says.
+ */
+/datum/computer_file/program/supermatter_monitor/proc/clear_signals()
+	if(active)
+		UnregisterSignal(active, COMSIG_SUPERMATTER_DELAM_ALARM)
+		UnregisterSignal(active, COMSIG_SUPERMATTER_DELAM_START_ALARM)
+
+/**
+  * Sends an SM delam alert to the computer.
+  *
+  * Triggered by a signal from the selected supermatter, this proc sends a notification
+  * to the computer if the program is either closed or minimized. We do not send these
+  * notifications to the comptuer if we're the active program, because engineers fixing
+  * the supermatter probably don't need constant beeping to distract them.
+ */
+/datum/computer_file/program/supermatter_monitor/proc/send_alert()
+	if(!computer.get_ntnet_status())
+		return
+	if(computer.active_program != src)
+		computer.alert_call(src, "Crystal delamination in progress!")
+		alert_pending = TRUE
+
+/**
+  * Sends an SM delam start alert to the computer.
+  *
+  * Triggered by a signal from the selected supermatter at the start of a delamination,
+  * this proc sends a notification to the computer if this program is the active one.
+  * We do this so that people carrying a tablet with NT CIMS open but with the NTOS window
+  * closed will still get one audio alert. This is not sent to computers with the program
+  * minimized or closed to avoid double-notifications.
+ */
+/datum/computer_file/program/supermatter_monitor/proc/send_start_alert()
+	if(!computer.get_ntnet_status())
+		return
+	if(computer.active_program == src)
+		computer.alert_call(src, "Crystal delamination in progress!")
 
 /datum/computer_file/program/supermatter_monitor/ui_data()
 	var/list/data = get_header_data()
@@ -114,6 +173,7 @@
 
 	switch(action)
 		if("PRG_clear")
+			clear_signals()
 			active = null
 			return TRUE
 		if("PRG_refresh")
@@ -124,6 +184,7 @@
 			for(var/obj/machinery/power/supermatter_crystal/S in supermatters)
 				if(S.uid == newuid)
 					active = S
+					set_signals()
 			return TRUE
 
 /datum/computer_file/program/supermatter_monitor/proc/react_to_del(datum/source)

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -9,8 +9,7 @@
 	network_destination = "supermatter monitoring system"
 	size = 5
 	tgui_id = "NtosSupermatterMonitor"
-
-
+	program_icon = "radiation"
 	var/last_status = SUPERMATTER_INACTIVE
 	var/list/supermatters
 	var/obj/machinery/power/supermatter_crystal/active		// Currently selected supermatter crystal.

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -10,9 +10,11 @@
 	// Computer that holds this hardware, if any.
 
 	var/power_usage = 0 			// If the hardware uses extra power, change this.
-	var/enabled = 1					// If the hardware is turned off set this to 0.
-	var/critical = 0				// Prevent disabling for important component, like the CPU.
-	var/can_install = 1				// Prevents direct installation of removable media.
+	var/enabled = TRUE				// If the hardware is turned off set this to 0.
+	var/critical = FALSE			// Prevent disabling for important component, like the CPU.
+	var/can_install = TRUE			// Prevents direct installation of removable media.
+	var/expansion_hw = FALSE		// Hardware that fits into expansion bays.
+	var/removable = TRUE			// Whether the hardware is removable or not.
 	var/damage = 0					// Current damage level
 	var/max_damage = 100			// Maximal damage level.
 	var/damage_malfunction = 20		// "Malfunction" threshold. When damage exceeds this value the hardware piece will semi-randomly fail and do !!FUN!! things

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -20,12 +20,6 @@
 	if(stored_card)
 		. += "There appears to be an intelliCard loaded. There appears to be a pinhole protecting a manual eject button. A screwdriver could probably press it."
 
-/obj/item/computer_hardware/ai_slot/on_install(obj/item/modular_computer/M, mob/living/user = null)
-	M.add_computer_verbs(device_type)
-
-/obj/item/computer_hardware/ai_slot/on_remove(obj/item/modular_computer/M, mob/living/user = null)
-	M.remove_computer_verbs(device_type)
-
 /obj/item/computer_hardware/ai_slot/try_insert(obj/item/I, mob/living/user = null)
 	if(!holder)
 		return FALSE

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -5,6 +5,7 @@
 	icon_state = "card_mini"
 	w_class = WEIGHT_CLASS_SMALL
 	device_type = MC_AI
+	expansion_hw = TRUE
 
 	var/obj/item/aicard/stored_card
 	var/locked = FALSE
@@ -39,7 +40,7 @@
 	return TRUE
 
 
-/obj/item/computer_hardware/ai_slot/try_eject(slot=0,mob/living/user = null,forced = 0)
+/obj/item/computer_hardware/ai_slot/try_eject(mob/living/user = null,forced = FALSE)
 	if(!stored_card)
 		to_chat(user, "<span class='warning'>There is no card in \the [src].</span>")
 		return FALSE

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -19,11 +19,10 @@
 	QDEL_NULL(battery)
 	return ..()
 
-///What happens when the battery is removed (or deleted) from the module, through try_eject() or not.
-/obj/item/computer_hardware/battery/Exited(atom/movable/gone, atom/newloc)
-	if(gone == battery)
-		try_eject(0, null, TRUE)
-	return ..()
+/obj/item/computer_hardware/battery/handle_atom_del(atom/A)
+	if(A == battery)
+		try_eject(forced = TRUE)
+	. = ..()
 
 /obj/item/computer_hardware/battery/try_insert(obj/item/I, mob/living/user = null)
 	if(!holder)
@@ -49,7 +48,7 @@
 	return TRUE
 
 
-/obj/item/computer_hardware/battery/try_eject(slot=0, mob/living/user = null, forced = 0)
+/obj/item/computer_hardware/battery/try_eject(mob/living/user = null, forced = FALSE)
 	if(!battery)
 		to_chat(user, "<span class='warning'>There is no power cell connected to \the [src].</span>")
 		return FALSE

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -1,5 +1,5 @@
 /obj/item/computer_hardware/card_slot
-	name = "identification card authentication module"	// \improper breaks the find_hardware_by_name proc
+	name = "primary RFID card module"	// \improper breaks the find_hardware_by_name proc
 	desc = "A module allowing this computer to read or write data on ID cards. Necessary for some programs to run properly."
 	power_usage = 10 //W
 	icon_state = "card_mini"
@@ -106,8 +106,10 @@
 	expansion_hw = !expansion_hw
 	if(expansion_hw)
 		device_type = MC_CARD2
+		name = "secondary RFID card module"
 	else
 		device_type = MC_CARD
+		name = "primary RFID card module"
 
 /obj/item/computer_hardware/card_slot/examine(mob/user)
 	. = ..()
@@ -116,5 +118,6 @@
 		. += "There appears to be something loaded in the card slots."
 
 /obj/item/computer_hardware/card_slot/secondary
+	name = "secondary RFID card module"
 	device_type = MC_CARD2
 	expansion_hw = TRUE

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -59,12 +59,6 @@
 		if(!try_eject(2))
 			return null
 
-/obj/item/computer_hardware/card_slot/on_install(obj/item/modular_computer/M, mob/living/user = null)
-	M.add_computer_verbs(device_type)
-
-/obj/item/computer_hardware/card_slot/on_remove(obj/item/modular_computer/M, mob/living/user = null)
-	M.remove_computer_verbs(device_type)
-
 /obj/item/computer_hardware/card_slot/try_insert(obj/item/I, mob/living/user = null)
 	if(!holder)
 		return FALSE

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -6,58 +6,37 @@
 	w_class = WEIGHT_CLASS_TINY
 	device_type = MC_CARD
 
-	var/obj/item/card/id/stored_card
-	var/obj/item/card/id/stored_card2
+	var/obj/item/card/id/stored_card = null
 
-/obj/item/computer_hardware/card_slot/Exited(atom/movable/gone, direction)
-	if(!(gone == stored_card || gone == stored_card2))
-		return ..()
-	if(holder)
-		if(holder.active_program)
-			holder.active_program.event_idremoved(0)
-		for(var/p in holder.idle_threads)
-			var/datum/computer_file/program/computer_program = p
-			computer_program.event_idremoved(1)
-
-		holder.update_slot_icon()
-
-		if(!ishuman(holder.loc))
-			return ..()
-		var/mob/living/carbon/human/human_wearer = holder.loc
-		if(human_wearer.wear_id == holder)
-			human_wearer.sec_hud_set_ID()
-	return ..()
+/obj/item/computer_hardware/card_slot/handle_atom_del(atom/A)
+	if(A == stored_card)
+		try_eject(null, TRUE)
+	. = ..()
 
 /obj/item/computer_hardware/card_slot/Destroy()
 	try_eject()
 	return ..()
 
 /obj/item/computer_hardware/card_slot/GetAccess()
-	if(stored_card && stored_card2) // Best of both worlds
-		return (stored_card.GetAccess() | stored_card2.GetAccess())
-	else if(stored_card)
-		return stored_card.GetAccess()
-	else if(stored_card2)
-		return stored_card2.GetAccess()
-	return ..()
+	var/list/total_access
+	if(stored_card)
+		total_access = stored_card.GetAccess()
+	var/obj/item/computer_hardware/card_slot/card_slot2 = holder?.all_components[MC_CARD2] //Best of both worlds
+	if(card_slot2?.stored_card)
+		total_access |= card_slot2.stored_card.GetAccess()
+	return total_access
 
 /obj/item/computer_hardware/card_slot/GetID()
 	if(stored_card)
 		return stored_card
-	else if(stored_card2)
-		return stored_card2
 	return ..()
 
 /obj/item/computer_hardware/card_slot/RemoveID()
 	if(stored_card)
 		. = stored_card
-		if(!try_eject(1))
+		if(!try_eject())
 			return null
 		return
-	if(stored_card2)
-		. = stored_card2
-		if(!try_eject(2))
-			return null
 
 /obj/item/computer_hardware/card_slot/try_insert(obj/item/I, mob/living/user = null)
 	if(!holder)
@@ -66,8 +45,7 @@
 	if(!istype(I, /obj/item/card/id))
 		return FALSE
 
-	if(stored_card && stored_card2)
-		to_chat(user, "<span class='warning'>You try to insert \the [I] into \the [src], but its slots are occupied.</span>")
+	if(stored_card)
 		return FALSE
 	if(user)
 		if(!user.transferItemToLoc(I, src))
@@ -75,12 +53,9 @@
 	else
 		I.forceMove(src)
 
-	if(!stored_card)
-		stored_card = I
-	else
-		stored_card2 = I
-	to_chat(user, "<span class='notice'>You insert \the [I] into \the [src].</span>")
-	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
+	stored_card = I
+	to_chat(user, "<span class='notice'>You insert \the [I] into \the [expansion_hw ? "secondary":"primary"] [src].</span>")
+	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.sec_hud_set_ID()
@@ -88,53 +63,58 @@
 	return TRUE
 
 
-/obj/item/computer_hardware/card_slot/try_eject(slot=0, mob/living/user = null, forced = 0)
-	if(!stored_card && !stored_card2)
+/obj/item/computer_hardware/card_slot/try_eject(mob/living/user = null, forced = FALSE)
+	if(!stored_card)
 		to_chat(user, "<span class='warning'>There are no cards in \the [src].</span>")
 		return FALSE
 
-	var/ejected = 0
-	if(stored_card && (!slot || slot == 1))
-		if(user && in_range(src, user))
-			user.put_in_hands(stored_card)
-		else
-			stored_card.forceMove(drop_location())
-		stored_card = null
-		ejected++
+	if(user)
+		user.put_in_hands(stored_card)
+	else
+		stored_card.forceMove(drop_location())
+	stored_card = null
 
-	if(stored_card2 && (!slot || slot == 2))
-		if(user && in_range(src, user))
-			user.put_in_hands(stored_card2)
-		else
-			stored_card2.forceMove(drop_location())
-		stored_card2 = null
-		ejected++
+	if(holder)
+		if(holder.active_program)
+			holder.active_program.event_idremoved(0)
 
-	if(ejected)
-		if(holder)
-			if(holder.active_program)
-				holder.active_program.event_idremoved(0, slot)
-
-			for(var/I in holder.idle_threads)
-				var/datum/computer_file/program/P = I
-				P.event_idremoved(1, slot)
-		if(ishuman(user))
-			var/mob/living/carbon/human/H = user
-			H.sec_hud_set_ID()
-		to_chat(user, "<span class='notice'>You eject the card[ejected>1 ? "s" : ""] from \the [src].</span>")
-		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
-		return TRUE
-	return FALSE
+		for(var/p in holder.idle_threads)
+			var/datum/computer_file/program/computer_program = p
+			computer_program.event_idremoved(1)
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		human_user.sec_hud_set_ID()
+	to_chat(user, "<span class='notice'>You remove the card from \the [src].</span>")
+	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
+	return TRUE
 
 /obj/item/computer_hardware/card_slot/attackby(obj/item/I, mob/living/user)
 	if(..())
 		return
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		to_chat(user, "<span class='notice'>You press down on the manual eject button with \the [I].</span>")
-		try_eject(0,user)
-		return
+		if(stored_card)
+			to_chat(user, "<span class='notice'>You press down on the manual eject button with \the [I].</span>")
+			try_eject(user)
+			return
+		swap_slot()
+		to_chat(user, "<span class='notice'>You adjust the connecter to fit into [expansion_hw ? "an expansion bay" : "the primary ID bay"].</span>")
+
+/**
+  *Swaps the card_slot hardware between using the dedicated card slot bay on a computer, and using an expansion bay.
+*/
+/obj/item/computer_hardware/card_slot/proc/swap_slot()
+	expansion_hw = !expansion_hw
+	if(expansion_hw)
+		device_type = MC_CARD2
+	else
+		device_type = MC_CARD
 
 /obj/item/computer_hardware/card_slot/examine(mob/user)
 	. = ..()
-	if(stored_card || stored_card2)
+	. += "The connector is set to fit into [expansion_hw ? "an expansion bay" : "a computer's primary ID bay"], but can be adjusted with a screwdriver."
+	if(stored_card)
 		. += "There appears to be something loaded in the card slots."
+
+/obj/item/computer_hardware/card_slot/secondary
+	device_type = MC_CARD2
+	expansion_hw = TRUE

--- a/code/modules/modular_computers/hardware/portable_disk.dm
+++ b/code/modules/modular_computers/hardware/portable_disk.dm
@@ -8,12 +8,8 @@
 	max_capacity = 16
 	device_type = MC_SDD
 
-/obj/item/computer_hardware/hard_drive/portable/on_install(obj/item/modular_computer/M, mob/living/user = null)
-	M.add_computer_verbs(device_type)
-
-/obj/item/computer_hardware/hard_drive/portable/on_remove(obj/item/modular_computer/M, mob/living/user = null)
-	..()
-	M.remove_computer_verbs(device_type)
+/obj/item/computer_hardware/hard_drive/portable/on_remove(obj/item/modular_computer/MC, mob/user)
+	return //this is a floppy disk, let's not shut the computer down when it gets pulled out.
 
 /obj/item/computer_hardware/hard_drive/portable/install_default_programs()
 	return // Empty by default

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -5,6 +5,7 @@
 	icon_state = "printer"
 	w_class = WEIGHT_CLASS_NORMAL
 	device_type = MC_PRINT
+	expansion_hw = TRUE
 	var/stored_paper = 20
 	var/max_paper = 30
 

--- a/code/modules/modular_computers/hardware/sensor_package.dm
+++ b/code/modules/modular_computers/hardware/sensor_package.dm
@@ -1,0 +1,8 @@
+//This item doesn't do much on its own, but is required by apps such as AtmoZphere.
+/obj/item/computer_hardware/sensorpackage
+	name = "sensor package"
+	desc = "An integrated sensor package allowing a computer to take readings from the environment. Required by certain programs."
+	icon_state = "servo"
+	w_class = WEIGHT_CLASS_TINY
+	device_type = MC_SENSORS
+	expansion_hw = TRUE

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -56,6 +56,7 @@
 		var/obj/item/computer_hardware/battery/battery_module = null
 		if(fabricate)
 			fabricated_laptop = new /obj/item/modular_computer/laptop/buildable(src)
+			fabricated_laptop.install_component(new /obj/item/computer_hardware/card_slot)
 			fabricated_laptop.install_component(new /obj/item/computer_hardware/battery)
 			battery_module = fabricated_laptop.all_components[MC_CELL]
 		total_price = 99
@@ -111,7 +112,7 @@
 		if(dev_card)
 			total_price += 199
 			if(fabricate)
-				fabricated_laptop.install_component(new /obj/item/computer_hardware/card_slot)
+				fabricated_laptop.install_component(new /obj/item/computer_hardware/card_slot/secondary)
 
 		ui_update()
 		return total_price
@@ -121,6 +122,7 @@
 			fabricated_tablet = new(src)
 			fabricated_tablet.install_component(new /obj/item/computer_hardware/battery)
 			fabricated_tablet.install_component(new /obj/item/computer_hardware/processor_unit/small)
+			fabricated_tablet.install_component(new/obj/item/computer_hardware/card_slot)
 			battery_module = fabricated_tablet.all_components[MC_CELL]
 		total_price = 199
 		switch(dev_battery)
@@ -159,11 +161,11 @@
 		if(dev_printer)
 			total_price += 99
 			if(fabricate)
-				fabricated_tablet.install_component(new/obj/item/computer_hardware/printer)
+				fabricated_tablet.install_component(new/obj/item/computer_hardware/printer/mini)
 		if(dev_card)
 			total_price += 199
 			if(fabricate)
-				fabricated_tablet.install_component(new/obj/item/computer_hardware/card_slot)
+				fabricated_tablet.install_component(new/obj/item/computer_hardware/card_slot/secondary)
 		ui_update()
 		return total_price
 	ui_update()
@@ -270,7 +272,7 @@
 			say("Insufficient money on card to purchase!")
 			return
 		credits += target_credits
-		say("$[target_credits] has been deposited from your account.")
+		say("[target_credits] cr have been withdrawn from your account.")
 		ui_update()
 		return
 	return ..()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -498,11 +498,14 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			supermatter_anomaly_gen(src, PYRO_ANOMALY, rand(5, 10))
 
 	if(damage > warning_point) // while the core is still damaged and it's still worth noting its status
+		if(damage_archived < warning_point) //If damage_archive is under the warning point, this is the very first cycle that we've reached said point.
+			SEND_SIGNAL(src, COMSIG_SUPERMATTER_DELAM_START_ALARM)
 		if((REALTIMEOFDAY - lastwarning) / 10 >= WARNING_DELAY)
 			alarm()
 
 			if(damage > emergency_point)
 				radio.talk_into(src, "[emergency_alert] Integrity: [get_integrity()]%", common_channel)
+				SEND_SIGNAL(src, COMSIG_SUPERMATTER_DELAM_ALARM)
 				lastwarning = REALTIMEOFDAY
 				if(!has_reached_emergency)
 					investigate_log("has reached the emergency point for the first time.", INVESTIGATE_ENGINES)
@@ -510,6 +513,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 					has_reached_emergency = TRUE
 			else if(damage >= damage_archived) // The damage is still going up
 				radio.talk_into(src, "[warning_alert] Integrity: [get_integrity()]%", engineering_channel)
+				SEND_SIGNAL(src, COMSIG_SUPERMATTER_DELAM_ALARM)
 				lastwarning = REALTIMEOFDAY - (WARNING_DELAY * 5)
 
 			else                                                 // Phew, we're safe

--- a/code/modules/research/designs/computer_part_designs.dm
+++ b/code/modules/research/designs/computer_part_designs.dm
@@ -289,3 +289,12 @@
 	category = list("Computer Parts")
 	lathe_time_factor = 0.2
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/sensorpackage
+	name = "Sensor Package"
+	id = "sensorpackage"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 200, /datum/material/glass = 100, /datum/material/gold = 50, /datum/material/silver = 50)
+	build_path = /obj/item/computer_hardware/sensorpackage
+	category = list("Computer Parts")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -567,7 +567,7 @@
 	export_price = 2000
 	design_ids = list("hdd_basic", "hdd_advanced", "hdd_super", "hdd_cluster", "ssd_small", "ssd_micro", "netcard_basic", "netcard_advanced", "netcard_wired",
 	"portadrive_basic", "portadrive_advanced", "portadrive_super", "cardslot", "aislot", "miniprinter", "APClink", "bat_control", "bat_normal", "bat_advanced",
-	"bat_super", "bat_micro", "bat_nano", "cpu_normal", "pcpu_normal", "cpu_small", "pcpu_small")
+	"bat_super", "bat_micro", "bat_nano", "cpu_normal", "pcpu_normal", "cpu_small", "pcpu_small", "sensorpackage")
 
 /datum/techweb_node/computer_board_gaming
 	id = "computer_board_gaming"

--- a/code/modules/vending/modularpc.dm
+++ b/code/modules/vending/modularpc.dm
@@ -15,7 +15,8 @@
 					/obj/item/computer_hardware/battery = 8,
 					/obj/item/stock_parts/cell/computer = 8,
 					/obj/item/computer_hardware/processor_unit = 4,
-					/obj/item/computer_hardware/processor_unit/small = 4)
+					/obj/item/computer_hardware/processor_unit/small = 4,
+					/obj/item/computer_hardware/sensorpackage = 4)
 	premium = list(/obj/item/computer_hardware/card_slot = 2,
 		           /obj/item/computer_hardware/ai_slot = 2,
 		           /obj/item/computer_hardware/printer/mini = 2,

--- a/tgui/packages/tgui/interfaces/ComputerFabricator.js
+++ b/tgui/packages/tgui/interfaces/ComputerFabricator.js
@@ -252,8 +252,7 @@ const CfStep2 = (props, context) => {
                 allow the device to read your identification, but one
                 is included in the base price.
               `}
-              position="right">
-            </Tooltip>
+              position="right" />
           </Table.Cell>
           <Table.Cell>
             <Button

--- a/tgui/packages/tgui/interfaces/ComputerFabricator.js
+++ b/tgui/packages/tgui/interfaces/ComputerFabricator.js
@@ -243,15 +243,16 @@ const CfStep2 = (props, context) => {
         </Table.Row>
         <Table.Row>
           <Table.Cell bold position="relative">
+            Secondary Card Reader:
             <Tooltip
               content={multiline`
-                Adds a slot that allows you to manipulate RFID cards.
-                Please note that this is not necessary to allow the device
-                to read your identification, it is just necessary to
-                manipulate other cards.
+                Adds a secondary RFID card reader, for manipulating or
+                reading from a second standard RFID card.
+                Please note that a primary card reader is necessary to
+                allow the device to read your identification, but one
+                is included in the base price.
               `}
               position="right">
-              Card Reader:
             </Tooltip>
           </Table.Cell>
           <Table.Cell>

--- a/tgui/packages/tgui/interfaces/NtosFileManager.js
+++ b/tgui/packages/tgui/interfaces/NtosFileManager.js
@@ -22,7 +22,8 @@ export const NtosFileManager = (props, context) => {
               name: file,
               new_name: newName,
             })}
-            onDuplicate={file => act('PRG_clone', { file: file })} />
+            onDuplicate={file => act('PRG_clone', { file: file })}
+            onToggleSilence={file => act('PRG_togglesilence', { name: file })} />
         </Section>
         {usbconnected && (
           <Section title="Data Disk">
@@ -52,6 +53,7 @@ const FileTable = props => {
     onUpload,
     onDelete,
     onRename,
+    onToggleSilence,
   } = props;
   return (
     <Table>
@@ -87,6 +89,13 @@ const FileTable = props => {
             {file.size}
           </Table.Cell>
           <Table.Cell collapsing>
+            {!!file.alert_able && (
+              <Button
+                icon={file.alert_silenced ? 'bell-slash' : 'bell'}
+                color={file.alert_silenced ? 'red' : 'default'}
+                tooltip={file.alert_silenced ? 'Unmute Alerts' : 'Mute Alerts'}
+                onClick={() => onToggleSilence(file.name)} />
+            )}
             {!file.undeletable && (
               <>
                 <Button.Confirm

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -27,6 +27,8 @@ export const NtosMain = (props, context) => {
     has_light,
     light_on,
     comp_light_color,
+    removable_media = [],
+    login = [],
   } = data;
   return (
     <NtosWindow
@@ -48,6 +50,44 @@ export const NtosMain = (props, context) => {
               Color:
               <ColorBox ml={1} color={comp_light_color} />
             </Button>
+          </Section>
+        )}
+        <Section
+          title="User Login"
+          buttons={(
+            <Button
+              icon="eject"
+              content="Eject ID"
+              disabled={!login.IDName}
+              onClick={() => act('PC_Eject_Disk', { name: "ID" })}
+            />
+          )}>
+          <Table>
+            <Table.Row>
+              ID Name: {login.IDName}
+            </Table.Row>
+            <Table.Row>
+              Assignment: {login.IDJob}
+            </Table.Row>
+          </Table>
+        </Section>
+        {!!removable_media.length && (
+          <Section title="Media Eject">
+            <Table>
+              {removable_media.map(device => (
+                <Table.Row key={device}>
+                  <Table.Cell>
+                    <Button
+                      fluid
+                      color="transparent"
+                      icon="eject"
+                      content={device}
+                      onClick={() => act('PC_Eject_Disk', { name: device })}
+                    />
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table>
           </Section>
         )}
         <Section title="Programs">

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -80,7 +80,7 @@ export const NtosMain = (props, context) => {
                   <Button
                     fluid
                     lineHeight="24px"
-                    color="transparent"
+                    color={program.alert ? 'yellow' : 'transparent'}
                     icon={program.icon}
                     content={program.desc}
                     onClick={() => act('PC_runprogram', {

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -2,24 +2,6 @@ import { useBackend } from '../backend';
 import { Button, ColorBox, Section, Table } from '../components';
 import { NtosWindow } from '../layouts';
 
-const PROGRAM_ICONS = {
-  compconfig: 'cog',
-  ntndownloader: 'download',
-  filemanager: 'folder',
-  smmonitor: 'radiation',
-  alarmmonitor: 'bell',
-  cardmod: 'id-card',
-  arcade: 'gamepad',
-  ntnrc_client: 'comment-alt',
-  nttransfer: 'exchange-alt',
-  powermonitor: 'plug',
-  job_manage: 'address-book',
-  crewmani: 'clipboard-list',
-  robocontrol: 'robot',
-  atmosscan: 'thermometer-half',
-  shipping: 'tags',
-};
-
 export const NtosMain = (props, context) => {
   const { act, data } = useBackend(context);
   const {
@@ -99,8 +81,7 @@ export const NtosMain = (props, context) => {
                     fluid
                     lineHeight="24px"
                     color="transparent"
-                    icon={PROGRAM_ICONS[program.name]
-                      || 'window-maximize-o'}
+                    icon={program.icon}
                     content={program.desc}
                     onClick={() => act('PC_runprogram', {
                       name: program.name,

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -122,7 +122,7 @@ const Program = (props, context) => {
     downloading,
     downloadname,
     downloadcompletion,
-    emagged
+    emagged,
   } = data;
   const disk_free = disk_size - disk_used;
   return (

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -40,11 +40,20 @@ export const NtosNetDownloader = (props, context) => {
           </LabeledList>
         </Section>
         <Section>
-          {downloadable_programs.map(program => (
-            <Program
-              key={program.filename}
-              program={program} />
-          ))}
+          {downloadable_programs
+            .filter(program => program.access)
+            .map(program => (
+              <Program
+                key={program.filename}
+                program={program} />
+            ))}
+          {downloadable_programs
+            .filter(program => !program.access)
+            .map(program => (
+              <Program
+                key={program.filename}
+                program={program} />
+            ))}
         </Section>
         {!!hackedavailable && (
           <Section title="UNKNOWN Software Repository">
@@ -97,7 +106,9 @@ const Program = (props, context) => {
               fluid
               icon="download"
               content="Download"
-              disabled={downloading || program.size > disk_free}
+              disabled={
+                downloading || program.size > disk_free || !program.access
+              }
               onClick={() => act('PRG_downloadfile', {
                 filename: program.filename,
               })} />
@@ -108,6 +119,12 @@ const Program = (props, context) => {
         <Box mt={1} italic fontSize="12px" position="relative">
           <Icon mx={1} color="red" name="times" />
           Incompatible!
+        </Box>
+      )}
+      {!(program.access) && (
+        <Box mt={1} italic fontSize="12px" position="relative">
+          <Icon mx={1} color="red" name="times" />
+          Invalid credentials loaded!
         </Box>
       )}
       {program.size > disk_free && (

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -1,5 +1,8 @@
-import { useBackend } from '../backend';
-import { Box, Button, Flex, Icon, LabeledList, NoticeBox, ProgressBar, Section } from '../components';
+import { scale, toFixed } from 'common/math';
+import { useBackend, useLocalState } from '../backend';
+import { Box, Button, Stack, Icon, LabeledList, NoticeBox, ProgressBar, Section, Tabs } from '../components';
+import { flow } from 'common/fp';
+import { filter, sortBy } from 'common/collections';
 import { NtosWindow } from '../layouts';
 
 export const NtosNetDownloader = (props, context) => {
@@ -7,15 +10,42 @@ export const NtosNetDownloader = (props, context) => {
   const {
     disk_size,
     disk_used,
-    downloadable_programs = [],
+    downloadcompletion,
+    downloading,
+    downloadname,
+    downloadsize,
     error,
-    hacked_programs = [],
-    hackedavailable,
+    emagged,
+    categories,
+    programs,
   } = data;
+  const all_categories = ['All'].concat(categories);
+  const downloadpercentage = toFixed(
+    scale(downloadcompletion, 0, downloadsize) * 100
+  );
+  const [
+    selectedCategory,
+    setSelectedCategory,
+  ] = useLocalState(context, 'category', all_categories[0]);
+  const items = flow([
+    // This filters the list to only contain programs with category
+    selectedCategory !== all_categories[0]
+    && filter(program => program.category === selectedCategory),
+    // This filters the list to only contain verified programs
+    !emagged
+    && filter(program => program.verifiedsource === 1),
+    // This sorts all programs in the lists by name and compatibility
+    sortBy(
+      program => -program.compatible,
+      program => program.filedesc),
+  ])(programs);
+  const disk_free_space = downloading
+    ? disk_size - toFixed(disk_used + downloadcompletion)
+    : disk_size - disk_used;
   return (
     <NtosWindow
-      width={480}
-      height={735}>
+      width={600}
+      height={600}>
       <NtosWindow.Content scrollable>
         {!!error && (
           <NoticeBox>
@@ -29,45 +59,55 @@ export const NtosNetDownloader = (props, context) => {
         )}
         <Section>
           <LabeledList>
-            <LabeledList.Item label="Disk usage">
+            <LabeledList.Item
+              label="Hard drive"
+              buttons={(!!downloading) && (
+                <Button
+                  icon="spinner"
+                  iconSpin={1}
+                  tooltipPosition="left"
+                  tooltip={!!downloading && (
+                    `Download: ${downloadname}.prg (${downloadpercentage}%)`
+                  )} />
+              ) || (!!downloadname && (
+                <Button
+                  color="good"
+                  icon="download"
+                  tooltipPosition="left"
+                  tooltip={`${downloadname}.prg downloaded`} />
+              ))}>
               <ProgressBar
-                value={disk_used}
+                value={downloading ? disk_used + downloadcompletion : disk_used}
                 minValue={0}
                 maxValue={disk_size}>
-                {`${disk_used} GQ / ${disk_size} GQ`}
+                <Box textAlign="left">
+                  {`${disk_free_space} GQ free of ${disk_size} GQ`}
+                </Box>
               </ProgressBar>
             </LabeledList.Item>
           </LabeledList>
         </Section>
-        <Section>
-          {downloadable_programs
-            .filter(program => program.access)
-            .map(program => (
+        <Stack>
+          <Stack.Item minWidth="105px" shrink={0} basis={0}>
+            <Tabs vertical>
+              {all_categories.map(category => (
+                <Tabs.Tab
+                  key={category}
+                  selected={category === selectedCategory}
+                  onClick={() => setSelectedCategory(category)}>
+                  {category}
+                </Tabs.Tab>
+              ))}
+            </Tabs>
+          </Stack.Item>
+          <Stack.Item grow={1} basis={0}>
+            {items?.map(program => (
               <Program
                 key={program.filename}
                 program={program} />
             ))}
-          {downloadable_programs
-            .filter(program => !program.access)
-            .map(program => (
-              <Program
-                key={program.filename}
-                program={program} />
-            ))}
-        </Section>
-        {!!hackedavailable && (
-          <Section title="UNKNOWN Software Repository">
-            <NoticeBox mb={1}>
-              Please note that Nanotrasen does not recommend download
-              of software from non-official servers.
-            </NoticeBox>
-            {hacked_programs.map(program => (
-              <Program
-                key={program.filename}
-                program={program} />
-            ))}
-          </Section>
-        )}
+          </Stack.Item>
+        </Stack>
       </NtosWindow.Content>
     </NtosWindow>
   );
@@ -79,63 +119,72 @@ const Program = (props, context) => {
   const {
     disk_size,
     disk_used,
-    downloadcompletion,
     downloading,
     downloadname,
-    downloadsize,
+    downloadcompletion,
+    emagged
   } = data;
   const disk_free = disk_size - disk_used;
   return (
-    <Box mb={3}>
-      <Flex align="baseline">
-        <Flex.Item bold grow={1}>
+    <Section>
+      <Stack align="baseline">
+        <Stack.Item grow={1} blod>
+          <Icon name={program.icon} mr={1} />
           {program.filedesc}
-        </Flex.Item>
-        <Flex.Item color="label" nowrap>
+        </Stack.Item>
+        <Stack.Item shrink={0} width="48px" textAlign="right" color="label" nowrap>
           {program.size} GQ
-        </Flex.Item>
-        <Flex.Item ml={2} width="94px" textAlign="center">
-          {program.filename === downloadname && (
+        </Stack.Item>
+        <Stack.Item shrink={0} width="134px" textAlign="right">
+          {(downloading && program.filename === downloadname) && (
             <ProgressBar
-              color="green"
+              width="101px"
+              height="23px"
+              color="good"
               minValue={0}
-              maxValue={downloadsize}
+              maxValue={program.size}
               value={downloadcompletion} />
           ) || (
-            <Button
-              fluid
-              icon="download"
-              content="Download"
-              disabled={
-                downloading || program.size > disk_free || !program.access
-              }
-              onClick={() => act('PRG_downloadfile', {
-                filename: program.filename,
-              })} />
+            (!program.installed
+              && program.compatible
+              && program.access
+              && program.size < disk_free) && (
+              <Button
+                bold
+                icon="download"
+                content="Download"
+                disabled={downloading}
+                tooltipPosition="left"
+                tooltip={!!downloading && ('Awaiting download completion...')}
+                onClick={() => act('PRG_downloadfile', {
+                  filename: program.filename,
+                })} />
+            ) || (
+              <Button
+                bold
+                icon={program.installed ? 'check' : 'times'}
+                color={
+                  program.installed ? 'good'
+                    : !program.compatible ? 'bad' : 'grey'
+                }
+                content={
+                  program.installed ? 'Installed'
+                    : !program.compatible ? 'Incompatible'
+                      : !program.access ? 'No Access' : 'No Space'
+                } />
+            )
           )}
-        </Flex.Item>
-      </Flex>
-      {program.compatibility !== 'Compatible' && (
-        <Box mt={1} italic fontSize="12px" position="relative">
-          <Icon mx={1} color="red" name="times" />
-          Incompatible!
-        </Box>
-      )}
-      {!(program.access) && (
-        <Box mt={1} italic fontSize="12px" position="relative">
-          <Icon mx={1} color="red" name="times" />
-          Invalid credentials loaded!
-        </Box>
-      )}
-      {program.size > disk_free && (
-        <Box mt={1} italic fontSize="12px" position="relative">
-          <Icon mx={1} color="red" name="times" />
-          Not enough disk space!
-        </Box>
-      )}
-      <Box mt={1} italic color="label" fontSize="12px">
+        </Stack.Item>
+      </Stack>
+      <Box mt={1} italic color="label">
         {program.fileinfo}
       </Box>
-    </Box>
+      {(!program.verifiedsource && !emagged) && (
+        <NoticeBox mt={1} mb={0} danger fontSize="12px">
+          Unverified source. Please note that Nanotrasen does not recommend
+          download and usage of software from non-official servers.
+        </NoticeBox>
+      )}
+    </Section>
   );
 };


### PR DESCRIPTION
## About The Pull Request

~~Depends on #7335 - I will forcepush a rebased version without said commits when merged~~

Ports:
- https://github.com/tgstation/tgstation/pull/52489
- https://github.com/tgstation/tgstation/pull/52644
- https://github.com/tgstation/tgstation/pull/53009 (fixes above PR)
- https://github.com/tgstation/tgstation/pull/53597
- https://github.com/tgstation/tgstation/pull/54075 (superseded by new download UI)
- https://github.com/tgstation/tgstation/pull/54158
- https://github.com/tgstation/tgstation/pull/54724
- https://github.com/tgstation/tgstation/pull/55629
- https://github.com/tgstation/tgstation/pull/56704

Also includes a runtime fix for recharger examine text when the item's power cell is null

## Why It's Good For The Game

Up to date modular pc code is good and lots of QoL fixes here

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Early testing video for expansion slot PR, also shows new ejection system

https://user-images.githubusercontent.com/10366817/180596955-78a5ef52-6bcb-4a48-b1e8-c6b116acf945.mp4

Icons and new software download tool are nearly identical to the ones from TG's testing video, their names are different but everything else is the same, the Cargo app we have that they don't uses `fa-credit-card`

https://user-images.githubusercontent.com/3625094/107362787-46f0a680-6aea-11eb-9077-7ca6ad9d34a0.mp4

Notification system works as expected with the SM, although I will note the beep is the same as the PDA messenger one which I have trouble hearing, but for consistency it'll stay as that.

</details>

## Changelog
:cl:
refactor: Software Downloader program UI revamp
tweak: The NtOS home screen has been updated with disk and ID eject buttons.
add: Added support for modular PC expansion bays, or hardware bays designed to be used by nonessential hardware. Devices have a limited number of bays (tablets less than others).
balance: The AI card slot, printer, and APC-siphoning recharger are now expansion bay hardware.
balance: The modular PC atmos scanner now requires a new expansion bay hardware item - the sensor package. Certain shift-start tablets have been adjusted to reflect this.
refactor: Modular PC card readers have been split -- The primary ID card reader, which comes pre-installed on nearly all devices, and a secondary ID card reader which is an expansion bay hardware and will need to be purchased separately. Certain shift-start devices have a secondary reader pre-installed.
fix: Buying a tablet from the Laptop/Tablet vendor, and paying extra for the mini-printer, will now attach the correct printer rather than attempt to stuff a laptop printer into a tablet and silently fail but still take your cash.
add: Added icons for all modular computer programs
add: Supermatter Monitoring will now send notifications if the app is closed with a supermatter selected, and the selected supermatter starts delaminating.
fix: Modular computers can now be attacked with non-help intent.
code: Fixes a runtime error with recharger examine text if the inserted item's power cell is null
fix: Fixed a runtime with ID modification program when the second ID slot is missing.
fix: ID modification program now follows the standard for ID reading and requires you to insert your card.
tweak: Primary and secondary ID card slots in ModPCs have separate names to make it easier to differentiate.
/:cl:
