### PR TITLE
Tweaks Xenomorph embryo growth times

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -62,10 +62,10 @@
 	if(L.IsInStasis())
 		return
 	if(!next_stage_time)
-		COOLDOWN_START(src, next_stage_time, 1 MINUTES)
+		COOLDOWN_START(src, next_stage_time, 30 SECONDS)
 		return
 	if(COOLDOWN_FINISHED(src, next_stage_time) && stage < 5)
-		COOLDOWN_START(src, next_stage_time, rand(1 MINUTES, 1.5 MINUTES)) // Somewhere from 5-7 minutes to fully grow
+		COOLDOWN_START(src, next_stage_time, rand(30 SECONDS, 45 SECONDS)) // Somewhere from 2.5-3.5 minutes to fully grow
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -65,7 +65,12 @@
 		COOLDOWN_START(src, next_stage_time, 30 SECONDS)
 		return
 	if(COOLDOWN_FINISHED(src, next_stage_time) && stage < 5)
-		COOLDOWN_START(src, next_stage_time, rand(30 SECONDS, 45 SECONDS)) // Somewhere from 2.5-3.5 minutes to fully grow
+		var/additional_grow_time = 0 SECONDS
+		for(var/mob/living/carbon/alien/humanoid/A in GLOB.alive_mob_list) // Add more growing time based on how many aliens are alive
+			if(!A.key || A.stat == DEAD) // Don't count dead/SSD aliens
+				continue
+			additional_grow_time += 2 SECONDS
+		COOLDOWN_START(src, next_stage_time, rand(30 SECONDS, 45 SECONDS) + additional_grow_time) // Somewhere from 2.5-3.5 minutes to fully grow
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -70,6 +70,7 @@
 			if(!A.key || A.stat == DEAD) // Don't count dead/SSD aliens
 				continue
 			additional_grow_time += 2 SECONDS
+		additional_grow_time = min(additional_grow_time, 1 MINUTES)
 		COOLDOWN_START(src, next_stage_time, rand(30 SECONDS, 45 SECONDS) + additional_grow_time) // Somewhere from 2.5-3.5 minutes to fully grow
 		stage++
 		INVOKE_ASYNC(src, .proc/RefreshInfectionImage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This reduces xeno chestbursting time from 5-7 minutes to 2.5-3.5 minutes.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
When I originally made my PR tweaking how alien embryos work, I chose about a minute a stage, but that's proven to be too long for xenos in practice. This should make it easier for xenos to expand compared to what it is now, while avoiding having near-instant bursts.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Testing shows it working fine, with the expected time for bursts.

</details>

## Changelog
:cl:
balance: Tweaks xenomorph embryo bursting time. Embryos will now take 2.5-3.5 minutes to burst.
balance: Xenomorph embryo growth times now scale based on the amount of living xenos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
