### PR TITLE
PKAs are now as weak in a vacuum as they are in a pressurized environment

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -164,7 +164,8 @@
 #define ATMOS_TANK_AIRMIX			"o2=2644;n2=10580;TEMP=293.15"
 
 //LAVALAND
-#define LAVALAND_EQUIPMENT_EFFECT_PRESSURE 90 //! what pressure you have to be under to increase the effect of equipment meant for lavaland
+#define MAXIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE 90 //! what pressure you have to be under to increase the effect of equipment meant for lavaland
+#define MINIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE 25 //! what pressure you have to be over to increase the effect of equipment meant for lavaland
 #define LAVALAND_DEFAULT_ATMOS		"o2=14;n2=5;co2=13;TEMP=300"
 
 //ATMOS MIX IDS

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -567,7 +567,7 @@
 	if(!istype(environment))
 		return
 	var/pressure = environment.return_pressure()
-	if(pressure <= LAVALAND_EQUIPMENT_EFFECT_PRESSURE & pressure > 0)
+	if(pressure <= MAXIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE & pressure >= MINIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
 		. = TRUE
 
 /proc/ispipewire(item)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -567,7 +567,7 @@
 	if(!istype(environment))
 		return
 	var/pressure = environment.return_pressure()
-	if(pressure <= LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
+	if(pressure <= LAVALAND_EQUIPMENT_EFFECT_PRESSURE & pressure > 0)
 		. = TRUE
 
 /proc/ispipewire(item)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -567,7 +567,7 @@
 	if(!istype(environment))
 		return
 	var/pressure = environment.return_pressure()
-	if(pressure <= MAXIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE & pressure >= MINIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
+	if(pressure <= MAXIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE && pressure >= MINIMUM_LAVALAND_EQUIPMENT_EFFECT_PRESSURE)
 		. = TRUE
 
 /proc/ispipewire(item)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -509,7 +509,7 @@
 //Indoors
 /obj/item/borg/upgrade/modkit/indoors
 	name = "decrease pressure penalty"
-	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure environments."
+	desc = "A syndicate modification kit that increases the damage a kinetic accelerator does in high pressure and full vacuum environments."
 	modifier = 2
 	denied_type = /obj/item/borg/upgrade/modkit/indoors
 	maximum_of_type = 2

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -19,7 +19,6 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
-	pin = /obj/item/firing_pin/off_station
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -19,6 +19,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
+	pin = /obj/item/firing_pin/off_station
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2230,7 +2230,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/role_restricted/pressure_mod
 	name = "Kinetic Accelerator Pressure Mod"
-	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors. \
+	desc = "A modification kit which allows Kinetic Accelerators to do greatly increased damage while indoors and in a vacuum. \
 			Occupies 35% mod capacity."
 	item = /obj/item/borg/upgrade/modkit/indoors
 	cost = 5 //you need two for full damage, so total of 10 for maximum damage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
PKAs now have the same weakness in a vacuum as they have in a pressurized environment 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The current miner antag strat is getting spaceproof and then going to space with PKAs then depressurizing sec to fight them and easily curb stomp them. PKAs are not balanced for non-mining combat. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
PKA works as it should in a pressurized environment

![image](https://user-images.githubusercontent.com/55861563/187093515-3b0eee87-c5a1-4849-9ce6-e24d21adad67.png)

PKA has its damage debuff in a vacuum as well

![image](https://user-images.githubusercontent.com/55861563/187093558-367bcafe-4ea4-4cdf-91c7-f658b1649103.png)

PKA works as intended on lavaland
![image](https://user-images.githubusercontent.com/55861563/187093803-2947620b-f52e-41b7-b0db-3308d58d77db.png)



</details>

## Changelog
:cl: Phil Smith
balance: PKAs now have the same weakness in a vacuum as they have in a pressurized environment 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
