### PR TITLE
Nuke ops now get an extra 10 minutes before the shuttle can be called.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,7 @@
 #define CHALLENGE_TELECRYSTALS 280
-#define CHALLENGE_TIME_LIMIT 3000
+#define CHALLENGE_TIME_LIMIT 5 MINUTES
 #define CHALLENGE_MIN_PLAYERS 50
-#define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+#define CHALLENGE_SHUTTLE_DELAY 35 MINUTES	//35 minutes, giving nukies at least 20 minutes to enact their assault.
 
 /obj/item/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -48,6 +48,9 @@
 	if(!check_allowed(user) || !war_declaration)
 		return
 
+	declare_war()
+
+/obj/item/nuclear_challenge/proc/declare_war()
 	priority_announce(war_declaration, "Declaration of War", 'sound/machines/alarm.ogg',  has_important_message = TRUE)
 
 	play_soundtrack_music(/datum/soundtrack_song/bee/future_perception)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -48,14 +48,15 @@
 	if(!check_allowed(user) || !war_declaration)
 		return
 
-	declare_war()
+	declare_war(user, war_declaration)
 
-/obj/item/nuclear_challenge/proc/declare_war()
+/obj/item/nuclear_challenge/proc/declare_war(mob/user, war_declaration)
 	priority_announce(war_declaration, "Declaration of War", 'sound/machines/alarm.ogg',  has_important_message = TRUE)
 
 	play_soundtrack_music(/datum/soundtrack_song/bee/future_perception)
 
-	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
+	if(user)
+		to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
 	for(var/V in GLOB.syndicate_shuttle_boards)
 		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
@@ -84,8 +85,9 @@
 		uplink.telecrystals += tc_per_nukie
 		tc_to_distribute -= tc_per_nukie
 
+
 	for (var/mob/living/L in orphans)
-		var/TC = new /obj/item/stack/telecrystal(user.drop_location(), tc_per_nukie)
+		var/TC = new /obj/item/stack/telecrystal(L.drop_location(), tc_per_nukie)
 		to_chat(L, "<span class='warning'>Your uplink could not be found so your share of the team's bonus telecrystals has been bluespaced to your [L.put_in_hands(TC) ? "hands" : "feet"].</span>")
 		tc_to_distribute -= tc_per_nukie
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increases the timer in which the shuttle is callable during war-ops from 5 minutes to 15 minutes.
Also converts the part that does war to its own proc, so that admins can force war if they need.

## Why It's Good For The Game

Despite being much more fun to deal with the threats, the optimal strategy in SS13 is often to attempt to flee the threat entirely and not have to deal with it.
This increases the shuttle time during war-ops by an extra 10 minutes, forcing the crew to deal with the nukies and have to survive a non-trivial amount of time in order to escape.
10 minutes isn't enough time to have a proper assault take place on the station and almost requires the strategy of getting speed boosts and going straight for the captain.
This gives more time to perform indirect actions, such as bombing critical parts of the station and disabling important infrastructure in preperation of taking down the captain and getting the disk.
Forces players to deal with the extreme threat posed to the station which is more fun than avoiding it entirely. Since nuclear operatives is more a war of attrition, which the nukies wearing down the station as they attempt to reach the captain, this still gives the crew a chance to escape the station (as oppossed to just declaring a hostile environment until the nukies are dead). If you want to survive, you better have some good defenses to hold the nukies off for longer than 5 minutes.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/180659997-8579fd1f-8b69-4d86-89cc-6e7d10036fb6.png)

Kind of hard to test alone :^) Seems to work fine still

## Changelog
:cl:
balance: War-op shuttle call timer has been increased from 5 minutes to 15 minutes.
fix: Fixes TC being dropped to the declarer of war if you do not have an uplink.
:/cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
