### PR TITLE
adds in a midround zombie outbreak event

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -2061,6 +2061,7 @@
 #include "code\modules\events\spontaneous_appendicitis.dm"
 #include "code\modules\events\supermatter_surge.dm"
 #include "code\modules\events\wormholes.dm"
+#include "code\modules\events\zombie_outbreak.dm"
 #include "code\modules\events\holiday\halloween.dm"
 #include "code\modules\events\holiday\vday.dm"
 #include "code\modules\events\holiday\xmas.dm"

--- a/code/modules/events/wizard/blobies.dm
+++ b/code/modules/events/wizard/blobies.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/wizard/blobies //avast!
-	name = "Zombie Outbreak"
+	name = "Blob Zombie Outbreak"
 	weight = 3
 	typepath = /datum/round_event/wizard/blobies
 	max_occurrences = 3

--- a/code/modules/events/zombie_outbreak.dm
+++ b/code/modules/events/zombie_outbreak.dm
@@ -14,18 +14,19 @@
 	living_crew = get_living_station_crew()
 	var/infection_count = round(length(living_crew) / 10)
 
-	for(var/i in 0 to infection_count)
-		for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-			if(H.stat == DEAD)
-				continue
-			if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions))
-				continue
-			if(!H.getorgan(/obj/item/organ/brain))
-				continue
-			if(!(MOB_ORGANIC in H.mob_biotypes))
-				continue
-			if(!H.getorganslot(ORGAN_SLOT_ZOMBIE))
-				var/obj/item/organ/zombie_infection/ZI = new()
-				ZI.Insert(H)
-			announce_to_ghosts(H)
+	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
+		if(H.stat == DEAD)
+			continue
+		if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions))
+			continue
+		if(!H.getorgan(/obj/item/organ/brain))
+			continue
+		if(!(MOB_ORGANIC in H.mob_biotypes))
+			continue
+		if(!H.getorganslot(ORGAN_SLOT_ZOMBIE))
+			var/obj/item/organ/zombie_infection/ZI = new()
+			ZI.Insert(H)
+		announce_to_ghosts(H)
+		infection_count  --
+		if (infection_count <= 0)
 			break

--- a/code/modules/events/zombie_outbreak.dm
+++ b/code/modules/events/zombie_outbreak.dm
@@ -1,0 +1,29 @@
+/datum/round_event_control/zombie_outbreak
+	name = "Zombie Outbreak"
+	typepath = /datum/round_event/zombie_outbreak
+	weight = 5
+	max_occurrences = 1
+	min_players = 30
+
+/datum/round_event/zombie_outbreak
+	fakeable = FALSE
+
+/datum/round_event/zombie_outbreak/start()
+	// The amount of infections among the crew depends on the amount of living, non-AFK, non-silicon players on the station
+	var/list/living_crew = list()
+	living_crew = get_living_station_crew()
+	var/infection_count = round(length(living_crew) / 10)
+
+	for(var/i = 0, i < infection_count, i++)
+		for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
+			if(H.stat == DEAD)
+				continue
+			if(!SSjob.GetJob(H.mind.assigned_role) || (H.mind.assigned_role in GLOB.nonhuman_positions))
+				continue
+			if(!H.getorgan(/obj/item/organ/brain))
+				continue
+			if(!H.getorganslot(ORGAN_SLOT_ZOMBIE))
+				var/obj/item/organ/zombie_infection/ZI = new()
+				ZI.Insert(H)
+			announce_to_ghosts(H)
+			break

--- a/code/modules/events/zombie_outbreak.dm
+++ b/code/modules/events/zombie_outbreak.dm
@@ -22,6 +22,8 @@
 				continue
 			if(!H.getorgan(/obj/item/organ/brain))
 				continue
+			if(!(MOB_ORGANIC in H.mob_biotypes))
+				continue
 			if(!H.getorganslot(ORGAN_SLOT_ZOMBIE))
 				var/obj/item/organ/zombie_infection/ZI = new()
 				ZI.Insert(H)

--- a/code/modules/events/zombie_outbreak.dm
+++ b/code/modules/events/zombie_outbreak.dm
@@ -14,7 +14,7 @@
 	living_crew = get_living_station_crew()
 	var/infection_count = round(length(living_crew) / 10)
 
-	for(var/i = 0, i < infection_count, i++)
+	for(var/i in 0 to infection_count)
 		for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 			if(H.stat == DEAD)
 				continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds in a new midround event with the same weight as xenos and blobs. a minimum population of 30 crew is required for the event to be triggered.

1/10th of the living station crew, so anywhere between 3 and 5 people, randomly grow a deadly zombie tumor. it then becomes a race against time to get rid of the tumor before the infected turn into zombies. it can occur once per round maximum.

also changes the related wizard event's name to avoid confusion.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

this adds greater variety in terms of midround conflict and a much-needed alternative to xenomorph infestations. should add some more spice to highpop rounds.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

![image](https://user-images.githubusercontent.com/35978630/183170787-39c1e0e3-aebc-4a5b-ba09-c80a805d20c6.png)

</details>

## Changelog
:cl:
add: added a new midround event with the same weight as xenos and blobs: spontaneous zombie infection
tweak: changed the wizard blob zombies event's name to avoid confusion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
