### PR TITLE
Makes the atmospherics beret obtainable from the AtmosDrobe vendor

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -123,7 +123,8 @@
 					/obj/item/clothing/head/helmet/space/plasmaman/engineering/atmospherics = 3,
 					/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos = 3,
 					/obj/item/clothing/under/rank/engineering/atmospheric_technician = 3,
-					/obj/item/clothing/shoes/sneakers/black = 3)
+					/obj/item/clothing/shoes/sneakers/black = 3,
+					/obj/item/clothing/head/beret/atmos = 3)
 	contraband = list(/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos/old = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/atmos_wardrobe
 	payment_department = ACCOUNT_ENG


### PR DESCRIPTION
## About The Pull Request

Exactly what the title says.

## Why It's Good For The Game

The beret is already in the game, so why not make it obtainable?

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/93578146/183611289-eee9ad01-6a0f-486d-9da4-126ab6feb568.png)

</details>

## Changelog
:cl:
tweak: atmospherics beret now obtainable from the AtmosDrobe vendor
/:cl: