### PR TITLE
Dynamic: Lowpop tweaks - lower threat, max antag%

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -170,7 +170,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/latejoin_roll_chance = 50
 
 	/// The maximum percentage of (living antags / living players) can be before midround traitors, heretics, and all latejoins stop injecting while under "max_traitor_injection_max_pop" population.
-	var/max_traitor_injection_antag_percent = 18
+	var/max_traitor_injection_antag_percent = 10
 
 	/// The population size where dynamic stops caring about antag percents during injections. This is usually because on higher pop it isn't forced to spawn a bunch of sleeper agents.
 	var/max_traitor_injection_max_pop = 30
@@ -664,11 +664,13 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	return FALSE
 
 /datum/game_mode/dynamic/proc/check_lowpop_lowimpact_injection()
-	var/living_players_count = current_players[CURRENT_LIVING_PLAYERS]
-	var/living_antags_count = current_players[CURRENT_LIVING_ANTAGS]
-	if(living_players_count && living_players_count < max_traitor_injection_max_pop && (living_antags_count / living_players_count) * 100 > max_traitor_injection_antag_percent)
-		log_game("DYNAMIC: FAIL: [src] has too many living antags for the population ([living_antags_count] of [living_players_count] players)")
+	var/living_players_count = length(current_players[CURRENT_LIVING_PLAYERS])
+	var/antags_count = length(current_players[CURRENT_LIVING_ANTAGS])
+	var/antag_percent = living_players_count ? (living_antags_count / living_players_count) * 100 : 0
+	if(living_players_count && living_players_count < max_traitor_injection_max_pop && antag_percent > max_traitor_injection_antag_percent)
+		log_game("DYNAMIC: FAIL: [src] has too many living antags for the population ([living_antags_count] antags of [living_players_count] players - [antag_percent]%)")
 		return TRUE
+	log_game("DYNAMIC: [src] passed lowpop_lowimpact requirement: ([living_antags_count] antags of [living_players_count] players - [antag_percent]%)")
 	return FALSE
 
 /// Checks if client age is age or older.

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -169,6 +169,12 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// The chance for latejoins to roll when ready
 	var/latejoin_roll_chance = 50
 
+	/// The maximum percentage of (living antags / living players) can be before midround traitors, heretics, and all latejoins stop injecting while under "max_traitor_injection_max_pop" population.
+	var/max_traitor_injection_antag_percent = 18
+
+	/// The population size where dynamic stops caring about antag percents during injections. This is usually because on higher pop it isn't forced to spawn a bunch of sleeper agents.
+	var/max_traitor_injection_max_pop = 30
+
 	// == EVERYTHING BELOW THIS POINT SHOULD NOT BE CONFIGURED ==
 
 	/// A list of recorded "snapshots" of the round, stored in the dynamic.json log
@@ -655,6 +661,14 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				if(blocking == executed.type)
 					log_game("DYNAMIC: FAIL: check_blocking - [blocking] conflicts with [executed.type]")
 					return TRUE
+	return FALSE
+
+/datum/game_mode/dynamic/proc/check_lowpop_lowimpact_injection()
+	var/living_players_count = current_players[CURRENT_LIVING_PLAYERS]
+	var/living_antags_count = current_players[CURRENT_LIVING_ANTAGS]
+	if(living_players_count && living_players_count < max_traitor_injection_max_pop && (living_antags_count / living_players_count) * 100 > max_traitor_injection_antag_percent)
+		log_game("DYNAMIC: FAIL: [src] has too many living antags for the population ([living_antags_count] of [living_players_count] players)")
+		return TRUE
 	return FALSE
 
 /// Checks if client age is age or older.

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -170,7 +170,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/latejoin_roll_chance = 50
 
 	/// The maximum percentage of (living antags / living players) can be before midround traitors, heretics, and all latejoins stop injecting while under "max_traitor_injection_max_pop" population.
-	var/max_traitor_injection_antag_percent = 10
+	var/max_traitor_injection_antag_percent = 15
 
 	/// The population size where dynamic stops caring about antag percents during injections. This is usually because on higher pop it isn't forced to spawn a bunch of sleeper agents.
 	var/max_traitor_injection_max_pop = 30

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -665,7 +665,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 /datum/game_mode/dynamic/proc/check_lowpop_lowimpact_injection()
 	var/living_players_count = length(current_players[CURRENT_LIVING_PLAYERS])
-	var/antags_count = length(current_players[CURRENT_LIVING_ANTAGS])
+	var/living_antags_count = length(current_players[CURRENT_LIVING_ANTAGS])
 	var/antag_percent = living_players_count ? (living_antags_count / living_players_count) * 100 : 0
 	if(living_players_count && living_players_count < max_traitor_injection_max_pop && antag_percent > max_traitor_injection_antag_percent)
 		log_game("DYNAMIC: FAIL: [src] has too many living antags for the population ([living_antags_count] antags of [living_players_count] players - [antag_percent]%)")

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -175,11 +175,11 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	/// The chance for latejoins to roll when ready
 	var/latejoin_roll_chance = 50
 
-	/// The maximum percentage of (living antags / living players) can be before midround traitors, heretics, and all latejoins stop injecting while under "max_traitor_injection_max_pop" population.
-	var/max_traitor_injection_antag_percent = 15
+	/// The maximum percentage of (living antags / living players) can be before midround traitors, heretics, and all latejoins stop injecting while under "traitor_percentage_population_threshold" population.
+	var/lowpop_max_traitor_percentage = 15
 
 	/// The population size where dynamic stops caring about antag percents during injections. This is usually because on higher pop it isn't forced to spawn a bunch of sleeper agents.
-	var/max_traitor_injection_max_pop = 30
+	var/traitor_percentage_population_threshold = 30
 
 	// == EVERYTHING BELOW THIS POINT SHOULD NOT BE CONFIGURED ==
 
@@ -682,7 +682,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/living_players_count = length(current_players[CURRENT_LIVING_PLAYERS])
 	var/living_antags_count = length(current_players[CURRENT_LIVING_ANTAGS])
 	var/antag_percent = living_players_count ? (living_antags_count / living_players_count) * 100 : 0
-	if(living_players_count && living_players_count < max_traitor_injection_max_pop && antag_percent > max_traitor_injection_antag_percent)
+	if(living_players_count && living_players_count < traitor_percentage_population_threshold && antag_percent > lowpop_max_traitor_percentage)
 		log_game("DYNAMIC: FAIL: [src] has too many living antags for the population ([living_antags_count] antags of [living_players_count] players - [antag_percent]%)")
 		return TRUE
 	log_game("DYNAMIC: [src] passed lowpop_lowimpact requirement: ([living_antags_count] antags of [living_players_count] players - [antag_percent]%)")

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -389,8 +389,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/relative_threat = LORENTZ_DISTRIBUTION(threat_curve_centre, threat_curve_width)
 	threat_level = clamp(round(lorentz_to_amount(relative_threat), 0.1), 0, max_threat_level)
 
-	if (SSticker.totalPlayersReady < low_pop_player_threshold)
-		threat_level = min(threat_level, LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold))
+	if (roundstart_pop_ready < low_pop_player_threshold)
+		threat_level = min(threat_level, LERP(low_pop_maximum_threat, max_threat_level, roundstart_pop_ready / low_pop_player_threshold))
 
 	peaceful_percentage = round(LORENTZ_CUMULATIVE_DISTRIBUTION(relative_threat, threat_curve_centre, threat_curve_width), 0.01)*100
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -123,7 +123,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/threat_curve_width = 1.8
 
 	/// Population at which the threat curve center starts getting reduced by 'threat_curve_lowop_coeff' for every X players under the threshold.
-	var/threat_curve_centre_lowpop_reduction_threshold = 35
+	var/threat_curve_centre_lowpop_reduction_threshold = 30
 
 	/// The amount the threat curve centre is reduced for every player under 'threat_curve_centre_lowpop_reduction_threshold'
 	var/threat_curve_centre_lowpop_reduction_coeff = 1

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -45,6 +45,9 @@
 		log_game("DYNAMIC: FAIL: [src] is not ready, because there are not enough enemies: [required_enemies[threat]] needed, [job_check] found")
 		return FALSE
 
+	if (mode.check_lowpop_lowimpact_injection())
+		return FALSE
+
 	return ..()
 
 /datum/dynamic_ruleset/latejoin/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -210,6 +210,8 @@
 	if (required_candidates > length(living_players))
 		log_game("DYNAMIC: FAIL: [src] does not have enough candidates, using living_players ([required_candidates] needed, [living_players.len] found)")
 		return FALSE
+	if (mode.check_lowpop_lowimpact_injection())
+		return FALSE
 	return ..()
 
 /datum/dynamic_ruleset/midround/autotraitor/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -623,6 +623,8 @@
 /datum/dynamic_ruleset/midround/obsessed/ready(forced = FALSE)
 	if(!check_candidates())
 		return FALSE
+	if(mode.check_lowpop_lowimpact_injection())
+		return FALSE
 	return ..()
 
 /datum/dynamic_ruleset/midround/obsessed/execute()

--- a/code/game/gamemodes/dynamic/dynamic_simulations.dm
+++ b/code/game/gamemodes/dynamic/dynamic_simulations.dm
@@ -4,8 +4,9 @@
 	var/datum/dynamic_simulation_config/config
 	var/list/mock_candidates = list()
 
-/datum/dynamic_simulation/proc/initialize_gamemode(forced_threat)
+/datum/dynamic_simulation/proc/initialize_gamemode(forced_threat, roundstart_players)
 	gamemode = new
+	gamemode.roundstart_pop_ready = roundstart_players
 
 	if (forced_threat)
 		gamemode.create_threat(forced_threat)
@@ -42,7 +43,7 @@
 /datum/dynamic_simulation/proc/simulate(datum/dynamic_simulation_config/config)
 	src.config = config
 
-	initialize_gamemode(config.forced_threat_level)
+	initialize_gamemode(config.forced_threat_level, config.roundstart_players)
 	create_candidates(config.roundstart_players)
 	gamemode.pre_setup()
 


### PR DESCRIPTION
## About The Pull Request

Adds new options to dynamic.json's Dynamic section.

`lowpop_max_traitor_percentage`: The maximum percentage of (living antags / living players) can be before midround traitors, heretics, and all latejoins stop injecting while under "traitor_percentage_population_threshold" population.

Default 15%

`traitor_percentage_population_threshold`: The population size where dynamic stops caring about antag percents during injections. This is usually because on higher pop it isn't forced to spawn a bunch of sleeper agents.

Default 30

Basically, at <30 pop, if more than 15% of living players are antags, dynamic will NOT spawn sleepers or latejoin traitors/heretics.


`threat_curve_centre_lowpop_reduction_threshold`: Population at which the threat curve center starts getting reduced by 'threat_curve_lowop_coeff' for every X players under the threshold.

Default 30

`threat_curve_centre_lowpop_reduction_coeff`: The amount the threat curve centre is reduced for every player under 'threat_curve_centre_lowpop_reduction_threshold'

Default 1

Here is what the threat curve reduction looks like. Keep in mind this is the CENTER of the lorentz distribution, which I will include a pic of after.

![image](https://user-images.githubusercontent.com/10366817/190036792-bdea2b19-b964-4562-b8d4-449ff292a997.png)

Basically, the "middle ground" threat of 50 is reduced by 1 point for each population it goes down. This does NOT mean that lowpop will never get high threat, just that it's MORE LIKELY to get the middle ground threat, which is now lower.

![image](https://user-images.githubusercontent.com/10366817/190036510-f7d37f4a-aa14-4e7d-962f-0c3eb1069bb2.png)

## Why It's Good For The Game

Dynamic has been spamming sleepers at lowpop because it has nothing else to spend its threat on. Stahp it.

## Testing Photographs and Procedure

<details>
<summary>
Screenshots
</summary>

2 pop
![image](https://user-images.githubusercontent.com/10366817/191653709-6834037c-5b86-474c-b914-970203abdb85.png)

60 pop
![image](https://user-images.githubusercontent.com/10366817/191654103-1c11ab1f-083a-431e-8dad-f77a9ceeb696.png)

</details>

## Changelog
:cl:
balance: Dynamic will not spawn midround traitors, obsessed, or heretics at lowpop if over 15% of the living crew is antag.
balance: Dynamic's threat will now scale the center of the threat curve down by one threat for each player under 30 players readied at roundstart.
fix: Fixed dynamic simulation capping threat based on actual roundstart players ready instead of simulated players ready.
/:cl: