### PR TITLE
Make newscaster images less breakage-prone

### DIFF
--- a/code/game/machinery/newscaster/newscaster_data.dm
+++ b/code/game/machinery/newscaster/newscaster_data.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_EMPTY(request_list)
 		// instead we browse_rsc the image to *everyone* because the game is stupid - now everyone has the image cached before opening the newscaster
 		// this means the only person that will get possibly glitchy behavior is the person who posted the image, but it will be fixed the next time the UI opens.
 		var/photo_ID = "tmp_newscaster_[newMsg.parent_ID]_[newMsg.message_ID].png"
-		for(var/client/C in GLOB.clients)
+		for(var/client/C as anything in GLOB.clients)
 			C << browse_rsc(newMsg.img, photo_ID)
 	for(var/obj/machinery/newscaster/NEWSCASTER in GLOB.allCasters)
 		NEWSCASTER.news_alert(channel_name, update_alert)

--- a/code/game/machinery/newscaster/newscaster_data.dm
+++ b/code/game/machinery/newscaster/newscaster_data.dm
@@ -216,6 +216,13 @@ GLOBAL_LIST_EMPTY(request_list)
 			FC.messages += newMsg
 			newMsg.parent_ID = FC.channel_ID
 			break
+	if(picture)
+		// browse_rsc is stupid and too slow to call in ui_data (the image will not be received before the UI renders)
+		// instead we browse_rsc the image to *everyone* because the game is stupid - now everyone has the image cached before opening the newscaster
+		// this means the only person that will get possibly glitchy behavior is the person who posted the image, but it will be fixed the next time the UI opens.
+		var/photo_ID = "tmp_newscaster_[newMsg.parent_ID]_[newMsg.message_ID].png"
+		for(var/client/C in GLOB.clients)
+			C << browse_rsc(newMsg.img, photo_ID)
 	for(var/obj/machinery/newscaster/NEWSCASTER in GLOB.allCasters)
 		NEWSCASTER.news_alert(channel_name, update_alert)
 	last_action ++

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -178,8 +178,8 @@
 			var/photo_ID = null
 			var/list/comment_list
 			if(feed_message.img)
-				user << browse_rsc(feed_message.img, "tmp_photo[feed_message.message_ID].png")
-				photo_ID = "tmp_photo[feed_message.message_ID].png"
+				photo_ID = "tmp_newscaster_[current_channel.channel_ID]_[feed_message.message_ID].png"
+				user << browse_rsc(feed_message.img, photo_ID)
 			for(var/datum/feed_comment/comment_message as anything in feed_message.comments)
 				comment_list += list(list(
 					"auth" = comment_message.author,
@@ -830,6 +830,7 @@
 			wanted_image = !!current_image
 		if(current_image)
 			balloon_alert(usr, "photo selected.")
+			playsound(src, 'sound/machines/terminal_success.ogg', 15, TRUE)
 		else
 			balloon_alert(usr, "no photo identified.")
 


### PR DESCRIPTION
## About The Pull Request

Newscasters call browse_rsc, sending an image to the client inside `ui_data`, and then rendering it from the cache immediately after.

Unfortunately, the delay between these two events is not long enough for the client to fully process the browse_rsc call, so images can often show on first open/render as a missing image. This attempts to remedy that by sending all clients newscaster images when they are broadcast, so they're already cached.

It's a shitty solution to a stupid problem that shouldn't exist.

## Why It's Good For The Game

Newscaster images will actually properly appear.

## Testing Photographs and Procedure

It doesn't break as often

## Changelog
:cl:
fix: Reduced the amount that newscaster images error out.
tweak: Added a success sound when a newscaster scans a photo.
/:cl: