### PR TITLE
Deny access to clients that don't send telemetry

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -46,7 +46,7 @@
 /**
  * Maximum time allocated for sending a telemetry packet.
  */
-#define TGUI_TELEMETRY_RESPONSE_WINDOW 30 SECONDS
+#define TGUI_TELEMETRY_RESPONSE_WINDOW 2 MINUTES
 
 /// Telemetry statuses
 #define TGUI_TELEMETRY_STAT_NOT_REQUESTED 0 //Not Yet Requested

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -29,6 +29,20 @@
 			"connections" = TGUI_TELEMETRY_MAX_CONNECTIONS,
 		),
 	))
+	addtimer(CALLBACK(src, .proc/handle_telemetry_timeout), TGUI_TELEMETRY_RESPONSE_WINDOW) // give them 30 seconds to send telemetry
+
+/**
+ * private
+ *
+ * Handles a timeout from telemetry (usually, the client has lost connection or is actively refusing to send telemetry)
+ */
+/datum/tgui_panel/proc/handle_telemetry_timeout()
+	if(client && !QDELETED(client) && !telemetry_analyzed_at && telemetry_status <= TGUI_TELEMETRY_STAT_AWAITING && !broken)
+		telemetry_status = TGUI_TELEMETRY_STAT_MISSING
+		var/msg = "[key_name(client)] has timed out on the telemetry request. It's possible they are using a hacked client. Kicking them from the server."
+		message_admins(msg)
+		log_admin_private(msg)
+		qdel(client)
 
 /**
  * private

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -29,7 +29,7 @@
 			"connections" = TGUI_TELEMETRY_MAX_CONNECTIONS,
 		),
 	))
-	addtimer(CALLBACK(src, .proc/handle_telemetry_timeout), TGUI_TELEMETRY_RESPONSE_WINDOW) // give them 30 seconds to send telemetry
+	addtimer(CALLBACK(src, .proc/handle_telemetry_timeout), TGUI_TELEMETRY_RESPONSE_WINDOW) // give [TGUI_TELEMETRY_RESPONSE_WINDOW] to send telemetry
 
 /**
  * private


### PR DESCRIPTION
## About The Pull Request

Fixes #7405

Clients have 2 minutes to send telemetry, if they fail to send telemetry after this period, and their TGUI panel is not broken, a message will be sent to admins and logged to adminprivate and they will be kicked from the server.

## Why It's Good For The Game

Requested by Crossed. Denies some hacked clients.

## Testing Photographs and Procedure

Test by commenting out call to `analyze_telemetry` in `tgui_panel.dm`

After 30 seconds (of server tick time, so longer), client is kicked.

Clients with telemetry intact are allowed access as expected.

This should possibly be testmerged as it may have unintended side effects on players with bad connection or broken TGUI.

## Changelog
:cl:
admin: Clients without telemetry are denied access
/:cl: