### PR TITLE
Add Minimal Runtimes menu for non-admins

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -290,3 +290,10 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 		pct += delta
 		winset(src, "mainwindow.split", "splitter=[pct]")
+
+/client/verb/view_runtimes_minimal()
+	set name = "View Minimal Runtimes"
+	set category = "OOC"
+	set desc = "Open the runtime error viewer, with reduced information"
+
+	GLOB.error_cache.show_to_minimal(src)

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -23,6 +23,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 // Common vars and procs are kept at the error_viewer level
 /datum/error_viewer
 	var/name = ""
+	var/min_name = ""
 
 /datum/error_viewer/proc/browse_to(client/user, html)
 	var/datum/browser/browser = new(user.mob, "error_viewer", null, 600, 400)
@@ -77,6 +78,16 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 	var/list/errors = list()
 	var/list/error_sources = list()
 	var/list/errors_silenced = list()
+
+/datum/error_viewer/error_cache/proc/show_to_minimal(user, datum/error_viewer/back_to, linear)
+	var/html = "<b>[GLOB.total_runtimes]</b> runtimes, <b>[GLOB.total_runtimes_skipped]</b> skipped<br><br>"
+	for (var/datum/error_viewer/error_entry/error_entry in errors)
+		var/datum/error_viewer/error_source/error_source
+		for (var/erroruid in error_sources)
+			error_source = error_sources[erroruid]
+			html += "[error_source.min_name]<br>"
+
+	browse_to(user, html)
 
 /datum/error_viewer/error_cache/show_to(user, datum/error_viewer/back_to, linear)
 	var/html = build_header()
@@ -134,7 +145,8 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		name = "\[[time_stamp()]] Uncaught exceptions"
 		return
 
-	name = "<b>\[[time_stamp()]]</b> Runtime in <b>[e.file]</b>, line <b>[e.line]</b>: <b>[html_encode(e.name)]</b>"
+	min_name = "<b>\[[time_stamp()]]</b> Runtime in <b>[e.file]</b>, line <b>[e.line]</b>"
+	name = min_name + ": <b>[html_encode(e.name)]</b>"
 
 /datum/error_viewer/error_source/show_to(user, datum/error_viewer/back_to, linear)
 	if (!istype(back_to))
@@ -164,7 +176,8 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 		is_skip_count = TRUE
 		return
 
-	name = "<b>\[[time_stamp()]]</b> Runtime in <b>[e.file]</b>, line <b>[e.line]</b>: <b>[html_encode(e.name)]</b>"
+	min_name = "<b>\[[time_stamp()]]</b> Runtime in <b>[e.file]</b>, line <b>[e.line]</b>"
+	name = min_name + ": <b>[html_encode(e.name)]</b>"
 	exc = e
 	if (istype(desclines))
 		for (var/line in desclines)


### PR DESCRIPTION
## About The Pull Request

Adds "View Minimal Runtimes" verb to OOC tab for non-admins

## Why It's Good For The Game

Contributors and non-admins can view runtimes and fix them - does not include runtime info as this could contain sensitive info

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

No refresh button (because it was a pain to code) or runtime details to avoid leaking sensitive info
![image](https://user-images.githubusercontent.com/10366817/180600768-7d04855b-543f-44fa-8b41-6ec2fc9c4bf2.png)

</details>

## Changelog
:cl:
admin: Added View Minimal Runtimes verb to OOC tab for non-admins with less details
/:cl: