### PR TITLE
 An extra 5 ooc coins if your body gets to cc

### DIFF
--- a/code/__DEFINES/metacoin.dm
+++ b/code/__DEFINES/metacoin.dm
@@ -4,6 +4,8 @@
 #define METACOIN_ESCAPE_REWARD           30
 /// Rewarded when you survive the round
 #define METACOIN_SURVIVE_REWARD          20
+/// Rewarded when you don't survive the round, but your corpse escapes
+#define METACOIN_CORPSE_REWARD			15
 /// Rewarded when you don't survive the round, but stick around till the end
 #define METACOIN_NOTSURVIVE_REWARD       10
 /// Rewarded when you are alive and active for 10 minutes

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -12,7 +12,10 @@
             else
                 inc_metabalance(METACOIN_ESCAPE_REWARD, reason="Survived the shift.")
         else
-            inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
+			if(M.onCentCom() || M.onSyndieBase())
+				inc_metabalance(METACOIN_CORPSE_REWARD, reason="You died, but your corpse escaped. Spooky!")
+			else
+	            inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
 
 /client/proc/process_greentext()
 	src.give_award(/datum/award/achievement/misc/greentext, src.mob)

--- a/code/modules/metacoin/metacoin.dm
+++ b/code/modules/metacoin/metacoin.dm
@@ -12,10 +12,10 @@
             else
                 inc_metabalance(METACOIN_ESCAPE_REWARD, reason="Survived the shift.")
         else
-			if(M.onCentCom() || M.onSyndieBase())
-				inc_metabalance(METACOIN_CORPSE_REWARD, reason="You died, but your corpse escaped. Spooky!")
+			if(!M.onCentCom() && !M.onSyndieBase())
+				inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
 			else
-	            inc_metabalance(METACOIN_NOTSURVIVE_REWARD, reason="You tried.")
+				inc_metabalance(METACOIN_CORPSE_REWARD, reason="You died, but your corpse escaped. Spooky!")
 
 /client/proc/process_greentext()
 	src.give_award(/datum/award/achievement/misc/greentext, src.mob)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If you die, but your corpse makes it to cc, then you get an extra 5 ooc coins
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its right inbetween straight out dying, and living, meaning you get no benefit from suiciding
IC it makes sense, because nanotrasen has the most advanced medcare in the universe, so if they salvaged a body they can revive you inbetween rounds.
Also gives more benefit to attempting revive on the shuttle medbay
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
tweak: Nanotrasen issues bonus beecoins if your corpse is recovered and sent back to centcom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
