### PR TITLE
Modernises the box labour shuttle.

### DIFF
--- a/_maps/shuttles/labour/labour_box.dmm
+++ b/_maps/shuttles/labour/labour_box.dmm
@@ -62,15 +62,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
-"k" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/chair/fancy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/labor)
 "l" = (
 /obj/machinery/door/window/brigdoor/southleft{
 	req_one_access_txt = "2";
@@ -99,6 +90,9 @@
 	},
 /obj/structure/chair/fancy/shuttle{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
@@ -149,6 +143,7 @@
 /area/shuttle/labor)
 "x" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "A" = (
@@ -247,7 +242,7 @@ G
 b
 e
 h
-k
+n
 n
 o
 U

--- a/_maps/shuttles/labour/labour_box.dmm
+++ b/_maps/shuttles/labour/labour_box.dmm
@@ -65,12 +65,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
-"n" = (
-/obj/structure/chair/fancy/shuttle{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/labor)
 "o" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Labor Shuttle Airlock";
@@ -123,9 +117,6 @@
 	machinedir = 1;
 	pixel_x = -32
 	},
-/obj/structure/chair/fancy/shuttle{
-	dir = 4
-	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "s" = (
@@ -147,6 +138,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/chair/fancy/shuttle,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "B" = (
@@ -218,7 +210,7 @@ b
 c
 B
 j
-f
+j
 C
 p
 r
@@ -239,7 +231,7 @@ G
 b
 e
 g
-n
+f
 m
 o
 U

--- a/_maps/shuttles/labour/labour_box.dmm
+++ b/_maps/shuttles/labour/labour_box.dmm
@@ -7,37 +7,29 @@
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "c" = (
-/obj/machinery/computer/shuttle_flight/labor{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -31
 	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/machinery/computer/shuttle_flight/labor,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "d" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "e" = (
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "f" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "g" = (
-/obj/machinery/button/flasher{
-	id = "gulagshuttleflasher";
-	name = "Flash Control";
-	pixel_y = -26;
-	req_access_txt = "1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/light,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "h" = (
@@ -46,6 +38,9 @@
 	pixel_x = 30;
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "i" = (
@@ -53,57 +48,71 @@
 	name = "Labor Shuttle Airlock";
 	req_access_txt = "2"
 	},
-/turf/open/floor/plating,
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "j" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Labor Shuttle Airlock";
-	req_access_txt = "2"
-	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "k" = (
-/obj/machinery/mineral/stacking_machine/laborstacker{
-	input_dir = 2;
-	output_dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/labor)
-"l" = (
-/turf/open/floor/mineral/titanium,
-/area/shuttle/labor)
-"m" = (
 /obj/machinery/light{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/labor)
-"n" = (
-/obj/machinery/mineral/labor_claim_console{
-	machinedir = 1;
-	pixel_x = 30
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/labor)
-"o" = (
 /obj/structure/chair/fancy/shuttle{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "gulagshuttleflasher";
-	pixel_x = 25
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"l" = (
+/obj/machinery/door/window/brigdoor/southleft{
+	req_one_access_txt = "2";
+	name = "Prisoner Area"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"m" = (
+/obj/structure/closet/crate,
+/obj/item/storage/firstaid,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"n" = (
+/obj/structure/chair/fancy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"o" = (
+/obj/structure/window/reinforced{
+	pixel_y = 1
+	},
+/obj/structure/chair/fancy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "p" = (
-/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/mineral/labor_claim_console{
+	machinedir = 1;
+	pixel_x = -32
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "q" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "prisonshuttle";
-	name = "Labor Shuttle Airlock"
-	},
 /obj/docking_port/mobile{
 	dir = 8;
 	dwidth = 2;
@@ -113,39 +122,112 @@
 	port_direction = 4;
 	width = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/airlock/titanium{
+	id_tag = "prisonshuttle";
+	name = "Labor Shuttle Airlock"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "r" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "s" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating/airless,
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/labor)
+"v" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/labor)
+"x" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"A" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"B" = (
+/obj/structure/chair/fancy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/button/flasher{
+	id = "gulagshuttleflasher";
+	name = "Flash Control";
+	req_access_txt = "1";
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/labor)
+"C" = (
+/obj/machinery/mineral/stacking_machine/laborstacker{
+	input_dir = 2;
+	output_dir = 1;
+	pixel_x = -3
+	},
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/labor)
+"G" = (
+/obj/structure/shuttle/engine/propulsion{
+	pixel_y = -16
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/labor)
+"T" = (
+/obj/structure/shuttle/engine/heater{
+	pixel_y = -16
+	},
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/labor)
+"U" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/labor)
+"Y" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/flasher{
+	id = "gulagshuttleflasher";
+	pixel_x = 25
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 
 (1,1,1) = {"
 a
 a
-b
-a
 a
 b
-a
-a
-a
+b
+v
+v
+T
+G
 "}
 (2,1,1) = {"
 b
 c
-f
+B
 j
-l
-l
+m
+C
 p
 r
 s
@@ -154,12 +236,12 @@ s
 b
 d
 g
-a
-m
+f
+f
 l
-l
-r
-s
+A
+x
+G
 "}
 (4,1,1) = {"
 b
@@ -168,18 +250,18 @@ h
 k
 n
 o
-l
-r
+U
+Y
 s
 "}
 (5,1,1) = {"
 a
 a
 i
-a
-a
-a
+b
+b
+v
 q
-a
-a
+T
+G
 "}

--- a/_maps/shuttles/labour/labour_box.dmm
+++ b/_maps/shuttles/labour/labour_box.dmm
@@ -19,8 +19,7 @@
 /area/shuttle/labor)
 "e" = (
 /obj/structure/table,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
+/obj/item/storage/firstaid,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "f" = (
@@ -33,14 +32,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "h" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 2;
-	pixel_x = 30;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/light,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "i" = (
@@ -58,24 +50,19 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "j" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/labor)
-"l" = (
-/obj/machinery/door/window/brigdoor/southleft{
-	req_one_access_txt = "2";
-	name = "Prisoner Area"
+/obj/structure/chair/fancy/shuttle{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "m" = (
-/obj/structure/closet/crate,
-/obj/item/storage/firstaid,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
+/obj/machinery/button/flasher{
+	id = "gulagshuttleflasher";
+	name = "Flash Control";
+	req_access_txt = "1";
+	pixel_y = -22;
+	pixel_x = 22
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "n" = (
@@ -85,24 +72,23 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "o" = (
-/obj/structure/window/reinforced{
-	pixel_y = 1
+/obj/machinery/door/airlock/titanium{
+	name = "Labor Shuttle Airlock";
+	req_access_txt = "2"
 	},
-/obj/structure/chair/fancy/shuttle{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "p" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/mineral/labor_claim_console{
-	machinedir = 1;
-	pixel_x = -32
+/obj/machinery/mineral/stacking_machine/laborstacker{
+	input_dir = 2;
+	output_dir = 1
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
@@ -133,6 +119,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/mineral/labor_claim_console{
+	machinedir = 1;
+	pixel_x = -32
+	},
+/obj/structure/chair/fancy/shuttle{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "s" = (
@@ -144,6 +137,10 @@
 "x" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
+/obj/machinery/flasher{
+	id = "gulagshuttleflasher";
+	pixel_y = -25
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "A" = (
@@ -165,16 +162,20 @@
 	req_access_txt = "1";
 	pixel_x = -32
 	},
+/obj/structure/window/reinforced/spawner,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "C" = (
-/obj/machinery/mineral/stacking_machine/laborstacker{
-	input_dir = 2;
-	output_dir = 1;
-	pixel_x = -3
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 2;
+	pixel_x = -32
 	},
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "G" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -198,10 +199,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/flasher{
-	id = "gulagshuttleflasher";
-	pixel_x = 25
-	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 
@@ -221,7 +218,7 @@ b
 c
 B
 j
-m
+f
 C
 p
 r
@@ -232,8 +229,8 @@ b
 d
 g
 f
-f
-l
+h
+v
 A
 x
 G
@@ -241,9 +238,9 @@ G
 (4,1,1) = {"
 b
 e
-h
+g
 n
-n
+m
 o
 U
 Y


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've recently noticed that the box shuttle is really fucking old, either that or it's dumb. This pulls it out of the stone age with the following changes:
-Oxygen Tanks
-Small first aid station featuring a first aid kit, a bed&IV stand, and 4 random bloodbags
-Tinyfans, so that you can actually use it outside of just ferrying prisoners from lavaland.

The new layout is more generalised to support a wider variety of use-cases, now that supercruise is starting to come along in use. It has a larger general crew area, with a small 2x3 area for passengers/prisoners/cargo.
The windows are placed centrally on both sides, to function as provisional embrasures for officers shooting outside using lasers.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I've noticed that ever since supercruise came out, security has used their labourshuttle more as a general response vehicle than a ferry, this is fine and good on the newer shuttles, but box is just not designed to cope with it.

I'm also debating whether to put a recharger into it, but that might be too much.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/56017258/189801097-0872633a-b4b6-44d9-bc02-7177b7008b39.png)

</details>

## Changelog
:cl:
tweak: tweaked the box labour shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
