### PR TITLE
Space Carp Sect

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -285,6 +285,9 @@
 	icon_state = "bluestream_fade"
 	duration = 9
 
+/obj/effect/temp_visual/bluespace_fissure/long
+	duration = 300
+
 /obj/effect/temp_visual/gib_animation
 	icon = 'icons/mob/mob.dmi'
 	duration = 15

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -262,7 +262,7 @@
 	tgui_icon = "fish"
 	alignment = ALIGNMENT_NEUT
 	max_favor = 10000
-	desired_items = list(/obj/item/reagent_containers/food/snacks/meat, "of the meat variety")
+	desired_items = list(/obj/item/reagent_containers/food/snacks/meat/slab)
 	rites_list = list(/datum/religion_rites/summon_carp, /datum/religion_rites/flood_area, /datum/religion_rites/summon_carpsuit)
 	altar_icon_state = "convertaltar-blue"
 

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -250,3 +250,36 @@
 	to_chat(L, "<span class='notice'>You offer [N] to [GLOB.deity], pleasing them and gaining 10 favor in the process.</span>")
 	qdel(N)
 	return TRUE
+
+
+
+/**** Carp Sect ****/
+
+/datum/religion_sect/carp_sect
+	name = "Followers of the Great Carp"
+	desc = "A sect dedicated to the space carp and carp'sie, Offer the gods meat for favor."
+	quote = "Drown the station in fish and water."
+	tgui_icon = "fish"
+	alignment = ALIGNMENT_NEUT
+	max_favor = 10000
+	desired_items = list(/obj/item/reagent_containers/food/snacks/meat, "of the meat variety")
+	rites_list = list(/datum/religion_rites/summon_carp, /datum/religion_rites/flood_area, /datum/religion_rites/summon_carpsuit)
+	altar_icon_state = "convertaltar-blue"
+
+//Carp bibles give people the carp faction!
+/datum/religion_sect/carp_sect/sect_bless(mob/living/L, mob/living/user)
+	if(!isliving(L))
+		return FALSE
+	L.faction |= "carp"
+	user.visible_message("<span class='notice'>[user] blessed [L] with the power of [GLOB.deity]! They are now protected from Space Carps, Although carps will still fight back if attacked.</span>")
+	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
+	return TRUE
+
+/datum/religion_sect/carp_sect/on_sacrifice(obj/item/N, mob/living/L) //and this
+	var/obj/item/reagent_containers/food/snacks/meat/meat = N
+	if(!istype(meat)) //how...
+		return
+	adjust_favor(20, L)
+	to_chat(L, "<span class='notice'>You offer [meat] to [GLOB.deity], pleasing them and gaining 20 favor in the process.</span>")
+	qdel(N)
+	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -411,3 +411,98 @@
 	playsound(get_turf(religious_tool), 'sound/effects/bamf.ogg', 50, TRUE)
 	chosen_sacrifice = null
 	return ..()
