### PR TITLE
extends area markers in corg to fix emergency maints toggle

### DIFF
--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -5848,7 +5848,7 @@
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 1;
+	dir = 2;
 	icon_state = "right";
 	name = "Cargo Window";
 	pixel_y = 1;
@@ -7576,7 +7576,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/medical/cryo)
+/area/maintenance/starboard/aft)
 "bKE" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
@@ -19840,7 +19840,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/eva)
+/area/maintenance/department/science/central)
 "fvw" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -23736,7 +23736,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/quartermaster/storage)
+/area/maintenance/starboard/fore)
 "gAI" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -35053,7 +35053,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/crew_quarters/dorms)
+/area/maintenance/port/central)
 "jJM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -51899,7 +51899,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/medical/surgery)
+/area/maintenance/starboard/aft)
 "oFY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -63023,7 +63023,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/chemistry)
+/area/maintenance/starboard/central)
 "rYP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -64154,7 +64154,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/crew_quarters/dorms)
+/area/maintenance/port)
 "srG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -65550,6 +65550,23 @@
 /obj/item/modular_computer/laptop/preset/civillian,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
+"sMF" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/port/central)
 "sMX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -67652,7 +67669,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/maintenance/starboard/fore)
 "tuK" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -74053,7 +74070,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/security/checkpoint/medical)
+/area/maintenance/starboard/central)
 "vrp" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -77257,7 +77274,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/science/research)
+/area/maintenance/department/science/central)
 "wkq" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -82729,7 +82746,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/science/shuttle)
+/area/maintenance/department/science/central)
 "xRf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -108952,7 +108969,7 @@ pDf
 uPx
 nKN
 ydM
-ixJ
+yak
 dcu
 dcu
 gIZ
@@ -113350,7 +113367,7 @@ cEu
 cEu
 cEu
 iQt
-auR
+vhc
 rXr
 dqw
 nxL
@@ -113864,7 +113881,7 @@ vAA
 vAA
 cEu
 iQt
-auR
+vhc
 fIO
 bzW
 fzo
@@ -115116,9 +115133,9 @@ pga
 pga
 sVn
 pga
-pga
-wkh
-pga
+vux
+sMF
+vux
 jNE
 opq
 pdg
@@ -115411,9 +115428,9 @@ awJ
 qfp
 awJ
 aTc
-auR
+hzU
 jJK
-auR
+hzU
 gfB
 ahK
 ayj
@@ -123886,7 +123903,7 @@ jbP
 bvM
 bCU
 jwZ
-vFZ
+kfy
 reX
 eWX
 qrm
@@ -124143,7 +124160,7 @@ eeb
 jco
 ydH
 oFE
-vFZ
+kfy
 uyh
 nmr
 tBk
@@ -124400,7 +124417,7 @@ lwg
 ptI
 sQk
 ayc
-vFZ
+kfy
 uyh
 tsG
 iEf
@@ -125943,7 +125960,7 @@ pCn
 inN
 weB
 egU
-mVi
+kfy
 mVi
 mVi
 mVi
@@ -127188,7 +127205,7 @@ kNZ
 ihW
 qOW
 mbE
-aWM
+jdN
 gAu
 aWM
 aWM
@@ -130548,14 +130565,14 @@ hfh
 hfh
 hfh
 jjI
-wSu
-wSu
-wSu
+cSs
+cSs
+cSs
 rYy
-vQz
-vQz
+cSs
+cSs
 vrg
-vQz
+cSs
 tij
 vXS
 hRF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Extends the maintenence area markers, so doors that lead to maints are emergency access enabled from the comms console
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes the emergency access event more consistent and easier to escape
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/187799826-5279aac9-1144-469e-b00d-ab56e82efe3d.png)

</details>

## Changelog
:cl:
tweak: fixes some doors not being emergency access enabled from comms machine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
