### PR TITLE
Fix for null species blocking Character Setup

### DIFF
--- a/code/modules/client/preferences2/character_save.dm
+++ b/code/modules/client/preferences2/character_save.dm
@@ -82,16 +82,21 @@
 	var/species_id
 	SAFE_READ_QUERY(2, species_id)
 
-	if(!species_id) // There was no species ID saved, make it human
-		species_id = SPECIES_HUMAN
+	if(!species_id) // There was no species ID saved, make it random
+		species_id = pick(GLOB.roundstart_races)
 
 	var/newtype = GLOB.species_list[species_id]
 
-	if(!newtype) // The species ID doesn't exist, make it human
-		species_id = SPECIES_HUMAN
-		newtype = GLOB.species_list[SPECIES_HUMAN]
+	if(!newtype) // The species ID doesn't exist in the species list, make it random
+		species_id = pick(GLOB.roundstart_races)
+		newtype = GLOB.species_list[species_id]
 
 	pref_species = new newtype
+
+	if(!pref_species) // there are no roundstart species enabled. Time to die
+		pref_species = new /datum/species/human
+		if(!length(GLOB.roundstart_races))
+			CRASH("There are no roundstart races enabled! You must enable at least one for the character setup to function.")
 
 	//Character
 	SAFE_READ_QUERY(3, real_name)

--- a/code/modules/client/preferences2/character_save.dm
+++ b/code/modules/client/preferences2/character_save.dm
@@ -81,10 +81,17 @@
 	//Species
 	var/species_id
 	SAFE_READ_QUERY(2, species_id)
-	if(species_id)
-		var/newtype = GLOB.species_list[species_id]
-		if(newtype)
-			pref_species = new newtype
+
+	if(!species_id) // There was no species ID saved, make it human
+		species_id = SPECIES_HUMAN
+
+	var/newtype = GLOB.species_list[species_id]
+
+	if(!newtype) // The species ID doesn't exist, make it human
+		species_id = SPECIES_HUMAN
+		newtype = GLOB.species_list[SPECIES_HUMAN]
+
+	pref_species = new newtype
 
 	//Character
 	SAFE_READ_QUERY(3, real_name)

--- a/code/modules/client/preferences2/character_save.dm
+++ b/code/modules/client/preferences2/character_save.dm
@@ -88,8 +88,7 @@
 	var/newtype = GLOB.species_list[species_id]
 
 	if(!newtype) // The species ID doesn't exist in the species list, make it random
-		species_id = pick(GLOB.roundstart_races)
-		newtype = GLOB.species_list[species_id]
+		newtype = GLOB.species_list[pick(GLOB.roundstart_races)]
 
 	pref_species = new newtype
 


### PR DESCRIPTION
## About The Pull Request

If your species ID is not one in the game (ex: Grod), the character slot is unselectable and will break your character setup. This sets the slot to human if the species does not exist.

## Why It's Good For The Game

Fixes a bug.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Cannot test really but the code is simple

</details>

## Changelog
:cl:
fix: Fixed having nonexistent species data blocking Character Setup from opening by setting the slot to a random existing species.
/:cl:
