### PR TITLE
Fixes conveyors moving anchored things

### DIFF
--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -169,7 +169,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	operating = new_value
 	update_icon_state()
 	update_move_direction()
-	if(!operating) //If we ever turn off, disable moveloops
+	//If we ever turn off, disable moveloops
+	if(!operating)
 		for(var/atom/movable/movable in get_turf(src))
 			stop_conveying(movable)
 
@@ -192,10 +193,6 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(!operating)
 		SSmove_manager.stop_looping(convayable, SSconveyors)
 		return
-	var/datum/move_loop/move/moving_loop = SSmove_manager.processing_on(convayable, SSconveyors)
-	if(moving_loop)
-		moving_loop.direction = movedir
-		return
 	start_conveying(convayable)
 
 /obj/machinery/conveyor/proc/conveyable_exit(datum/source, atom/convayable, direction)
@@ -205,6 +202,12 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		SSmove_manager.stop_looping(convayable, SSconveyors)
 
 /obj/machinery/conveyor/proc/start_conveying(atom/movable/moving)
+	var/datum/move_loop/move/moving_loop = SSmove_manager.processing_on(moving, SSconveyors)
+	if(moving_loop)
+		moving_loop.direction = movedir
+		moving_loop.delay = 0.2 SECONDS
+		return
+
 	var/static/list/unconveyables = typecacheof(list(/obj/effect, /mob/dead))
 	if(!istype(moving) || is_type_in_typecache(moving, unconveyables) || moving == src)
 		return


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/67456

From parent PR:

Fixes conveyor belts moving things which shouldn't be moved.
- So, whenever an area power update occurs, it tries to re-add everything present overtop to the moving loop. Unfortunately, it made no checks for whether a move loop existed already. Meaning there'd be multiple move loops tied to the object, but only one conveyor component dictating when something should or shouldn't move. By unifying the behavior, hopefully this will stop happening.

## Why It's Good For The Game

Conveyors creating holes in spacetime is not cool

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Said conveyors, before PR

![image](https://user-images.githubusercontent.com/10366817/193956051-6ac00a69-3c39-4ec5-af23-c776146548f3.png)

Said conveyors, working

![image](https://user-images.githubusercontent.com/10366817/193956030-919d7bad-d09b-49a7-9a6e-516b44486e21.png)

![image](https://user-images.githubusercontent.com/10366817/193956040-c0ebd28e-8542-467a-b237-d66bf4bbfedb.png)


</details>

## Changelog
:cl:
fix: Fixed conveyors creating holes in spacetime and moving anchored things.
/:cl:
