### PR TITLE
Revises a few delimber anomaly features

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -503,7 +503,7 @@
 		target.update_body(TRUE)
 		to_chat(target, "<span class='warning'>Something feels different...</span>")
 		log_game("[key_name(owner)] has caused a delimber pulse affecting [english_list(affected)].")
-		target.log_message("[owner] has caused [target]'s [picked_part] to turn into [new_part.name] and deleted their [picked_user_part.name].", LOG_ATTACK)
+		target.log_message("[owner] has caused [target]'s [picked_part] to turn into [new_part.name] and delimbed their [picked_user_part.name].", LOG_ATTACK)
 
 	if(message_admins)
 		message_admins("[ADMIN_LOOKUPFLW(owner)] has caused a delimber pulse affecting [english_list(affected)].")

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -11,7 +11,6 @@
 #define ANOMALY_DELIMBER_ZONE_R_LEG typesof(/obj/item/bodypart/r_arm)
 #define ANOMALY_DELIMBER_ZONE_L_ARM typesof(/obj/item/bodypart/l_leg)
 #define ANOMALY_DELIMBER_ZONE_R_ARM typesof(/obj/item/bodypart/r_leg)
-#define ANOMALY_DELIMBER_ZONE_ORGANS typesof(/obj/item/organ) - typesof(/obj/item/organ/brain) - typesof(/obj/item/organ/body_egg) - /obj/item/organ/alien/eggsac - /obj/item/organ/zombie_infection
 
 /////////////////////
 
@@ -450,18 +449,12 @@
 	name = "delimber anomaly"
 	icon_state = "delimber_anomaly"
 	aSignal = /obj/item/assembly/signaler/anomaly/delimber
-	immortal = TRUE
 	/// Cooldown for every anomaly pulse
 	COOLDOWN_DECLARE(pulse_cooldown)
 	/// How many seconds between each anomaly pulses
 	var/pulse_delay = 15 SECONDS
 	/// Range of the anomaly pulse
 	var/range = 5
-
-/obj/effect/anomaly/delimber/Initialize(mapload, new_lifespan)
-	. = ..()
-	if(new_lifespan)
-		immortal = FALSE //manually override the immortality lifespan
 
 /obj/effect/anomaly/delimber/anomalyEffect(delta_time)
 	. = ..()
@@ -484,17 +477,11 @@
 		// Add target
 		affected += target
 
-		// Insert a random organ
-		var/obj/item/organ/picked_organ = pick(ANOMALY_DELIMBER_ZONE_ORGANS)
-		var/obj/item/organ/new_organ = new picked_organ
-		new_organ.Insert(target, TRUE, FALSE)
-
 		// Replace a random limb
 		var/picked_zone = pick(ANOMALY_DELIMBER_ZONES)
 		var/obj/item/bodypart/picked_user_part = target.get_bodypart(picked_zone)
 		if(!picked_user_part)
 			target.update_body(TRUE)
-			target.balloon_alert(target, "something has changed about you")
 			return
 		var/obj/item/bodypart/picked_part
 		switch(picked_zone)
@@ -514,11 +501,11 @@
 		new_part.replace_limb(target, TRUE, is_creating = TRUE)
 		qdel(picked_user_part)
 		target.update_body(TRUE)
-		target.balloon_alert(target, "something has changed about you")
+		to_chat(target, "<span class='warning'>Something feels different...</span>")
+		log_game("[key_name(owner)] has caused a delimber pulse affecting [english_list(affected)].")
 
 	if(message_admins)
 		message_admins("[ADMIN_LOOKUPFLW(owner)] has caused a delimber pulse affecting [english_list(affected)].")
-		log_game("[key_name(owner)] has caused a delimber pulse affecting [english_list(affected)].")
 
 #undef ANOMALY_MOVECHANCE
 #undef ANOMALY_DELIMBER_ZONES
@@ -528,4 +515,3 @@
 #undef ANOMALY_DELIMBER_ZONE_R_LEG
 #undef ANOMALY_DELIMBER_ZONE_L_ARM
 #undef ANOMALY_DELIMBER_ZONE_R_ARM
-#undef ANOMALY_DELIMBER_ZONE_ORGANS

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -481,7 +481,6 @@
 		var/picked_zone = pick(ANOMALY_DELIMBER_ZONES)
 		var/obj/item/bodypart/picked_user_part = target.get_bodypart(picked_zone)
 		if(!picked_user_part)
-			target.update_body(TRUE)
 			return
 		var/obj/item/bodypart/picked_part
 		switch(picked_zone)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -503,6 +503,7 @@
 		target.update_body(TRUE)
 		to_chat(target, "<span class='warning'>Something feels different...</span>")
 		log_game("[key_name(owner)] has caused a delimber pulse affecting [english_list(affected)].")
+		target.log_message("[owner] has caused [target]'s [picked_part] to turn into [new_part.name] and deleted their [picked_user_part.name].", LOG_ATTACK)
 
 	if(message_admins)
 		message_admins("[ADMIN_LOOKUPFLW(owner)] has caused a delimber pulse affecting [english_list(affected)].")

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -379,7 +379,7 @@
 	var/datum/effect_system/spark_spread/sparks = new /datum/effect_system/spark_spread
 	sparks.set_up(1, 1, src)
 	sparks.start()
-	..()
+	return ..()
 
 /obj/item/clothing/suit/armor/reactive/delimbering/reactive_activation(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	owner.visible_message("<span class='danger'>[src] blocks [attack_text], biohazard body scramble released!</span>")

--- a/code/modules/events/anomaly_delimber.dm
+++ b/code/modules/events/anomaly_delimber.dm
@@ -12,4 +12,4 @@
 	anomaly_path = /obj/effect/anomaly/delimber
 
 /datum/round_event/anomaly/anomaly_delimber/announce(fake)
-	priority_announce("Localized limb swapping agent. Expected location: [impact_area.name]. Wear biosuits to counter the effects. Calculated half-life of %9£$T$%F3 years", "Anomaly Alert")
+	priority_announce("Localized limb swapping agent. Expected location: [impact_area.name]. Wear biosuits to counter the effects.", "Anomaly Alert")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Removes it's ability to give you new organs
- It actually now expires and isn't eternal
- It's actually logged now

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I'm already seeing people just stand on top of it and hug it to roll for gamer organs. It being eternal also means that if nobody deals with it people's limbs will just be gone, which is way more debilitating than any of the other anomaly effects. I don't think I need to explain why it being logged good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

![dreamseeker_YXq2Xsgppu](https://user-images.githubusercontent.com/22431091/185634847-5a6e8a8c-a252-4940-98e6-b4bc1fd1559b.png)

I've updated the announcement description since, but yeah. It works.

</details>

## Changelog
:cl:
balance: The delimber anomaly doesn't give out random organs anymore
balance: The delimber anomaly isn't eternal anymore
administration: The delimber anomaly is now actually logged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
