### PR TITLE
Fix runtime with MedHUD SSD indicator

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -113,7 +113,8 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	if (isturf(T))
 		update_z(T.z)
 	// Update SSD indicator for ghost's body
-	mind?.current?.med_hud_set_status()
+	if(isliving(mind?.current))
+		mind.current.med_hud_set_status()
 
 /mob/dead/auto_deadmin_on_login()
 	return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -163,7 +163,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
 /mob/dead/observer/Destroy()
 	// Update medhud on their body (soul departed?)
-	if(mind?.current)
+	if(isliving(mind?.current))
 		addtimer(CALLBACK(mind.current, /mob/living.proc/med_hud_set_status), 1 SECONDS)
 	if(data_huds_on)
 		remove_data_huds()
@@ -383,7 +383,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 
 	can_reenter_corpse = FALSE
-	mind?.current?.med_hud_set_status()
+	if(isliving(mind?.current))
+		mind.current.med_hud_set_status()
 	to_chat(src, "You can no longer be brought back into your body.")
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

It runtimes whenever someone joins. This is bad. Now it checks the type.

From #7672

## Why It's Good For The Game

Fix bug

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/192639165-e27bf722-d196-4577-869f-f90821b028f2.png)

</details>

## Changelog
:cl:
fix: Fixed a runtime with medhud SSD indicators whenever a player joined or left.
/:cl:
