### PR TITLE
Fixes radio jammer hard-dels

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -281,6 +281,10 @@ effective or pretty fucking useless.
 	var/active = FALSE
 	var/range = 12
 
+/obj/item/jammer/Destroy()
+		GLOB.active_jammers -= src
+	return ..()
+
 /obj/item/jammer/attack_self(mob/user)
 	to_chat(user,"<span class='notice'>You [active ? "deactivate" : "activate"] [src].</span>")
 	active = !active

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -282,7 +282,7 @@ effective or pretty fucking useless.
 	var/range = 12
 
 /obj/item/jammer/Destroy()
-		GLOB.active_jammers -= src
+	GLOB.active_jammers -= src
 	return ..()
 
 /obj/item/jammer/attack_self(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/70225
Removes jammers from a global list when they are destroyed. 

## Why It's Good For The Game

This will result in hard-deletions if a jammer is destroyed somehow while active. While unlikely, this is bad for obvious reasons.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/193450501-8d711a80-5980-46a9-8c93-fca6370bdc31.png)

![image](https://user-images.githubusercontent.com/26465327/193450506-368acdd7-566e-463e-8068-ef8795339b9c.png)


## Changelog
:cl: PowerfulBacon, tf-4
fix: Jammers are now removed from the global list when deleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
