### PR TITLE
Adds a new, sick way to unmount a skateboar

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -85,6 +85,7 @@
 /obj/vehicle/ridden/scooter/skateboard/generate_actions()
 	. = ..()
 	initialize_controller_action_type(/datum/action/vehicle/ridden/scooter/skateboard/ollie, VEHICLE_CONTROL_DRIVE)
+	initialize_controller_action_type(/datum/action/vehicle/ridden/scooter/skateboard/kflip, VEHICLE_CONTROL_DRIVE)
 
 /obj/vehicle/ridden/scooter/skateboard/post_buckle_mob(mob/living/M)//allows skateboards to be non-dense but still allows 2 skateboarders to collide with each other
 	density = TRUE

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -243,10 +243,14 @@
 		playsound(src, 'sound/effects/bang.ogg', 20, TRUE)
 		V.unbuckle_mob(L)
 		L.Paralyze(50)
-		L.adjustBruteLoss(10)  // thats gonna leave a mark
-		V.visible_message("<span class='userdanger'>You fall flat onto the board!</span>","<span class='danger'>[L] misses the landing and falls on [L.p_their()] face!</span>")
+		if(prob(15))
+			V.visible_message("<span class='userdanger'>You smack against the board, hard.</span>", "<span class='danger'>[L] misses the landing and falls on [L.p_their()] face!</span>")
+			L.emote("scream")
+			L.adjustBruteLoss(10)  // thats gonna leave a mark
+			return
+		V.visible_message("<span class='userdanger'>You fall flat onto the board!</span>", "<span class='danger'>[L] misses the landing and falls on [L.p_their()] face!</span>")
 	else
-		L.visible_message("[L] does a neat kickflip and catches [L.p_their()] board in midair.", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.")
+		L.visible_message("<span class='notice'>[L] does a sick kickflip and catches [L.p_their()] board in midair.</span>", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.</span>")
 		playsound(V, 'sound/vehicles/skateboard_ollie.ogg', 50, TRUE)
 		L.spin(4, 1)
 		animate(L, pixel_y = -6, time = 4)

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -228,3 +228,19 @@
 			V.icon_state = "[V.board_icon]-grind"
 			addtimer(CALLBACK(V, /obj/vehicle/ridden/scooter/skateboard/.proc/grind), 2)
 		next_ollie = world.time + 5
+
+/datum/action/vehicle/ridden/scooter/skateboard/kflip
+	name = "Kick Flip"
+	desc = "Do a sweet kickflip to dismount..in style."
+	button_icon_state = "skateboard_ollie"
+
+/datum/action/vehicle/ridden/scooter/skateboard/kflip/Trigger()
+	var/obj/vehicle/ridden/scooter/skateboard/V = vehicle_target
+	var/mob/living/L = owner
+
+	L.visible_message("[L] does a neat kickflip and catches [L.p_their()] board in midair.", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.")
+	L.spin(4, 1)
+	animate(L, pixel_y = -6, time = 4)
+	animate(V, pixel_y = -6, time = 3)
+	V.unbuckle_mob(L)
+	addtimer(CALLBACK(V, /obj/vehicle/ridden/scooter/skateboard/.proc/pick_up_board, L), 2)

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -231,7 +231,7 @@
 
 /datum/action/vehicle/ridden/scooter/skateboard/kflip
 	name = "Kick Flip"
-	desc = "Do a sweet kickflip to dismount..in style."
+	desc = "Do a sweet kickflip to dismount... in style."
 	button_icon_state = "skateboard_ollie"
 
 /datum/action/vehicle/ridden/scooter/skateboard/kflip/Trigger()

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -239,6 +239,7 @@
 	var/mob/living/L = owner
 
 	L.visible_message("[L] does a neat kickflip and catches [L.p_their()] board in midair.", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.")
+	playsound(V, 'sound/vehicles/skateboard_ollie.ogg', 50, TRUE)
 	L.spin(4, 1)
 	animate(L, pixel_y = -6, time = 4)
 	animate(V, pixel_y = -6, time = 3)

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -238,7 +238,7 @@
 	var/obj/vehicle/ridden/scooter/skateboard/V = vehicle_target
 	var/mob/living/L = owner
 
-	L.visible_message("[L] does a neat kickflip and catches [L.p_their()] board in midair.", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.")
+	L.visible_message("[L] does a neat kickflip and catches [L.p_their()] board in midair.", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.</span>")
 	playsound(V, 'sound/vehicles/skateboard_ollie.ogg', 50, TRUE)
 	L.spin(4, 1)
 	animate(L, pixel_y = -6, time = 4)

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -238,10 +238,17 @@
 	var/obj/vehicle/ridden/scooter/skateboard/V = vehicle_target
 	var/mob/living/L = owner
 
-	L.visible_message("[L] does a neat kickflip and catches [L.p_their()] board in midair.", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.")
-	playsound(V, 'sound/vehicles/skateboard_ollie.ogg', 50, TRUE)
-	L.spin(4, 1)
-	animate(L, pixel_y = -6, time = 4)
-	animate(V, pixel_y = -6, time = 3)
-	V.unbuckle_mob(L)
-	addtimer(CALLBACK(V, /obj/vehicle/ridden/scooter/skateboard/.proc/pick_up_board, L), 2)
+	L.adjustStaminaLoss(V.instability)
+	if (L.getStaminaLoss() >= 100)
+			playsound(src, 'sound/effects/bang.ogg', 20, TRUE)
+			V.unbuckle_mob(L)
+			L.Paralyze(50)
+			V.visible_message("<span class='userdanger'>You fall flat onto the board!</span>","<span class='danger'>[L] misses the landing and falls on [L.p_their()] face!</span>")
+	else
+		L.visible_message("[L] does a neat kickflip and catches [L.p_their()] board in midair.", "<span class='notice'>You do a sick kickflip, catching the board in midair! Stylish.")
+		playsound(V, 'sound/vehicles/skateboard_ollie.ogg', 50, TRUE)
+		L.spin(4, 1)
+		animate(L, pixel_y = -6, time = 4)
+		animate(V, pixel_y = -6, time = 3)
+		V.unbuckle_mob(L)
+		addtimer(CALLBACK(V, /obj/vehicle/ridden/scooter/skateboard/.proc/pick_up_board, L), 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new ui action for the skateboard, for a kickflip. On use, you will jump in place and "catch" the skateboard in midair, putting it in your hands.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unmounting skateboards is TEDIOUS, the sprite is too small to reliably click drag it. Considering you can quickly mount a skateboard from the held item version, it makes sense that you can have an option to quickly get it in your hands.
Its also slick as hell.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/73374039/184525670-a9630e37-917a-4d32-b874-7a9a3868fd58.mp4



</details>

## Changelog
:cl:
add: Nanotrasen has implemented kickflip skills into all employees, in an attempt to boost skateboard sales.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
