### PR TITLE
Allows non-welding tool welders to repair IPCs and prosthetics

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -686,6 +686,7 @@
 #include "code\datums\elements\firestacker.dm"
 #include "code\datums\elements\forced_gravity.dm"
 #include "code\datums\elements\item_scaling.dm"
+#include "code\datums\elements\mechanical_repair.dm"
 #include "code\datums\elements\rust.dm"
 #include "code\datums\elements\squish.dm"
 #include "code\datums\elements\strippable.dm"

--- a/code/datums/elements/mechanical_repair.dm
+++ b/code/datums/elements/mechanical_repair.dm
@@ -1,0 +1,46 @@
+// Handles repairing mechanical limbs on humans
+// Originally moved from cable coil/welder code
+
+/datum/element/mechanical_repair
+	element_flags = ELEMENT_DETACH
+
+/datum/element/mechanical_repair/Attach(datum/target)
+	. = ..()
+	if(!ishuman(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_PARENT_ATTACKBY, .proc/try_repair)
+
+/datum/element/mechanical_repair/Detach(datum/source, ...)
+	. = ..()
+	UnregisterSignal(source, COMSIG_PARENT_ATTACKBY)
+
+/datum/element/mechanical_repair/proc/try_repair(datum/source, obj/item/I, mob/user)
+	var/mob/living/carbon/human/target = source
+	var/obj/item/bodypart/affecting = target.get_bodypart(check_zone(user.zone_selected))
+
+	// Check to make sure we can repair
+	if((!affecting || (IS_ORGANIC_LIMB(affecting))) || user.a_intent == INTENT_HARM)
+		return
+
+	// Handles welder repairs on human limbs
+	if(I.tool_behaviour == TOOL_WELDER)
+		if(I.use_tool(source, user, 0, volume=50, amount=1))
+			if(user == target)
+				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [target == user ? "[p_their()]" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>",
+				"<span class='notice'>You start fixing some of the dents on [target == user ? "your" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>")
+				if(!do_mob(user, target, 50))
+					return
+			item_heal_robotic(target, user, 15, 0)
+			return COMPONENT_NO_AFTERATTACK // We managed to heal the limb
+
+	// Handles cable repairs
+	if(istype(I, /obj/item/stack/cable_coil))
+		var/obj/item/stack/cable_coil/coil = I
+		if(user == target)
+			user.visible_message("<span class='notice'>[user] starts to fix some of the burn wires in [target == user ? "[p_their()]" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>",
+			"<span class='notice'>You start fixing some of the burnt wires in [target == user ? "your" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>")
+			if(!do_mob(user, target, 50))
+				return
+		if(item_heal_robotic(target, user, 0, 15))
+			coil.use(1)
+		return COMPONENT_NO_AFTERATTACK

--- a/code/datums/elements/mechanical_repair.dm
+++ b/code/datums/elements/mechanical_repair.dm
@@ -22,16 +22,20 @@
 	if((!affecting || (IS_ORGANIC_LIMB(affecting))) || user.a_intent == INTENT_HARM)
 		return
 
+	if(target in user.do_afters)
+		return COMPONENT_NO_AFTERATTACK
+
 	// Handles welder repairs on human limbs
 	if(I.tool_behaviour == TOOL_WELDER)
 		if(I.use_tool(source, user, 0, volume=50, amount=1))
 			if(user == target)
 				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [target == user ? "[p_their()]" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>",
 				"<span class='notice'>You start fixing some of the dents on [target == user ? "your" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>")
-				if(!do_mob(user, target, 50))
-					return
-			item_heal_robotic(target, user, 15, 0)
+				if(!do_mob(user, target, 15))
+					return COMPONENT_NO_AFTERATTACK
+			item_heal_robotic(target, user, 15, 0, affecting)
 			return COMPONENT_NO_AFTERATTACK // We managed to heal the limb
+		return COMPONENT_NO_AFTERATTACK
 
 	// Handles cable repairs
 	if(istype(I, /obj/item/stack/cable_coil))
@@ -39,8 +43,8 @@
 		if(user == target)
 			user.visible_message("<span class='notice'>[user] starts to fix some of the burn wires in [target == user ? "[p_their()]" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>",
 			"<span class='notice'>You start fixing some of the burnt wires in [target == user ? "your" : "[target]'s"] [parse_zone(affecting.body_zone)].</span>")
-			if(!do_mob(user, target, 50))
-				return
-		if(item_heal_robotic(target, user, 0, 15))
-			coil.use(1)
+			if(!do_mob(user, target, 15))
+				return COMPONENT_NO_AFTERATTACK
+		if(coil.use(1))
+			item_heal_robotic(target, user, 0, 15, affecting)
 		return COMPONENT_NO_AFTERATTACK

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -107,25 +107,6 @@
 	dyn_explosion(T, plasmaAmount/5)//20 plasma in a standard welder has a 4 power explosion. no breaches, but enough to kill/dismember holder
 	qdel(src)
 
-/obj/item/weldingtool/attack(mob/living/carbon/human/H, mob/user)
-	if(!istype(H))
-		return ..()
-
-	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
-
-	if(affecting && (!IS_ORGANIC_LIMB(affecting)) && user.a_intent != INTENT_HARM)
-		if(src.use_tool(H, user, 0, volume=50, amount=1))
-			if(user == H)
-				if (H in user.do_afters) // one at a time
-					return
-				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [H]'s [parse_zone(affecting.body_zone)].</span>",
-					"<span class='notice'>You start fixing some of the dents on [H == user ? "your" : "[H]'s"] [parse_zone(affecting.body_zone)].</span>")
-				if(!do_mob(user, H, 15))
-					return
-			item_heal_robotic(H, user, 15, 0, affecting)
-	else
-		return ..()
-
 /obj/item/weldingtool/use_tool(atom/target, mob/living/user, delay, amount, volume, datum/callback/extra_checks)
 	target.add_overlay(GLOB.welding_sparks)
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -68,19 +68,6 @@
 			if((S.self_operable || user != src) && (user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM))
 				if(S.next_step(user,user.a_intent))
 					return TRUE
-
-	var/obj/item/bodypart/affecting = src.get_bodypart(check_zone(user.zone_selected))
-	// Handles welder repairs on carbon limbs (IPCs/prosthetics)
-	if(I.tool_behaviour == TOOL_WELDER && affecting && (!IS_ORGANIC_LIMB(affecting)) && user.a_intent != INTENT_HARM)
-		if(I.use_tool(src, user, 0, volume=50, amount=1))
-			if(user == src)
-				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [src]'s [parse_zone(affecting.body_zone)].</span>",
-				"<span class='notice'>You start fixing some of the dents on [src == user ? "your" : "[src]'s"] [parse_zone(affecting.body_zone)].</span>")
-				if(!do_mob(user, src, 50))
-					return
-			item_heal_robotic(src, user, 15, 0)
-			return TRUE // We managed to heal the limb
-
 	return ..()
 
 /mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -67,7 +67,21 @@
 		if(!(mobility_flags & MOBILITY_STAND) || !S.lying_required)
 			if((S.self_operable || user != src) && (user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM))
 				if(S.next_step(user,user.a_intent))
-					return 1
+					return TRUE
+
+	if(iscarbon(user))
+		var/obj/item/bodypart/affecting = src.get_bodypart(check_zone(user.zone_selected))
+		// Handles welder repairs on carbon limbs (IPCs/prosthetics)
+		if(I.tool_behaviour == TOOL_WELDER && affecting && (!IS_ORGANIC_LIMB(affecting)) && user.a_intent != INTENT_HARM)
+			if(I.use_tool(src, user, 0, volume=50, amount=1))
+				if(user == src)
+					user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [src]'s [parse_zone(affecting.body_zone)].</span>",
+					"<span class='notice'>You start fixing some of the dents on [src == user ? "your" : "[src]'s"] [parse_zone(affecting.body_zone)].</span>")
+					if(!do_mob(user, src, 50))
+						return
+				item_heal_robotic(src, user, 15, 0)
+				return TRUE // We managed to heal the limb
+
 	return ..()
 
 /mob/living/carbon/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -69,18 +69,17 @@
 				if(S.next_step(user,user.a_intent))
 					return TRUE
 
-	if(iscarbon(user))
-		var/obj/item/bodypart/affecting = src.get_bodypart(check_zone(user.zone_selected))
-		// Handles welder repairs on carbon limbs (IPCs/prosthetics)
-		if(I.tool_behaviour == TOOL_WELDER && affecting && (!IS_ORGANIC_LIMB(affecting)) && user.a_intent != INTENT_HARM)
-			if(I.use_tool(src, user, 0, volume=50, amount=1))
-				if(user == src)
-					user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [src]'s [parse_zone(affecting.body_zone)].</span>",
-					"<span class='notice'>You start fixing some of the dents on [src == user ? "your" : "[src]'s"] [parse_zone(affecting.body_zone)].</span>")
-					if(!do_mob(user, src, 50))
-						return
-				item_heal_robotic(src, user, 15, 0)
-				return TRUE // We managed to heal the limb
+	var/obj/item/bodypart/affecting = src.get_bodypart(check_zone(user.zone_selected))
+	// Handles welder repairs on carbon limbs (IPCs/prosthetics)
+	if(I.tool_behaviour == TOOL_WELDER && affecting && (!IS_ORGANIC_LIMB(affecting)) && user.a_intent != INTENT_HARM)
+		if(I.use_tool(src, user, 0, volume=50, amount=1))
+			if(user == src)
+				user.visible_message("<span class='notice'>[user] starts to fix some of the dents on [src]'s [parse_zone(affecting.body_zone)].</span>",
+				"<span class='notice'>You start fixing some of the dents on [src == user ? "your" : "[src]'s"] [parse_zone(affecting.body_zone)].</span>")
+				if(!do_mob(user, src, 50))
+					return
+			item_heal_robotic(src, user, 15, 0)
+			return TRUE // We managed to heal the limb
 
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -35,6 +35,7 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	AddElement(/datum/element/strippable, GLOB.strippable_human_items, /mob/living/carbon/human/.proc/should_strip, GLOB.strippable_human_layout)
+	AddElement(/datum/element/mechanical_repair)
 
 /mob/living/carbon/human/proc/setup_human_dna()
 	//initialize dna. for spawned humans; overwritten by other code

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -540,27 +540,6 @@ GLOBAL_LIST_INIT(cable_coil_recipes, list (new/datum/stack_recipe("cable restrai
 // General procedures
 ///////////////////////////////////
 
-
-//you can use wires to heal robotics
-/obj/item/stack/cable_coil/attack(mob/living/carbon/human/H, mob/user)
-	if(!istype(H))
-		return ..()
-
-	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
-	if(affecting && (!IS_ORGANIC_LIMB(affecting)))
-		if(user == H)
-			if (H in user.do_afters) // one at a time
-				return
-			user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [parse_zone(affecting.body_zone)].</span>", "<span class='notice'>You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [parse_zone(affecting.body_zone)].</span>")
-			if(!do_mob(user, H, 15))
-				return
-		if(item_heal_robotic(H, user, 0, 15, affecting))
-			use(1)
-		return
-	else
-		return ..()
-
-
 /obj/item/stack/cable_coil/update_icon()
 	icon_state = "[initial(item_state)][amount < 3 ? amount : ""]"
 	name = "cable [amount < 3 ? "piece" : "coil"]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This changes welding carbons to be handled by an element, and not the welding tool, allowing things with the welding tool tool behavior to repair mechanical limbs. It also moves cable repairs to said element as well.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Accidentally delimbing IPCs with a plasma cutter sucks.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/9423435/191390413-21665072-5158-45d9-a004-f33366a95d4a.mp4


</details>

## Changelog
:cl:
fix: Repairing prosthetic limbs with non-welding tool welders works now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
