### PR TITLE
Fix pirate ship spawning again

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -53,7 +53,9 @@
 				spawn_pirates(threat, TRUE)
 
 /proc/spawn_pirates(datum/comm_message/threat, skip_answer_check)
-	if(!skip_answer_check && threat?.answered == PIRATE_RESPONSE_NO_PAY)
+	// If they paid it off in the meantime, don't spawn pirates
+	// If they didn't pay, don't spawn another - it already spawned
+	if(!skip_answer_check && threat?.answered)
 		return
 
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -42,20 +42,23 @@
 	if(world.time > initial_send_time + response_max_time)
 		priority_announce("Too late to beg for mercy!",sender_override = ship_name)
 		return
-	if(threat?.answered)
+	// Attempted to pay off
+	if(threat?.answered == PIRATE_RESPONSE_PAY)
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(D)
-			if(D.adjust_money(-payoff))
-				priority_announce("Thanks for the credits, landlubbers.", sound = SSstation.announcer.get_rand_alert_sound(), sender_override = ship_name)
-				return
-			else
-				priority_announce("Trying to cheat us? You'll regret this!", sound = SSstation.announcer.get_rand_alert_sound(), sender_override = ship_name)
-				spawn_pirates(threat, TRUE)
+		if(!D)
+			return
+		// Check if they can afford it
+		if(D.adjust_money(-payoff))
+			priority_announce("Thanks for the credits, landlubbers.", sound = SSstation.announcer.get_rand_alert_sound(), sender_override = ship_name)
+		else
+			priority_announce("Trying to cheat us? You'll regret this!", sound = SSstation.announcer.get_rand_alert_sound(), sender_override = ship_name)
+			spawn_pirates(threat, TRUE) // insta-spawn!
 
 /proc/spawn_pirates(datum/comm_message/threat, skip_answer_check)
 	// If they paid it off in the meantime, don't spawn pirates
-	// If they didn't pay, don't spawn another - it already spawned
-	if(!skip_answer_check && threat?.answered)
+	// If they couldn't afford to pay, don't spawn another - it already spawned (see above)
+	// If they selected "No way.", this spawns on the timeout, so we don't want to return for the answer check
+	if(!skip_answer_check && threat?.answered == PIRATE_RESPONSE_PAY)
 		return
 
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)


### PR DESCRIPTION
## About The Pull Request

I made a small logic error in #7608 that would make a pirate ship spawn even if you paid them off.

There's also a bug where if you hit "No way" it would still attempt to pay them off.

## Why It's Good For The Game

Fix bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/189268601-e2ff04b7-00c7-4792-b12b-2a939523aad8.png)

</details>

## Changelog
:cl:
fix: Pirates will no longer ignore the fact that you paid them off.
fix: Refusing to pay pirates will no longer still attempt to pay them off.
/:cl:
