### PR TITLE
nerfs meme-induced lag

### DIFF
--- a/code/datums/diseases/advance/symptoms/meme.dm
+++ b/code/datums/diseases/advance/symptoms/meme.dm
@@ -37,14 +37,14 @@
 	var/mob/living/carbon/M = A.affected_mob
 	if(prob(20 * A.stage) && !M.stat && !HAS_TRAIT(M, TRAIT_MINDSHIELD))
 		M.emote(emote)
-		if(A.stage >= 5)
-			for(var/mob/living/carbon/C in oviewers(M, 7))
+		if(A.stage >= 5 && prob(20))
+			for(var/mob/living/carbon/C in oviewers(M, 4))
 				var/obj/item/organ/eyes/eyes = C.getorganslot(ORGAN_SLOT_EYES)
 				if(!eyes || HAS_TRAIT(C, TRAIT_BLIND) || HAS_TRAIT(C, TRAIT_MINDSHIELD) || istype(C.get_item_by_slot(ITEM_SLOT_HEAD), /obj/item/clothing/head/foilhat))
 					continue
 				for(var/datum/disease/advance/D in C.diseases)
 					if(D.GetDiseaseID() == A.GetDiseaseID())
-						C.emote(emote)
+						continue
 				if(A.transmission >= 14)
 					if(C.ForceContractDisease(A))
 						C.emote(emote)

--- a/code/datums/diseases/advance/symptoms/meme.dm
+++ b/code/datums/diseases/advance/symptoms/meme.dm
@@ -42,9 +42,6 @@
 				var/obj/item/organ/eyes/eyes = C.getorganslot(ORGAN_SLOT_EYES)
 				if(!eyes || HAS_TRAIT(C, TRAIT_BLIND) || HAS_TRAIT(C, TRAIT_MINDSHIELD) || istype(C.get_item_by_slot(ITEM_SLOT_HEAD), /obj/item/clothing/head/foilhat))
 					continue
-				for(var/datum/disease/advance/D in C.diseases)
-					if(D.GetDiseaseID() == A.GetDiseaseID())
-						continue
 				if(A.transmission >= 14)
 					if(C.ForceContractDisease(A))
 						C.emote(emote)

--- a/code/datums/diseases/advance/symptoms/meme.dm
+++ b/code/datums/diseases/advance/symptoms/meme.dm
@@ -37,11 +37,10 @@
 	var/mob/living/carbon/M = A.affected_mob
 	if(prob(20 * A.stage) && !M.stat && !HAS_TRAIT(M, TRAIT_MINDSHIELD))
 		M.emote(emote)
-		if(A.stage >= 5 && prob(20))
+		if(A.stage >= 5 && prob(20) && A.transmission >= 14)
 			for(var/mob/living/carbon/C in oviewers(M, 4))
 				var/obj/item/organ/eyes/eyes = C.getorganslot(ORGAN_SLOT_EYES)
 				if(!eyes || HAS_TRAIT(C, TRAIT_BLIND) || HAS_TRAIT(C, TRAIT_MINDSHIELD) || istype(C.get_item_by_slot(ITEM_SLOT_HEAD), /obj/item/clothing/head/foilhat))
 					continue
-				if(A.transmission >= 14)
-					if(C.ForceContractDisease(A))
-						C.emote(emote)
+				if(C.ForceContractDisease(A))
+					C.emote(emote)


### PR DESCRIPTION

## About The Pull Request
massively reduces the distance in which the hysteria symptom effects other mobs, reduces the frequency with which it does so, and it no longer makes other infectees emote

## Why It's Good For The Game
lag fixes

## Testing Photographs and Procedure
-spawn a shitload of monkeys
-show them a funny meme
-no lag
![image](https://user-images.githubusercontent.com/49600480/180916676-6804ca58-23f0-4ae6-b122-b390dc71de47.png)


## Changelog
:cl:
tweak: the hysteria symptom has been toned down to avoid lag
/:cl:

