### PR TITLE
Nostalgic & Atmos Winter Coats in Shop

### DIFF
--- a/code/modules/client/loadout/loadout_suit.dm
+++ b/code/modules/client/loadout/loadout_suit.dm
@@ -59,10 +59,10 @@
 	path = /obj/item/clothing/suit/hooded/wintercoat/engineering
 	allowed_roles = list(JOB_NAME_CHIEFENGINEER, JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN)
 
-/datum/gear/suit/wintercoat/hydro
-	display_name = "hydroponics winter coat"
-	path = /obj/item/clothing/suit/hooded/wintercoat/hydro
-	allowed_roles = list(JOB_NAME_BOTANIST)
+/datum/gear/suit/wintercoat/atmos
+	display_name = "atmospherics winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
+	allowed_roles = list(JOB_NAME_CHIEFENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN)
 
 /datum/gear/suit/wintercoat/hydro
 	display_name = "hydroponics winter coat"
@@ -78,6 +78,47 @@
 	display_name = "mining winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/miner
 	allowed_roles = list(JOB_NAME_SHAFTMINER)
+
+//NOSTALGIC WINTER COATS
+
+/datum/gear/suit/oldwintercoat
+	subtype_path = /datum/gear/suit/oldwintercoat
+	cost = 6000
+
+/datum/gear/suit/oldwintercoat/grey
+	display_name = "nostalgic winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/old
+	cost = 3000
+
+/datum/gear/suit/oldwintercoat/security
+	display_name = "nostalgic security winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/security/old
+	allowed_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_BRIGPHYSICIAN, JOB_NAME_HEADOFSECURITY)
+
+/datum/gear/suit/oldwintercoat/medical
+	display_name = "nostalgic medical winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/medical/old
+	allowed_roles = list(JOB_NAME_PARAMEDIC, JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_CHEMIST, JOB_NAME_GENETICIST)
+
+/datum/gear/suit/oldwintercoat/science
+	display_name = "nostalgic science winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/science/old
+	allowed_roles = list(JOB_NAME_SCIENTIST, JOB_NAME_ROBOTICIST, JOB_NAME_RESEARCHDIRECTOR)
+
+/datum/gear/suit/oldwintercoat/engineering
+	display_name = "nostalgic engineering winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/engineering/old
+	allowed_roles = list(JOB_NAME_CHIEFENGINEER, JOB_NAME_STATIONENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN)
+
+/datum/gear/suit/oldwintercoat/atmos
+	display_name = "nostalgic atmospherics winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos/old
+	allowed_roles = list(JOB_NAME_CHIEFENGINEER, JOB_NAME_ATMOSPHERICTECHNICIAN)
+
+/datum/gear/suit/oldwintercoat/hydro
+	display_name = "nostalgic hydroponics winter coat"
+	path = /obj/item/clothing/suit/hooded/wintercoat/hydro/old
+	allowed_roles = list(JOB_NAME_BOTANIST)
 
 //JACKETS
 

--- a/code/modules/client/loadout/loadout_suit.dm
+++ b/code/modules/client/loadout/loadout_suit.dm
@@ -42,17 +42,17 @@
 /datum/gear/suit/wintercoat/security
 	display_name = "security winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/security
-	allowed_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_BRIGPHYSICIAN, JOB_NAME_HEADOFSECURITY)
+	allowed_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_BRIGPHYSICIAN, JOB_NAME_HEADOFSECURITY, JOB_NAME_WARDEN, JOB_NAME_DETECTIVE)
 
 /datum/gear/suit/wintercoat/medical
 	display_name = "medical winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/medical
-	allowed_roles = list(JOB_NAME_PARAMEDIC, JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_CHEMIST, JOB_NAME_GENETICIST)
+	allowed_roles = list(JOB_NAME_PARAMEDIC, JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_CHEMIST, JOB_NAME_GENETICIST, JOB_NAME_VIROLOGIST, JOB_NAME_BRIGPHYSICIAN)
 
 /datum/gear/suit/wintercoat/science
 	display_name = "science winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/science
-	allowed_roles = list(JOB_NAME_SCIENTIST, JOB_NAME_ROBOTICIST, JOB_NAME_RESEARCHDIRECTOR)
+	allowed_roles = list(JOB_NAME_SCIENTIST, JOB_NAME_ROBOTICIST, JOB_NAME_RESEARCHDIRECTOR, JOB_NAME_EXPLORATIONCREW)
 
 /datum/gear/suit/wintercoat/engineering
 	display_name = "engineering winter coat"
@@ -93,17 +93,17 @@
 /datum/gear/suit/oldwintercoat/security
 	display_name = "nostalgic security winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/security/old
-	allowed_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_BRIGPHYSICIAN, JOB_NAME_HEADOFSECURITY)
+	allowed_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_BRIGPHYSICIAN, JOB_NAME_HEADOFSECURITY, JOB_NAME_WARDEN, JOB_NAME_DETECTIVE)
 
 /datum/gear/suit/oldwintercoat/medical
 	display_name = "nostalgic medical winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/medical/old
-	allowed_roles = list(JOB_NAME_PARAMEDIC, JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_CHEMIST, JOB_NAME_GENETICIST)
+	allowed_roles = list(JOB_NAME_PARAMEDIC, JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_CHEMIST, JOB_NAME_GENETICIST, JOB_NAME_VIROLOGIST, JOB_NAME_BRIGPHYSICIAN)
 
 /datum/gear/suit/oldwintercoat/science
 	display_name = "nostalgic science winter coat"
 	path = /obj/item/clothing/suit/hooded/wintercoat/science/old
-	allowed_roles = list(JOB_NAME_SCIENTIST, JOB_NAME_ROBOTICIST, JOB_NAME_RESEARCHDIRECTOR)
+	allowed_roles = list(JOB_NAME_SCIENTIST, JOB_NAME_ROBOTICIST, JOB_NAME_RESEARCHDIRECTOR, JOB_NAME_EXPLORATIONCREW)
 
 /datum/gear/suit/oldwintercoat/engineering
 	display_name = "nostalgic engineering winter coat"


### PR DESCRIPTION
## About The Pull Request

Adds nostalgic winter coats to the BeeCoin shop, as well as the default atmospherics winter coat that was missing. Nostalgic coats cost 20% more than their counterpart due to the increased difficulty of getting them in-shift, but this can be changed if unnecessary. There was also a duplicate hydroponics winter coat entry that has been removed.

## Why It's Good For The Game

More fashion choices in the BeeCoin shop is nice, and this increases the ease of access to any non-engineering staff (pesky vendor shocks) that would like a nostalgic coat.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![New entries in the shop](https://darkwindleaf.s-ul.eu/aidxF3jW)
New entries in the shop, including the atmospherics coat.

![Shift start nostalgic winter coat](https://darkwindleaf.s-ul.eu/Zs79HoNs)
Nostalgic winter coat on shift start!

</details>

## Changelog
:cl:
add: Nostalgic winter coats added to BeeCoin shop.
add: Atmospherics winter coat added to BeeCoin shop.
/:cl: