### PR TITLE
Flashlights use batteries

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -118,7 +118,7 @@
 		A.UpdateButtonIcon()
 	return 1
 
-/obj/item/flashlight/attack_by(obj/item/I, mob/user)
+/obj/item/flashlight/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/stock_parts/cell))
 		if(uses_battery)
 			if(int_battery)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -64,7 +64,7 @@
 		STOP_PROCESSING(SSobj, src)
 		return
 	if(int_battery)
-		int_battery.charge = max(int_battery.charge - (battery_use_rate * delta_time), 0)
+		int_battery.use(battery_use_rate * delta_time)
 	update_power()
 	update_brightness()
 
@@ -117,6 +117,16 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 	return 1
+
+/obj/item/flashlight/attack_by(obj/item/I, mob/user)
+	if(istype(I, /obj/item/stock_parts/cell))
+		if(uses_battery)
+			if(int_battery)
+				to_chat(user, "<span class='warning'>There's already a cell inside!</span>")
+				return
+			int_battery = I
+			I.forceMove(src)
+			to_chat(user, "<span class='notice'>You plug the cell into \the [src].")
 
 /obj/item/flashlight/screwdriver_act(mob/user, obj/item/I)
 	if(int_battery)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -40,6 +40,7 @@
 	if(uses_battery)
 		if(istype(int_battery))
 			. += "The flashlight is at [round(int_battery.percent() )]%."
+			. += "<span class='notice'>Alt-click to remove cell.</span>"
 		else
 			. += "There doesn't seem to be a cell inserted."
 
@@ -128,7 +129,7 @@
 			I.forceMove(src)
 			to_chat(user, "<span class='notice'>You plug the cell into \the [src].")
 
-/obj/item/flashlight/screwdriver_act(mob/user, obj/item/I)
+/obj/item/flashlight/AltClick(mob/user)
 	if(int_battery)
 		to_chat(user, "<span class='notice'>You remove the battery from \the [src]</span>")
 		user.put_in_hands(int_battery)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Flashlights use an internal battery, and the light starts dying at around 500kw left, before dimming further at 200kw and cutting out at 0
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Flashlights are so, so easy to get and discount every other light emitter (besides maybe the hardhat?)

also its setting up my next pr stay tuned :)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/187323753-eafdd7d7-94ea-402a-9b34-7893ffcf3d71.png)

</details>

## Changelog
:cl:
balance: Nanotrasen has stopped using infinite cells for their flashlights, downgrading to basic (flashlights have internal cells now)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
