### PR TITLE
Fixes plasma cutters being able to heat things while not having power

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -138,14 +138,13 @@
 	sharpness = IS_SHARP
 	can_charge = FALSE
 	dead_cell = TRUE
-
-	heat = 3800
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 0.7 //plasmacutters can be used as welders, and are faster than standard welders
 	var/progress_flash_divisor = 10  //copypasta is best pasta
 	var/light_intensity = 1
 	var/charge_weld = 25 //amount of charge used up to start action (multiplied by amount) and per progress_flash_divisor ticks of welding
+	var/heat_weld = 3800
 	weapon_weight = WEAPON_LIGHT
 	fire_rate = 3
 	automatic = 1
@@ -218,6 +217,11 @@
 		target.cut_overlay(GLOB.welding_sparks)
 	else
 		. = ..(amount=1)
+
+/obj/item/gun/energy/plasmacutter/is_hot()
+	if(use(1))
+		return heat_weld
+	return heat
 
 
 /obj/item/gun/energy/plasmacutter/update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #7528, hopefully stopping newbie miners from burning cargo to the ground.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This just makes heating things with a plasma cutter consume energy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Tested on plasma, plasma doesn't ignite without charge, but does if the plasma cutter is charged.


## Changelog
:cl:
fix: Plasma cutters will no longer heat things while unpowered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
