### PR TITLE
Mind-to-mind communication now capitalizes and punctuates

### DIFF
--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -192,7 +192,6 @@ GLOBAL_VAR(clockcult_eminence)
 
 //Transmits a message to everyone in the cult
 //Doesn't work if the cultists contain holy water, or are not on the station or Reebe
-//TODO: SANITIZE MESSAGES WITH THE NORMAL SAY STUFF (punctuation)
 /proc/hierophant_message(msg, mob/living/sender, span = "<span class='brass'>", use_sanitisation=TRUE, say=TRUE)
 	if(CHAT_FILTER_CHECK(msg))
 		if(sender)

--- a/code/game/gamemodes/clock_cult/clockcult.dm
+++ b/code/game/gamemodes/clock_cult/clockcult.dm
@@ -211,7 +211,7 @@ GLOBAL_VAR(clockcult_eminence)
 	if(sender)
 		if(say)
 			sender.say("#[text2ratvar(msg)]")
-		msg = sender.treat_message(msg)
+		msg = sender.treat_message_min(msg)
 		var/datum/antagonist/servant_of_ratvar/SoR = is_servant_of_ratvar(sender)
 		var/prefix = "Clockbrother"
 		switch(SoR.prefix)

--- a/code/game/machinery/computer/prisoner/management.dm
+++ b/code/game/machinery/computer/prisoner/management.dm
@@ -128,6 +128,7 @@
 			var/warning = stripped_input(usr, "Message:", "Enter your message here!", "", MAX_MESSAGE_LEN)
 			if(!warning)
 				return
+			warning = usr.treat_message_min(warning)
 			var/obj/item/implant/I = locate(href_list["warn"]) in GLOB.tracked_implants
 			if(I && istype(I) && I.imp_in)
 				var/mob/living/R = I.imp_in

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -19,12 +19,7 @@
 		if(CHAT_FILTER_CHECK(input))
 			to_chat(imp_in, "<span class='warning'>The message contains prohibited words!</span>")
 			return
-		// check for and apply punctuation
-		var/end = copytext(input, length(input))
-		if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
-			input += "."
-
-		input = capitalize(input)
+		input = imp_in.treat_message_min(input)
 
 		var/my_message = "<font color=\"[implant_colour]\"><b><i>[imp_in]:</i></b></font> [input]" //add sender, color source with syndie color
 		var/ghost_message = "<font color=\"[implant_colour]\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [input]"

--- a/code/game/objects/items/implants/implant_bb.dm
+++ b/code/game/objects/items/implants/implant_bb.dm
@@ -19,6 +19,12 @@
 		if(CHAT_FILTER_CHECK(input))
 			to_chat(imp_in, "<span class='warning'>The message contains prohibited words!</span>")
 			return
+		// check for and apply punctuation
+		var/end = copytext(input, length(input))
+		if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
+			input += "."
+
+		input = capitalize(input)
 
 		var/my_message = "<font color=\"[implant_colour]\"><b><i>[imp_in]:</i></b></font> [input]" //add sender, color source with syndie color
 		var/ghost_message = "<font color=\"[implant_colour]\"><b><i>[imp_in] -> Blood Brothers:</i></b></font> [input]"

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -365,6 +365,7 @@
 		var/message = stripped_input(user, "Write a message to send to your target's brain.","Enter message")
 		if(!message)
 			return
+		message = user.treat_message_min(message)
 		if(QDELETED(L) || L.stat == DEAD)
 			return
 

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -72,6 +72,8 @@
 /mob/living/simple_animal/hostile/blob/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!overmind)
 		return ..()
+	message = treat_message_min(message)
+	log_talk(message, LOG_SAY, tag="blob")
 	var/spanned_message = say_quote(message)
 	var/rendered = "<font color=\"#EE4000\"><b>\[Blob Telepathy\] [real_name]</b> [spanned_message]</font>"
 	for(var/M in GLOB.mob_list)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -240,7 +240,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	if (!message)
 		return
 	message = treat_message_min(message)
-	src.log_talk(message, LOG_SAY)
+	src.log_talk(message, LOG_SAY, tag="blob")
 
 	var/message_a = say_quote(message)
 	var/rendered = "<span class='big'><font color=\"#EE4000\"><b>\[Blob Telepathy\] [name](<font color=\"[blobstrain.color]\">[blobstrain.name]</font>)</b> [message_a]</font></span>"

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -239,7 +239,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 	if (!message)
 		return
-
+	message = treat_message_min(message)
 	src.log_talk(message, LOG_SAY)
 
 	var/message_a = say_quote(message)

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -39,7 +39,7 @@
 		title = "Master"
 	else if(!ishuman(user))
 		title = "Construct"
-	message = user.treat_message(message)
+	message = user.treat_message_min(message)
 	my_message = "<span class='[span]'><b>[title] [findtextEx(user.name, user.real_name) ? user.name : "[user.real_name] (as [user.name])"]:</b> [message]</span>"
 	for(var/i in GLOB.player_list)
 		var/mob/M = i

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -39,6 +39,7 @@
 		title = "Master"
 	else if(!ishuman(user))
 		title = "Construct"
+	message = user.treat_message(message)
 	my_message = "<span class='[span]'><b>[title] [findtextEx(user.name, user.real_name) ? user.name : "[user.real_name] (as [user.name])"]:</b> [message]</span>"
 	for(var/i in GLOB.player_list)
 		var/mob/M = i

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -610,7 +610,7 @@
 		CRASH("Uh oh the mansus link got somehow activated without it being linked to a raw prophet or the mob not being in a list of mobs that should be able to do it.")
 
 	var/message = sanitize(input("Message:", "Telepathy from the Manse") as text|null)
-
+	message = living_owner.treat_message_min(message)
 	if(QDELETED(living_owner))
 		return
 

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -163,7 +163,7 @@
 /mob/living/simple_animal/revenant/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!message)
 		return
-	message = treat_message(message)
+	message = treat_message_min(message)
 	src.log_talk(message, LOG_SAY)
 	var/rendered = "<span class='revennotice'><b>[src]</b> says, \"[message]\"</span>"
 	for(var/mob/M in GLOB.mob_list)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -163,6 +163,7 @@
 /mob/living/simple_animal/revenant/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!message)
 		return
+	message = treat_message(message)
 	src.log_talk(message, LOG_SAY)
 	var/rendered = "<span class='revennotice'><b>[src]</b> says, \"[message]\"</span>"
 	for(var/mob/M in GLOB.mob_list)

--- a/code/modules/guardian/guardian.dm
+++ b/code/modules/guardian/guardian.dm
@@ -564,6 +564,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		if(!input)
 			return
 
+		input = treat_message_min(input)
 		var/preliminary_message = "<span class='holoparasite bold'>[input]</span>" //apply basic color/bolding
 		var/my_message = "<font color=\"[guardiancolor]\"><b><i>[src]:</i></b></font> [preliminary_message]" //add source, color source with the guardian's color
 		var/ghost_message = "<font color=\"[guardiancolor]\"><b><i>[src] -> [summoner.name]:</i></b></font> [preliminary_message]"
@@ -622,6 +623,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	if(!input)
 		return
 
+	input = treat_message_min(input)
 	var/preliminary_message = "<span class='holoparasite bold'>[input]</span>" //apply basic color/bolding
 	var/my_message = "<span class='holoparasite bold'><i>[src]:</i> [preliminary_message]</span>" //add source, color source with default grey...
 

--- a/code/modules/mob/living/brain/say.dm
+++ b/code/modules/mob/living/brain/say.dm
@@ -23,9 +23,4 @@
 	return LINGHIVE_NONE
 
 /mob/living/brain/treat_message(message)
-	// check for and apply punctuation
-	var/end = copytext(message, length(message))
-	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
-		message += "."
-	message = capitalize(message)
-	return message
+	return treat_message_min(message)

--- a/code/modules/mob/living/brain/say.dm
+++ b/code/modules/mob/living/brain/say.dm
@@ -23,5 +23,9 @@
 	return LINGHIVE_NONE
 
 /mob/living/brain/treat_message(message)
+	// check for and apply punctuation
+	var/end = copytext(message, length(message))
+	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
+		message += "."
 	message = capitalize(message)
 	return message

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -92,6 +92,7 @@ Doesn't work on other aliens/AI.*/
 	var/msg = stripped_input(usr, "Message:", "Alien Whisper")
 	if(!msg)
 		return FALSE
+	msg = user.treat_message_min(msg)
 	log_directed_talk(user, M, msg, LOG_SAY, tag="alien whisper")
 	to_chat(M, "<span class='noticealien'>You hear a strange, alien voice in your head.</span>[msg]")
 	to_chat(user, "<span class='noticealien'>You said: \"[msg]\" to [M]</span>")

--- a/code/modules/mob/living/carbon/alien/say.dm
+++ b/code/modules/mob/living/carbon/alien/say.dm
@@ -1,9 +1,9 @@
 /mob/living/proc/alien_talk(message, shown_name = real_name)
-	log_talk(message, LOG_SAY)
 	message = trim(message)
 	if(!message)
 		return
-
+	message = treat_message_min(message)
+	log_talk(message, LOG_SAY)
 	var/message_a = say_quote(message)
 	var/rendered = "<i><span class='alien'>Hivemind, <span class='name'>[shown_name]</span> <span class='message'>[message_a]</span></span></i>"
 	for(var/mob/S in GLOB.player_list)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -743,7 +743,7 @@
 
 	var/msg = stripped_input(usr, "Message:", "Telepathy")
 	if(msg)
-		msg = H.treat_message_min(H)
+		msg = H.treat_message_min(msg)
 		log_directed_talk(H, M, msg, LOG_SAY, "slime telepathy")
 		to_chat(M, "<span class='notice'>You hear an alien voice in your head... </span><font color=#008CA2>[msg]</font>")
 		to_chat(H, "<span class='notice'>You telepathically said: \"[msg]\" to [M].</span>")

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -692,7 +692,7 @@
 		return
 
 	var/message = stripped_input(usr, "Message:", "Slime Telepathy")
-
+	message = H.treat_message_min(message)
 	if(!species || !(H in species.linked_mobs))
 		to_chat(H, "<span class='warning'>The link seems to have been severed...</span>")
 		Remove(H)
@@ -743,6 +743,7 @@
 
 	var/msg = stripped_input(usr, "Message:", "Telepathy")
 	if(msg)
+		msg = H.treat_message_min(H)
 		log_directed_talk(H, M, msg, LOG_SAY, "slime telepathy")
 		to_chat(M, "<span class='notice'>You hear an alien voice in your head... </span><font color=#008CA2>[msg]</font>")
 		to_chat(H, "<span class='notice'>You telepathically said: \"[msg]\" to [M].</span>")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -366,7 +366,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	return treat_message_min(message)
 
-/mob/living/proc/treat_message_min(message)
+/mob/proc/treat_message_min(message)
 	var/end = copytext(message, length(message))
 	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
 		message += "."

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -364,13 +364,14 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(clockslurring)
 		message = clockslur(message)
 
-	// check for and apply punctuation
+	return treat_message_min(message)
+
+/mob/living/proc/treat_message_min(message)
 	var/end = copytext(message, length(message))
 	if(!(end in list("!", ".", "?", ":", "\"", "-", "~")))
 		message += "."
 
 	message = capitalize(message)
-
 	return message
 
 /mob/living/proc/radio(message, list/message_mods = list(), list/spans, language)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -395,7 +395,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		var/input = stripped_input(src, "Please enter a message to tell your summoner.", "Guardian", "")
 		if(!input)
 			return
-
+		input = treat_message_min(input)
 		var/preliminary_message = "<span class='holoparasite bold'>[input]</span>" //apply basic color/bolding
 		var/my_message = "<font color=\"[guardiancolor]\"><b><i>[src]:</i></b></font> [preliminary_message]" //add source, color source with the guardian's color
 
@@ -416,7 +416,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	var/input = stripped_input(src, "Please enter a message to tell your guardian.", "Message", "")
 	if(!input)
 		return
-
+	input = treat_message_min(input)
 	var/preliminary_message = "<span class='holoparasite bold'>[input]</span>" //apply basic color/bolding
 	var/my_message = "<span class='holoparasite bold'><i>[src]:</i> [preliminary_message]</span>" //add source, color source with default grey...
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -503,8 +503,8 @@
 /datum/action/innate/spider/comm/proc/spider_command(mob/living/user, message)
 	if(!message)
 		return
-	var/my_message
-	my_message = "<span class='spider'><b>Command from [user]:</b> [message]</span>"
+	message = user.treat_message_min(message)
+	var/my_message = "<span class='spider'><b>Command from [user]:</b> [message]</span>"
 	for(var/mob/living/simple_animal/hostile/poison/giant_spider/M in GLOB.spidermobs)
 		to_chat(M, my_message)
 	for(var/M in GLOB.dead_mob_list)

--- a/code/modules/spells/spell_types/hivemind.dm
+++ b/code/modules/spells/spell_types/hivemind.dm
@@ -958,6 +958,7 @@
 	var/message = stripped_input(user, "What do you want to say?", "Hive Communication")
 	if(!message)
 		return
+	message = user.treat_message_min(message)
 	var/title = "One Mind"
 	var/span = "changeling"
 	if(user.mind && user.mind.has_antag_datum(/datum/antagonist/hivemind))

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -23,6 +23,7 @@
 	if(!msg)
 		charge_counter = charge_max
 		return
+	msg = user.treat_message_min(msg)
 	to_chat(user, "<span class='boldnotice'>You concentrate and send thoughts to your other self:</span> <span class='notice'>[msg]</span>")
 	to_chat(trauma.owner, "<span class='boldnotice'>[flufftext]</span> <span class='notice'>[msg]</span>")
 	log_directed_talk(user, trauma.owner, msg, LOG_SAY ,"[name]")

--- a/code/modules/spells/spell_types/telepathy.dm
+++ b/code/modules/spells/spell_types/telepathy.dm
@@ -25,6 +25,7 @@
 		if(CHAT_FILTER_CHECK(msg))
 			to_chat(user, "<span class='warning'>Your message contains forbidden words.</span>")
 			return
+		msg = user.treat_message_min(msg)
 		log_directed_talk(user, M, msg, LOG_SAY, "[name]")
 		to_chat(user, "<span class='[boldnotice]'>You transmit to [M]:</span> <span class='[notice]'>[msg]</span>")
 		if(!M.anti_magic_check(magic_check, holy_check)) //hear no evil


### PR DESCRIPTION
## About The Pull Request

Adds auto-capitalization and auto-punctuation to:
- Brains/MMIs
- Blood Brother Implants
- Blood Cult Communion
- Blob Telepathy
- Holoparasite communication
- Abductor communication
- Giant spider commands
- Hivemind telepathy
- Revenant speech
- Telepathy ability/spell (genetics, revenant)
- Prisoner console telepathy
- Abductor mind device telepathy
- Mansus Link
- Xeno telepathic whisper
- Slime telepathy
- Slime link
- Split Personality commune

Adds logging to blob talk from non-overminds (this wasn't a thing apparently)

Removes a TODO comment from the eminence that was already done relating to `treat_message`

## Why It's Good For The Game

It encourages higher standards of RP within these types of communication as seeing
"you are dumb" is a little bit less LRP-neuron-firing than "You are dumb."

Also it just looks better.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/184516203-927aad3b-937a-4ac0-b8e3-bb8317c86bec.png)

![image](https://user-images.githubusercontent.com/10366817/184516204-586d773a-92a9-4a8d-81d2-cda4ec73d6fc.png)

</details>

## Changelog
:cl:
tweak: All forms of mind-to-mind communication now properly capitalize and auto-punctuate text.
tweak: MMIs and posibrains now auto-punctuate speech.
admin: Added logging to blob telepathy speech from non-overminds.
/:cl:
