### PR TITLE
Fixes repairing cyborgs with plasma cutters

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -422,7 +422,7 @@
 		updatehealth()
 		add_fingerprint(user)
 		user.visible_message("[user] has fixed some of the dents on [src].", "<span class='notice'>You fix some of the dents on [src].</span>")
-		return
+		return TRUE
 
 	else if(istype(W, /obj/item/stack/cable_coil) && wiresexposed)
 		user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
So when you try to fix cyborgs by using a plasma cutter as a welder, you'll point-blank them after repairing them. This fixes that by making cyborg attackby handling return true when fixing them using a welder.

The attackby won't return true if it fails, though, which allows the plasma cutter to click if it's out of fuel.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Bugs are generally a bad thing.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/9423435/189037607-c28a3f8e-a201-496b-8b40-11dc9ac669d8.png)

Cyborg after being repaired, noticeably not shot.

</details>

## Changelog
:cl:
fix: Fixes repairing cyborgs with plasma cutters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
