### PR TITLE
Vehicle movement speed is decreased proportional to the runspeed

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -8,6 +8,8 @@
 #define INFINITY				1e31	//closer then enough
 #define SYSTEM_TYPE_INFINITY					1.#INF //only for isinf check
 
+#define SQRT_TWO 1.414214
+
 #define SHORT_REAL_LIMIT 16777216
 
 /// A 32 bit single-precision floating point number's mantissa gives us 7 significant digits

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -3,6 +3,7 @@
 	var/last_move_diagonal = FALSE
 	var/vehicle_move_delay = 2 //tick delay between movements, lower = faster, higher = slower
 	var/keytype
+	var/vehicle_move_multiplier = 1
 
 	var/slowed = FALSE
 	var/slowvalue = 1
@@ -27,6 +28,8 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, .proc/vehicle_mob_buckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, .proc/vehicle_mob_unbuckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/vehicle_moved)
+	//Calculate the move multiplier speed, to be proportional to mob speed
+	vehicle_move_multiplier = 1.5 / CONFIG_GET(number/movedelay/run_delay)
 
 /datum/component/riding/proc/vehicle_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
 	SIGNAL_HANDLER
@@ -160,7 +163,7 @@
 		Unbuckle(user)
 		return
 
-	if(world.time < last_vehicle_move + ((last_move_diagonal? 2 : 1) * vehicle_move_delay))
+	if(world.time < last_vehicle_move + ((last_move_diagonal? SQRT_TWO : 1) * vehicle_move_delay * vehicle_move_multiplier))
 		return
 	last_vehicle_move = world.time
 

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -29,7 +29,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, .proc/vehicle_mob_unbuckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/vehicle_moved)
 	//Calculate the move multiplier speed, to be proportional to mob speed
-	vehicle_move_multiplier = 1.5 / CONFIG_GET(number/movedelay/run_delay)
+	vehicle_move_multiplier = CONFIG_GET(number/movedelay/run_delay) / 1.5
 
 /datum/component/riding/proc/vehicle_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
 	SIGNAL_HANDLER

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -930,7 +930,7 @@
 		var/obj/vehicle/V = C
 		var/datum/component/riding/R = V.GetComponent(/datum/component/riding)
 		if(R)
-			var/vehicle_speed_mod = round(CONFIG_GET(number/movedelay/run_delay) * 0.85, 0.01)
+			var/vehicle_speed_mod = round(1.5 * 0.85, 0.01)
 			if(R.vehicle_move_delay <= vehicle_speed_mod)
 				to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
 				return ..()

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -22,7 +22,7 @@
 	for(var/obj/item/stock_parts/capacitor/C in contents)
 		power_efficiency = C.rating
 	var/datum/component/riding/D = GetComponent(/datum/component/riding)
-	D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / speed
+	D.vehicle_move_delay = round(1.5 * delay_multiplier) / speed
 
 
 /obj/vehicle/ridden/wheelchair/motorized/get_cell()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -50,7 +50,7 @@
 	var/datum/component/riding/D = GetComponent(/datum/component/riding)
 	//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
 	//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-	D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / clamp(user.get_num_arms(), arms_required, 2)
+	D.vehicle_move_delay = round(1.5 * delay_multiplier) / clamp(user.get_num_arms(), arms_required, 2)
 
 /obj/vehicle/ridden/wheelchair/Moved()
 	. = ..()
@@ -110,5 +110,5 @@
 /obj/vehicle/ridden/wheelchair/the_whip/driver_move(mob/living/user, direction)
 	if(istype(user))
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / user.get_num_arms()
+		D.vehicle_move_delay = round(1.5 * 6.7) / user.get_num_arms()
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Vehicle movespeed is now multiplied proportionally to the runspeed.
At a value of 1.5 (Original), the multiplier for vehicle movespeed is 1. When the move delay is increased, the multiplier decreases, making vehicles slower proportional to that value.

## Why It's Good For The Game

The movespeed of vehicles should mostly be proportional to the movespeed of mobs, secways are extremely fast compared to people now.

## Testing Photographs and Procedure


https://user-images.githubusercontent.com/26465327/194756699-b233ea3c-ea73-4e4c-afaf-8bf2542df92b.mp4


https://user-images.githubusercontent.com/26465327/194756703-77ec810a-fdd1-4158-97b1-40b3e131139f.mp4



## Changelog
:cl:
balance: The movespeed of vehicles has been modified to be proportional to the configuration run delay value.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
