### PR TITLE
Cyborg Monitoring Improvements

### DIFF
--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -88,7 +88,9 @@
 
 ///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
 /datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)
-	if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
+	var/turf/computer_turf = get_turf(computer)
+	var/turf/robot_turf = get_turf(R)
+	if(computer_turf.get_virtual_z_level() != robot_turf.get_virtual_z_level())
 		return FALSE
 	if(R.scrambledcodes)
 		return FALSE

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -17,15 +17,12 @@
 /datum/computer_file/program/borg_monitor/ui_data(mob/user)
 	var/list/data = get_header_data()
 
-	data["card"] = FALSE
-	if(computer.GetID())
-		data["card"] = TRUE
+	// Syndicate version doesn't require an ID - so we use this proc instead of computer.GetID()
+	data["card"] = !!get_id_name()
 
 	data["cyborgs"] = list()
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
-		if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
-			continue
-		if(R.scrambledcodes)
+		if(!evaluate_borg(R))
 			continue
 
 		var/list/upgrade
@@ -58,17 +55,53 @@
 			var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 			if(!istype(R))
 				return
-			var/obj/item/card/id/ID = computer.GetID()
-			if(!ID)
+			var/sender_name = get_id_name()
+			if(!sender_name)
 				return
 			if(R.stat == DEAD) //Dead borgs will listen to you no longer
 				to_chat(usr, "<span class='warn'>Error -- Could not open a connection to unit:[R]</span>")
 			var/message = stripped_input(usr, message = "Enter message to be sent to remote cyborg.", title = "Send Message")
 			if(!message)
 				return
-			to_chat(R, "<br><br><span class='notice'>Message from [ID.registered_name] -- \"[message]\"</span><br>")
+			to_chat(R, "<br><br><span class='notice'>Message from [sender_name] -- \"[message]\"</span><br>")
 			SEND_SOUND(R, 'sound/machines/twobeep_high.ogg')
 			if(R.connected_ai)
-				to_chat(R.connected_ai, "<br><br><span class='notice'>Message from [ID.registered_name] to [R] -- \"[message]\"</span><br>")
+				to_chat(R.connected_ai, "<br><br><span class='notice'>Message from [sender_name] to [R] -- \"[message]\"</span><br>")
 				SEND_SOUND(R.connected_ai, 'sound/machines/twobeep_high.ogg')
-			R.logevent("Message from [ID] -- \"[message]\"")
+			R.logevent("Message from [sender_name] -- \"[message]\"")
+			usr.log_talk(message, LOG_PDA, tag="Cyborg Monitor Program: ID name \"[sender_name]\" to [R]")
+
+///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
+/datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)
+	if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
+		return FALSE
+	if(R.scrambledcodes)
+		return FALSE
+	return TRUE
+
+///Gets the ID's name, if one is inserted into the device. This is a seperate proc solely to be overridden by the syndicate version of the app.
+/datum/computer_file/program/borg_monitor/proc/get_id_name()
+	var/obj/item/card/id/ID = computer.GetID()
+	if(!istype(ID))
+		return FALSE
+	return ID.registered_name
+
+/datum/computer_file/program/borg_monitor/syndicate
+	filename = "scyborgmonitor"
+	filedesc = "Mission-Specific Cyborg Remote Monitoring"
+	extended_desc = "This program allows for remote monitoring of mission-assigned cyborgs."
+	requires_ntnet = FALSE
+	available_on_ntnet = FALSE
+	available_on_syndinet = TRUE
+	transfer_access = null
+	tgui_id = "NtosCyborgRemoteMonitorSyndicate"
+
+/datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)
+	if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())
+		return FALSE
+	if(!R.scrambledcodes)
+		return FALSE
+	return TRUE
+
+/datum/computer_file/program/borg_monitor/syndicate/get_id_name()
+	return "\[REDACTED\]" //no ID is needed for the syndicate version's message function, and the borg will see "[REDACTED]" as the message sender.

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -11,6 +11,13 @@
 	size = 5
 	tgui_id = "NtosCyborgRemoteMonitor"
 	program_icon = "project-diagram"
+	var/emagged = FALSE
+
+/datum/computer_file/program/borg_monitor/run_emag()
+	if(emagged)
+		return FALSE
+	emagged = TRUE
+	return TRUE
 
 
 
@@ -88,7 +95,7 @@
 /datum/computer_file/program/borg_monitor/proc/get_id_name()
 	var/obj/item/card/id/ID = computer.GetID()
 	if(!istype(ID))
-		return FALSE
+		return emagged ? "STDERR:UNDF" : FALSE
 	return ID.registered_name
 
 /datum/computer_file/program/borg_monitor/syndicate
@@ -100,6 +107,9 @@
 	available_on_syndinet = TRUE
 	transfer_access = null
 	tgui_id = "NtosCyborgRemoteMonitorSyndicate"
+
+/datum/computer_file/program/borg_monitor/syndicate/run_emag()
+	return FALSE
 
 /datum/computer_file/program/borg_monitor/syndicate/evaluate_borg(mob/living/silicon/robot/R)
 	if((get_turf(computer)).get_virtual_z_level() != (get_turf(R)).get_virtual_z_level())

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -73,6 +73,9 @@
 			var/message = stripped_input(usr, message = "Enter message to be sent to remote cyborg.", title = "Send Message")
 			if(!message)
 				return
+			if(CHAT_FILTER_CHECK(message))
+				to_chat(usr, "<span class='warning'>ERROR: Prohibited word(s) detected in message.</span>")
+				return
 			to_chat(usr, "<br><br><span class='notice'>Message to [R] (as [sender_name]) -- \"[message]\"</span><br>")
 			playsound(usr, 'sound/machines/terminal_success.ogg', 15, TRUE)
 			to_chat(R, "<br><br><span class='notice'>Message from [sender_name] -- \"[message]\"</span><br>")

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -57,12 +57,17 @@
 				return
 			var/sender_name = get_id_name()
 			if(!sender_name)
+				// This can only happen if the action somehow gets called as UI blocks this action with no ID
+				computer.visible_message("<span class='notice'>Insert an ID to send messages.</span>")
+				playsound(usr, 'sound/machines/terminal_error.ogg', 15, TRUE)
 				return
 			if(R.stat == DEAD) //Dead borgs will listen to you no longer
 				to_chat(usr, "<span class='warn'>Error -- Could not open a connection to unit:[R]</span>")
 			var/message = stripped_input(usr, message = "Enter message to be sent to remote cyborg.", title = "Send Message")
 			if(!message)
 				return
+			to_chat(usr, "<br><br><span class='notice'>Message to [R] (as [sender_name]) -- \"[message]\"</span><br>")
+			playsound(usr, 'sound/machines/terminal_success.ogg', 15, TRUE)
 			to_chat(R, "<br><br><span class='notice'>Message from [sender_name] -- \"[message]\"</span><br>")
 			SEND_SOUND(R, 'sound/machines/twobeep_high.ogg')
 			if(R.connected_ai)

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -183,6 +183,7 @@
 	store_file(new/datum/computer_file/program/ntnetdownload/syndicate(src)) // Syndicate version; automatic access to syndicate apps and no NT apps
 	store_file(new/datum/computer_file/program/filemanager(src))
 	store_file(new/datum/computer_file/program/radar/fission360(src)) //I am legitimately afraid if I don't do this, Ops players will think they just don't get a pinpointer anymore.
+	store_file(new/datum/computer_file/program/borg_monitor/syndicate(src))
 
 /obj/item/computer_hardware/hard_drive/micro
 	name = "micro solid state drive"

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
@@ -3,8 +3,13 @@ import { Box, Button, LabeledList, NoticeBox, Section } from '../components';
 import { NtosWindow } from '../layouts';
 
 export const NtosCyborgRemoteMonitor = (props, context) => {
+  const { data } = useBackend(context);
+  const {
+    theme,
+  } = data;
   return (
     <NtosWindow
+      theme={data.theme}
       width={600}
       height={800}>
       <NtosWindow.Content scrollable>

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitorSyndicate.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitorSyndicate.js
@@ -1,0 +1,12 @@
+import { NtosWindow } from '../layouts';
+import { NtosCyborgRemoteMonitorContent } from './NtosCyborgRemoteMonitor';
+
+export const NtosCyborgRemoteMonitorSyndicate = (props, context) => {
+  return (
+    <NtosWindow theme="syndicate">
+      <NtosWindow.Content scrollable>
+        <NtosCyborgRemoteMonitorContent />
+      </NtosWindow.Content>
+    </NtosWindow>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

Ports some improvements to Cyborg Monitoring app, and adds a syndicate version for nukies.

- https://github.com/tgstation/tgstation/pull/50691
- https://github.com/tgstation/tgstation/pull/55593

Also includes logging and an IC filter check for the app.

## Why It's Good For The Game

Nukies can track syndieborgs and message them, the monitor app is generally better, has more feedback, and more interactions with the game. Now with 100% gamer filter.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/188338522-027a1333-9f66-4e4b-8cb6-93fdca000910.png)

![image](https://user-images.githubusercontent.com/10366817/188338534-74b1d4e4-4126-4262-a21e-3df2536ce820.png)

![image](https://user-images.githubusercontent.com/10366817/188338543-e4a98dd8-9d6f-4322-959d-b1619a00bd54.png)

![image](https://user-images.githubusercontent.com/10366817/188338567-3ebd1db5-83d1-4878-b039-5ce56294d29e.png)

![image](https://user-images.githubusercontent.com/10366817/188338572-0768049d-8a52-4c42-af1c-b43579684f57.png)

![image](https://user-images.githubusercontent.com/10366817/188338601-6c45cdb9-f546-44f1-89a1-f45722c414f3.png)

![image](https://user-images.githubusercontent.com/10366817/188338710-792976f1-80c9-4570-9d8f-fd5e52e0f743.png)

</details>

## Changelog
:cl:
qol: The Cyborg Remote Monitoring app has auditory and text feedback when sending a message.
tweak: Emagged tablets can use Cyborg Monitoring's message feature without an ID inserted.
add: Added a syndicate version of Cyborg Monitoring for messaging/monitoring syndicate borgs.
admin: Added an IC filter check and logging to Cyborg Monitoring messages.
/:cl: