### PR TITLE
Revert "Forensic scanners can no longer be printed"

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -84,7 +84,7 @@
 	display_name = "Advanced Biotechnology"
 	description = "Advanced Biotechnology"
 	prereq_ids = list("biotech")
-	design_ids = list("piercesyringe", "crewpinpointer", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "healthanalyzer_advanced", "harvester", "holobarrier_med", "defibrillator_compact")
+	design_ids = list("piercesyringe", "crewpinpointer", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "healthanalyzer_advanced", "harvester", "holobarrier_med", "detective_scanner", "defibrillator_compact")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
Reverts BeeStation/BeeStation-Hornet#6715

About The Pull Request
Reads the forensic scanner to techwebs

Why It's Good For The Game
The detective deserves to be unique, however making it completely impossible to obtain forensic analyzers if the original and spare are lost is not the best solution. There has been cases where security has wanted to investigate crimes however were unable to find a forensic analyzer whatsoever. I dont think it should be possible for security to loose access to forensics entirely.

The detective instead is unique because they start with a large amount of different equipment highly applicable to their role, such as crew monitors, evidence bags, tape recorders, ect. Forensics as a system should not be locked purely to their role, especially when you consider low pop rounds where a detective may not be present.

If you want to add even more uniqueness to the detective, perhaps consider giving them a pair of gloves that dont leave prints or boots that dont leave blood trails so they dont contaminate crime scenes or something.

Changelog
🆑
balance: forensic scanner is one again printable in techfabs
/🆑