### PR TITLE
Remove ! from all verbs and add to check_grep + check_grep improvements

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -58,7 +58,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead/proc/server_hop()
 	set category = "OOC"
-	set name = "Server Hop!"
+	set name = "Server Hop"
 	set desc= "Jump to the other server"
 	if(notransform)
 		return

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -58,7 +58,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead/proc/server_hop()
 	set category = "OOC"
-	set name = "Server Hop"
+	set name = "Server Hop!"
 	set desc= "Jump to the other server"
 	if(notransform)
 		return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -530,8 +530,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		client.rescale_view(input, 0, ((max_view*2)+1) - 15)
 
 /mob/dead/observer/verb/boo()
+	set name = "Boo"
 	set category = "Ghost"
-	set name = "Boo!"
 	set desc= "Scare your crew members because of boredom!"
 
 	if(bootime > world.time)
@@ -617,9 +617,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 				client.images |= (GLOB.ghost_images_simple-ghostimage_simple)
 
 /mob/dead/observer/verb/possess()
-	set category = "Ghost"
-	set name = "Possess!"
+	set name = "Possess"
 	set desc= "Take over the body of a mindless creature!"
+	set category = "Ghost"
 
 	var/list/possessible = list()
 	for(var/mob/living/L in GLOB.alive_mob_list)

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -4,96 +4,123 @@ set -euo pipefail
 #nb: must be bash to support shopt globstar
 shopt -s globstar
 
+#ANSI Escape Codes for colors to increase contrast of errors
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+BLUE="\033[0;34m"
+NC="\033[0m" # No Color
+
 st=0
 
-if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
-    echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
+echo -e "${BLUE}Checking for map issues...${NC}"
+
+if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;    then
+    echo
+    echo -e "${RED}ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!${NC}"
     st=1
 fi;
-if grep -P '^\ttag = \"icon' _maps/**/*.dmm;	then
-    echo "ERROR: tag vars from icon state generation detected in maps, please remove them."
+if grep -P '^\ttag = \"icon' _maps/**/*.dmm;    then
+    echo
+    echo -e "${RED}ERROR: Tag vars from icon state generation detected in maps, please remove them.${NC}"
     st=1
 fi;
-if grep -P 'step_[xy]' _maps/**/*.dmm;	then
-    echo "ERROR: step_x/step_y variables detected in maps, please remove them."
+if grep -P 'step_[xy]' _maps/**/*.dmm;    then
+    echo
+    echo -e "${RED}ERROR: step_x/step_y variables detected in maps, please remove them.${NC}"
     st=1
 fi;
-if grep -m 1 'pixel_[xy] = 0' _maps/**/*.dmm;	then
-    echo "ERROR: pixel_x/pixel_y = 0 variables detected in maps, please review to ensure they are not dirty varedits."
+if grep -m 1 'pixel_[xy] = 0' _maps/**/*.dmm;    then
+    echo
+    echo -e "${RED}ERROR: pixel_x/pixel_y = 0 variables detected in maps, please review to ensure they are not dirty varedits.${NC}"
     st=1
 fi;
-if grep -P '\td[1-2] =' _maps/**/*.dmm;	then
-    echo "ERROR: d1/d2 cable variables detected in maps, please remove them."
+if grep -P '\td[1-2] =' _maps/**/*.dmm;    then
+    echo
+    echo -e "${RED}ERROR: d1/d2 cable variables detected in maps, please remove them.${NC}"
     st=1
 fi;
-echo "Checking for stacked cables"
-if grep -P '"\w+" = \(\n([^)]+\n)*/obj/structure/cable,\n([^)]+\n)*/obj/structure/cable,\n([^)]+\n)*/area/.+\)' _maps/**/*.dmm;	then
-    echo "found multiple cables on the same tile, please remove them."
+echo -e "${BLUE}Checking for stacked cables...${NC}"
+if grep -P '"\w+" = \(\n([^)]+\n)*/obj/structure/cable,\n([^)]+\n)*/obj/structure/cable,\n([^)]+\n)*/area/.+\)' _maps/**/*.dmm;    then
+    echo
+    echo -e "${RED}ERROR: Found multiple cables on the same tile, please remove them.${NC}"
     st=1
 fi;
-if grep '^/area/.+[\{]' _maps/**/*.dmm;	then
-    echo "ERROR: Vareditted /area path use detected in maps, please replace with proper paths."
+if grep '^/area/.+[\{]' _maps/**/*.dmm;    then
+    echo
+    echo -e "${RED}ERROR: Variable editted /area path use detected in a map, please replace with a proper area path.${NC}"
     st=1
 fi;
 if grep -P '\W\/turf\s*[,\){]' _maps/**/*.dmm; then
-    echo "ERROR: base /turf path use detected in maps, please replace with proper paths."
+    echo
+    echo -e "${RED}ERROR: Base /turf path use detected in maps, please replace a with proper turf path.${NC}"
     st=1
 fi;
 if grep -P '^/*var/' code/**/*.dm; then
-    echo "ERROR: Unmanaged global var use detected in code, please use the helpers."
+    echo
+    echo -e "${RED}ERROR: Unmanaged global var use detected in code, please use the helpers.${NC}"
     st=1
 fi;
 if grep -i 'centcomm' code/**/*.dm; then
-    echo "ERROR: Misspelling(s) of CENTCOM detected in code, please remove the extra M(s)."
+    echo
+    echo -e "${RED}ERROR: Misspelling(s) of CentCom detected in code, please remove the extra M(s).${NC}"
     st=1
 fi;
-if grep -i 'centcomm' _maps/**/*.dmm; then
-    echo "ERROR: Misspelling(s) of CENTCOM detected in maps, please remove the extra M(s)."
-    st=1
-fi;
-if grep 'set name\s*=\s*"[\S\s]*![\S\s]*"' code/**/*.dm; then
-    echo "ERROR: Verb with name containing an exclamation point found. These verbs are not compatible with TGUI chat's statpanel or chat box."
+if grep -P 'set name\s*=\s*"[\S\s]*![\S\s]*"' code/**/*.dm; then
+    echo
+    echo -e "${RED}ERROR: Verb with name containing an exclamation point found. These verbs are not compatible with TGUI chat's statpanel or chat box.${NC}"
     st=1
 fi;
 if ls _maps/*.json | grep -P "[A-Z]"; then
-    echo "ERROR: Uppercase in a map json detected, these must be all lowercase."
+    echo
+    echo -e "${RED}ERROR: Uppercase in a map .JSON file detected, these must be all lowercase.${NC}"
     st=1
 fi;
 for json in _maps/*.json
 do
-	filepath="_maps/$(jq -r '.map_path' $json)"
-	filenames=$(jq -r '.map_file' $json)
-	if [[ "$filenames" =~ ^\[ ]] # If it starts with brackets it's a list
-	then
-		echo "$filenames" | jq -c '.[]' | while read filename
-		do
-			#Remove quotes
-			filename="${filename%\"}"
-			filename="${filename#\"}"
+    filepath="_maps/$(jq -r '.map_path' $json)"
+    filenames=$(jq -r '.map_file' $json)
+    if [[ "$filenames" =~ ^\[ ]] # If it starts with brackets it's a list
+    then
+        echo "$filenames" | jq -c '.[]' | while read filename
+        do
+            #Remove quotes
+            filename="${filename%\"}"
+            filename="${filename#\"}"
 
-			if [ ! -f "$filepath/$filename" ]
-			then
-				echo "WARNING: Found potential invalid file reference to $filepath/$filename in _maps/$json"
-				st=1
-			fi
-		done
-	else # It's not a list, it's just one file name
-		if [ ! -f "$filepath/$filenames" ]
-		then
-			echo "WARNING: Found potential invalid file reference to $filepath/$filenames in _maps/$json"
-			st=1
-		fi
-	fi
+            if [ ! -f "$filepath/$filename" ]
+            then
+                echo -e "${RED}WARNING: Found potential invalid file reference to $filepath/$filename in _maps/$json${NC}"
+                st=1
+            fi
+        done
+    else # It's not a list, it's just one file name
+        if [ ! -f "$filepath/$filenames" ]
+        then
+            echo -e "${RED}WARNING: Found potential invalid file reference to $filepath/$filenames in _maps/$json${NC}"
+            st=1
+        fi
+    fi
 done
-echo "Checking for missing newlines"
+echo -e "${BLUE}Checking for missing newlines...${NC}"
 nl='
 '
 nl=$'\n'
 while read f; do
     t=$(tail -c2 "$f"; printf x); r1="${nl}$"; r2="${nl}${r1}"
     if [[ ! ${t%x} =~ $r1 ]]; then
-        echo "file $f is missing a trailing newline"
+        echo -e "${RED}ERROR: file $f is missing a trailing newline${NC}"
         st=1
     fi;
 done < <(find . -type f -not \( -path "./.git/*" -prune \) -exec grep -Iq . {} \; -print)
+
+if [ $st = 0 ]; then
+    echo
+    echo -e "${GREEN}No errors found using grep!${NC}"
+fi;
+
+if [ $st = 1 ]; then
+    echo
+    echo -e "${RED}Errors found, please fix them and try again.${NC}"
+fi;
+
 exit $st

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -51,6 +51,10 @@ if grep -i 'centcomm' _maps/**/*.dmm; then
     echo "ERROR: Misspelling(s) of CENTCOM detected in maps, please remove the extra M(s)."
     st=1
 fi;
