### PR TITLE
ChemMaster can now input a target volume and preset packaging name + chat filter check

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -1,5 +1,5 @@
 import { useBackend, useSharedState } from '../backend';
-import { AnimatedNumber, Box, Button, ColorBox, LabeledList, NumberInput, Section, Table } from '../components';
+import { AnimatedNumber, Box, Button, ColorBox, Input, LabeledList, NumberInput, Section, Table } from '../components';
 import { Window } from '../layouts';
 
 export const ChemMaster = (props, context) => {
@@ -22,14 +22,12 @@ export const ChemMaster = (props, context) => {
 
 const ChemMasterContent = (props, context) => {
   const { act, data } = useBackend(context);
-  const [
-    volumeState,
-    setVolumeState,
-  ] = useSharedState(context, 'volume_state', "Exact");
-  const [
-    volumeExact,
-    setVolume,
-  ] = useSharedState(context, 'volume', 10);
+  const {
+    saved_volume,
+    saved_name,
+    saved_volume_state,
+    saved_name_state,
+  } = data;
   const {
     screen,
     beakerContents = [],
@@ -117,25 +115,44 @@ const ChemMasterContent = (props, context) => {
               Mode:
             </Box>
             <Button
-              icon={volumeState === "Exact" ? "eye-dropper" : "flask"}
-              content={`${volumeState}`}
+              icon={saved_volume_state === "Exact" ? "eye-dropper" : "flask"}
+              content={`${saved_volume_state}`}
               tooltip="Volume Distribution"
-              onClick={() => setVolumeState(volumeState === "Exact" ? "Auto" : "Exact")}
+              onClick={() => act('setSavedVolumeState', { volume_state: saved_volume_state === "Exact" ? "Auto" : "Exact" })}
             />
-            {volumeState === "Exact" && (
+            {saved_volume_state === "Exact" && (
               <NumberInput
                 width="84px"
                 unit="units"
                 stepPixelSize={15}
-                value={volumeExact}
+                value={saved_volume}
                 minValue={0.01}
                 maxValue={50}
-                onChange={(e, value) => setVolume(value)} />
+                onChange={(e, value) => act('setSavedVolume', { volume: value })} />
             )}
           </>
         )}>
+        <Box mb={2}>
+          <Box inline color="label" mr={1}>
+            Naming Mode:
+          </Box>
+          <Button
+            icon={saved_name_state === "Manual" ? "pen" : "print"}
+            content={`${saved_name_state}`}
+            onClick={() => act('setSavedNameState', { name_state: saved_name_state === "Manual" ? "Auto" : "Manual" })}
+          />
+          {saved_name_state === "Manual" && (
+            <Input
+              fluid
+              value={saved_name}
+              placeholder="Name"
+              onInput={(e, value) => {
+                act('setSavedName', { name: value });
+              }} />
+          )}
+        </Box>
         <PackagingControls
-          volume={volumeState === "Exact" ? volumeExact : "auto"} />
+          volume={saved_volume_state === "Exact" ? saved_volume : "auto"} packagingName={saved_name_state === "Manual" ? saved_name : null} />
       </Section>
       {!!isPillBottleLoaded && (
         <Section
@@ -248,7 +265,7 @@ const PackagingControlsItem = props => {
   );
 };
 
-const PackagingControls = ({ volume }, context) => {
+const PackagingControls = ({ volume, packagingName }, context) => {
   const { act, data } = useBackend(context);
   const [
     pillAmount,
@@ -299,6 +316,7 @@ const PackagingControls = ({ volume }, context) => {
             type: 'pill',
             amount: pillAmount,
             volume: volume,
+            name: packagingName,
           })} />
       )}
       {!condi && (
@@ -312,6 +330,7 @@ const PackagingControls = ({ volume }, context) => {
             type: 'patch',
             amount: patchAmount,
             volume: volume,
+            name: packagingName,
           })} />
       )}
       {!condi && (
@@ -325,6 +344,7 @@ const PackagingControls = ({ volume }, context) => {
             type: 'bottle',
             amount: bottleAmount,
             volume: volume,
+            name: packagingName,
           })} />
       )}
       {!!condi && (
@@ -338,6 +358,7 @@ const PackagingControls = ({ volume }, context) => {
             type: 'condimentPack',
             amount: packAmount,
             volume: volume,
+            name: packagingName,
           })} />
       )}
       {!!condi && (
@@ -351,6 +372,7 @@ const PackagingControls = ({ volume }, context) => {
             type: 'condimentBottle',
             amount: bottleAmount,
             volume: volume,
+            name: packagingName,
           })} />
       )}
     </LabeledList>

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -125,7 +125,7 @@ const ChemMasterContent = (props, context) => {
             {volumeState === "Exact" && (
               <NumberInput
                 width="84px"
-                amountUnit="units"
+                unit="units"
                 stepPixelSize={15}
                 value={volumeExact}
                 minValue={0.01}

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -135,8 +135,7 @@ const ChemMasterContent = (props, context) => {
           </>
         )}>
         <PackagingControls
-          volumeState={volumeState}
-          volumeExact={volumeExact} />
+          volume={volumeState === "Exact" ? volumeExact : "auto"} />
       </Section>
       {!!isPillBottleLoaded && (
         <Section
@@ -249,7 +248,7 @@ const PackagingControlsItem = props => {
   );
 };
 
-const PackagingControls = ({ volumeState, volumeExact }, context) => {
+const PackagingControls = ({ volume }, context) => {
   const { act, data } = useBackend(context);
   const [
     pillAmount,
@@ -272,7 +271,6 @@ const PackagingControls = ({ volumeState, volumeExact }, context) => {
     chosenPillStyle,
     pillStyles = [],
   } = data;
-  const volume = volumeState === "Exact" ? volumeExact : "auto";
   return (
     <LabeledList>
       {!condi && (

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -113,6 +113,9 @@ const ChemMasterContent = (props, context) => {
         title="Packaging"
         buttons={(
           <>
+            <Box inline color="label" mr={1}>
+              Mode:
+            </Box>
             <Button
               icon={volumeState === "Exact" ? "eye-dropper" : "flask"}
               content={`${volumeState}`}

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -22,6 +22,14 @@ export const ChemMaster = (props, context) => {
 
 const ChemMasterContent = (props, context) => {
   const { act, data } = useBackend(context);
+  const [
+    volumeState,
+    setVolumeState,
+  ] = useSharedState(context, 'volume_state', "Exact");
+  const [
+    volumeExact,
+    setVolume,
+  ] = useSharedState(context, 'volume', 10);
   const {
     screen,
     beakerContents = [],
@@ -102,8 +110,30 @@ const ChemMasterContent = (props, context) => {
         </ChemicalBuffer>
       </Section>
       <Section
-        title="Packaging">
-        <PackagingControls />
+        title="Packaging"
+        buttons={(
+          <>
+            <Button
+              icon={volumeState === "Exact" ? "eye-dropper" : "flask"}
+              content={`${volumeState}`}
+              tooltip="Volume Distribution"
+              onClick={() => setVolumeState(volumeState === "Exact" ? "Auto" : "Exact")}
+            />
+            {volumeState === "Exact" && (
+              <NumberInput
+                width="84px"
+                amountUnit="units"
+                stepPixelSize={15}
+                value={volumeExact}
+                minValue={0.01}
+                maxValue={50}
+                onChange={(e, value) => setVolume(value)} />
+            )}
+          </>
+        )}>
+        <PackagingControls
+          volumeState={volumeState}
+          volumeExact={volumeExact} />
       </Section>
       {!!isPillBottleLoaded && (
         <Section
@@ -216,7 +246,7 @@ const PackagingControlsItem = props => {
   );
 };
 
-const PackagingControls = (props, context) => {
+const PackagingControls = ({ volumeState, volumeExact }, context) => {
   const { act, data } = useBackend(context);
   const [
     pillAmount,
@@ -239,6 +269,7 @@ const PackagingControls = (props, context) => {
     chosenPillStyle,
     pillStyles = [],
   } = data;
+  const volume = volumeState === "Exact" ? volumeExact : "auto";
   return (
     <LabeledList>
       {!condi && (
@@ -266,7 +297,7 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'pill',
             amount: pillAmount,
-            volume: 'auto',
+            volume: volume,
           })} />
       )}
       {!condi && (
@@ -279,7 +310,7 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'patch',
             amount: patchAmount,
-            volume: 'auto',
+            volume: volume,
           })} />
       )}
       {!condi && (
@@ -292,7 +323,7 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'bottle',
             amount: bottleAmount,
-            volume: 'auto',
+            volume: volume,
           })} />
       )}
       {!!condi && (
@@ -305,7 +336,7 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'condimentPack',
             amount: packAmount,
-            volume: 'auto',
+            volume: volume,
           })} />
       )}
       {!!condi && (
@@ -318,7 +349,7 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'condimentBottle',
             amount: bottleAmount,
-            volume: 'auto',
+            volume: volume,
           })} />
       )}
     </LabeledList>


### PR DESCRIPTION
## About The Pull Request

You can now switch the output mode from "auto" to a specific volume amount, allowing for more precise creation of pill dosages.

Doing a bunch of division just to get the right dosage is a pain, nobody likes it, and it doesn't make the game any better or more fun/balanced.

Created in response to this comment @Coding-Grape

https://github.com/BeeStation/BeeStation-Hornet/pull/7324#issuecomment-1192060234

You can also set the naming mode to Manual and it will bypass the name input and use the name in the text box - it's also persistent and shared state, so the name will stay if you close the UI.

## Why It's Good For The Game

ChemMasters are more usable, as dosages can be set more precisely.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/187973005-1b04feb3-1248-4519-ab6c-b7cbe634224f.png)

![image](https://user-images.githubusercontent.com/10366817/187973124-2edf35de-6111-4d77-9fee-7d899dffdea8.png)

![image](https://user-images.githubusercontent.com/10366817/187559293-1296edba-a9c8-4ee5-9eff-d5191b78dd16.png)

![image](https://user-images.githubusercontent.com/10366817/187559299-8bee3c3d-e7e8-4167-968a-e6781e5e0129.png)

![image](https://user-images.githubusercontent.com/10366817/187559305-14fa56ef-26ad-4910-8fe4-85be3d33b863.png)

</details>

## Changelog
:cl:
tweak: ChemMasters now have an exact output units mode for pills/patches/bottles.
tweak: ChemMasters can now have a set name input to use for all pills, instead of prompting every time.
admin: ChemMaster packaging names are now subject to the IC filter.
/:cl:
