### PR TITLE
Improves the ahelp resolution message

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -615,9 +615,15 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		discordsendmsg("ahelp", "Ticket #[id] closed by [key_name(usr, include_link=0)]")
 
 //Mark open ticket as resolved/legitimate, returns ahelp verb
-/datum/admin_help/proc/Resolve(key_name = key_name_admin(usr), silent = FALSE)
+/datum/admin_help/proc/Resolve(key_name = key_name_admin(usr), silent = FALSE, status = "Resolved", message = null)
 	if(state > AHELP_ACTIVE)
 		return
+
+	var/final_output = "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp [status]</b></span><br />"
+	final_output += message || "An administrator has handled your ticket. If your ticket was a report, then the appropriate action has been taken where necessary.<br />\
+		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />\"
+	final_output += "Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>
+
 	RemoveActive()
 	state = AHELP_RESOLVED
 	GLOB.ahelp_tickets.ListInsert(src)
@@ -625,10 +631,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 50)
 
 	AddInteraction("green", "Resolved by [key_name].")
-	to_chat(initiator, "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp Resolved</b></span><br />\
-	An administrator has handled your ticket and has taken the appropriate action, if required.<br />\
-	Thank you for creating a ticket, your adminhelp verb will be returned shortly.<br />\
-	Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>")
+	to_chat(initiator, final_output)
 	if(!silent)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "resolved")
 		var/msg = "Ticket [TicketHref("#[id]")] resolved by [key_name]"
@@ -648,9 +651,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 		SEND_SOUND(initiator, sound('sound/effects/adminhelp.ogg'))
 
-		to_chat(initiator, "<font color='red' size='4'><b>- AdminHelp Rejected! -</b></font>")
-		to_chat(initiator, "<font color='red'><b>The administrators could not resolve your ticket.</b> The adminhelp verb has been returned to you so that you may try again.</font>")
-		to_chat(initiator, "Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting.")
+		to_chat(initiator, "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp Rejected</b></span><br/>\
+			<b>The administrators could not resolve your ticket.</b> The adminhelp verb has been returned to you so that you may try again.<br/>\
+			Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting.<br/>\
+			Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>")
 
 	SSblackbox.record_feedback("tally", "ahelp_stats", 1, "rejected")
 	var/msg = "Ticket [TicketHref("#[id]")] rejected by [key_name]"
@@ -667,18 +671,17 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(state > AHELP_ACTIVE)
 		return
 
-	var/msg = "<font color='red' size='4'><b>- AdminHelp marked as IC issue! -</b></font><br>"
-	msg += "<font color='red'>Your issue has been determined by an administrator to be an in character issue and does NOT require administrator intervention at this time. For further resolution you should pursue options that are in character.</font><br>"
-
-	if(initiator)
-		to_chat(initiator, msg)
-
 	SSblackbox.record_feedback("tally", "ahelp_stats", 1, "IC")
 	msg = "Ticket [TicketHref("#[id]")] marked as IC by [key_name]"
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("red", "Marked as IC issue by [key_name]")
-	Resolve(silent = TRUE)
+	Resolve(
+		silent = TRUE,
+		status = "Resolved - IC Issue",
+		message = "An administrator has handled your ticket and has determined that the issue you are facing is an in-character issue and does not require administrator intervention at this time.<br />\
+		For further resolution, you should pursue options that are in character, such as filing a report with security or a head of staff.<br>\
+		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />\")
 
 	if(!bwoink)
 		discordsendmsg("ahelp", "Ticket #[id] marked as IC by [key_name(usr, include_link=0)]")
@@ -692,8 +695,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 		SEND_SOUND(initiator, sound('sound/effects/adminhelp.ogg'))
 
-		to_chat(initiator, "<font color='red' size='4'><b>- AdminHelp Rejected! -</b></font>")
-		to_chat(initiator, "<font color='red'>This question may regard <b>game mechanics or how-tos</b>. Such questions should be asked with <b>Mentorhelp</b>.</font>")
+		to_chat(initiator, "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp Rejected</b></span><br/>\
+			This question may regard <b>game mechanics or how-tos</b>. Such questions should be asked with <b>Mentorhelp</b><br/>\
+			Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>")
 
 	SSblackbox.record_feedback("tally", "ahelp_stats", 1, "mhelp this")
 	var/msg = "Ticket [TicketHref("#[id]")] told to mentorhelp by [key_name]"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -672,7 +672,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		return
 
 	SSblackbox.record_feedback("tally", "ahelp_stats", 1, "IC")
-	msg = "Ticket [TicketHref("#[id]")] marked as IC by [key_name]"
+	var/msg = "Ticket [TicketHref("#[id]")] marked as IC by [key_name]"
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("red", "Marked as IC issue by [key_name]")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -621,7 +621,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	var/final_output = "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp [status]</b></span><br />"
 	final_output += message || "An administrator has handled your ticket. If your ticket was a report, then the appropriate action has been taken where necessary.<br />\
-		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />\"
+		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />"
 	final_output += "Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>
 
 	RemoveActive()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -619,7 +619,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(state > AHELP_ACTIVE)
 		return
 
-	var/final_output = "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp [status]</b></span><br />"
+	var/final_output = "<span class='adminhelp_conclusion'><span class='big'><b>Adminhelp [status]</b></span><br />"
 	final_output += message || "An administrator has handled your ticket. If your ticket was a report, then the appropriate action has been taken where necessary.<br />\
 		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />"
 	final_output += "Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>"
@@ -651,7 +651,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 		SEND_SOUND(initiator, sound('sound/effects/adminhelp.ogg'))
 
-		to_chat(initiator, "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp Rejected</b></span><br/>\
+		to_chat(initiator, "<span class='adminhelp_conclusion'><span class='big'><b>Adminhelp Rejected</b></span><br/>\
 			<b>The administrators could not resolve your ticket.</b> The adminhelp verb has been returned to you so that you may try again.<br/>\
 			Please try to be calm, clear, and descriptive in admin helps, do not assume the admin has seen any related events, and clearly state the names of anybody you are reporting.<br/>\
 			Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>")
@@ -695,7 +695,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 		SEND_SOUND(initiator, sound('sound/effects/adminhelp.ogg'))
 
-		to_chat(initiator, "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp Rejected</b></span><br/>\
+		to_chat(initiator, "<span class='adminhelp_conclusion'><span class='big'><b>Adminhelp Rejected</b></span><br/>\
 			This question may regard <b>game mechanics or how-tos</b>. Such questions should be asked with <b>Mentorhelp</b><br/>\
 			Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>")
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -622,7 +622,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/final_output = "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp [status]</b></span><br />"
 	final_output += message || "An administrator has handled your ticket. If your ticket was a report, then the appropriate action has been taken where necessary.<br />\
 		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />"
-	final_output += "Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>
+	final_output += "Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>"
 
 	RemoveActive()
 	state = AHELP_RESOLVED

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -681,7 +681,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		status = "Resolved - IC Issue",
 		message = "An administrator has handled your ticket and has determined that the issue you are facing is an in-character issue and does not require administrator intervention at this time.<br />\
 		For further resolution, you should pursue options that are in character, such as filing a report with security or a head of staff.<br>\
-		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />\")
+		Thank you for creating a ticket, the adminhelp verb will be returned to you shortly.<br />")
 
 	if(!bwoink)
 		discordsendmsg("ahelp", "Ticket #[id] marked as IC by [key_name(usr, include_link=0)]")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -625,7 +625,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 50)
 
 	AddInteraction("green", "Resolved by [key_name].")
-	to_chat(initiator, "<span class='adminhelp'>Your ticket has been resolved by an admin. The Adminhelp verb will be returned to you shortly.</span>")
+	to_chat(initiator, "<span class='adminhelp_conclussion'><span class='big'><b>Adminhelp Resolved</b></span><br />\
+	An administrator has handled your ticket and has taken the appropriate action, if required.<br />\
+	Thank you for creating a ticket, your adminhelp verb will be returned shortly.<br />\
+	Your ticket was handled by: <span class='adminooc'>[usr.ckey]</span></span>")
 	if(!silent)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "resolved")
 		var/msg = "Ticket [TicketHref("#[id]")] resolved by [key_name]"

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -82,20 +82,15 @@ h1.alert, h2.alert		{color: #000000;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .adminnotice			{color: #0000ff;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
-.adminhelp_conclussion {
+.adminhelp_conclusion {
   display: block;
   color: white;
   text-align: center;
   background-color: black;
-  border: solid;
-  border-color: red;
-  border-width: 2px;
+  border: 2px solid red;
   border-radius: 10px;
   padding: 10px;
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin: 10px 20px;
 }
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -82,6 +82,21 @@ h1.alert, h2.alert		{color: #000000;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .adminnotice			{color: #0000ff;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
+.adminhelp_conclussion {
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: solid;
+  border-color: red;
+  border-width: 2px;
+  border-radius: 10px;
+  padding: 10px;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -323,20 +323,15 @@ em						{font-style: normal;	font-weight: bold;}
 .boldnotice				{color: #6685f5;	font-weight: bold;}
 .adminnotice			{color: #6685f5;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
-.adminhelp_conclussion {
+.adminhelp_conclusion {
   display: block;
   color: white;
   text-align: center;
   background-color: black;
-  border: solid;
-  border-color: red;
-  border-width: 2px;
+  border: 2px solid red;
   border-radius: 10px;
   padding: 10px;
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin: 10px 20px;
 }
 .unconscious			{color: #a4bad6;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -323,6 +323,21 @@ em						{font-style: normal;	font-weight: bold;}
 .boldnotice				{color: #6685f5;	font-weight: bold;}
 .adminnotice			{color: #6685f5;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
+.adminhelp_conclussion {
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: solid;
+  border-color: red;
+  border-width: 2px;
+  border-radius: 10px;
+  padding: 10px;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
 .unconscious			{color: #a4bad6;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #059223;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -321,20 +321,15 @@ h1.alert, h2.alert		{color: #000000;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .adminnotice			{color: #0000ff;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
-.adminhelp_conclussion {
+.adminhelp_conclusion {
   display: block;
-  color: black;
+  color: white;
   text-align: center;
-  background-color: white;
-  border: solid;
-  border-color: red;
-  border-width: 2px;
+  background-color: black;
+  border: 2px solid red;
   border-radius: 10px;
   padding: 10px;
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin: 10px 20px;
 }
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -321,6 +321,21 @@ h1.alert, h2.alert		{color: #000000;}
 .boldnotice				{color: #000099;	font-weight: bold;}
 .adminnotice			{color: #0000ff;}
 .adminhelp              {color: #ff0000;    font-weight: bold;}
+.adminhelp_conclussion {
+  display: block;
+  color: black;
+  text-align: center;
+  background-color: white;
+  border: solid;
+  border-color: red;
+  border-width: 2px;
+  border-radius: 10px;
+  padding: 10px;
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Improves the adminhelp resolution message:
 - It now is a large message in chat, indicating that the adminhelp has been resolved.
 - The message now contains text saying that appropriate action has been taken if required (Users don't know what was taken, but should know that action *may* have been taken even if they don't know it).
 - The ckey of the handling administrator is now included in the resolution box, making it easier to know who handled a ticket (Useful for following up handling of bad tickets).

## Why It's Good For The Game

Players will be informed that action has been taken if required, they should know that even if they aren't explicitly told what happened to the other person, something did happen.
Better ability for players to follow up on poor ticket handling, admins that are handling tickets improperly can be trained and talked to.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/181038590-9b33743d-8e53-4989-bea8-2917649048d1.png)

![image](https://user-images.githubusercontent.com/26465327/181038711-c8b7380d-7bcf-43f8-84af-76cfeb1707d8.png)

![image](https://user-images.githubusercontent.com/26465327/181038757-709a4452-7cc2-41f2-81e9-34ccf30eda1f.png)

![image](https://user-images.githubusercontent.com/26465327/181038787-03d2c806-a4e6-46c7-8daf-a64bad283761.png)

![image](https://user-images.githubusercontent.com/26465327/181038811-260753d5-0d52-402f-9f5e-bc5fbb98b511.png)


## Changelog
:cl:
admin: The adminhelp resolution message has been updated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
