### PR TITLE
[PORT] Improves Chat Highlighting + Messages by yourself no longer highlight

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -477,9 +477,9 @@ GLOBAL_LIST_EMPTY(species_list)
 				var/turf_link = TURF_LINK(M, turf_target)
 				rendered_message = "[turf_link] [message]"
 
-			to_chat(M, rendered_message)
+			to_chat(M, rendered_message, avoid_highlighting = speaker_key == M.key)
 		else
-			to_chat(M, message)
+			to_chat(M, message, avoid_highlighting = speaker_key == M.key)
 
 //Used in chemical_mob_spawn. Generates a random mob based on a given gold_core_spawnable value.
 /proc/create_random_mob(spawn_location, mob_class = HOSTILE_SPAWN)

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -29,4 +29,6 @@
 	var/link = FOLLOW_LINK(src, to_follow)
 	// Recompose the message, because it's scrambled by default
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
-	to_chat(src, "[link] [message]")
+	to_chat(src,
+		html = "[link] [message]",
+		avoid_highlighting = speaker == src)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -218,6 +218,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		return
 	var/deaf_message
 	var/deaf_type
+	var/avoid_highlight
+	if(istype(speaker, /atom/movable/virtualspeaker))
+		var/atom/movable/virtualspeaker/virt = speaker
+		avoid_highlight = src == virt.source
+	else
+		avoid_highlight = src == speaker
+
 	if(speaker != src)
 		if(!radio_freq) //These checks have to be seperate, else people talking on the radio will make "You can't hear yourself!" appear when hearing people over the radio while deaf.
 			deaf_message = "<span class='name'>[speaker]</span> [speaker.verb_say] something but you cannot hear [speaker.p_them()]."
@@ -229,7 +236,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
-	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlighting = speaker == src)
+	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlight)
 	return message
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, list/message_mods = list())

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
-	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type)
+	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlighting = speaker == src)
 	return message
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, list/message_mods = list())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -150,7 +150,7 @@
 /**
   * Show a message to this mob (visual or audible)
   */
-/mob/proc/show_message(msg, type, alt_msg, alt_type)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
+/mob/proc/show_message(msg, type, alt_msg, alt_type, avoid_highlighting = FALSE)//Message, type of message (1 or 2), alternative message, alt message type (1 or 2)
 
 	if(!client)
 		return
@@ -178,7 +178,7 @@
 		if(type & MSG_AUDIBLE) //audio
 			to_chat(src, "<I>... You can almost hear something ...</I>")
 		return
-	to_chat(src, msg)
+	to_chat(src, msg, avoid_highlighting = avoid_highlighting)
 
 
 /atom/proc/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, list/visible_message_flags)
@@ -1148,34 +1148,34 @@
 
 	if(href_list[VV_HK_PLAYER_PANEL] && check_rights(R_ADMIN))
 		usr.client.holder.show_player_panel(src)
-	
+
 	if(href_list[VV_HK_GODMODE] && check_rights(R_FUN))
 		usr.client.cmd_admin_godmode(src)
-	
+
 	if(href_list[VV_HK_GIVE_SPELL] && check_rights(R_FUN))
 		usr.client.give_spell(src)
-	
+
 	if(href_list[VV_HK_REMOVE_SPELL] && check_rights(R_FUN))
 		usr.client.remove_spell(src)
-	
+
 	if(href_list[VV_HK_GIVE_DISEASE] && check_rights(R_FUN))
 		usr.client.give_disease(src)
-	
+
 	if(href_list[VV_HK_GIB] && check_rights(R_FUN))
 		usr.client.cmd_admin_gib(src)
-	
+
 	if(href_list[VV_HK_BUILDMODE] && check_rights(R_BUILD))
 		togglebuildmode(src)
-	
+
 	if(href_list[VV_HK_DROP_ALL] && check_rights(R_FUN))
 		usr.client.cmd_admin_drop_everything(src)
-	
+
 	if(href_list[VV_HK_DIRECT_CONTROL] && check_rights(R_ADMIN))
 		usr.client.cmd_assume_direct_control(src)
-	
+
 	if(href_list[VV_HK_GIVE_DIRECT_CONTROL] && check_rights(R_ADMIN))
 		usr.client.cmd_give_direct_control(src)
-	
+
 	if(href_list[VV_HK_OFFER_GHOSTS] && check_rights(R_ADMIN))
 		offer_control(src)
 

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -118,7 +118,9 @@ export const chatMiddleware = store => {
       const settings = selectSettings(store.getState());
       chatRenderer.setHighlight(
         settings.highlightText,
-        settings.highlightColor);
+        settings.highlightColor,
+        settings.matchWord,
+        settings.matchCase);
       chatRenderer.setHighContrast(
         settings.highContrast,
       );

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -250,6 +250,8 @@ class ChatRenderer {
     }
     const lines = String(text)
       .split(',')
+      // replace() escapes every character found by the regex
+      // by placing a \ infront of each
       // eslint-disable-next-line no-useless-escape
       .map(str => str.trim().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
       .filter(str => (

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -242,21 +242,19 @@ class ChatRenderer {
     }
   }
 
-  setHighlight(text, color) {
+  setHighlight(text, color, matchWord, matchCase) {
     if (!text || !color) {
       this.highlightRegex = null;
       this.highlightColor = null;
       return;
     }
-    const allowedRegex = /^[a-z0-9_\-\s]+$/ig;
     const lines = String(text)
       .split(',')
-      .map(str => str.trim())
+      // eslint-disable-next-line no-useless-escape
+      .map(str => str.trim().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
       .filter(str => (
         // Must be longer than one character
         str && str.length > 1
-        // Must be alphanumeric (with some punctuation)
-        && allowedRegex.test(str)
       ));
     // Nothing to match, reset highlighting
     if (lines.length === 0) {
@@ -264,7 +262,9 @@ class ChatRenderer {
       this.highlightColor = null;
       return;
     }
-    this.highlightRegex = new RegExp('(' + lines.join('|') + ')', 'gi');
+    const pattern = `${(matchWord ? '\\b' : '')}(${lines.join('|')})${(matchWord ? '\\b' : '')}`;
+    const flags = 'g' + (matchCase ? '' : 'i');
+    this.highlightRegex = new RegExp(pattern, flags);
     this.highlightColor = color;
   }
 

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -62,8 +62,6 @@ export const SettingsGeneral = (props, context) => {
     highContrast,
     fontSize,
     lineHeight,
-    matchWord,
-    matchCase,
   } = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
   const [freeFont, setFreeFont] = useLocalState(context, "freeFont", false);
@@ -184,6 +182,8 @@ export const SettingsHighlight = (props, context) => {
   const {
     highlightText,
     highlightColor,
+    matchWord,
+    matchCase,
   } = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
   return (

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -62,6 +62,8 @@ export const SettingsGeneral = (props, context) => {
     highContrast,
     fontSize,
     lineHeight,
+    matchWord,
+    matchCase,
   } = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
   const [freeFont, setFreeFont] = useLocalState(context, "freeFont", false);
@@ -193,7 +195,7 @@ export const SettingsHighlight = (props, context) => {
         <Divider />
         <Flex mb={1} color="label" align="baseline">
           <Flex.Item grow={1}>
-            Highlight words (comma separated):
+            Highlight text (comma separated):
           </Flex.Item>
           <Flex.Item shrink={0}>
             <ColorBox mr={1} color={highlightColor} />
@@ -213,6 +215,22 @@ export const SettingsHighlight = (props, context) => {
           onChange={(e, value) => dispatch(updateSettings({
             highlightText: value,
           }))} />
+        <Button.Checkbox
+          checked={matchWord}
+          tooltipPosition="bottom-start"
+          tooltip="Not compatible with punctuation."
+          onClick={() => dispatch(updateSettings({
+            matchWord: !matchWord,
+          }))}>
+          Match word
+        </Button.Checkbox>
+        <Button.Checkbox
+          checked={matchCase}
+          onClick={() => dispatch(updateSettings({
+            matchCase: !matchCase,
+          }))}>
+          Match case
+        </Button.Checkbox>
       </Box>
       <Divider />
       <Box>

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -18,6 +18,8 @@ const initialState = {
   highlightText: '',
   highlightColor: '#ffdd44',
   highContrast: false,
+  matchWord: false,
+  matchCase: false,
   view: {
     visible: false,
     activeTab: SETTINGS_TABS[0].id,


### PR DESCRIPTION
## About The Pull Request

Ports:
https://github.com/tgstation/tgstation/pull/60146
https://github.com/tgstation/tgstation/pull/52991

Improves the chat highlighting and makes it so messages by oneself aren't highlighted anymore (if the second thing is not wanted i can remove it).

## Why It's Good For The Game

Fixes the highlighting of multiple entries, and quality of life for matching whole words or by case etc.

## Testing Photographs and Procedure
Note: i also did some other testing, like examining things, announcements etc.
<details>
<summary>Single word</summary>

## Normal

![ai no match word](https://user-images.githubusercontent.com/53494785/182933825-701ed704-747e-41b6-bb69-915d65cdb35b.png)

## Match Word

![ai with match word](https://user-images.githubusercontent.com/53494785/182933867-6dfde5cf-95a2-49e1-96e2-c3d6f51e16d4.png)

## Match Word and Case

![ai with match word and case](https://user-images.githubusercontent.com/53494785/182933891-91f86cf7-e1b1-4bc4-9e47-fc301f162f7e.png)

## By self

![ai by self](https://user-images.githubusercontent.com/53494785/182933960-d92bbf60-3bbf-41ce-890f-a2fa7ad46d5e.png)

</details>

<details>
<summary>Multiple Words</summary>

## Normal

![multiple no word or case](https://user-images.githubusercontent.com/53494785/182934372-d2d956f4-eda6-4b14-9565-4db78f61c5c7.png)

## Match Word

![multiple with word](https://user-images.githubusercontent.com/53494785/182934428-3e55dfb3-0ff4-4467-b208-e441c1f03922.png)

## Match Word and Case

![multiple with word or case](https://user-images.githubusercontent.com/53494785/182934447-8171c901-e4b2-4bac-80d0-ce97949449e2.png)

## By self

![multiple by self](https://user-images.githubusercontent.com/53494785/182934483-5e516ddf-b778-45ef-b403-a4b1f9f7e153.png)

</details>

## Changelog
:cl: Sarchutar, Mothblocks, Wayland-Smithy
fix: Chat highlighting now takes every entry into account
add: Hightlighting can now be case sensitive and/or matched by whole words
tweak: Messages sent by yourself no longer highlight
/:cl:
