### PR TITLE
Refactors mood events (again) to generate spans from mood changes

### DIFF
--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -1,28 +1,28 @@
 /datum/mood_event/drunk
 	mood_change = 3
-	description = "<span class='nicegreen'>Everything just feels better after a drink or two.</span>\n"
+	description = "Everything just feels better after a drink or two.\n"
 
 /datum/mood_event/quality_bad
-	description = "<span class='warning'>That drink wasn't good at all.</span>\n"
+	description = "That drink wasn't good at all.\n"
 	mood_change = -2
 	timeout = 7 MINUTES
 
 /datum/mood_event/quality_nice
-	description = "<span class='nicegreen'>That drink wasn't bad at all.</span>\n"
+	description = "That drink wasn't bad at all.\n"
 	mood_change = 2
 	timeout = 7 MINUTES
 
 /datum/mood_event/quality_good
-	description = "<span class='nicegreen'>That drink was pretty good.</span>\n"
+	description = "That drink was pretty good.\n"
 	mood_change = 4
 	timeout = 7 MINUTES
 
 /datum/mood_event/quality_verygood
-	description = "<span class='nicegreen'>That drink was great!</span>\n"
+	description = "That drink was great!\n"
 	mood_change = 6
 	timeout = 7 MINUTES
 
 /datum/mood_event/quality_fantastic
-	description = "<span class='nicegreen'>That drink was amazing!</span>\n"
+	description = "That drink was amazing!\n"
 	mood_change = 8
 	timeout = 7 MINUTES

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -1,14 +1,14 @@
 /datum/mood_event/high
 	mood_change = 6
-	description = "<span class='nicegreen'>Woooow duudeeeeee...I'm tripping baaalls...</span>\n"
+	description = "Woooow duudeeeeee...I'm tripping baaalls...\n"
 
 /datum/mood_event/smoked
-	description = "<span class='nicegreen'>I have had a smoke recently.</span>\n"
+	description = "I have had a smoke recently.\n"
 	mood_change = 2
 	timeout = 6 MINUTES
 
 /datum/mood_event/wrong_brand
-	description = "<span class='warning'>I hate that brand of cigarettes.</span>\n"
+	description = "I hate that brand of cigarettes.\n"
 	mood_change = -2
 	timeout = 6 MINUTES
 
@@ -17,44 +17,44 @@
 	timeout = 5 MINUTES
 
 /datum/mood_event/overdose/add_effects(drug_name)
-	description = "<span class='warning'>I think I took a bit too much of that [drug_name]</span>\n"
+	description = "I think I took a bit too much of that [drug_name]\n"
 
 /datum/mood_event/withdrawal_light
 	mood_change = -2
 
 /datum/mood_event/withdrawal_light/add_effects(drug_name)
-	description = "<span class='warning'>I could use some [drug_name]</span>\n"
+	description = "I could use some [drug_name]\n"
 
 /datum/mood_event/withdrawal_medium
 	mood_change = -5
 
 /datum/mood_event/withdrawal_medium/add_effects(drug_name)
-	description = "<span class='warning'>I really need [drug_name]</span>\n"
+	description = "I really need [drug_name]\n"
 
 /datum/mood_event/withdrawal_severe
 	mood_change = -8
 
 /datum/mood_event/withdrawal_severe/add_effects(drug_name)
-	description = "<span class='boldwarning'>Oh god I need some [drug_name]</span>\n"
+	description = "Oh god I need some [drug_name]\n"
 
 /datum/mood_event/withdrawal_critical
 	mood_change = -10
 
 /datum/mood_event/withdrawal_critical/add_effects(drug_name)
-	description = "<span class='boldwarning'>[drug_name]! [drug_name]! [drug_name]!</span>\n"
+	description = "[drug_name]! [drug_name]! [drug_name]!\n"
 
 /datum/mood_event/happiness_drug
-	description = "<span class='nicegreen'>I can't feel anything and I never want this to end.</span>\n"
+	description = "I can't feel anything and I never want this to end.\n"
 	mood_change = 50
 
 /datum/mood_event/happiness_drug_good_od
-	description = "<span class='nicegreen'>YES! YES!! YES!!!</span>\n"
+	description = "YES! YES!! YES!!!\n"
 	mood_change = 100
 	timeout = 30 SECONDS
 	special_screen_obj = "mood_happiness_good"
 
 /datum/mood_event/happiness_drug_bad_od
-	description = "<span class='boldwarning'>NO! NO!! NO!!!</span>\n"
+	description = "NO! NO!! NO!!!\n"
 	mood_change = -100
 	timeout = 30 SECONDS
 	special_screen_obj = "mood_happiness_bad"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -1,93 +1,95 @@
 /datum/mood_event/handcuffed
-	description = "<span class='warning'>I guess my antics have finally caught up with me.</span>\n"
+	description = "I guess my antics have finally caught up with me.\n"
 	mood_change = -1
 
 /datum/mood_event/broken_vow //Used for when mimes break their vow of silence
-  description = "<span class='boldwarning'>I have brought shame upon my name, and betrayed my fellow mimes by breaking our sacred vow...</span>\n"
+  description = "I have brought shame upon my name, and betrayed my fellow mimes by breaking our sacred vow...\n"
   mood_change = -8
 
 /datum/mood_event/on_fire
-	description = "<span class='boldwarning'>I'M ON FIRE!!!</span>\n"
+	description = "I'M ON FIRE!!!\n"
 	mood_change = -12
 
 /datum/mood_event/suffocation
-	description = "<span class='boldwarning'>CAN'T... BREATHE...</span>\n"
+	description = "CAN'T... BREATHE...\n"
 	mood_change = -12
 
 /datum/mood_event/burnt_thumb
-	description = "<span class='warning'>I shouldn't play with lighters...</span>\n"
+	description = "I shouldn't play with lighters...\n"
 	mood_change = -1
 	timeout = 2 MINUTES
 
 /datum/mood_event/cold
-	description = "<span class='warning'>It's way too cold in here.</span>\n"
+	description = "It's way too cold in here.\n"
 	mood_change = -5
 
 /datum/mood_event/hot
-	description = "<span class='warning'>It's getting hot in here.</span>\n"
+	description = "It's getting hot in here.\n"
 	mood_change = -5
 
 /datum/mood_event/creampie
-	description = "<span class='warning'>I've been creamed. Tastes like pie flavor.</span>\n"
+	description = "I've been creamed. Tastes like pie flavor.\n"
 	mood_change = -2
 	timeout = 3 MINUTES
 
 /datum/mood_event/slipped
-	description = "<span class='warning'>I slipped. I should be more careful next time...</span>\n"
+	description = "I slipped. I should be more careful next time...\n"
 	mood_change = -2
 	timeout = 3 MINUTES
 
 /datum/mood_event/eye_stab
-	description = "<span class='boldwarning'>I used to be an adventurer like you, until I took a screwdriver to the eye.</span>\n"
+	description = "I used to be an adventurer like you, until I took a screwdriver to the eye.\n"
 	mood_change = -4
+	span = "boldwarning"
 	timeout = 3 MINUTES
 
 /datum/mood_event/delam //SM delamination
-	description = "<span class='boldwarning'>Those God damn engineers can't do anything right...</span>\n"
+	description = "Those God damn engineers can't do anything right...\n"
 	mood_change = -2
+	span = "boldwarning"
 	timeout = 4 MINUTES
 
 /datum/mood_event/depression
-	description = "<span class='warning'>I feel sad for no particular reason.</span>\n"
+	description = "I feel sad for no particular reason.\n"
 	mood_change = -12
 	timeout = 2 MINUTES
 
 /datum/mood_event/anxiety
-	description = "<span class='warning'>I feel scared around all these people..</span>\n"
+	description = "I feel scared around all these people..\n"
 	mood_change = -2
 	timeout = 60 SECONDS
 
 /datum/mood_event/anxiety_mute
-	description = "<span class='boldwarning'>I can't speak up, not with everyone here!</span>\n"
-	mood_change = -4
+	description = "I can't speak up, not with everyone here!\n"
+	mood_change = -5
 	timeout = 2 MINUTES
 
 /datum/mood_event/anxiety_dumb
-	description = "<span class='boldwarning'>Oh god, I made a fool of myself.</span>\n"
+	description = "Oh god, I made a fool of myself.\n"
 	mood_change = -10
 	timeout = 2 MINUTES
 
 /datum/mood_event/shameful_suicide //suicide_acts that return SHAME, like sord
-  description = "<span class='boldwarning'>I can't even end it all!</span>\n"
+  description = "I can't even end it all!\n"
   mood_change = -15
   timeout = 60 SECONDS
 
 /datum/mood_event/dismembered
-  description = "<span class='boldwarning'>AHH! I WAS USING THAT LIMB!</span>\n"
+  description = "AHH! I WAS USING THAT LIMB!\n"
   mood_change = -10
   timeout = 8 MINUTES
 
 /datum/mood_event/tased
-	description = "<span class='warning'>There's no \"z\" in \"taser\". It's in the zap.</span>\n"
+	description = "There's no \"z\" in \"taser\". It's in the zap.\n"
 	mood_change = -3
 	timeout = 2 MINUTES
 
 /datum/mood_event/embedded
-	description = "<span class='boldwarning'>Pull it out!</span>\n"
+	description = "Pull it out!\n"
 	mood_change = -7
 
 /datum/mood_event/table
-	description = "<span class='warning'>Someone threw me on a table!</span>\n"
+	description = "Someone threw me on a table!\n"
 	mood_change = -2
 	timeout = 2 MINUTES
 
@@ -105,7 +107,7 @@
 
 
 /datum/mood_event/table_headsmash
-	description = "<span class='warning'>My fucking head, that hurt...</span>"
+	description = "My fucking head, that hurt..."
 	mood_change = -3
 	timeout = 3 MINUTES
 
@@ -114,67 +116,67 @@
 
 /datum/mood_event/brain_damage/add_effects()
   var/damage_message = pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage")
-  description = "<span class='warning'>Hurr durr... [damage_message]</span>\n"
+  description = "Hurr durr... [damage_message]\n"
 
 /datum/mood_event/hulk //Entire duration of having the hulk mutation
-  description = "<span class='warning'>HULK SMASH!</span>\n"
+  description = "HULK SMASH!\n"
   mood_change = -4
 
 /datum/mood_event/epilepsy //Only when the mutation causes a seizure
-  description = "<span class='warning'>I should have paid attention to the epilepsy warning.</span>\n"
+  description = "I should have paid attention to the epilepsy warning.\n"
   mood_change = -3
   timeout = 5 MINUTES
 
 /datum/mood_event/nyctophobia
-	description = "<span class='warning'>It sure is dark around here...</span>\n"
+	description = "It sure is dark around here...\n"
 	mood_change = -3
 
 /datum/mood_event/family_heirloom_missing
-	description = "<span class='warning'>I'm missing my family heirloom...</span>\n"
+	description = "I'm missing my family heirloom...\n"
 	mood_change = -4
 
 /datum/mood_event/healsbadman
-	description = "<span class='warning'>I feel a lot better, but wow that was disgusting.</span>\n" //when you read the latest felinid removal PR and realize you're really not that much of a degenerate
+	description = "I feel a lot better, but wow that was disgusting.\n" //when you read the latest felinid removal PR and realize you're really not that much of a degenerate
 	mood_change = -4
 	timeout = 2 MINUTES
 
 /datum/mood_event/jittery
-	description = "<span class='warning'>I'm nervous and on edge and I can't stand still!!</span>\n"
+	description = "I'm nervous and on edge and I can't stand still!!\n"
 	mood_change = -2
 
 /datum/mood_event/vomit
-	description = "<span class='warning'>I just threw up. Gross.</span>\n"
+	description = "I just threw up. Gross.\n"
 	mood_change = -2
 	timeout = 2 MINUTES
 
 /datum/mood_event/vomitself
-	description = "<span class='warning'>I just threw up all over myself. This is disgusting.</span>\n"
+	description = "I just threw up all over myself. This is disgusting.\n"
 	mood_change = -4
 	timeout = 3 MINUTES
 
 /datum/mood_event/painful_medicine
-	description = "<span class='warning'>Medicine may be good for me but right now it stings like hell.</span>\n"
+	description = "Medicine may be good for me but right now it stings like hell.\n"
 	mood_change = -5
 	timeout = 60 SECONDS
 
 /datum/mood_event/spooked
-	description = "<span class='warning'>The rattling of those bones...It still haunts me.</span>\n"
+	description = "The rattling of those bones...It still haunts me.\n"
 	mood_change = -4
 	timeout = 4 MINUTES
 
 /datum/mood_event/loud_gong
-	description = "<span class='warning'>That loud gong noise really hurt my ears!</span>\n"
+	description = "That loud gong noise really hurt my ears!\n"
 	mood_change = -3
 	timeout = 2 MINUTES
 
 /datum/mood_event/notcreeping
-	description = "<span class='warning'>The voices are not happy, and they painfully contort my thoughts into getting back on task.</span>\n"
+	description = "The voices are not happy, and they painfully contort my thoughts into getting back on task.\n"
 	mood_change = -6
 	timeout = 30
 	hidden = TRUE
 
 /datum/mood_event/notcreepingsevere//not hidden since it's so severe
-	description = "<span class='boldwarning'>THEY NEEEEEEED OBSESSIONNNN!!</span>\n"
+	description = "THEY NEEEEEEED OBSESSIONNNN!!\n"
 	mood_change = -30
 	timeout = 30
 
@@ -183,80 +185,82 @@
 	for(var/i in 1 to rand(3,5))
 		unstable += copytext_char(name, -1)
 	var/unhinged = uppertext(unstable.Join(""))//example Tinea Luxor > TINEA LUXORRRR (with randomness in how long that slur is)
-	description = "<span class='boldwarning'>THEY NEEEEEEED [unhinged]!!</span>\n"
+	description = "THEY NEEEEEEED [unhinged]!!\n"
 
 /datum/mood_event/sapped
-	description = "<span class='boldwarning'>Some unexplainable sadness is consuming me...</span>\n"
+	description = "Some unexplainable sadness is consuming me...\n"
 	mood_change = -15
 	timeout = 90 SECONDS
 
 /datum/mood_event/back_pain
-	description = "<span class='boldwarning'>Bags never sit right on my back, this hurts like hell!</span>\n"
+	description = "Bags never sit right on my back, this hurts like hell!\n"
 	mood_change = -15
 
 /datum/mood_event/sad_empath
-	description = "<span class='warning'>Someone seems upset...</span>\n"
+	description = "Someone seems upset...\n"
 	mood_change = -2
 	timeout = 60 SECONDS
 
 /datum/mood_event/sad_empath/add_effects(mob/sadtarget)
-	description = "<span class='warning'>[sadtarget.name] seems upset...</span>\n"
+	description = "[sadtarget.name] seems upset...\n"
 
 /datum/mood_event/sacrifice_bad
-	description ="<span class='warning'>Those darn savages!</span>\n"
+	description ="Those darn savages!\n"
 	mood_change = -5
 	timeout = 2 MINUTES
 
 /datum/mood_event/artbad
-	description = "<span class='warning'>I've produced better art than that from my ass.</span>\n"
+	description = "I've produced better art than that from my ass.\n"
 	mood_change = -2
 	timeout = 1200
 
 /datum/mood_event/gates_of_mansus
-	description = "<span class='boldwarning'>LIVING IN A PERFORMANCE IS WORSE THAN DEATH</span>\n"
+	description = "LIVING IN A PERFORMANCE IS WORSE THAN DEATH\n"
 	mood_change = -25
 	timeout = 4 MINUTES
 
 //These are unused so far but I want to remember them to use them later
 /datum/mood_event/cloned_corpse
-	description = "<span class='boldwarning'>I recently saw my own corpse...</span>\n"
+	description = "I recently saw my own corpse...\n"
 	mood_change = -6
 
 /datum/mood_event/surgery
-	description = "<span class='boldwarning'>HE'S CUTTING ME OPEN!!</span>\n"
+	description = "HE'S CUTTING ME OPEN!!\n"
 	mood_change = -8
 
 /datum/mood_event/nanite_sadness
-	description = "<span class='warning robot'>+++++++HAPPINESS SUPPRESSION+++++++</span>\n"
+	description = "+++++++HAPPINESS SUPPRESSION+++++++\n"
+	span = "warning robot"
 	mood_change = -7
 
 /datum/mood_event/nanite_sadness/add_effects(message)
-	description = "<span class='warning robot'>+++++++[message]+++++++</span>\n"
+	description = "+++++++[message]+++++++\n"
+	span = "warning robot"
 
 /datum/mood_event/sec_insulated_gloves
-	description = "<span class='warning'>I look like an Assistant...</span>\n"
+	description = "I look like an Assistant...\n"
 	mood_change = -1
 
 /datum/mood_event/burnt_wings
-	description = "<span class='boldwarning'>MY PRECIOUS WINGS!!</span>\n"
+	description = "MY PRECIOUS WINGS!!\n"
 	mood_change = -10
 	timeout = 10 MINUTES
 
 /datum/mood_event/aquarium_negative
-	description = "<span class='warning'>All the fish are dead...</span>\n"
+	description = "All the fish are dead...\n"
 	mood_change = -3
 	timeout = 1.5 MINUTES
 
 /datum/mood_event/feline_dysmorphia
-	description = "<span class='boldwarning'>I'm so ugly. I wish I was cuter!</span>\n"
+	description = "I'm so ugly. I wish I was cuter!\n"
 	mood_change = -10
 
 /datum/mood_event/nervous
-	description = "<span class='warning'>I feel on edge... Gotta get a grip.</span>\n"
+	description = "I feel on edge... Gotta get a grip.\n"
 	mood_change = -3
 	timeout = 30 SECONDS
 
 /datum/mood_event/paranoid
-	description = "<span class='boldwarning'>I'm not safe! I can't trust anybody!</span>\n"
+	description = "I'm not safe! I can't trust anybody!\n"
 	mood_change = -6
 	timeout = 30 SECONDS

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -1,86 +1,86 @@
 /datum/mood_event/hug
-	description = "<span class='nicegreen'>Hugs are nice.</span>\n"
+	description = "Hugs are nice.\n"
 	mood_change = 1
 	timeout = 2 MINUTES
 
 /datum/mood_event/betterhug
-	description = "<span class='nicegreen'>Someone was very nice to me.</span>\n"
+	description = "Someone was very nice to me.\n"
 	mood_change = 3
 	timeout = 4 MINUTES
 
 /datum/mood_event/betterhug/add_effects(mob/friend)
-	description = "<span class='nicegreen'>[friend.name] was very nice to me.</span>\n"
+	description = "[friend.name] was very nice to me.\n"
 
 /datum/mood_event/besthug
-	description = "<span class='nicegreen'>Someone is great to be around, they make me feel so happy!</span>\n"
+	description = "Someone is great to be around, they make me feel so happy!\n"
 	mood_change = 5
 	timeout = 4 MINUTES
 
 /datum/mood_event/besthug/add_effects(mob/friend)
-	description = "<span class='nicegreen'>[friend.name] is great to be around, [friend.p_they()] makes me feel so happy!</span>\n"
+	description = "[friend.name] is great to be around, [friend.p_they()] makes me feel so happy!\n"
 
 /datum/mood_event/headpat
-	description = "<span class='nicegreen'>Headpats are lovely!</span>\n"
+	description = "Headpats are lovely!\n"
 	mood_change = 1
 	timeout = 2 MINUTES
 
 /datum/mood_event/arcade
-	description = "<span class='nicegreen'>I beat the arcade game!</span>\n"
+	description = "I beat the arcade game!\n"
 	mood_change = 3
 	timeout = 8 MINUTES
 
 /datum/mood_event/blessing
-	description = "<span class='nicegreen'>I've been blessed.</span>\n"
+	description = "I've been blessed.\n"
 	mood_change = 3
 	timeout = 8 MINUTES
 
 /datum/mood_event/book_nerd
-	description = "<span class='nicegreen'>I have recently read a book.</span>\n"
+	description = "I have recently read a book.\n"
 	mood_change = 1
 	timeout = 5 MINUTES
 
 /datum/mood_event/exercise
-	description = "<span class='nicegreen'>Working out releases those endorphins!</span>\n"
+	description = "Working out releases those endorphins!\n"
 	mood_change = 2
 	timeout = 5 MINUTES
 
 /datum/mood_event/pet_animal
-	description = "<span class='nicegreen'>Animals are adorable! I can't stop petting them!</span>\n"
+	description = "Animals are adorable! I can't stop petting them!\n"
 	mood_change = 2
 	timeout = 5 MINUTES
 
 /datum/mood_event/pet_animal/add_effects(mob/animal)
-	description = "<span class='nicegreen'>\The [animal.name] is adorable! I can't stop petting [animal.p_them()]!</span>\n"
+	description = "\The [animal.name] is adorable! I can't stop petting [animal.p_them()]!\n"
 
 /datum/mood_event/animal_play
-	description = "<span class='nicegreen'>Aww, it's having fun!</span>\n"
+	description = "Aww, it's having fun!\n"
 	mood_change = 2
 	timeout = 3 MINUTES
 
 /datum/mood_event/animal_play/add_effects(mob/animal)
-	description = "<span class='nicegreen'>Aww, [animal.name]'s having fun!</span>\n"
+	description = "Aww, [animal.name]'s having fun!\n"
 
 /datum/mood_event/honk
-	description = "<span class='nicegreen'>Maybe clowns aren't so bad after all. Honk!</span>\n"
+	description = "Maybe clowns aren't so bad after all. Honk!\n"
 	mood_change = 2
 	timeout = 4 MINUTES
 
 /datum/mood_event/perform_cpr
-	description = "<span class='nicegreen'>It feels good to save a life.</span>\n"
+	description = "It feels good to save a life.\n"
 	mood_change = 6
 	timeout = 8 MINUTES
 
 /datum/mood_event/oblivious
-	description = "<span class='nicegreen'>What a lovely day.</span>\n"
+	description = "What a lovely day.\n"
 	mood_change = 3
 
 /datum/mood_event/jolly
-	description = "<span class='nicegreen'>I feel happy for no particular reason.</span>\n"
+	description = "I feel happy for no particular reason.\n"
 	mood_change = 6
 	timeout = 2 MINUTES
 
 /datum/mood_event/focused
-	description = "<span class='nicegreen'>I have a goal, and I will reach it, whatever it takes!</span>\n" //Used for syndies, nukeops etc so they can focus on their goals
+	description = "I have a goal, and I will reach it, whatever it takes!\n" //Used for syndies, nukeops etc so they can focus on their goals
 	mood_change = 4
 	hidden = TRUE
 
@@ -92,104 +92,107 @@
 	special_screen_replace = FALSE
 
 /datum/mood_event/creeping
-	description = "<span class='greentext'>The voices have released their hooks on my mind! I feel free again!</span>\n" //creeps get it when they are around their obsession
+	description = "The voices have released their hooks on my mind! I feel free again!\n" //creeps get it when they are around their obsession
+	span = "greentext"
 	mood_change = 18
 	timeout = 3 SECONDS
 	hidden = TRUE
 
 /datum/mood_event/revolution
-	description = "<span class='nicegreen'>VIVA LA REVOLUTION!</span>\n"
+	description = "VIVA LA REVOLUTION!\n"
 	mood_change = 3
 	hidden = TRUE
 
 /datum/mood_event/cult
-	description = "<span class='nicegreen'>I have seen the truth, praise the almighty one!</span>\n"
+	description = "I have seen the truth, praise the almighty one!\n"
 	mood_change = 10 //maybe being a cultist isn't that bad after all
 	hidden = TRUE
 
 /datum/mood_event/determined
-	description = "<span class='nicegreen'>I am determined to keep my friends safe.</span>\n"
+	description = "I am determined to keep my friends safe.\n"
 	mood_change = 2
 	hidden = TRUE
 
 /datum/mood_event/heretics
-	description = "<span class='nicegreen'>THE HIGHER I RISE , THE MORE I SEE.</span>\n"
+	description = "THE HIGHER I RISE , THE MORE I SEE.\n"
 	mood_change = 10 //maybe being a cultist isn't that bad after all
 	hidden = TRUE
 
 /datum/mood_event/family_heirloom
-	description = "<span class='nicegreen'>My family heirloom is safe with me.</span>\n"
+	description = "My family heirloom is safe with me.\n"
 	mood_change = 1
 
 /datum/mood_event/goodmusic
-	description = "<span class='nicegreen'>There is something soothing about this music.</span>\n"
+	description = "There is something soothing about this music.\n"
 	mood_change = 3
 	timeout = 60 SECONDS
 
 /datum/mood_event/chemical_euphoria
-	description = "<span class='nicegreen'>Heh...hehehe...hehe...</span>\n"
+	description = "Heh...hehehe...hehe...\n"
 	mood_change = 4
 
 /datum/mood_event/chemical_laughter
-	description = "<span class='nicegreen'>Laughter really is the best medicine! Or is it?</span>\n"
+	description = "Laughter really is the best medicine! Or is it?\n"
 	mood_change = 4
 	timeout = 3 MINUTES
 
 /datum/mood_event/chemical_superlaughter
-	description = "<span class='nicegreen'>*WHEEZE*</span>\n"
+	description = "*WHEEZE*\n"
 	mood_change = 12
 	timeout = 3 MINUTES
 
 /datum/mood_event/religiously_comforted
-	description = "<span class='nicegreen'>I feel comforted by the presence of a holy person.</span>\n"
+	description = "I feel comforted by the presence of a holy person.\n"
 	mood_change = 3
 
 /datum/mood_event/clownshoes
-	description = "<span class='nicegreen'>The shoes are a clown's legacy, I never want to take them off!</span>\n"
+	description = "The shoes are a clown's legacy, I never want to take them off!\n"
 	mood_change = 5
 
 /datum/mood_event/sacrifice_good
-	description ="<span class='nicegreen'>The gods are pleased with this offering!</span>\n"
+	description ="The gods are pleased with this offering!\n"
 	mood_change = 5
 	timeout = 3 MINUTES
 
 /datum/mood_event/artok
-	description = "<span class='nicegreen'>It's nice to see people are making art around here.</span>\n"
+	description = "It's nice to see people are making art around here.\n"
 	mood_change = 2
 	timeout = 5 MINUTES
 
 /datum/mood_event/artgood
-	description = "<span class='nicegreen'>What a thought-provoking piece of art. I'll remember that for a while.</span>\n"
+	description = "What a thought-provoking piece of art. I'll remember that for a while.\n"
 	mood_change = 4
 	timeout = 5 MINUTES
 
 /datum/mood_event/artgreat
-	description = "<span class='nicegreen'>That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this.</span>\n"
+	description = "That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this.\n"
 	mood_change = 6
 	timeout = 5 MINUTES
 
 /datum/mood_event/bottle_flip
-	description = "<span class='nicegreen'>The bottle landing like that was satisfying.</span>\n"
+	description = "The bottle landing like that was satisfying.\n"
 	mood_change = 2
 	timeout = 3 MINUTES
 
 /datum/mood_event/hope_lavaland
-	description = "<span class='nicegreen'>What a peculiar emblem.  It makes me feel hopeful for my future.</span>\n"
+	description = "What a peculiar emblem.  It makes me feel hopeful for my future.\n"
 	mood_change = 5
 
 /datum/mood_event/nanite_happiness
-	description = "<span class='nicegreen robot'>+++++++HAPPINESS ENHANCEMENT+++++++</span>\n"
+	description = "+++++++HAPPINESS ENHANCEMENT+++++++\n"
+	span = "nicegreen robot"
 	mood_change = 7
 
 /datum/mood_event/nanite_happiness/add_effects(message)
-	description = "<span class='nicegreen robot'>+++++++[message]+++++++</span>\n"
+	description = "+++++++[message]+++++++\n"
+	span = "nicegreen robot"
 
 /datum/mood_event/poppy_pin
-	description = "<span class='nicegreen'>I feel proud to show my remembrance of the many who have died to ensure that I have freedom.</span>\n"
+	description = "I feel proud to show my remembrance of the many who have died to ensure that I have freedom.\n"
 	mood_change = 1
 
 /datum/mood_event/funny_prank
-	description = "<span class='nicegreen'>That was a funny prank, clown!</span>\n"
+	description = "That was a funny prank, clown!\n"
 	mood_change = 2
 	timeout = 2 MINUTES
 
@@ -202,29 +205,29 @@
 	description = param[2]
 
 /datum/mood_event/sec_black_gloves
-	description = "<span class='nicegreen'>Black gloves look good on me.</span>\n"
+	description = "Black gloves look good on me.\n"
 	mood_change = 1
 
 /datum/mood_event/assistant_insulated_gloves
-	description = "<span class='nicegreen'>Finally got my hands on a good pair of gloves!</span>\n"
+	description = "Finally got my hands on a good pair of gloves!\n"
 	mood_change = 1
 
 /datum/mood_event/aquarium_positive
-	description = "<span class='nicegreen'>Watching fish in aquarium is calming.</span>\n"
+	description = "Watching fish in aquarium is calming.\n"
 	mood_change = 3
 	timeout = 1.5 MINUTES
 
 /datum/mood_event/toxoplasmosis
-	description = "<span class='nicegreen'>I really like being around cats!</span>\n"
+	description = "I really like being around cats!\n"
 	mood_change = 2
 	timeout = 30 SECONDS
 
 /datum/mood_event/feline_mania
-	description = "<span class='nicegreen'>I'M SO HECKIN CUTE OMIGOSH!</span>\n"
+	description = "I'M SO HECKIN CUTE OMIGOSH!\n"
 	mood_change = 5
 
 /datum/mood_event/brain_tumor_mannitol
-	description = "<span class='nicegreen'>Mannitol makes my brain calm down.</span>\n"
+	description = "Mannitol makes my brain calm down.\n"
 	mood_change = 0
 	timeout = 30 SECONDS
 

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -22,17 +22,17 @@
 	description = "<span class='[span]'>[description]</span>"
 
 /proc/generate_mood_span(adjust)
-    switch(mood_change)
+    switch(adjust)
         if(-BOLD_LIMIT to -1)
-            span = "warning"
+            return "warning"
         if(-INFINITY to -BOLD_LIMIT)
-            span = "boldwarning"
+            return "boldwarning"
         if(0)
-            span = "emote"  // nice grey color
+            return "emote"  // nice grey color
         if(1 to BOLD_LIMIT)
-            span = "nicegreen"
+            return "nicegreen"
         if(BOLD_LIMIT to INFINITY)
-            span = "greenannounce"
+            return "greenannounce"
 
 /datum/mood_event/Destroy()
 	remove_effects()

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -1,3 +1,5 @@
+#define BOLD_LIMIT 5  // used for both positive and negative bolds for symmetry
+
 /datum/mood_event
 	var/description ///For descriptions, use the span classes bold nicegreen, nicegreen, none, warning and boldwarning in order from great to horrible.
 	var/mood_change = 0
@@ -8,10 +10,29 @@
 	var/special_screen_obj //if it isn't null, it will replace or add onto the mood icon with this (same file). see happiness drug for example
 	var/special_screen_replace = TRUE //if false, it will be an overlay instead
 	var/mob/owner
+	var/span // if null, will be generated from mood change
 
 /datum/mood_event/New(mob/M, param)
 	owner = M
 	add_effects(param)
+
+	if(!span)
+		span = generate_mood_span(mood_change)
+
+	description = "<span class='[span]'>[description]</span>"
+
+/proc/generate_mood_span(adjust)
+    switch(mood_change)
+        if(-INFINITY to -BOLD_LIMIT)
+            span = "boldwarning"
+        if(-BOLD_LIMIT to -1)
+            span = "warning"
+        if(0)
+            span = "emote"  // nice grey color
+        if(BOLD_LIMIT to INFINITY)  // need to catch the upper bolding first
+            span = "greenannounce"
+        if(1 to BOLD_LIMIT)
+            span = "nicegreen"
 
 /datum/mood_event/Destroy()
 	remove_effects()
@@ -25,3 +46,5 @@
 
 /datum/mood_event/proc/remove_effects()
 	return
+
+#undef BOLD_LIMIT

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -22,17 +22,17 @@
 	description = "<span class='[span]'>[description]</span>"
 
 /proc/generate_mood_span(adjust)
-    switch(mood_change)
+    switch(adjust)
         if(-INFINITY to -BOLD_LIMIT)
-            span = "boldwarning"
+            return "boldwarning"
         if(-BOLD_LIMIT to -1)
-            span = "warning"
+            return "warning"
         if(0)
-            span = "emote"  // nice grey color
+            return "emote"  // nice grey color
         if(BOLD_LIMIT to INFINITY)  // need to catch the upper bolding first
-            span = "greenannounce"
+            return "greenannounce"
         if(1 to BOLD_LIMIT)
-            span = "nicegreen"
+            return "nicegreen"
 
 /datum/mood_event/Destroy()
 	remove_effects()

--- a/code/datums/mood_events/mood_event.dm
+++ b/code/datums/mood_events/mood_event.dm
@@ -22,17 +22,17 @@
 	description = "<span class='[span]'>[description]</span>"
 
 /proc/generate_mood_span(adjust)
-    switch(adjust)
-        if(-INFINITY to -BOLD_LIMIT)
-            return "boldwarning"
+    switch(mood_change)
         if(-BOLD_LIMIT to -1)
-            return "warning"
+            span = "warning"
+        if(-INFINITY to -BOLD_LIMIT)
+            span = "boldwarning"
         if(0)
-            return "emote"  // nice grey color
-        if(BOLD_LIMIT to INFINITY)  // need to catch the upper bolding first
-            return "greenannounce"
+            span = "emote"  // nice grey color
         if(1 to BOLD_LIMIT)
-            return "nicegreen"
+            span = "nicegreen"
+        if(BOLD_LIMIT to INFINITY)
+            span = "greenannounce"
 
 /datum/mood_event/Destroy()
 	remove_effects()

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -1,85 +1,85 @@
 //nutrition
 /datum/mood_event/fat
-	description = "<span class='warning'><B>I'm so fat.</B></span>\n" //muh fatshaming
+	description = "<B>I'm so fat.</B>\n" //muh fatshaming
 	mood_change = -6
 
 /datum/mood_event/wellfed
-	description = "<span class='nicegreen'>I'm stuffed!</span>\n"
+	description = "I'm stuffed!\n"
 	mood_change = 8
 
 /datum/mood_event/fed
-	description = "<span class='nicegreen'>I have recently had some food.</span>\n"
+	description = "I have recently had some food.\n"
 	mood_change = 5
 
 /datum/mood_event/hungry
-	description = "<span class='warning'>I'm getting a bit hungry.</span>\n"
+	description = "I'm getting a bit hungry.\n"
 	mood_change = -10
 
 /datum/mood_event/starving
-	description = "<span class='boldwarning'>I'm starving!</span>\n"
+	description = "I'm starving!\n"
 	mood_change = -16
 
 //charge
 /datum/mood_event/charged
-	description = "<span class='nicegreen'>I feel the power in my veins!</span>\n"
+	description = "I feel the power in my veins!\n"
 	mood_change = 6
 
 /datum/mood_event/lowpower
-	description = "<span class='warning'>My power is running low, I should go charge up somewhere.</span>\n"
+	description = "My power is running low, I should go charge up somewhere.\n"
 	mood_change = -10
 
 /datum/mood_event/decharged
-	description = "<span class='boldwarning'>I'm in desperate need of some electricity!</span>\n"
+	description = "I'm in desperate need of some electricity!\n"
 	mood_change = -15
 
 //Disgust
 /datum/mood_event/gross
-	description = "<span class='warning'>I saw something gross.</span>\n"
+	description = "I saw something gross.\n"
 	mood_change = -4
 
 /datum/mood_event/verygross
-	description = "<span class='warning'>I think I'm going to puke.</span>\n"
+	description = "I think I'm going to puke.\n"
 	mood_change = -6
 
 /datum/mood_event/disgusted
-	description = "<span class='boldwarning'>Oh god, that's disgusting.</span>\n"
+	description = "Oh god, that's disgusting.\n"
 	mood_change = -8
 
 /datum/mood_event/disgust/bad_smell
-	description = "<span class='warning'>I can smell something horribly decayed inside this room.</span>\n"
+	description = "I can smell something horribly decayed inside this room.\n"
 	mood_change = -6
 
 /datum/mood_event/disgust/nauseating_stench
-	description = "<span class='warning'>The stench of rotting carcasses is unbearable!</span>\n"
+	description = "The stench of rotting carcasses is unbearable!\n"
 	mood_change = -12
 
 //Generic needs events
 /datum/mood_event/favorite_food
-	description = "<span class='nicegreen'>I really enjoyed eating that.</span>\n"
+	description = "I really enjoyed eating that.\n"
 	mood_change = 5
 	timeout = 4 MINUTES
 
 /datum/mood_event/gross_food
-	description = "<span class='warning'>I really didn't like that food.</span>\n"
+	description = "I really didn't like that food.\n"
 	mood_change = -2
 	timeout = 4 MINUTES
 
 /datum/mood_event/disgusting_food
-	description = "<span class='warning'>That food was disgusting!</span>\n"
+	description = "That food was disgusting!\n"
 	mood_change = -6
 	timeout = 4 MINUTES
 
 /datum/mood_event/breakfast
-	description = "<span class='nicegreen'>Nothing like a hearty breakfast to start the shift.</span>\n"
+	description = "Nothing like a hearty breakfast to start the shift.\n"
 	mood_change = 2
 	timeout = 10 MINUTES
 
 /datum/mood_event/nice_shower
-	description = "<span class='nicegreen'>I have recently had a nice shower.</span>\n"
+	description = "I have recently had a nice shower.\n"
 	mood_change = 4
 	timeout = 5 MINUTES
 
 /datum/mood_event/fresh_laundry
-	description = "<span class='nicegreen'>There's nothing like the feeling of a freshly laundered jumpsuit.</span>\n"
+	description = "There's nothing like the feeling of a freshly laundered jumpsuit.\n"
 	mood_change = 2
 	timeout = 10 MINUTES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the spans autogenerate based on the mood_effect amount. You can still manually set a span with var/span. 

below -5, and above 5, the text will be bolded
0 is now gray, in case there were any gray moods.

also theres now a green bolded for super good moodlets
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the mood code cleaner and consistent, also makes it easier for the player to estimate their mood levels
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/188369644-6e51b78f-a59b-47eb-bf2b-04f39d5c6053.png)


</details>

## Changelog
:cl:
refactor: mood_event now generates span on New()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
