### PR TITLE
robotic mobs and organic mobs have different whistle noises

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -627,4 +627,7 @@
 	message_ipc = "whistles a few synthesized notes"
 
 /datum/emote/living/whistle/get_sound(mob/living/user)
-	return 'sound/items/megaphone.ogg'
+	if(MOB_ROBOTIC in user.mob_biotypes)
+		return 'sound/items/megaphone.ogg'
+	else
+		return 'sound/magic/warpwhistle.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

previously, the whistle emote always used the megaphone sound. now, organic mobs make the warp whistle sound and robotic mobs use the old megaphone sound

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

organic mobs shouldn't sound robotic

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

https://user-images.githubusercontent.com/35978630/189462545-13b33842-bc87-4f5e-9fef-a138e83aa1cf.mp4


https://user-images.githubusercontent.com/35978630/189462549-8c264308-646d-4304-ad34-ee8f29e8d2b4.mp4


https://user-images.githubusercontent.com/35978630/189462550-5d857f5f-3ac4-4c75-9529-5575f7a1895c.mp4

</details>

## Changelog
:cl:
tweak: robotic mobs and organic mobs now have different whistling noises
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
