### PR TITLE
Hiding paper inside of your pen

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -28,6 +28,14 @@
 	var/degrees = 0
 	var/font = PEN_FONT
 
+	var/obj/item/paper/int_storage  // the paper rolled inside the pen
+
+/obj/item/pen/examine(mob/M)
+	. = ..()
+	if(int_storage || prob(30))  // fun little guessing game :)
+		. += "Something rattles inside!"
+
+
 /obj/item/pen/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is scribbling numbers all over [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit sudoku...</span>")
 	return(BRUTELOSS)
@@ -166,6 +174,21 @@
 				return
 			O.desc = input
 			to_chat(user, "You have successfully changed \the [O.name]'s description.")
+
+/obj/item/pen/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I, /obj/item/paper))
+		if(int_storage)
+			to_chat(user, "<span class='notice'>You can't fit any more paper in!</span>")
+			return
+		to_chat(user, "<span class='notice'>You discretely roll the paper up, and stuff it into your pen.</span>")
+		I.forceMove(src)
+		int_storage	= I
+
+/obj/item/pen/attack_hand(mob/user)
+	if(int_storage)
+		to_chat(user, "<span class='notice'>You carefully shake a paper sheet out of the [src].")
+		user.put_in_hands(int_storage)
+		int_storage = null
 
 /*
  * Sleepypens


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now slip paper into your pen, having one very hidden note not tied to your pda notekeep
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Saves an inventory slot for very important papers (nuke codes, monitor decryptor, etc), gives you a new excuse for wanting your traitor pen back bc you "have some important docs inside it"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![paperhide](https://user-images.githubusercontent.com/73374039/184803748-6e85f7c7-f470-4e9d-8476-9b4fac5fb004.png)

</details>

## Changelog
:cl:
add: Due to budget cuts, Nanotrasen issued pens are now more hollow. They might even be hollow enough to slip something inside..
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
