### PR TITLE
Heads can send messages to CentCom during Red Alert

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -160,7 +160,7 @@
 			make_announcement(usr)
 			. = TRUE
 		if ("messageAssociates")
-			if (!authenticated(usr) || issilicon(usr))
+			if (!authenticated(usr) || issilicon(usr) || (GLOB.security_level < SEC_LEVEL_RED && !authenticated_as_non_silicon_captain(usr)))
 				return
 			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
 				return
@@ -351,7 +351,7 @@
 		//Main section is always visible when authenticated
 		data["canBuyShuttles"] = can_buy_shuttles(user)
 		data["canMakeAnnouncement"] = FALSE
-		data["canMessageAssociates"] = !issilicon(user)
+		data["canMessageAssociates"] = !issilicon(user) && GLOB.security_level >= SEC_LEVEL_RED
 		data["canRecallShuttles"] = !issilicon(user)
 		data["canRequestNuke"] = FALSE
 		data["canSendToSectors"] = FALSE
@@ -367,6 +367,7 @@
 		data["shuttleCanEvacOrFailReason"] = SSshuttle.canEvac(user)
 
 		if (authenticated_as_non_silicon_captain(user))
+			data["canMessageAssociates"] = TRUE
 			data["canRequestNuke"] = TRUE
 
 		if (can_send_messages_to_other_sectors(user))

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -160,7 +160,7 @@
 			make_announcement(usr)
 			. = TRUE
 		if ("messageAssociates")
-			if (!authenticated_as_non_silicon_captain(usr))
+			if (!authenticated(usr))
 				return
 			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
 				return
@@ -351,7 +351,7 @@
 		//Main section is always visible when authenticated
 		data["canBuyShuttles"] = can_buy_shuttles(user)
 		data["canMakeAnnouncement"] = FALSE
-		data["canMessageAssociates"] = FALSE
+		data["canMessageAssociates"] = TRUE
 		data["canRecallShuttles"] = !issilicon(user)
 		data["canRequestNuke"] = FALSE
 		data["canSendToSectors"] = FALSE
@@ -367,7 +367,6 @@
 		data["shuttleCanEvacOrFailReason"] = SSshuttle.canEvac(user)
 
 		if (authenticated_as_non_silicon_captain(user))
-			data["canMessageAssociates"] = TRUE
 			data["canRequestNuke"] = TRUE
 
 		if (can_send_messages_to_other_sectors(user))

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -160,7 +160,7 @@
 			make_announcement(usr)
 			. = TRUE
 		if ("messageAssociates")
-			if (!authenticated(usr))
+			if (!authenticated(usr) || issilicon(usr))
 				return
 			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
 				return
@@ -351,7 +351,7 @@
 		//Main section is always visible when authenticated
 		data["canBuyShuttles"] = can_buy_shuttles(user)
 		data["canMakeAnnouncement"] = FALSE
-		data["canMessageAssociates"] = TRUE
+		data["canMessageAssociates"] = !issilicon(user)
 		data["canRecallShuttles"] = !issilicon(user)
 		data["canRequestNuke"] = FALSE
 		data["canSendToSectors"] = FALSE

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -496,7 +496,7 @@ const PageMain = (props, context) => {
 
       {!!canMessageAssociates && messagingAssociates && <MessageModal
         label={`Message to transmit to ${emagged ? "[ABNORMAL ROUTING COORDINATES]" : "CentCom"} via quantum entanglement`}
-        notice="Please be aware that this process is very expensive, and abuse will lead to...termination. Transmission does not guarantee a response."
+        notice="Please be aware that this process is very expensive, and abuse will lead to...termination. Transmission does not guarantee a response. Use by heads of staff is only authorized during an emergency situation."
         icon="bullhorn"
         buttonText="Send"
         onBack={() => setMessagingAssociates(false)}


### PR DESCRIPTION
## About The Pull Request

Allows heads to message CentCom during Red Alert.

As an addition to this, it adds to the blurb notice in the CC messaging menu saying heads of staff are only to use it in case of an emergency

I would recommend also adding something about this to SoP.

## Why It's Good For The Game

During emergencies, or if the captain is somehow incapacitated or unwilling to contact CentCom during a situation where it is necessary, if no one can find / get a spare heads are sort of left in the dark and have no IC way to contact CC and possibly request help. Allowing heads to use this only the case of an emergency allows more CC interaction. For example, if the captain turned out to be a changeling (the original captain being dead somewhere) and security was all but missing, any head could request CC assistance instead of hunting the valids. Especially if the rogue captain were to recall the shuttle, preventing escape.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

### Green Alert

![image](https://user-images.githubusercontent.com/10366817/182256132-d66b1768-5a59-43dc-a7da-0751e9464622.png)

### Blue Alert

![image](https://user-images.githubusercontent.com/10366817/182256195-32f69ab1-bf38-4b62-8eff-0450127e17a7.png)

### Red Alert

![image](https://user-images.githubusercontent.com/10366817/182256236-bd707609-7b79-4912-8dcc-df4e216c1ebc.png)

### Delta Alert

![image](https://user-images.githubusercontent.com/10366817/182256274-9d69130f-677f-40bf-a554-fc34e23a216e.png)

### As Captain (Green Alert)

![image](https://user-images.githubusercontent.com/10366817/182256346-1b64a735-f985-4679-8e25-bc27c6be01eb.png)

### As AI / silicon (Red Alert)

![image](https://user-images.githubusercontent.com/10366817/182256534-3bdd1649-fb1f-4d3e-9fda-59151c31a06b.png)

![image](https://user-images.githubusercontent.com/10366817/182235240-2d09be0c-d085-4062-bf45-a183b30d488a.png)

</details>

## Changelog
:cl:
tweak: Heads of staff can now message CentCom during Red Alert.
/:cl:
