### PR TITLE
Inform dead AIs of their revival from modpc app

### DIFF
--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -44,6 +44,7 @@
 		if("PRG_beginReconstruction")
 			if(A && A.health < 100)
 				restoring = TRUE
+				A.notify_ghost_cloning("Your core files are being restored!", source = computer)
 			return TRUE
 		if("PRG_eject")
 			if(computer.all_components[MC_AI])


### PR DESCRIPTION
## About The Pull Request

It's in the AI restorer console, but not the app - this is bad.

Port of https://github.com/tgstation/tgstation/pull/44870

## Why It's Good For The Game

Fix missing thing

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/188340936-b8113bbe-d93c-44e4-b801-608d8a85edf5.png)

</details>

## Changelog
:cl:
fix: Restoring an AI through the modular computer app now properly informs their ghost.
/:cl:
