### PR TITLE
Fixes 2 runtimes related to zclear

### DIFF
--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -246,35 +246,37 @@ SUBSYSTEM_DEF(zclear)
 /datum/controller/subsystem/zclear/proc/clear_turf_atoms(list/turfs)
 	//Clear atoms
 	for(var/turf/T as() in turfs)
-		// Remove all atoms except abstract mobs
-		var/list/allowed_contents = T.GetAllContentsIgnoring(ignored_atoms)
-		allowed_contents -= T
-		for(var/i in 1 to allowed_contents.len)
-			var/thing = allowed_contents[i]
-			//Remove powernet to prevent massive amounts of propagate networks, everythings getting deleted so who cares.
-			if(istype(thing, /obj/structure/cable))
-				var/obj/structure/cable/cable = thing
-				cable.powernet = null
-			if(ismob(thing))
-				if(!isliving(thing))
-					continue
-				var/mob/living/M = thing
-				if(M.mind || M.key)
-					if(M.stat == DEAD)
-						//Store them for later
-						M.ghostize(TRUE)
-						M.forceMove(null)
-						nullspaced_mobs += M
+		var/max_iterations = 3
+		var/list/allowed_contents = typecache_filter_list_reverse(T.contents, ignored_atoms)
+		while (max_iterations -- > 0 && length(allowed_contents))
+			// Remove all atoms except abstract mobs
+			for(var/i in 1 to allowed_contents.len)
+				var/thing = allowed_contents[i]
+				//Remove powernet to prevent massive amounts of propagate networks, everythings getting deleted so who cares.
+				if(istype(thing, /obj/structure/cable))
+					var/obj/structure/cable/cable = thing
+					cable.powernet = null
+				if(ismob(thing))
+					if(!isliving(thing))
+						continue
+					var/mob/living/M = thing
+					if(M.mind || M.key)
+						if(M.stat == DEAD)
+							//Store them for later
+							M.ghostize(TRUE)
+							M.forceMove(null)
+							nullspaced_mobs += M
+						else
+							//If the mob has a key (but is DC) then teleport them to a safe z-level where they can potentially be retrieved.
+							//Since the wiping takes 90 seconds they could potentially still be on the z-level as it is wiping if they reconnect in time
+							random_teleport_atom(M)
+							M.Knockdown(5)
+							to_chat(M, "<span class='warning'>You feel sick as your body lurches through space and time, the ripples of the starship that brought you here eminate no more and you get the horrible feeling that you have been left behind.</span>")
 					else
-						//If the mob has a key (but is DC) then teleport them to a safe z-level where they can potentially be retrieved.
-						//Since the wiping takes 90 seconds they could potentially still be on the z-level as it is wiping if they reconnect in time
-						random_teleport_atom(M)
-						M.Knockdown(5)
-						to_chat(M, "<span class='warning'>You feel sick as your body lurches through space and time, the ripples of the starship that brought you here eminate no more and you get the horrible feeling that you have been left behind.</span>")
+						delete_atom(thing)
 				else
 					delete_atom(thing)
-			else
-				delete_atom(thing)
+			allowed_contents = typecache_filter_list_reverse(T.contents, ignored_atoms)
 
 /*
  * DELETES AN ATOM OR TELEPORTS IT TO A RANDOM LOCATION IF IT IS INDESTRUCTIBLE
@@ -311,7 +313,7 @@ SUBSYSTEM_DEF(zclear)
 		if (D.linkage == CROSSLINKED)
 			possible_transtitons += D.z_value
 
-	if(!possible_transtitons)
+	if(!length(possible_transtitons))
 		possible_transtitons = list(SSmapping.empty_space)
 
 	var/_z = pick(possible_transtitons)


### PR DESCRIPTION
fixes #7748

## About The Pull Request

 - Zclear will now only clear the top level contents, until everything on the turf is deleted. (Things inside objects won't be deleted unless they are dropped, this caused energy guns to runtime)
 - Fixes random_teleport_atom failing to randomly teleport atoms.

## Why It's Good For The Game

Resolves 2 runtimes related to z-clear. Less bugs in the game.

## Testing Photographs and Procedure

I forgot to get a screenshot, although this was tested 3 times and confirmed to be working.
![image](https://user-images.githubusercontent.com/26465327/193448687-171bec13-2e1f-4219-ba94-52422f039d41.png)


## Changelog
:cl:
fix: Fixes energy guns runtiming when deleted by z-clear.
fix: Fixes things not being randomly teleported by z-clear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
