### PR TITLE
Adds a new Station trait that randomizes department signs

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -386,6 +386,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
 #define STATION_TRAIT_DISTANT_SUPPLY_LINES "distant_supply_lines"
 #define STATION_TRAIT_STRONG_SUPPLY_LINES "strong_supply_lines"
+#define STATION_TRAIT_RANDOM_DEPT "random_dept_signs"
 
 /// Trait applied when the MMI component is added to an [/obj/item/integrated_circuit]
 #define TRAIT_COMPONENT_MMI "component_mmi"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -386,7 +386,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
 #define STATION_TRAIT_DISTANT_SUPPLY_LINES "distant_supply_lines"
 #define STATION_TRAIT_STRONG_SUPPLY_LINES "strong_supply_lines"
-#define STATION_TRAIT_RANDOM_DEPT "random_dept_signs"
 
 /// Trait applied when the MMI component is added to an [/obj/item/integrated_circuit]
 #define TRAIT_COMPONENT_MMI "component_mmi"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -74,5 +74,5 @@
 
 /datum/station_trait/random_dept_signs/New()
 	. = ..()
-	for(var/obj/structure/sign/the_sign in GLOB.dept_signs)
+	for(var/obj/structure/sign/departments/the_sign in GLOB.dept_signs)
 		the_sign.randomize()

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -64,3 +64,11 @@
 /datum/station_trait/announcement_baystation/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/baystation
+
+/datum/station_trait/random_dept_signs
+	name = "Department Sign Mixup"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 10
+	show_in_report = TRUE
+	report_message = "Our engineers seem to have messed up sign placement. Please bear with us until we can get a repair crew out."  // nobody is coming
+	trait_to_give = STATION_TRAIT_RANDOM_DEPT

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -75,5 +75,4 @@
 /datum/station_trait/random_dept_signs/New()
 	. = ..()
 	for(var/obj/structure/sign/the_sign in GLOB.dept_signs)
-		if(istype(the_sign))
-			the_sign.randomize()
+		the_sign.randomize()

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -72,3 +72,9 @@
 	show_in_report = TRUE
 	report_message = "Our engineers seem to have messed up sign placement. Please bear with us until we can get a repair crew out."  // nobody is coming
 	trait_to_give = STATION_TRAIT_RANDOM_DEPT
+
+/datum/station_trait/random_dept_signs/New()
+	. = ..()
+	for(var/obj/structure/sign/the_sign in GLOB.dept_signs)
+		if(istype(the_sign))
+			the_sign.randomize()

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -71,7 +71,6 @@
 	weight = 10
 	show_in_report = TRUE
 	report_message = "Our engineers seem to have messed up sign placement. Please bear with us until we can get a repair crew out."  // nobody is coming
-	trait_to_give = STATION_TRAIT_RANDOM_DEPT
 
 /datum/station_trait/random_dept_signs/New()
 	. = ..()

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -20,9 +20,9 @@ GLOBAL_LIST_EMPTY(dept_signs)
 /obj/structure/sign/proc/randomize()
 	if(!random_dept_base)
 		return
-	var/list/all_dept = subtypesof(random_dept_base)
-	while(TRUE)
-		var/obj/structure/sign/departments/new_dept = pick(all_dept)
+	var/static/list/all_dept = subtypesof(random_dept_base)
+	shuffle_inplace(all_dept)
+	for(var/obj/structure/sign/departments/new_dept in all_dept)
 		if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
 			name = initial(new_dept.name)
 			desc = initial(new_dept.desc)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_EMPTY(dept_signs)
 	if(!random_dept_base)
 		return
 	var/static/list/all_dept = subtypesof(random_dept_base)
-	var/picked = pick(all_dept)
+	var/obj/structure/sign/departments/picked = pick(all_dept)
 	while(!initial(picked.desc) || !initial(picked.icon_state))  // prevents null entries
 		picked = pick(all_dept)
 

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -21,13 +21,13 @@ GLOBAL_LIST_EMPTY(dept_signs)
 	if(!random_dept_base)
 		return
 	var/static/list/all_dept = subtypesof(random_dept_base)
-	shuffle_inplace(all_dept)
-	for(var/obj/structure/sign/departments/new_dept in all_dept)
-		if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
-			name = initial(new_dept.name)
-			desc = initial(new_dept.desc)
-			icon_state = initial(new_dept.icon_state)
-			break
+	var/picked = pick(all_dept)
+	while(!initial(picked.desc) || !initial(picked.icon_state))  // prevents null entries
+		picked = pick(all_dept)
+
+	name = initial(picked.name)
+	desc = initial(picked.desc)
+	icon_state = initial(picked.icon_state)
 
 
 /obj/structure/sign/basic

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -10,29 +10,6 @@ GLOBAL_LIST_EMPTY(dept_signs)
 	armor = list("melee" = 50, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 0)
 	var/buildable_sign = 1 //unwrenchable and modifiable
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
-	var/random_dept_base  // will be replaced by a random subtype if the station has random_dept and this is defined
-
-/obj/structure/sign/Initialize(mapload)
-	. = ..()
-	if(random_dept_base)
-		GLOB.dept_signs += src
-
-/obj/structure/sign/Destroy()
-	GLOB.dept_signs -= src
-	. = ..()
-
-/obj/structure/sign/proc/randomize()
-	if(!random_dept_base)
-		return
-	var/static/list/all_dept = subtypesof(random_dept_base)
-	var/obj/structure/sign/departments/picked = pick(all_dept)
-	while(!initial(picked.desc) || !initial(picked.icon_state))  // prevents null entries
-		picked = pick(all_dept)
-
-	name = initial(picked.name)
-	desc = initial(picked.desc)
-	icon_state = initial(picked.icon_state)
-
 
 /obj/structure/sign/basic
 	name = "blank sign"
@@ -157,8 +134,20 @@ GLOBAL_LIST_EMPTY(dept_signs)
 
 // probably a better way to do this..
 
-/obj/structure/sign/departments
-	random_dept_base = /obj/structure/sign/departments
+/obj/structure/sign/departments/Initialize(mapload)
+	. = ..()
+		GLOB.dept_signs += src
 
-/obj/structure/sign/directions
-	random_dept_base = /obj/structure/sign/directions
+/obj/structure/sign/departments/Destroy()
+	GLOB.dept_signs -= src
+	. = ..()
+
+/obj/structure/sign/departments/proc/randomize()
+	var/static/list/all_dept = subtypesof(/obj/structure/sign/departments)
+	var/obj/structure/sign/departments/picked = pick(all_dept)
+	while(!initial(picked.desc) || !initial(picked.icon_state))  // prevents null entries
+		picked = pick(all_dept)
+
+	name = initial(picked.name)
+	desc = initial(picked.desc)
+	icon_state = initial(picked.icon_state)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -17,6 +17,10 @@ GLOBAL_LIST_EMPTY(dept_signs)
 	if(random_dept_base)
 		GLOB.dept_signs += src
 
+/obj/structure/sign/Destroy()
+	GLOB.dept_signs -= src
+	. = ..()
+
 /obj/structure/sign/proc/randomize()
 	if(!random_dept_base)
 		return

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -8,6 +8,26 @@
 	armor = list("melee" = 50, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "stamina" = 0)
 	var/buildable_sign = 1 //unwrenchable and modifiable
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	var/random_dept_base  // will be replaced by a random subtype if the station has random_dept and this is defined
+
+/obj/structure/sign/Initialize(mapload)
+	. = ..()
+	if(random_dept_base)
+		return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/sign/LateInitialize(mapload)
+	. = ..()
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(50))
+		var/list/all_dept = subtypesof(random_dept_base)
+
+		while(TRUE)
+			var/obj/structure/sign/departments/new_dept = pick(all_dept)
+			if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
+				name = initial(new_dept.name)
+				desc = initial(new_dept.desc)
+				icon_state = initial(new_dept.icon_state)
+				break
+
 
 /obj/structure/sign/basic
 	name = "blank sign"
@@ -133,29 +153,7 @@
 // probably a better way to do this..
 
 /obj/structure/sign/departments
-/obj/structure/sign/departments/Initialize(mapload)
-	. = ..()
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(50))
-		var/list/all_dept = subtypesof(/obj/structure/sign/departments)
-
-		while(TRUE)
-			var/obj/structure/sign/departments/new_dept = pick(all_dept)
-			if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
-				name = initial(new_dept.name)
-				desc = initial(new_dept.desc)
-				icon_state = initial(new_dept.icon_state)
-				break
+	random_dept_base = /obj/structure/sign/departments
 
 /obj/structure/sign/directions
-/obj/structure/sign/directions/Initialize(mapload)
-	. = ..()
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(50))
-		var/list/all_dept = subtypesof(/obj/structure/sign/directions)
-
-		while(TRUE)
-			var/obj/structure/sign/departments/new_dept = pick(all_dept)
-			if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
-				name = initial(new_dept.name)
-				desc = initial(new_dept.desc)
-				icon_state = initial(new_dept.icon_state)
-				break
+	random_dept_base = /obj/structure/sign/directions

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -129,3 +129,14 @@
 	name = "\improper Nanotrasen logo"
 	desc = "The Nanotrasen corporate logo."
 	icon_state = "nanotrasen_sign1"
+
+/obj/structure/sign/departments
+/obj/structure/sign/departments/Initialize(mapload)
+	. = ..()
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(99))  // note to self dont forget to reset this to 50 and delete this note if you dont i will be very sad
+		var/list/all_dept = subtypesof(/obj/structure/sign/departments)
+		var/obj/structure/sign/departments/new_dept = pick(all_dept)
+
+		name = initial(new_dept.name)
+		desc = initial(new_dept.desc)
+		icon_state = initial(new_dept.icon_state)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -143,10 +143,9 @@ GLOBAL_LIST_EMPTY(dept_signs)
 	. = ..()
 
 /obj/structure/sign/departments/proc/randomize()
-	var/static/list/all_dept = subtypesof(/obj/structure/sign/departments)
-	var/obj/structure/sign/departments/picked = pick(all_dept)
+	var/obj/structure/sign/departments/picked = pick(GLOB.dept_signs)
 	while(!initial(picked.desc) || !initial(picked.icon_state))  // prevents null entries
-		picked = pick(all_dept)
+		picked = pick(GLOB.dept_signs)
 
 	name = initial(picked.name)
 	desc = initial(picked.desc)

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_EMPTY(dept_signs)
 
 /obj/structure/sign/departments/Initialize(mapload)
 	. = ..()
-		GLOB.dept_signs += src
+	GLOB.dept_signs += src
 
 /obj/structure/sign/departments/Destroy()
 	GLOB.dept_signs -= src

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_EMPTY(dept_signs)
+
 /obj/structure/sign
 	icon = 'icons/obj/decals.dmi'
 	anchored = TRUE
@@ -13,20 +15,19 @@
 /obj/structure/sign/Initialize(mapload)
 	. = ..()
 	if(random_dept_base)
-		return INITIALIZE_HINT_LATELOAD
+		GLOB.dept_signs += src
 
-/obj/structure/sign/LateInitialize(mapload)
-	. = ..()
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(50))
-		var/list/all_dept = subtypesof(random_dept_base)
-
-		while(TRUE)
-			var/obj/structure/sign/departments/new_dept = pick(all_dept)
-			if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
-				name = initial(new_dept.name)
-				desc = initial(new_dept.desc)
-				icon_state = initial(new_dept.icon_state)
-				break
+/obj/structure/sign/proc/randomize()
+	if(!random_dept_base)
+		return
+	var/list/all_dept = subtypesof(random_dept_base)
+	while(TRUE)
+		var/obj/structure/sign/departments/new_dept = pick(all_dept)
+		if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
+			name = initial(new_dept.name)
+			desc = initial(new_dept.desc)
+			icon_state = initial(new_dept.icon_state)
+			break
 
 
 /obj/structure/sign/basic

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -130,13 +130,32 @@
 	desc = "The Nanotrasen corporate logo."
 	icon_state = "nanotrasen_sign1"
 
+// probably a better way to do this..
+
 /obj/structure/sign/departments
 /obj/structure/sign/departments/Initialize(mapload)
 	. = ..()
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(99))  // note to self dont forget to reset this to 50 and delete this note if you dont i will be very sad
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(50))
 		var/list/all_dept = subtypesof(/obj/structure/sign/departments)
-		var/obj/structure/sign/departments/new_dept = pick(all_dept)
 
-		name = initial(new_dept.name)
-		desc = initial(new_dept.desc)
-		icon_state = initial(new_dept.icon_state)
+		while(TRUE)
+			var/obj/structure/sign/departments/new_dept = pick(all_dept)
+			if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
+				name = initial(new_dept.name)
+				desc = initial(new_dept.desc)
+				icon_state = initial(new_dept.icon_state)
+				break
+
+/obj/structure/sign/directions
+/obj/structure/sign/directions/Initialize(mapload)
+	. = ..()
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_DEPT) && prob(50))
+		var/list/all_dept = subtypesof(/obj/structure/sign/directions)
+
+		while(TRUE)
+			var/obj/structure/sign/departments/new_dept = pick(all_dept)
+			if(initial(new_dept.desc) || initial(new_dept.icon_state))  // prevents null entries
+				name = initial(new_dept.name)
+				desc = initial(new_dept.desc)
+				icon_state = initial(new_dept.icon_state)
+				break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a station trait that randomizes what signs show up for departments
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its an interesting annoyance for the station, gives engineers something to fix, pretty funny
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/188999927-1c02fc63-f021-4478-ad9e-4bcab1d09458.png)

</details>

## Changelog
:cl:
add: station trait: dept signs are randomized
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
