### PR TITLE
Adjusts oozelings to use slime speaking verbs

### DIFF
--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -7,3 +7,6 @@
 #define CENTER(text) {"<center>[##text]</center>"}
 
 #define SANITIZE_FILENAME(text) (GLOB.filename_forbidden_chars.Replace(text, ""))
+
+// for things that could be a list or a str, if its a list return rand element  - candy/ether
+#define PICK_ONE(x) islist(x) ? pick(x) : x

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -7,5 +7,3 @@
 #define CENTER(text) {"<center>[##text]</center>"}
 
 #define SANITIZE_FILENAME(text) (GLOB.filename_forbidden_chars.Replace(text, ""))
-
-

--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -8,5 +8,4 @@
 
 #define SANITIZE_FILENAME(text) (GLOB.filename_forbidden_chars.Replace(text, ""))
 
-// for things that could be a list or a str, if its a list return rand element  - candy/ether
-#define PICK_ONE(x) islist(x) ? pick(x) : x
+

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -2,7 +2,7 @@
 	var/obj/item/organ/tongue/T = getorganslot(ORGAN_SLOT_TONGUE)
 	if(T)
 		verb_say = pick(T.say_mod)
-		verb_ask = pick(T.ask_mod)  // cant believe nobody coded this yet - ether
+		verb_ask = pick(T.ask_mod)
 		verb_yell = pick(T.yell_mod)
 		verb_exclaim = pick(T.exclaim_mod)
 	if(slurring || !T)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,10 +1,10 @@
 /mob/living/carbon/human/say_mod(input, list/message_mods = list())
 	var/obj/item/organ/tongue/T = getorganslot(ORGAN_SLOT_TONGUE)
 	if(T)
-		verb_say = PICK_ONE(T.say_mod)
-		verb_ask = PICK_ONE(T.ask_mod)  // cant believe nobody coded this yet - ether
-		verb_yell = PICK_ONE(T.yell_mod)
-		verb_exclaim = PICK_ONE(T.exclaim_mod)
+		verb_say = pick(T.say_mod)
+		verb_ask = pick(T.ask_mod)  // cant believe nobody coded this yet - ether
+		verb_yell = pick(T.yell_mod)
+		verb_exclaim = pick(T.exclaim_mod)
 	if(slurring || !T)
 		return "slurs"
 	else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,7 +1,10 @@
 /mob/living/carbon/human/say_mod(input, list/message_mods = list())
 	var/obj/item/organ/tongue/T = getorganslot(ORGAN_SLOT_TONGUE)
 	if(T)
-		verb_say = T.say_mod
+		verb_say = PICK_ONE(T.say_mod)
+		verb_ask = PICK_ONE(T.ask_mod)  // cant believe nobody coded this yet - ether
+		verb_yell = PICK_ONE(T.yell_mod)
+		verb_exclaim = PICK_ONE(T.exclaim_mod)
 	if(slurring || !T)
 		return "slurs"
 	else

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -319,7 +319,7 @@
 	desc = "It's a piece of slime, shaped like a tongue."
 	say_mod = list("blorbles", "bubbles")
 	ask_mod = "inquisitively blorbles"
-	yell_mod = "blorble screams"
+	yell_mod = "shrilly blorbles"
 	exclaim_mod = "loudly blorbles"
 	toxic_food = NONE
 	disliked_food = NONE

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -314,7 +314,10 @@
 /obj/item/organ/tongue/slime
 	name = "slimey tongue"
 	desc = "It's a piece of slime, shaped like a tongue."
-	say_mod = "blorbles"
+	say_mod = list("blorbles", "bubbles")
+	verb_ask = "inquisitively blorbles"
+	verb_exclaim = "blorble screams"
+	verb_yell = "loudly blorbles"
 	toxic_food = NONE
 	disliked_food = NONE
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -7,6 +7,9 @@
 	attack_verb = list("licked", "slobbered", "slapped", "frenched", "tongued")
 	var/list/languages_possible
 	var/say_mod = "says"
+	var/ask_mod = "asks"
+	var/yell_mod = "yells"
+	var/exclaim_mod = "exclaims"
 	var/liked_food = JUNKFOOD | FRIED
 	var/disliked_food = GROSS | RAW
 	var/toxic_food = TOXIC
@@ -315,9 +318,9 @@
 	name = "slimey tongue"
 	desc = "It's a piece of slime, shaped like a tongue."
 	say_mod = list("blorbles", "bubbles")
-	verb_ask = "inquisitively blorbles"
-	verb_exclaim = "blorble screams"
-	verb_yell = "loudly blorbles"
+	ask_mod = "inquisitively blorbles"
+	yell_mod = "blorble screams"
+	exclaim_mod = "loudly blorbles"
 	toxic_food = NONE
 	disliked_food = NONE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the oozeling class to use the ask and yell speaking verbs from slimes.

Also comes with a free refactor, for some reason tounges couldnt modify your ask yell or exclaim verbs so i added that too
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency with the slimes mob, ic it makes no sense that you stop blorbling messages when asking a question.

The tounge refactor allows for more creativity with tounge types, with 3 new verbs to define
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/184263442-4d4a6a9a-1989-4307-9b78-644621f74f0d.png)

</details>

## Changelog
:cl:
tweak: oozelings have 50% more blorbles
refactor: tounges can now modify your ask, yell, and exclaim verbs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
