### PR TITLE
Balances crew monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -1,5 +1,5 @@
 /// How often the sensor data updates.
-#define SENSORS_UPDATE_PERIOD 10 SECONDS
+#define SENSORS_UPDATE_PERIOD 1 MINUTES
 
 /// The job sorting ID associated with otherwise unknown jobs
 #define UNKNOWN_JOB_ID	81


### PR DESCRIPTION
## About The Pull Request

Very simple PR, ups the refresh time for the crew monitor from 10 seconds to 60 seconds.

## Why It's Good For The Game

Crewmonitor has been used to validhunt for ages. If you time yourself between refresh updates, you get only 10 seconds to either EMP your victim/remove its jumpsuit. But on average you only have 5 seconds, this is really not enough for most antags.
On the other hand, you have people like EMTs, doctors, AI, warden who watch the monitor constantly and can almost pinpoint wherabouts of a murder, making it incredibly easy for sec to just curbstomp antags. 

So what this PR does: makes EMT validhunters blind most of the time, makes AI and sec unable to just pinpoint where murder is happening without eyes on site. Basically makes the game better for antags, and by extension for everyone.

## Testing Photographs and Procedure


https://user-images.githubusercontent.com/29757616/180879299-02258822-b1cc-4049-8ea0-edbd653d552b.mp4

Time between updates is roughly time between triggered breakpoints.
</details>

## Changelog
:cl: Mat05usz
balance: Refresh rate for crew monitor goes up from 10 seconds to 60 seconds
/:cl: