### PR TITLE
Change chat colour of custom command

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -185,7 +185,7 @@
 
 //////////// Color defines
 // Command
-#define JOB_CHATCOLOR_RAWCOMMAND    "#CACFF0" // custom command color
+#define JOB_CHATCOLOR_RAWCOMMAND    "#AFB4D3" // custom command color
 #define JOB_CHATCOLOR_CAPTAIN       "#FFDC9B"
 #define JOB_CHATCOLOR_ACTINGCAPTAIN "#FFDC9B"
 

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -185,7 +185,7 @@
 
 //////////// Color defines
 // Command
-#define JOB_CHATCOLOR_RAWCOMMAND    "#FFECCA" // custom command color
+#define JOB_CHATCOLOR_RAWCOMMAND    "#CACFF0" // custom command color
 #define JOB_CHATCOLOR_CAPTAIN       "#FFDC9B"
 #define JOB_CHATCOLOR_ACTINGCAPTAIN "#FFDC9B"
 

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -471,7 +471,7 @@ em						{font-style: normal;	font-weight: bold;}
 //Make sure you add to replacementNodes in renderer.js
 // ----------
 // command
-.rawcommand {color: #c1cef1}
+.rawcommand {color: #99afe9}
 .captain {color: #ecc478}
 .actingcaptain {color: #ecc478}
 // Service

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -471,7 +471,7 @@ em						{font-style: normal;	font-weight: bold;}
 //Make sure you add to replacementNodes in renderer.js
 // ----------
 // command
-.rawcommand {color: #ddccad}
+.rawcommand {color: #c1cef1}
 .captain {color: #ecc478}
 .actingcaptain {color: #ecc478}
 // Service

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -470,7 +470,7 @@ h1.alert, h2.alert		{color: #000000;}
 //Make sure you add to replacementNodes in renderer.js
 // ----------
 // command
-.rawcommand {color: #99afe9}
+.rawcommand {color: #8496c7}
 .captain {color: #d8aa53}
 .actingcaptain {color: #cfa962}
 // Service

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -470,7 +470,7 @@ h1.alert, h2.alert		{color: #000000;}
 //Make sure you add to replacementNodes in renderer.js
 // ----------
 // command
-.rawcommand {color: #8496c7}
+.rawcommand {color: #7584ad}
 .captain {color: #d8aa53}
 .actingcaptain {color: #cfa962}
 // Service

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -470,7 +470,7 @@ h1.alert, h2.alert		{color: #000000;}
 //Make sure you add to replacementNodes in renderer.js
 // ----------
 // command
-.rawcommand {color: #cfa962}
+.rawcommand {color: #99afe9}
 .captain {color: #d8aa53}
 .actingcaptain {color: #cfa962}
 // Service


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Change chat colour of custom command into more commander-like colour.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Their current colour is not that different from assistant's.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

chat
----
![image](https://user-images.githubusercontent.com/87972842/181185011-f0c8bc21-3b0b-4fcb-b44c-965fe811d8e5.png)

light theme
----
![image](https://user-images.githubusercontent.com/87972842/181187017-babbf45b-51df-4818-9ca0-7502c5a19f17.png)

dark theme
----
![image](https://user-images.githubusercontent.com/87972842/181186475-23ab4063-7b65-4f65-8ce1-3a89be95f60e.png)


</details>

## Changelog
:cl:
tweak: Custom command job now has blue chat colour rather than assistant-like white
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
