### PR TITLE
AI hologram speech is now visible, outside runechat

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -471,6 +471,8 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/holopad/proc/unset_holo(mob/living/user)
 	var/mob/living/silicon/ai/AI = user
+	holo = masters[user]
+	RegisterSignal(masters[user], COMSIG_PARENT_QDELETING, .proc/handle_holo_del)
 	if(istype(AI) && AI.current == src)
 		AI.current = null
 	LAZYREMOVE(masters, user) // Discard AI from the list of those who use holopad
@@ -478,6 +480,10 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	LAZYREMOVE(holorays, user)
 	SetLightsAndPower()
 	return TRUE
+
+/obj/machinery/holopad/proc/handle_holo_del()
+	UnregisterSignal(holo, COMSIG_PARENT_QDELETING)
+	holo = null
 
 //Try to transfer hologram to another pad that can project on T
 /obj/machinery/holopad/proc/transfer_to_nearby_pad(turf/T,mob/holo_owner)
@@ -511,7 +517,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/holopad/proc/move_hologram(mob/living/user, turf/new_turf)
 	if(LAZYLEN(masters) && masters[user])
-		holo = masters[user]
 		var/transfered = FALSE
 		if(!validate_location(new_turf))
 			if(!transfer_to_nearby_pad(new_turf,user))

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -417,9 +417,9 @@ Possible to do for anyone motivated enough:
 For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/holopad/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
 	. = ..()
-	if(speaker && LAZYLEN(masters) && !radio_freq && speaker != holo)//Master is mostly a safety in case lag hits or something. Radio_freq so AIs dont hear holopad stuff through radios.
+	if(speaker && LAZYLEN(masters) && !radio_freq)//Master is mostly a safety in case lag hits or something. Radio_freq so AIs dont hear holopad stuff through radios.
 		for(var/mob/living/silicon/ai/master in masters)
-			if(masters[master] && speaker != master)
+			if(masters[master] && speaker != master && speaker != holo)
 				master.relay_speech(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
 	for(var/I in holo_calls)
@@ -524,8 +524,9 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 				return FALSE
 			else
 				transfered = TRUE
-		//All is good.
-		holo.abstract_move(new_turf)
+		//Better than referecing holo
+		var/obj/effect/overlay/holo_pad_hologram/H = masters[user]
+		H.abstract_move(new_turf)
 		if(!transfered)
 			update_holoray(user,new_turf)
 	return TRUE

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -59,6 +59,8 @@ Possible to do for anyone motivated enough:
 	var/ringing = FALSE
 	var/offset = FALSE
 	var/on_network = TRUE
+	///AI hologram
+	var/obj/effect/overlay/holo_pad_hologram/holo
 
 /obj/machinery/holopad/Initialize(mapload)
 	. = ..()
@@ -509,7 +511,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/holopad/proc/move_hologram(mob/living/user, turf/new_turf)
 	if(LAZYLEN(masters) && masters[user])
-		var/obj/effect/overlay/holo_pad_hologram/holo = masters[user]
+		holo = masters[user]
 		var/transfered = FALSE
 		if(!validate_location(new_turf))
 			if(!transfer_to_nearby_pad(new_turf,user))

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -417,7 +417,7 @@ Possible to do for anyone motivated enough:
 For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 /obj/machinery/holopad/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
 	. = ..()
-	if(speaker && LAZYLEN(masters) && !radio_freq)//Master is mostly a safety in case lag hits or something. Radio_freq so AIs dont hear holopad stuff through radios.
+	if(speaker && LAZYLEN(masters) && !radio_freq && speaker != holo)//Master is mostly a safety in case lag hits or something. Radio_freq so AIs dont hear holopad stuff through radios.
 		for(var/mob/living/silicon/ai/master in masters)
 			if(masters[master] && speaker != master)
 				master.relay_speech(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -951,6 +951,9 @@
 			if(I)
 				jobpart = "[I.assignment]"
 
+	//AIs can't hear holograms
+	if(istype(speaker, /obj/effect/overlay/holo_pad_hologram))
+		return
 	var/rendered = "<i><span class='game say'>[start]<span class='name'>[hrefpart][namepart] ([jobpart])</a> </span><span class='message'>[treated_message]</span></span></i>"
 
 	show_message(rendered, 2)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -944,18 +944,14 @@
 	var/hrefpart = "<a href='?src=[REF(src)];track=[html_encode(namepart)]'>"
 	var/jobpart = "Unknown"
 
-	if (ishuman(speaker))
+	if(ishuman(speaker))
 		var/mob/living/carbon/human/S = speaker
 		if(S.wear_id)
 			var/obj/item/card/id/I = S.wear_id.GetID()
 			if(I)
 				jobpart = "[I.assignment]"
 
-	//AIs can't hear holograms
-	if(istype(speaker, /obj/effect/overlay/holo_pad_hologram))
-		return
 	var/rendered = "<i><span class='game say'>[start]<span class='name'>[hrefpart][namepart] ([jobpart])</a> </span><span class='message'>[treated_message]</span></span></i>"
-
 	show_message(rendered, 2)
 
 /mob/living/silicon/ai/fully_replace_character_name(oldname,newname)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -41,7 +41,7 @@
 		else
 			padloc = "(UNKNOWN)"
 		src.log_talk(message, LOG_SAY, tag="HOLOPAD in [padloc]")
-		T?.holo?.say("[message]", MODE_ROBOT, language = language)
+		T.holo?.say("[message]", MODE_ROBOT, language = language)
 		to_chat(src, "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> <span class='message robot'>\"[message]\"</span></span></i>")
 	else
 		to_chat(src, "No holopad connected.")

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -34,12 +34,6 @@
 
 	var/obj/machinery/holopad/T = current
 	if(istype(T) && T.masters[src])//If there is a hologram and its master is the user.
-		var/turf/padturf = get_turf(T)
-		var/padloc
-		if(padturf)
-			padloc = AREACOORD(padturf)
-		else
-			padloc = "(UNKNOWN)"
 		T.holo?.say("[message]", MODE_ROBOT, language = language)
 		to_chat(src, "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> <span class='message robot'>\"[message]\"</span></span></i>")
 	else

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -40,7 +40,6 @@
 			padloc = AREACOORD(padturf)
 		else
 			padloc = "(UNKNOWN)"
-		src.log_talk(message, LOG_SAY, tag="HOLOPAD in [padloc]")
 		T.holo?.say("[message]", MODE_ROBOT, language = language)
 		to_chat(src, "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> <span class='message robot'>\"[message]\"</span></span></i>")
 	else

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -41,7 +41,7 @@
 		else
 			padloc = "(UNKNOWN)"
 		src.log_talk(message, LOG_SAY, tag="HOLOPAD in [padloc]")
-		send_speech(message, 7, T, MODE_ROBOT, message_language = language)
+		T?.holo?.say("[message]", MODE_ROBOT, language = language)
 		to_chat(src, "<i><span class='game say'>Holopad transmitted, <span class='name'>[real_name]</span> <span class='message robot'>\"[message]\"</span></span></i>")
 	else
 		to_chat(src, "No holopad connected.")

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -39,7 +39,6 @@
 	else
 		to_chat(src, "No holopad connected.")
 
-
 // Make sure that the code compiles with AI_VOX undefined
 #ifdef AI_VOX
 #define VOX_DELAY 600


### PR DESCRIPTION
## About The Pull Request

AI hologram speech is now visible, swapping the ``send_speech()`` proc to ``say()``.

## Why It's Good For The Game

Makes interacting with AI holograms easier. Currently, people often forget to check runechat, to see what AI holograms are saying.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/40559528/184520644-3f775fe6-0fd5-4578-bc20-0cefcbac214c.png)

![image](https://user-images.githubusercontent.com/40559528/184520639-d0e7000f-d572-4821-99ad-521d64200d93.png)

![image](https://user-images.githubusercontent.com/40559528/184520672-ac4db2de-2a35-4208-9833-65e6829dd31e.png)

![image](https://user-images.githubusercontent.com/40559528/184520674-a63f49f3-1155-4198-9724-147281dcae27.png)

</details>

## Changelog
:cl:
tweak: Swap ``holopad_talk`` to use ``say`` instead of ``send_speech``
add: Holopad machines now have a reference to AI-Holograms, for manipulation. 
/:cl: