### PR TITLE
Voice changer randomizes your name if emp'd

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -544,7 +544,7 @@
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 
 	var/vchange = TRUE
-	var/rname_cooldown = 0
+	COOLDOWN_DECLARE(rname_cooldown)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -561,7 +561,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	chameleon_action.emp_randomise()
-	rname_cooldown = world.time + 2 MINUTES
+	COOLDOWN_START(src, rname_cooldown, 2 MINUTES)
 
 /obj/item/clothing/mask/chameleon/broken/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -566,6 +566,7 @@
 /obj/item/clothing/mask/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+	rname_cooldown = INFINITY  // mulligan
 
 /obj/item/clothing/mask/chameleon/attack_self(mob/user)
 	vchange = !vchange

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -543,7 +543,8 @@
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 
-	var/vchange = 1
+	var/vchange = TRUE
+	var/rname_cooldown = 0
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -560,6 +561,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	chameleon_action.emp_randomise()
+	rname_cooldown = world.time + 2 MINUTES
 
 /obj/item/clothing/mask/chameleon/broken/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -560,6 +560,8 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
+	if(!COOLDOWN_FINISHED(src, rname_cooldown))
+		return
 	chameleon_action.emp_randomise()
 	COOLDOWN_START(src, rname_cooldown, 2 MINUTES)
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -13,7 +13,8 @@
 		if(V.vchange && wear_id)
 			var/obj/item/card/id/idcard = wear_id.GetID()
 			if(V.rname_cooldown > world.time)
-				return dna.species.random_name(rand(1, 2))
+				var/randomize = dna.species.random_name(rand(1, 2))
+				return randomize | "John Doe"  // fallback
 			if(istype(idcard))
 				return idcard.registered_name
 			else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -12,7 +12,7 @@
 		var/obj/item/clothing/mask/chameleon/V = wear_mask
 		if(V.vchange && wear_id)
 			var/obj/item/card/id/idcard = wear_id.GetID()
-			if(COOLDOWN_FINISHED(V, rname_cooldown))
+			if(!COOLDOWN_FINISHED(V, rname_cooldown))
 				var/randomize = dna.species.random_name(rand(1, 2))
 				return (randomize || "John Doe")  // fallback
 			if(istype(idcard))

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -12,9 +12,9 @@
 		var/obj/item/clothing/mask/chameleon/V = wear_mask
 		if(V.vchange && wear_id)
 			var/obj/item/card/id/idcard = wear_id.GetID()
-			if(V.rname_cooldown > world.time)
+			if(COOLDOWN_FINISHED(V, rname_cooldown))
 				var/randomize = dna.species.random_name(rand(1, 2))
-				return randomize ?? "John Doe"  // fallback
+				return (randomize || "John Doe")  // fallback
 			if(istype(idcard))
 				return idcard.registered_name
 			else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -14,7 +14,7 @@
 			var/obj/item/card/id/idcard = wear_id.GetID()
 			if(V.rname_cooldown > world.time)
 				var/randomize = dna.species.random_name(rand(1, 2))
-				return randomize | "John Doe"  // fallback
+				return randomize ?? "John Doe"  // fallback
 			if(istype(idcard))
 				return idcard.registered_name
 			else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -12,6 +12,8 @@
 		var/obj/item/clothing/mask/chameleon/V = wear_mask
 		if(V.vchange && wear_id)
 			var/obj/item/card/id/idcard = wear_id.GetID()
+			if(V.rname_cooldown > world.time)
+				return dna.species.random_name(rand(1, 2))
 			if(istype(idcard))
 				return idcard.registered_name
 			else

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -315,7 +315,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/index = rand(1, 20)
 	starting_crate_value = index * 5
 	if(index == 1)
-		to_chat(user, "<span class='warning'><b>Incomming transmission from the syndicate.</b></span>")
+		to_chat(user, "<span class='warning'><b>Incoming transmission from the syndicate.</b></span>")
 		to_chat(user, "<span class='warning'>You feel an overwhelming sense of pride and accomplishment.</span>")
 		var/obj/item/clothing/mask/joy/funny_mask = new(get_turf(user))
 		ADD_TRAIT(funny_mask, TRAIT_NODROP, CURSED_ITEM_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If your voice changer mask is emp'd, it generates a random name every message.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives a unique effect for the voice changer emp (it currently does nothing), can also be seen as a positive if you want to cause chaos over the radio
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/188226913-cf9b676b-bc52-49b8-91da-d833fd00ffd0.png)

</details>

## Changelog
:cl:
tweak: voice changer now randomizes your name when emp'd
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
