### PR TITLE
Adds in generic UI style

### DIFF
--- a/tgui/packages/tgui/index.js
+++ b/tgui/packages/tgui/index.js
@@ -14,6 +14,7 @@ import './styles/themes/hackerman.scss';
 import './styles/themes/malfunction.scss';
 import './styles/themes/neutral.scss';
 import './styles/themes/ntos.scss';
+import './styles/themes/generic.scss';
 import './styles/themes/paper.scss';
 import './styles/themes/retro.scss';
 import './styles/themes/syndicate.scss';

--- a/tgui/packages/tgui/interfaces/Achievements.js
+++ b/tgui/packages/tgui/interfaces/Achievements.js
@@ -13,6 +13,7 @@ export const Achievements = (props, context) => {
     .filter(x => x.category === selectedCategory);
   return (
     <Window
+      theme="generic"
       title="Achievements"
       width={540}
       height={680}>

--- a/tgui/packages/tgui/interfaces/AdminSecretsPanel.js
+++ b/tgui/packages/tgui/interfaces/AdminSecretsPanel.js
@@ -102,6 +102,7 @@ export const AdminSecretsPanel = (props, context) => {
 
   return (
     <Window
+      theme="admin"
       width={720}
       height={480}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/CellularEmporium.js
+++ b/tgui/packages/tgui/interfaces/CellularEmporium.js
@@ -7,6 +7,7 @@ export const CellularEmporium = (props, context) => {
   const { abilities } = data;
   return (
     <Window
+      theme="generic"
       width={900}
       height={480}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher.js
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher.js
@@ -23,6 +23,7 @@ export const CentcomPodLauncher = (props, context) => {
   return (
     <Window
       key={'CPL_' + compact}
+      theme="admin"
       title={compact
         ? "Use against Helen Weinstein"
         : "Supply Pod Menu (Use against Helen Weinstein)"}

--- a/tgui/packages/tgui/interfaces/CodexGigas.js
+++ b/tgui/packages/tgui/interfaces/CodexGigas.js
@@ -53,6 +53,7 @@ export const CodexGigas = (props, context) => {
   const { act, data } = useBackend(context);
   return (
     <Window
+      theme="generic"
       width={450}
       height={450}>
       <Window.Content>

--- a/tgui/packages/tgui/interfaces/EightBallVote.js
+++ b/tgui/packages/tgui/interfaces/EightBallVote.js
@@ -10,6 +10,7 @@ export const EightBallVote = (props, context) => {
   } = data;
   return (
     <Window
+      theme="generic"
       width={400}
       height={600}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/EngravedMessage.js
+++ b/tgui/packages/tgui/interfaces/EngravedMessage.js
@@ -19,6 +19,7 @@ export const EngravedMessage = (props, context) => {
   } = data;
   return (
     <Window
+      theme="generic"
       width={600}
       height={300}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/FishCatalog.js
+++ b/tgui/packages/tgui/interfaces/FishCatalog.js
@@ -21,6 +21,7 @@ export const FishCatalog = (props, context) => {
   ] = useLocalState(context, 'currentFish', null);
   return (
     <Window
+      theme="generic"
       width={500}
       height={300}
       resizable>

--- a/tgui/packages/tgui/interfaces/ForbiddenLore.js
+++ b/tgui/packages/tgui/interfaces/ForbiddenLore.js
@@ -19,6 +19,7 @@ export const ForbiddenLore = (props, context) => {
 
   return (
     <Window
+      theme="generic"
       width={500}
       height={900}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/GhostPoolProtection.js
+++ b/tgui/packages/tgui/interfaces/GhostPoolProtection.js
@@ -13,6 +13,7 @@ export const GhostPoolProtection = (props, context) => {
   } = data;
   return (
     <Window
+      theme="admin"
       title="Ghost Pool Protection"
       width={400}
       height={285}>

--- a/tgui/packages/tgui/interfaces/Guardian.js
+++ b/tgui/packages/tgui/interfaces/Guardian.js
@@ -8,6 +8,7 @@ export const Guardian = (props, context) => {
   const [tab, setTab] = useLocalState(context, 'tab', 'general');
   return (
     <Window
+      theme="generic"
       width={580}
       height={600}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/Interview.js
+++ b/tgui/packages/tgui/interfaces/Interview.js
@@ -29,6 +29,7 @@ export const Interview = (props, context) => {
 
   return (
     <Window
+      theme="generic"
       width={500}
       height={600}
       noClose={!is_admin}>

--- a/tgui/packages/tgui/interfaces/InterviewManager.js
+++ b/tgui/packages/tgui/interfaces/InterviewManager.js
@@ -22,6 +22,7 @@ export const InterviewManager = (props, context) => {
 
   return (
     <Window
+      theme="admin"
       width={500}
       height={600}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/LanguageMenu.js
+++ b/tgui/packages/tgui/interfaces/LanguageMenu.js
@@ -13,6 +13,7 @@ export const LanguageMenu = (props, context) => {
   } = data;
   return (
     <Window
+      theme="generic"
       width={700}
       height={600}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/NotificationPreferences.js
+++ b/tgui/packages/tgui/interfaces/NotificationPreferences.js
@@ -20,6 +20,7 @@ export const NotificationPreferences = (props, context) => {
 
   return (
     <Window
+      theme="generic"
       width={270}
       height={360}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.js
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.js
@@ -58,6 +58,7 @@ export const PersonalCrafting = (props, context) => {
     .filter(recipe => recipe.category === tab);
   return (
     <Window
+      theme="generic"
       title="Crafting Menu"
       width={700}
       height={800}>

--- a/tgui/packages/tgui/interfaces/ReligiousTool.js
+++ b/tgui/packages/tgui/interfaces/ReligiousTool.js
@@ -13,7 +13,11 @@ export const ReligiousTool = (props, context) => {
   const [tab, setTab] = useSharedState(context, 'tab', 1);
   const { sects, alignment, toolname } = data;
   return (
-    <Window title={toolname} width={560} height={500}>
+    <Window
+      theme="generic"
+      title={toolname}
+      width={560}
+      height={500}>
       <Window.Content scrollable>
         <Stack vertical fill>
           <Stack.Item>

--- a/tgui/packages/tgui/interfaces/SlimeBodySwapper.js
+++ b/tgui/packages/tgui/interfaces/SlimeBodySwapper.js
@@ -60,6 +60,7 @@ export const SlimeBodySwapper = (props, context) => {
 
   return (
     <Window
+      theme="generic"
       width={400}
       height={400}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/SpawnersMenu.js
+++ b/tgui/packages/tgui/interfaces/SpawnersMenu.js
@@ -7,6 +7,7 @@ export const SpawnersMenu = (props, context) => {
   const spawners = data.spawners || [];
   return (
     <Window
+      theme="generic"
       width={700}
       height={600}>
       <Window.Content scrollable>

--- a/tgui/packages/tgui/interfaces/Vote.js
+++ b/tgui/packages/tgui/interfaces/Vote.js
@@ -16,6 +16,7 @@ export const Vote = (props, context) => {
 
   return (
     <Window
+      theme="generic"
       title={`Vote${
         mode
           ? `: ${

--- a/tgui/packages/tgui/styles/themes/generic.scss
+++ b/tgui/packages/tgui/styles/themes/generic.scss
@@ -1,7 +1,8 @@
 @use 'sass:color';
 @use 'sass:meta';
 
-$generic: #6d697a;
+$generic: #484455;
+$accent: #6a70ad;
 
 @use '../colors.scss' with (
   $fg-map-keys: (),
@@ -12,14 +13,14 @@ $generic: #6d697a;
   $border-radius: 2px,
 );
 
-.theme-admin {
+.theme-generic {
   // Components
   @include meta.load-css('../components/Button.scss', $with: (
-    'color-default': color.scale($generic, $lightness: -40%),
+    'color-default': $accent,
     'color-transparent-text': rgba(227, 240, 255, 0.75),
   ));
   @include meta.load-css('../components/ProgressBar.scss', $with: (
-    'color-default-fill': $generic,
+    'color-default-fill': $accent,
     'background-color': rgba(0, 0, 0, 0.5),
   ));
   @include meta.load-css('../components/Section.scss');

--- a/tgui/packages/tgui/styles/themes/generic.scss
+++ b/tgui/packages/tgui/styles/themes/generic.scss
@@ -2,7 +2,7 @@
 @use 'sass:meta';
 
 $generic: #484455;
-$accent: #6a70ad;
+$accent: #4f56a5;
 
 @use '../colors.scss' with (
   $fg-map-keys: (),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a generic UI style, for user interfaces that aren't nanotrasen computers.
The cellular emporium will no longer be brandished with the beautiful nanotrasen N.

## Why It's Good For The Game

A new unique theme to distinguish non-world UI objects.
Better clarity between what is IC and OOC.
No more Nanotrasen N on the vote panel.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/180662510-cf52ebad-ebe9-4f12-ba91-c33e06911648.png)

![image](https://user-images.githubusercontent.com/26465327/180662529-5b865d97-ae01-4235-abac-80f315b76025.png)

![image](https://user-images.githubusercontent.com/26465327/180662537-323e5dea-befa-43b1-8a4b-10f87f792ce7.png)

![image](https://user-images.githubusercontent.com/26465327/180662560-9298b5fc-208f-4374-8b64-c44531d4a7a0.png)

## Changelog
:cl:
add: Adds in a new UI style for non-world UIs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
