### PR TITLE
[PORT] Fixes an oversight that allowed the Supply Shuttle to sell the electronics contained in its buttons

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -236,8 +236,6 @@ GLOBAL_LIST_INIT(heavyfootmob, typecacheof(list(
 
 #define ismachinery(A) (istype(A, /obj/machinery))
 
-#define isbutton(A) (istype(A, /obj/machinery/button))
-
 #define ismecha(A) (istype(A, /obj/mecha))
 
 #define is_cleanable(A) (istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/rune)) //if something is cleanable

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -236,6 +236,8 @@ GLOBAL_LIST_INIT(heavyfootmob, typecacheof(list(
 
 #define ismachinery(A) (istype(A, /obj/machinery))
 
+#define isbutton(A) (istype(A, /obj/machinery/button))
+
 #define ismecha(A) (istype(A, /obj/mecha))
 
 #define is_cleanable(A) (istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/rune)) //if something is cleanable

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -177,7 +177,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	for(var/place in shuttle_areas)
 		var/area/shuttle/shuttle_area = place
 		for(var/atom/movable/AM in shuttle_area)
-			if(iscameramob(AM))
+			if(iscameramob(AM) || isbutton(AM))
 				continue
 			if(bounty_ship_item_and_contents(AM, dry_run = FALSE))
 				matched_bounty = TRUE

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -177,13 +177,13 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	for(var/place in shuttle_areas)
 		var/area/shuttle/shuttle_area = place
 		for(var/atom/movable/AM in shuttle_area)
-			if(iscameramob(AM) || isbutton(AM))
+			if(iscameramob(AM))
 				continue
 			if(bounty_ship_item_and_contents(AM, dry_run = FALSE))
 				matched_bounty = TRUE
 			if(!AM.anchored || istype(AM, /obj/mecha))
 				export_item_and_contents(AM, export_categories , dry_run = FALSE, external_report = ex)
-			else
+			else if(!ismachinery(AM))
 				//Exports the contents of things but not the item itself, so you can have conveyor belt that won't get sold
 				export_contents(AM, export_categories , dry_run = FALSE, external_report = ex)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pulls a PR from downstream: [#2070](https://github.com/BeeStation/NSV13/pull/2070)

This fixes an oversight made during this PR: [#2412](https://github.com/BeeStation/BeeStation-Hornet/pull/2412)

The oversight allowed the supply shuttle to sell the blast door electronics contained inside its own buttons. 

Addendum: This PR now makes the cargo shuttle not sell the contents of any machines that are anchored

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents the supply shuttle shutters from becoming inoperable by having their buttons electronics sold.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
fix: Fixed an oversight, now buttons inside shuttles no longer have their electronics sold!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
