### PR TITLE
Corg maintenance fixes

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -3658,10 +3658,7 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/stamp/cmo{
-	pixel_x = 7;
-	pixel_y = 4
-	},
+/obj/item/stamp/cmo,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "aLL" = (
@@ -4699,7 +4696,6 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/wirecutters,
-/obj/item/clipboard,
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
@@ -6206,14 +6202,11 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "Cargo Window";
-	pixel_y = 1;
-	req_access_txt = "31"
+/obj/structure/window/reinforced{
+	pixel_y = 1
+	},
+/obj/machinery/computer/bounty{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -7833,15 +7826,9 @@
 /area/science/xenobiology)
 "bNp" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/yellow{
-	pixel_y = 3;
-	pixel_x = -4
-	},
+/obj/item/folder/yellow,
+/obj/item/stamp/quartermaster,
 /obj/effect/turf_decal/tile/brown,
-/obj/item/stamp/quartermaster{
-	pixel_y = -2;
-	pixel_x = 6
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -7866,14 +7853,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
-	},
-/obj/item/stamp{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/stamp/denied{
-	pixel_x = 9;
-	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
@@ -10456,22 +10435,10 @@
 /area/engine/atmos)
 "cDm" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/pen/red{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/aicard{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/stamp/research_director{
-	pixel_x = 9;
-	pixel_y = 2
-	},
+/obj/item/paper_bin,
+/obj/item/pen/red,
+/obj/item/stamp/research_director,
+/obj/item/aicard,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "cDp" = (
@@ -13244,10 +13211,6 @@
 /obj/item/storage/firstaid,
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
-	},
-/obj/item/folder/yellow{
-	pixel_x = 4;
-	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -16215,10 +16178,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/item/stamp/hos{
-	pixel_x = 13;
-	pixel_y = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "enz" = (
@@ -23730,11 +23689,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Cargo Maintenance";
 	req_access_txt = "31"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "gAI" = (
@@ -28624,15 +28583,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"hVd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/ecto_sniffer{
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/lab)
 "hVn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -29099,13 +29049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"iap" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "iaw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30285,10 +30228,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ipP" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Library Maintenance";
-	req_one_access_txt = "12;37"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -30299,6 +30238,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Library Maintenance";
+	req_one_access_txt = "12;37"
+	},
 /turf/open/floor/plating,
 /area/library)
 "ipV" = (
@@ -35996,8 +35939,23 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "jXu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/machinery/computer/cargo{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "jXv" = (
 /obj/structure/chair/comfy/black{
@@ -39514,6 +39472,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "kYB" = (
@@ -43548,6 +43509,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mcV" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/office)
 "mdf" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -45195,9 +45167,8 @@
 /obj/machinery/requests_console{
 	pixel_x = -32
 	},
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
+/obj/structure/chair/office,
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "mFB" = (
@@ -46346,13 +46317,6 @@
 /obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/quartermaster/storage)
-"mYG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "mYL" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -50612,6 +50576,7 @@
 	pixel_x = -6;
 	pixel_y = 13
 	},
+/obj/item/stamp/captain,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "ojz" = (
@@ -58810,11 +58775,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"qGQ" = (
-/obj/structure/cable/yellow,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/office)
 "qHh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -59706,14 +59666,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "qVA" = (
@@ -65844,9 +65804,6 @@
 	pixel_x = -28;
 	pixel_y = -2
 	},
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "sRB" = (
@@ -67845,9 +67802,6 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
@@ -72016,16 +71970,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"uIp" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/office)
 "uIs" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
@@ -80026,6 +79970,13 @@
 /obj/effect/spawner/lootdrop/glowstick/lit,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"wYF" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "wYR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -80818,16 +80769,16 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "xnU" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "35"
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "35"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -83446,7 +83397,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ybQ" = (
@@ -83807,10 +83757,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "yfC" = (
@@ -109797,7 +109743,7 @@ iOL
 iOL
 iOB
 iQt
-iHe
+iOB
 iOB
 vhc
 iOB
@@ -115407,7 +115353,7 @@ fKx
 fKx
 aTq
 hzU
-iap
+wYF
 lxe
 eJK
 eJK
@@ -117695,7 +117641,7 @@ pkM
 pJu
 iQx
 skb
-hVd
+skb
 skb
 dLC
 pkM
@@ -122623,7 +122569,7 @@ kfy
 qzK
 rKM
 kfy
-mYG
+tqu
 tqu
 vUC
 jLT
@@ -125412,7 +125358,7 @@ vnF
 qdx
 chA
 sDz
-qGQ
+ftE
 duj
 jzg
 sRy
@@ -125673,7 +125619,7 @@ ftE
 aVQ
 bfS
 yfw
-atC
+mcV
 bqW
 tbA
 jwt
@@ -125930,7 +125876,7 @@ ftE
 kNa
 ikJ
 cjv
-uIp
+atC
 blL
 tbA
 lqJ

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -9132,10 +9132,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "ciM" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Cargo Maintenance";
-	req_access_txt = "31"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9144,6 +9140,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ciW" = (
@@ -12163,6 +12163,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"deU" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "dfn" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -30280,7 +30287,7 @@
 "ipP" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Library Maintenance";
-	req_access_txt = "12"
+	req_one_access_txt = "12;37"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31139,11 +31146,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Cargo Maintenance";
+	req_access_txt = "31"
+	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "iCW" = (
@@ -59694,7 +59701,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Bar Maintenance";
-	req_access_txt = "25"
+	req_one_access_txt = "12;25"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -67414,7 +67421,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "tqu" = (
-/obj/machinery/rnd/production/protolathe/department/service,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tqE" = (
@@ -74197,6 +74204,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"vtz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "vtC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -74749,8 +74763,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Cargo Maintenance";
-	req_access_txt = "31"
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -80804,16 +80818,16 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "xnU" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "35"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "35"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -81461,10 +81475,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "xxQ" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -81481,6 +81491,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "xxR" = (
@@ -108731,8 +108745,8 @@ vhc
 iOB
 ono
 lUW
-lUW
 qBW
+lUW
 aLx
 lUW
 lUW
@@ -115393,7 +115407,7 @@ fKx
 fKx
 aTq
 hzU
-lzJ
+deU
 lxe
 eJK
 eJK
@@ -115650,7 +115664,7 @@ fKx
 fKx
 fKx
 laH
-nHS
+aPI
 fHC
 fHC
 fHC
@@ -122606,10 +122620,10 @@ iXF
 mef
 wnG
 kfy
-kDi
+qzK
 rKM
 kfy
-qzK
+vtz
 tqu
 vUC
 jLT

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -3658,7 +3658,10 @@
 	pixel_x = -2;
 	pixel_y = 2
 	},
-/obj/item/stamp/cmo,
+/obj/item/stamp/cmo{
+	pixel_x = 7;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
 "aLL" = (
@@ -4696,6 +4699,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/wirecutters,
+/obj/item/clipboard,
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
@@ -6202,11 +6206,14 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
-/obj/machinery/computer/bounty{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Cargo Window";
+	pixel_y = 1;
+	req_access_txt = "31"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -7826,9 +7833,15 @@
 /area/science/xenobiology)
 "bNp" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/quartermaster,
+/obj/item/folder/yellow{
+	pixel_y = 3;
+	pixel_x = -4
+	},
 /obj/effect/turf_decal/tile/brown,
+/obj/item/stamp/quartermaster{
+	pixel_y = -2;
+	pixel_x = 6
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -7853,6 +7866,14 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/item/stamp{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/stamp/denied{
+	pixel_x = 9;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/qm)
@@ -10435,10 +10456,22 @@
 /area/engine/atmos)
 "cDm" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/red,
-/obj/item/stamp/research_director,
-/obj/item/aicard,
+/obj/item/paper_bin{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/pen/red{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/aicard{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/research_director{
+	pixel_x = 9;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "cDp" = (
@@ -13211,6 +13244,10 @@
 /obj/item/storage/firstaid,
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -16178,6 +16215,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/item/stamp/hos{
+	pixel_x = 13;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "enz" = (
@@ -35939,23 +35980,8 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "jXu" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/computer/cargo{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/quartermaster/office)
 "jXv" = (
 /obj/structure/chair/comfy/black{
@@ -39472,9 +39498,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/chair/office{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "kYB" = (
@@ -43509,17 +43532,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mcV" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/chair/office,
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/office)
 "mdf" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -45167,8 +45179,9 @@
 /obj/machinery/requests_console{
 	pixel_x = -32
 	},
-/obj/structure/chair/office,
-/obj/effect/landmark/start/cargo_technician,
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "mFB" = (
@@ -50576,7 +50589,6 @@
 	pixel_x = -6;
 	pixel_y = 13
 	},
-/obj/item/stamp/captain,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain/private)
 "ojz" = (
@@ -58775,6 +58787,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"qGQ" = (
+/obj/structure/cable/yellow,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "qHh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -65804,6 +65821,9 @@
 	pixel_x = -28;
 	pixel_y = -2
 	},
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "sRB" = (
@@ -67802,6 +67822,9 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
@@ -71970,6 +71993,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"uIp" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/quartermaster/office)
 "uIs" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
@@ -83390,6 +83423,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "ybQ" = (
@@ -83750,6 +83784,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "yfC" = (
@@ -125351,7 +125389,7 @@ vnF
 qdx
 chA
 sDz
-ftE
+qGQ
 duj
 jzg
 sRy
@@ -125612,7 +125650,7 @@ ftE
 aVQ
 bfS
 yfw
-mcV
+atC
 bqW
 tbA
 jwt
@@ -125869,7 +125907,7 @@ ftE
 kNa
 ikJ
 cjv
-atC
+uIp
 blL
 tbA
 lqJ

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -12163,13 +12163,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"deU" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "dfn" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -29106,6 +29099,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"iap" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "iaw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46346,6 +46346,13 @@
 /obj/item/bedsheet/dorms,
 /turf/open/floor/wood,
 /area/quartermaster/storage)
+"mYG" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mYL" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -74204,13 +74211,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"vtz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "vtC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -81493,7 +81493,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Bar Maintenance";
-	req_one_access_txt = "12;25"
+	req_one_access_txt = "12;25;48"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
@@ -115407,7 +115407,7 @@ fKx
 fKx
 aTq
 hzU
-deU
+iap
 lxe
 eJK
 eJK
@@ -122623,7 +122623,7 @@ kfy
 qzK
 rKM
 kfy
-vtz
+mYG
 tqu
 vUC
 jLT

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -28624,6 +28624,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"hVd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/ecto_sniffer{
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/robotics/lab)
 "hVn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -117672,7 +117681,7 @@ pkM
 pJu
 iQx
 skb
-skb
+hVd
 skb
 dLC
 pkM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
Despite technically being a fork of my other Corg changes, it doesn't actually have the changes included in it ~because I have no idea how GitHub works and I don't feel like opening a second fork for these issue even though it really wouldn't be that hard to do~

Fixes multiple issues with Corg maintenance, including broken access for the bar, cargo, library, and miners. Modifies maintenance to fix misplaced airlocks, wires, and removes the second service protolathe being accessible by botany exclusively.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes issues [7344](https://github.com/BeeStation/BeeStation-Hornet/issues/7344), [7475](https://github.com/BeeStation/BeeStation-Hornet/issues/7475), and fixes other issues with maintenance access. Shaft miners can finally use the Aux base area, and it gives the bartender and curator access to their respective maintenance areas (even if they really shouldn't be lurking around there).

Botany doesn't need its own Service Protolathe either, there shouldn't be one tucked away in maintenance for *just* them, so it's been replaced with two extra hydroponics trays.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/97719613/185679295-2806bbbf-e5f4-4382-bf01-ff9e49945685.mp4



</details>

## Changelog
:cl: Impish_Delights
add: Two hydro trays in hydro maintenance
del: Hydro-exclusive service protolathe removed
tweak: Added bartender access to bar maintenance doors
tweak: Added curator access to library maintenance door
fix: Removed random maintenance airlocks not lined up with walls (science and dorm maint)
fix: Mended broken wire in science maintenance
fix: un-borked maintenance airlocks by cargo, maintenance now accessible with just maintenance access.
fix: Shaft miners can now access the auxiliary construction base by the bar (via the bar maintenance airlock)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
