### PR TITLE
Rework hearing for INVISIBILITY_MAXIMUM mobs

### DIFF
--- a/code/__DEFINES/sight.dm
+++ b/code/__DEFINES/sight.dm
@@ -14,6 +14,7 @@
 #define SEE_INVISIBLE_OBSERVER 60
 
 #define INVISIBILITY_MAXIMUM 100 //! the maximum allowed for "real" objects
+#define SEE_INVISIBLE_MAXIMUM 100
 
 #define INVISIBILITY_ABSTRACT 101 //! only used for abstract objects (e.g. spacevine_controller), things that are not really there.
 

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -65,6 +65,7 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	see_invisible = SEE_INVISIBLE_LIVING
 	invisibility = INVISIBILITY_MAXIMUM
+	can_hear_init = TRUE // Enable hearing sensitive trait
 	var/icon/human_image
 	var/image/current_image
 	var/hidden = FALSE
@@ -147,6 +148,9 @@
 			return
 
 	friend_talk(message)
+
+/mob/camera/imaginary_friend/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
+	to_chat(src, compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode))
 
 /mob/camera/imaginary_friend/proc/friend_talk(message)
 	message = capitalize(trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)))

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -38,7 +38,7 @@
 	if(!istype(AI))
 		return
 	if(AI.eyeobj)
-		AI.eyeobj.relay_speech = TRUE
+		AI.eyeobj.set_relay_speech(TRUE)
 		to_chat(AI, "<span class='userdanger'>[user] has upgraded you with surveillance software!</span>")
 		to_chat(AI, "Via a combination of hidden microphones and lip reading software, you are able to use your cameras to listen in on conversations.")
 	to_chat(user, "<span class='notice'>You upgrade [AI]. [src] is consumed in the process.</span>")

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/send_speech(message, range = 7, obj/source = src, bubble_type, list/spans, datum/language/message_language = null, list/message_mods = list())
 	var/rendered = compose_message(src, message_language, message, , spans, message_mods)
 	var/list/show_overhead_message_to = list()
-	for(var/atom/movable/AM as() in get_hearers_in_view(range, source))
+	for(var/atom/movable/AM as() in get_hearers_in_view(range, source, SEE_INVISIBLE_MAXIMUM))
 		if(ismob(AM))
 			var/mob/M = AM
 			if(M.should_show_chat_message(source, message_language, FALSE, is_heard = TRUE))

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -857,7 +857,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 
 /datum/AI_Module/large/eavesdrop/upgrade(mob/living/silicon/ai/AI)
 	if(AI.eyeobj)
-		AI.eyeobj.relay_speech = TRUE
+		AI.eyeobj.set_relay_speech(TRUE)
 
 
 //Fake Alert: Overloads a random number of lights across the station. Three uses.

--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -161,7 +161,7 @@
 	var/list/old = hearing_mobs.Copy()
 	hearing_mobs.len = 0
 	var/turf/source = get_turf(parent)
-	for(var/mob/M in get_hearers_in_view(instrument_range, source, SEE_INVISIBLE_OBSERVER))
+	for(var/mob/M in get_hearers_in_view(instrument_range, source, SEE_INVISIBLE_MAXIMUM))
 		hearing_mobs[M] = get_dist(M, source)
 	var/list/exited = old - hearing_mobs
 	for(var/i in exited)

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -11,6 +11,14 @@
 	invisibility = INVISIBILITY_ABSTRACT // No one can see us
 	sight = SEE_SELF
 	move_on_shuttle = FALSE
+	/// Only used at init, assigning to this will do nothing after the camera is initialized
+	var/can_hear_init = FALSE
+
+/mob/camera/Initialize(mapload)
+	. = ..()
+	if(!can_hear_init)
+		// Cameras should not be able to hear by default despite being mobs
+		REMOVE_TRAIT(src, TRAIT_HEARING_SENSITIVE, TRAIT_GENERIC)
 
 /mob/camera/experience_pressure_difference()
 	return

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -237,7 +237,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/eavesdrop_range = 0
 	if(message_mods[WHISPER_MODE]) //If we're whispering
 		eavesdrop_range = EAVESDROP_EXTRA_RANGE
-	var/list/listening = get_hearers_in_view(message_range+eavesdrop_range, source, SEE_INVISIBLE_OBSERVER)
+	var/list/listening = get_hearers_in_view(message_range+eavesdrop_range, source, SEE_INVISIBLE_MAXIMUM)
 	var/list/the_dead = list()
 	for(var/mob/M as() in GLOB.player_list)
 		if(!M)				//yogs
@@ -245,14 +245,14 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(M.stat != DEAD) //not dead, not important
 			continue
 		if(!M.client || !client) //client is so that ghosts don't have to listen to mice
-			listening -= M // remove (added by SEE_INVISIBLE_OBSERVER)
+			listening -= M // remove (added by SEE_INVISIBLE_MAXIMUM)
 			continue
 		if(get_dist(M, src) > 7 || M.get_virtual_z_level() != get_virtual_z_level()) //they're out of range of normal hearing
 			if(eavesdrop_range && !(M.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
-				listening -= M // remove (added by SEE_INVISIBLE_OBSERVER)
+				listening -= M // remove (added by SEE_INVISIBLE_MAXIMUM)
 				continue
 			if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
-				listening -= M // remove (added by SEE_INVISIBLE_OBSERVER)
+				listening -= M // remove (added by SEE_INVISIBLE_MAXIMUM)
 				continue
 		listening |= M
 		the_dead[M] = TRUE

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -11,7 +11,6 @@
 	hud_possible = list(ANTAG_HUD, AI_DETECT_HUD = HUD_LIST_LIST)
 	var/list/visibleCameraChunks = list()
 	var/mob/living/silicon/ai/ai = null
-	var/relay_speech = FALSE
 	var/use_static = TRUE
 	var/static_visibility_range = 16
 	var/ai_detector_visible = TRUE
@@ -22,6 +21,12 @@
 	GLOB.ai_eyes += src
 	update_ai_detect_hud()
 	setLoc(loc, TRUE)
+
+/mob/camera/ai_eye/proc/set_relay_speech(relay)
+	if(relay)
+		become_hearing_sensitive()
+	else
+		REMOVE_TRAIT(src, TRAIT_HEARING_SENSITIVE, TRAIT_GENERIC)
 
 /mob/camera/ai_eye/proc/update_ai_detect_hud()
 	var/datum/atom_hud/ai_detector/hud = GLOB.huds[DATA_HUD_AI_DETECT]
@@ -213,7 +218,7 @@
 
 /mob/camera/ai_eye/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
 	. = ..()
-	if(relay_speech && speaker && ai && !radio_freq && speaker != ai && near_camera(speaker))
+	if(speaker && ai && !radio_freq && speaker != ai && near_camera(speaker))
 		ai.relay_speech(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
 /obj/effect/overlay/ai_detect_hud

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -243,7 +243,7 @@
   * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
   */
 /atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, list/audible_message_flags)
-	var/list/hearers = get_hearers_in_view(hearing_distance, src, SEE_INVISIBLE_OBSERVER)
+	var/list/hearers = get_hearers_in_view(hearing_distance, src, SEE_INVISIBLE_MAXIMUM)
 	if(self_message)
 		hearers -= src
 
@@ -1148,34 +1148,34 @@
 
 	if(href_list[VV_HK_PLAYER_PANEL] && check_rights(R_ADMIN))
 		usr.client.holder.show_player_panel(src)
-	
+
 	if(href_list[VV_HK_GODMODE] && check_rights(R_FUN))
 		usr.client.cmd_admin_godmode(src)
-	
+
 	if(href_list[VV_HK_GIVE_SPELL] && check_rights(R_FUN))
 		usr.client.give_spell(src)
-	
+
 	if(href_list[VV_HK_REMOVE_SPELL] && check_rights(R_FUN))
 		usr.client.remove_spell(src)
-	
+
 	if(href_list[VV_HK_GIVE_DISEASE] && check_rights(R_FUN))
 		usr.client.give_disease(src)
-	
+
 	if(href_list[VV_HK_GIB] && check_rights(R_FUN))
 		usr.client.cmd_admin_gib(src)
-	
+
 	if(href_list[VV_HK_BUILDMODE] && check_rights(R_BUILD))
 		togglebuildmode(src)
-	
+
 	if(href_list[VV_HK_DROP_ALL] && check_rights(R_FUN))
 		usr.client.cmd_admin_drop_everything(src)
-	
+
 	if(href_list[VV_HK_DIRECT_CONTROL] && check_rights(R_ADMIN))
 		usr.client.cmd_assume_direct_control(src)
-	
+
 	if(href_list[VV_HK_GIVE_DIRECT_CONTROL] && check_rights(R_ADMIN))
 		usr.client.cmd_give_direct_control(src)
-	
+
 	if(href_list[VV_HK_OFFER_GHOSTS] && check_rights(R_ADMIN))
 		offer_control(src)
 


### PR DESCRIPTION
## About The Pull Request

As a sort of sequel to #7241, I've fixed up hearing for mobs with INVISIBILITY_MAXIMUM. This includes cameras (AI cam, blob overmind, clockcult eminence) and imaginary friends.

Cameras no longer have the hearing sensitive trait by default, this removes any unexpected hearing behavior.

The AI eye will receive the trait when it is upgraded.

Imaginary friends have the trait enabled and now override `Hear()` properly (this replaces my fixes from #7441)

As far as I can tell, this has been broken since #3431, which reworked `get_hearers_in_view` and added the invisibility check in the first place.

## Why It's Good For The Game

Hearing behavior is more consistent

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

**Blob no longer gets runechat at all (before, you would get runechat but not text chat)**
![image](https://user-images.githubusercontent.com/10366817/183392983-22c351e4-3e1c-40a0-8255-8fc72f1f6829.png)

**AI eye with upgrade**
![image](https://user-images.githubusercontent.com/10366817/183392803-9e38ff98-8162-4ba8-a193-d731a65f0774.png)

**Imaginary friend**
![image](https://user-images.githubusercontent.com/10366817/183392830-d6f0e500-e7b4-4ef4-a9bc-df59f8b28f00.png)

</details>

## Changelog
:cl:
fix: Overmind and eminence can no longer see runechat
fix: Imaginary friends can hear again
/:cl: