### PR TITLE
[Port] Moves base_icon_state to base of atom and adds it to mechs

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -98,6 +98,9 @@
 	/// Last color calculated for the the chatmessage overlays
 	var/chat_color
 
+	///Used for changing icon states for different base sprites.
+	var/base_icon_state
+
 	///The config type to use for greyscaled sprites. Both this and greyscale_colors must be assigned to work.
 	var/greyscale_config
 	///A string of hex format colors to be used by greyscale sprites, ex: "#0054aa#badcff"
@@ -1091,10 +1094,10 @@
 							valid_id = TRUE
 						if(!valid_id)
 							to_chat(usr, "<span class='warning'>A reagent with that ID doesn't exist!</span>")
-				
+
 				if("Choose from a list")
 					chosen_id = input(usr, "Choose a reagent to add.", "Choose a reagent.") as null|anything in subtypesof(/datum/reagent)
-				
+
 				if("I'm feeling lucky")
 					chosen_id = pick(subtypesof(/datum/reagent))
 

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -20,7 +20,7 @@
 
 	var/uses_stored = TRUE	//if TRUE this will cause the turret to stop working if the stored_gun var is null in process()
 
-	var/base_icon_state = "standard"
+	base_icon_state = "standard"
 	var/scan_range = 7
 	var/atom/base = null //for turrets inside other objects
 

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -2,6 +2,7 @@
 	desc = "An aging combat exosuit utilized by the Nanotrasen corporation. Originally developed to combat hostile alien lifeforms."
 	name = "\improper Durand"
 	icon_state = "durand"
+	base_icon_state = "durand"
 	step_in = 4
 	dir_in = 1 //Facing North.
 	max_integrity = 400

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -2,6 +2,7 @@
 	desc = "A lightweight, security exosuit. Popular among private and corporate security."
 	name = "\improper Gygax"
 	icon_state = "gygax"
+	base_icon_state = "gygax"
 	step_in = 3
 	dir_in = 1 //Facing North.
 	max_integrity = 250

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -2,6 +2,7 @@
 	desc = "Produced by \"Tyranny of Honk, INC\", this exosuit is designed as heavy clown-support. Used to spread the fun and joy of life. HONK!"
 	name = "\improper H.O.N.K"
 	icon_state = "honker"
+	base_icon_state = "honker"
 	step_in = 3
 	max_integrity = 140
 	deflect_chance = 60

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -2,6 +2,7 @@
 	desc = "Heavy-duty, combat exosuit, developed after the Durand model. Rarely found among civilian populations."
 	name = "\improper Marauder"
 	icon_state = "marauder"
+	base_icon_state = "marauder"
 	step_in = 5
 	max_integrity = 500
 	deflect_chance = 25

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -2,6 +2,7 @@
 	desc = "This is a Phazon exosuit. The pinnacle of scientific research and pride of Nanotrasen, it uses cutting edge bluespace technology and expensive materials."
 	name = "\improper Phazon"
 	icon_state = "phazon"
+	base_icon_state = "phazon"
 	step_in = 2
 	dir_in = 2 //Facing South.
 	step_energy_drain = 3

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -2,6 +2,7 @@
 	desc = "A silent, fast, and nigh-invisible miming exosuit. Popular among mimes and mime assassins."
 	name = "\improper reticence"
 	icon_state = "reticence"
+	base_icon_state = "reticence"
 	step_in = 2
 	dir_in = 1 //Facing North.
 	max_integrity = 100

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -778,7 +778,7 @@
 			card.AI = AI
 			AI.controlled_mech = null
 			AI.remote_control = null
-			icon_state = initial(icon_state)+"-open"
+			icon_state = "[base_icon_state]-open"
 			to_chat(AI, "You have been downloaded to a mobile storage device. Wireless connection offline.")
 			to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [AI.name] ([rand(1000,9999)].exe) removed from [name] and stored within local memory.")
 
@@ -816,7 +816,7 @@
 	AI.forceMove(src)
 	occupant = AI
 	silicon_pilot = TRUE
-	icon_state = initial(icon_state)
+	icon_state = base_icon_state
 	update_icon()
 	playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
 	if(!internal_damage)
@@ -840,7 +840,7 @@
 	if(pilot_mob && pilot_mob.Adjacent(src))
 		if(occupant)
 			return
-		icon_state = initial(icon_state)
+		icon_state = base_icon_state
 		occupant = pilot_mob
 		pilot_mob.mecha = src
 		pilot_mob.forceMove(src)
@@ -851,7 +851,7 @@
 		occupant = null
 	if(pilot_mob.mecha == src)
 		pilot_mob.mecha = null
-	icon_state = "[initial(icon_state)]-open"
+	icon_state = "[base_icon_state]-open"
 	pilot_mob.forceMove(get_turf(src))
 	RemoveActions(pilot_mob)
 
@@ -953,7 +953,7 @@
 		GrantActions(H, human_occupant=1)
 		forceMove(loc)
 		log_message("[H] moved in as pilot.", LOG_MECHA)
-		icon_state = initial(icon_state)
+		icon_state = base_icon_state
 		setDir(dir_in)
 		playsound(src, 'sound/machines/windowdoor.ogg', 50, 1)
 		if(!internal_damage)
@@ -1008,7 +1008,7 @@
 	brainmob.remote_control = src
 	brainmob.update_mobility()
 	brainmob.update_mouse_pointer()
-	icon_state = initial(icon_state)
+	icon_state = base_icon_state
 	update_icon()
 	setDir(dir_in)
 	log_message("[mmi_as_oc] moved in as pilot.", LOG_MECHA)
@@ -1095,7 +1095,7 @@
 			mmi.mecha = null
 			mmi.update_icon()
 			L.mobility_flags = NONE
-		icon_state = initial(icon_state)+"-open"
+		icon_state = "[base_icon_state]-open"
 		setDir(dir_in)
 
 	if(L?.client)

--- a/code/game/mecha/medical/odysseus.dm
+++ b/code/game/mecha/medical/odysseus.dm
@@ -2,6 +2,7 @@
 	desc = "These exosuits are developed and produced by Vey-Med. (&copy; All rights reserved)."
 	name = "\improper Odysseus"
 	icon_state = "odysseus"
+	base_icon_state = "odysseus"
 	step_in = 2
 	max_temperature = 15000
 	max_integrity = 120

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -2,6 +2,7 @@
 	desc = "Autonomous Power Loader Unit MK-I. Designed primarily around heavy lifting, the Ripley can be outfitted with utility equipment to fill a number of roles."
 	name = "\improper APLU MK-I \"Ripley\""
 	icon_state = "ripley"
+	base_icon_state = "ripley"
 	silicon_icon_state = "ripley-empty"
 	step_in = 1.5 //Move speed, lower is faster.
 	var/fast_pressure_step_in = 1.5 //step_in while in low pressure conditions
@@ -76,6 +77,7 @@
 	desc = "Autonomous Power Loader Unit MK-II. This prototype Ripley is refitted with a pressurized cabin, trading its prior speed for atmospheric protection"
 	name = "\improper APLU MK-II \"Ripley\""
 	icon_state = "ripleymkii"
+	base_icon_state = "ripleymkii"
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
 	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
 	step_in = 4
@@ -90,6 +92,7 @@
 	desc = "Autonomous Power Loader Unit MK-III. This model is refitted with a pressurized cabin and additional hazard protection."
 	name = "\improper APLU MK-III \"Firefighter\""
 	icon_state = "firefighter"
+	base_icon_state = "firefighter"
 	max_temperature = 65000
 	max_integrity = 250
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
@@ -111,6 +114,7 @@
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE"
 	name = "\improper DEATH-RIPLEY"
 	icon_state = "deathripley"
+	base_icon_state = "deathripley"
 	fast_pressure_step_in = 2 //step_in while in low pressure conditions
 	slow_pressure_step_in = 4 //step_in while in normal pressure conditions
 	step_in = 4

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -309,7 +309,7 @@
 
 	var/mob/listeningTo
 
-	var/base_icon_state = "defibpaddles"
+	base_icon_state = "defibpaddles"
 
 /obj/item/shockpaddles/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -258,7 +258,7 @@
 	max_integrity = 50
 	block_sound = 'sound/weapons/egloves.ogg'
 	block_flags = BLOCKING_PROJECTILE
-	var/base_icon_state = "eshield" // [base_icon_state]1 for expanded, [base_icon_state]0 for contracted
+	base_icon_state = "eshield" // [base_icon_state]1 for expanded, [base_icon_state]0 for contracted
 	var/on_force = 10
 	var/on_throwforce = 8
 	var/on_throw_speed = 2

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -9,7 +9,7 @@
 	req_access = list(ACCESS_ARMORY)
 	var/broken = FALSE
 	var/open = FALSE
-	var/base_icon_state = "lockbox"
+	base_icon_state = "lockbox"
 
 /obj/item/storage/lockbox/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/structures/artstuff.dm
+++ b/code/game/objects/structures/artstuff.dm
@@ -247,7 +247,7 @@
 	desc = "Art or \"Art\"? You decide."
 	icon = 'icons/obj/decals.dmi'
 	icon_state = "frame-empty"
-	var/base_icon_state = "frame" //temporal replacement before the update_appearance() port
+	base_icon_state = "frame" //temporal replacement before the update_appearance() port
 	buildable_sign = FALSE
 	///Canvas we're currently displaying.
 	var/obj/item/canvas/current_canvas

--- a/code/game/objects/structures/beds_chairs/bench.dm
+++ b/code/game/objects/structures/beds_chairs/bench.dm
@@ -53,7 +53,7 @@
 	name = "corporate bench"
 	desc = "Perfectly designed to be comfortable to sit on, and hellish to sleep on."
 	icon_state = "corporate_bench_middle_mapping"
-	var/base_icon_state = "corporate_bench_middle"
+	base_icon_state = "corporate_bench_middle"
 	///icon for the cover seat
 	var/image/cover
 	///cover seat color, by default this one

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -4,7 +4,7 @@
 	//- floor_tile is now a path, and not a tile obj
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'
-	var/base_icon_state = "floor"
+	base_icon_state = "floor"
 	baseturfs = /turf/open/floor/plating
 
 	footstep = FOOTSTEP_FLOOR

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -22,7 +22,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	var/gasefficency = 0.15
 
-	var/base_icon_state = "darkmatter"
+	base_icon_state = "darkmatter"
 
 	var/final_countdown = FALSE
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -3,7 +3,7 @@
 	desc = "A syringe that can hold up to 15 units."
 	icon = 'icons/obj/syringe.dmi'
 	item_state = "syringe_0"
-	var/base_icon_state = "syringe"
+	base_icon_state = "syringe"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	icon_state = "syringe_0"

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -4,7 +4,7 @@
 	var/projectile_type = /obj/item/projectile/magic/teleport
 	var/deactive_msg = "You discharge your projectile..."
 	var/active_msg = "You charge your projectile!"
-	var/base_icon_state = "projectile"
+	base_icon_state = "projectile"
 	var/active_icon_state = "projectile"
 	var/list/projectile_var_overrides = list()
 	var/projectile_amount = 1	//Projectiles per cast.

--- a/code/modules/spells/spell_types/pointed.dm
+++ b/code/modules/spells/spell_types/pointed.dm
@@ -6,7 +6,7 @@
 	/// Message showing to the spell owner upon activating pointed spell.
 	var/active_msg = "You prepare to use the spell on a target..."
 	/// Default icon for the pointed spell, used for active/inactive states switching.
-	var/base_icon_state = "projectile"
+	base_icon_state = "projectile"
 
 /obj/effect/proc_holder/spell/pointed/Click()
 	var/mob/living/user = usr


### PR DESCRIPTION
## About The Pull Request

**This is a port of https://github.com/Monkestation/MonkeStation/pull/277**

Porting:
"Moves base_icon_state to the base of atom" https://github.com/tgstation/tgstation/pull/52917
"mechs now use base_icon_state for their icon changes" https://github.com/tgstation/tgstation/pull/56480

Atomizes base_icon_state since multiple objects across the game use it*. Then adds a base_icon_state instead of initial(icon_state) to mechs, which "allows custom icons without the mech disappearing, fun!"

*worth mentioning that there may be more objects that have a variable like this under different names.

## Why It's Good For The Game

More modern code, good for coders.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

The game runs and there's no real way to proof that anything changed it aside an in-game screen, so have one:

![immagine](https://user-images.githubusercontent.com/75247747/194566089-cfe86027-7ec7-418a-91f8-6f652f83c723.png)

</details>

## Changelog
:cl:
refactor: base_icon_state is now an atomized variable
code: mechs now use base_icon_state for their icon changes
/:cl:
