### PR TITLE
Fixes the Meson goggles no longer protecting you from SM hallucinations if you drop a second pair while wearing them.

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -72,9 +72,12 @@
 
 /obj/item/clothing/glasses/meson/dropped(mob/living/carbon/human/user)
 	..()
-	if(!ishuman(user) || user.glasses != src)
-		return
-	REMOVE_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)
+	if(ishuman(user))
+       var/mob/living/carbon/human/H = user
+       if(H.glasses != src)
+             return
+		else
+			REMOVE_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)
 
 /obj/item/clothing/glasses/meson/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is putting \the [src] to [user.p_their()] eyes and overloading the brightness! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -71,7 +71,7 @@
 		ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)
 
 /obj/item/clothing/glasses/meson/dropped(mob/living/carbon/human/user)
-	. = ..()
+	..()
 	if(!ishuman(user) || user.glasses != src)
 		return
 	REMOVE_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -73,9 +73,9 @@
 /obj/item/clothing/glasses/meson/dropped(mob/living/carbon/human/user)
 	..()
 	if(ishuman(user))
-    	var/mob/living/carbon/human/H = user
-    	if(H.glasses != src)
-        	return
+		var/mob/living/carbon/human/H = user
+		if(H.glasses != src)
+			return
 		else
 			REMOVE_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)
 

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -73,9 +73,9 @@
 /obj/item/clothing/glasses/meson/dropped(mob/living/carbon/human/user)
 	..()
 	if(ishuman(user))
-       var/mob/living/carbon/human/H = user
-       if(H.glasses != src)
-             return
+    	var/mob/living/carbon/human/H = user
+    	if(H.glasses != src)
+        	return
 		else
 			REMOVE_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)
 

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -70,8 +70,10 @@
 	if(ishuman(user) && slot == ITEM_SLOT_EYES)
 		ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)
 
-/obj/item/clothing/glasses/meson/dropped(mob/user)
+/obj/item/clothing/glasses/meson/dropped(mob/living/carbon/human/user)
 	. = ..()
+	if(!ishuman(user) || user.glasses != src)
+		return
 	REMOVE_TRAIT(user, TRAIT_MADNESS_IMMUNE, CLOTHING_TRAIT)
 
 /obj/item/clothing/glasses/meson/suicide_act(mob/living/carbon/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a small issue that makes you no longer immune to the SM hallucinations if you drop a second pair of meson goggles while wearing then.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency good. Also closes https://github.com/BeeStation/BeeStation-Hornet/issues/7734
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Dropped a second pair and nothing happened :

![image](https://user-images.githubusercontent.com/110184118/193408000-c344b33a-f6d8-488f-a224-ff7606beeda1.png)
Dropped the ones I was wearing : 

![image](https://user-images.githubusercontent.com/110184118/193408025-94914c6c-028c-4e25-a66a-c2b89191501d.png)

</details>

## Changelog
:cl:
fix: Fixed meson goggles no longer giving you SM hallucination immunity if you dropped a second pair of mesons while wearing them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
