### PR TITLE
Laser crates from cargo are now in the right section (and also the option to buy singular laser guns)

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -344,16 +344,6 @@
 					/obj/item/gun/energy/disabler)
 	crate_name = "disabler crate"
 
-/datum/supply_pack/security/dumdum
-	name = ".38 DumDum Speedloader"
-	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets. Requires Security or Forensics access to open."
-	cost = 1200
-	access = FALSE
-	small_item = TRUE
-	access_any = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
-	contains = list(/obj/item/ammo_box/c38/dumdum)
-	crate_name = ".38 match crate"
-
 /datum/supply_pack/security/forensics
 	name = "Forensics Crate"
 	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."
@@ -366,6 +356,16 @@
 					/obj/item/toy/crayon/white,
 					/obj/item/clothing/head/fedora/det_hat)
 	crate_name = "forensics crate"
+
+/datum/supply_pack/security/dumdum
+	name = ".38 DumDum Speedloader"
+	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets. Requires Security or Forensics access to open."
+	cost = 1200
+	access = FALSE
+	small_item = TRUE
+	access_any = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
+	contains = list(/obj/item/ammo_box/c38/dumdum)
+	crate_name = ".38 match crate"
 
 /datum/supply_pack/security/match
 	name = ".38 Match Grade Speedloader"
@@ -607,19 +607,18 @@
 	crate_name = "bulk energy guns crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
-/datum/supply_pack/armory/laser
+/datum/supply_pack/security/armory/laser
 	name = "Laser gun Single-Pack"
 	desc = "Contains one lethal, high-energy laser gun, Requires Armory access to open."
-	cost = 1200
-	access_budget = ACCESS_ARMORY
+	cost = 1000
+	small_item = TRUE
 	contains = list(/obj/item/gun/energy/laser)
 	crate_name = "single laser gun crate"
 
-/datum/supply_pack/armory/laser_single
-	name = "Lasers Crate"
+/datum/supply_pack/security/armory/laser_single
+	name = "Bulk Laser guns Crate"
 	desc = "Contains three lethal, high-energy laser guns. Requires Armory access to open."
-	cost = 2100
-	access_budget = ACCESS_ARMORY
+	cost = 2150
 	contains = list(/obj/item/gun/energy/laser,
 					/obj/item/gun/energy/laser,
 					/obj/item/gun/energy/laser)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -625,7 +625,6 @@
 					/obj/item/gun/energy/laser)
 	crate_name = "bulk laser guns crate"
 
-
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"
 	desc = "Contains five Exile implants. Requires Armory access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -608,7 +608,7 @@
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/security/armory/laser
-	name = "Laser gun Single-Pack"
+	name = "Laser Gun Single-Pack"
 	desc = "Contains one lethal, high-energy laser gun, Requires Armory access to open."
 	cost = 1000
 	small_item = TRUE
@@ -616,7 +616,7 @@
 	crate_name = "single laser gun crate"
 
 /datum/supply_pack/security/armory/laser_single
-	name = "Bulk Laser guns Crate"
+	name = "Bulk Laser Guns Crate"
 	desc = "Contains three lethal, high-energy laser guns. Requires Armory access to open."
 	cost = 2150
 	contains = list(/obj/item/gun/energy/laser,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -367,16 +367,6 @@
 					/obj/item/clothing/head/fedora/det_hat)
 	crate_name = "forensics crate"
 
-/datum/supply_pack/security/laser
-	name = "Lasers Crate"
-	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
-	cost = 1800
-	access_budget = ACCESS_ARMORY
-	contains = list(/obj/item/gun/energy/laser,
-					/obj/item/gun/energy/laser,
-					/obj/item/gun/energy/laser)
-	crate_name = "laser crate"
-
 /datum/supply_pack/security/match
 	name = ".38 Match Grade Speedloader"
 	desc = "Contains one speedloader of match grade .38 ammunition, perfect for showing off trickshots. Requires Security or Forensics access to open."
@@ -540,6 +530,15 @@
 	contains = list(/obj/item/storage/box/chemimp)
 	crate_name = "chemical implant crate"
 
+/datum/supply_pack/security/armory/dragnet
+	name = "DRAGnet Crate"
+	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."
+	cost = 1500
+	contains = list(/obj/item/gun/energy/e_gun/dragnet,
+					/obj/item/gun/energy/e_gun/dragnet,
+					/obj/item/gun/energy/e_gun/dragnet)
+	crate_name = "\improper DRAGnet crate"
+
 /datum/supply_pack/security/armory/combatknives_single
 	name = "Combat Knife Single-Pack"
 	desc = "Contains one sharpened combat knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot. Requires Armory access to open."
@@ -590,15 +589,6 @@
 					/obj/item/gun/ballistic/shotgun/riot,
 					/obj/item/gun/ballistic/shotgun/riot)
 
-/datum/supply_pack/security/armory/dragnet
-	name = "DRAGnet Crate"
-	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."
-	cost = 1500
-	contains = list(/obj/item/gun/energy/e_gun/dragnet,
-					/obj/item/gun/energy/e_gun/dragnet,
-					/obj/item/gun/energy/e_gun/dragnet)
-	crate_name = "\improper DRAGnet crate"
-
 /datum/supply_pack/security/armory/energy_single
 	name = "Energy Gun Single-Pack"
 	desc = "Contains one Energy Gun, capable of firing both nonlethal and lethal blasts of light. Requires Armory access to open."
@@ -616,6 +606,25 @@
 					/obj/item/gun/energy/e_gun)
 	crate_name = "bulk energy guns crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
+
+/datum/supply_pack/armory/laser
+	name = "Laser gun Single-Pack"
+	desc = "Contains one lethal, high-energy laser gun, Requires Armory access to open."
+	cost = 1200
+	access_budget = ACCESS_ARMORY
+	contains = list(/obj/item/gun/energy/laser)
+	crate_name = "single laser gun crate"
+
+/datum/supply_pack/armory/laser_single
+	name = "Lasers Crate"
+	desc = "Contains three lethal, high-energy laser guns. Requires Armory access to open."
+	cost = 2100
+	access_budget = ACCESS_ARMORY
+	contains = list(/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser)
+	crate_name = "bulk laser guns crate"
+
 
 /datum/supply_pack/security/armory/exileimp
 	name = "Exile Implants Crate"


### PR DESCRIPTION
## About The Pull Request

This PR aim to fix Laser guns being first in the wrong section, and thus more secure from a normal security officer being able to open it, and secondly implement a singular laser gun crate.

* also address #7003

## Why It's Good For The Game

Balances out an issue that went overlooked for a loooong time, and really secoffs shouldn't be allowed to open crates with lethals in the first place.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![immagine](https://user-images.githubusercontent.com/75247747/193427406-03179f55-680e-4f2d-aed5-e184227af9ed.png)

</details>

## Changelog
:cl:
add: Cargo has now the option to buy singular or in bulk laser guns
tweak: The laser guns are now under "Armory" rather than "Security"
tweak: The cost for a bulk laser gun crate is now rebalanced to be a cheaper option compared to Energy guns
/:cl:
