### PR TITLE
Minor supercruise fixes and objective payout changes.

### DIFF
--- a/code/modules/projectiles/projectile/special/vortex.dm
+++ b/code/modules/projectiles/projectile/special/vortex.dm
@@ -7,7 +7,8 @@
 	nodamage = FALSE
 	flag = "energy"
 	range = 10
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMOB
+	projectile_phasing = ALL
+	projectile_piercing = NONE
 
 /obj/item/projectile/energy/vortex/Range()
 	new /obj/effect/temp_visual/hierophant/blast/vortex(get_turf(src), firer, FALSE)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/vortex_rifle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/vortex_rifle.dm
@@ -4,3 +4,8 @@
 	icon_state = "vortex"
 	item_state = null
 	ammo_type = list(/obj/item/ammo_casing/energy/vortex)
+
+/obj/item/gun/energy/vortex/examine(mob/user)
+	. = ..()
+	if(isabductor(user))
+		. += "<span class='abductor'>This shouldn't be here... It's not from this era...</span>"

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/vortex_rifle.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/loot/vortex_rifle.dm
@@ -8,4 +8,4 @@
 /obj/item/gun/energy/vortex/examine(mob/user)
 	. = ..()
 	if(isabductor(user))
-		. += "<span class='abductor'>This shouldn't be here... It's not from this era...</span>"
+		. += "<span class='abductor'>It has a subspace power core installed.</span>"

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -4,7 +4,7 @@
 	//The blackbox required to recover.
 	var/obj/item/alienartifact/objective/linked_artifact
 	min_payout = 5000
-	max_payout = 20000
+	max_payout = 25000
 
 /datum/orbital_objective/artifact/generate_objective_stuff(turf/chosen_turf)
 	generated = TRUE

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/assassination.dm
@@ -6,8 +6,8 @@
 	var/tank_type = /obj/item/tank/internals/oxygen
 	var/mask_type = /obj/item/clothing/mask/gas
 	var/belt_type = /obj/item/storage/belt/utility/full
-	min_payout = 15000
-	max_payout = 40000
+	min_payout = 10000
+	max_payout = 30000
 
 /datum/orbital_objective/assassination/get_text()
 	return "We have located a hostile agent currently stranded at [station_name]. We need you to send in a team and eliminate the \

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -4,9 +4,8 @@
 	//The blackbox required to recover.
 	var/obj/machinery/nuclearbomb/decomission/nuclear_bomb
 	var/obj/item/disk/nuclear/decommission/nuclear_disk
-	//Relatively easy mission.
-	min_payout = 8000
-	max_payout = 40000
+	min_payout = 6000
+	max_payout = 25000
 
 /datum/orbital_objective/nuclear_bomb/generate_objective_stuff(turf/chosen_turf)
 	generated = TRUE

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
@@ -4,8 +4,8 @@
 	//The blackbox required to recover.
 	var/obj/item/blackbox/objective/linked_blackbox
 	//Relatively easy mission.
-	min_payout = 5000	//1k credits for sci/sec/eng, 500 for ser / civ
-	max_payout = 10000	//2k credits for sci/sec/eng, 1k for serv / civ
+	min_payout = 5000
+	max_payout = 20000
 
 /datum/orbital_objective/recover_blackbox/generate_objective_stuff(turf/chosen_turf)
 	generated = TRUE

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_ratvar.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/generator_settings/generator_ratvar.dm
@@ -1,9 +1,9 @@
-/datum/generator_settings/blob
+/datum/generator_settings/ratvar
 	probability = 2
 	floor_break_prob = 8
 	structure_damage_prob = 6
 
-/datum/generator_settings/blob/get_floortrash()
+/datum/generator_settings/ratvar/get_floortrash()
 	. = list(
 		/obj/effect/decal/cleanable/dirt = 6,
 		/obj/effect/decal/cleanable/blood/old = 3,
@@ -26,14 +26,14 @@
 	for(var/trash in subtypesof(/obj/item/trash))
 		.[trash] = 1
 
-/datum/generator_settings/blob/get_directional_walltrash()
+/datum/generator_settings/ratvar/get_directional_walltrash()
 	return list(
 		/obj/machinery/light/broken = 4,
 		/obj/machinery/light/small = 1,
 		null = 75,
 	)
 
-/datum/generator_settings/blob/get_non_directional_walltrash()
+/datum/generator_settings/ratvar/get_non_directional_walltrash()
 	return list(
 		/obj/item/radio/intercom = 2,
 		/obj/structure/sign/poster/random = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some minor changes to supercruise that wasn't worth including in the major update.

 - Objective payouts have been changed. Their ranges now all intersect, making it not just the same assassination mission that will have the best payout.
 - Vortex rifle has been fixed.
 - Blob ruin generator has been fixed.

## Why It's Good For The Game

Fixes some bugs, better payouts.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/180659446-feee7da4-474c-4cee-b692-de59b6c5dc2c.png)

![image](https://user-images.githubusercontent.com/26465327/180659451-7446165b-0461-46e0-90e3-c0d20e479b1a.png)

![image](https://user-images.githubusercontent.com/26465327/180659474-abfb0520-2e3f-4817-a472-09253def55ae.png)


## Changelog
:cl:
fix: Vortex rifles can now damage mobs
fix: Blob ruin generator has been fixed
tweak: Objective payout ranges have been adjusted to always intersect with each other.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
