### PR TITLE
Fixed old job paths being used for some mail item lists

### DIFF
--- a/code/modules/jobs/job_mail.dm
+++ b/code/modules/jobs/job_mail.dm
@@ -13,7 +13,7 @@
 	)
 
 //ATMOSPHERIC TECHNICIAN
-/datum/job/atmos
+/datum/job/atmospheric_technician
 	mail_goodies = list(
 		/obj/item/book/manual/wiki/atmospherics = 12,
 		/obj/item/tank/internals/emergency_oxygen/engi = 10,
@@ -237,7 +237,7 @@
 	)
 
 //HEAD OF PERSONNEL
-/datum/job/hop
+/datum/job/head_of_personnel
 	mail_goodies = list(
 		/obj/item/card/id/silver = 10,
 		/obj/item/assembly/flash/handheld = 5,
@@ -248,7 +248,7 @@
 	)
 
 //HEAD OF SECURITY
-/datum/job/hos
+/datum/job/head_of_security
 	mail_goodies = list(
 		/obj/effect/spawner/mail/donut = 20,
 		/obj/effect/spawner/mail/rdonut = 15,
@@ -329,7 +329,7 @@
 	)
 
 //QUARTERMASTER
-/datum/job/qm
+/datum/job/quartermaster
 	mail_goodies = list(
 		/obj/item/reagent_containers/food/snacks/donkpocket/random = 10,
 		//the beginning of your department's independence
@@ -387,7 +387,7 @@
 	)
 
 //SHAFT MINER
-/datum/job/mining
+/datum/job/shaft_miner
 	mail_goodies = list(
 		/obj/item/reagent_containers/hypospray/medipen/survival = 10,
 		/obj/item/tank/internals/emergency_oxygen/double = 7,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The job_mail.dm file didn't get updated with unabbreviated job paths. This makes them match the main job definitions.

## Why It's Good For The Game
Keeps the game from having extra job datums in it and lets the affected jobs get their special mail goodies.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
fix: Fixed atmospheric technicians, shaft miners, the HOP, the HOS, and the QM lacking their specialized list of mail goodies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
