### PR TITLE
Pushes the suicider verb from medwrench to a generic /obj var

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -545,8 +545,7 @@
 	icon_state = "moffplush"
 	attack_verb = list("fluttered", "flapped")
 	squeak_override = list('sound/voice/moth/scream_moth.ogg'=1)
-///Used to track how many people killed themselves with item/toy/plush/moth
-	var/suicide_count = 0
+	hide_suicide = TRUE  // they will never find the bodies :)
 
 /obj/item/toy/plush/moth/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] stares deeply into the eyes of [src]. The plush begins to consume [user.p_their()] soul!  It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -45,13 +45,9 @@
 	force = 2 //MEDICAL
 	throwforce = 4
 	attack_verb = list("healed", "medicaled", "tapped", "poked", "analyzed") //"cobbyed"
-	///var to hold the name of the person who suicided
-	var/suicider
 
 /obj/item/wrench/medical/examine(mob/user)
 	. = ..()
-	if(suicider)
-		. += "<span class='notice'>For some reason, it reminds you of [suicider].</span>"
 
 /obj/item/wrench/medical/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is praying to the medical wrench to take [user.p_their()] soul. It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -69,7 +65,6 @@
 		return
 	for(var/obj/item/W in user)
 		user.dropItemToGround(W)
-	suicider = user.real_name
 	user.dust()
 	return OXYLOSS
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -59,6 +59,8 @@
 	var/suicider
 	/// holds the number of people to suicide with this item (ideally 0)
 	var/suicide_count = 0
+	/// hides the suicide stuff from examine
+	var/hide_suicide
 
 /obj/vv_edit_var(vname, vval)
 	switch(vname)
@@ -374,6 +376,8 @@
 	if(unique_reskin && !current_skin)
 		. += "<span class='notice'>Alt-click it to reskin it.</span>"
 
+	if(hide_suicide)
+		return
 	if(suicider)
 		. += "<span class='notice'>For some reason, it reminds you of [suicider].</span>"
 	if(suicide_count >= SUICIDE_CONCERN)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,3 +1,6 @@
+#define SUICIDE_MIN_NOTICE 2
+#define SUICIDE_CONCERN 5
+
 /obj
 	animate_movement = SLIDE_STEPS
 	speech_span = SPAN_ROBOT
@@ -51,6 +54,11 @@
 
 	var/investigate_flags = NONE
 	// ADMIN_INVESTIGATE_TARGET: investigate_log on pickup/drop
+
+	/// holds the last person to suicide
+	var/suicider
+	/// holds the number of people to suicide with this item (ideally 0)
+	var/suicide_count = 0
 
 /obj/vv_edit_var(vname, vval)
 	switch(vname)
@@ -365,6 +373,13 @@
 		. += "<span class='notice'>Use a pen on it to rename it or change its description.</span>"
 	if(unique_reskin && !current_skin)
 		. += "<span class='notice'>Alt-click it to reskin it.</span>"
+
+	if(suicider)
+		. += "<span class='notice'>For some reason, it reminds you of [suicider].</span>"
+	if(suicide_count >= SUICIDE_CONCERN)
+		. += "<span class='warning'>You feel an aura of despair around this [src].</span>"  // why would so many ppl use the same item
+	else if(suicide_count >= SUICIDE_MIN_NOTICE)
+		. += "<span class='notice'>You feel a slight twinge of despair looking at \the [src]</span>"
 
 /obj/AltClick(mob/user)
 	. = ..()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -14,7 +14,7 @@
 	var/frequency = FREQ_SIGNALER
 	var/datum/radio_frequency/radio_connection
 	///Holds the mind that commited suicide.
-	var/datum/mind/suicider
+	var/datum/mind/danger_man
 	///Holds a reference string to the mob, decides how much of a gamer you are.
 	var/suicide_mob
 	var/hearing_range = 1
@@ -23,7 +23,7 @@
 	user.visible_message("<span class='suicide'>[user] eats \the [src]! If it is signaled, [user.p_they()] will die!</span>")
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
 	moveToNullspace()
-	suicider = user.mind
+	danger_man = user.mind
 	suicide_mob = REF(user)
 	return MANUAL_SUICIDE_NONLETHAL
 
@@ -48,7 +48,7 @@
 
 /obj/item/assembly/signaler/Destroy()
 	SSradio.remove_object(src,frequency)
-	suicider = null
+	danger_man = null
 	. = ..()
 
 /obj/item/assembly/signaler/activate()
@@ -144,8 +144,8 @@
 		return
 	if(!(src.wires & WIRE_RADIO_RECEIVE))
 		return
-	if(suicider)
-		manual_suicide(suicider)
+	if(danger_man)
+		manual_suicide(danger_man)
 		return
 	pulse(TRUE)
 	audible_message("[icon2html(src, hearers(src))] *beep* *beep* *beep*", null, hearing_range)
@@ -195,8 +195,8 @@
 		return FALSE
 	if(signal.data["code"] != code)
 		return FALSE
-	if(suicider)
-		manual_suicide(suicider)
+	if(danger_man)
+		manual_suicide(danger_man)
 	for(var/obj/effect/anomaly/A in get_turf(src))
 		A.anomalyNeutralize()
 	return TRUE

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -83,6 +83,8 @@
 
 				death(FALSE)
 				ghostize(FALSE,SENTIENCE_ERASE)	// Disallows reentering body and disassociates mind
+				held_item.suicider = real_name
+				held_item.suicide_count += 1
 
 				return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ports the suicider mechanic (you can see the last person to suicide) to every item and also adds a counter for how many people suicide with that item
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
 because ~~when every item is special none will be~~ it could be a fun mechanic  and also clue you in if someone is missing that they shouldnt be looked for
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/193705744-5f8578be-afa8-4c64-9ad1-6bfb0baf0b45.png)

</details>

## Changelog
:cl:
add: every item has medwrenches suicider mechanic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
