### PR TITLE
Post-round nukes dont mute ooc

### DIFF
--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -66,9 +66,9 @@
 	//Handle what happens when a different cinematic tries to play over us
 	RegisterSignal(SSdcs, COMSIG_GLOB_PLAY_CINEMATIC, .proc/replacement_cinematic)
 
-	//Pause OOC
+	//Pause OOC (unless admin sets off bomb after the rounds over)
 	var/ooc_toggled = FALSE
-	if(is_global && stop_ooc && GLOB.ooc_allowed)
+	if(is_global && stop_ooc && GLOB.ooc_allowed && SSticker.current_state != GAME_STATE_FINISHED)
 		ooc_toggled = TRUE
 		toggle_ooc(FALSE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
*Certain* admins spawning nukes after round end doesnt mute ooc
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The round's already over, please dont waste some of the 5-6 minutes we get to talk because you think it'd be "funny"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/189459450-48035b41-07db-4160-82ac-fed0b2e8c058.png)

</details>

## Changelog
:cl:
admin: nukes going off after round end no longer mutes ooc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
