### PR TITLE
Cluwne rune can no longer be scribed by cultist

### DIFF
--- a/code/game/objects/effects/mainttraps.dm
+++ b/code/game/objects/effects/mainttraps.dm
@@ -286,6 +286,7 @@
 	pixel_x = -32
 	pixel_y = -32
 	rune_in_use = FALSE
+	can_be_scribed = FALSE
 
 /obj/effect/rune/cluwne/attackby(obj/I, mob/user, params)
 	if(istype(I, /obj/item/melee/cultblade/dagger) && iscultist(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cult dagger refactor made it so they could scribe the maintenance cluwne rune
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They aren't supposed to be able to do so
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

![Screenshot_1189](https://user-images.githubusercontent.com/53474257/183100254-6f3ddef4-8ca2-48e7-b732-1b033b290131.png)


## Changelog
:cl:
fix: Cultists can't draw the cluwne rune anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
