### PR TITLE
(Re)moved the (accidental) MD spawn in Delta's Virology

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -56909,6 +56909,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "diE" = (
@@ -80453,7 +80454,6 @@
 	},
 /area/maintenance/port)
 "ilp" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
@@ -96604,6 +96604,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "oZh" = (
@@ -99664,11 +99665,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms)
-"qoQ" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "qpb" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -165641,7 +165637,7 @@ ilp
 dXY
 aem
 dBo
-qoQ
+dXY
 dFm
 taz
 dGM


### PR DESCRIPTION
## About The Pull Request

This PR fixes https://github.com/BeeStation/BeeStation-Hornet/issues/7397, as there was two medical doctors spawns that where in a virologist zone only for some reason.

## Why It's Good For The Game

Fixes spawns that are detrimental gameplay wise.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![immagine](https://user-images.githubusercontent.com/75247747/181612181-ffbbf498-4190-4038-b434-0c68a4f410ed.png)

This PR remove those two spawns, moves them in the medbay hallway

</details>

## Changelog
:cl:
fix: moved the two MD spawn from the virology ward in Deltastation from virology to medbay's hallways
/:cl:
