### PR TITLE
Solves the problem of Metastation being picked too often.

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -29,6 +29,7 @@ endmap
 map metastation
 	default
 	votable
+	voteweight 0.5
 endmap
 
 map pubbystation


### PR DESCRIPTION

## About The Pull Request

Votes towards Metastation in map votes now count as half vote.

## Why It's Good For The Game

People should ~~go outside and touch grass~~ play on other maps more often.

<details>

![image](https://user-images.githubusercontent.com/34888552/188333545-21699195-af57-473d-927d-a09465c4cfb2.png)


![image](https://user-images.githubusercontent.com/34888552/188333457-3781a28a-07c3-4823-aee0-7faf859f5501.png)
</details>

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I can't test it on my machine without having other people.
![image](https://user-images.githubusercontent.com/34888552/188333441-f9260bb4-cb06-43aa-bd76-1495ae6dc2ce.png)

</details>

## Changelog
:cl:
balance: Rigged the voting system to favor MetaStation half as much.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
