### PR TITLE
Remove useless admin message for invalid keybinds

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -35,7 +35,6 @@ GLOBAL_LIST_INIT(valid_keys, list(
 		message_admins("Mob [(C.mob)] with the ckey [(C.ckey)] just attempted to send an invalid keypress with length over 32 characters, likely malicious.")
 	else
 		log_admin_private("[key_name(C)] just attempted to send an invalid keypress - \"[key]\".")
-		message_admins("Mob [(C.mob)] with the ckey [(C.ckey)] just attempted to send an invalid keypress - \"[sanitize(key)]\".")
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

It serves no purpose at all and will probably just annoy admins or make them paranoid.

## Why It's Good For The Game

See above

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

It doesn't message you

</details>

## Changelog
:cl:
admin: Removed a useless admin message for if someone has an invalid keybind set.
/:cl:
