### PR TITLE
fixes an ancient viro exploit

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -12,8 +12,7 @@
 	symptom_delay_min = 1
 	symptom_delay_max = 1
 	var/passive_message = "" //random message to infected but not actively healing people
-	threshold_desc = "<b>Stage Speed 6:</b> Doubles healing speed.<br>\
-					  <b>Stealth 4:</b> Healing will no longer be visible to onlookers."
+	threshold_desc = "<b>Stealth 4:</b> Healing will no longer be visible to onlookers."
 
 /datum/symptom/heal/Start(datum/disease/advance/A)
 	if(!..())

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -18,8 +18,6 @@
 /datum/symptom/heal/Start(datum/disease/advance/A)
 	if(!..())
 		return FALSE
-	if(A.stage_rate >= 6) //stronger healing
-		power = 2
 	return TRUE //For super calls of subclasses
 
 /datum/symptom/heal/Activate(datum/disease/advance/A)


### PR DESCRIPTION
## About The Pull Request
regenerative coma and superficial healing had a weird threshold inherited from a parent that changed their effects at 6 speed, which has been removed

## Why It's Good For The Game
obviously not intended, given regenerative coma has a stage speed 8 threshold that lowers power back to 1.5, and superficial healing has a stage speed 8 threshold that does the same thing as the hidden one, with more stat reqs. also, i added the latter, and didnt intend for this

## Testing Photographs and Procedure
![image](https://user-images.githubusercontent.com/49600480/180926544-0695a0d8-8a61-4c90-90ba-e65aa666f924.png)

## Changelog
:cl:
fix: fixes an exploit involving superficial healing and regen coma
balance: superficial healing and regen coma no longer have an undocumented stage speed six threshold that doubles healing
/:cl:

