### PR TITLE
Finally fixes the Social Anxiety quirk (and adds mood change!)

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -52,6 +52,21 @@
 	mood_change = -12
 	timeout = 2 MINUTES
 
+/datum/mood_event/anxiety
+	description = "<span class='warning'>I feel scared around all these people..</span>\n"
+	mood_change = -2
+	timeout = 60 SECONDS
+
+/datum/mood_event/anxiety_mute
+	description = "<span class='boldwarning'>I can't speak up, not with everyone here!</span>\n"
+	mood_change = -4
+	timeout = 2 MINUTES
+
+/datum/mood_event/anxiety_dumb
+	description = "<span class='boldwarning'>Oh god, I made a fool of myself.</span>\n"
+	mood_change = -10
+	timeout = 2 MINUTES
+
 /datum/mood_event/shameful_suicide //suicide_acts that return SHAME, like sord
   description = "<span class='boldwarning'>I can't even end it all!</span>\n"
   mood_change = -15

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -479,7 +479,7 @@
 	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
 	value = -1
 	gain_text = "<span class='danger'>You start worrying about what you're saying.</span>"
-	lose_text = "<span class='notice'>You feel comfortable with talking again.</span>" //if only it were that easy! (second this - etherware)
+	lose_text = "<span class='notice'>You feel comfortable with talking again.</span>" //if only it were that easy!
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
 	process = TRUE
 	var/dumb_thing = TRUE

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -479,15 +479,14 @@
 	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
 	value = -1
 	gain_text = "<span class='danger'>You start worrying about what you're saying.</span>"
-	lose_text = "<span class='notice'>You feel easier about talking again.</span>" //if only it were that easy!
+	lose_text = "<span class='notice'>You feel more comftorable with talking again.</span>" //if only it were that easy! (second this - etherware)
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
 	var/dumb_thing = TRUE
 
 /datum/quirk/social_anxiety/on_process(delta_time)
 	var/nearby_people = 0
 	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
-		if(H.client)
-			nearby_people++
+		nearby_people++
 	var/mob/living/carbon/human/H = quirk_holder
 	if(DT_PROB(2 + nearby_people, delta_time))
 		H.stuttering = max(3, H.stuttering)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -481,15 +481,20 @@
 	gain_text = "<span class='danger'>You start worrying about what you're saying.</span>"
 	lose_text = "<span class='notice'>You feel more comftorable with talking again.</span>" //if only it were that easy! (second this - etherware)
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
+	process = TRUE
 	var/dumb_thing = TRUE
 
 /datum/quirk/social_anxiety/on_process(delta_time)
+	to_chat(quirk_holder, "start process")
 	var/nearby_people = 0
-	for(var/mob/living/carbon/human/H in oview(3, quirk_holder))
+	for(var/mob/living/carbon/human/dump in oview(3, quirk_holder))
 		nearby_people++
+	to_chat(quirk_holder, delta_time)
+	to_chat(quirk_holder, nearby_people)  // debug
 	var/mob/living/carbon/human/H = quirk_holder
 	if(DT_PROB(2 + nearby_people, delta_time))
 		H.stuttering = max(3, H.stuttering)
+		to_chat(H, "stuttering triggered")  // debug
 	else if(DT_PROB(min(3, nearby_people), delta_time) && !H.silent)
 		to_chat(H, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
 		H.silent = max(10, H.silent)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -479,15 +479,16 @@
 	desc = "Talking to people is very difficult for you, and you often stutter or even lock up."
 	value = -1
 	gain_text = "<span class='danger'>You start worrying about what you're saying.</span>"
-	lose_text = "<span class='notice'>You feel more comftorable with talking again.</span>" //if only it were that easy! (second this - etherware)
+	lose_text = "<span class='notice'>You feel comfortable with talking again.</span>" //if only it were that easy! (second this - etherware)
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
 	process = TRUE
 	var/dumb_thing = TRUE
 
 /datum/quirk/social_anxiety/on_process(delta_time)
 	var/nearby_people = 0
-	for(var/mob/living/carbon/human/dump in oview(3, quirk_holder))
-		nearby_people++
+	for(var/mob/living/carbon/human/stranger in oview(3, quirk_holder))
+		if(stranger.client)
+			nearby_people++
 	var/mob/living/carbon/human/H = quirk_holder
 	if(DT_PROB(2 + nearby_people, delta_time))
 		H.stuttering = max(3, H.stuttering)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -485,22 +485,21 @@
 	var/dumb_thing = TRUE
 
 /datum/quirk/social_anxiety/on_process(delta_time)
-	to_chat(quirk_holder, "start process")
 	var/nearby_people = 0
 	for(var/mob/living/carbon/human/dump in oview(3, quirk_holder))
 		nearby_people++
-	to_chat(quirk_holder, delta_time)
-	to_chat(quirk_holder, nearby_people)  // debug
 	var/mob/living/carbon/human/H = quirk_holder
 	if(DT_PROB(2 + nearby_people, delta_time))
 		H.stuttering = max(3, H.stuttering)
-		to_chat(H, "stuttering triggered")  // debug
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety", /datum/mood_event/anxiety)
 	else if(DT_PROB(min(3, nearby_people), delta_time) && !H.silent)
 		to_chat(H, "<span class='danger'>You retreat into yourself. You <i>really</i> don't feel up to talking.</span>")
 		H.silent = max(10, H.silent)
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety_mute", /datum/mood_event/anxiety_mute)
 	else if(DT_PROB(0.5, delta_time) && dumb_thing)
 		to_chat(H, "<span class='userdanger'>You think of a dumb thing you said a long time ago and scream internally.</span>")
 		dumb_thing = FALSE //only once per life
+		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "anxiety_dumb", /datum/mood_event/anxiety_dumb)
 		if(prob(1))
 			new/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato(get_turf(H)) //now that's what I call spaghetti code
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The social anxiety trait was not processing correctly, so i went in and fixed it. On top of that, I added some fun mood events to make it more fun/realistic.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes social anxiety being a free trait, makes it more interesting, closes #7145 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![meirl](https://user-images.githubusercontent.com/73374039/184505030-6ccfde00-6b25-4857-a1e4-ccb9a17f3947.png)

</details>

## Changelog
:cl:
balance: social anxiety trait now works
add: social anxiety trait has unique moodlets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
