### PR TITLE
Atmos machines properly initialize when loaded from a map not at round start.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -502,6 +502,7 @@ SUBSYSTEM_DEF(air)
 	var/obj/machinery/atmospherics/AM
 	for(var/A in 1 to atmos_machines.len)
 		AM = atmos_machines[A]
+		AM.atmosinit()
 		CHECK_TICK
 
 	for(var/A in 1 to atmos_machines.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Readds a missing line in setup_templete_machinery() responsible for initializing atmos machines when a map template is loaded.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previously, maps loaded midround with atmos machines would have all its pipes be invisible and disconnected, this fixes that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Shuttle capsule test</summary>

https://user-images.githubusercontent.com/51838176/184733602-f646fa0f-2d82-41f1-af12-e9fa6d1a394e.mp4


As seen in the video, the pipes are loaded properly when the shuttle is loaded.

</details>

## Changelog
:cl:
fix: Atmos machines initialize properly when maploaded. Traitor shuttle capsules are functional again!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
