### PR TITLE
Heavily nerfs the damage of the blood boil rune instead of outright removing it

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -790,7 +790,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	req_cultists = 3
 	invoke_damage = 10
 	construct_invoke = FALSE
-	var/tick_damage = 25
+	var/tick_damage = 10
 	rune_in_use = FALSE
 
 /obj/effect/rune/blood_boil/do_invoke_glow()

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -790,7 +790,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	req_cultists = 3
 	invoke_damage = 10
 	construct_invoke = FALSE
-	var/tick_damage = 10
+	var/tick_damage = 15
 	rune_in_use = FALSE
 
 /obj/effect/rune/blood_boil/do_invoke_glow()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heavily nerfs the damage value of the blood boil rune from 25 to 10.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The blood boil rune is one of the only runes that forces cultists to work together. Which in and of itself is a good thing. The damage of the rune was just way too high which this PR is supposed to fix.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

Don't think anything here is necessary

## Changelog
:cl:

balance: Nerfed the damage of the blood boil rune from 25 to 15

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
