### PR TITLE
Autolathes now properly display material costs

### DIFF
--- a/code/game/machinery/fabricators/modular_fabricator.dm
+++ b/code/game/machinery/fabricators/modular_fabricator.dm
@@ -101,6 +101,8 @@
 		efficiency -= new_manipulator.rating*0.2
 	creation_efficiency = max(1,efficiency) // creation_efficiency goes 1.6 -> 1.4 -> 1.2 -> 1 per level of manipulator efficiency
 
+	update_viewer_statics()
+
 /obj/machinery/modular_fabricator/examine(mob/user)
 	. += ..()
 	var/datum/component/material_container/materials = get_material_container()

--- a/code/game/machinery/fabricators/modular_fabricator.dm
+++ b/code/game/machinery/fabricators/modular_fabricator.dm
@@ -149,7 +149,7 @@
 			for(var/material_id in D.materials)
 				material_cost += list(list(
 					"name" = material_id,
-					"amount" = D.materials[material_id] / MINERAL_MATERIAL_AMOUNT,
+					"amount" = ( D.materials[material_id] / MINERAL_MATERIAL_AMOUNT) * creation_efficiency,
 				))
 
 			//Add


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes autolathes display the proper material cost for items, depending on parts installed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Due to how unupgraded autolathes actually consume 160% of the material cost per item, it tends to lead to confusing situations where you run out of materials sooner than you expected. This PR aims to fix that. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>
Unupgraded autolathe : 

![image](https://user-images.githubusercontent.com/110184118/194757860-5d3007e6-3856-4813-b990-4e754c8676f9.png)
Material list after printing a singular hatchet :

![image](https://user-images.githubusercontent.com/110184118/194757879-277f40e7-25f8-4bee-a8e3-e74130306a86.png)
Autolathe with tier 4 parts : 

![image](https://user-images.githubusercontent.com/110184118/194757892-ba0887b2-488b-4105-b571-d134e169815c.png)
Material list after printing a singular hatchet :

![image](https://user-images.githubusercontent.com/110184118/194757905-59ba5250-230d-420e-9035-1dbf96138d85.png)

</details>

## Changelog
:cl:
fix: Autolathes now display the correct material cost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
