### PR TITLE
Observers can alt click outside stat menu

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -34,7 +34,7 @@
 		ShiftClickOn(A)
 		return
 	if(modifiers["alt"])
-		AltClickNoInteract(src, A)
+		AltClickOn(A)
 		return
 	if(modifiers["ctrl"])
 		CtrlClickOn(A)

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -241,7 +241,7 @@
 			to_chat(user, "<span class='notice'>[src] is empty.</span>")
 
 /obj/machinery/pdapainter/AltClick(mob/user)
-	if(usr.stat || usr.restrained())
+	if(!user.canUseTopic(src, !issilicon(user)) || usr.stat || usr.restrained())
 		return
 	if(storedpda || storedid)
 		ejectid()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -97,6 +97,8 @@
 	user.examinate(src)
 
 /obj/machinery/clonepod/AltClick(mob/user)
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
 	if (alert(user, "Are you sure you want to empty the cloning pod?", "Empty Reagent Storage:", "Yes", "No") != "Yes")
 		return
 	to_chat(user, "<span class='notice'>You empty \the [src]'s release valve onto the floor.</span>")

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -188,6 +188,8 @@
 
 /obj/machinery/computer/cloning/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
 	EjectDisk(user)
 
 /obj/machinery/computer/cloning/proc/EjectDisk(mob/user)

--- a/code/game/machinery/computer/prisoner/_prisoner.dm
+++ b/code/game/machinery/computer/prisoner/_prisoner.dm
@@ -15,6 +15,8 @@
 
 
 /obj/machinery/computer/prisoner/AltClick(mob/user)
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
 	id_eject(user)
 
 /obj/machinery/computer/prisoner/proc/id_insert(mob/user, obj/item/card/id/prisoner/P)

--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -173,6 +173,8 @@
 
 /obj/item/airlock_painter/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(ink)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		ink.forceMove(user.drop_location())

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1059,7 +1059,7 @@
 	to_chat(user, "<span class='notice'>You [suction ? "enable" : "disable"] the board's suction function.</span>")
 
 /obj/item/circuitboard/machine/dish_drive/AltClick(mob/living/user)
