### PR TITLE
Emagged and syndicate borg self-desctruct

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -130,14 +130,7 @@
 			if(allowed(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 				if(can_control(usr, R) && !..())
-					var/turf/T = get_turf(R)
-					message_admins("<span class='notice'>[ADMIN_LOOKUPFLW(usr)] detonated [key_name_admin(R, R.client)] at [ADMIN_VERBOSEJMP(T)]!</span>")
-					log_game("\<span class='notice'>[key_name(usr)] detonated [key_name(R)]!</span>")
-					log_combat(usr, R, "detonated cyborg")
-
-					if(R.connected_ai)
-						to_chat(R.connected_ai, "<br><br><span class='alert'>ALERT - Cyborg detonation detected: [R.name]</span><br>")
-					R.self_destruct()
+					R.self_destruct(usr)
 			else
 				to_chat(usr, "<span class='danger'>Access Denied.</span>")
 		if("stopbot")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -184,6 +184,30 @@
 	modularInterface.layer = ABOVE_HUD_PLANE
 	modularInterface.plane = ABOVE_HUD_PLANE
 
+/mob/living/silicon/robot/modules/syndicate/create_modularInterface()
+	if(!modularInterface)
+		modularInterface = new /obj/item/modular_computer/tablet/integrated/syndicate(src)
+	return ..()
+
+/**
+ * Sets the tablet theme and icon
+ *
+ * These variables are based on if the borg is a syndicate type or is emagged. This gets used in model change code
+ * and also borg emag code.
+ */
+/mob/living/silicon/robot/proc/set_modularInterface_theme()
+	if(istype(module, /obj/item/robot_module/syndicate) || emagged)
+		modularInterface.device_theme = "syndicate"
+		modularInterface.icon_state = "tablet-silicon-syndicate"
+		modularInterface.icon_state_powered = "tablet-silicon-syndicate"
+		modularInterface.icon_state_unpowered = "tablet-silicon-syndicate"
+	else
+		modularInterface.device_theme = "ntos"
+		modularInterface.icon_state = "tablet-silicon"
+		modularInterface.icon_state_powered = "tablet-silicon"
+		modularInterface.icon_state_unpowered = "tablet-silicon"
+	modularInterface.update_icon()
+
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
 	var/atom/T = drop_location()//To hopefully prevent run time errors.
@@ -682,7 +706,14 @@
 		add_overlay(head_overlay)
 	update_fire()
 
-/mob/living/silicon/robot/proc/self_destruct()
+/mob/living/silicon/robot/proc/self_destruct(mob/usr)
+	var/turf/groundzero = get_turf(src)
+	message_admins("<span class='notice'>[ADMIN_LOOKUPFLW(usr)] detonated [key_name_admin(src, client)] at [ADMIN_VERBOSEJMP(groundzero)]!</span>")
+	log_game("\<span class='notice'>[key_name(usr)] detonated [key_name(src)]!</span>")
+	log_combat(usr, src, "detonated cyborg")
+	if(connected_ai)
+		to_chat(connected_ai, "<br><br><span class='alert'>ALERT - Cyborg detonation detected: [name]</span><br>")
+
 	if(emagged)
 		if(mmi)
 			qdel(mmi)
@@ -740,6 +771,7 @@
 		throw_alert("hacked", /atom/movable/screen/alert/hacked)
 	else
 		clear_alert("hacked")
+	set_modularInterface_theme()
 
 /mob/living/silicon/robot/proc/SetRatvar(new_state, rebuild=TRUE)
 	ratvar = new_state

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -198,6 +198,7 @@
 	R.module = RM
 	R.update_module_innate()
 	RM.rebuild_modules()
+	R.set_modularInterface_theme()
 	INVOKE_ASYNC(RM, .proc/do_transform_animation)
 	qdel(src)
 	return RM

--- a/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
@@ -56,8 +56,9 @@
 	data["printerTonerMax"] = borgo.tonermax //It's a variable, might as well use it
 	data["thrustersInstalled"] = borgo.ionpulse //If we have a thruster uprade
 	data["thrustersStatus"] = "[borgo.ionpulse_on?"ACTIVE":"DISABLED"]" //Feedback for thruster status
+	data["selfDestructAble"] = (borgo.emagged || istype(borgo, /mob/living/silicon/robot/modules/syndicate))
 
-	//DEBUG -- Cover, TRUE for locked
+	//Cover, TRUE for locked
 	data["cover"] = "[borgo.locked? "LOCKED":"UNLOCKED"]"
 	//Ability to move. FAULT if lockdown wire is cut, DISABLED if borg locked, ENABLED otherwise
 	data["locomotion"] = "[borgo.wires.is_cut(WIRE_LOCKDOWN)?"FAULT":"[borgo.lockcharge?"DISABLED":"ENABLED"]"]"
@@ -132,6 +133,12 @@
 		if("lampIntensity")
 			borgo.lamp_intensity = CLAMP(text2num(params["ref"]), 1, 5)
 			borgo.toggle_headlamp(FALSE, TRUE)
+
+		if("selfDestruct")
+			if(borgo.stat || borgo.lockcharge) //No detonation while stunned or locked down
+				return
+			if(borgo.emagged || istype(borgo, /mob/living/silicon/robot/modules/syndicate)) //This option shouldn't even be showing otherwise
+				borgo.self_destruct(borgo)
 
 /**
   * Forces a full update of the UI, if currently open.

--- a/tgui/packages/tgui/interfaces/NtosCyborgSelfMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgSelfMonitor.js
@@ -46,6 +46,7 @@ export const NtosCyborgSelfMonitorContent = (props, context) => {
     printerTonerMax,
     thrustersInstalled,
     thrustersStatus,
+    selfDestructAble,
   } = data;
   const borgName = data.name || [];
   const borgType = data.designation || [];
@@ -197,6 +198,15 @@ export const NtosCyborgSelfMonitorContent = (props, context) => {
                           content={thrustersStatus}
                           onClick={() => act('toggleThrusters')}
                         />
+                      </LabeledList.Item>
+                    )}
+                    {!!selfDestructAble && (
+                      <LabeledList.Item
+                        label="Self Destruct">
+                        <Button.Confirm
+                          content="ACTIVATE"
+                          color="red"
+                          onClick={() => act('selfDestruct')} />
                       </LabeledList.Item>
                     )}
                   </LabeledList>


### PR DESCRIPTION
## About The Pull Request

Allows emagged/hacked and syndicate cyborgs to blow themselves up.

Emagged/hacked malf borgs get their MMI deleted (round removal)

Syndicate borgs get a weaker version, but their MMI stays.

## Why It's Good For The Game

A new last resort tactic for antagonist silicons. As an AI, blowing my shell up was actually a really effective strategy, and it has serious tradeoffs. Allowing borgs to self-destruct as well would be the ultimate tradeoff on their part. Law 2-ing a borg to blow itself up is not possible due to silicon policy (read it!).

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Normal borg

![image](https://user-images.githubusercontent.com/10366817/188339913-dada7e7d-ef78-4673-9dbe-72d210e68104.png)

Emagged (with confirmation)

![image](https://user-images.githubusercontent.com/10366817/188339945-53bc0caf-6c5a-4efe-965a-66723930f73e.png)

Aftermath (emagged)

![image](https://user-images.githubusercontent.com/10366817/188339960-783b5137-f393-4a08-bc86-449bdb1cf1ec.png)

Aftermath (syndicate)

![image](https://user-images.githubusercontent.com/10366817/188340010-6cd81ebd-5836-4e69-bf0a-c907725c4fe1.png)

</details>

## Changelog
:cl:
add: Emagged and syndicate borgs can now self destruct from their management app.
tweak: Syndicate and emagged borgs get their interface theme set to syndicate and properly recolored on the HUD.
/:cl:
