### PR TITLE
Adds the ability to insert screwdrives into autolathes

### DIFF
--- a/code/game/machinery/fabricators/autolathe.dm
+++ b/code/game/machinery/fabricators/autolathe.dm
@@ -92,7 +92,7 @@
 		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
 		return TRUE
 
-	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+	if((user.a_intent == INTENT_HARM || panel_open) && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O)) //only unscrew it on harm intent or when it's already open
 		return TRUE
 
 	if(default_deconstruction_crowbar(O))

--- a/code/game/machinery/fabricators/autolathe.dm
+++ b/code/game/machinery/fabricators/autolathe.dm
@@ -92,7 +92,7 @@
 		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
 		return TRUE
 
-	if((user.a_intent == INTENT_HARM || panel_open) && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O)) //only unscrew it on harm intent or when it's already open
+	if((!(user.a_intent == INTENT_HELP) || panel_open) && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O)) //only unscrew it on harm intent or when it's already open
 		return TRUE
 
 	if(default_deconstruction_crowbar(O))


### PR DESCRIPTION
## About The Pull Request

Lets you insert screwdrivers into autolathes when using help intent. Using a screwdriver on a screwed-open autolathe will still close it no matter the intent.

## Why It's Good For The Game

Finally we will have a way to deposit the ten extra screwdrivers we accidentally printed back into the autolathe.

## Changelog
:cl:
tweak: Made it possible to insert screwdrivers into autolathes with help intent.
/:cl:

