### PR TITLE
Staff of Change improvements with silicons and message to prevent self-antag

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -163,12 +163,16 @@
 	M.invisibility = INVISIBILITY_ABSTRACT
 
 	var/list/contents = M.contents.Copy()
-
-	if(iscyborg(M))
-		var/mob/living/silicon/robot/Robot = M
-		if(Robot.mmi)
-			qdel(Robot.mmi)
-		Robot.notify_ai(NEW_BORG)
+	if(issilicon(M)) // silicons should not drop internal parts since they are supposed to be unobtainable
+		for(var/obj/item/W in contents)
+			qdel(W)
+		if(iscyborg(M))
+			var/mob/living/silicon/robot/Robot = M
+			if(Robot.deployed || Robot.mainframe)
+				Robot.undeploy() // disconnect any AI shells first
+			if(Robot.mmi)
+				qdel(Robot.mmi)
+			Robot.notify_ai(NEW_BORG)
 	else
 		for(var/obj/item/W in contents)
 			if(!M.dropItemToGround(W))
@@ -282,6 +286,9 @@
 	M.wabbajack_act(new_mob)
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
+
+	if((istype(new_mob, /mob/living/silicon/robot/modules/syndicate) || istype(new_mob, /mob/living/carbon/alien/humanoid) || istype(new_mob, /mob/living/simple_animal/hostile)))
+		to_chat(new_mob, "<span class='userdanger'>Despite taking the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>")
 
 	var/poly_msg = CONFIG_GET(keyed_list/policy)["polymorph"]
 	if(poly_msg)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -287,12 +287,12 @@
 
 	to_chat(new_mob, "<span class='warning'>Your form morphs into that of a [randomize].</span>")
 
-	if((istype(new_mob, /mob/living/silicon/robot/modules/syndicate) || istype(new_mob, /mob/living/carbon/alien/humanoid) || istype(new_mob, /mob/living/simple_animal/hostile)))
-		to_chat(new_mob, "<span class='userdanger'>Despite taking the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>")
-
 	var/poly_msg = CONFIG_GET(keyed_list/policy)["polymorph"]
 	if(poly_msg)
 		to_chat(new_mob, poly_msg)
+
+	if((istype(new_mob, /mob/living/silicon/robot/modules/syndicate) || istype(new_mob, /mob/living/carbon/alien/humanoid) || istype(new_mob, /mob/living/simple_animal/hostile)))
+		to_chat(new_mob, "<span class='userdanger'>Despite taking the form of an antagonistic being, you have the same mind as before your transformation. Your loyalties and interests remain the same. Unless you were turned into a shade, or were previously an antagonist, this is not a pass to go antagonize the station.</span>")
 
 	M.transfer_observers_to(new_mob)
 


### PR DESCRIPTION
## About The Pull Request

Fixes #7360

- Silicons no longer drop their internal parts when transformed (internal photo cameras, core module boards, encryption keys, etc)
- AI shells are disconnected before transformation
- If you're transformed into a hostile/antagonistic creature, a message will inform you that your mind is the same and not to self-antag

## Why It's Good For The Game

So far I've had to report two people for self-antagging when turned into syndicate cyborgs (yes, they're not antagonists unless they're sharded, turned into a construct, then transformed)

Also AI/cyborg internal items should not be obtainable.

AIs should not get locked into their shells if they get transformed. Makes it far too easy to remove the AI from control.

## Testing Photographs and Procedure

<details>

<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/10366817/182260259-5caf880e-27b4-447a-9e29-137a8cece8fa.mp4

</details>

## Changelog
:cl:
fix: Using staff of change on remote AI shells will first disconnect the AI instead of locking them into the new body.
fix: Staff of change transformations on silicons no longer drops their internal, unobtainable parts.
add: Added a message when transformed into antagonistic forms with the staff of change not to self-antag.
/:cl:
