### PR TITLE
You can't withdraw credits from budget card anymore

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -798,7 +798,7 @@ update_label("John Doe", "Clowny")
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
-	to_chat(user, "<span class='warning'>You bypassed the credit withdraw lock of [src].</span>")
+	to_chat(user, "<span class='warning'>You bypassed the credit withdrawal lock of [src].</span>")
 
 /obj/item/card/id/departmental_budget/Destroy()
 	SSeconomy.dep_cards -= src

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -260,7 +260,7 @@
 		registered_account.bank_card_talk("<span class='warning'>ERROR: UNABLE TO LOGIN DUE TO SCHEDULED MAINTENANCE. MAINTENANCE IS SCHEDULED TO COMPLETE IN [(registered_account.withdrawDelay - world.time)/10] SECONDS.</span>", TRUE)
 		return
 
-	var/amount_to_remove =  FLOOR(input(user, "How much do you want to withdraw? Current Balance: [registered_account.account_balance]", "Withdraw Funds", 5) as num, 1)
+	var/amount_to_remove = FLOOR(input(user, "How much do you want to withdraw? Current Balance: [registered_account.account_balance]", "Withdraw Funds", 5) as num, 1)
 
 	if(!amount_to_remove || amount_to_remove < 0)
 		to_chat(user, "<span class='warning'>You're pretty sure that's not how money works.</span>")

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -760,6 +760,22 @@ update_label("John Doe", "Clowny")
 		desc = "Provides access to the [department_name]."
 	SSeconomy.dep_cards += src
 
+/obj/item/card/id/departmental_budget/AltClick(mob/living/user)
+	if(!alt_click_can_use_id(user))
+		return
+
+	if(!(obj_flags & EMAGGED))
+		to_chat(user, "<span class='warning'>Budget card isn't allowed to withdraw credits directly.</span>")
+		return
+
+	..()
+
+/obj/item/card/id/departmental_budget/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	to_chat(user, "<span class='warning'>You bypassed [src]'s credit withdraw lock.</span>")
+
 /obj/item/card/id/departmental_budget/Destroy()
 	SSeconomy.dep_cards -= src
 	return ..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -774,7 +774,7 @@ update_label("John Doe", "Clowny")
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
-	to_chat(user, "<span class='warning'>You bypassed [src]'s credit withdraw lock.</span>")
+	to_chat(user, "<span class='warning'>You bypassed the credit withdraw lock of [src].</span>")
 
 /obj/item/card/id/departmental_budget/Destroy()
 	SSeconomy.dep_cards -= src

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -791,8 +791,7 @@ update_label("John Doe", "Clowny")
 			var/difference = amount_to_remove - B_from.account_balance
 			B_from.bank_card_talk("<span class='warning'>ERROR: The linked account requires [difference] more credit\s to perform that transfer.</span>", TRUE)
 			return
-	else
-		return ..()
+	return ..()
 
 /obj/item/card/id/departmental_budget/emag_act(mob/user)
 	if(obj_flags & EMAGGED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Budget card is no longer withdraw-able
* Budget card can be emagged for withdraw feature unlock
(space pirates just can bypass this lock)
* budget to budget transfer feature - touch your budget card to the target budget card
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
extreme amount of money shouldn't be that easily accessible, but also heads should utilise their console to give payment bonus, not just withdraw money from the budget card when they want to give bonus.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


(Image missing somehow. It tells a warning instead of allowing you to withdraw)

You can't withdraw

![image](https://user-images.githubusercontent.com/87972842/187301048-4cac078f-bf68-4f5a-b313-2b95305f1d1c.png)

![image](https://user-images.githubusercontent.com/87972842/187301198-6c1b52aa-e412-41e8-bf2b-b7c4b36635c7.png)

emag can make it withdrew

---------------

![image](https://user-images.githubusercontent.com/87972842/187310975-87ea6e7d-dbf8-4433-badc-cb383da70c4f.png)

3571 to both

----

![image](https://user-images.githubusercontent.com/87972842/187311006-c62306de-1c35-4b58-9f63-981df39d2c44.png)

when you touch a budget card with a budget card

----

![image](https://user-images.githubusercontent.com/87972842/187311047-f5f111b1-d636-4dd1-be6e-61af348f1907.png)
![image](https://user-images.githubusercontent.com/87972842/187311123-783dbdbe-f1b7-406a-b8c1-8fc5c903cc79.png)
![image](https://user-images.githubusercontent.com/87972842/187311189-8f4024b4-d6d4-4bab-b58d-a55dc2500f48.png)

after transferred


</details>

## Changelog
:cl:
balance: budget card is locked and you can't withdraw credits from it. You can withdraw when you emag the cards, or be a space pirate to withdraw freely.
add: budget card can transfer its money into another budget card when you touch it into another card.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
