### PR TITLE
Fix spawning multiple pirate ships and refactor comms console answer keys

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -469,3 +469,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define ALIGNMENT_GOOD "good"
 #define ALIGNMENT_NEUT "neutral"
 #define ALIGNMENT_EVIL "evil"
+
+// Pirates threat
+#define PIRATE_RESPONSE_NO_PAY "pirate_answer_no_pay"
+#define PIRATE_RESPONSE_PAY "pirate_answer_pay"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -92,14 +92,14 @@
 		if ("answerMessage")
 			if (!authenticated(usr))
 				return
-			var/answer_index = text2num(params["answer"])
+			var/answer_key = params["answer"]
 			var/message_index = text2num(params["message"])
-			if (!answer_index || !message_index || answer_index < 1 || message_index < 1)
+			if (!answer_key || !message_index || message_index < 1)
 				return
 			var/datum/comm_message/message = messages[message_index]
-			if (message.answered)
+			if (!(answer_key in message.possible_answers) || message.answered)
 				return
-			message.answered = answer_index
+			message.answered = answer_key
 			message.answer_callback.InvokeAsync()
 			. = TRUE
 		if ("callShuttle")

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -30,7 +30,10 @@
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 	threat.title = "Business proposition"
 	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
-	threat.possible_answers = list("We'll pay.","No way.")
+	threat.possible_answers = list(
+		PIRATE_RESPONSE_PAY = "We'll pay.",
+		PIRATE_RESPONSE_NO_PAY = "No way.",
+	)
 	threat.answer_callback = CALLBACK(GLOBAL_PROC, .proc/pirates_answered, threat, payoff, ship_name, initial_send_time, response_max_time)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/spawn_pirates, threat, FALSE), response_max_time)
 	SScommunications.send_message(threat,unique = TRUE)
@@ -50,7 +53,7 @@
 				spawn_pirates(threat, TRUE)
 
 /proc/spawn_pirates(datum/comm_message/threat, skip_answer_check)
-	if(!skip_answer_check && threat?.answered)
+	if(!skip_answer_check && threat?.answered == PIRATE_RESPONSE_NO_PAY)
 		return
 
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -39,7 +39,7 @@
 	if(world.time > initial_send_time + response_max_time)
 		priority_announce("Too late to beg for mercy!",sender_override = ship_name)
 		return
-	if(threat && threat.answered == 1)
+	if(threat?.answered)
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			if(D.adjust_money(-payoff))
@@ -47,10 +47,10 @@
 				return
 			else
 				priority_announce("Trying to cheat us? You'll regret this!", sound = SSstation.announcer.get_rand_alert_sound(), sender_override = ship_name)
-	spawn_pirates(threat, TRUE)
+				spawn_pirates(threat, TRUE)
 
 /proc/spawn_pirates(datum/comm_message/threat, skip_answer_check)
-	if(!skip_answer_check && threat?.answered == TRUE)
+	if(!skip_answer_check && threat?.answered)
 		return
 
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -197,8 +197,8 @@ const PageBuyingShuttle = (props, context) => {
                           data.budget < shuttle.creditCost ? (`You need ${
                             shuttle.creditCost - data.budget
                           } more credits.`
-                          ) : (shuttle.illegal 
-                            ? ILLEGAL_SHUTTLE_NOTICE 
+                          ) : (shuttle.illegal
+                            ? ILLEGAL_SHUTTLE_NOTICE
                             : undefined)
                         }
                         tooltipPosition="left"
@@ -619,17 +619,17 @@ const PageMessages = (props, context) => {
         messages.map((message, messageIndex) => {
           let answers = null;
 
-          if (message.possibleAnswers.length > 0) {
+          if (Object.keys(message.possibleAnswers).length > 0) {
             answers = (
               <Box mt={1}>
-                {message.possibleAnswers.map((answer, answerIndex) => (
+                {Object.entries(message.possibleAnswers).map((answer) => (
                   <Button
-                    content={answer}
-                    color={message.answered === answerIndex + 1 ? "good" : undefined}
-                    key={answerIndex}
+                    content={answer[1]}
+                    color={message.answered === answer[0] ? "good" : undefined}
+                    key={answer[0]}
                     onClick={message.answered ? undefined : () => act("answerMessage", {
                       message: messageIndex + 1,
-                      answer: answerIndex + 1,
+                      answer: answer[0],
                     })}
                   />
                 ))}
@@ -678,7 +678,7 @@ const ConditionalTooltip = (props, context) => {
   {
     return children;
   }
-  
+
   return (
     <Tooltip {...rest}>
       {children}
@@ -748,7 +748,7 @@ export const CommunicationsConsole = (props, context) => {
                           <Tabs.Tab fluid
                             icon="shopping-cart"
                             selected={page===STATE_BUYING_SHUTTLE}
-                            onClick={() => act("setState", 
+                            onClick={() => act("setState",
                               { state: STATE_BUYING_SHUTTLE }
                             )}>
                             Purchase Shuttle


### PR DESCRIPTION
## About The Pull Request

Fixes #7607

Also refactors comms console messages to use string keys instead of numbers, that way you can use DEFINES. Changes the pirate responses to use DEFINES.

## Why It's Good For The Game

Having multiple pirate ships is bad

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/188283927-70c753f2-b4c6-495a-9ef3-00beb4cd22c1.png)

![image](https://user-images.githubusercontent.com/10366817/188284954-5f8e0bfc-21db-48a0-ad03-8a525a665516.png)

</details>

## Changelog
:cl:
fix: Pirates event no longer spawns two pirate ships.
refactor: Comms console message responses now use string keys so that DEFINES can be used.
/:cl:
