### PR TITLE
Corg Maint Airlock, Wiring, Service Lathe Fixes

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -9132,10 +9132,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "ciM" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Cargo Maintenance";
-	req_access_txt = "31"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9144,6 +9140,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ciW" = (
@@ -23730,11 +23730,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Cargo Maintenance";
 	req_access_txt = "31"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "gAI" = (
@@ -30280,7 +30280,7 @@
 "ipP" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Library Maintenance";
-	req_access_txt = "12"
+	req_one_access_txt = "12;37"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31139,11 +31139,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Cargo Maintenance";
+	req_access_txt = "31"
+	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "iCW" = (
@@ -58568,6 +58568,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qCW" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "qDh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -59694,7 +59701,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Bar Maintenance";
-	req_access_txt = "25"
+	req_one_access_txt = "12;25"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -67414,7 +67421,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "tqu" = (
-/obj/machinery/rnd/production/protolathe/department/service,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tqE" = (
@@ -74749,8 +74756,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance_hatch{
-	name = "Cargo Maintenance";
-	req_access_txt = "31"
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -81461,10 +81468,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "xxQ" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -81481,6 +81484,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bar Maintenance";
+	req_one_access_txt = "12;25;48"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "xxR" = (
@@ -108731,8 +108738,8 @@ vhc
 iOB
 ono
 lUW
-lUW
 qBW
+lUW
 aLx
 lUW
 lUW
@@ -109783,7 +109790,7 @@ iOL
 iOL
 iOB
 iQt
-iHe
+iOB
 iOB
 vhc
 iOB
@@ -115393,7 +115400,7 @@ fKx
 fKx
 aTq
 hzU
-lzJ
+qCW
 lxe
 eJK
 eJK
@@ -115650,7 +115657,7 @@ fKx
 fKx
 fKx
 laH
-nHS
+aPI
 fHC
 fHC
 fHC
@@ -122606,10 +122613,10 @@ iXF
 mef
 wnG
 kfy
-kDi
+qzK
 rKM
 kfy
-qzK
+tqu
 tqu
 vUC
 jLT


### PR DESCRIPTION
Removes redundant airlock in dorm maint, moves sci maint airlock, fixes sci maint broken wire. Fixes access for bar, library, and cargo maint. Removes 2nd service protolathe in hydro maint.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a handful of issues with Corg maintenance, between broken airlock access, airlocks just not being attached to walls in some parts of maintenance, a wire in science maintenance terminating into a wall and possibly causing round start power issues, and hydroponics having *a spare entire service protolathe that only they can access.*

This also gives shaft miners access to the Aux Construction base (as well as the bartender and librarian access to the maintenance doors connected directly to their departments).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes #7344 and #7475 as well as fixing a few other issues. Having access to maintenance functioning properly is very important as well!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

This should show proper access working for everything except shaft miners unfortunately (it also leaves out the second airlock I removed in dorm maint)

https://user-images.githubusercontent.com/97719613/185682911-60829855-1bfd-4257-b44e-6b3ec26d50a5.mp4



</details>

## Changelog
:cl: Impish_Delights
add: Two hydro trays to botany maint to replace missing service lathe
del: Random airlock in dorm maint room removed
del: Botany private service protolathe removed
tweak: Rearranged botany maint slightly
tweak: Bartender and Curator can now access their respective maintenance airlocks
fix: Shaft Miners can now access the Aux Base construction room via the bar maint airlock
fix: cargo maintenance by brig now has proper access set on airlock, maintenance can be traversed without cargo access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
