### PR TITLE
Fixes Signaller ModPC program issue

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -125,16 +125,27 @@
 		to_chat(user, "<span class='danger'>\The [computer] flashes an \"Access Denied\" warning.</span>")
 	return FALSE
 
-// This attempts to retrieve header data for UIs. If implementing completely new device of different type than existing ones
-// always include the device here in this proc. This proc basically relays the request to whatever is running the program.
+/**
+ * This attempts to retrieve header data for UIs.
+ *
+ * If implementing completely new device of different type than existing ones
+ * always include the device here in this proc. This proc basically relays the request to whatever is running the program.
+ **/
 /datum/computer_file/program/proc/get_header_data()
 	if(computer)
 		return computer.get_header_data()
 	return list()
 
-// This is performed on program startup. May be overridden to add extra logic. Remember to include ..() call. Return 1 on success, 0 on failure.
-// When implementing new program based device, use this to run the program.
+/**
+ * Called on program startup.
+ *
+ * May be overridden to add extra logic. Remember to include ..() call. Return 1 on success, 0 on failure.
+ * When implementing new program based device, use this to run the program.
+ * Arguments:
+ * * user - The mob that started the program
+ **/
 /datum/computer_file/program/proc/run_program(mob/living/user)
+	SHOULD_CALL_PARENT(TRUE)
 	if(can_run(user, 1))
 		if(requires_ntnet && network_destination)
 			generate_network_log("Connection opened to [network_destination].")
@@ -156,8 +167,15 @@
 /datum/computer_file/program/proc/run_emag()
 	return FALSE
 
-// Use this proc to kill the program. Designed to be implemented by each program if it requires on-quit logic, such as the NTNRC client.
+/**
+ * Kills the running program
+ *
+ * Use this proc to kill the program. Designed to be implemented by each program if it requires on-quit logic, such as the NTNRC client.
+ * Arguments:
+ * * forced - Boolean to determine if this was a forced close. Should be TRUE if the user did not willingly close the program.
+ **/
 /datum/computer_file/program/proc/kill_program(forced = FALSE)
+	SHOULD_CALL_PARENT(TRUE)
 	program_state = PROGRAM_STATE_KILLED
 	if(network_destination)
 		generate_network_log("Connection to [network_destination] closed.")

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -114,6 +114,8 @@
 
 /datum/computer_file/program/alarm_monitor/run_program(mob/user)
 	. = ..(user)
+	if(!.)
+		return
 	GLOB.alarmdisplay += src
 
 /datum/computer_file/program/alarm_monitor/kill_program(forced = FALSE)

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -16,9 +16,6 @@
 	var/assigned = FALSE
 	var/first_load = TRUE
 
-/datum/computer_file/program/contract_uplink/run_program(var/mob/living/user)
-	. = ..(user)
-
 /datum/computer_file/program/contract_uplink/ui_act(action, params)
 	if(..())
 		return TRUE

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -12,8 +12,10 @@
 	program_icon = "magnet"
 	var/armed = 0
 
-/datum/computer_file/program/revelation/run_program(var/mob/living/user)
-	. = ..(user)
+/datum/computer_file/program/revelation/run_program(mob/living/user)
+	. = ..()
+	if(!.)
+		return
 	if(armed)
 		activate()
 

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -34,6 +34,8 @@
 
 /datum/computer_file/program/ntnetdownload/run_program()
 	. = ..()
+	if(!.)
+		return
 	main_repo = SSnetworks.station_network.available_station_software
 	antag_repo = SSnetworks.station_network.available_antag_software
 
@@ -210,5 +212,7 @@
 
 /datum/computer_file/program/ntnetdownload/syndicate/run_program()
 	. = ..()
+	if(!.)
+		return
 	main_repo = SSnetworks.station_network.available_antag_software
 	antag_repo = null

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -28,6 +28,8 @@
 
 /datum/computer_file/program/power_monitor/run_program(mob/living/user)
 	. = ..(user)
+	if(!.)
+		return
 	search()
 	history["supply"] = list()
 	history["demand"] = list()

--- a/code/modules/modular_computers/file_system/programs/signaller.dm
+++ b/code/modules/modular_computers/file_system/programs/signaller.dm
@@ -15,17 +15,17 @@
 	/// Radio connection datum used by signallers.
 	var/datum/radio_frequency/radio_connection
 
-/datum/computer_file/program/signaller/New()
-	set_frequency(signal_frequency)
-	return ..()
-
 /datum/computer_file/program/signaller/run_program(mob/living/user)
 	. = ..()
 	if (!.)
 		return
+	set_frequency(signal_frequency)
 	if(!computer?.get_modular_computer_part(MC_SIGNALLER)) //Giving a clue to users why the program is spitting out zeros.
 		to_chat(user, "<span class='warning'>\The [computer] flashes an error: \"hardware\\signal_hardware\\startup.bin -- file not found\".</span>")
 
+/datum/computer_file/program/signaller/kill_program(forced)
+	. = ..()
+	SSradio.remove_object(computer, signal_frequency)
 
 /datum/computer_file/program/signaller/ui_data(mob/user)
 	var/list/data = get_header_data()

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -33,6 +33,8 @@
 
 /datum/computer_file/program/supermatter_monitor/run_program(mob/living/user)
 	. = ..(user)
+	if(!.)
+		return
 	if(!(active in GLOB.machines))
 		active = null
 	refresh()


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/69773

Also enforces parent checks in modpc's `run_program` and fixes some bad syntax.

## Why It's Good For The Game

I don't think we actually inherited this issue, but it's a needed change.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/190121003-a14dc1bd-d73a-49b8-a2cb-8ade6e604dff.png)

</details>

## Changelog
:cl:
code: Fixes an issue with the modular PC singaller app initializing its frequency too early.
code: Enforces parent proc calls in run_program
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
