### PR TITLE
PDA rejects a broken chameleon ID + Debug outfit now has a full radio channels

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -969,7 +969,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	else if(istype(C, /obj/item/card/id))
 		var/obj/item/card/id/idcard = C
-		if(!idcard.registered_name)
+		if(!idcard.registered_name || istype(idcard, /obj/item/card/id/syndicate/broken)) // also rejects a broken chameleon
 			to_chat(user, "<span class='warning'>\The [src] rejects the ID!</span>")
 			if(!silent)
 				playsound(src, 'sound/machines/terminal_error.ogg', 50, TRUE)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -10,7 +10,9 @@
 	suit_store = /obj/item/tank/internals/oxygen
 	internals_slot = ITEM_SLOT_SUITSTORE
 	glasses = /obj/item/clothing/glasses/hud/debug
-	ears = /obj/item/radio/headset/headset_cent/commander
+	ears = /obj/item/radio/headset/headset_cent/alt{
+		keyslot = new /obj/item/encryptionkey/debug
+	}
 	box = /obj/item/storage/box/debugtools
 	back = /obj/item/storage/backpack/holding
 	backpack_contents = list(/obj/item/gun/magic/wand/resurrection/debug=1,\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
a minor fix and a minor QoL
* PDA rejects a broken chameleon ID
* Debug outfit now has full radio channels
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
broken chameleon id in PDA is actually functional a little bit - you can fixate a hud and a job status. It wasn't intentional, the fix was made by rejecting the card rather than updating PDA every time.
and a minor QoL for admins.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![image](https://user-images.githubusercontent.com/87972842/180872416-722e5d96-4051-4962-8c44-ab96741c16e3.png)

centcom headset


![image](https://user-images.githubusercontent.com/87972842/180872648-206a0690-b420-46a6-8610-693ae3e5286c.png)

no to broken id card. it's still fine with functional cards.

</details>

## Changelog
:cl:
tweak: Admin debug outfit now has full radio channels
tweak: PDA no longer accepts a broken chameleon agent card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
