### PR TITLE
Changelings can now use the Reviving Stasis in the Monkey Form

### DIFF
--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -37,16 +37,17 @@
 	user.regenerate_organs()
 
 /datum/action/changeling/fakedeath/proc/ready_to_regenerate(datum/mind/mind)
-	if(mind && ishuman(mind.current))
-		var/datum/antagonist/changeling/C = mind.has_antag_datum(/datum/antagonist/changeling)
-		if(C?.purchasedpowers)
-			to_chat(mind.current, "<span class='notice'>We are ready to revive.</span>")
-			name = "Revive"
-			desc = "We arise once more."
-			button_icon_state = "revive"
-			UpdateButtonIcon()
-			chemical_cost = 0
-			revive_ready = TRUE
+	if(!mind || !iscarbon(mind.current))
+		return
+	var/datum/antagonist/changeling/C = mind.has_antag_datum(/datum/antagonist/changeling)
+	if(C?.purchasedpowers)
+		to_chat(mind.current, "<span class='notice'>We are ready to revive.</span>")
+		name = "Revive"
+		desc = "We arise once more."
+		button_icon_state = "revive"
+		UpdateButtonIcon()
+		chemical_cost = 0
+		revive_ready = TRUE
 
 /datum/action/changeling/fakedeath/can_sting(mob/living/user)
 	if(HAS_TRAIT(user, TRAIT_HUSK))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #7310 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes the bug that caused Changelings to get stuck in the stasis if they were in the lesser form.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


![now](https://user-images.githubusercontent.com/45698448/180609245-b55f4f50-7765-42e8-89ad-c0667aa1e077.png)


![Captura de pantalla 2022-07-23 161109](https://user-images.githubusercontent.com/45698448/180608884-426e8e06-d8b7-4924-a743-31982555f50d.png)

</details>

## Changelog
:cl:
fix: fixes changelings getting stucked in the stasis while being Monkeys
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
