### PR TITLE
Moves the Laser gun cargo supply crate from the Security section to Armory section

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -367,16 +367,6 @@
 					/obj/item/clothing/head/fedora/det_hat)
 	crate_name = "forensics crate"
 
-/datum/supply_pack/security/laser
-	name = "Lasers Crate"
-	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
-	cost = 1800
-	access_budget = ACCESS_ARMORY
-	contains = list(/obj/item/gun/energy/laser,
-					/obj/item/gun/energy/laser,
-					/obj/item/gun/energy/laser)
-	crate_name = "laser crate"
-
 /datum/supply_pack/security/match
 	name = ".38 Match Grade Speedloader"
 	desc = "Contains one speedloader of match grade .38 ammunition, perfect for showing off trickshots. Requires Security or Forensics access to open."
@@ -616,6 +606,15 @@
 					/obj/item/gun/energy/e_gun)
 	crate_name = "bulk energy guns crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
+
+/datum/supply_pack/security/armory/laser
+	name = "Lasers Crate"
+	desc = "Contains three lethal, high-energy laser guns. Requires Armory access to open."
+	cost = 1800
+	contains = list(/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser)
+	crate_name = "laser crate"
 
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply moves the Laser Crate from the Security section to Armory section with proper access modifications.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sec being able to order lethal laser weapons without requiring the Warden or HoS to open them is dumb. Also is inconsistent as all the other crates with lethal weaponry are located in the Armory section and require Armory access to open. Also closes https://github.com/BeeStation/BeeStation-Hornet/issues/7003
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Lasers crate being in the Armory section

![image](https://user-images.githubusercontent.com/110184118/193426964-e140be0b-b64b-409e-992e-da282bdd2242.png)

Secoffs can't open it :
![image](https://user-images.githubusercontent.com/110184118/193427016-abc4433c-30ce-408b-a54e-86de357688e5.png)

Warden can :
![image](https://user-images.githubusercontent.com/110184118/193427032-eb64b63b-6b2a-4b2d-bd87-78b913399bf2.png)


</details>

## Changelog
:cl:
tweak: Moved the Laser Crate from the Security to Armory section of supplies
/:cl: