### PR TITLE
Captains alert does different noises for each sec level

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(communications)
 		minor_announce(input,"[user.name] Announces:", html_encode = FALSE)
 		silicon_message_cooldown = world.time + COMMUNICATION_COOLDOWN_AI
 	else
-		alert_sound = 'sound/misc/announce.ogg'
+		var/alert_sound = 'sound/misc/announce.ogg'
 		switch(GLOB.security_level)
 			if(SEC_LEVEL_BLUE)
 				alert_sound = 'sound/misc/announce_dig.ogg'

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -23,7 +23,15 @@ SUBSYSTEM_DEF(communications)
 		minor_announce(input,"[user.name] Announces:", html_encode = FALSE)
 		silicon_message_cooldown = world.time + COMMUNICATION_COOLDOWN_AI
 	else
-		priority_announce(html_decode(user.treat_message(input)), null, 'sound/misc/announce.ogg', "Captain", has_important_message = TRUE, auth_id = auth_id)
+		alert_sound = 'sound/misc/announce.ogg'
+		switch(GLOB.security_level)
+			if(SEC_LEVEL_BLUE)
+				alert_sound = 'sound/misc/announce_dig.ogg'
+			if(SEC_LEVEL_RED)
+				alert_sound = 'sound/items/geiger/ext1.ogg'
+			if(SEC_LEVEL_DELTA)
+				alert_sound = 'sound/items/airhorn.ogg'  // why are you announcing on delta
+		priority_announce(html_decode(user.treat_message(input)), null, alert_sound, "Captain", has_important_message = TRUE, auth_id = auth_id)
 		nonsilicon_message_cooldown = world.time + COMMUNICATION_COOLDOWN
 	user.log_talk(input, LOG_SAY, tag="priority announcement")
 	message_admins("[ADMIN_LOOKUPFLW(user)] has made a priority announcement.")

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(communications)
 	else
 		. = TRUE
 
-/datum/controller/subsystem/communications/proc/make_announcement(mob/living/user, is_silicon, input, auth_id)
+/datum/controller/subsystem/communications/proc/make_announcement(mob/living/user, is_silicon, input, auth_id, sound_override = null)
 	if(!can_announce(user, is_silicon))
 		return FALSE
 	if(is_silicon)
@@ -26,11 +26,13 @@ SUBSYSTEM_DEF(communications)
 		var/alert_sound = 'sound/misc/announce.ogg'
 		switch(GLOB.security_level)
 			if(SEC_LEVEL_BLUE)
-				alert_sound = 'sound/misc/announce_dig.ogg'
+				alert_sound = 'sound/misc/announce_dig.ogg'  // suprised nobodys used this before
 			if(SEC_LEVEL_RED)
-				alert_sound = 'sound/items/geiger/ext1.ogg'
+				alert_sound = 'sound/misc/notice1.ogg'
 			if(SEC_LEVEL_DELTA)
-				alert_sound = 'sound/items/airhorn.ogg'  // why are you announcing on delta
+				alert_sound = 'sound/misc/bloblarm.ogg'  // why are you announcing on delta
+		if(sound_override)
+			alert_sound = sound_override  // admins can have a little fun, as a treat
 		priority_announce(html_decode(user.treat_message(input)), null, alert_sound, "Captain", has_important_message = TRUE, auth_id = auth_id)
 		nonsilicon_message_cooldown = world.time + COMMUNICATION_COOLDOWN
 	user.log_talk(input, LOG_SAY, tag="priority announcement")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Each sec level makes the captains announcer have a different noise
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives more attention to the announcement at higher seclevels
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/73374039/189497004-bd5e44f8-549c-4e40-9b3a-36658a31d3ac.mp4


</details>

## Changelog
:cl:
add: captains alert noise changes per sec level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
