### PR TITLE
Makes simple bots unable to be summoned while on stationary mode

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -715,8 +715,6 @@ Pass a positive integer as an argument to override a bot's default speed.
 /mob/living/simple_animal/bot/proc/bot_control(command, mob/user, list/user_access = list())
 	if(!on || emagged == 2 || remote_disabled) //Emagged bots do not respect anyone's authority! Bots with their remote controls off cannot get commands.
 		return TRUE //ACCESS DENIED
-	if(stationary_mode)
-		speak("Stationary mode active, not responding.", radio_channel)
 	if(client)
 		bot_control_message(command, user)
 	// process control input
@@ -729,6 +727,9 @@ Pass a positive integer as an argument to override a bot's default speed.
 			auto_patrol = 1
 
 		if("summon")
+			if(stationary_mode)
+				speak("Stationary mode active, not responding.", radio_channel)
+				return
 			bot_reset()
 			summon_target = get_turf(user)
 			if(user_access.len != 0)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -98,6 +98,8 @@
 
 	hud_possible = list(DIAG_STAT_HUD, DIAG_BOT_HUD, DIAG_HUD, DIAG_PATH_HUD = HUD_LIST_LIST) //Diagnostic HUD views
 
+	var/stationary_mode = FALSE  // moved here for general stationary checks
+
 /mob/living/simple_animal/bot/proc/get_mode()
 	if(client) //Player bots do not have modes, thus the override. Also an easy way for PDA users/AI to know when a bot is a player.
 		if(paicard)
@@ -713,6 +715,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 /mob/living/simple_animal/bot/proc/bot_control(command, mob/user, list/user_access = list())
 	if(!on || emagged == 2 || remote_disabled) //Emagged bots do not respect anyone's authority! Bots with their remote controls off cannot get commands.
 		return TRUE //ACCESS DENIED
+	if(stationary_mode)
+		speak("Stationary mode active, not responding.", radio_channel)
 	if(client)
 		bot_control_message(command, user)
 	// process control input

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -37,7 +37,6 @@
 
 	var/extinguish_people = TRUE
 	var/extinguish_fires = TRUE
-	var/stationary_mode = FALSE
 
 /mob/living/simple_animal/bot/firebot/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -47,7 +47,6 @@ GLOBAL_VAR(medibot_unique_id_gen)
 	var/heal_threshold = 10 //Start healing when they have this much damage in a category
 	var/declare_crit = 1 //If active, the bot will transmit a critical patient alert to MedHUD users.
 	var/declare_cooldown = 0 //Prevents spam of critical patient alerts.
-	var/stationary_mode = 0 //If enabled, the Medibot will not move automatically.
 	//Are we tipped over? Used to stop the mode from being conflicted.
 	var/tipped = FALSE
 	///How panicked we are about being tipped over (why would you do this?)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes simple bots (medbot, beepsky, cleanbot, etc) unable to be summoned by PDA. Note the ai can still summon stationary bots

as a bonus refactor, stationary_mode is now general to all simple bots and can be tested against for more items in the future
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents any old roboticist, med staff, captain, etc. from stealing your personal medibots! Or the stationary medbot that spawns outside medbay,,
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/185849448-b04918a4-35a8-4f57-be9c-aaaf4f4febfb.png)

</details>

## Changelog
:cl:
tweak: medbots can no longer be summoned by PDA while in stationary mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
