### PR TITLE
Setting for self highlighting in chat

### DIFF
--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -120,7 +120,8 @@ export const chatMiddleware = store => {
         settings.highlightText,
         settings.highlightColor,
         settings.matchWord,
-        settings.matchCase);
+        settings.matchCase,
+        settings.highlightSelf);
       chatRenderer.setHighContrast(
         settings.highContrast,
       );

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -242,7 +242,7 @@ class ChatRenderer {
     }
   }
 
-  setHighlight(text, color, matchWord, matchCase) {
+  setHighlight(text, color, matchWord, matchCase, highlightSelf) {
     if (!text || !color) {
       this.highlightRegex = null;
       this.highlightColor = null;
@@ -268,6 +268,7 @@ class ChatRenderer {
     const flags = 'g' + (matchCase ? '' : 'i');
     this.highlightRegex = new RegExp(pattern, flags);
     this.highlightColor = color;
+    this.highlightSelf = highlightSelf;
   }
 
   setHighContrast(newValue) {
@@ -389,7 +390,8 @@ class ChatRenderer {
           logger.error('Error: message is missing text payload', message);
         }
         // Highlight text
-        if (!message.avoidHighlighting && this.highlightRegex) {
+        if ((!message.avoidHighlighting || this.highlightSelf)
+        && this.highlightRegex) {
           const highlighted = highlightNode(node,
             this.highlightRegex,
             text => (

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -184,6 +184,7 @@ export const SettingsHighlight = (props, context) => {
     highlightColor,
     matchWord,
     matchCase,
+    highlightSelf,
   } = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
   return (
@@ -230,6 +231,13 @@ export const SettingsHighlight = (props, context) => {
             matchCase: !matchCase,
           }))}>
           Match case
+        </Button.Checkbox>
+        <Button.Checkbox
+          checked={highlightSelf}
+          onClick={() => dispatch(updateSettings({
+            highlightSelf: !highlightSelf,
+          }))}>
+          Highlight own Messages
         </Button.Checkbox>
       </Box>
       <Divider />

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -20,6 +20,7 @@ const initialState = {
   highContrast: false,
   matchWord: false,
   matchCase: false,
+  highlightSelf: false,
   view: {
     visible: false,
     activeTab: SETTINGS_TABS[0].id,


### PR DESCRIPTION
## About The Pull Request

Adds a setting to the tgui chat for higlighting ones own messages.

## Why It's Good For The Game

Some people seem to like having their own messages highlighted.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![turned off](https://user-images.githubusercontent.com/53494785/184986955-cdd3ba6a-479b-41e1-acc0-e53f7d88cb1a.png)
![turned on](https://user-images.githubusercontent.com/53494785/184986958-31f91dd4-3ee5-4253-bd5e-dfd1ce390f4a.png)

</details>

## Changelog
:cl:
add: Highlighting for your own messages in chat is now a setting (default - off, found next to the match word and case settings)
/:cl: