### PR TITLE
Adds station name to the announcements welcomer

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	circuit = /obj/item/circuitboard/machine/announcement_system
 
 	var/obj/item/radio/headset/radio
-	var/arrival = "%PERSON has signed up as %RANK."
+	var/arrival = "%PERSON has signed up as %RANK. Welcome to %STNAME."
 	var/arrivalToggle = 1
 	var/newhead = "%PERSON, %RANK, is the department head."
 	var/newheadToggle = 1
@@ -76,6 +76,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 /obj/machinery/announcement_system/proc/CompileText(str, user, rank) //replaces user-given variables with actual thingies.
 	str = replacetext(str, "%PERSON", "[user]")
 	str = replacetext(str, "%RANK", "[rank]")
+	str = replacetext(str, "%STNAME", "[GLOB.station_name]")  // retrieves the stations name
 	return str
 
 /obj/machinery/announcement_system/proc/announce(message_type, user, rank, list/channels)

--- a/tgui/packages/tgui/interfaces/AutomatedAnnouncement.js
+++ b/tgui/packages/tgui/interfaces/AutomatedAnnouncement.js
@@ -6,6 +6,7 @@ import { Window } from '../layouts';
 const TOOLTIP_TEXT = multiline`
   %PERSON will be replaced with their name.
   %RANK with their job.
+  %STNAME fills in the station name.
 `;
 
 export const AutomatedAnnouncement = (props, context) => {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds %STNAME, which gets filled out by the station's name
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brings a bit more attention to the 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/188339707-305e16a7-f7ef-40b0-b61f-7fb394c95f5d.png)
![image](https://user-images.githubusercontent.com/73374039/188339727-68a82983-3f1a-4d18-9784-4a41d9bfb0e3.png)
![image](https://user-images.githubusercontent.com/73374039/188339750-598cd198-8c6e-4935-9065-a155e8afb94d.png)
![image](https://user-images.githubusercontent.com/73374039/188339933-ccd9ad6d-a7ce-41b0-a664-9994a19eaf23.png)


</details>

## Changelog
:cl:
tweak: Automated welcomer announces station name now
tweak: %STNAME is filled out by station name in welcome message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
