### PR TITLE
Fix duplicates in minimal runtimes and lag caused by it

### DIFF
--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -81,11 +81,10 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 
 /datum/error_viewer/error_cache/proc/show_to_minimal(user, datum/error_viewer/back_to, linear)
 	var/html = "<b>[GLOB.total_runtimes]</b> runtimes, <b>[GLOB.total_runtimes_skipped]</b> skipped<br><br>"
-	for (var/datum/error_viewer/error_entry/error_entry in errors)
-		var/datum/error_viewer/error_source/error_source
-		for (var/erroruid in error_sources)
-			error_source = error_sources[erroruid]
-			html += "[error_source.min_name]<br>"
+	var/datum/error_viewer/error_source/error_source
+	for (var/erroruid in error_sources)
+		error_source = error_sources[erroruid]
+		html += "[error_source.min_name]<br>"
 
 	browse_to(user, html)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #7382

If there's a lot of runtimes, it was iterating (runtimes_total)*(runtimes_sources) times instead of (runtimes_sources) times causing big lag lots of duplicates

## Why It's Good For The Game

Bug bad

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/181622472-9d20bda8-ead8-40be-af4c-182004ce809e.png)

vs linear view from regular menu

![image](https://user-images.githubusercontent.com/10366817/181622530-b3503408-7292-493c-b7c9-c405de2a9678.png)

</details>

## Changelog
:cl:
fix: Minimal runtimes menu will no longer show duplicates and lag
/:cl: