### PR TITLE
Replaces the bluespace trash bag with a dish drive styled varient

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -147,15 +147,12 @@
 		return
 	var/obj/machinery/disposal/bin/bin = locate() in view(7, src.loc)
 	if(!bin)
-		to_chat(world, "no bin")  // DEBUG
 		return
 	var/disposed = 0
 	for(var/obj/item/I in contents)
-		to_chat(world, I)  // DEBUG
 		I.forceMove(bin)
 		disposed++
 	if (disposed)
-		to_chat(world, "beam stuff")  // DEBUG
 		visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams [disposed] stored item\s into the nearby [bin.name].</span>")
 		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 		playsound(bin, 'sound/items/pshoom.ogg', 50, TRUE)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -116,6 +116,7 @@
 /obj/item/storage/bag/trash/beam
 	name = "Trash Drive"
 	desc = "The power of a dish drive, shoved into a trash bag."
+	w_class = WEIGHT_CLASS_NORMAL  // its not a real trashbag
 	var/fire_every = 2 MINUTES  /// how often the bag will try to fire trash
 	COOLDOWN_DECLARE(time_to_next_beam)
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -113,6 +113,29 @@
 /obj/item/storage/bag/trash/bluespace/cyborg
 	insertable = FALSE
 
+/obj/item/storage/bag/trash/beam
+	name = "Trash Drive"
+	desc = "The power of a dish drive, shoved into a trash bag."
+	var/fire_every = 2 MINUTES  /// how often the bag will try to fire trash
+	var/auto_empty_full = TRUE  /// if set, will automatically attempt to fire when reaching capacity
+
+/obj/item/storage/bag/trash/beam/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_TRY_STORAGE_INSERT, .proc/try_empty_full)
+
+/obj/item/storage/bag/trash/beam/proc/try_empty_full(datum/source, obj/item/I, mob/M)
+	SIGNAL_HANDLER
+
+	if(!auto_empty_full)
+		return
+	if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_CAN_INSERT, I, M))  // if the bag is (close to) full
+		if(!dump_it())
+			to_chat(M, "<span class='warning'>The [src] cannot locate a nearby trashcan, and is\
+			past the maximum storage amount. Please empty manually for continued use.</span>")
+
+/obj/item/storage/bag/trash/beam/proc/dump_it(manual)  // dumpeet
+	return  // placeholder
+
 // -----------------------------
 //        Mining Satchel
 // -----------------------------

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -150,7 +150,7 @@
 		trashitem.forceMove(bin)
 		disposed++
 	if (disposed)
-		visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams [disposed] stored item\s into the nearby [bin.name].</span>")
+		visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams [disposed] stored item\s into the nearby [bin].</span>")
 		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 		playsound(bin, 'sound/items/pshoom.ogg', 50, TRUE)
 		Beam(bin, icon_state = "rped_upgrade", time = 5)

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -117,19 +117,16 @@
 	name = "Trash Drive"
 	desc = "The power of a dish drive, shoved into a trash bag."
 	w_class = WEIGHT_CLASS_NORMAL  // its not a real trashbag
-	var/fire_every = 2 MINUTES  /// how often the bag will try to fire trash
+	/// how often the bag will try to fire trash
+	var/fire_every = 2 MINUTES
 	COOLDOWN_DECLARE(time_to_next_beam)
-
-/obj/item/storage/bag/trash/beam/New()
-	. = ..()
-	START_PROCESSING(SSobj, src)
 
 /obj/item/storage/bag/trash/beam/Initialize(mapload)
 	. = ..()
+	START_PROCESSING(SSobj, src)
 	COOLDOWN_START(src, time_to_next_beam, fire_every)
 
 /obj/item/storage/bag/trash/beam/process(delta_time)
-	to_chat(world, "proccessing")
 	if(COOLDOWN_FINISHED(src, time_to_next_beam))
 		dump_it()
 
@@ -143,14 +140,14 @@
 
 /// the meat of the bag, returns false if it couldnt run properly
 /obj/item/storage/bag/trash/beam/proc/dump_it()  // dumpeet
-	if(!contents.len)
+	if(!length(contents))
 		return
-	var/obj/machinery/disposal/bin/bin = locate() in view(7, src.loc)
+	var/obj/machinery/disposal/bin/bin = locate() in view(7, get_turf(src))
 	if(!bin)
 		return
 	var/disposed = 0
-	for(var/obj/item/I in contents)
-		I.forceMove(bin)
+	for(var/obj/item/trashitem in contents)
+		trashitem.forceMove(bin)
 		disposed++
 	if (disposed)
 		visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams [disposed] stored item\s into the nearby [bin.name].</span>")

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -118,10 +118,17 @@
 	desc = "The power of a dish drive, shoved into a trash bag."
 	var/fire_every = 2 MINUTES  /// how often the bag will try to fire trash
 	var/auto_empty_full = TRUE  /// if set, will automatically attempt to fire when reaching capacity
+	COOLDOWN_DECLARE(time_to_next_beam)
 
 /obj/item/storage/bag/trash/beam/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_TRY_STORAGE_INSERT, .proc/try_empty_full)
+	COOLDOWN_START(src, time_to_next_beam, fire_every)
+	START_PROCESSING(src)
+
+/obj/item/storage/bag/trash/beam/process(delta_time)
+	if(COOLDOWN_FINISHED(src, time_to_next_beam))
+		dump_it()
 
 /obj/item/storage/bag/trash/beam/proc/try_empty_full(datum/source, obj/item/I, mob/M)
 	SIGNAL_HANDLER
@@ -130,11 +137,37 @@
 		return
 	if(!SEND_SIGNAL(src, COMSIG_TRY_STORAGE_CAN_INSERT, I, M))  // if the bag is (close to) full
 		if(!dump_it())
-			to_chat(M, "<span class='warning'>The [src] cannot locate a nearby trashcan, and is\
+			to_chat(M, "<span class='warning'>\The [src] cannot locate a nearby trashcan, and is\
 			past the maximum storage amount. Please empty manually for continued use.</span>")
 
-/obj/item/storage/bag/trash/beam/proc/dump_it(manual)  // dumpeet
-	return  // placeholder
+/obj/item/storage/bag/trash/beam/AltClick(mob/user)
+	. = ..()
+	if(!dump_it())
+		to_chat(user, "<span class='warning'>\The [src] cannot beam items. Please try again later.")
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
+	COOLDOWN_START(time_to_next_beam, fire_every)  // overrides the default cooldown
+
+/// the meat of the bag, returns false if it couldnt run properly
+/obj/item/storage/bag/trash/beam/proc/dump_it()  // dumpeet
+	if(!contents.len)
+		return
+	var/obj/machinery/disposal/bin/bin = locate() in view(7, src)
+	if(!bin)
+		return
+	var/disposed = 0
+	for(var/obj/item/I in contents)
+		if(is_type_in_list(I, disposable_items))
+			I.forceMove(bin)
+			disposed++
+	if (disposed)
+		visible_message("<span class='notice'>[src] [pick("whooshes", "bwooms", "fwooms", "pshooms")] and beams [disposed] stored item\s into the nearby [bin.name].</span>")
+		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
+		playsound(bin, 'sound/items/pshoom.ogg', 50, TRUE)
+		Beam(bin, icon_state = "rped_upgrade", time = 5)
+		bin.update_icon()
+		COOLDOWN_START(time_to_next_beam, fire_every)
+		return TRUE
+	COOLDOWN_START(time_to_next_beam, fire_every / 2)  // makes it fire more often on failing
 
 // -----------------------------
 //        Mining Satchel

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -5,10 +5,10 @@
 	wanted_types = list(/obj/item/storage/backpack/holding)
 
 /datum/bounty/item/science/tboh
-	name = "Trash Bag of Holding"
-	description = "Nanotrasen would make good use of high-capacity trash bags. If you have any, please ship them."
+	name = "Trash Driver"
+	description = "Nanotrasen would make good use of energy beaming trash bags. If you have any, please ship them."
 	reward = 10000
-	wanted_types = list(/obj/item/storage/bag/trash/bluespace)
+	wanted_types = list(/obj/item/storage/bag/trash/beam)
 
 /datum/bounty/item/science/bluespace_syringe
 	name = "Bluespace Syringe"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -268,7 +268,7 @@
 	belt = /obj/item/storage/belt/janitor/full
 	r_pocket = /obj/item/grenade/chem_grenade/cleaner
 	l_pocket = /obj/item/grenade/chem_grenade/cleaner
-	l_hand = /obj/item/storage/bag/trash/bluespace
+	l_hand = /obj/item/storage/bag/trash/beam
 	backpack_contents = list(/obj/item/storage/box/engineer=1,
 		/obj/item/storage/box/lights/mixed=1,
 		/obj/item/melee/baton/loaded=1,

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -286,7 +286,7 @@
 	id = "blutrash"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/gold = 1500, /datum/material/uranium = 250, /datum/material/plasma = 1500)
-	build_path = /obj/item/storage/bag/trash/bea,
+	build_path = /obj/item/storage/bag/trash/beam
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -281,12 +281,12 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/blutrash
-	name = "Trashbag of Holding"
-	desc = "An advanced trash bag with bluespace properties; capable of holding a plethora of garbage."
+	name = "Trash Driver"
+	desc = "An advanced trash bag with bluespace properties; capable of holding trash as energy and beaming it away."
 	id = "blutrash"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/gold = 1500, /datum/material/uranium = 250, /datum/material/plasma = 1500)
-	build_path = /obj/item/storage/bag/trash/bluespace
+	build_path = /obj/item/storage/bag/trash/bea,
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
# IM BACK BABY

## About The Pull Request
Replaces the bluespace trash bag with one that works similar to the dish drive.

How it works:
Every 2 minutes (or manually with alt click), the bag will look for nearby bins and dump all the trash into it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The current bluespace bag is boring, having an extended storage may be nice, but this implementation is more generally useful. Being able to snap all your garbage into a can without having to stop, pull out the bag, and dump it manually is very handy for janitors, and encourages the janitor to walk by/clean in more populated areas, giving more rp opprotunities
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/192081015-8f8a4b97-11a6-4e21-99f1-6735b7436ff8.png)
![image](https://user-images.githubusercontent.com/73374039/192081028-c8ab3dda-4514-45d4-800d-5af7e12e5ab9.png)


</details>

## Changelog
:cl:
add: Trash Dish Driver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
