### PR TITLE
Minor tweaks to Virology room + fixes windoor access requirement

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -33607,11 +33607,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "fkB" = (
-/obj/machinery/button/door{
-	id = "medpriv4";
-	name = "Privacy Shutters";
-	pixel_y = 25
-	},
 /obj/machinery/computer/pandemic,
 /obj/structure/sign/departments/minsky/medical/virology/virology1{
 	pixel_y = 29
@@ -39790,7 +39785,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Virology Desk";
-	req_access_txt = "20"
+	req_access_txt = "39"
 	},
 /obj/item/storage/box/masks,
 /obj/item/reagent_containers/syringe/antiviral{

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -7845,13 +7845,13 @@
 "bNp" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow{
-	pixel_y = 3;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/item/stamp/quartermaster{
-	pixel_y = -2;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -2
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -31911,7 +31911,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	name = "Virology Desk";
-	req_access_txt = "20"
+	req_access_txt = "39"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1514,7 +1514,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	name = "Virology Desk";
-	req_access_txt = "20"
+	req_access_txt = "39"
 	},
 /obj/item/reagent_containers/food/drinks/bottle/virusfood{
 	pixel_x = 2;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -37079,7 +37079,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Virology Desk";
-	req_access_txt = "20"
+	req_access_txt = "39"
 	},
 /obj/item/reagent_containers/glass/bottle/spaceacillin{
 	pixel_x = 9;
@@ -41337,6 +41337,9 @@
 "cHr" = (
 /obj/structure/bed/dogbed/vector,
 /mob/living/simple_animal/pet/hamster/vector,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "cHt" = (
@@ -69448,9 +69451,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pQJ" = (
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
 /obj/structure/sign/departments/minsky/medical/virology/virology1{
 	pixel_y = 32
 	},
@@ -82384,9 +82384,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xyY" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 28
-	},
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical1{
 	pixel_y = 32
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -49652,7 +49652,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Virology Desk";
-	req_access_txt = "20"
+	req_access_txt = "39"
 	},
 /obj/item/paper_bin{
 	pixel_x = -2;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #7448 

Meta : Removes Nanomed hidden under the virology poster inside of a wall. Fixes windoor ID access. Moves the lightswitch out from underneath a poster.
Box : Removes an old now unused privacy shutter button hiding under one of the posters. Fixes windoor ID access
Delta : Fixes windoor ID access
Pubby : Fixes windoor ID access
Corg : Fixes windoor ID access
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You shouldn't need Captain access to open the VIROLOGY windoor.
Also it makes no sense to hide stuff underneath posters.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

I'm really not sure what to put here. None of these changes are visible ones (except for the lightswitch on Meta moving 3 tiles).

</details>

## Changelog
:cl:
del: Removed hidden unused objects from Virology.
fix: Fixed virology windoor access, viro's now have access to their own windoor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
