### PR TITLE
Spraypaint wires to make it hard to tell what wires what

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -34,6 +34,8 @@
 	var/randomize = 0 // If every instance of these wires should be random.
 					  // Prevents wires from showing up in station blueprints
 
+	var/spray_lock = FALSE  // whether every wire is the same from spraycan use
+
 /datum/wires/New(atom/holder)
 	..()
 	if(!istype(holder, holder_type))
@@ -258,7 +260,7 @@
 
 	for(var/color in colors)
 		payload.Add(list(list(
-			"color" = color,
+			"color" = spray_lock ? "red" : color,
 			"wire" = ((reveal_wires && !is_dud_color(color)) ? get_wire(color) : null),
 			"cut" = is_color_cut(color),
 			"attached" = is_attached(color)
@@ -310,5 +312,18 @@
 						. = TRUE
 					else
 						to_chat(L, "<span class='warning'>You need an attachable assembly!</span>")
+
+/datum/wires/proc/apply_paint()
+	if(spray_lock)
+		return FALSE
+	spray_lock = TRUE
+	ui_update()
+	addtimer(CALLBACK(src, .proc/remove_paint), 5 MINUTES)
+	return TRUE
+
+/datum/wires/proc/remove_paint()
+	spray_lock = FALSE
+	ui_update()
+
 
 #undef MAXIMUM_EMP_WIRES

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1044,6 +1044,15 @@
 	else if(is_wire_tool(C) && panel_open)
 		attempt_wire_interaction(user)
 		return
+	else if(istype(C, /obj/item/toy/crayon/spraycan))
+		var/obj/item/toy/crayon/spraycan/can = C
+		if(can.charges <= 0)
+			to_chat(user, "<span class='warning'>The can is empty!</span>")
+			return
+		if(wires.apply_paint(C))
+			to_chat(user, "<span class='notice'>You spray paint on the wires!</span>")
+			can.charges -= 1
+			return
 	else if(istype(C, /obj/item/pai_cable))
 		var/obj/item/pai_cable/cable = C
 		cable.plugin(src, user)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -644,6 +644,9 @@
 	if(!proximity)
 		return
 
+	if(istype(target.wires) && user.a_intent != INTENT_HARM)
+		return TRUE
+
 	if(is_capped)
 		if(istype(target, /obj/machinery/modular_fabricator/autolathe))
 			return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can spraycan wires on airlocks to make every wire red
The code for this is very portable, letting you put this on any wire object.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
funny and makes hacking harder
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/189047082-78ac0529-92e6-4827-8c47-ae20da72336a.png)


</details>

## Changelog
:cl:
tweak: spraypaint wires to ruin em
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
