### PR TITLE
Some Medical item accessibility adjustments

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -36,8 +36,7 @@
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/bruise_pack = 2,
 		/obj/item/stack/medical/ointment = 2,
-		/obj/item/reagent_containers/hypospray/medipen = 1,
-		/obj/item/healthanalyzer = 1)
+		/obj/item/reagent_containers/hypospray/medipen = 2)
 	generate_items_inside(items_inside,src)
 
 
@@ -134,7 +133,7 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/stack/medical/gauze = 1,
+		/obj/item/stack/medical/gauze = 2,
 		/obj/item/stack/medical/bruise_pack = 3,
 		/obj/item/stack/medical/ointment= 3)
 	generate_items_inside(items_inside,src)
@@ -162,8 +161,7 @@
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/silver_sulf = 4,
 		/obj/item/storage/pill_bottle/kelotane = 1,
-		/obj/item/reagent_containers/hypospray/medipen = 1,
-		/obj/item/healthanalyzer = 1)
+		/obj/item/stack/medical/ointment = 2)
 	generate_items_inside(items_inside,src)
 
 
@@ -187,11 +185,10 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/syringe/antitoxin = 3,
+		/obj/item/reagent_containers/syringe/antitoxin = 4,
 		/obj/item/reagent_containers/syringe/calomel = 1,
 		/obj/item/reagent_containers/syringe/diphenhydramine = 1,
-		/obj/item/storage/pill_bottle/charcoal = 1,
-		/obj/item/healthanalyzer = 1)
+		/obj/item/storage/pill_bottle/charcoal = 1)
 	generate_items_inside(items_inside,src)
 
 
@@ -209,16 +206,13 @@
 /obj/item/storage/firstaid/radbgone/PopulateContents()
 	if(empty)
 		return
-	if(prob(50))
-		new /obj/item/reagent_containers/pill/mutarad(src)
-	if(prob(80))
-		new /obj/item/reagent_containers/pill/antirad_plus(src)
-	new /obj/item/reagent_containers/syringe/charcoal(src)
-	new /obj/item/storage/pill_bottle/charcoal(src)
-	new /obj/item/reagent_containers/pill/mutadone(src)
-	new /obj/item/reagent_containers/pill/antirad(src)
-	new /obj/item/reagent_containers/food/drinks/bottle/vodka(src)
-	new /obj/item/healthanalyzer(src)
+	var/static/items_inside = list(
+		/obj/item/reagent_containers/pill/antirad_plus = 2,
+		/obj/item/reagent_containers/pill/antirad = 2,
+		/obj/item/storage/pill_bottle/charcoal = 1,
+		/obj/item/storage/pill_bottle/penacid = 1,
+		/obj/item/reagent_containers/pill/mutarad = 1)
+	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/radbgone/Initialize(mapload)
 	. = ..()
@@ -240,10 +234,9 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/reagent_containers/pill/salbutamol = 2,
-		/obj/item/reagent_containers/hypospray/medipen = 2,
-		/obj/item/reagent_containers/hypospray/medipen/dexalin = 2,
-		/obj/item/healthanalyzer = 1)
+		/obj/item/storage/pill_bottle/salbutamol = 1,
+		/obj/item/reagent_containers/hypospray/medipen = 3,
+		/obj/item/reagent_containers/hypospray/medipen/dexalin = 3)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/o2/Initialize(mapload)
@@ -269,8 +262,8 @@
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/styptic = 4,
 		/obj/item/storage/pill_bottle/bicaridine = 1,
-		/obj/item/stack/medical/gauze = 2,
-		/obj/item/healthanalyzer = 1)
+		/obj/item/stack/medical/bruise_pack = 1,
+		/obj/item/stack/medical/gauze = 1)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/firstaid/brute/Initialize(mapload)
@@ -339,7 +332,6 @@
 		/obj/item/storage/pill_bottle/charcoal,
 		/obj/item/reagent_containers/pill/patch/silver_sulf,
 		/obj/item/storage/pill_bottle/kelotane)
-	new /obj/item/healthanalyzer(src)
 	for(var/i in 1 to 6)
 		var/selected_type = pick(supplies)
 		new selected_type(src)
@@ -563,7 +555,7 @@
 	desc = "Contains pills to expunge radiation and toxins."
 
 /obj/item/storage/pill_bottle/penacid/PopulateContents()
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/penacid(src)
 
 
@@ -591,3 +583,11 @@
 /obj/item/storage/pill_bottle/floorpill/full/PopulateContents()
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/floorpill(src)
+
+/obj/item/storage/pill_bottle/salbutamol
+	name = "bottle of salbutamol pills"
+	desc = "Contains pills to heal suffocation damage."
+
+/obj/item/storage/pill_bottle/salbutamol/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/salbutamol(src)

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -542,15 +542,6 @@
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SERVICE
 
-/datum/design/healthanalyzer
-	name = "Health Analyzer"
-	id = "healthanalyzer"
-	build_type = AUTOLATHE | PROTOLATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
-	build_path = /obj/item/healthanalyzer
-	category = list("initial", "Medical", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
 /datum/design/pillbottle
 	name = "Pill Bottle"
 	id = "pillbottle"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -542,6 +542,15 @@
 	category = list("initial", "Medical", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SERVICE
 
+/datum/design/healthanalyzer
+	name = "Health Analyzer"
+	id = "healthanalyzer"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
+	build_path = /obj/item/healthanalyzer
+	category = list("hacked", "Medical", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/pillbottle
 	name = "Pill Bottle"
 	id = "pillbottle"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -664,7 +664,7 @@
 	id = "med_scanner"
 	tech_tier = 3
 	display_name = "Medical Scanning"
-	description = "NT didn't trust us with their design data for this, so we figured it out ourselves."
+	description = "By taking apart the ones we already had, we figured out how to make them ourselves."
 	prereq_ids = list("adv_biotech")
 	design_ids = list("healthanalyzer")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -74,7 +74,7 @@
 	display_name = "Biological Technology"
 	description = "What makes us tick."	//the MC, silly!
 	prereq_ids = list("base")
-	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "sleeper", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "healthanalyzer", "medspray","genescanner", "medipen_epi", "medipen_dex", "medipen_atropine")
+	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "sleeper", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "medspray","genescanner", "medipen_epi", "medipen_dex", "medipen_atropine")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -84,7 +84,7 @@
 	display_name = "Advanced Biotechnology"
 	description = "Advanced Biotechnology"
 	prereq_ids = list("biotech")
-	design_ids = list("piercesyringe", "crewpinpointer", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "healthanalyzer_advanced", "harvester", "holobarrier_med", "defibrillator_compact")
+	design_ids = list("piercesyringe", "crewpinpointer", "smoke_machine", "plasmarefiller", "limbgrower", "meta_beaker", "harvester", "holobarrier_med", "defibrillator_compact")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -352,7 +352,6 @@
 	hidden = TRUE
 
 /////////////////////////integrated circuits tech/////////////////////////
-
 /datum/techweb_node/math_circuits
 	id = "math_circuits"
 	tech_tier = 1
@@ -661,6 +660,26 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000
 
+/datum/techweb_node/med_scanning
+	id = "med_scanner"
+	tech_tier = 3
+	display_name = "Medical Scanning"
+	description = "NT didn't trust us with their design data for this, so we figured it out ourselves."
+	prereq_ids = list("adv_biotech")
+	design_ids = list("healthanalyzer")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	export_price = 5000
+
+/datum/techweb_node/adv_med_scanning
+	id = "adv_med_scanner"
+	tech_tier = 4
+	display_name = "Advanced Medical Scanning"
+	description = "By integrating advanced AI into our scanners, we can diagnose even the most minute of abnormalities. Well, the AI is doing it, but we get the credit."
+	prereq_ids = list("med_scanner", "posibrain")
+	design_ids = list("healthanalyzer_advanced")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	export_price = 5000
+
 /datum/techweb_node/cyber_organs_upgraded
 	id = "cyber_organs_upgraded"
 	tech_tier = 5
@@ -735,7 +754,6 @@
 	hidden = TRUE
 
 ////////////////////////Tools////////////////////////
-
 /datum/techweb_node/basic_mining
 	id = "basic_mining"
 	tech_tier = 1
@@ -818,7 +836,6 @@
 
 
 /////////////////////////weaponry tech/////////////////////////
-
 /datum/techweb_node/landmine
 	id = "nonlethal_mines"
 	tech_tier = 3

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -11,7 +11,6 @@
 					/obj/item/reagent_containers/medspray = 6,
 					/obj/item/storage/pill_bottle = 6,
 					/obj/item/reagent_containers/glass/bottle = 10,
-					/obj/item/healthanalyzer = 4,
 				    /obj/item/reagent_containers/spray/cleaner = 1,
 					/obj/item/stack/medical/gauze = 8,
 					/obj/item/reagent_containers/hypospray/medipen = 8,
@@ -31,6 +30,7 @@
 				   /obj/item/storage/belt/medical = 3,
 				   /obj/item/sensor_device = 2,
 				   /obj/item/pinpointer/crew = 2,
+				   /obj/item/healthanalyzer = 2,
 		           /obj/item/wrench/medical = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "stamina" = 0)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This does the following:
- Removes health analyzers from every medkit excepting the one doctors spawn with.
- Moves health analyzers from normal to premium in the medical vendors, and restricts supply to 2 instead of 4.
- Fills the empty space in the medkit with items that would make sense to be there.
- Removes the god-awful randomness of radiation kits, and makes them actually an effective medical kit.
- Moves some other resources around in medkits, nothing major.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Health Analyzers are the single most powerful tool that medical has access to, they are immensely valuable and advanced devices able to note and document nearly every malady that a body could have in less than a second. I doubt that something like that would be given out like literal hotcakes in every little medkit. The station is figuratively swimming in them, that's bad imo.
Additionally, the radiation kit was more joke than helpful, which is very annoying since radiation is probably the single worst thing someone can have. It's so damn slow to scrub out.
This will restrict them to only places where the mappers have placed them(robotics mostly), and the medbay's personnel.

Points of note: 
- For the medbay, this won't change anything(except clutter), as every doctor starts with an analyzer by default.
- Some of the new supplies are things that really ought to have been included.
- This effectively moves first aid kits into just that, kits that have stuff to stabilize and treat rudimentary damage.
- Other kits are now more of a resource cache for medicines related to the noted damage type.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

First Aid Kit:
Included Items: Gauze, Bruise Pack x2, Ointment x2, Epipen x2
![image](https://user-images.githubusercontent.com/56017258/185185265-242add12-47bb-44bf-a970-fc886efc872d.png)

Medical Aid Kit:
Included Items: Gauze, Bruise Pack x2, Ointment x2, Epipen x1, Basic surgery tools, Health Analyzer
![image](https://user-images.githubusercontent.com/56017258/185185360-7f6866e8-b946-409e-82fa-5cff95370d8d.png)

Brute Treatment Kit:
Included Items: Brute Patch x4, Bicaridine Pill x7, Bruise Pack, Gauze
![image](https://user-images.githubusercontent.com/56017258/185185455-9c1a45aa-9877-43f6-b48d-83e0b6f055d0.png)

Burn Treatment Kit:
Included Items: Burn Patch x4, Kelotane Pill x7, Ointment x2
![image](https://user-images.githubusercontent.com/56017258/185185799-35eb2691-fd4f-4989-835f-a56f91ab2599.png)

Toxin Treatment Kit:
Included Items:Antitox Syringe x4, Calomel Syringe, Diphenhydramine Syringe, Charcoal Pill x7
![image](https://user-images.githubusercontent.com/56017258/185185843-01aa5f49-3311-4403-8e1c-f86a4bf740d5.png)

Oxy Treatment Kit:
Included Items: Salbutamol Pill x7, Epipen x3, Dexalin Medpen x3
![image](https://user-images.githubusercontent.com/56017258/185185896-8b840c21-482c-4cdd-a31c-8d4dcbdc008d.png)

Radiation Treatment Kit:
Included Items: Radiation+ Pill x2, Potassium Iodide Pill x2, Charcoal Pill x7, Pentetic Acid Pill x7, Radiation Treatment Deluxe Pill
![image](https://user-images.githubusercontent.com/56017258/185186027-103a6c5a-6bd0-4bbf-8eef-23d670b5866f.png)

</details>

## Changelog
:cl:
del: Removed old Health Analyzers from most medkits and made them less accessible in vendor.
tweak: Tweaked some Medkit Items.
add: Health analyzers now have their own research nodes and need to be unlocked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
