### PR TITLE
Fix various ModPC runtimes

### DIFF
--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -213,7 +213,7 @@
 // ALWAYS INCLUDE PARENT CALL ..() OR DIE IN FIRE.
 /datum/computer_file/program/ui_act(action,params,datum/tgui/ui)
 	if(..())
-		return 1
+		return TRUE
 	if(computer)
 		if(computer.device_theme == THEME_THINKTRONIC)
 			computer.send_select_sound()
@@ -240,6 +240,7 @@
 
 				if(user && istype(user))
 					computer.ui_interact(user) // Re-open the UI on this computer. It should show the main screen now.
+				return TRUE
 
 
 /datum/computer_file/program/ui_host()

--- a/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_self_monitor.dm
@@ -50,7 +50,7 @@
 	data["integrity"] = ((borgo.health + 100) / 2) //Borgo health, as percentage
 	data["lampIntensity"] = borgo.lamp_intensity //Borgo lamp power setting
 	data["sensors"] = "[borgo.sensors_on?"ACTIVE":"DISABLED"]"
-	data["printerPictures"] =  borgo.connected_ai? borgo.connected_ai.aicamera.stored.len : borgo.aicamera.stored.len //Number of pictures taken, synced to AI if available
+	data["printerPictures"] = borgo.connected_ai ? length(borgo.connected_ai.aicamera?.stored) : length(borgo.aicamera?.stored) //Number of pictures taken, synced to AI if available
 	data["printerToner"] = borgo.toner //amount of toner
 	data["printerTonerMax"] = borgo.tonermax //It's a variable, might as well use it
 	data["thrustersInstalled"] = borgo.ionpulse //If we have a thruster uprade

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -101,24 +101,22 @@
 	if(..())
 		return TRUE
 
-	var/obj/item/computer_hardware/card_slot/card_slot
-	var/obj/item/computer_hardware/card_slot/card_slot2
-	var/obj/item/computer_hardware/printer/printer
-	if(computer)
-		card_slot = computer.all_components[MC_CARD]
-		card_slot2 = computer.all_components[MC_CARD2]
-		printer = computer.all_components[MC_PRINT]
-		if(!card_slot || !card_slot2)
-			return
+	if(!computer)
+		return
+
+	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
+	var/obj/item/computer_hardware/card_slot/card_slot2 = computer.all_components[MC_CARD2]
+	var/obj/item/computer_hardware/printer/printer = computer.all_components[MC_PRINT]
+	if(!card_slot || !card_slot2)
+		return
 
 	var/mob/user = usr
 	var/obj/item/card/id/user_id_card = card_slot.stored_card
-
 	var/obj/item/card/id/target_id_card = card_slot2.stored_card
 
 	switch(action)
 		if("PRG_authenticate")
-			if(!computer || !user_id_card)
+			if(!user_id_card)
 				playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 				return
 			if(authenticate(user, user_id_card))