+
+/**** Carp rites ****/
+
+/datum/religion_rites/summon_carp
+	name = "Summon Carp"
+	desc = "Creates a Sentient Space Carp, if a soul is willing to take it. If not, the favor is refunded."
+	ritual_length = 90 SECONDS
+	ritual_invocations = list("Grant us a new follower ...",
+	"... let them enter our realm ...",
+	"... become one with our world ...",
+	"... to swim in our space ...",
+	"... and help our cause ...")
+	invoke_msg = "... We summon thee, Holy Carp!"
+	favor_cost = 500
+
+/datum/religion_rites/summon_carp/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	var/turf/altar_turf = get_turf(religious_tool)
+	new /obj/effect/temp_visual/bluespace_fissure/long(altar_turf)
+	user.visible_message("<span class'notice'>A tear in reality appears above the altar!</span>")
+	var/list/jobbans = list(ROLE_BRAINWASHED, ROLE_DEATHSQUAD, ROLE_DRONE, ROLE_LAVALAND, ROLE_MIND_TRANSFER, ROLE_POSIBRAIN, ROLE_SENTIENCE)
+	var/list/candidates = pollGhostCandidates("Do you wish to be summoned as a Holy Carp?", jobbans, null, FALSE)
+	if(!length(candidates))
+		new /obj/effect/gibspawner/generic(altar_turf)
+		user.visible_message("<span class='warning'>The carp pool was not strong enough to bring forth a space carp.")
+		GLOB.religious_sect?.adjust_favor(400, user)
+		return NOT_ENOUGH_PLAYERS
+	var/mob/dead/observer/selected = pick_n_take(candidates)
+	var/datum/mind/M = new /datum/mind(selected.key)
+	var/carp_species = pick(/mob/living/simple_animal/hostile/carp/megacarp, /mob/living/simple_animal/hostile/carp)
+	var/mob/living/simple_animal/hostile/carp = new carp_species(altar_turf)
+	carp.name = "Holy Space-Carp ([rand(1,999)])"
+	carp.key = selected.key
+	carp.sentience_act()
+	carp.maxHealth += 100
+	carp.health += 100
+	M.transfer_to(carp)
+	if(GLOB.religion)
+		carp.mind?.holy_role = HOLY_ROLE_PRIEST
+		to_chat(carp, "There is already an established religion onboard the station. You are an acolyte of [GLOB.deity]. Defer to the Chaplain.")
+		GLOB.religious_sect?.on_conversion(carp)
+	playsound(altar_turf, 'sound/effects/slosh.ogg', 50, TRUE)
+	return ..()
+
+/datum/religion_rites/summon_carpsuit
+	name = "Summon Carp-Suit"
+	desc = "Summons a Space-Carp Suit"
+	ritual_length = 60 SECONDS
+	ritual_invocations = list("We shall become one ...",
+	"... we shall blend in ...",
+	"... we shall join in the ways of the carp ...",
+	"... grant us new clothing ...")
+	invoke_msg = "So we can swim."
+	favor_cost = 300
+	var/obj/item/clothing/suit/chosen_clothing
+
+/datum/religion_rites/summon_carpsuit/perform_rite(mob/living/user, atom/religious_tool)
+	var/turf/T = get_turf(religious_tool)
+	var/list/L = T.contents
+	if(!locate(/obj/item/clothing/suit) in L)
+		to_chat(user, "<span class='warning'>There is no suit clothing on the altar!</span>")
+		return FALSE
+	for(var/obj/item/clothing/suit/apparel in L)
+		chosen_clothing = apparel //the apparel has been chosen by our lord and savior
+		return ..()
+	return FALSE
+
+/datum/religion_rites/summon_carpsuit/invoke_effect(mob/living/user, atom/religious_tool)
+	if(!QDELETED(chosen_clothing) && get_turf(religious_tool) == chosen_clothing.loc) //check if the same clothing is still there
+		user.visible_message("<span class'notice'>The [chosen_clothing] transforms!</span>")
+		qdel(chosen_clothing)
+		new /obj/item/clothing/suit/space/hardsuit/carp/old(get_turf(religious_tool))
+		playsound(get_turf(religious_tool), 'sound/effects/slosh.ogg', 50, TRUE)
+		chosen_clothing = null //our lord and savior no longer cares about this apparel
+		return ..()
+	chosen_clothing = null
+	to_chat(user, "<span class='warning'>The clothing that was chosen for the rite is no longer on the altar!</span>")
+	return FALSE
+
+/datum/religion_rites/flood_area
+	name = "Flood Area"
+	desc = "Flood the area with water vapor, great for learning to swim!"
+	ritual_length = 40 SECONDS
+	ritual_invocations = list("We must swim ...",
+	"... but to do so, we need water ...",
+	"... grant us a great flood ...",
+	"... soak us in your glory ...",
+	"... we shall swim forever ...")
+	invoke_msg = "... in our own personal ocean."
+	favor_cost = 200
+
+/datum/religion_rites/flood_area/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	var/turf/open/T = get_turf(religious_tool)
+	if(istype(T))
+		T.atmos_spawn_air("water_vapor=5000;TEMP=255")
+	return ..()

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -480,10 +480,10 @@
 /datum/religion_rites/summon_carpsuit/invoke_effect(mob/living/user, atom/religious_tool)
 	if(!QDELETED(chosen_clothing) && get_turf(religious_tool) == chosen_clothing.loc) //check if the same clothing is still there
 		user.visible_message("<span class'notice'>The [chosen_clothing] transforms!</span>")
-		QDEL_NULL(chosen_clothing)
+		chosen_clothing.obj_destruction()
+		chosen_clothing = null
 		new /obj/item/clothing/suit/space/hardsuit/carp/old(get_turf(religious_tool))
 		playsound(get_turf(religious_tool), 'sound/effects/slosh.ogg', 50, TRUE)
-		chosen_clothing = null //our lord and savior no longer cares about this apparel
 		return ..()
 	chosen_clothing = null
 	to_chat(user, "<span class='warning'>The clothing that was chosen for the rite is no longer on the altar!</span>")

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -480,7 +480,7 @@
 /datum/religion_rites/summon_carpsuit/invoke_effect(mob/living/user, atom/religious_tool)
 	if(!QDELETED(chosen_clothing) && get_turf(religious_tool) == chosen_clothing.loc) //check if the same clothing is still there
 		user.visible_message("<span class'notice'>The [chosen_clothing] transforms!</span>")
-		qdel(chosen_clothing)
+		QDEL_NULL(chosen_clothing)
 		new /obj/item/clothing/suit/space/hardsuit/carp/old(get_turf(religious_tool))
 		playsound(get_turf(religious_tool), 'sound/effects/slosh.ogg', 50, TRUE)
 		chosen_clothing = null //our lord and savior no longer cares about this apparel


### PR DESCRIPTION
Take Two- https://github.com/BeeStation/BeeStation-Hornet/pull/7190

## About The Pull Request

Sorry, I'm slightly obsessed with making Sects now... oops

Adds a Carp Sect to the Chaplain's sect choices
You can offer up meat for 20 favor each.
You can then spend that favor on either summoning a holy space-carp from the observer pool, summoning a space-carp suit, 
or spend it on "flooding" the chapel with water vapor!

Flood Area - Costs 200 favor - Takes 40 seconds
Summon Carp-Suit - Costs 300 favor - Takes 60 seconds
Summon Carp - Costs 500 - Takes 90 seconds
Meat - Gives 20 favor per meat


## Why It's Good For The Game

Yet another way to keep players in-round, but this time as holy space-carp!

As far as I can tell, without any admin responses to prayers, the Chaplain has almost nothing going on during most rounds.
Occasinally they get funerals, or get to fight a cult or revenant, and theres the flame and tech sects too, but this brings a bit more to the table, and hopefully crew will come by the chapel more often to interact with the chaplain and join the carp-cult!

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![Screenshot_3](https://user-images.githubusercontent.com/17776299/177059735-b6c65be1-3011-4f20-b0ed-4cf748b972dd.png)
![Screenshot_4](https://user-images.githubusercontent.com/17776299/177059723-997c294b-f289-447b-b0e6-b5c73a07090d.png)
![Screenshot_2](https://user-images.githubusercontent.com/17776299/177059724-39b89cd0-3585-45e6-afd1-23d482e0f42d.png)
![Screenshot_10](https://user-images.githubusercontent.com/17776299/177059746-3eeca689-e372-4a9e-82a4-c0e9497a42fd.png)
![Screenshot_11](https://user-images.githubusercontent.com/17776299/177059748-7b4546af-8232-4f3e-a0c0-e9cbe7f93bbb.png)
![Screenshot_5](https://user-images.githubusercontent.com/17776299/177059749-3d70cd53-3f8c-4c3e-9bf3-bcf41aa20ed9.png)
![Screenshot_6](https://user-images.githubusercontent.com/17776299/177059750-e2bc01c6-3a7b-4d6d-be65-81052da99682.png)
![Screenshot_7](https://user-images.githubusercontent.com/17776299/177059751-4c3def6f-5f10-4341-894f-648fcfcd9918.png)
![Screenshot_8](https://user-images.githubusercontent.com/17776299/177059752-92f542ff-dd51-42bd-8d76-41208438d6eb.png)
![Screenshot_9](https://user-images.githubusercontent.com/17776299/177059753-7017eef1-0c68-43b5-bf8b-8483f6901322.png)


</details>

## Changelog
:cl:
add: The Chaplain now has access to a Space Carp Sect!
add: Flood Area rite for the Carp Sect, flood the chapel with water - 200 Favor Cost
add: Summon Carp-Suit rite for the Carp Sect, Summons a Space-Carp suit! - 300 Favor cost
add: Summon Carp rite for the Carp Sect, Summon a Holy Space-Carp from the observer pool - 500 Favor cost
add: Carp Sect uses the blue altar
add: Summoned Carp are sub-chaplains and as such, are holy!
/:cl:
