### PR TITLE
Replaces the door to Robotics with a glass version on Meta Station

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53268,10 +53268,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
 "fXi" = (
-/obj/machinery/door/airlock/research{
-	name = "Robotics Lab";
-	req_access_txt = "29"
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -53294,6 +53290,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/door/airlock/research/glass{
+	name = "Robotics Lab";
+	req_access_txt = "29"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)


### PR DESCRIPTION
## About The Pull Request
This PR replaces the current non-transparent Robotics door with a glass version.

## Why It's Good For The Game

The entrance to Robotics already has two windows on either side; there are no shutters over the windows adjacent to the door, so there is really no reason for the door not to be glass - currently, it only limits the player's field of view with no purpose.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/76962592/180614658-e3cce03e-d186-49eb-a809-7ebd8da99189.png)

</details>

## Changelog
:cl: dokorwueue, dog132
tweak: Meta Station: Replaces the door to Robotics with a glass version
/:cl: