### PR TITLE
Fix +1 traitor objectives

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -83,7 +83,7 @@
 			assign_exchange_role(SSticker.mode.exchange_blue)
 		objective_count += 1					//Exchange counts towards number of objectives
 	var/toa = CONFIG_GET(number/traitor_objectives_amount)
-	for(var/i = objective_count, i < toa, i++)
+	for(var/i = objective_count, i < toa - 1, i++)
 		forge_single_objective()
 
 	//Add a gimmick objective

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -244,7 +244,7 @@ SECURITY_SCALING_COEFF 10
 
 ## The number of objectives traitors get.
 ## Not including escaping/hijacking.
-TRAITOR_OBJECTIVES_AMOUNT 2
+TRAITOR_OBJECTIVES_AMOUNT 3
 BROTHER_OBJECTIVES_AMOUNT 2
 
 ## Uncomment to prohibit jobs that start with loyalty


### PR DESCRIPTION
## About The Pull Request

The last change was super patch-on and breaks martyr objectives completely. #7576 

The config needs to be updated. This for loop had `-1` so that space could be made for martyr objectives.

## Why It's Good For The Game

Fix bug

## Testing Photographs and Procedure

No visible changes.

## Changelog
:cl:
fix: Martyr/hijack objectives spawn properly again.
/:cl: