### PR TITLE
Rebalances dormant diseases and sample crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1609,7 +1609,7 @@
 /datum/supply_pack/medical/randomvirus
 	name = "Virus Sample Crate"
 	desc = "Contains five random experimental disease cultures for epidemiological research"
-	cost = 3750
+	cost = 6000
 	access = ACCESS_VIROLOGY
 	access_budget = ACCESS_VIROLOGY
 	contains = list(/obj/item/reagent_containers/glass/bottle/random_virus,

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -378,7 +378,7 @@
 		guaranteed = /datum/symptom/undead_adaptation
 	else if(!(MOB_ORGANIC in H.mob_biotypes))
 		return //this mob cant be given a disease
-	if(prob min(100, (biohazard * sickrisk)))
+	if(prob (min(100, (biohazard * sickrisk))))
 		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(2, 4), 9, unfunny, guaranteed, infected = H)
 		scandisease.dormant = TRUE
 		scandisease.spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -79,7 +79,7 @@
 	/// Should this job be allowed to be picked for the bureaucratic error event?
 	var/allow_bureaucratic_error = TRUE
 	///how at risk is this occupation at for being a carrier of a dormant disease
-	var/biohazard = 10
+	var/biohazard = 20
 
 	///A dictionary of species IDs and a path to the outfit.
 	var/list/species_outfits = null
@@ -378,8 +378,8 @@
 		guaranteed = /datum/symptom/undead_adaptation
 	else if(!(MOB_ORGANIC in H.mob_biotypes))
 		return //this mob cant be given a disease
-	if(prob(biohazard * sickrisk))
-		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(1, 4), rand(7, 9), unfunny, guaranteed, infected = H)
+	if(prob min(100, (biohazard * sickrisk)))
+		var/datum/disease/advance/scandisease = new /datum/disease/advance/random(rand(2, 4), 9, unfunny, guaranteed, infected = H)
 		scandisease.dormant = TRUE
 		scandisease.spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 		scandisease.spread_text = "None"

--- a/code/modules/jobs/job_types/brig_physician.dm
+++ b/code/modules/jobs/job_types/brig_physician.dm
@@ -27,7 +27,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/brig_physician
 	)
-	biohazard = 15 //still deals with the sick and injured, just less than a medical doctor
+	biohazard = 25 //still deals with the sick and injured, just less than a medical doctor
 
 /datum/outfit/job/brig_physician
 	name = JOB_NAME_BRIGPHYSICIAN

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -23,7 +23,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/cargo_technician
 	)
-	biohazard = 15
+	biohazard = 25
 
 /datum/outfit/job/cargo_technician
 	name = JOB_NAME_CARGOTECHNICIAN

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -26,7 +26,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/chemist
 	)
-	biohazard = 15
+	biohazard = 25
 
 /datum/outfit/job/chemist
 	name = JOB_NAME_CHEMIST

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -35,7 +35,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/cmo
 	)
-	biohazard = 20
+	biohazard = 45
 
 /datum/outfit/job/chief_medical_officer
 	name = JOB_NAME_CHIEFMEDICALOFFICER

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -24,7 +24,7 @@
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/curator
 	)
 	//they doesnt get out that much
-	biohazard = 5
+	biohazard = 10
 
 /datum/outfit/job/curator
 	name = JOB_NAME_CURATOR

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -26,7 +26,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/exploration_crew
 	)
-	biohazard = 20//who knows what you'll find out there that could have nasties on it...
+	biohazard = 40//who knows what you'll find out there that could have nasties on it...
 
 /datum/job/exploration_crew/equip(mob/living/carbon/human/H, visualsOnly, announce, latejoin, datum/outfit/outfit_override, client/preference_source)
 	if(outfit_override)

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -26,7 +26,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/genetics
 	)
-	biohazard = 15
+	biohazard = 25
 
 /datum/outfit/job/geneticist
 	name = JOB_NAME_GENETICIST

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -19,7 +19,7 @@
 	display_order = JOB_DISPLAY_ORDER_JANITOR
 	departments = DEPARTMENT_BITFLAG_SERVICE
 	rpg_title = "Groundskeeper"
-	biohazard = 20//cleaning up hazardous messes puts janitors at extra risk
+	biohazard = 40//cleaning up hazardous messes puts janitors at extra risk
 
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/janitor

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -26,7 +26,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/medical
 	)
-	biohazard = 20
+	biohazard = 40
 
 /datum/outfit/job/medical_doctor
 	name = JOB_NAME_MEDICALDOCTOR

--- a/code/modules/jobs/job_types/paramedic.dm
+++ b/code/modules/jobs/job_types/paramedic.dm
@@ -28,7 +28,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/paramedic
 	)
-	biohazard = 25//deal with sick like MDS, but also muck around in maint and get into the thick of it
+	biohazard = 50//deal with sick like MDS, but also muck around in maint and get into the thick of it
 
 /datum/outfit/job/paramedic
 	name = JOB_NAME_PARAMEDIC

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -38,7 +38,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/rd
 	)
-	biohazard = 20
+	biohazard = 40
 
 /datum/outfit/job/research_director
 	name = JOB_NAME_RESEARCHDIRECTOR

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -27,7 +27,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/science
 	)
-	biohazard = 15
+	biohazard = 35
 
 /datum/outfit/job/scientist
 	name = JOB_NAME_SCIENTIST

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -31,7 +31,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/security_officer
 	)
-	biohazard = 15 //clean your baton, man
+	biohazard = 25 //clean your baton, man
 
 /datum/job/security_officer/get_access()
 	var/list/L = list()

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -27,7 +27,7 @@
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/virologist
 	)
-	biohazard = 50 //duh
+	biohazard = 75 //duh
 
 /datum/outfit/job/virologist
 	name = JOB_NAME_VIROLOGIST


### PR DESCRIPTION

## About The Pull Request
dormant diseases should be about twice as common, and have better symptoms
virus sample crates have had their cost increased from 3750 to 6000

## Why It's Good For The Game
Dormant diseases are far less likely to appear than intended currently
virus sample crates are still king for virologists

this pr should mitigate that somewhat

## Testing Photographs and Procedure
![image](https://user-images.githubusercontent.com/49600480/195023337-2d79fa20-8c70-4858-bb79-ad362c5db83a.png)
it compiles, but this is a probability change, largely

## Changelog
:cl:
balance: dormant diseases should now be more common, virus sample crate price has significantly increased
/:cl:
