### PR TITLE
Cuffs are now included in get_equipped_items() (mob transformation fix)

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -59,19 +59,7 @@
 		if(affected_mob.notransform)
 			return
 		affected_mob.notransform = 1
-		for(var/obj/item/W in affected_mob.get_equipped_items(TRUE))
-			affected_mob.dropItemToGround(W)
-		for(var/obj/item/I in affected_mob.held_items)
-			affected_mob.dropItemToGround(I)
-		var/mob/living/carbon/C = affected_mob
-		if(C.handcuffed)
-			C.handcuffed.forceMove(C.drop_location())
-			C.handcuffed.dropped(C)
-			C.handcuffed = null
-		if(C.legcuffed)
-			C.legcuffed.forceMove(C.drop_location())
-			C.legcuffed.dropped(C)
-			C.legcuffed = null
+		affected_mob.unequip_everything()
 		var/mob/living/new_mob = new new_form(affected_mob.loc)
 		if(istype(new_mob))
 			if(bantype && is_banned_from(affected_mob.ckey, bantype))

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -63,6 +63,15 @@
 			affected_mob.dropItemToGround(W)
 		for(var/obj/item/I in affected_mob.held_items)
 			affected_mob.dropItemToGround(I)
+		var/mob/living/carbon/C = affected_mob
+		if(C.handcuffed)
+			C.handcuffed.forceMove(C.drop_location())
+			C.handcuffed.dropped(C)
+			C.handcuffed = null
+		if(C.legcuffed)
+			C.legcuffed.forceMove(C.drop_location())
+			C.legcuffed.dropped(C)
+			C.legcuffed = null
 		var/mob/living/new_mob = new new_form(affected_mob.loc)
 		if(istype(new_mob))
 			if(bantype && is_banned_from(affected_mob.ckey, bantype))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -664,6 +664,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		A.Remove(user)
 	if(item_flags & DROPDEL)
 		qdel(src)
+	item_flags &= ~BEING_REMOVED
 	item_flags &= ~PICKED_UP
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	SEND_SIGNAL(user, COMSIG_MOB_DROPPED_ITEM, src, loc)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -349,6 +349,10 @@
 		items += wear_mask
 	if(wear_neck)
 		items += wear_neck
+	if(handcuffed)
+		items += handcuffed
+	if(legcuffed)
+		items += legcuffed
 	return items
 
 /mob/living/carbon/human/get_equipped_items(include_pockets = FALSE)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -57,6 +57,20 @@
 		O.set_suicide(suiciding)
 	O.a_intent = INTENT_HARM
 
+	//Move cuffs over
+	if(handcuffed)
+		handcuffed.item_flags &= ~BEING_REMOVED
+		handcuffed.forceMove(O)
+		O.handcuffed = handcuffed
+		handcuffed = null
+		O.update_handcuffed()
+	if(legcuffed)
+		legcuffed.item_flags &= ~BEING_REMOVED
+		legcuffed.forceMove(O)
+		O.legcuffed = legcuffed
+		legcuffed = null
+		O.update_inv_legcuffed()
+
 	//keep viruses?
 	if (tr_flags & TR_KEEPVIRUS)
 		O.diseases = diseases
@@ -360,6 +374,20 @@
 		if(C.anchored)
 			continue
 		O.equip_to_appropriate_slot(C)
+
+	//Move cuffs over
+	if(handcuffed)
+		handcuffed.item_flags &= ~BEING_REMOVED
+		handcuffed.forceMove(O)
+		O.handcuffed = handcuffed
+		handcuffed = null
+		O.update_handcuffed()
+	if(legcuffed)
+		legcuffed.item_flags &= ~BEING_REMOVED
+		legcuffed.forceMove(O)
+		O.legcuffed = legcuffed
+		legcuffed = null
+		O.update_inv_legcuffed()
 
 	dna.transfer_identity(O, tr_flags & TR_KEEPSE)
 	O.dna.set_se(FALSE, GET_INITIALIZED_MUTATION(RACEMUT))

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -232,6 +232,20 @@
 		O.set_suicide(suiciding)
 	O.a_intent = INTENT_HARM
 
+	//Move cuffs over
+	if(handcuffed)
+		handcuffed.item_flags &= ~BEING_REMOVED
+		handcuffed.forceMove(O)
+		O.handcuffed = handcuffed
+		handcuffed = null
+		O.update_handcuffed()
+	if(legcuffed)
+		legcuffed.item_flags &= ~BEING_REMOVED
+		legcuffed.forceMove(O)
+		O.legcuffed = legcuffed
+		legcuffed = null
+		O.update_inv_legcuffed()
+
 	//keep viruses?
 	if (tr_flags & TR_KEEPVIRUS)
 		O.diseases = diseases
@@ -519,6 +533,14 @@
 	Paralyze(1, ignore_canstun = TRUE)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
+	if(handcuffed)
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
+		handcuffed = null
+	if(legcuffed)
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
+		legcuffed = null
 	regenerate_icons()
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -567,6 +589,20 @@
 			qdel(W)
 		else
 			dropItemToGround(W)
+	if(delete_items)
+		if(handcuffed)
+			handcuffed.forceMove(drop_location())
+			handcuffed.dropped(src)
+			handcuffed = null
+		if(legcuffed)
+			legcuffed.forceMove(drop_location())
+			legcuffed.dropped(src)
+			legcuffed = null
+	else
+		if(handcuffed)
+			qdel(handcuffed)
+		if(legcuffed)
+			qdel(legcuffed)
 	regenerate_icons()
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -610,6 +646,14 @@
 	mobility_flags = NONE
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
+	if(handcuffed)
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
+		handcuffed = null
+	if(legcuffed)
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
+		legcuffed = null
 	regenerate_icons()
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -640,6 +684,14 @@
 	mobility_flags = NONE
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
+	if(handcuffed)
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
+		handcuffed = null
+	if(legcuffed)
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
+		legcuffed = null
 	regenerate_icons()
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -679,6 +731,14 @@
 	Paralyze(1, ignore_canstun = TRUE)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
+	if(handcuffed)
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
+		handcuffed = null
+	if(legcuffed)
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
+		legcuffed = null
 	regenerate_icons()
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -705,6 +765,14 @@
 	Itemlist += held_items
 	for(var/obj/item/W in Itemlist)
 		dropItemToGround(W, TRUE)
+	if(handcuffed)
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
+		handcuffed = null
+	if(legcuffed)
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
+		legcuffed = null
 
 	regenerate_icons()
 	icon = null
@@ -731,6 +799,14 @@
 	Itemlist += held_items
 	for(var/obj/item/W in Itemlist)
 		dropItemToGround(W, TRUE)
+	if(handcuffed)
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
+		handcuffed = null
+	if(legcuffed)
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
+		legcuffed = null
 
 	regenerate_icons()
 	icon = null
@@ -763,6 +839,14 @@
 
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
+	if(handcuffed)
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
+		handcuffed = null
+	if(legcuffed)
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
+		legcuffed = null
 
 	regenerate_icons()
 	icon = null

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -59,17 +59,13 @@
 
 	//Move cuffs over
 	if(handcuffed)
-		handcuffed.item_flags &= ~BEING_REMOVED
-		handcuffed.forceMove(O)
-		O.handcuffed = handcuffed
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
 		handcuffed = null
-		O.update_handcuffed()
 	if(legcuffed)
-		legcuffed.item_flags &= ~BEING_REMOVED
-		legcuffed.forceMove(O)
-		O.legcuffed = legcuffed
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
 		legcuffed = null
-		O.update_inv_legcuffed()
 
 	//keep viruses?
 	if (tr_flags & TR_KEEPVIRUS)
@@ -234,17 +230,13 @@
 
 	//Move cuffs over
 	if(handcuffed)
-		handcuffed.item_flags &= ~BEING_REMOVED
-		handcuffed.forceMove(O)
-		O.handcuffed = handcuffed
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
 		handcuffed = null
-		O.update_handcuffed()
 	if(legcuffed)
-		legcuffed.item_flags &= ~BEING_REMOVED
-		legcuffed.forceMove(O)
-		O.legcuffed = legcuffed
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
 		legcuffed = null
-		O.update_inv_legcuffed()
 
 	//keep viruses?
 	if (tr_flags & TR_KEEPVIRUS)
@@ -391,17 +383,13 @@
 
 	//Move cuffs over
 	if(handcuffed)
-		handcuffed.item_flags &= ~BEING_REMOVED
-		handcuffed.forceMove(O)
-		O.handcuffed = handcuffed
+		handcuffed.forceMove(drop_location())
+		handcuffed.dropped(src)
 		handcuffed = null
-		O.update_handcuffed()
 	if(legcuffed)
