### PR TITLE
Fix tablet flashlight incorrectly starting on

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -46,7 +46,7 @@
 	var/has_light = FALSE						//If the computer has a flashlight/LED light/what-have-you installed
 	var/comp_light_luminosity = 3				//The brightness of that light
 	var/comp_light_color			//The color of that light
-
+	light_on = FALSE // override behavior from atom so flashlight button is not marked as ON
 
 /obj/item/modular_computer/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Tablets start with the flashlight in their menu marked as "ON", despite being off. This fixes that.

Fixes #6187

## Why It's Good For The Game

Fix bug

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/184391655-a0974508-f888-42a7-bfc9-45f9ceba7ffc.png)

![image](https://user-images.githubusercontent.com/10366817/184391663-d9a443e8-eee1-4e54-a5dc-2ebe873a0fa2.png)

</details>

## Changelog
:cl:
fix: Tablet flashlights no longer incorrectly start as ON
/:cl:
