### PR TITLE
EMP Boombox

### DIFF
--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -75,3 +75,29 @@
         M.playsound_local(get_turf(src), selected_sound, volume, shiftpitch)
         spam_flag = world.timeofday
         //to_chat(M, selected_sound) //this doesn't actually go to their chat very much at all.
+
+/obj/item/soundsynth/boombox  // tator item
+	var/trigger_sound
+	var/recharge_rate = 5 MINUTES
+	COOLDOWN_DECLARE(kaboom)
+
+/obj/item/soundsynth/boombox/generate_sound()
+	trigger_sound = pick(sound_list)
+	return trigger_sound // returns to the uplink buy proc, to add to memory
+
+/obj/item/soundsynth/boombox/attack_self(mob/user)
+	if(trigger_sound == selected_sound)
+		if(COOLDOWN_FINISHED(src, kaboom))
+			for(atom/movable/affected in oview(2, user))
+				affected.emp_act(EMP_HEAVY)
+				do_sparks(1, FALSE, affected)
+				if(ismob(affected))
+					var/mob/A = affected
+					log_combat(user, A, "attacked", "EMP-boombox")
+			user.visible_message("<span class='danger'>A wave of static seems to eminate out of [user].</span>")"
+			do_sparks(1, FALSE, user)
+			COOLDOWN_START(src, kaboom, 5 MINUTES)
+		else
+			to_chat(user, "<span class='warning'>\The [src] is still recharging! You can use it again in [round((kaboom - world.time) / 10)] seconds.")
+		return
+	. = ..()

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -83,19 +83,14 @@
 
 /obj/item/soundsynth/boombox/proc/generate_sound()
 	var/sound_index = pick(sound_list)
-    var/list/assblast = params2list(sound_list[sound_index])
-    trigger_sound = assblast["selected_sound"]
-	return trigger_sound // returns to the uplink buy proc, to add to memory
+	var/list/assblast = params2list(sound_list[sound_index])
+	trigger_sound = assblast["selected_sound"]
+	return sound_index // returns to the uplink buy proc, to add to memory
 
 /obj/item/soundsynth/boombox/attack_self(mob/user)
 	if(trigger_sound == selected_sound)
 		if(COOLDOWN_FINISHED(src, kaboom))
-			for(var/atom/movable/affected in oview(2, user))
-				affected.emp_act(EMP_HEAVY)
-				do_sparks(1, FALSE, affected)
-				if(ismob(affected))
-					var/mob/A = affected
-					log_combat(user, A, "attacked", "EMP-boombox")
+			empulse(get_turf(user), 1, 2)
 			user.visible_message("<span class='danger'>A wave of static seems to eminate out of [user].</span>")
 			do_sparks(1, FALSE, user)
 			COOLDOWN_START(src, kaboom, 5 MINUTES)

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -90,7 +90,7 @@
 /obj/item/soundsynth/boombox/attack_self(mob/user)
 	if(trigger_sound == selected_sound)
 		if(COOLDOWN_FINISHED(src, kaboom))
-			empulse(get_turf(user), 1, 2)
+			empulse(get_turf(user), 2, 3)
 			user.visible_message("<span class='danger'>A wave of static seems to eminate out of [user].</span>")
 			do_sparks(1, FALSE, user)
 			COOLDOWN_START(src, kaboom, 5 MINUTES)

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -81,20 +81,22 @@
 	var/recharge_rate = 5 MINUTES
 	COOLDOWN_DECLARE(kaboom)
 
-/obj/item/soundsynth/boombox/generate_sound()
-	trigger_sound = pick(sound_list)
+/obj/item/soundsynth/boombox/proc/generate_sound()
+	var/sound_index = pick(sound_list)
+    var/list/assblast = params2list(sound_list[sound_index])
+    trigger_sound = assblast["selected_sound"]
 	return trigger_sound // returns to the uplink buy proc, to add to memory
 
 /obj/item/soundsynth/boombox/attack_self(mob/user)
 	if(trigger_sound == selected_sound)
 		if(COOLDOWN_FINISHED(src, kaboom))
-			for(atom/movable/affected in oview(2, user))
+			for(var/atom/movable/affected in oview(2, user))
 				affected.emp_act(EMP_HEAVY)
 				do_sparks(1, FALSE, affected)
 				if(ismob(affected))
 					var/mob/A = affected
 					log_combat(user, A, "attacked", "EMP-boombox")
-			user.visible_message("<span class='danger'>A wave of static seems to eminate out of [user].</span>")"
+			user.visible_message("<span class='danger'>A wave of static seems to eminate out of [user].</span>")
 			do_sparks(1, FALSE, user)
 			COOLDOWN_START(src, kaboom, 5 MINUTES)
 		else

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2101,8 +2101,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list(JOB_NAME_CLOWN, JOB_NAME_MIME)
 
 /datum/uplink_item/role_restricted/boombox/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
-	/obj/item/soundsynth/boombox/new_box = ..()
-	var/code = new_box.generate_sound
+	var/obj/item/soundsynth/boombox/new_box = ..()
+	var/code = new_box.generate_sound()
 	if(user.mind)
 		user.mind.store_memory("Code for [new_box] : [code]")
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2090,6 +2090,24 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted = TRUE
 	restricted_roles = list(JOB_NAME_CLOWN, JOB_NAME_CHAPLAIN)
 
+/datum/uplink_item/role_restricted/boombox
+	name = "EMP Sound Synthesizer"
+	desc = "An emp blaster disguised as a sound synth.\
+	 Simply play the code sound, and the device will automatically emp everything in a certain range."
+	item = /obj/item/soundsynth/boombox
+	cost = 5
+	limited_stock = 1  // mostly just to prevent memory spam
+	restricted = TRUE
+	restricted_roles = list(JOB_NAME_CLOWN, JOB_NAME_MIME)
+
+/datum/uplink_item/role_restricted/boombox/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
+	/obj/item/soundsynth/boombox/new_box = ..()
+	var/code = new_box.generate_sound
+	if(user.mind)
+		user.mind.store_memory("Code for [new_box] : [code]")
+
+	return new_box
+
 /datum/uplink_item/role_restricted/concealed_weapon_bay
 	name = "Concealed Weapon Bay"
 	desc = "A modification for non-combat mechas that allows them to equip one piece of equipment designed for combat mechs. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds an emp sound synthesizer for clowns and mimes. It works by choosing a random sound to trigger it, then saving it to the traitors memory. When that sound is played, it emp's devices in a 5x5 radius. It then takes 5 minutes to recharge.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A more interesting and riskier emp flashlight, as its far more obvious that you're the one doing it, and you only get 1 charge. On the other hand, you can quickly emp multiple close devices at once, and quickly decommision certain consoles.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/188511680-4b3d80de-df96-4184-8247-9444d03bc174.png)
![image](https://user-images.githubusercontent.com/73374039/188511730-47f4fd89-2eae-4559-99c6-4349aa890f4c.png)


</details>

## Changelog
:cl:
add: Clown EMP synth
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