-		legcuffed.item_flags &= ~BEING_REMOVED
-		legcuffed.forceMove(O)
-		O.legcuffed = legcuffed
+		legcuffed.forceMove(drop_location())
+		legcuffed.dropped(src)
 		legcuffed = null
-		O.update_inv_legcuffed()
 
 	dna.transfer_identity(O, tr_flags & TR_KEEPSE)
 	O.dna.set_se(FALSE, GET_INITIALIZED_MUTATION(RACEMUT))

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -464,7 +464,7 @@
 	qdel(src)
 
 //A common proc to start an -ize transformation
-/mob/living/carbon/proc/pre_fooize(delete_items = FALSE)
+/mob/living/carbon/proc/pre_transform(delete_items = FALSE)
 	if(notransform)
 		return TRUE
 	notransform = TRUE
@@ -482,7 +482,7 @@
 		qdel(t)
 
 /mob/living/carbon/AIize(transfer_after = TRUE, client/preference_source)
-	return pre_fooize() ? null : ..()
+	return pre_transform() ? null : ..()
 
 /mob/proc/AIize(transfer_after = TRUE, client/preference_source)
 	var/list/turf/landmark_loc = list()
@@ -517,7 +517,7 @@
 	qdel(src)
 
 /mob/living/carbon/human/proc/Robotize(delete_items = 0, transfer_after = TRUE)
-	if(pre_fooize(delete_items))
+	if(pre_transform(delete_items))
 		return
 
 	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
@@ -551,7 +551,7 @@
 
 //human -> alien
 /mob/living/carbon/human/proc/Alienize()
-	if(pre_fooize())
+	if(pre_transform())
 		return
 
 	var/alien_caste = pick("Hunter","Sentinel","Drone")
@@ -572,7 +572,7 @@
 	qdel(src)
 
 /mob/living/carbon/human/proc/slimeize(reproduce as num)
-	if(pre_fooize())
+	if(pre_transform())
 		return
 
 	var/mob/living/simple_animal/slime/new_slime
@@ -602,7 +602,7 @@
 
 
 /mob/living/carbon/proc/corgize()
-	if(pre_fooize())
+	if(pre_transform())
 		return
 
 	var/mob/living/simple_animal/pet/dog/corgi/new_corgi = new /mob/living/simple_animal/pet/dog/corgi (loc)
@@ -614,7 +614,7 @@
 	qdel(src)
 
 /mob/living/carbon/proc/gorillize()
-	if(pre_fooize())
+	if(pre_transform())
 		return
 	var/mob/living/simple_animal/hostile/gorilla/new_gorilla = new (get_turf(src))
 	new_gorilla.a_intent = INTENT_HARM
@@ -627,7 +627,7 @@
 	qdel(src)
 
 /mob/living/carbon/proc/junglegorillize()
-	if(pre_fooize())
+	if(pre_transform())
 		return
 	var/mob/living/simple_animal/hostile/gorilla/rabid/new_gorilla = new (get_turf(src))
 	new_gorilla.a_intent = INTENT_HARM
@@ -650,7 +650,7 @@
 		to_chat(usr, "<span class='danger'>Sorry but this mob type is currently unavailable.</span>")
 		return
 
-	if(pre_fooize())
+	if(pre_transform())
 		return
 
 	var/mob/new_mob = new mobpath(src.loc)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -22,10 +22,7 @@
 		CH.cavity_item = null
 
 	if(tr_flags & TR_KEEPITEMS)
-		var/Itemlist = get_equipped_items(TRUE)
-		Itemlist += held_items
-		for(var/obj/item/W in Itemlist)
-			dropItemToGround(W)
+		unequip_everything()
 
 	//Make mob invisible and spawn animation
 	notransform = TRUE
@@ -56,16 +53,6 @@
 	if(suiciding)
 		O.set_suicide(suiciding)
 	O.a_intent = INTENT_HARM
-
-	//Move cuffs over
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
 
 	//keep viruses?
 	if (tr_flags & TR_KEEPVIRUS)
@@ -190,10 +177,7 @@
 		CH.cavity_item = null
 
 	if(tr_flags & TR_KEEPITEMS)
-		var/Itemlist = get_equipped_items(TRUE)
-		Itemlist += held_items
-		for(var/obj/item/W in Itemlist)
-			dropItemToGround(W)
+		unequip_everything()
 
 	//Make mob invisible and spawn animation
 	notransform = TRUE
@@ -227,16 +211,6 @@
 	if(suiciding)
 		O.set_suicide(suiciding)
 	O.a_intent = INTENT_HARM
-
-	//Move cuffs over
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
 
 	//keep viruses?
 	if (tr_flags & TR_KEEPVIRUS)
@@ -353,14 +327,7 @@
 
 	//now the rest
 	if (tr_flags & TR_KEEPITEMS)
-		var/Itemlist = get_equipped_items(TRUE)
-		Itemlist += held_items
-		for(var/obj/item/W in Itemlist)
-			dropItemToGround(W, TRUE)
-			if (client)
-				client.screen -= W
-
-
+		unequip_everything()
 
 	//Make mob invisible and spawn animation
 	notransform = TRUE
@@ -380,16 +347,6 @@
 		if(C.anchored)
 			continue
 		O.equip_to_appropriate_slot(C)
-
-	//Move cuffs over
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
 
 	dna.transfer_identity(O, tr_flags & TR_KEEPSE)
 	O.dna.set_se(FALSE, GET_INITIALIZED_MUTATION(RACEMUT))
@@ -506,33 +463,26 @@
 
 	qdel(src)
 
-/mob/living/carbon/human/AIize(transfer_after = TRUE, client/preference_source)
-	if (notransform)
-		return
-	for(var/t in bodyparts)
-		qdel(t)
-
-	return ..()
-
-/mob/living/carbon/AIize(transfer_after = TRUE, client/preference_source)
-	if (notransform)
-		return
+//A common proc to start an -ize transformation
+/mob/living/carbon/proc/pre_fooize(delete_items = FALSE)
+	if(notransform)
+		return TRUE
 	notransform = TRUE
 	Paralyze(1, ignore_canstun = TRUE)
-	for(var/obj/item/W in src)
-		dropItemToGround(W)
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
+
+	if(delete_items)
+		for(var/obj/item/W in get_equipped_items(TRUE) | held_items)
+			qdel(W)
+	else
+		unequip_everything()
 	regenerate_icons()
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
-	return ..()
+	for(var/t in bodyparts)
+		qdel(t)
+
+/mob/living/carbon/AIize(transfer_after = TRUE, client/preference_source)
+	return pre_fooize() ? null : ..()
 
 /mob/proc/AIize(transfer_after = TRUE, client/preference_source)
 	var/list/turf/landmark_loc = list()
@@ -567,35 +517,8 @@
 	qdel(src)
 
 /mob/living/carbon/human/proc/Robotize(delete_items = 0, transfer_after = TRUE)
-	if (notransform)
+	if(pre_fooize(delete_items))
 		return
-	notransform = TRUE
-	Paralyze(1, ignore_canstun = TRUE)
-
-	for(var/obj/item/W in src)
-		if(delete_items)
-			qdel(W)
-		else
-			dropItemToGround(W)
-	if(delete_items)
-		if(handcuffed)
-			handcuffed.forceMove(drop_location())
-			handcuffed.dropped(src)
-			handcuffed = null
-		if(legcuffed)
-			legcuffed.forceMove(drop_location())
-			legcuffed.dropped(src)
-			legcuffed = null
-	else
-		if(handcuffed)
-			qdel(handcuffed)
-		if(legcuffed)
-			qdel(legcuffed)
-	regenerate_icons()
-	icon = null
-	invisibility = INVISIBILITY_MAXIMUM
-	for(var/t in bodyparts)
-		qdel(t)
 
 	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
 
@@ -628,25 +551,8 @@
 
 //human -> alien
 /mob/living/carbon/human/proc/Alienize()
-	if (notransform)
+	if(pre_fooize())
 		return
-	notransform = TRUE
-	mobility_flags = NONE
-	for(var/obj/item/W in src)
-		dropItemToGround(W)
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
-	regenerate_icons()
-	icon = null
-	invisibility = INVISIBILITY_MAXIMUM
-	for(var/t in bodyparts)
-		qdel(t)
 
 	var/alien_caste = pick("Hunter","Sentinel","Drone")
 	var/mob/living/carbon/alien/humanoid/new_xeno
@@ -666,25 +572,8 @@
 	qdel(src)
 
 /mob/living/carbon/human/proc/slimeize(reproduce as num)
-	if (notransform)
+	if(pre_fooize())
 		return
-	notransform = TRUE
-	mobility_flags = NONE
-	for(var/obj/item/W in src)
-		dropItemToGround(W)
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
-	regenerate_icons()
-	icon = null
-	invisibility = INVISIBILITY_MAXIMUM
-	for(var/t in bodyparts)
-		qdel(t)
 
 	var/mob/living/simple_animal/slime/new_slime
 	if(reproduce)
@@ -713,25 +602,8 @@
 
 
 /mob/living/carbon/proc/corgize()
-	if (notransform)
+	if(pre_fooize())
 		return
-	notransform = TRUE
-	Paralyze(1, ignore_canstun = TRUE)
-	for(var/obj/item/W in src)
-		dropItemToGround(W)
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
-	regenerate_icons()
-	icon = null
-	invisibility = INVISIBILITY_MAXIMUM
-	for(var/t in bodyparts)	//this really should not be necessary
-		qdel(t)
 
 	var/mob/living/simple_animal/pet/dog/corgi/new_corgi = new /mob/living/simple_animal/pet/dog/corgi (loc)
 	new_corgi.a_intent = INTENT_HARM
@@ -742,29 +614,8 @@
 	qdel(src)
 
 /mob/living/carbon/proc/gorillize()
-	if(notransform)
+	if(pre_fooize())
 		return
-	notransform = TRUE
-	Paralyze(1, ignore_canstun = TRUE)
-
-	SSblackbox.record_feedback("amount", "gorillas_created", 1)
-
-	var/Itemlist = get_equipped_items(TRUE)
-	Itemlist += held_items
-	for(var/obj/item/W in Itemlist)
-		dropItemToGround(W, TRUE)
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
-
-	regenerate_icons()
-	icon = null
-	invisibility = INVISIBILITY_MAXIMUM
 	var/mob/living/simple_animal/hostile/gorilla/new_gorilla = new (get_turf(src))
 	new_gorilla.a_intent = INTENT_HARM
 	if(mind)
@@ -776,29 +627,8 @@
 	qdel(src)
 
 /mob/living/carbon/proc/junglegorillize()
-	if(notransform)
+	if(pre_fooize())
 		return
-	notransform = TRUE
-	Paralyze(1, ignore_canstun = TRUE)
-
-	SSblackbox.record_feedback("amount", "gorillas_created", 1)
-
-	var/Itemlist = get_equipped_items(TRUE)
-	Itemlist += held_items
-	for(var/obj/item/W in Itemlist)
-		dropItemToGround(W, TRUE)
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
-
-	regenerate_icons()
-	icon = null
-	invisibility = INVISIBILITY_MAXIMUM
 	var/mob/living/simple_animal/hostile/gorilla/rabid/new_gorilla = new (get_turf(src))
 	new_gorilla.a_intent = INTENT_HARM
 	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
@@ -820,28 +650,8 @@
 		to_chat(usr, "<span class='danger'>Sorry but this mob type is currently unavailable.</span>")
 		return
 
-	if(notransform)
+	if(pre_fooize())
 		return
-	notransform = TRUE
-	Paralyze(1, ignore_canstun = TRUE)
-
-	for(var/obj/item/W in src)
-		dropItemToGround(W)
-	if(handcuffed)
-		handcuffed.forceMove(drop_location())
-		handcuffed.dropped(src)
-		handcuffed = null
-	if(legcuffed)
-		legcuffed.forceMove(drop_location())
-		legcuffed.dropped(src)
-		legcuffed = null
-
-	regenerate_icons()
-	icon = null
-	invisibility = INVISIBILITY_MAXIMUM
-
-	for(var/t in bodyparts)
-		qdel(t)
 
 	var/mob/new_mob = new mobpath(src.loc)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Handcuffs and legcuffs are now included when get_equipped_items() is called. This means that cuffs are included too when something needs to happen to everything on a mob, most commonly if everything needs to be dropped/destroyed when the mob is transformed/dusted. This was in response to fix #7519, making legcuffs and handcuffs are dropped carbon is transformed into something else. The exception to this being mutation toxins, which I did not touch because they already account for cuffs by keeping them. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #7519. Cuffs randomly disappearing is bad, bugs are bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing</summary>

https://user-images.githubusercontent.com/51838176/188252638-d046aa00-616d-4186-857c-055c9158f904.mp4

</details>

## Changelog
:cl:
fix: cuffs are now properly accounted for in situations that affects all equipped items on a mob. This  most notable affects when a mob transforms, where cuffs will now drop with everything else rather than being deleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
