### PR TITLE
Makes Shield Generator Satellite crates and Shield System Control Board crates always available for purchase.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1003,7 +1003,6 @@
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains three Shield Generator Satellites."
 	cost = 3000
-	special = TRUE
 	access_budget = ACCESS_HEADS
 	contains = list(
 					/obj/machinery/satellite/meteor_shield,
@@ -1017,7 +1016,6 @@
 	name = "Shield System Control Board"
 	desc = "A control system for the Shield Generator Satellite system."
 	cost = 5000
-	special = TRUE
 	access_budget = ACCESS_HEADS
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -81,11 +81,6 @@
 
 /datum/round_event/meteor_wave/announce(fake)
 	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: 10 MINUTES. Anti-meteor point defense is available for purchase via the station's cargo shuttle.", "Meteor Alert", ANNOUNCER_METEORS)
-	if(!fake)
-		var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat]
-		P.special_enabled = TRUE
-		P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat_control]
-		P.special_enabled = TRUE
 
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -12,15 +12,6 @@
 			 You can order the satellites and control systems at cargo.
 			 "}
 
-
-/datum/station_goal/station_shield/on_report()
-	//Unlock
-	var/datum/supply_pack/P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat]
-	P.special_enabled = TRUE
-
-	P = SSshuttle.supply_packs[/datum/supply_pack/engineering/shield_sat_control]
-	P.special_enabled = TRUE
-
 /datum/station_goal/station_shield/check_completion()
 	if(..())
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Simply makes both the crates available for purchase whenever, instead of being locked behind a station goal/meteor announcement.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
As it is right now, a meteor announcement almost always results in a shuttle call, simply because there's usually not enough time to set up the satellites and the damage is too severe to repair it and continue playing. This gives engineers something more to do while things are calm, besides working on CO2 SM set ups and Fusion.
## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/110184118/188559475-cd7b5a9f-8195-467f-8dc5-78d8894c62f9.png)
As you can see the station goal is a custom shuttle
![image](https://user-images.githubusercontent.com/110184118/188559503-98e691d5-f2b7-45bc-8279-c41b5a78be47.png)
But the shield sat crate is available for purchase.

</details>

## Changelog
:cl:
tweak: Made shield sattelite and shield system control crates always available for purchase
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
