### PR TITLE
Changelings can now open their disguise's mail

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -155,12 +155,11 @@
 		// If the recipient's mind has gone, then anyone can open their mail
 		// whether a mind can actually be qdel'd is an exercise for the reader
 		if(recipient && recipient != user?.mind)
-			if(is_changeling(user))
-				if(user.real_name != recipient.name)
-					to_chat(user, "<span class='warning'>We must keep our disguise intact.</span>")  // cuz your disguise cant open the mail so you shouldnt either
-					return
-			else
+			if(!is_changeling(user))
 				to_chat(user, "<span class='notice'>You can't open somebody else's mail! That's <em>immoral</em>!</span>")
+				return
+			if(user.real_name != recipient.name)
+				to_chat(user, "<span class='warning'>We must keep our disguise intact.</span>")  // cuz your disguise cant open the mail so you shouldnt either
 				return
 
 	user.visible_message("[user] start to unwrap a package...", \

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -155,8 +155,13 @@
 		// If the recipient's mind has gone, then anyone can open their mail
 		// whether a mind can actually be qdel'd is an exercise for the reader
 		if(recipient && recipient != user?.mind)
-			to_chat(user, "<span class='notice'>You can't open somebody else's mail! That's <em>immoral</em>!</span>")
-			return
+			if(is_changeling(user))
+				if(user.real_name != recipient.name)
+					to_chat(user, "<span class='warning'>We must keep our disguise intact.</span>")  // cuz your disguise cant open the mail so you shouldnt either
+					return
+			else
+				to_chat(user, "<span class='notice'>You can't open somebody else's mail! That's <em>immoral</em>!</span>")
+				return
 
 	user.visible_message("[user] start to unwrap a package...", \
 			"<span class='notice'>You start to unwrap the package...</span>", \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changelings now have the ability to open others mail IF they are disguised as them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents powergaming by making people try to open their own mail, more gameplay/roleplay opprotunities to steal someone's mail, closes #7497 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/184558662-711d7e55-f731-4c0f-b54f-157a554dfb05.png)

</details>

## Changelog
:cl:
add: Nanotrasen has weakened the dna lock on mail, allowing changelings to open their disguise's mail.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
