### PR TITLE
Corg Bureacracy Update (+ Robo Ghost Sniffer)

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -3658,7 +3658,10 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/stamp/cmo,
+/obj/item/stamp/cmo{
+	pixel_x = 7;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "aLL" = (
@@ -4696,6 +4699,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/wirecutters,
+/obj/item/clipboard,
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
@@ -6202,11 +6206,14 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
-/obj/machinery/computer/bounty{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Cargo Window";
+	pixel_y = 1;
+	req_access_txt = "31"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -7826,9 +7833,15 @@
 /area/science/xenobiology)
 "bNp" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/quartermaster,
+/obj/item/folder/yellow{
+	pixel_y = 3;
+	pixel_x = -4
+	},
 /obj/effect/turf_decal/tile/brown,
+/obj/item/stamp/quartermaster{
+	pixel_y = -2;
+	pixel_x = 6
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -7853,6 +7866,14 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/item/stamp{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/stamp/denied{
+	pixel_x = 9;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
@@ -10435,10 +10456,22 @@
 /area/engine/atmos)
 "cDm" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/red,
-/obj/item/stamp/research_director,
-/obj/item/aicard,
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/pen/red{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/aicard{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/research_director{
+	pixel_x = 9;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "cDp" = (
@@ -13211,6 +13244,10 @@
 /obj/item/storage/firstaid,
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -16178,6 +16215,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/item/stamp/hos{
+	pixel_x = 13;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "enz" = (
@@ -35939,23 +35980,8 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "jXu" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/computer/cargo{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/quartermaster/office)
 "jXv" = (
 /obj/structure/chair/comfy/black{
@@ -39472,9 +39498,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/chair/office{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "kYB" = (
@@ -43509,17 +43532,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mcV" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/chair/office,
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/office)
 "mdf" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -45167,8 +45179,9 @@
 /obj/machinery/requests_console{
 	pixel_x = -32
 	},
-/obj/structure/chair/office,
-/obj/effect/landmark/start/cargo_technician,
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "mFB" = (
@@ -50576,7 +50589,6 @@
 	pixel_x = -6;
 	pixel_y = 13
 	},
-/obj/item/stamp/captain,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "ojz" = (
@@ -58775,6 +58787,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"qGQ" = (
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "qHh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -65804,6 +65821,9 @@
 	pixel_x = -28;
 	pixel_y = -2
 	},
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "sRB" = (
@@ -67802,6 +67822,9 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
@@ -71970,6 +71993,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"uIp" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/office)
 "uIs" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
@@ -83390,6 +83423,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ybQ" = (
@@ -83750,6 +83784,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "yfC" = (
@@ -125351,7 +125389,7 @@ vnF
 qdx
 chA
 sDz
-ftE
+qGQ
 duj
 jzg
 sRy
@@ -125612,7 +125650,7 @@ ftE
 aVQ
 bfS
 yfw
-mcV
+atC
 bqW
 tbA
 jwt
@@ -125869,7 +125907,7 @@ ftE
 kNa
 ikJ
 cjv
-atC
+uIp
 blL
 tbA
 lqJ

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -28624,6 +28624,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"hVd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/ecto_sniffer{
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "hVn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -117672,7 +117681,7 @@ pkM
 pJu
 iQx
 skb
-skb
+hVd
 skb
 dLC
 pkM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The main part of this is to modify the front-facing cargo lobby to add a desk that people can actually use, seeing as it was left out of the original Corg redesign. There are a few other very small QoL changes to help bring it in line with some of the other maps in rotation as well!

This adds a few chest drawers across the map as well (in the HoP's office by the first desk, and in the new redesigned cargo office) as well as finally providing the HoS with their official stamp (which will see _extraordinary use_ in sentencing paperwork) and removing the Captain's spare stamp (no use in having a spare laying around, especially when they're not even 5 tiles away from each other on the map).

I also added in the Ecto-Sniffer to robotics to bring it in line with other maps, as it didn't make much sense to have an entire PR for a single device.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having a front desk for the job that requires a lot of desk work is nice, especially to stop people from just running in the door the moment you open it to hand something off to them, or vice versa. Even if it's just as simple as having a place to drop off bounties, it's nice.

The Ecto-Sniffer also helps cut down on robotics Positronic Brain spam for ghosts, by letting either side ping the Ecto-Sniffer to let them know that they're ready!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Here are the main changes to cargo, along with the very minor ones made to the HoP's Office and Robotics Lab
![Cargo Lobby](https://user-images.githubusercontent.com/97719613/185521145-baaf9506-3b92-4e6e-b35f-d2aacb9ed496.PNG)
![Paperwork HoP Chest Drawer](https://user-images.githubusercontent.com/97719613/185521208-42f86e0a-d8f2-4e5d-9bb0-d6d33ae59088.PNG)
![Ecto Sniffer Added](https://user-images.githubusercontent.com/97719613/185521216-fd2e7a48-6ea4-4266-978f-b84a26ab67d5.PNG)

Below are where the additional stamps were added, to the HoS's office and QM's office respectively
![HoS Stamp Added](https://user-images.githubusercontent.com/97719613/185521264-50c0952e-2d4c-4fa0-9ec8-3347cb594419.PNG)
![QM Office Additional Stamps](https://user-images.githubusercontent.com/97719613/185521278-57a9baa0-1442-4b97-a395-78fa446f1374.PNG)

The circled portion of the image is where the second Captain's stamp was located; as said, not even five tiles away from the one in the Captain's office.
![2nd Cap Stamp Removed](https://user-images.githubusercontent.com/97719613/185521284-9825cfe4-e5f2-4c6c-9190-600e222de088.PNG)

</details>

## Changelog
:cl: Impish_Delights
add: Added additional set of deny and approval stamps to QM's office
add: Added HoS stamp to HoS's quarters
add: Added Ecto-Sniffer to robotics, to bring in line with other maps
add: Added chest drawers to store paperwork in both the HoP's office, and cargo lobby
del: Removed redundant Captain's stamp from quarters
tweak: Shifted around RD & CMO stamps so they are not hidden under items at round start
tweak: Modified cargo bay lobby to have a desk, consoles shifted to side
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
