### PR TITLE
Dynamic: Block traitors/heretics/lings/bros during cults/nukies/wiz/revs

### DIFF
--- a/code/__DEFINES/dynamic.dm
+++ b/code/__DEFINES/dynamic.dm
@@ -7,6 +7,9 @@
 /// This ruleset can only be picked once. Anything that does not have a scaling_cost MUST have this.
 #define LONE_RULESET (1 << 2)
 
+/// This ruleset can't execute alongside ANY other roundstart ruleset.
+#define NO_OTHER_ROUNDSTARTS_RULESET (1 << 3)
+
 /// This is a "heavy" midround ruleset, and should be run later into the round
 #define MIDROUND_RULESET_STYLE_HEAVY "Heavy"
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -547,6 +547,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				if (other_ruleset.flags & HIGH_IMPACT_RULESET)
 					drafted_rules[other_ruleset] = null
 
+		if (ruleset.flags & NO_OTHER_ROUNDSTARTS_RULESET)
+			drafted_rules.Cut()
+
 		if (ruleset.flags & LONE_RULESET)
 			drafted_rules[ruleset] = null
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -553,6 +553,12 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if (ruleset.flags & LONE_RULESET)
 			drafted_rules[ruleset] = null
 
+	for (var/datum/dynamic_ruleset/ruleset in rulesets_picked)
+		if(ruleset.flags & NO_OTHER_ROUNDSTARTS_RULESET)
+			rulesets_picked = list()
+			rulesets_picked[ruleset] = 1
+			break
+
 	for (var/ruleset in rulesets_picked)
 		spend_roundstart_budget(picking_roundstart_rule(ruleset, rulesets_picked[ruleset] - 1))
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -71,6 +71,13 @@
 	cost = 5
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	repeatable = TRUE
+	blocking_rules = list(
+		/datum/dynamic_ruleset/roundstart/bloodcult,
+		/datum/dynamic_ruleset/roundstart/clockcult,
+		/datum/dynamic_ruleset/roundstart/nuclear,
+		/datum/dynamic_ruleset/roundstart/wizard,
+		/datum/dynamic_ruleset/roundstart/revs
+	)
 
 //////////////////////////////////////////////
 //                                          //
@@ -166,3 +173,10 @@
 	cost = 7
 	requirements = list(101,101,101,10,10,10,10,10,10,10)
 	repeatable = TRUE
+	blocking_rules = list(
+		/datum/dynamic_ruleset/roundstart/bloodcult,
+		/datum/dynamic_ruleset/roundstart/clockcult,
+		/datum/dynamic_ruleset/roundstart/nuclear,
+		/datum/dynamic_ruleset/roundstart/wizard,
+		/datum/dynamic_ruleset/roundstart/revs
+	)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -192,6 +192,13 @@
 	cost = 3
 	requirements = list(3,3,3,3,3,3,3,3,3,3)
 	repeatable = TRUE
+	blocking_rules = list(
+		/datum/dynamic_ruleset/roundstart/bloodcult,
+		/datum/dynamic_ruleset/roundstart/clockcult,
+		/datum/dynamic_ruleset/roundstart/nuclear,
+		/datum/dynamic_ruleset/roundstart/wizard,
+		/datum/dynamic_ruleset/roundstart/revs
+	)
 
 /datum/dynamic_ruleset/midround/autotraitor/trim_candidates()
 	..()
@@ -238,6 +245,7 @@
 	weight = 2
 	cost = 10
 	required_type = /mob/living/silicon/ai
+	blocking_rules = list(/datum/dynamic_ruleset/roundstart/nuclear)
 	var/ion_announce = 33
 	var/removeDontImproveChance = 10
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -172,7 +172,7 @@
 	name = "Wizard"
 	antag_flag = ROLE_WIZARD
 	antag_datum = /datum/antagonist/wizard
-	flags = HIGH_IMPACT_RULESET
+	flags = HIGH_IMPACT_RULESET | NO_OTHER_ROUNDSTARTS_RULESET
 	minimum_required_age = 14
 	restricted_roles = list(JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN) // Just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	required_candidates = 1
@@ -222,7 +222,7 @@
 	weight = 3
 	cost = 20
 	requirements = list(100,90,80,60,40,30,10,10,10,10)
-	flags = HIGH_IMPACT_RULESET
+	flags = HIGH_IMPACT_RULESET | NO_OTHER_ROUNDSTARTS_RULESET
 	antag_cap = list("denominator" = 20, "offset" = 1)
 	var/datum/team/cult/main_cult
 
@@ -278,7 +278,7 @@
 	weight = 3
 	cost = 20
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
-	flags = HIGH_IMPACT_RULESET
+	flags = HIGH_IMPACT_RULESET | NO_OTHER_ROUNDSTARTS_RULESET
 	antag_cap = list("denominator" = 18, "offset" = 1)
 	var/datum/team/nuclear/nuke_team
 
@@ -365,7 +365,7 @@
 	cost = 20
 	requirements = list(101,101,70,40,30,20,10,10,10,10)
 	antag_cap = 3
-	flags = HIGH_IMPACT_RULESET
+	flags = HIGH_IMPACT_RULESET | NO_OTHER_ROUNDSTARTS_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/latejoin/provocateur)
 	// I give up, just there should be enough heads with 35 players...
 	minimum_players = 35
@@ -581,7 +581,7 @@
 	weight = 3
 	cost = 35
 	requirements = list(100,90,80,70,60,50,30,30,30,30)
-	flags = HIGH_IMPACT_RULESET
+	flags = HIGH_IMPACT_RULESET | NO_OTHER_ROUNDSTARTS_RULESET
 	var/datum/team/clock_cult/main_cult
 	var/list/selected_servants = list()
 


### PR DESCRIPTION
## About The Pull Request

Blocks:
- Syndicate Sleeper Agent
- Syndicate Latejoin
- Heretic Latejoin

If any of the following rulesets are present:
- Blood Cult
- Clock Cult
- Nuclear Assault Roundstart
- Wizard Roundstart
- Revs Roundstart

Also blocks Malf AI Midround during Nuclear Assault Roundstart

Blocks ANY other roundstart ruleset from executing alongside:
- Blood Cult
- Clock Cult
- Nuclear Assault Roundstart
- Wizard Roundstart
- Revs Roundstart

## Why It's Good For The Game

Traitors and Heretics spawning in copious amounts during these "gamemodes" is really strange and clashing, and makes for unfun interactions. Especially having regular tots completely wreaking havoc or getting murdered by nukies, or heretics during a clock cult, etc.

These interactions are really weird and conflict with the normal gamemode system and flow of the round. These gamemodes can already sustain enough fun on their own, and should be locked to only spawning ghost style/medium-high impact antags like blob, xeno, ayys, revenant, nightmare, etc. Traitors/heretics just create too much RP conflict.

Also Malf AI opening the door for nukies so they can kill the Captain is really lame and shouldn't happen since it already can't happen roundstart.

## Testing Photographs and Procedure

Game starties!! It's using a built in system so basically it'll just work (revs already use it to stop spawning more revs from the latejoin rev)

## Changelog
:cl:
balance: Dynamic will no longer spawn traitors, changeling, blood brothers, or heretics during the cult, nuclear assault, wizard, and revs roundstart rules.
/:cl:
