### PR TITLE
Fixes corgium lasting forever

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -338,7 +338,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define HAND_REPLACEMENT_TRAIT "magic-hand"
 #define HOT_POTATO_TRAIT "hot-potato"
 #define SABRE_SUICIDE_TRAIT "sabre-suicide"
-#define CORGIUM_TRAIT "corgium"
 #define ABDUCTOR_VEST_TRAIT "abductor-vest"
 #define CAPTURE_THE_FLAG_TRAIT "capture-the-flag"
 #define EYE_OF_GOD_TRAIT "eye-of-god"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -129,7 +129,6 @@
 	if(H)
 		to_chat(L, "<span class='warning'>You're already corgified!</span>")
 		return
-	ADD_TRAIT(L, TRAIT_MUTE, CORGIUM_TRAIT)
 	new_corgi = new(L.loc)
 	//hat check
 	var/mob/living/carbon/C = L
@@ -147,7 +146,6 @@
 		return
 	//Remove all the corgium from the person
 	L.reagents?.remove_reagent(/datum/reagent/corgium, INFINITY)
-	REMOVE_TRAIT(L, TRAIT_MUTE, CORGIUM_TRAIT)
 	if(QDELETED(new_corgi))
 		return
 	var/obj/shapeshift_holder/H = locate() in new_corgi

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -138,20 +138,14 @@
 		if(hat?.dog_fashion)
 			new_corgi.place_on_head(hat,null,FALSE)
 	H = new(new_corgi,src,L)
-
-/datum/reagent/corgium/on_mob_life(mob/living/carbon/M)
-	. = ..()
-	//If our corgi died :(
-	if(new_corgi.stat)
-		holder.remove_all_type(type)
-		addtimer(CALLBACK(src, .proc/restore, M), 2 SECONDS)
-
-/datum/reagent/corgium/on_mob_end_metabolize(mob/living/L)
-	. = ..()
-	restore(L)
+	//Restore after this time
+	addtimer(CALLBACK(src, .proc/restore, L), volume / metabolization_rate)
 
 /datum/reagent/corgium/proc/restore(mob/living/L)
-	ADD_TRAIT(L, TRAIT_MUTE, CORGIUM_TRAIT)
+	//The mob was qdeleted by an explosion or something
+	if(QDELETED(L))
+		return
+	REMOVE_TRAIT(L, TRAIT_MUTE, CORGIUM_TRAIT)
 	var/obj/shapeshift_holder/H = locate() in L
 	if(!H)
 		return
@@ -1361,7 +1355,7 @@
 	color = "#E1A116"
 	chem_flags = CHEMICAL_RNG_GENERAL | CHEMICAL_RNG_FUN | CHEMICAL_RNG_BOTANY
 	taste_description = "sourness"
-	///stores whether or not the mob has been warned that they are having difficulty breathing. 
+	///stores whether or not the mob has been warned that they are having difficulty breathing.
 	var/warned = FALSE
 
 /datum/reagent/stimulum/on_mob_metabolize(mob/living/L)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -148,7 +148,9 @@
 	//Remove all the corgium from the person
 	L.reagents?.remove_reagent(/datum/reagent/corgium, INFINITY)
 	REMOVE_TRAIT(L, TRAIT_MUTE, CORGIUM_TRAIT)
-	var/obj/shapeshift_holder/H = locate() in L
+	if(QDELETED(new_corgi))
+		return
+	var/obj/shapeshift_holder/H = locate() in new_corgi
 	if(!H)
 		return
 	H.restore(convert_damage = TRUE)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -145,6 +145,8 @@
 	//The mob was qdeleted by an explosion or something
 	if(QDELETED(L))
 		return
+	//Remove all the corgium from the person
+	L.reagents?.remove_reagent(/datum/reagent/corgium, INFINITY)
 	REMOVE_TRAIT(L, TRAIT_MUTE, CORGIUM_TRAIT)
 	var/obj/shapeshift_holder/H = locate() in L
 	if(!H)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -138,7 +138,7 @@
 			new_corgi.place_on_head(hat,null,FALSE)
 	H = new(new_corgi,src,L)
 	//Restore after this time
-	addtimer(CALLBACK(src, .proc/restore, L), volume / metabolization_rate)
+	addtimer(CALLBACK(src, .proc/restore, L), 5 * (volume / metabolization_rate))
 
 /datum/reagent/corgium/proc/restore(mob/living/L)
 	//The mob was qdeleted by an explosion or something


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Shapeshift holders apply no_transform, which in turn disables life() which disables reagent metabolism. This makes corgium last forever.
Instead of doing that, we will use timers instead to force call the restore proc after the reagents should have worn off.

## Why It's Good For The Game

Corgium should not be infinite, as funny as it is.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/181732660-ff5ada5b-9cce-41ce-a5d6-3388c28b48f9.png)

![image](https://user-images.githubusercontent.com/26465327/181732690-55c214ec-e6c7-414b-a743-bc61362e95e4.png)

## Changelog
:cl:
fix: Corgium will no longer last forever and will no longer affect people with damaged livers forever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
