### PR TITLE
Gas synthesis gives discovery research

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -482,6 +482,7 @@
 	air.adjust_moles(GAS_PLASMA, -2*reaction_efficency)
 
 	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, min((reaction_efficency**2)*BZ_RESEARCH_SCALE,BZ_RESEARCH_MAX_AMOUNT))
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, min((reaction_efficency**2)*BZ_RESEARCH_SCALE,BZ_RESEARCH_MAX_AMOUNT)*0.5)
 
 	if(energy_released > 0)
 		var/new_heat_capacity = air.heat_capacity()
@@ -515,6 +516,7 @@
 	air.adjust_moles(GAS_NITRYL, -heat_scale)
 	air.adjust_moles(GAS_TRITIUM, -heat_scale)
 	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, STIMULUM_RESEARCH_AMOUNT*max(stim_energy_change,0))
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, STIMULUM_RESEARCH_AMOUNT*max(stim_energy_change,0)*0.5)
 	if(stim_energy_change)
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
@@ -542,6 +544,7 @@
 	air.adjust_moles(GAS_N2, -20*nob_formed)
 	air.adjust_moles(GAS_HYPERNOB, nob_formed)
 	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, nob_formed*NOBLIUM_RESEARCH_AMOUNT)
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, nob_formed*NOBLIUM_RESEARCH_AMOUNT*0.5)
 
 	if (nob_formed)
 		var/new_heat_capacity = air.heat_capacity()


### PR DESCRIPTION
## About The Pull Request

Synthesizing certain gases will now give discovery research as well, instead of only standard research points.

## Why It's Good For The Game

Atmospheric technicians will be more useful to the rest of the station, and it will be a bit easier to get research done if there aren't enough/any miners or explorers.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/93578146/184466894-0dfce4cd-42c7-4f6f-a697-3a7172ad0c36.png)
![image](https://user-images.githubusercontent.com/93578146/184466732-6bf3a3bd-3c77-4638-a27a-b96e32951577.png)

</details>

## Changelog
:cl:
tweak: gas synthesis gives discovery research
/:cl: