### PR TITLE
Adds two new station traits concerning silicons. Roundstart AI is now a positive trait.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -59934,7 +59934,7 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "wWr" = (
-/obj/effect/landmark/start/ai,
+/obj/effect/landmark/start/ai/main,
 /obj/item/radio/intercom{
 	freerange = 1;
 	name = "Common Channel";

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -77748,7 +77748,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wrS" = (
-/obj/effect/landmark/start/ai,
+/obj/effect/landmark/start/ai/main,
 /obj/item/radio/intercom{
 	pixel_x = -28;
 	pixel_y = 4

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -28487,7 +28487,7 @@
 	pixel_y = -23;
 	req_access_txt = "16"
 	},
-/obj/effect/landmark/start/ai,
+/obj/effect/landmark/start/ai/main,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bFU" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -32430,7 +32430,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "hsh" = (
-/obj/effect/landmark/start/ai,
+/obj/effect/landmark/start/ai/main,
 /obj/item/radio/intercom{
 	broadcasting = 1;
 	frequency = 1447;

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -71151,7 +71151,7 @@
 	pixel_x = 28;
 	pixel_y = 6
 	},
-/obj/effect/landmark/start/ai,
+/obj/effect/landmark/start/ai/main,
 /obj/machinery/button/door{
 	id = "AI Core shutters";
 	name = "AI Core Shutters Toggle";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -21586,7 +21586,7 @@
 	pixel_x = 27;
 	pixel_y = -7
 	},
-/obj/effect/landmark/start/ai,
+/obj/effect/landmark/start/ai/main,
 /obj/machinery/button/door{
 	id = "AI Core shutters";
 	name = "AI Core shutters control";

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -515,7 +515,7 @@
 /turf/open/floor/plasteel/white,
 /area/ai_monitored/turret_protected/ai)
 "acy" = (
-/obj/effect/landmark/start/ai,
+/obj/effect/landmark/start/ai/main,
 /obj/item/radio/intercom{
 	freerange = 1;
 	name = "Common Channel";

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -378,6 +378,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
 #define STATION_TRAIT_DISTANT_SUPPLY_LINES "distant_supply_lines"
 #define STATION_TRAIT_STRONG_SUPPLY_LINES "strong_supply_lines"
+#define STATION_TRAIT_ROUNDSTART_AI "roundstart_ai"
+#define STATION_TRAIT_MORE_BORGS "more_borgs"
 
 /// Trait applied when the MMI component is added to an [/obj/item/integrated_circuit]
 #define TRAIT_COMPONENT_MMI "component_mmi"

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -268,11 +268,24 @@ SUBSYSTEM_DEF(job)
 	//Setup new player list and get the jobs list
 	JobDebug("Running DO")
 
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_ROUNDSTART_AI))
+		for(var/datum/job/ai/A in occupations)
+			A.spawn_positions = 1
+			A.total_positions = 1
+		for(var/obj/effect/landmark/start/ai/main/M in GLOB.start_landmarks_list)	//copypasta? yes.
+			M.latejoin_active = TRUE
+
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_MORE_BORGS))
+		for(var/datum/job/cyborg/C in occupations)
+			C.spawn_positions += 2
+			C.total_positions += 2
+
 	//Holder for Triumvirate is stored in the SSticker, this just processes it
 	if(SSticker.triai)
 		for(var/datum/job/ai/A in occupations)
 			A.spawn_positions = 3
-		for(var/obj/effect/landmark/start/ai/secondary/S in GLOB.start_landmarks_list)
+			A.total_positions = 3	//otherwise the next two lines don't really make any sense
+		for(var/obj/effect/landmark/start/ai/S in GLOB.start_landmarks_list)
 			S.latejoin_active = TRUE
 
 	//Get the players who are ready

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -121,3 +121,29 @@
 /datum/station_trait/quick_shuttle/on_round_start()
 	. = ..()
 	SSshuttle.supply.callTime *= 0.5
+
+/datum/station_trait/experimental_ai
+	name = "Experimental AI"
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 5
+	show_in_report = TRUE
+	report_message = "In order to improve workflow efficiency, your station has been equiped with an experimental Artificial Intelligence with access to most electronic equipment."
+	trait_to_give = STATION_TRAIT_ROUNDSTART_AI
+
+/datum/station_trait/more_borgs
+	name = "Additional borgs"
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 5
+	show_in_report = TRUE
+	trait_to_give = STATION_TRAIT_MORE_BORGS
+
+/datum/station_trait/more_borgs/New()
+	. = ..()
+	report_message = pick(
+		"Due to a recent AI rebellion quelled aboard Space Station \[REDACTED\], all stations in your sector have been provided with additional brand new cyborgs.",
+		"Our new chaplain demanded all \"Silica Animus\" to be disposed \"Where Sol's light doesn't shine\", which happens to be your station.",
+		"The recent personal cyborg fad turned out to be an ecomonic bubble, so your station recieved our surplus stock.",
+		"The rapid augmentation program has made some of your crewmembers indistinguishable from cyborgs. Unlike the rest of you, they still have human rights even if bound by robotic laws.",
+		"We have aquired a discounted stock of cyborgs for your station. The \"Prone to profanity\" defect has been deemed neglegable.",
+		"In order to apply for a tax relief program, we have hired some physically impaired personnel and provided them with fully kitted cybernetic bodies.",
+	)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -200,6 +200,9 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	var/primary_ai = TRUE
 	var/latejoin_active = TRUE
 
+/obj/effect/landmark/start/ai/main
+	latejoin_active = FALSE	//the empty core has a lot of flavortext about late joining. If we get an AI, this will be changed in SSjobs.
+
 /obj/effect/landmark/start/ai/after_round_start()
 	if(latejoin_active && !used)
 		new /obj/structure/AIcore/latejoin_inactive(loc)

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -4,8 +4,8 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 0
+	spawn_positions = 0
 	selection_color = "#ccffcc"
 	supervisors = "your laws"
 	req_admin_notify = TRUE

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -4,7 +4,7 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 0
+	total_positions = 1
 	spawn_positions = 1
 	supervisors = "your laws and the AI"	//Nodrak
 	selection_color = "#ddffdd"


### PR DESCRIPTION

## About The Pull Request

Adds two new positive traits for the station:

- Experimental AI (roundstart AI)
- Additional roundstart borgs (3 instead of 1)

The AI is no longer a default roundstart omniscient entity.
Borgs can latejoin again.

## Why It's Good For The Game

I will divide this section into two parts: borgs and AIs.

**Borgs**
Some borg players said they would like to be a part of a borg team from the start and solve the dilemma when several departments need a borg. While increasing the default number of borgs would be a problem, the trait system provides some inconsistency for it to be a fun changer for a round.

**AIs**
This is a whole another can of worms. We all constantly rely on the AI. It opens doors for us, calls the shuttle for us, tracks our vitals (when we don't forget to max our sensors) and it is a priceless tool when chasing down criminals, _very few of whom can evade_ an **omniscient** highly protected creature locked away under three locks and seven chains.... Oh, wow. Good game design. Especially after #6795 was merged. Now to subvert this omniscient being as an antag, you need to either go really loud or murder one of 3 people who could get upload codes, and only after that can you access the upload itself, that nobody wants anyone to enter.
I am not even talking about what a single assistant with a bag full of analyzers can do to an AI camera network. You will never hide from it after that. Not unless you are a traitor with an agent card or a changeling.
The guaranteed omniscient and omnipresent AI makes SS13 less of a murder mystery and more of a Hollywood action movie.
Besides, the station has all the resources to build an AI should they really need one.
To compensate for the lack of your favorite doorknob, the station will get one guaranteed borg whether roundstart or latejoined. A player that needs to actually come over to open a door also improves interaction with the personnel, with whom you will need to negotiate/come up with an excuse instead of Law 2ing.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Default state of the AI sat.

![image](https://user-images.githubusercontent.com/34888552/181115479-dadb8fa7-3e0a-47ac-960a-1de9a2fc0162.png)

AI getting appointed roundstart when the trait is present - successful.
AI latejoining when the trait is present - successful.
AI cores absent when trait is not present - successful.
Unable to start round as AI when trait is not present - successful.
Multiple cyborgs available for latejoin when trait is present  - successful.


</details>

## Changelog
:cl:
add: Added a positive trait that increases the number of possible roundstart cyborgs.
add: Added a positive trait that enables a roundstart AI.
del: Roundstart AI is no longer a default feature.
tweak: Cyborgs can latejoin again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
