### PR TITLE
nerfs pituitary disruption's disruption

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -505,7 +505,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	var/mob/living/carbon/M = A.affected_mob
 	ownermind = M.mind
 	if(!A.carrier && !A.dormant)
-		sizemult = CLAMP((0.5 + A.stage_rate / 10), 1.1, 2.5)
+		sizemult = CLAMP((0.5 + A.stage_rate / 10), 1.1, 1.5)
 		M.resize = sizemult
 		M.update_transform()
 
@@ -573,48 +573,6 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 	to_chat(M, "<span class='notice'>You lose your balance and stumble as you shrink, and your legs come out from underneath you!</span>")
 	M.resize = 1/sizemult
 	M.update_transform()
-
-//they are used for the maintenance spawn, for ling teratoma see changeling\teratoma.dm
-/obj/effect/mob_spawn/teratomamonkey //spawning these is one of the downsides of overclocking the symptom
-	name = "fleshy mass"
-	desc = "A writhing mass of flesh."
-	icon = 'icons/mob/blob.dmi'
-	icon_state = "blob_spore_temp"
-	density = FALSE
-	anchored = FALSE
-
-	antagonist_type = /datum/antagonist/teratoma/hugbox
-	mob_type = /mob/living/carbon/monkey/tumor
-	mob_name = "a living tumor"
-	death = FALSE
-	roundstart = FALSE
-	use_cooldown = TRUE
-	show_flavour = FALSE	//it's handled by antag datum
-	short_desc = "You are a living tumor. By all accounts you should not exist."
-	flavour_text = "Spread misery and chaos upon the station."
-	important_info = "Avoid killing unprovoked, kill only in self defense!"
-
-/obj/effect/mob_spawn/teratomamonkey/Initialize(mapload)
-	. = ..()
-	var/area/A = get_area(src)
-	if(A)
-		notify_ghosts("A living tumor has been born in [A.name].", 'sound/effects/splat.ogg', source = src, action = NOTIFY_ATTACK, flashwindow = FALSE)
-
-/obj/effect/mob_spawn/teratomamonkey/attack_hand(mob/living/user)
-	. = ..()
-	if(.)
-		return
-	to_chat(user, "<span class='notice'>Ew. It would be a bad idea to touch this. It could probably be destroyed with the extreme heat of a welder.</span>")
-
-/obj/effect/mob_spawn/teratomamonkey/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WELDER && user.a_intent != INTENT_HARM)
-		user.visible_message("<span class='warning'>[usr.name] destroys [src].</span>",
-			"<span class='notice'>You hold the welder to [src] and it violently bursts!</span>",
-			"<span class='italics'>You hear a gurgling noise.</span>")
-		new /obj/effect/gibspawner/human(get_turf(src))
-		qdel(src)
-	else
-		..()
 
 #undef TELEPORT_COOLDOWN
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -530,7 +530,7 @@ im not even gonna bother with these for the following symptoms. typed em out, co
 					new /obj/effect/spawner/lootdrop/teratoma/minor(M.loc)
 				if(tetsuo)
 					var/list/missing = M.get_missing_limbs()
-					if(prob(35))
+					if(prob(35) && M.mind && ishuman(M))
 						new /obj/effect/decal/cleanable/blood/gibs(M.loc) //yes. this is very messy. very, very messy.
 						new /obj/effect/spawner/lootdrop/teratoma/major(M.loc)
 					if(missing.len) //we regrow one missing limb

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -236,7 +236,6 @@
 		/obj/item/organ/vocal_cords/adamantine = 1,
 		/obj/effect/gibspawner/xeno = 1,
 		/obj/effect/mob_spawn/human/corpse/assistant = 1,
-		/obj/effect/mob_spawn/teratomamonkey = 1,
 		/obj/item/organ/wings/moth/robust = 1,
 		/obj/item/organ/wings/dragon = 1)
 

--- a/code/game/objects/effects/spawners/mailspawner.dm
+++ b/code/game/objects/effects/spawners/mailspawner.dm
@@ -62,7 +62,6 @@
 		/obj/item/organ/vocal_cords/adamantine,
 		/obj/effect/gibspawner/xeno,
 		/obj/effect/mob_spawn/human/corpse/assistant,
-		/obj/effect/mob_spawn/teratomamonkey,
 		/obj/item/organ/wings/moth/robust,
 		/obj/item/organ/wings/dragon,)
 	new mail_organmajor(loc)


### PR DESCRIPTION


## About The Pull Request
pituitary disruption tumors no longer appear at all on monkeys
teratomas now only appear from changelings
pituitary disruption's size boost is now far smaller

## Why It's Good For The Game
pituitary disruption is a bit too flashy and disruptive, i've been intending to tone this down for awhile

## Testing Photographs and Procedure
![image](https://user-images.githubusercontent.com/49600480/182241085-9c1b7b20-c4bb-4199-befa-7cb277a5c7d9.png)
this is the max size boost now. the blood in monkey cages is them trying and failing to vomit organs

## Changelog
:cl:
del: random organ drops no longer create teratoma spawners. this means maint and mail tomas no longer exist, either
tweak: pituitary disruption no longer makes you grow nearly as large
balance: pituitary disruption no longer drops random organs from monkeys
/:cl:

