### PR TITLE
Adds a flash pen disguised as a medical holopen

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -345,14 +345,6 @@
 			holo_cooldown = world.time + 100
 			return
 
-
-/obj/item/assembly/flash/pen/suicide_act(mob/living/carbon/human/user)
-	if (user.eye_blind)
-		user.visible_message("<span class='suicide'>[user] is putting [src] close to [user.p_their()] eyes and turning it on... but [user.p_theyre()] blind!</span>")
-		return SHAME
-	user.visible_message("<span class='suicide'>[user] is putting [src] close to [user.p_their()] eyes and turning it on! It looks like [user.p_theyre()] trying to commit suicide!</span>")
-	return (FIRELOSS)
-
 /obj/item/assembly/flash/cyborg
 	bulb = /obj/item/flashbulb/recharging/cyborg
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -332,7 +332,7 @@
 	var/on = FALSE
 	var/holo_cooldown = 0
 
-/obj/item/flashlight/pen/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/assembly/flash/pen/afterattack(atom/target, mob/user, proximity_flag)
 	if(user.a_intent == INTENT_HARM)
 		return ..()
 	if(!proximity_flag)
@@ -346,16 +346,12 @@
 			return
 
 
-/obj/item/flashlight/pen/suicide_act(mob/living/carbon/human/user)
+/obj/item/assembly/flash/pen/suicide_act(mob/living/carbon/human/user)
 	if (user.eye_blind)
 		user.visible_message("<span class='suicide'>[user] is putting [src] close to [user.p_their()] eyes and turning it on... but [user.p_theyre()] blind!</span>")
 		return SHAME
 	user.visible_message("<span class='suicide'>[user] is putting [src] close to [user.p_their()] eyes and turning it on! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (FIRELOSS)
-
-/obj/item/flashlight/pen/attack_self(mob/user)
-	to_chat(user, "You sneak a glance at the side of \the [src], and a small screen notifies you there [bulb ? "is [bulb.charges_left] flashes left" : "is no bulb" ].")
-
 
 /obj/item/assembly/flash/cyborg
 	bulb = /obj/item/flashbulb/recharging/cyborg

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -315,6 +315,47 @@
 			if(!converter.add_revolutionary(H.mind))
 				to_chat(user, "<span class='warning'>This mind seems resistant to the flash!</span>")
 
+/obj/item/assembly/flash/pen
+	name = "penlight"
+	desc = "A pen-sized light, used by medical staff. It can also be used to create a hologram to alert people of incoming medical assistance."
+	icon_state = "penlight"
+	item_state = ""
+	icon = 'icons/obj/lighting.dmi'
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	flags_1 = CONDUCT_1
+	actions_types = list(/datum/action/item_action/toggle_light)
+	light_system = MOVABLE_LIGHT
+	light_range = 2
+	light_power = 1
+	light_on = FALSE
+	var/on = FALSE
+	var/holo_cooldown = 0
+
+/obj/item/flashlight/pen/afterattack(atom/target, mob/user, proximity_flag)
+	if(user.a_intent == INTENT_HARM)
+		return ..()
+	if(!proximity_flag)
+		if(holo_cooldown > world.time)
+			to_chat(user, "<span class='warning'>[src] is not ready yet!</span>")
+			return
+		var/T = get_turf(target)
+		if(locate(/mob/living) in T)
+			new /obj/effect/temp_visual/medical_holosign(T,user) //produce a holographic glow
+			holo_cooldown = world.time + 100
+			return
+
+
+/obj/item/flashlight/pen/suicide_act(mob/living/carbon/human/user)
+	if (user.eye_blind)
+		user.visible_message("<span class='suicide'>[user] is putting [src] close to [user.p_their()] eyes and turning it on... but [user.p_theyre()] blind!</span>")
+		return SHAME
+	user.visible_message("<span class='suicide'>[user] is putting [src] close to [user.p_their()] eyes and turning it on! It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	return (FIRELOSS)
+
+/obj/item/flashlight/pen/attack_self(mob/user)
+	to_chat(user, "You sneak a glance at the side of \the [src], and a small screen notifies you there [bulb ? "is [bulb.charges_left] flashes left" : "is no bulb" ].")
+
 
 /obj/item/assembly/flash/cyborg
 	bulb = /obj/item/flashbulb/recharging/cyborg

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1992,6 +1992,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list(JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_ROBOTICIST, JOB_NAME_PARAMEDIC, JOB_NAME_BRIGPHYSICIAN)
 	cost = 3
 
+/datum/uplink_item/role_restricted/holoflash
+	name = "Penlight Flash"
+	desc = "Modifying the standard issue penlight, we were able to make it emit light similar to that of a disorienting flash. Be careful, as it also requires flash bulbs, and it only comes with one."
+	item = /obj/item/flashlight/pen
+	restricted_roles = list(JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_ROBOTICIST, JOB_NAME_PARAMEDIC, JOB_NAME_BRIGPHYSICIAN)
+	cost = 6
+
 /datum/uplink_item/role_restricted/syndicate_mmi
 	name = "Syndicate MMI"
 	desc = "An MMI which autmatically applies the Syndimov laws to any borg it is placed in. Great for adding known allies to assist you with a little more stealth than a fully emagged borg."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1995,7 +1995,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/holoflash
 	name = "Penlight Flash"
 	desc = "Modifying the standard issue penlight, we were able to make it emit light similar to that of a disorienting flash. Be careful, as it also requires flash bulbs, and it only comes with one."
-	item = /obj/item/flashlight/pen
+	item = /obj/item/assembly/flash/pen
 	restricted_roles = list(JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_ROBOTICIST, JOB_NAME_PARAMEDIC, JOB_NAME_BRIGPHYSICIAN)
 	cost = 6
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1997,7 +1997,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Modifying the standard issue penlight, we were able to make it emit light similar to that of a disorienting flash. Be careful, as it also requires flash bulbs, and it only comes with one."
 	item = /obj/item/assembly/flash/pen
 	restricted_roles = list(JOB_NAME_MEDICALDOCTOR, JOB_NAME_CHIEFMEDICALOFFICER, JOB_NAME_ROBOTICIST, JOB_NAME_PARAMEDIC, JOB_NAME_BRIGPHYSICIAN)
-	cost = 6
+	cost = 4
 
 /datum/uplink_item/role_restricted/syndicate_mmi
 	name = "Syndicate MMI"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tators in the medical field can get a flash disguised as a medical holopen now! it costs 6 tc
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
more stealth opprotunities?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/185262901-bd52e8ac-7061-4b86-af3c-35700ee2f0d7.png)

</details>

## Changelog
:cl:
add: flash holopen tator item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