+if grep 'set name\s*=\s*?"[\S\s]*![\S\s]*"' code/**/*.dm; then
+    echo "ERROR: Verb with name containing an exclamation point found. These verbs are not compatible with TGUI chat's statpanel or chat box."
+    st=1
+fi;
 if ls _maps/*.json | grep -P "[A-Z]"; then
     echo "ERROR: Uppercase in a map json detected, these must be all lowercase."
     st=1

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -65,6 +65,11 @@ if grep -i 'centcomm' code/**/*.dm; then
     echo -e "${RED}ERROR: Misspelling(s) of CentCom detected in code, please remove the extra M(s).${NC}"
     st=1
 fi;
+if grep -i 'centcomm' _maps/**/*.dm; then
+    echo
+    echo -e "${RED}ERROR: Misspelling(s) of CentCom detected in maps, please remove the extra M(s).${NC}"
+    st=1
+fi;
 if grep -P 'set name\s*=\s*"[\S\s]*![\S\s]*"' code/**/*.dm; then
     echo
     echo -e "${RED}ERROR: Verb with name containing an exclamation point found. These verbs are not compatible with TGUI chat's statpanel or chat box.${NC}"

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -51,7 +51,7 @@ if grep -i 'centcomm' _maps/**/*.dmm; then
     echo "ERROR: Misspelling(s) of CENTCOM detected in maps, please remove the extra M(s)."
     st=1
 fi;
-if grep 'set name\s*=\s*?"[\S\s]*![\S\s]*"' code/**/*.dm; then
+if grep 'set name\s*=\s*"[\S\s]*![\S\s]*"' code/**/*.dm; then
     echo "ERROR: Verb with name containing an exclamation point found. These verbs are not compatible with TGUI chat's statpanel or chat box."
     st=1
 fi;


### PR DESCRIPTION
## About The Pull Request

These verbs do technically work, on old chat, but due to the winset call TGUI uses to do verbs, it doesn't work well with formatting like that. I tried to escape it, etc, but it's far easier to just do this and add a lint check.

`set name\s*=\s*"[\S\s]*![\S\s]*`

Fixes #7518

Ports

- https://github.com/tgstation/tgstation/pull/68387

## Why It's Good For The Game

You can use Server Hop, Boo, and Possess properly. Plus it prevents future bug introduction with a test.

## Testing Photographs and Procedure

I can't show the Server Hop verb working because local config blah blah, the Boo and Possess verbs do work if you set the fun_verbs to TRUE, however.

Boo in action
![image](https://user-images.githubusercontent.com/10366817/188040436-c32aeab4-9c51-46ad-bb1f-58497f2fed13.png)

![image](https://user-images.githubusercontent.com/10366817/188208831-75946513-25ba-4595-b66f-c6d6b16e9c64.png)

## Changelog
:cl:
fix: Verbs with ! in the name have had it removed, and can now be run from TGUI chat (Server Hop)
code: Added a linter check for to prevent verbs with ! in the name
code: Improved clarity of check_grep
/:cl:
