### PR TITLE
New engineering objectives

### DIFF
--- a/code/modules/crew_objectives/engineering_objectives.dm
+++ b/code/modules/crew_objectives/engineering_objectives.dm
@@ -54,18 +54,8 @@
 
 /datum/objective/crew/apc/check_completion()
 	var/total_power = 0
-	var/list/powermonitors = list()
-
-	for(var/obj/machinery/computer/monitor/pMon in GLOB.machines)
-		if(pMon.stat & (NOPOWER | BROKEN)) //check to make sure the computer is functional
-			continue
-		if(pMon.is_secret_monitor) //make sure it isn't a secret one (ie located on a ruin), allowing people to metagame that the location exists
-			continue
-		powermonitors += pMon
-
-	for(var/obj/machinery/computer/monitor/pMon in powermonitors)
-		var/datum/powernet/connected_powernet = pMon.get_powernet()
-		total_power += connected_powernet.viewavail
+	for(var/datum/powernet/PN in SSmachines.powernets)
+		total_power += PN.avail
 
 	if(total_power >= target_amount)
 		return TRUE

--- a/code/modules/crew_objectives/engineering_objectives.dm
+++ b/code/modules/crew_objectives/engineering_objectives.dm
@@ -34,7 +34,7 @@
 	return ..()
 
 /datum/objective/crew/supermatter_survive
-	explanation_text = "Prevent the main supermatter from exploding. This does not count additional supermatters constructed."
+	explanation_text = "Prevent the main supermatter crystal from exploding. This does not count additional supermatters constructed."
 	jobs = "chiefengineer,stationengineer"
 
 /datum/objective/crew/supermatter_survive/check_completion()
@@ -53,14 +53,14 @@
 	explanation_text = "Make sure the station has above [target_amount]kW in the powernet."
 
 /datum/objective/crew/apcc/check_completion()
-	var/total_power += 0
+	var/total_power = 0
+	var/list/powermonitors = list()
 
 	for(var/obj/machinery/computer/monitor/pMon in GLOB.machines)
 		if(pMon.stat & (NOPOWER | BROKEN)) //check to make sure the computer is functional
 			continue
 		if(pMon.is_secret_monitor) //make sure it isn't a secret one (ie located on a ruin), allowing people to metagame that the location exists
 			continue
-		powercount++
 		powermonitors += pMon
 
 	for(var/obj/machinery/computer/monitor/pMon in powermonitors)

--- a/code/modules/crew_objectives/engineering_objectives.dm
+++ b/code/modules/crew_objectives/engineering_objectives.dm
@@ -34,7 +34,7 @@
 	return ..()
 
 /datum/objective/crew/supermatter_survive
-	explanation_text = "Prevent the main supermatter crystal from exploding. This does not count additional supermatters constructed."
+	explanation_text = "Prevent the primary Supermatter engine from fully delaminating. Additional Supermatter shards ordered from cargo do not count for this"
 	jobs = "chiefengineer,stationengineer"
 
 /datum/objective/crew/supermatter_survive/check_completion()

--- a/code/modules/crew_objectives/engineering_objectives.dm
+++ b/code/modules/crew_objectives/engineering_objectives.dm
@@ -32,3 +32,29 @@
 			if(istype(dumbbird.ears, /obj/item/radio/headset))
 				return TRUE
 	return ..()
+
+/datum/objective/crew/supermatter_survive
+	explanation_text = "Prevent the main supermatter from exploding. This does not count additional supermatters constructed."
+	jobs = "chiefengineer,stationengineer"
+
+/datum/objective/crew/supermatter_survive/check_completion()
+	if(GLOB.main_supermatter_engine)  // handy it qdel's itself
+		return TRUE
+	return ..()
+
+
+/datum/objective/crew/apc
+	explanation_text = "Make sure the station has above (something broke message us)kW in the powernet."
+	jobs = "chiefengineer,stationengineer,atmospherictechnician"
+
+/datum/objective/crew/apc/New()
+	. = ..()
+	target_amount = rand(100,500)  // no i dont know how much a normal amount is :>
+	explanation_text = "Make sure the station has above [target_amount]kW in the powernet."
+
+/datum/objective/crew/apcc/check_completion()
+	var/datum/powernet/connected_powernet = get_powernet()
+
+	if(connected_powernet.viewavail >= target_amount)
+		return TRUE
+	return ..()

--- a/code/modules/crew_objectives/engineering_objectives.dm
+++ b/code/modules/crew_objectives/engineering_objectives.dm
@@ -53,8 +53,20 @@
 	explanation_text = "Make sure the station has above [target_amount]kW in the powernet."
 
 /datum/objective/crew/apcc/check_completion()
-	var/datum/powernet/connected_powernet = get_powernet()
+	var/total_power += 0
 
-	if(connected_powernet.viewavail >= target_amount)
+	for(var/obj/machinery/computer/monitor/pMon in GLOB.machines)
+		if(pMon.stat & (NOPOWER | BROKEN)) //check to make sure the computer is functional
+			continue
+		if(pMon.is_secret_monitor) //make sure it isn't a secret one (ie located on a ruin), allowing people to metagame that the location exists
+			continue
+		powercount++
+		powermonitors += pMon
+
+	for(var/obj/machinery/computer/monitor/pMon in powermonitors)
+		var/datum/powernet/connected_powernet = pMon.get_powernet()
+		total_power += connected_powernet.viewavail
+
+	if(total_power >= target_amount)
 		return TRUE
 	return ..()

--- a/code/modules/crew_objectives/engineering_objectives.dm
+++ b/code/modules/crew_objectives/engineering_objectives.dm
@@ -52,7 +52,7 @@
 	target_amount = rand(100,500)  // no i dont know how much a normal amount is :>
 	explanation_text = "Make sure the station has above [target_amount]kW in the powernet."
 
-/datum/objective/crew/apcc/check_completion()
+/datum/objective/crew/apc/check_completion()
 	var/total_power = 0
 	var/list/powermonitors = list()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Addss two engineering objectives, keep the sm up and keep the power up
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Engineering SEVERELY lacks crew objectives, only having one for standard engineers and a unique one for the ce. The standard engie one is also extremely easy to complete, usually being accomplished by accident. These new objectives encourage engineers to DO THEIR JOB (power and not creating a singulo)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/187354360-0f11bb70-8ad4-451c-b3c0-d7871970ad27.png)
![image](https://user-images.githubusercontent.com/73374039/187628074-4a22384d-08ea-4500-86b4-d5b4b06051fd.png)


</details>

## Changelog
:cl:
add: New engineer crew objectives
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
