### PR TITLE
Lowers the default movement speed, removes outdated movedelay

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -295,28 +295,6 @@
 /datum/config_entry/number/movedelay/walk_delay
 	integer = FALSE
 
-/////////////////////////////////////////////////Outdated move delay
-/datum/config_entry/number/outdated_movedelay
-	deprecated_by = /datum/config_entry/keyed_list/multiplicative_movespeed
-	abstract_type = /datum/config_entry/number/outdated_movedelay
-	integer = FALSE
-	var/movedelay_type
-
-/datum/config_entry/number/outdated_movedelay/DeprecationUpdate(value)
-	return "[movedelay_type] [value]"
-
-/datum/config_entry/number/outdated_movedelay/human_delay
-	movedelay_type = /mob/living/carbon/human
-/datum/config_entry/number/outdated_movedelay/robot_delay
-	movedelay_type = /mob/living/silicon/robot
-/datum/config_entry/number/outdated_movedelay/monkey_delay
-	movedelay_type = /mob/living/carbon/monkey
-/datum/config_entry/number/outdated_movedelay/alien_delay
-	movedelay_type = /mob/living/carbon/alien
-/datum/config_entry/number/outdated_movedelay/slime_delay
-	movedelay_type = /mob/living/simple_animal/slime
-/datum/config_entry/number/outdated_movedelay/animal_delay
-	movedelay_type = /mob/living/simple_animal
 /////////////////////////////////////////////////
 
 /datum/config_entry/flag/virtual_reality	//Will virtual reality be loaded

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -40,8 +40,8 @@ BADGES
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 1.5
-WALK_DELAY 3
+RUN_DELAY 2
+WALK_DELAY 3.5
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Decreases the run and walking speeds.

Run delay is from 1.5 to 2
Walk delay is from 3 to 3.5

Running now covers 5 tiles per second as opposed to 6.7 tiles per second.
Walking now covers 2.9 tiles per second as opposed to 3.3 tiles per second.

It's a slight decrease, might lower it more in the future.

## Why It's Good For The Game

Decreasing the move speed has several effects:
 - Response times across the station are slightly lowered. Calling for help or for security's precense will have a slightly increased delay before the swarms arrive to capture you.
 - Players are slightly slower in general, making it easier to react to someone moving near you.
 - The skill ceiling of combat will be slightly lowered, clicking on someone during combat will be easier and making insane evasive manouvers won't be quite as powerful. I don't expect this to make an enourmous difference, however its a step in the right direction to more roleplay oriented combat, as opposed to a highly competetive, high skill-ceiling oriented combat system.

The main reason the move speed has historically been so high has been due to combat, however as we progress towards a more roleplay oriented server, it doesn't make sense to keep in features which encourage high-skill ceiling competetive play. (The choice to strip out all randomness from combat was a mistake, except for the random instant wins)

## Testing Photographs and Procedure

Just editted the config entry on sage via varedit

https://user-images.githubusercontent.com/26465327/193307986-0b24f6ec-5474-4e9e-ac48-a93ac0d53bd6.mp4

## Changelog
:cl:
config: The default walk and run speed has been decreased by 0.5.
config: The depreciated config option, outdated_movedelay, has been removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
