### PR TITLE
mainly making a concept - Your mind remembers your original species

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -376,6 +376,8 @@ GLOBAL_LIST_EMPTY(species_list)
 		var/mob/living/carbon/human/H = A
 		if(H.dna && istype(H.dna.species, species_datum))
 			. = TRUE
+	if(ispath(A, species_datum))
+		. = TRUE
 
 /proc/spawn_atom_to_turf(spawn_type, target, amount, admin_spawn=FALSE, list/extra_args)
 	var/turf/T = get_turf(target)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -40,6 +40,7 @@
 
 	var/assigned_role
 	var/special_role
+	var/roundstart_species // this is your origin, regardless of your 'currently mutated' species
 	var/list/restricted_roles = list()
 
 	var/list/spell_list = list() // Wizard mode & "Give Spell" badmin button.

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -40,7 +40,7 @@
 
 	var/assigned_role
 	var/special_role
-	var/roundstart_species // this is your origin, regardless of your 'currently mutated' species
+	var/roundstart_species	// this is your origin, regardless of your 'currently mutated' species.
 	var/list/restricted_roles = list()
 
 	var/list/spell_list = list() // Wizard mode & "Give Spell" badmin button.

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -302,6 +302,7 @@
 	if(length(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		H.key = C.key
+		H.mind.roundstart_species = H.dna.species.type
 		log_game("[key_name(C)] became [H.real_name]'s experimental clone.")
 		message_admins("[key_name_admin(C)] became [H.real_name]'s experimental clone.")
 		to_chat(H, "<span class='warning'>You will instantly die if you do 'ghost'. Please stand by until the cloning is done.</span>")

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -396,8 +396,8 @@
 	name = "empty scroll"
 	icon_state = "blankscroll"
 
-/obj/item/book/granter/martial/tribal_claw/already_known(mob/user)
-	if(islizard(user))
+/obj/item/book/granter/martial/tribal_claw/already_known(mob/living/carbon/user)
+	if(islizard(user) && islizard(user?.mind?.roundstart_species)) // only true lizard mind can read this
 		return FALSE
 	else
 		to_chat(user, "<span class='warning'>You try to read the scroll but can't comprehend any of it.</span>")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -516,6 +516,8 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		H.equipOutfit(dresscode)
 
 	H.regenerate_icons()
+	if(H.mind)
+		H.mind.roundstart_species = H.dna.species.type
 
 	log_admin("[key_name(usr)] changed the equipment of [key_name(H)] to [dresscode].")
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] changed the equipment of [ADMIN_LOOKUPFLW(H)] to [dresscode].</span>")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -286,7 +286,7 @@
 	message_admins("[key_name_admin(usr)] has [muteunmute] [key_name_admin(whom)] from [mute_string].")
 	if(C)
 		to_chat(C, "You have been [muteunmute] from [mute_string] by [key_name(usr, include_name = FALSE)].")
-	
+
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Mute [feedback_string]", "[P.muted & mute_type]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -133,6 +133,11 @@
 	if(!permanent && !uses)
 		qdel(src)
 
+	if(M.mind)
+		M.mind.roundstart_species = mob_type
+
+	return M
+
 // Base version - place these on maps/templates.
 /obj/effect/mob_spawn/human
 	mob_type = /mob/living/carbon/human
@@ -179,6 +184,11 @@
 	if(!outfit)
 		outfit = new /datum/outfit
 	return ..()
+
+/obj/effect/mob_spawn/human/create(ckey, name)
+	var/mob/living/M = ..()
+	if(M.mind)
+		M.mind.roundstart_species = mob_type || mob_species
 
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -219,6 +219,9 @@
 		announce(H)
 	dormant_disease_check(H)
 
+	if(H.mind)
+		H.mind.roundstart_species = H.dna.species.type
+
 /datum/job/proc/get_access()
 	if(!config)	//Needed for robots.
 		return src.minimal_access.Copy()
@@ -321,19 +324,19 @@
 	if(!J)
 		J = SSjob.GetJob(H.job)
 
-	var/obj/item/card/id/C = H.wear_id
-	if(istype(C))
-		C.access = J.get_access()
-		shuffle_inplace(C.access) // Shuffle access list to make NTNet passkeys less predictable
-		C.registered_name = H.real_name
-		C.assignment = J.title
-		C.set_hud_icon_on_spawn(J.title)
-		C.update_label()
+	var/obj/item/card/id/I = H.wear_id
+	if(istype(I))
+		I.access = J.get_access()
+		shuffle_inplace(I.access) // Shuffle access list to make NTNet passkeys less predictable
+		I.registered_name = H.real_name
+		I.assignment = J.title
+		I.set_hud_icon_on_spawn(J.title)
+		I.update_label()
 		for(var/A in SSeconomy.bank_accounts)
 			var/datum/bank_account/B = A
 			if(B.account_id == H.account_id)
-				C.registered_account = B
-				B.bank_cards += C
+				I.registered_account = B
+				B.bank_cards += I
 				break
 		H.sec_hud_set_ID()
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -459,8 +459,8 @@
 		if(transfer_after)
 			mind.late_joiner = TRUE
 		mind.active = 0					//we wish to transfer the key manually
-		mind.transfer_to(H)					//won't transfer key since the mind is not active
-
+		mind.transfer_to(H)				//won't transfer key since the mind is not active
+		mind.roundstart_species = H.type  //remembers their real species as path.
 	H.name = real_name
 
 	. = H

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -460,7 +460,6 @@
 			mind.late_joiner = TRUE
 		mind.active = 0					//we wish to transfer the key manually
 		mind.transfer_to(H)				//won't transfer key since the mind is not active
-		mind.roundstart_species = H.type  //remembers their real species as path.
 	H.name = real_name
 
 	. = H

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -260,6 +260,9 @@
 	if(!O)
 		return 0
 
+	if(mind) // It's not good to put this here, but doing it here is quite optimised.
+		mind.roundstart_species = dna.species.type
+
 	return O.equip(src, visualsOnly)
 
 //delete all equipment without dropping anything

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -504,8 +504,10 @@
 		var/mob/dead/observer/C = pick(candidates)
 		to_chat(M, "Your mob has been taken over by a ghost!")
 		message_admins("[key_name_admin(C)] has taken control of ([ADMIN_LOOKUPFLW(M)])")
+		var/species_store = M.mind.roundstart_species
 		M.ghostize(0)
 		M.key = C.key
+		M?.mind.roundstart_species = species_store
 		return TRUE
 	else
 		to_chat(M, "There were no ghosts willing to take control.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
New variable to Mind that stores roundstart species of a person.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
some system is based on your current species, not your real origin species.
for example, if you become ashwalker somehow, you lose your galactic common and get draconic even if you're a human.
in this PR, it didn't change a lot, and mainly refactored to access their original species mind simply 

ID card var renaming refactor was done accidentally.


Q. Shouldn't it be fine to store it into a variable in mob?
A. No. If your brain is replaced into somewhere, your roundstart species will be changed. It MUST be stored in mind.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/180661818-ce6bbdf7-bfc2-4931-af98-b4a326646da8.png)

ghost spawning is fine

-------------

![image](https://user-images.githubusercontent.com/87972842/180662550-9222fd1d-02d5-4084-b0ca-c4e3a49f4656.png)

roundstart spawning is fine

-----------

![image](https://user-images.githubusercontent.com/87972842/180662660-f40093bf-ae8a-4577-b3e1-ec4e3a719ef5.png)

latejoin spawning is fine

--------

![image](https://user-images.githubusercontent.com/87972842/180664392-8ccf36d1-67bb-4a9b-8545-d049bbcc4bba.png)

when you admin spawn (*force humanize)

-----------

![image](https://user-images.githubusercontent.com/87972842/180662744-ac5bd7eb-5dce-460e-a47e-e4a2edfb9e87.png)

tribal scroll is fine

![image](https://user-images.githubusercontent.com/87972842/180662757-35779af4-2d08-4f85-b3fd-71039aaf3b25.png)

if you change 'roundstart_species` var into not lizard, they can't read tribal scroll



</details>

## Changelog
:cl:
refactor: changed capital C into capital I at id card variable in spawning code
refactor: "is_species" proc can accept type paths too.
refactor: New mind variable "roundstart_species" to remember the real origin you were. Spawning sets your mind species.
tweak: To read Old Tribal Scroll (lizard martial arts), your roundstart species should be lizardperson as well. You can't cheat your origin anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