-	if(!user.Adjacent(src))
+	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 	transmit = !transmit
 	to_chat(user, "<span class='notice'>You [transmit ? "enable" : "disable"] the board's automatic disposal transmission.</span>")

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -66,6 +66,8 @@
         spam_flag = world.timeofday
 
 /obj/item/soundsynth/AltClick(mob/living/carbon/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	pick_sound()
 
 /obj/item/soundsynth/attack(mob/living/M as mob, mob/living/user as mob, def_zone)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -886,6 +886,8 @@
 
 //Alt click drops stored item
 /obj/item/borg/apparatus/AltClick(mob/living/silicon/robot/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(!stored)
 		return ..()
 	stored.forceMove(get_turf(user))

--- a/code/modules/admin/sound_emitter.dm
+++ b/code/modules/admin/sound_emitter.dm
@@ -52,6 +52,8 @@
 	edit_emitter(user)
 
 /obj/effect/sound_emitter/AltClick(mob/user)
+	if(!user.canUseTopic(src))
+		return
 	if(check_rights_for(user.client, R_SOUND))
 		activate(user)
 		to_chat(user, "<span class='notice'>Sound emitter activated.</span>")

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -31,6 +31,8 @@
 	return secured
 
 /obj/item/assembly/health/AltClick(mob/living/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(alarm_health == HEALTH_THRESHOLD_CRIT)
 		alarm_health = HEALTH_THRESHOLD_DEAD
 		to_chat(user, "<span class='notice'>You toggle [src] to \"detect death\" mode.</span>")

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -514,6 +514,8 @@
 	..()
 
 /obj/item/clothing/glasses/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(glass_colour_type && !force_glass_colour && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(H.client)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -80,7 +80,7 @@
 				return
 			if(!user.transferItemToLoc(S, src))
 				return
-			
+
 			to_chat(user, "<span class='notice'>You click [S] into place on [src].</span>")
 			set_attached_light(S)
 			update_icon()
@@ -218,6 +218,8 @@
 		C.head_update(src, forced = TRUE)
 
 /obj/item/clothing/head/helmet/riot/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	toggle_helmlight(user)
 
 /obj/item/clothing/head/helmet/riot/ui_action_click(mob/user, datum/actiontype)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -267,6 +267,8 @@
 	adjustmask(user)
 
 /obj/item/clothing/mask/bandana/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if((C.get_item_by_slot(ITEM_SLOT_HEAD == src)) || (C.get_item_by_slot(ITEM_SLOT_MASK) == src))

--- a/code/modules/mining/equipment/mineral_scanner.dm
+++ b/code/modules/mining/equipment/mineral_scanner.dm
@@ -15,6 +15,8 @@
 	var/speaker = TRUE // Speaker that plays a sound when pulsed.
 
 /obj/item/mining_scanner/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	speaker = !speaker
 	to_chat(user, "<span class='notice'>You toggle [src]'s speaker to [speaker ? "<b>ON</b>" : "<b>OFF</b>"].</span>")
 
@@ -54,6 +56,8 @@
 	var/speaker = FALSE // Speaker that plays a sound when pulsed.
 
 /obj/item/t_scanner/adv_mining_scanner/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	speaker = !speaker
 	to_chat(user, "<span class='notice'>You toggle [src]'s speaker to [speaker ? "<b>ON</b>" : "<b>OFF</b>"].</span>")
 

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -24,6 +24,8 @@
 	quick_burst_mod = 1
 
 /obj/item/resonator/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(burst_time == 50)
 		burst_time = 30
 		to_chat(user, "<span class='info'>You set the resonator's fields to detonate after 3 seconds.</span>")

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -302,6 +302,8 @@
 /// Handles dropping ore
 /mob/living/simple_animal/hostile/mining_drone/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	to_chat(user, "<span class='info'>You instruct [src] to drop any collected ore.</span>")
 	drop_ore()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -439,6 +439,8 @@
 
 /mob/living/silicon/robot/AltClick(mob/user)
 	..()
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
 	togglelock(user)
 
 /mob/living/silicon/robot/attackby(obj/item/W, mob/user, params)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -340,6 +340,8 @@
 
 /mob/living/simple_animal/bot/AltClick(mob/user)
 	..()
+	if(!user.canUseTopic(src, !issilicon(user)))
+		return
 	togglelock(user)
 
 /mob/living/simple_animal/bot/bullet_act(obj/item/projectile/Proj)

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -69,6 +69,8 @@
 
 /obj/item/clipboard/AltClick(mob/user)
 	..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(pen)
 		remove_pen(user)
 

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -52,6 +52,8 @@
 
 /obj/item/folder/AltClick(mob/user)
 	..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(length(contents))
 		remove_item(contents[1], user)
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -248,6 +248,8 @@
 
 
 /obj/item/gun/ballistic/automatic/l6_saw/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	cover_open = !cover_open
 	to_chat(user, "<span class='notice'>You [cover_open ? "open" : "close"] [src]'s cover.</span>")
 	if(cover_open)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -316,6 +316,8 @@
 		. += "<span class='notice'>The cap has been taken off. Alt-click to put a cap on.</span>"
 
 /obj/item/reagent_containers/glass/waterbottle/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(cap_lost)
 		to_chat(user, "<span class='warning'>The cap seems to be missing! Where did it go?</span>")
 		return
@@ -415,6 +417,8 @@
 	var/obj/item/grinded
 
 /obj/item/reagent_containers/glass/mortar/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(grinded)
 		grinded.forceMove(drop_location())
 		grinded = null

--- a/code/modules/shuttle/custom_shuttle.dm
+++ b/code/modules/shuttle/custom_shuttle.dm
@@ -210,6 +210,8 @@
 		playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, 0)
 
 /obj/machinery/computer/shuttle_flight/custom_shuttle/AltClick(mob/user)
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	var/obj/item/shuttle_creator/designator = designator_ref?.resolve()
 	if(!designator)
 		return

--- a/code/modules/surgery/anesthetic_machine.dm
+++ b/code/modules/surgery/anesthetic_machine.dm
@@ -43,6 +43,8 @@
 
 /obj/machinery/anesthetic_machine/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	if(attached_tank)// If attached tank, remove it.
 		attached_tank.forceMove(loc)
 		to_chat(user, "<span class='notice'>You remove the [attached_tank].</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows ghosts to alt-click things without using the stat menu and adds a bunch of missing checks on alt clicks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Closes #7624 (may want to check ghost interaction config)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Enable ghost interaction in config: chair spins
Disable ghost interaction in config: chair doesn't spin
Alt click other stuff: nothing happens
<details>
<summary>Screenshots&Videos</summary>

![spinny_chair](https://user-images.githubusercontent.com/43815120/193491928-52ed38c7-ef4a-4966-9045-b599e62c1169.png)

</details>

## Changelog
:cl:
tweak: Ghosts can alt-click without using the stat menu
fix: Added missing checks on alt-clicks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
