### PR TITLE
Gives wizards pierce protection on their standard robes.

### DIFF
--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/head/wizard
 	name = "wizard hat"
 	desc = "Strange-looking hat-wear that most certainly belongs to a real magic user."
-	clothing_flags = SNUG_FIT
+	clothing_flags = SNUG_FIT | THICKMATERIAL
 	icon_state = "wizard"
 	gas_transfer_coefficient = 0.01 // IT'S MAGICAL OKAY JEEZ +1 TO NOT DIE
 	permeability_coefficient = 0.01
@@ -38,6 +38,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "stamina" = 0)
 	resistance_flags = FLAMMABLE
 	dog_fashion = /datum/dog_fashion/head/blue_wizard
+	clothing_flags = NONE
 
 /obj/item/clothing/head/wizard/marisa
 	name = "witch hat"
@@ -73,6 +74,7 @@
 	strip_delay = 50
 	equip_delay_other = 50
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	clothing_flags = THICKMATERIAL
 
 /obj/item/clothing/suit/wizrobe/red
 	name = "red wizard robe"
@@ -126,6 +128,7 @@
 	permeability_coefficient = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "stamina" = 0)
 	resistance_flags = FLAMMABLE
+	clothing_flags = NONE
 
 /obj/item/clothing/head/wizard/marisa/fake
 	name = "witch hat"
@@ -135,6 +138,7 @@
 	permeability_coefficient = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "stamina" = 0)
 	resistance_flags = FLAMMABLE
+	clothing_flags = NONE
 
 /obj/item/clothing/suit/wizrobe/marisa/fake
 	name = "witch robe"
@@ -145,6 +149,7 @@
 	permeability_coefficient = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "stamina" = 0)
 	resistance_flags = FLAMMABLE
+	clothing_flags = NONE
 
 /obj/item/clothing/suit/wizrobe/paper
 	name = "papier-mache robe" // no non-latin characters!
@@ -153,6 +158,7 @@
 	item_state = "wizard-paper"
 	var/robe_charge = TRUE
 	actions_types = list(/datum/action/item_action/stickmen)
+	clothing_flags = NONE
 
 
 /obj/item/clothing/suit/wizrobe/paper/ui_action_click(mob/user, action)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds pierce protection to wizard robes, meaning they cannot be shot with syringe guns and need to remove their clothing to heal.
Saw chemistry get abused in game against a wizard and it just shouldn't happen.

## Why It's Good For The Game

Wizards being able to be instantly killed by the chemist kind of sucks. In fact, chemists being able to instakill anyone at range with a near uncounterable gun kind of sucks but it would be difficult to get a syringe gun removal in compared to this.
Allows a greater diversification of strategies that the wizard can use without having to account for being instantly killed by something, having a requirement for the wizard to play a certain species at a magic mirror or be required to get something from their shop sucks and limits actual choice and meaningful decisions.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/180643252-9e7c45cc-3ba5-4345-901b-a5b745d2880a.png)

## Changelog
:cl:
balance: Wizards now get pierce protection on their standard robes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
