### PR TITLE
Rotates the "public" autolathes windoors to block the outside

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13320,7 +13320,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southright{
 	name = "Research and Development Desk";
-	req_one_access_txt = "7;29"
+	req_one_access_txt = "7;29";
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";
@@ -24060,7 +24061,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/closet/firecloset,
+/obj/machinery/modular_fabricator/autolathe,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfK" = (
@@ -38140,7 +38141,8 @@
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/window/westleft{
 	name = "Cargo Desk";
-	req_access_txt = "31"
+	req_access_txt = "31";
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/door/firedoor,
@@ -58116,7 +58118,8 @@
 "vBt" = (
 /obj/machinery/door/window/southright{
 	name = "Research and Development Desk";
-	req_one_access_txt = "7;29"
+	req_one_access_txt = "7;29";
+	dir = 1
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "rnd";

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -5848,7 +5848,7 @@
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 1;
+	dir = 2;
 	icon_state = "right";
 	name = "Cargo Window";
 	pixel_y = 1;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54080,6 +54080,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cZq" = (
@@ -71338,7 +71341,6 @@
 "eqS" = (
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/window/southleft{
-	dir = 1;
 	req_access_txt = "48"
 	},
 /obj/machinery/door/firedoor,
@@ -90330,7 +90332,8 @@
 	},
 /obj/machinery/door/window/southleft{
 	name = "Research Lab Desk";
-	req_one_access_txt = "7;29"
+	req_one_access_txt = "7;29";
+	dir = 1
 	},
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/firedoor,

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -31959,7 +31959,8 @@
 "hmo" = (
 /obj/machinery/door/window/eastright{
 	name = "Research and Development Desk";
-	req_one_access_txt = "7;29"
+	req_one_access_txt = "7;29";
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/modular_fabricator/autolathe,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -7189,7 +7189,7 @@
 	icon_state = "1-8"
 	},
 /mob/living/simple_animal/chicken/turkey{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=0,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A veteran of Nanotrasen's Animal Experimentation Program that attempted to replicate the organic space suit that some hostile entities are known to have exhibited, Tom now serves Nanotrasen as the mascot of the Exploration Crew.";
 	health = 200;
 	maxHealth = 200;
@@ -8988,7 +8988,7 @@
 /obj/item/reagent_containers/food/drinks/beer{
 	desc = "A station exclusive. Consumption may result in seizures, blindness, drunkenness, or even death.";
 	icon_state = "beer";
-	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko=30);
 	name = "Kilo-Kocktail";
 	pixel_x = 5;
 	pixel_y = 5
@@ -32179,7 +32179,7 @@
 "aXN" = (
 /obj/machinery/igniter/incinerator_toxmix,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -94640,7 +94640,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/westleft{
-	dir = 4;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
@@ -95086,7 +95085,8 @@
 	},
 /obj/machinery/door/window/eastright{
 	name = "Research Lab Desk";
-	req_one_access_txt = "7;29"
+	req_one_access_txt = "7;29";
+	dir = 8
 	},
 /obj/machinery/modular_fabricator/autolathe,
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19256,7 +19256,7 @@
 "bmh" = (
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/window/eastright{
-	dir = 1;
+	dir = 2;
 	name = "Cargo Office";
 	req_one_access_txt = "31;48"
 	},
@@ -32643,6 +32643,7 @@
 	name = "research shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
 /area/science/lab)
 "cgg" = (
@@ -77542,7 +77543,7 @@
 	name = "research shutters"
 	},
 /obj/machinery/door/window/eastright{
-	dir = 2;
+	dir = 1;
 	name = "Research and Development Desk";
 	req_one_access_txt = "7;29"
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -17458,6 +17458,7 @@
 	},
 /obj/item/folder/white,
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/plating,
 /area/science/lab)
 "bqe" = (
@@ -37249,7 +37250,7 @@
 	name = "research shutters"
 	},
 /obj/machinery/door/window/eastright{
-	dir = 2;
+	dir = 1;
 	name = "Research and Development Desk";
 	req_one_access_txt = "7;29"
 	},
@@ -57496,7 +57497,7 @@
 "txf" = (
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/window/westleft{
-	dir = 2;
+	dir = 1;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rotates cargo's and science's autolathe windoors 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The windoors currently ONLY act as a hinderance for the actual workers who use them, while allowing anyone to waltz up and print a dozen knives. Now, the department managers, heads, and ai can "better" control who can use the public lathes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/187797047-b0cf1da3-cf26-4f65-a094-5b731b991ba2.png)

</details>

## Changelog
:cl:
balance: the windoors to public autolathes have been rotated to block external use
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
