### PR TITLE
Refactor and small fix for the cyborg power connector

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -146,35 +146,43 @@
 /obj/item/borg/cyborghug/medical
 	boop = TRUE
 
+#define MODE_DRAW "draw"
+#define MODE_CHARGE "charge"
+
 /obj/item/borg/charger
 	name = "power connector"
 	icon_state = "charger_draw"
 	item_flags = NOBLUDGEON
-	var/mode = "draw"
+	var/mode = MODE_DRAW
+	var/work_mode	// mode the loops have been started with, to check with do_after
 	var/active = FALSE
 	var/static/list/charge_machines = typecacheof(list(/obj/machinery/cell_charger, /obj/machinery/recharger, /obj/machinery/recharge_station, /obj/machinery/mech_bay_recharge_port))
 	var/static/list/charge_items = typecacheof(list(/obj/item/stock_parts/cell, /obj/item/gun/energy))
-
-/obj/item/borg/charger/Initialize(mapload)
-	. = ..()
 
 /obj/item/borg/charger/update_icon()
 	..()
 	icon_state = "charger_[mode]"
 
 /obj/item/borg/charger/attack_self(mob/user)
-	if(mode == "draw")
-		mode = "charge"
+	if(mode == MODE_DRAW)
+		mode = MODE_CHARGE
 	else
-		mode = "draw"
-	to_chat(user, "<span class='notice'>You toggle [src] to \"[mode]\" mode.</span>")
+		mode = MODE_DRAW
+	balloon_alert(user, "You toggle [src] to [mode] mode")
 	update_icon()
 
 /obj/item/borg/charger/afterattack(obj/item/target, mob/living/silicon/robot/user, proximity_flag)
 	. = ..()
 	if(!proximity_flag || !iscyborg(user))
 		return
-	if(mode == "draw")
+	if(active)
+		if(mode == MODE_DRAW)
+			to_chat(user, "<span class='warning'>You're already drawing power from something!</span>")
+		else
+			to_chat(user, "<span class='warning'>You're already charging something!</span>")
+		return
+
+	if(mode == MODE_DRAW)
 		if(is_type_in_list(target, charge_machines))
 			var/obj/machinery/M = target
 
@@ -182,29 +190,10 @@
 				to_chat(user, "<span class='warning'>[M] is unpowered!</span>")
 				return
 
-			if (active) //Prevents charge stacking from the same or multiple targets.
-				to_chat(user, "<span class ='notice'>You're already charging from [target].</span>")
-				return
-
+			to_chat(user, "<span class='notice'>You connect to [M]'s power line...</span>")
 			active = TRUE
 
-			to_chat(user, "<span class='notice'>You connect to [M]'s power line...</span>")
-			while(do_after(user, 15, target = M, progress = 0))
-
-				if(!user || !user.cell || mode != "draw")
-					return
-
-				if((M.stat & (NOPOWER|BROKEN)) || !M.anchored)
-					break
-
-				if(!user.cell.give(150))
-					break
-
-				M.use_power(200)
-
-			active = FALSE
-
-			to_chat(user, "<span class='notice'>You stop charging yourself.</span>")
+			powerdraw_loop(user, M)
 
 		else if(is_type_in_list(target, charge_items))
 			var/obj/item/stock_parts/cell/cell = target
@@ -222,75 +211,149 @@
 
 			if(!cell.charge)
 				to_chat(user, "<span class='warning'>[target] has no power!</span>")
-
-
-			to_chat(user, "<span class='notice'>You connect to [target]'s power port...</span>")
-
-			while(do_after(user, 15, target = target, progress = 0))
-				if(!user || !user.cell || mode != "draw")
-					return
-
-				if(!cell || !target)
-					return
-
-				if(cell != target && cell.loc != target)
-					return
-
-				var/draw = min(cell.charge, cell.chargerate*0.5, user.cell.maxcharge-user.cell.charge)
-				if(!cell.use(draw))
-					break
-				if(!user.cell.give(draw))
-					break
-				target.update_icon()
-
-			to_chat(user, "<span class='notice'>You stop charging yourself.</span>")
-
-	else if(is_type_in_list(target, charge_items))
-		var/obj/item/stock_parts/cell/cell = target
-		if(!istype(cell))
-			cell = locate(/obj/item/stock_parts/cell) in target
-		if(!cell)
-			to_chat(user, "<span class='warning'>[target] has no power cell!</span>")
-			return
-
-		if(istype(target, /obj/item/gun/energy))
-			var/obj/item/gun/energy/E = target
-			if(!E.can_charge)
-				to_chat(user, "<span class='warning'>[target] has no power port!</span>")
 				return
 
-		if(cell.charge >= cell.maxcharge)
-			to_chat(user, "<span class='warning'>[target] is already charged!</span>")
+			to_chat(user, "<span class='notice'>You connect to [target]'s power port...</span>")
+			active = TRUE
 
-		if (active) //Prevents stacking charging on the target.
-			to_chat(user, "<span class ='notice'>You're already charging [target].</span>")
-			return
+			powerdraw_loop(user, target, cell)
 
-		to_chat(user, "<span class='notice'>You connect to [target]'s power port...</span>")
+	else
+		if(is_type_in_list(target, charge_items))
+			if(user.cell.charge <= 500) //leave them a bit
+				to_chat(user, "<span class='warning'>You don't have enough power to charge [target]!</span>")
+				return
 
-		active = TRUE
+			var/obj/item/stock_parts/cell/cell = target
+			if(!istype(cell))
+				cell = locate(/obj/item/stock_parts/cell) in target
+			if(!cell)
+				to_chat(user, "<span class='warning'>[target] has no power cell!</span>")
+				return
 
-		while(do_after(user, 15, target = target, progress = 0))
+			if(istype(target, /obj/item/gun/energy))
+				var/obj/item/gun/energy/E = target
+				if(!E.can_charge)
+					to_chat(user, "<span class='warning'>[target] has no power port!</span>")
+					return
 
-			if(!user || !user.cell || mode != "charge")
+			if(cell.charge >= cell.maxcharge)
+				to_chat(user, "<span class='warning'>[target] is already fully charged!</span>")
+				return
+
+			to_chat(user, "<span class='notice'>You connect to [target]'s power port...</span>")
+			active = TRUE
+
+			charging_loop(user, target, cell)
+
+/obj/item/borg/charger/proc/powerdraw_loop(mob/living/silicon/robot/user, atom/target, obj/item/stock_parts/cell/cell)
+	work_mode = mode
+
+	if(istype(cell))
+		while(do_after(user, 15, target = target, extra_checks = CALLBACK(src, .proc/mode_check)))
+			if(!user || !user.cell)
+				active = FALSE
 				return
 
 			if(!cell || !target)
+				active = FALSE
 				return
 
 			if(cell != target && cell.loc != target)
+				active = FALSE
 				return
 
-			var/draw = min(user.cell.charge, cell.chargerate*0.5, cell.maxcharge-cell.charge)
-			if(!user.cell.use(draw))
+			var/draw = min(cell.charge, cell.chargerate*0.5, user.cell.maxcharge-user.cell.charge)
+			if(!cell.use(draw))
 				break
-			if(!cell.give(draw))
+
+			if(!user.cell.give(draw))
 				break
+
 			target.update_icon()
 
+			if(!cell.charge)
+				to_chat(user, "<span class='warning'>[target] has no power!</span>")
+				active = FALSE
+				return
+
+			if(user.cell.charge == user.cell.maxcharge)
+				to_chat(user, "<span class='notice'>You finish charging from [target].</span>")
+				active = FALSE
+				return
+
+		to_chat(user, "<span class='notice'>You stop drawing power from [target].</span>")
+		active = FALSE
+	else
+		var/obj/machinery/M = target
+		while(do_after(user, 15, target = M, extra_checks = CALLBACK(src, .proc/mode_check)))
+			if(!user || !user.cell)
+				active = FALSE
+				return
+
+			if(!target)
+				active = FALSE
+				return
+
+			if((M.stat & (NOPOWER|BROKEN)) || !M.anchored)
+				break
+
+			if(!user.cell.give(150))
+				break
+
+			M.use_power(200)
+
+			if(user.cell.charge == user.cell.maxcharge)
+				to_chat(user, "<span class='notice'>You finish charging from [target].</span>")
+				active = FALSE
+				return
+
+		to_chat(user, "<span class='notice'>You stop charging yourself.</span>")
 		active = FALSE
 
-		to_chat(user, "<span class='notice'>You stop charging [target].</span>")
+/obj/item/borg/charger/proc/charging_loop(mob/living/silicon/robot/user, atom/target, obj/item/stock_parts/cell/cell)
+	work_mode = mode
+
+	while(do_after(user, 15, target = target, extra_checks = CALLBACK(src, .proc/mode_check)))
+		if(!user || !user.cell)
+			active = FALSE
+			return
+
+		if(!cell || !target)
+			active = FALSE
+			return
+
+		if(cell != target && cell.loc != target)
+			active = FALSE
+			return
+
+		var/draw = min(user.cell.charge, cell.chargerate*0.5, cell.maxcharge-cell.charge)
+		if(!user.cell.use(draw))
+			break
+
+		if(!cell.give(draw))
+			break
+
+		target.update_icon()
+
+		if(cell.charge == cell.maxcharge)
+			to_chat(user, "<span class='notice'>You finish charging [target].</span>")
+			active = FALSE
+			return
+
+		if(user.cell.charge <= 500) //leave them a bit
+			to_chat(user, "<span class='warning'>You don't have enough power to charge [target]!</span>")
+			active = FALSE
+			return
+
+	to_chat(user, "<span class='notice'>You stop charging [target].</span>")
+	active = FALSE
+
+/obj/item/borg/charger/proc/mode_check()
+	return mode == work_mode
+
+#undef MODE_DRAW
+#undef MODE_CHARGE
 
 /obj/item/harmalarm
 	name = "\improper Sonic Harm Prevention Tool"

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -156,6 +156,7 @@
 	var/mode = MODE_DRAW
 	var/work_mode	// mode the loops have been started with, to check with do_after
 	var/active = FALSE
+	var/cyborg_minimum_charge = 500 	// minimum charge cyborgs cannot go under when charging things
 	var/static/list/charge_machines = typecacheof(list(/obj/machinery/cell_charger, /obj/machinery/recharger, /obj/machinery/recharge_station, /obj/machinery/mech_bay_recharge_port))
 	var/static/list/charge_items = typecacheof(list(/obj/item/stock_parts/cell, /obj/item/gun/energy))
 
@@ -220,7 +221,7 @@
 
 	else
 		if(is_type_in_list(target, charge_items))
-			if(user.cell.charge <= 500) //leave them a bit
+			if(user.cell.charge <= cyborg_minimum_charge) //leave them a bit
 				to_chat(user, "<span class='warning'>You don't have enough power to charge [target]!</span>")
 				return
 
@@ -327,7 +328,12 @@
 			active = FALSE
 			return
 
-		var/draw = min(user.cell.charge, cell.chargerate*0.5, cell.maxcharge-cell.charge)
+		var/draw = min(max(user.cell.charge - cyborg_minimum_charge, 0), cell.chargerate*0.5, cell.maxcharge-cell.charge)
+		if(!draw)
+			to_chat(user, "<span class='warning'>Safeties prevent you from going under [cyborg_minimum_charge] charge!</span>")
+			active = FALSE
+			return
+
 		if(!user.cell.use(draw))
 			break
 
@@ -341,8 +347,8 @@
 			active = FALSE
 			return
 
-		if(user.cell.charge <= 500) //leave them a bit
-			to_chat(user, "<span class='warning'>You don't have enough power to charge [target]!</span>")
+		if(user.cell.charge <= cyborg_minimum_charge) //leave them a bit
+			to_chat(user, "<span class='warning'>You don't have enough power to continue charging [target]!</span>")
 			active = FALSE
 			return
 

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -251,7 +251,7 @@
 
 	if(istype(cell))
 		while(do_after(user, 15, target = target, extra_checks = CALLBACK(src, .proc/mode_check)))
-			if(!user || !user.cell)
+			if(!user?.cell)
 				active = FALSE
 				return
 
@@ -287,7 +287,7 @@
 	else
 		var/obj/machinery/M = target
 		while(do_after(user, 15, target = M, extra_checks = CALLBACK(src, .proc/mode_check)))
-			if(!user || !user.cell)
+			if(!user?.cell)
 				active = FALSE
 				return
 
@@ -315,7 +315,7 @@
 	work_mode = mode
 
 	while(do_after(user, 15, target = target, extra_checks = CALLBACK(src, .proc/mode_check)))
-		if(!user || !user.cell)
+		if(!user?.cell)
 			active = FALSE
 			return
 


### PR DESCRIPTION
## About The Pull Request

Fixes #7283

Refactors the cyborg power connector to be a bit more readable.
Changes the `attack_self` message to a balloon alert. 
Makes it use a progress bar in `do_after`  (why did it not use one initially?).
Addition of a small limit for when charging things, so cyborgs don't completely drain their cells.

Refactor also fixes a bug that made the connector unable to be used after moving while draining power from a power cell.


## Why It's Good For The Game

More readable stuff is always good i guess, the balloon alert/progress bar is nice to have and the limit is just a safety for charging things.
And as a side thing, bug fixes are good.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/53494785/183272855-3c1b7e15-d0db-4297-b6ba-c97c781f9168.mp4

</details>

## Changelog
:cl:
refactor: refactored the cyborg power connector code
add: changing modes of the power connector now uses a balloon alert
add: limit when charging things to not accidentally completely drain ones cell
add: when drawing power/charging it has a progress bar now
fix: fixed a bug which made the connector unusable when moving while drawing power from a cell
/:cl:
