### PR TITLE
A couple minebot tweaks

### DIFF
--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -1,7 +1,7 @@
 #define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE)
 #define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 #define QDEL_NULL(item) qdel(item); item = null
-#define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L.Cut(); }
+#define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); if(L) { L.Cut(); } }
 #define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/______qdel_list_wrapper, L), time, TIMER_STOPPABLE)
 #define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } L.Cut(); }
 #define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qdel(L[I]); L.Cut(); }

--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -1,7 +1,7 @@
 #define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE)
 #define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 #define QDEL_NULL(item) qdel(item); item = null
-#define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L?.Cut(); }
+#define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L.Cut(); }
 #define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/______qdel_list_wrapper, L), time, TIMER_STOPPABLE)
 #define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } L.Cut(); }
 #define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qdel(L[I]); L.Cut(); }

--- a/code/__HELPERS/qdel.dm
+++ b/code/__HELPERS/qdel.dm
@@ -1,7 +1,7 @@
 #define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE)
 #define QDEL_IN_CLIENT_TIME(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE | TIMER_CLIENT_TIME)
 #define QDEL_NULL(item) qdel(item); item = null
-#define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); if(L) { L.Cut(); } }
+#define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L?.Cut(); }
 #define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/______qdel_list_wrapper, L), time, TIMER_STOPPABLE)
 #define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } L.Cut(); }
 #define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qdel(L[I]); L.Cut(); }

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -94,7 +94,8 @@
 		qdel(action)
 
 	// Clear any equipment they might have
-	QDEL_LIST(installed_upgrades)
+	for(var/upgrade in installed_upgrades)
+		qdel(upgrade)
 	QDEL_NULL(stored_pka)
 	QDEL_NULL(stored_cutter)
 	QDEL_NULL(stored_drill)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -94,8 +94,7 @@
 		qdel(action)
 
 	// Clear any equipment they might have
-	for(var/upgrade in installed_upgrades)
-		qdel(upgrade)
+	QDEL_LIST(installed_upgrades)
 	QDEL_NULL(stored_pka)
 	QDEL_NULL(stored_cutter)
 	QDEL_NULL(stored_drill)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -284,6 +284,7 @@
 	if(user.a_intent != INTENT_HELP) // Smacking/grabbing
 		return ..()
 	if(client) // No messing with the minebot while there's a player inside it.
+		to_chat(user, "<span class='info'>[src]'s equipment is currently slaved to its onboard AI. Best not to touch it.</span>")
 		return ..()
 	if(mode == MODE_MINING && !mining_enabled)
 		mining_enabled = TRUE

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -329,7 +329,7 @@
 
 /// Melee attack handling
 /mob/living/simple_animal/hostile/mining_drone/AttackingTarget()
-	if(istype(target, /obj/machinery/computer))
+	if(client && istype(target, /obj/machinery/computer))
 		target.ui_interact(src)
 		return
 	if(stored_cutter && (istype(target, /obj/item/stack/ore/plasma) || istype(target, /obj/item/stack/sheet/mineral/plasma)) && mode == MODE_MINING) //Charging the on-board plasma cutter

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -109,9 +109,9 @@
 			if(health >= maxHealth)
 				hud_used.healths.icon_state = "health0"
 			else if(health > maxHealth*0.8)
-				hud_used.healths.icon_state = "health1"
-			else if(health > maxHealth * 0.5)
 				hud_used.healths.icon_state = "health2"
+			else if(health > maxHealth * 0.5)
+				hud_used.healths.icon_state = "health3"
 			else if(health > maxHealth*0.2)
 				hud_used.healths.icon_state = "health4"
 			else

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -94,7 +94,7 @@
 		qdel(action)
 
 	// Clear any equipment they might have
-	QDEL_LIST(installed_upgrades)
+	QDEL_LAZYLIST(installed_upgrades)
 	QDEL_NULL(stored_pka)
 	QDEL_NULL(stored_cutter)
 	QDEL_NULL(stored_drill)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -108,11 +108,11 @@
 		if(stat != DEAD)
 			if(health >= maxHealth)
 				hud_used.healths.icon_state = "health0"
-			else if(health > maxHealth*0.8)
+			else if(health > maxHealth * 0.7)
 				hud_used.healths.icon_state = "health2"
-			else if(health > maxHealth * 0.5)
+			else if(health > maxHealth * 0.4)
 				hud_used.healths.icon_state = "health3"
-			else if(health > maxHealth*0.2)
+			else if(health > maxHealth * 0.2)
 				hud_used.healths.icon_state = "health4"
 			else
 				hud_used.healths.icon_state = "health5"

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -30,7 +30,7 @@
 	deathmessage = "stops moving"
 	// AI stuff
 	check_friendly_fire = TRUE
-	move_to_delay = 10
+	move_to_delay = 5
 	ranged = TRUE
 	sentience_type = SENTIENCE_MINEBOT
 	stop_automated_movement_when_pulled = TRUE
@@ -82,7 +82,7 @@
 
 	// Setup radio
 	var/obj/item/implant/radio/mining/imp = new(src)
-	imp.implant(src)
+	imp.implant(src, force = TRUE)
 
 	// Setup access
 	access_card = new /obj/item/card/id(src)
@@ -109,9 +109,9 @@
 			if(health >= maxHealth)
 				hud_used.healths.icon_state = "health0"
 			else if(health > maxHealth*0.8)
-				hud_used.healths.icon_state = "health2"
+				hud_used.healths.icon_state = "health1"
 			else if(health > maxHealth * 0.5)
-				hud_used.healths.icon_state = "health3"
+				hud_used.healths.icon_state = "health2"
 			else if(health > maxHealth*0.2)
 				hud_used.healths.icon_state = "health4"
 			else
@@ -126,7 +126,7 @@
 		if(health >= maxHealth * 0.75)
 			. += "<span class='warning'>It looks slightly dented.</span>"
 		else if(health >= maxHealth * 0.25)
-			. += "<span class='warning'>It looks moderately dented.</span>"
+			. += "<span class='warning'>It looks <b>moderately</b> dented.</span>"
 		else if(health > 0)
 			. += "<span class='boldwarning'>It looks severely dented!</span>"
 		else
@@ -283,7 +283,6 @@
 	if(user.a_intent != INTENT_HELP) // Smacking/grabbing
 		return ..()
 	if(client) // No messing with the minebot while there's a player inside it.
-		to_chat(user, "<span class='info'>[src]'s equipment is currently slaved to its onboard AI. Best not to touch it.</span>")
 		return ..()
 	if(mode == MODE_MINING && !mining_enabled)
 		mining_enabled = TRUE
@@ -330,6 +329,9 @@
 
 /// Melee attack handling
 /mob/living/simple_animal/hostile/mining_drone/AttackingTarget()
+	if(istype(target, /obj/machinery/computer))
+		target.ui_interact(src)
+		return
 	if(stored_cutter && (istype(target, /obj/item/stack/ore/plasma) || istype(target, /obj/item/stack/sheet/mineral/plasma)) && mode == MODE_MINING) //Charging the on-board plasma cutter
 		stored_cutter.attackby(target, src)
 		if(stored_cutter.cell.charge == stored_cutter.cell.maxcharge) // Either charge the cutter or pick up the plasma if the cutter's full
@@ -602,7 +604,7 @@
 // Gives a health bonus to the minebot.
 /obj/item/minebot_upgrade/health
 	name = "minebot armor upgrade"
-	desc = "A minebot upgrade that improves a minebot's armor, allowing them to sustain more damage before being disabled."
+	desc = "Improves a minebot's armor, allowing them to sustain more damage before being disabled."
 	var/health_upgrade = 45
 
 /obj/item/minebot_upgrade/health/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/minebot, mob/user)

--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -1,5 +1,5 @@
 /datum/emote/silicon
-	mob_type_allowed_typecache = list(/mob/living/silicon)
+	mob_type_allowed_typecache = list(/mob/living/silicon, /mob/living/simple_animal/hostile/mining_drone)
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/silicon/boop


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes a bug with minebot radios, tweaks the minebot's health indicator to be a bit more accurate, and allows minebots to use consoles. This also increases the base speed of minebots.

Edit: I also added a fix for the destroy() logic that I didn't notice until now, as well as some more emotes for minebots, because emotes are cool.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This allows players to be a bit more independent while playing as a minebot. Bug fixes are also nice.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/183556677-5c8f17cf-fa73-4ef8-9953-3bb96ac76b22.png)

The new HUD element works fine, along with the fix for the radio implant and interfacing with consoles.
</details>

## Changelog
:cl:
tweak: Tweaks minebot HUDs a bit.
tweak: Minebots can now use all of the silicon emotes, instead of just beep.
fix: Fixes minebot radio implants.
balance: Minebots can now use computer and shuttle consoles. 
balance: Minebots are now slightly faster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
