### PR TITLE
Dynamic Incursion

### DIFF
--- a/code/game/gamemodes/incursion/incursion.dm
+++ b/code/game/gamemodes/incursion/incursion.dm
@@ -48,7 +48,7 @@
 		possible_traitors -= incursion
 		antag_candidates -= incursion
 		team.add_member(incursion)
-		incursion.special_role = "incursionist"
+		incursion.special_role = ROLE_INCURSION
 		incursion.restricted_roles = restricted_jobs
 		log_game("[key_name(incursion)] has been selected as a member of the incursion")
 	pre_incursionist_team = team
@@ -67,12 +67,12 @@
 	return "Intel suggests that the Syndicate have recently had high level meetings discussing your station, and are disgruntled due to recent classified events. A large terrorist force may wish to take the station by force."
 
 //===please merge heretics so these can be made not terrible===
-/datum/game_mode/proc/update_incursion_icons_added(datum/mind/incursion_mind)
+/proc/update_incursion_icons_added(datum/mind/incursion_mind)
 	var/datum/atom_hud/antag/incursionhud = GLOB.huds[ANTAG_HUD_INCURSION]
 	incursionhud.join_hud(incursion_mind.current)
 	set_antag_hud(incursion_mind.current, "incursion")
 
-/datum/game_mode/proc/update_incursion_icons_removed(datum/mind/incursion_mind)
+/proc/update_incursion_icons_removed(datum/mind/incursion_mind)
 	var/datum/atom_hud/antag/incursionhud = GLOB.huds[ANTAG_HUD_INCURSION]
 	incursionhud.leave_hud(incursion_mind.current)
 	set_antag_hud(incursion_mind.current, null)

--- a/code/game/gamemodes/incursion/incursion.dm
+++ b/code/game/gamemodes/incursion/incursion.dm
@@ -67,12 +67,12 @@
 	return "Intel suggests that the Syndicate have recently had high level meetings discussing your station, and are disgruntled due to recent classified events. A large terrorist force may wish to take the station by force."
 
 //===please merge heretics so these can be made not terrible===
-/proc/update_incursion_icons_added(datum/mind/incursion_mind)
+/datum/game_mode/proc/update_incursion_icons_added(datum/mind/incursion_mind)
 	var/datum/atom_hud/antag/incursionhud = GLOB.huds[ANTAG_HUD_INCURSION]
 	incursionhud.join_hud(incursion_mind.current)
 	set_antag_hud(incursion_mind.current, "incursion")
 
-/proc/update_incursion_icons_removed(datum/mind/incursion_mind)
+/datum/game_mode/proc/update_incursion_icons_removed(datum/mind/incursion_mind)
 	var/datum/atom_hud/antag/incursionhud = GLOB.huds[ANTAG_HUD_INCURSION]
 	incursionhud.leave_hud(incursion_mind.current)
 	set_antag_hud(incursion_mind.current, null)

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -60,12 +60,12 @@
 	if(issilicon(owner))
 		var/mob/living/silicon/S = owner
 		if(istype(S.laws, /datum/ai_laws/syndicate_override))
-			SSticker.mode.update_incursion_icons_added(owner)
+			update_incursion_icons_added(owner)
 	else
-		SSticker.mode.update_incursion_icons_added(owner)
+		update_incursion_icons_added(owner)
 
 /datum/antagonist/incursion/remove_innate_effects(mob/living/mob_override)
-	SSticker.mode.update_incursion_icons_removed(owner)
+	update_incursion_icons_removed(owner)
 
 /datum/antagonist/incursion/proc/finalize_incursion()
 	equip()
@@ -101,6 +101,12 @@
 
 /datum/team/incursion/is_solo()
 	return FALSE
+
+/datum/team/incursion/proc/check_incursion_victory()
+	for(var/datum/objective/objective in objectives)
+		if(!objective.check_completion())
+			return FALSE
+	return TRUE
 
 /datum/team/incursion/roundend_report()
 	var/list/parts = list()

--- a/code/modules/antagonists/incursion/incursion.dm
+++ b/code/modules/antagonists/incursion/incursion.dm
@@ -60,12 +60,12 @@
 	if(issilicon(owner))
 		var/mob/living/silicon/S = owner
 		if(istype(S.laws, /datum/ai_laws/syndicate_override))
-			update_incursion_icons_added(owner)
+			SSticker.mode.update_incursion_icons_added(owner)
 	else
-		update_incursion_icons_added(owner)
+		SSticker.mode.update_incursion_icons_added(owner)
 
 /datum/antagonist/incursion/remove_innate_effects(mob/living/mob_override)
-	update_incursion_icons_removed(owner)
+	SSticker.mode.update_incursion_icons_removed(owner)
 
 /datum/antagonist/incursion/proc/finalize_incursion()
 	equip()


### PR DESCRIPTION
## About The Pull Request

Adds the incursion gamemode as a dynamic roundstart ruleset with the same weight, cost, and requirement scaling as blood cult.

Instead of using the config for scaling, it uses the builtin antag-cap system that blood cult uses, tweaked be closer to the default config.

Here's a graph comparing y = team size, x = server population

The red line is the gamemode, the blue line is the dynamic ruleset. They're mostly the same, except now you get the chance for a sixth incursionist at near max pop. Also, everything below 15pop doesn't matter because you need a minimum of two incursionists. This graph is clamped from 2-6.

![image](https://user-images.githubusercontent.com/10366817/188354062-de719ed0-f02b-4993-a78b-4a8c62983faf.png)


## Why It's Good For The Game

Dynamic is good, and having all the possible gamemodes in it means we can make it the main gamemode... almost.

## Testing Photographs and Procedure

The main thing that needs testing is their objective generation and excomms. Considering it uses the same code as the original gamemode and just converts some people to excomms when the objectives are built, it should work fine.

I also tested, the Incursionist HUD icons work, but I forgot to get a screenshot.

<details>
<summary>Screenshots&Videos</summary>

It's super hard to test this locally, but I can get it to make two incursionists roundstart.

![image](https://user-images.githubusercontent.com/10366817/188354246-2b410a56-0e7d-4162-811f-2219f6e542d8.png)

Here's the roundend

![image](https://user-images.githubusercontent.com/10366817/188354271-717a7c9b-95ba-436e-a2f7-457f2bee1421.png)

</details>

## Changelog
:cl:
add: Added Incursion to dynamic.
/:cl:
