### PR TITLE
Adds the teleporter public-access gates

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1808,6 +1808,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"afm" = (
+/obj/machinery/button/door{
+	id = "publictele";
+	name = "Teleporter Shutters";
+	pixel_y = 26;
+	req_access_txt = "19"
+	},
+/turf/closed/wall,
+/area/teleporter)
 "afp" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -38790,6 +38799,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"jmZ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "publictele"
+	},
+/turf/open/floor/plasteel,
+/area/teleporter)
 "jnF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -92786,7 +92801,7 @@ bqH
 bsh
 bsh
 bsh
-bsh
+afm
 bqH
 aJq
 hKs
@@ -93558,7 +93573,7 @@ bsl
 ujg
 buW
 bwt
-bqH
+jmZ
 qVS
 sMZ
 mjS

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -15403,10 +15403,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/analyzer,
-/obj/item/extinguisher,
-/obj/item/extinguisher,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "dZs" = (
@@ -20407,13 +20403,17 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "fEM" = (
-/obj/machinery/teleport/station,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/radio,
+/obj/item/radio,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "fEW" = (
@@ -20487,10 +20487,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fFV" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "teleportershutters";
-	name = "Teleporter Shutters"
-	},
 /obj/machinery/button/door{
 	id = "teleportershutters";
 	name = "Teleporter Shutters";
@@ -20499,6 +20495,10 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "teleportershutters";
+	name = "Teleporter Shutters"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -25944,7 +25944,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "heW" = (
-/obj/machinery/teleport/hub,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -25952,6 +25951,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "heZ" = (
@@ -30563,6 +30565,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/teleport/station,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "irF" = (
@@ -31254,7 +31257,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "iCy" = (
-/obj/machinery/computer/teleporter,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -31266,6 +31268,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
+	},
+/obj/item/beacon,
+/obj/structure/rack,
+/obj/item/hand_tele{
+	pixel_x = -2;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -31558,15 +31566,14 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "iGT" = (
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen,
-/obj/item/tank/internals/oxygen,
-/obj/item/radio,
-/obj/item/radio,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/rack,
+/obj/item/extinguisher,
+/obj/item/extinguisher,
+/obj/item/analyzer,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "iGU" = (
@@ -40272,6 +40279,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
+/obj/machinery/teleport/hub,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lex" = (
@@ -59955,12 +59963,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "qVA" = (
-/obj/structure/rack,
-/obj/item/hand_tele{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/beacon,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -73903,9 +73905,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "vkT" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -75866,6 +75865,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/computer/teleporter,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "vJK" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9027,7 +9027,6 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aMa" = (
-/obj/structure/closet/crate,
 /obj/machinery/button/door{
 	id = "teleshutter";
 	name = "Teleporter Shutters Control";
@@ -9037,6 +9036,10 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/computer/teleporter{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aMd" = (
@@ -9543,6 +9546,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/teleport/station,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aNz" = (
@@ -9888,8 +9893,6 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/eva)
 "aOE" = (
-/obj/structure/table,
-/obj/item/hand_tele,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -9900,7 +9903,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -9942,6 +9944,8 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/teleport/hub,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "aOJ" = (
@@ -10244,19 +10248,15 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPN" = (
-/obj/machinery/computer/teleporter{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/hand_tele,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPO" = (
-/obj/machinery/teleport/station,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -10264,9 +10264,7 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPP" = (
-/obj/machinery/teleport/hub,
 /obj/machinery/light,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a gate to only get to the teleporter bit of the teleporter on corg box and pubby
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it helps give the ai/heads more control over who uses the teleporter without fear of someone teleporting into a hazard/stealing the hand tele
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/73374039/195016113-9676b873-333f-437c-a579-c8291c7253c4.png)

</details>

## Changelog
:cl:
add: teleporter has public gate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
