### PR TITLE
Fixes requesting the labor shuttle

### DIFF
--- a/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
+++ b/code/modules/shuttle/super_cruise/shuttle_components/shuttle_console.dm
@@ -70,7 +70,7 @@ GLOBAL_VAR_INIT(shuttle_docking_jammed, FALSE)
 	if(QDELETED(shuttleObject) && SSorbits.assoc_shuttles.Find(shuttleId))
 		shuttleObject = SSorbits.assoc_shuttles[shuttleId]
 
-	if(recall_docking_port_id && shuttleObject?.docking_target && shuttleObject.autopilot && shuttleObject.shuttleTarget == shuttleObject.docking_target && shuttleObject.controlling_computer == src)
+	if(recall_docking_port_id && shuttleObject?.docking_target && shuttleObject.shuttleTarget == shuttleObject.docking_target && shuttleObject.controlling_computer == src)
 		//We are at destination, dock.
 		shuttleObject.controlling_computer = null
 		switch(SSshuttle.moveShuttle(shuttleId, recall_docking_port_id, 1))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This fixes requesting the labor shuttle from the labor camp (and theoretically requesting shuttles in general) by removing an autopilot check when the shuttle is landing after being called. The bug was caused by this check, because a shuttleObject's autopilot var is set to false as soon as docking commences. 

Fixes #7698

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
This is very annoying for prisoners, so fixing it would be nice.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/9423435/193440752-96146734-78ab-45d5-95ae-4059a05ab183.mp4



</details>

## Changelog
:cl:
fix: Fixes calling the labor camp shuttle using the prison shuttle terminal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
