### PR TITLE
Players cannot see runtimes during a round (OOC information revealed)

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -296,4 +296,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set category = "OOC"
 	set desc = "Open the runtime error viewer, with reduced information"
 
+	if(!isobserver(mob) && SSticker.current_state != GAME_STATE_FINISHED)
+		to_chat(src, "<span class='warning'>You cannot currently do that at this time, please wait until the round end or while you are observing.</span>")
+		return
+
 	GLOB.error_cache.show_to_minimal(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Players can now only view runtimes as a ghost, or if the round has finished.

## Why It's Good For The Game

Pre-emptive PR before runtime in clockcult_massive.dm: Line 58.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/180614382-9a88457f-4fcb-4949-a483-489e5af0208b.png)

![image](https://user-images.githubusercontent.com/26465327/180614446-3ccb4bf5-f3f3-4d88-921f-0df7306c3421.png)


## Changelog
:cl:
tweak: You can now only view runtimes as a player if you are a ghost, or the round has ended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