@@ -129,7 +127,7 @@
 			playsound(computer, 'sound/machines/terminal_off.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_print")
-			if(!computer || !printer)
+			if(!printer)
 				return
 			if(!authenticated)
 				return
@@ -154,7 +152,7 @@
 				computer.visible_message("<span class='notice'>\The [computer] prints out a paper.</span>")
 			return TRUE
 		if("PRG_eject")
-			if(!computer || !card_slot2)
+			if(!card_slot2)
 				return
 			if(target_id_card)
 				GLOB.data_core.manifest_modify(target_id_card.registered_name, target_id_card.assignment, target_id_card.hud_state)
@@ -165,7 +163,7 @@
 					return card_slot2.try_insert(I, user)
 			return FALSE
 		if("PRG_terminate")
-			if(!computer || !authenticated)
+			if(!authenticated)
 				return
 			if(minor)
 				if(!(target_id_card.assignment in head_subordinates) && target_id_card.assignment != JOB_NAME_ASSISTANT)
@@ -178,7 +176,7 @@
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_edit")
-			if(!computer || !authenticated || !target_id_card)
+			if(!authenticated || !target_id_card)
 				return
 
 			// Sanitize the name first. We're not using the full sanitize_name proc as ID cards can have a wider variety of things on them that
@@ -196,7 +194,7 @@
 			playsound(computer, "terminal_type", 50, FALSE)
 			return TRUE
 		if("PRG_assign")
-			if(!computer || !authenticated || !target_id_card)
+			if(!authenticated || !target_id_card)
 				return
 			var/target = params["assign_target"]
 			if(!target)
@@ -239,7 +237,7 @@
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_access")
-			if(!computer || !authenticated)
+			if(!authenticated)
 				return
 			var/access_type = text2num(params["access_target"])
 			if(access_type in (is_centcom ? get_all_centcom_access() : get_all_accesses()))
@@ -252,21 +250,21 @@
 				playsound(computer, "terminal_type", 50, FALSE)
 				return TRUE
 		if("PRG_grantall")
-			if(!computer || !authenticated || minor)
+			if(!authenticated || minor)
 				return
 			target_id_card.access |= (is_centcom ? get_all_centcom_access() : get_all_accesses())
 			log_id("[key_name(usr)] granted All Access to [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_denyall")
-			if(!computer || !authenticated || minor)
+			if(!authenticated || minor)
 				return
 			target_id_card.access.Cut()
 			log_id("[key_name(usr)] removed All Access from [target_id_card] using [user_id_card] via a portable ID console at [AREACOORD(usr)].")
 			playsound(computer, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_grantregion")
-			if(!computer || !authenticated)
+			if(!authenticated)
 				return
 			var/region = text2num(params["region"])
 			if(isnull(region))
@@ -276,7 +274,7 @@
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_denyregion")
-			if(!computer || !authenticated)
+			if(!authenticated)
 				return
 			var/region = text2num(params["region"])
 			if(isnull(region))

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -82,19 +82,12 @@
 
 	var/list/standard_actions = list("patroloff", "patrolon", "ejectpai")
 	var/list/MULE_actions = list("stop", "go", "home", "destination", "setid", "sethome", "unload", "autoret", "autopick", "report", "ejectpai")
-	var/mob/living/simple_animal/bot/Bot = locate(params["robot"]) in GLOB.bots_list
-	var access_okay = TRUE
-	if(!id_card && !Bot.bot_core.allowed(current_user))
-		access_okay = FALSE
-	else if(id_card && !Bot.bot_core.check_access(id_card))
-		access_okay = FALSE
-	if (access_okay && (action in standard_actions))
-		Bot.bot_control(action, current_user, id_card ? id_card.access : current_access)
-	if (access_okay && (action in MULE_actions))
-		Bot.bot_control(action, current_user, id_card ? id_card.access : current_access, TRUE)
+	var/mob/living/simple_animal/bot/selected_bot = locate(params["robot"]) in GLOB.bots_list
 	switch(action)
 		if("summon")
-			Bot.bot_control(action, current_user, id_card ? id_card.access : current_access)
+			if(!selected_bot)
+				return
+			selected_bot.bot_control(action, current_user, id_card ? id_card.access : current_access)
 		if("ejectcard")
 			if(!computer || !card_slot)
 				return
@@ -103,4 +96,14 @@
 				card_slot.try_eject(current_user)
 			else
 				playsound(get_turf(ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
-	return
+	if(!selected_bot)
+		return
+	var access_okay = TRUE
+	if(!id_card && !selected_bot.bot_core.allowed(current_user))
+		access_okay = FALSE
+	else if(id_card && !selected_bot.bot_core.check_access(id_card))
+		access_okay = FALSE
+	if (access_okay && (action in standard_actions))
+		selected_bot.bot_control(action, current_user, id_card ? id_card.access : current_access)
+	if (access_okay && (action in MULE_actions))
+		selected_bot.bot_control(action, current_user, id_card ? id_card.access : current_access, TRUE)


### PR DESCRIPTION
## About The Pull Request

Fixes a few runtimes and cleans up some code.
- PC_Minimize now properly returns and prevents child calls
- borg_self_monitor no longer runtimes on the stored pictures list
- Card modification program ui_act has been cleaned up to early return if computer is null
- Bot access will early return if no bot is selected instead of runtiming and is restructured to make more sense

## Why It's Good For The Game

Runtimes bad

## Testing Photographs and Procedure

It does not runtime

## Changelog
:cl:
fix: Fixed some runtimes in Cyborg Self Monitoring and Robot Control.
/:cl:
