### PR TITLE
Dynamic: Lower midround Xenos weight

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -386,10 +386,10 @@
 	antag_datum = /datum/antagonist/xeno
 	antag_flag = ROLE_ALIEN
 	enemy_roles = list(JOB_NAME_SECURITYOFFICER, JOB_NAME_DETECTIVE, JOB_NAME_WARDEN, JOB_NAME_HEADOFSECURITY, JOB_NAME_CAPTAIN)
-	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_enemies = list(2,2,2,1,1,1,1,0,0,0)
 	required_candidates = 1
 	minimum_round_time = 40 MINUTES
-	weight = 5
+	weight = 3
 	cost = 10
 	minimum_players = 25
 	repeatable = TRUE


### PR DESCRIPTION
## About The Pull Request

Lowers the weight to match blob and ?nightmare apparently?

Also tweaks required secoffs to two (from one) at the 20-30 threat range.

## Why It's Good For The Game

Xenos have been spawning too much. Plus it makes more sense to have more secoffs needed, since realistically one cannot stop an infestation well.

## Testing Photographs and Procedure

Not really testable.

## Changelog
:cl:
tweak: Midround xenos now have a lower weight and will occur less often.
tweak: At 20 to 30 threat, midround xenos require two security instead of one.
/:cl: