### PR TITLE
Log admin supply pods

### DIFF
--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -800,9 +800,10 @@
 			whomString += "[key_name(M)], "
 
 	var/msg = "launched [podString] towards [whomString]"
-	var/full_msg = "[key_name_admin(usr)] [msg] in [ADMIN_VERBOSEJMP(specificTarget)]."
-	message_admins(full_msg)
-	log_game(full_msg)
+	var/full_msg_admins = "[key_name_admin(usr)] [msg] in [ADMIN_VERBOSEJMP(specificTarget)]."
+	var/full_msg_logs = "[key_name_admin(usr)] [msg] in [AREACOORD(specificTarget)]."
+	message_admins(full_msg_admins)
+	log_game(full_msg_logs)
 	if (length(whoDyin))
 		for (var/mob/living/M in whoDyin)
 			admin_ticket_log(M, "[key_name_admin(usr)] [msg]")

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -604,7 +604,7 @@
 			if (holder.holder)
 				supplypod_punish_log(bouttaDie)
 			else
-				var/msg = "[key_name_admin(user)] launched a supply pod at [COORD(get_turf(target))]."
+				var/msg = "[key_name_admin(user)] launched a supply pod at [AREACOORD(target)]"
 				message_admins(msg)
 				log_admin(msg)
 			if (!effectBurst) //If we're not using burst mode, just launch normally.

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -603,6 +603,10 @@
 				bouttaDie.Add(target_mob)
 			if (holder.holder)
 				supplypod_punish_log(bouttaDie)
+			else
+				var/msg = "[key_name_admin(user)] launched a supply pod at [COORD(get_turf(target))]."
+				message_admins(msg)
+				log_admin(msg)
 			if (!effectBurst) //If we're not using burst mode, just launch normally.
 				launch(target)
 			else
@@ -796,7 +800,9 @@
 			whomString += "[key_name(M)], "
 
 	var/msg = "launched [podString] towards [whomString]"
-	message_admins("[key_name_admin(usr)] [msg] in [ADMIN_VERBOSEJMP(specificTarget)].")
+	var/full_msg = "[key_name_admin(usr)] [msg] in [ADMIN_VERBOSEJMP(specificTarget)]."
+	message_admins(full_msg)
+	log_game(full_msg)
 	if (length(whoDyin))
 		for (var/mob/living/M in whoDyin)
 			admin_ticket_log(M, "[key_name_admin(usr)] [msg]")


### PR DESCRIPTION
well that's a real oversight

This is untested, have fun


## Changelog
:cl:
admin: Admin supply pod launches are now logged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
