### PR TITLE
Adds the science glasses and the diagnostic HUD to Research Director's locker.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -8,11 +8,8 @@
 	new /obj/item/storage/box/suitbox/rd(src)
 	new /obj/item/clothing/suit/armor/reactive/teleport(src)
 	new /obj/item/clothing/suit/toggle/labcoat/research_director(src)
-	new /obj/item/clothing/gloves/color/latex(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/radio/headset/heads/research_director(src)
-	new /obj/item/clothing/glasses/hud/diagnostic(src)
-	new /obj/item/clothing/glasses/science(src)
 
 	new /obj/item/clothing/suit/bio_suit/scientist(src)
 	new /obj/item/clothing/head/bio_hood/scientist(src)
@@ -33,6 +30,9 @@
 	// prioritized items
 	new /obj/item/card/id/departmental_budget/sci(src)
 	new /obj/item/clothing/neck/cloak/rd(src)
+	new /obj/item/clothing/gloves/color/latex(src)
+	new /obj/item/clothing/glasses/hud/diagnostic(src)
+	new /obj/item/clothing/glasses/science(src)
 	new /obj/item/door_remote/research_director(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/gun/energy/e_gun/mini/heads(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -11,6 +11,8 @@
 	new /obj/item/clothing/gloves/color/latex(src)
 	new /obj/item/clothing/mask/gas(src)
 	new /obj/item/radio/headset/heads/research_director(src)
+	new /obj/item/clothing/glasses/hud/diagnostic(src)
+	new /obj/item/clothing/glasses/science(src)
 
 	new /obj/item/clothing/suit/bio_suit/scientist(src)
 	new /obj/item/clothing/head/bio_hood/scientist(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds both the science glasses and the diagnostic HUD to RD's personal locker. Also a redo of https://github.com/BeeStation/BeeStation-Hornet/pull/7726 because I needed to clean up my files and accidentally deleted everything related to it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Kind of odd how the Head of a department needs to go scouring through his department to get the proper equipment. Doubly odd when all the other Heads get their relative glasses in their lockers. So, this fixes that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/110184118/193088848-3f68cc63-0673-4c68-a835-69d2ec63af08.png)

</details>

## Changelog
:cl:
add: Added the Science Glasses to RD's locker
add: Added the Diagnostic HUD to RD's locker
/:cl: