### PR TITLE
Shuttle engines and emitters apply wrenching from before the board is…

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -18,7 +18,7 @@
 	var/engine_power = 1
 	var/state = ENGINE_WELDED //welding shmelding
 
-/obj/structure/shuttle/Initialize(mapload)
+/obj/structure/shuttle/engine/Initialize(mapload)
 	. = ..()
 	if(anchored && state == ENGINE_UNWRENCHED)
 		state = ENGINE_WRENCHED

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -18,6 +18,11 @@
 	var/engine_power = 1
 	var/state = ENGINE_WELDED //welding shmelding
 
+/obj/structure/shuttle/Initialize(mapload)
+	. = ..()
+	if(anchored && state == ENGINE_UNWRENCHED)
+		state = ENGINE_WRENCHED
+
 //Ugh this is a lot of copypasta from emitters, welding need some boilerplate reduction
 /obj/structure/shuttle/engine/can_be_unfasten_wrench(mob/user, silent)
 	if(state == ENGINE_WELDED)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -88,6 +88,8 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		power_usage -= 50 * M.rating
 	active_power_usage = power_usage
+	if(anchored && state == EMITTER_UNWRENCHED)
+		state = EMITTER_WRENCHED
 
 /obj/machinery/power/emitter/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes #6306 

Before the state was not properly updated if it was wrench at init, now it is.

## Why It's Good For The Game

Fix bug

## Testing Photographs and Procedure

You can wrench it, I closed the game and forgot to screenshot, but it works. Before my changes, it did not work.

## Changelog
:cl:
fix: If you wrench an emitter or shuttle engine before adding the board to the machine frame, it now lets you weld the frame as expected.
/:cl: