### PR TITLE
Removes xray camera upgrades

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -117,10 +117,6 @@
 		. += "It has electromagnetic interference shielding installed."
 	else
 		. += "<span class='info'>It can be shielded against electromagnetic interference with some <b>plasma</b>.</span>"
-	if(isXRay(TRUE)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
-		. += "It has an X-ray photodiode installed."
-	else
-		. += "<span class='info'>It can be upgraded with an X-ray photodiode with an <b>analyzer</b>.</span>"
 	if(isMotion())
 		. += "It has a proximity sensor installed."
 	else

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -68,9 +68,7 @@
 	var/obj/structure/camera_assembly/assembly
 	if(CA)
 		assembly = CA
-		if(assembly.xray_module)
-			upgradeXRay()
-		else if(assembly.malf_xray_firmware_present) //if it was secretly upgraded via the MALF AI Upgrade Camera Network ability
+		if(assembly.malf_xray_firmware_present) //if it was secretly upgraded via the MALF AI Upgrade Camera Network ability
 			upgradeXRay(TRUE)
 
 		if(assembly.emp_module)
@@ -348,15 +346,12 @@
 	qdel(src)
 
 /obj/machinery/camera/update_icon() //TO-DO: Make panel open states, xray camera, and indicator lights overlays instead.
-	var/xray_module
-	if(isXRay(TRUE))
-		xray_module = "xray"
 	if(!status)
-		icon_state = "[xray_module][default_camera_icon]_off"
+		icon_state = "[default_camera_icon]_off"
 	else if (stat & EMPED)
-		icon_state = "[xray_module][default_camera_icon]_emp"
+		icon_state = "[default_camera_icon]_emp"
 	else
-		icon_state = "[xray_module][default_camera_icon][in_use_lights ? "_in_use" : ""]"
+		icon_state = "[default_camera_icon][in_use_lights ? "_in_use" : ""]"
 
 /obj/machinery/camera/proc/toggle_cam(mob/user, displaymessage = TRUE)
 	status = !status

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -18,7 +18,6 @@
 	icon_state = "camera_assembly"
 	max_integrity = 150
 	//	Motion, EMP-Proof, X-ray
-	var/obj/item/analyzer/xray_module
 	var/malf_xray_firmware_active //used to keep from revealing malf AI upgrades for user facing isXRay() checks when they use Upgrade Camera Network ability
 								//will be false if the camera is upgraded with the proper parts.
 	var/malf_xray_firmware_present //so the malf upgrade is restored when the normal upgrade part is removed.
@@ -38,11 +37,6 @@
 		has_upgrades = TRUE
 	else if(state == STATE_WIRED)
 		. += "<span class='info'>It can be shielded against electromagnetic interference with some <b>plasma</b>.</span>"
-	if(xray_module)
-		. += "It has an X-ray photodiode installed."
-		has_upgrades = TRUE
-	else if(state == STATE_WIRED)
-		. += "<span class='info'>It can be upgraded with an X-ray photodiode with an <b>analyzer</b>.</span>"
 	if(proxy_module)
 		. += "It has a proximity sensor installed."
 		has_upgrades = TRUE
@@ -67,19 +61,7 @@
 	if(building)
 		setDir(ndir)
 
-/obj/structure/camera_assembly/update_icon()
-	icon_state = "[xray_module ? "xray" : null][initial(icon_state)]"
-
 /obj/structure/camera_assembly/handle_atom_del(atom/A)
-	if(A == xray_module)
-		xray_module = null
-		update_icon()
-		if(malf_xray_firmware_present)
-			malf_xray_firmware_active = malf_xray_firmware_present //re-enable firmware based upgrades after the part is removed.
-		if(istype(loc, /obj/machinery/camera))
-			var/obj/machinery/camera/contained_camera = loc
-			contained_camera.removeXRay(malf_xray_firmware_present) //make sure we don't remove MALF upgrades.
-
 	else if(A == emp_module)
 		emp_module = null
 		if(malf_emp_firmware_present)
@@ -98,20 +80,14 @@
 
 
 /obj/structure/camera_assembly/Destroy()
-	QDEL_NULL(xray_module)
 	QDEL_NULL(emp_module)
 	QDEL_NULL(proxy_module)
 	return ..()
 
 /obj/structure/camera_assembly/proc/drop_upgrade(obj/item/I)
 	I.forceMove(drop_location())
-	if(I == xray_module)
-		xray_module = null
-		if(malf_xray_firmware_present)
-			malf_xray_firmware_active = malf_xray_firmware_present //re-enable firmware based upgrades after the part is removed.
-		update_icon()
 
-	else if(I == emp_module)
+	if(I == emp_module)
 		emp_module = null
 		if(malf_emp_firmware_present)
 			malf_emp_firmware_active = malf_emp_firmware_present //re-enable firmware based upgrades after the part is removed.
@@ -163,20 +139,6 @@
 				to_chat(user, "<span class='notice'>You attach [W] into [src]'s inner circuits.</span>")
 				return
 
-			else if(istype(W, /obj/item/analyzer)) //xray upgrade
-				if(xray_module)
-					to_chat(user, "<span class='warning'>[src] already contains a [xray_module]!</span>")
-					return
-				if(!user.transferItemToLoc(W, src))
-					return
-				to_chat(user, "<span class='notice'>You attach [W] into [src]'s inner circuits.</span>")
-				xray_module = W
-				if(malf_xray_firmware_active)
-					malf_xray_firmware_active = FALSE //flavor reason: MALF AI Upgrade Camera Network ability's firmware is incompatible with the new part
-														//real reason: make it a normal upgrade so the finished camera's icons and examine texts are restored.
-				update_icon()
-				return
-
 			else if(istype(W, /obj/item/assembly/prox_sensor)) //motion sensing upgrade
 				if(proxy_module)
 					to_chat(user, "<span class='warning'>[src] already contains a [proxy_module]!</span>")
@@ -193,8 +155,6 @@
 	if(state != STATE_WIRED)
 		return FALSE
 	var/list/droppable_parts = list()
-	if(xray_module)
-		droppable_parts += xray_module
 	if(emp_module)
 		droppable_parts += emp_module
 	if(proxy_module)
@@ -255,8 +215,6 @@
 	to_chat(user, "<span class='notice'>You detach [src] from its place.</span>")
 	new /obj/item/wallframe/camera(drop_location())
 	//drop upgrades
-	if(xray_module)
-		drop_upgrade(xray_module)
 	if(emp_module)
 		drop_upgrade(emp_module)
 	if(proxy_module)

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -62,7 +62,7 @@
 		setDir(ndir)
 
 /obj/structure/camera_assembly/handle_atom_del(atom/A)
-	else if(A == emp_module)
+	if(A == emp_module)
 		emp_module = null
 		if(malf_emp_firmware_present)
 			malf_emp_firmware_active = malf_emp_firmware_present //re-enable firmware based upgrades after the part is removed.

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -22,7 +22,7 @@
 
 /obj/machinery/camera/xray/Initialize(mapload)
 	. = ..()
-	upgradeXRay()
+	upgradeXRay(TRUE)
 
 // MOTION
 /obj/machinery/camera/motion
@@ -41,7 +41,6 @@
 /obj/machinery/camera/all/Initialize(mapload)
 	. = ..()
 	upgradeEmpProof()
-	upgradeXRay()
 	upgradeMotion()
 
 // AUTONAME
@@ -110,11 +109,6 @@
 	if(malf_upgrade)
 		assembly.malf_xray_firmware_active = TRUE //don't add parts to drop, update icon, ect. reconstructing it will also retain the upgrade.
 		assembly.malf_xray_firmware_present = TRUE //so the upgrade is retained after incompatible parts are removed.
-
-	else if(!assembly.xray_module) //only happens via upgrading in camera/attackby()
-		assembly.xray_module = new(assembly)
-		if(assembly.malf_xray_firmware_active)
-			assembly.malf_xray_firmware_active = FALSE //make it appear like it's just normally upgraded so the icons and examine texts are restored.
 
 	upgrades |= CAMERA_UPGRADE_XRAY
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the X-Ray camera upgrade module.

## Why It's Good For The Game

X-Ray modules provide no positive content to the game and only server to screw over antagonists who didn't notice a camera behind a wall they couldn't see.
The main uses for upgrading cameras to X-Ray is to spy on people in dorms, allowing you to see when someone buys a funny loot box or items inside.
Having the ability to detect antagonists that have no idea they are being watched ruins the fun for the antagonist players (And arguably the rest of the round after they are caught and no longer provide any interesting events), without providing any actual fun for the AI players: There is no skill or effort involved in using these.

Of course the upgrade is still available to malf AIs.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/181299526-bca3102e-cc62-41b7-a96e-70d5489abd78.png)

## Changelog
:cl:
balance: Cameras can no longer be upgraded with an analyser.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
