### PR TITLE
Burned mess burns into ash

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -314,11 +314,15 @@ All foods are distributed among various categories. Use common sense.
 	return result
 
 /obj/item/reagent_containers/food/snacks/burn()
+	if(QDELETED(src))
+		return
 	if(prob(25))
 		microwave_act()
 	else
 		var/turf/T = get_turf(src)
 		new /obj/item/reagent_containers/food/snacks/badrecipe(T)
+		if(resistance_flags & ON_FIRE)
+			SSfire_burning.processing -= src
 		qdel(src)
 
 /obj/item/reagent_containers/food/snacks/Destroy()

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -140,6 +140,16 @@
 	filling_color = "#8B4513"
 	foodtype = GROSS
 
+/obj/item/reagent_containers/food/snacks/badrecipe/burn()
+	if(QDELETED(src))
+		return
+	var/turf/T = get_turf(src)
+	var/obj/effect/decal/cleanable/ash/A = new /obj/effect/decal/cleanable/ash(T)
+	A.desc += "\nLooks like this used to be \an [name] some time ago."
+	if(resistance_flags & ON_FIRE)
+		SSfire_burning.processing -= src
+	qdel(src)
+
 /obj/item/reagent_containers/food/snacks/carrotfries
 	name = "carrot fries"
 	desc = "Tasty fries from fresh carrots."
@@ -457,13 +467,13 @@
 		timer_id = null
 	chewing = (slot == ITEM_SLOT_MASK ? TRUE : FALSE)
 	if(chewing) //Set a timer to chew(), instead of calling chew for the convenience of being able to equip/unequip our pop
-		timer_id = addtimer(CALLBACK(src, .proc/chew), bite_frequency, TIMER_STOPPABLE)	
+		timer_id = addtimer(CALLBACK(src, .proc/chew), bite_frequency, TIMER_STOPPABLE)
 
 /obj/item/reagent_containers/food/snacks/lollipop/dropped(mob/user)
 	. = ..()
 	if(timer_id)
 		deltimer(timer_id)
-		timer_id = null		
+		timer_id = null
 
 /obj/item/reagent_containers/food/snacks/lollipop/proc/chew()
 	if(iscarbon(loc) && chewing)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When food is burnt it turns into burned food, however since burned mess is also a type of food it would create an infinite loop of burning and creating more burned mess. This fixes that by having burned mess turn into ash instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Infinite lag machine bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
Set food on fire, now eventually becomes ash
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
![burned_mess_ash](https://user-images.githubusercontent.com/43815120/193530319-9ab1cbdd-1c02-468a-ab1a-8abd26e69da7.png)


</details>

## Changelog
:cl:
fix: Burned mess now becomes ash when burnt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
