### PR TITLE
Adds currency symbol for credits

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -34,6 +34,7 @@
 #define ACCOUNT_VIP_NAME "Nanotrasen VIP Expense Account Budget"
 
 #define NO_FREEBIES "commies go home"
+#define MONEY_SYMBOL "₡"
 
 /// How much mail the Economy SS will create per minute, regardless of firing time.
 #define MAX_MAIL_PER_MINUTE 3

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -33,7 +33,7 @@
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			D.adjust_money(value)
-			to_chat(user, "<span class='notice'>You deposit [I]. The Cargo Budget is now ₡[D.account_balance].</span>")
+			to_chat(user, "<span class='notice'>You deposit [I]. The Cargo Budget is now [MONEY_SYMBOL][D.account_balance].</span>")
 		qdel(I)
 		return
 	return ..()

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -33,7 +33,7 @@
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			D.adjust_money(value)
-			to_chat(user, "<span class='notice'>You deposit [I]. The Cargo Budget is now $[D.account_balance].</span>")
+			to_chat(user, "<span class='notice'>You deposit [I]. The Cargo Budget is now ₡[D.account_balance].</span>")
 		qdel(I)
 		return
 	return ..()

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -311,8 +311,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			dat += "<tr>"
 			dat += "<td>[B.account_holder]</td>"
 			dat += "<td>[B.account_job.title]</td>"
-			dat += "<td><a href='?src=[REF(src)];choice=adjust_pay;account=[B.account_holder]'>$[B.paycheck_amount]</a></td>"
-			dat += "<td><a href='?src=[REF(src)];choice=adjust_bonus;account=[B.account_holder]'>$[B.paycheck_bonus]</a></td>"
+			dat += "<td><a href='?src=[REF(src)];choice=adjust_pay;account=[B.account_holder]'>₡[B.paycheck_amount]</a></td>"
+			dat += "<td><a href='?src=[REF(src)];choice=adjust_bonus;account=[B.account_holder]'>₡[B.paycheck_bonus]</a></td>"
 	else
 		var/header = ""
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -311,8 +311,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			dat += "<tr>"
 			dat += "<td>[B.account_holder]</td>"
 			dat += "<td>[B.account_job.title]</td>"
-			dat += "<td><a href='?src=[REF(src)];choice=adjust_pay;account=[B.account_holder]'>₡[B.paycheck_amount]</a></td>"
-			dat += "<td><a href='?src=[REF(src)];choice=adjust_bonus;account=[B.account_holder]'>₡[B.paycheck_bonus]</a></td>"
+			dat += "<td><a href='?src=[REF(src)];choice=adjust_pay;account=[B.account_holder]'>[MONEY_SYMBOL][B.paycheck_amount]</a></td>"
+			dat += "<td><a href='?src=[REF(src)];choice=adjust_bonus;account=[B.account_holder]'>[MONEY_SYMBOL][B.paycheck_bonus]</a></td>"
 	else
 		var/header = ""
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -202,7 +202,7 @@
 			SSshuttle.existing_shuttle = SSshuttle.emergency
 			SSshuttle.action_load(shuttle)
 			bank_account.adjust_money(-shuttle.credit_cost)
-			minor_announce("[shuttle.name] has been purchased for [shuttle.credit_cost] credits! Purchase authorized by [authorize_name] [shuttle.extra_desc ? " [shuttle.extra_desc]" : ""]" , "Shuttle Purchase")
+			minor_announce("[shuttle.name] has been purchased for [MONEY_SYMBOL][shuttle.credit_cost]! Purchase authorized by [authorize_name] [shuttle.extra_desc ? " [shuttle.extra_desc]" : ""]" , "Shuttle Purchase")
 			message_admins("[ADMIN_LOOKUPFLW(usr)] purchased [shuttle.name].")
 			log_game("[key_name(usr)] has purchased [shuttle.name].")
 			SSblackbox.record_feedback("text", "shuttle_purchase", 1, shuttle.name)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -383,10 +383,10 @@
 						for(var/datum/data/crime/c in active2.fields["citation"])
 							var/owed = c.fine - c.paid
 							dat += {"<tr><td>[c.crimeName]</td>
-							<td>[c.fine] cr</td><td>[c.author]</td>
+							<td>[MONEY_SYMBOL][c.fine]</td><td>[c.author]</td>
 							<td>[c.time]</td>"}
 							if(owed > 0)
-								dat += "<td>[owed] cr <A href='?src=[REF(src)];choice=Pay;field=citation_pay;cdataid=[c.dataId]'>\[Pay\]</A></td></td>"
+								dat += "<td>[MONEY_SYMBOL][owed] <A href='?src=[REF(src)];choice=Pay;field=citation_pay;cdataid=[c.dataId]'>\[Pay\]</A></td></td>"
 							else
 								dat += "<td>All Paid Off</td>"
 							dat += {"<td>
@@ -536,9 +536,9 @@ What a mess.*/
 							else
 								var/diff = p.fine - p.paid
 								GLOB.data_core.payCitation(active2.fields["id"], text2num(href_list["cdataid"]), pay)
-								to_chat(usr, "<span class='notice'>You have paid [pay] credit\s towards your fine.</span>")
+								to_chat(usr, "<span class='notice'>You have paid [MONEY_SYMBOL][pay] towards your fine.</span>")
 								if (pay == diff || pay > diff || pay >= diff)
-									investigate_log("Citation Paid off: <strong>[p.crimeName]</strong> Fine: [p.fine] | Paid off by [key_name(usr)]", INVESTIGATE_RECORDS)
+									investigate_log("Citation Paid off: <strong>[p.crimeName]</strong> Fine: [MONEY_SYMBOL][p.fine] | Paid off by [key_name(usr)]", INVESTIGATE_RECORDS)
 									to_chat(usr, "<span class='notice'>The fine has been paid in full.</span>")
 								qdel(C)
 								playsound(src, "terminal_type", 25, FALSE)
@@ -870,7 +870,7 @@ What a mess.*/
 							var/datum/data/crime/crime = GLOB.data_core.createCrimeEntry(t1, "", authenticated, station_time_timestamp(), fine)
 							for (var/obj/item/modular_computer/tablet in GLOB.TabletMessengers)
 								if(tablet.saved_identification == active1.fields["name"])
-									var/message = "You have been fined [fine] credits for '[t1]'. Fines may be paid at security."
+									var/message = "You have been fined [MONEY_SYMBOL][fine] for '[t1]'. Fines may be paid at security."
 									var/datum/signal/subspace/messaging/tablet_msg/signal = new(src, list(
 										"name" = "Security Citation",
 										"job" = "Citation Server",
@@ -881,7 +881,7 @@ What a mess.*/
 									signal.send_to_receivers()
 									usr.log_message("(PDA: Citation Server) sent \"[message]\" to [signal.format_target()]", LOG_PDA)
 							GLOB.data_core.addCitation(active1.fields["id"], crime)
-							investigate_log("New Citation: <strong>[t1]</strong> Fine: [fine] | Added to [active1.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
+							investigate_log("New Citation: <strong>[t1]</strong> Fine: [MONEY_SYMBOL][fine] | Added to [active1.fields["name"]] by [key_name(usr)]", INVESTIGATE_RECORDS)
 					if("citation_delete")
 						if(istype(active1, /datum/data/record))
 							if(href_list["cdataid"])

--- a/code/game/machinery/computer/warrant.dm
+++ b/code/game/machinery/computer/warrant.dm
@@ -59,11 +59,11 @@
 			for(var/datum/data/crime/c in current.fields["citation"])
 				var/owed = c.fine - c.paid
 				dat += {"<tr><td>[c.crimeName]</td>
-				<td>₡[c.fine]</td>
+				<td>[MONEY_SYMBOL][c.fine]</td>
 				<td>[c.author]</td>
 				<td>[c.time]</td>"}
 				if(owed > 0)
-					dat += {"<td>₡[owed]</td>
+					dat += {"<td>[MONEY_SYMBOL][owed]</td>
 					<td><A href='?src=[REF(src)];choice=Pay;field=citation_pay;cdataid=[c.dataId]'>\[Pay\]</A></td>"}
 				else
 					dat += "<td colspan='2'>All Paid Off</td>"
@@ -126,9 +126,9 @@
 						else
 							var/diff = p.fine - p.paid
 							GLOB.data_core.payCitation(current.fields["id"], text2num(href_list["cdataid"]), pay)
-							to_chat(M, "<span class='notice'>You have paid [pay] credit\s towards your fine.</span>")
+							to_chat(M, "<span class='notice'>You have paid [MONEY_SYMBOL][pay] towards your fine.</span>")
 							if (pay == diff || pay > diff || pay >= diff)
-								investigate_log("Citation Paid off: <strong>[p.crimeName]</strong> Fine: [p.fine] | Paid off by [key_name(usr)]", INVESTIGATE_RECORDS)
+								investigate_log("Citation Paid off: <strong>[p.crimeName]</strong> Fine: [MONEY_SYMBOL][p.fine] | Paid off by [key_name(usr)]", INVESTIGATE_RECORDS)
 								to_chat(M, "<span class='notice'>The fine has been paid in full.</span>")
 							qdel(C)
 							playsound(src, "terminal_type", 25, 0)

--- a/code/game/machinery/computer/warrant.dm
+++ b/code/game/machinery/computer/warrant.dm
@@ -59,11 +59,11 @@
 			for(var/datum/data/crime/c in current.fields["citation"])
 				var/owed = c.fine - c.paid
 				dat += {"<tr><td>[c.crimeName]</td>
-				<td>$[c.fine]</td>
+				<td>₡[c.fine]</td>
 				<td>[c.author]</td>
 				<td>[c.time]</td>"}
 				if(owed > 0)
-					dat += {"<td>$[owed]</td>
+					dat += {"<td>₡[owed]</td>
 					<td><A href='?src=[REF(src)];choice=Pay;field=citation_pay;cdataid=[c.dataId]'>\[Pay\]</A></td>"}
 				else
 					dat += "<td colspan='2'>All Paid Off</td>"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -252,7 +252,7 @@
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, general_point_gain)
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, discovery_point_gain)
 
-			say("Explosion details and mixture analyzed and sold to the highest bidder for $[general_point_gain], with a reward of [general_point_gain] General Research points and [discovery_point_gain] Discovery Research points.")
+			say("Explosion details and mixture analyzed and sold to the highest bidder for ₡[general_point_gain], with a reward of [general_point_gain] General Research points and [discovery_point_gain] Discovery Research points.")
 
 	else //you've made smaller bombs
 		say("Data already captured. Aborting.")

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -252,7 +252,7 @@
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, general_point_gain)
 			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, discovery_point_gain)
 
-			say("Explosion details and mixture analyzed and sold to the highest bidder for ₡[general_point_gain], with a reward of [general_point_gain] General Research points and [discovery_point_gain] Discovery Research points.")
+			say("Explosion details and mixture analyzed and sold to the highest bidder for [MONEY_SYMBOL][general_point_gain], with a reward of [general_point_gain] General Research points and [discovery_point_gain] Discovery Research points.")
 
 	else //you've made smaller bombs
 		say("Data already captured. Aborting.")

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -931,7 +931,7 @@
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 		return TRUE
 	payment_target.transfer_money(account, active_request.value)
-	say("Paid out [active_request.value] credits.")
+	say("Paid out [MONEY_SYMBOL][active_request.value].")
 	GLOB.request_list.Remove(active_request)
 	qdel(active_request)
 

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -107,7 +107,7 @@
 			var/obj/item/holochip/H = I
 			if(!user.temporarilyRemoveItemFromInventory(H))
 				return
-			to_chat(user, "<span class='notice'>You insert [H.credits] holocredits into [src]'s slot!</span>")
+			to_chat(user, "<span class='notice'>You insert [MONEY_SYMBOL][H.credits] into [src]'s slot!</span>")
 			balance += H.credits
 			qdel(H)
 		else
@@ -151,7 +151,7 @@
 	else
 		dat = {"Five credits to play!<BR>
 		<B>Prize Money Available:</B> [money] (jackpot payout is ALWAYS 100%!)<BR>
-		<B>Credit Remaining:</B> [balance]<BR>
+		<B>Credit Remaining:</B> [MONEY_SYMBOL][balance]<BR>
 		[plays] players have tried their luck today, and [jackpots] have won a jackpot!<BR>
 		<HR><BR>
 		<A href='?src=[REF(src)];spin=1'>Play!</A><BR>
@@ -255,8 +255,8 @@
 	var/linelength = get_lines()
 
 	if(reels[1][2] + reels[2][2] + reels[3][2] + reels[4][2] + reels[5][2] == "[SEVEN][SEVEN][SEVEN][SEVEN][SEVEN]")
-		visible_message("<b>[src]</b> says, 'JACKPOT! You win [money] credits!'")
-		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the jackpot at the slot machine in [get_area(src)]!", sound = SSstation.announcer.get_rand_alert_sound())
+		visible_message("<b>[src]</b> says, 'JACKPOT! You win [MONEY_SYMBOL][money]!'")
+		priority_announce("Congratulations to [user ? user.real_name : usrname] for winning the [MONEY_SYMBOL][JACKPOT] jackpot at the slot machine in [get_area(src)]!", sound = SSstation.announcer.get_rand_alert_sound())
 		jackpots += 1
 		balance += money - give_payout(JACKPOT)
 		money = 0

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -195,7 +195,7 @@
 	else
 		to_chat(user, "<span class='notice'>You insert [I] into [src], adding [cash_money] credits to the linked account.</span>")
 
-	to_chat(user, "<span class='notice'>The linked account now reports a balance of $[registered_account.account_balance].</span>")
+	to_chat(user, "<span class='notice'>The linked account now reports a balance of ₡[registered_account.account_balance].</span>")
 	qdel(I)
 
 /obj/item/card/id/proc/mass_insert_money(list/money, mob/user)
@@ -292,11 +292,11 @@
 	if(mining_points)
 		. += "There's [mining_points] mining equipment redemption point\s loaded onto this card."
 	if(registered_account)
-		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of $[registered_account.account_balance]."
+		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of ₡[registered_account.account_balance]."
 		if(registered_account.account_job)
 			var/datum/bank_account/D = SSeconomy.get_dep_account(registered_account.account_department)
 			if(D)
-				. += "The [D.account_holder] reports a balance of $[D.account_balance]."
+				. += "The [D.account_holder] reports a balance of ₡[D.account_balance]."
 		. += "<span class='info'>Alt-Click the ID to pull money from the linked account in the form of holochips.</span>"
 		. += "<span class='info'>You can insert credits into the linked account by pressing holochips, cash, or coins against the ID.</span>"
 		if(registered_account.account_holder == user.real_name)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -175,7 +175,7 @@
 		var/money_added = mass_insert_money(money_contained, user)
 
 		if (money_added)
-			to_chat(user, "<span class='notice'>You stuff the contents into the card! They disappear in a puff of bluespace smoke, adding [money_added] worth of credits to the linked account.</span>")
+			to_chat(user, "<span class='notice'>You stuff the contents into the card! They disappear in a puff of bluespace smoke, adding [MONEY_SYMBOL][money_added] worth of credits to the linked account.</span>")
 		return
 	else
 		return ..()
@@ -191,11 +191,11 @@
 
 	registered_account.adjust_money(cash_money)
 	if(istype(I, /obj/item/stack/spacecash) || istype(I, /obj/item/coin))
-		to_chat(user, "<span class='notice'>You stuff [I] into [src]. It disappears in a small puff of bluespace smoke, adding [cash_money] credits to the linked account.</span>")
+		to_chat(user, "<span class='notice'>You stuff [I] into [src]. It disappears in a small puff of bluespace smoke, adding [MONEY_SYMBOL][cash_money] to the linked account.</span>")
 	else
-		to_chat(user, "<span class='notice'>You insert [I] into [src], adding [cash_money] credits to the linked account.</span>")
+		to_chat(user, "<span class='notice'>You insert [I] into [src], adding [MONEY_SYMBOL][cash_money] to the linked account.</span>")
 
-	to_chat(user, "<span class='notice'>The linked account now reports a balance of ₡[registered_account.account_balance].</span>")
+	to_chat(user, "<span class='notice'>The linked account now reports a balance of [MONEY_SYMBOL][registered_account.account_balance].</span>")
 	qdel(I)
 
 /obj/item/card/id/proc/mass_insert_money(list/money, mob/user)
@@ -279,11 +279,11 @@
 	if(registered_account.adjust_money(-amount_to_remove))
 		var/obj/item/holochip/holochip = new (user.drop_location(), amount_to_remove)
 		user.put_in_hands(holochip)
-		to_chat(user, "<span class='notice'>You withdraw [amount_to_remove] credits into a holochip.</span>")
+		to_chat(user, "<span class='notice'>You withdraw [MONEY_SYMBOL][amount_to_remove] into a holochip.</span>")
 		return
 	else
 		var/difference = amount_to_remove - registered_account.account_balance
-		registered_account.bank_card_talk("<span class='warning'>ERROR: The linked account requires [difference] more credit\s to perform that withdrawal.</span>", TRUE)
+		registered_account.bank_card_talk("<span class='warning'>ERROR: The linked account requires [MONEY_SYMBOL][difference] more to perform that withdrawal.</span>", TRUE)
 
 /obj/item/card/id/examine(mob/user)
 	. = ..()
@@ -292,11 +292,11 @@
 	if(mining_points)
 		. += "There's [mining_points] mining equipment redemption point\s loaded onto this card."
 	if(registered_account)
-		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of ₡[registered_account.account_balance]."
+		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [MONEY_SYMBOL][registered_account.account_balance]."
 		if(registered_account.account_job)
 			var/datum/bank_account/D = SSeconomy.get_dep_account(registered_account.account_department)
 			if(D)
-				. += "The [D.account_holder] reports a balance of ₡[D.account_balance]."
+				. += "The [D.account_holder] reports a balance of [MONEY_SYMBOL][D.account_balance]."
 		. += "<span class='info'>Alt-Click the ID to pull money from the linked account in the form of holochips.</span>"
 		. += "<span class='info'>You can insert credits into the linked account by pressing holochips, cash, or coins against the ID.</span>"
 		if(registered_account.account_holder == user.real_name)

--- a/code/game/objects/items/credit_holochip.dm
+++ b/code/game/objects/items/credit_holochip.dm
@@ -15,14 +15,14 @@
 
 /obj/item/holochip/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>It's loaded with [credits] credit[( credits > 1 ) ? "s" : ""]</span>\n"+\
+	. += "<span class='notice'>It's loaded with [MONEY_SYMBOL][credits]</span>\n"+\
 	"<span class='notice'>Alt-Click to split.</span>"
 
 /obj/item/holochip/get_item_credit_value()
 	return credits
 
 /obj/item/holochip/update_icon()
-	name = "\improper [credits] credit holochip"
+	name = "\improper [MONEY_SYMBOL][credits] holochip"
 	var/rounded_credits = credits
 	switch(credits)
 		if(1 to 999)
@@ -95,7 +95,7 @@
 				H.forceMove(user.drop_location())
 			add_fingerprint(user)
 		H.add_fingerprint(user)
-		to_chat(user, "<span class='notice'>You extract [split_amount] credits into a new holochip.</span>")
+		to_chat(user, "<span class='notice'>You extract [MONEY_SYMBOL][split_amount] into a new holochip.</span>")
 
 /obj/item/holochip/emp_act(severity)
 	. = ..()

--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -19,7 +19,7 @@
 
 /obj/item/stack/spacecash/proc/update_desc()
 	var/total_worth = get_item_credit_value()
-	desc = "It's worth [total_worth] credit[( total_worth > 1 ) ? "s" : ""]."
+	desc = "It's worth [MONEY_SYMBOL][total_worth]."
 
 /obj/item/stack/spacecash/get_item_credit_value()
 	return (amount*value)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1625,7 +1625,7 @@
 
 /obj/item/gobbler/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The Coin Gobbler holds [money] credits.</span>"
+	. += "<span class='notice'>The Coin Gobbler holds [MONEY_SYMBOL][money].</span>"
 
 /obj/item/gobbler/attackby()
 	return

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -488,7 +488,7 @@
 				if(payments_acc)
 					payments_acc.adjust_money(sale_price)
 				usr.put_in_hands(showpiece)
-				to_chat(usr, "<span class='notice'>You purchase [showpiece] for [sale_price] credits.</span>")
+				to_chat(usr, "<span class='notice'>You purchase [showpiece] for [MONEY_SYMBOL][sale_price].</span>")
 				playsound(src, 'sound/effects/cashregister.ogg', 40, TRUE)
 				flick("[initial(icon_state)]_vend", src)
 				showpiece = null
@@ -591,7 +591,7 @@
 /obj/structure/displaycase/forsale/examine(mob/user)
 	. = ..()
 	if(showpiece && !open)
-		. += "<span class='notice'>[showpiece] is for sale for [sale_price] credits.</span>"
+		. += "<span class='notice'>[showpiece] is for sale for [MONEY_SYMBOL][sale_price].</span>"
 	if(broken)
 		. += "<span class='notice'>[src] is sparking and the hover field generator seems to be overloaded. Use a multitool to fix it.</span>"
 

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -89,7 +89,7 @@
 
 /obj/structure/sign/departments/minsky/research/robotics
 	name = "Robotics Division"
-	desc = "A sign labelling the robotics division of the station. Produces ₡6 cyborgs."
+	desc = "A sign labelling the robotics division of the station. Produces 6 credit cyborgs."
 	icon_state = "minskyrobo"
 
 /obj/structure/sign/departments/minsky/research/xenobiology

--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -89,7 +89,7 @@
 
 /obj/structure/sign/departments/minsky/research/robotics
 	name = "Robotics Division"
-	desc = "A sign labelling the robotics division of the station. Produces $6 cyborgs."
+	desc = "A sign labelling the robotics division of the station. Produces ₡6 cyborgs."
 	icon_state = "minskyrobo"
 
 /obj/structure/sign/departments/minsky/research/xenobiology

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -100,7 +100,7 @@
 	parts += "Loot stolen: "
 	var/datum/objective/loot/L = locate() in objectives
 	parts += L.loot_listing()
-	parts += "Total loot value : [L.get_loot_value()]/[L.target_value] credits"
+	parts += "Total loot value : [MONEY_SYMBOL][L.get_loot_value()]/[L.target_value]"
 
 	if(L.check_completion() && !all_dead)
 		parts += "<span class='greentext big'>The pirate crew was successful!</span>"

--- a/code/modules/antagonists/traitor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/syndicate_contract.dm
@@ -155,7 +155,7 @@
 			C.registered_account.adjust_money(ransom * 0.35)
 
 			C.registered_account.bank_card_talk("We've processed the ransom, agent. Here's your cut - your balance is now \
-			[C.registered_account.account_balance] cr.", TRUE)
+			[MONEY_SYMBOL][C.registered_account.account_balance].", TRUE)
 
 // They're off to holding - handle the return timer and give some text about what's going on.
 /datum/syndicate_contract/proc/handleVictimExperience(var/mob/living/M)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -55,7 +55,7 @@
 
 /datum/bounty/item/science/advanced_mop
 	name = "Advanced Mop"
-	description = "Excuse me. I'd like to request ₡17 for a push broom rebristling. Either that, or an advanced mop."
+	description = "Excuse me. I'd like to request 17 credits for a push broom rebristling. Either that, or an advanced mop."
 	reward = 10000
 	wanted_types = list(/obj/item/mop/advanced)
 

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -55,7 +55,7 @@
 
 /datum/bounty/item/science/advanced_mop
 	name = "Advanced Mop"
-	description = "Excuse me. I'd like to request $17 for a push broom rebristling. Either that, or an advanced mop."
+	description = "Excuse me. I'd like to request ₡17 for a push broom rebristling. Either that, or an advanced mop."
 	reward = 10000
 	wanted_types = list(/obj/item/mop/advanced)
 

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_EMPTY(bounties_list)
 
 // Displayed on bounty UI screen.
 /datum/bounty/proc/reward_string()
-	return "[reward * SSeconomy.bounty_modifier] Credits"
+	return "[MONEY_SYMBOL][reward * SSeconomy.bounty_modifier]"
 
 /datum/bounty/proc/can_claim()
 	return !claimed

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -38,7 +38,7 @@
 			price += ex.total_value[x]
 
 		if(price)
-			to_chat(user, "<span class='notice'>Scanned [O], value: <b>[price]</b> credits[O.contents.len ? " (contents included)" : ""].</span>")
+			to_chat(user, "<span class='notice'>Scanned [O], value: <b>[MONEY_SYMBOL][price]</b>[O.contents.len ? " (contents included)" : ""].</span>")
 		else
 			to_chat(user, "<span class='warning'>Scanned [O], no export value.</span>")
 		if(bounty_ship_item_and_contents(O, dry_run=TRUE))

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -106,7 +106,7 @@
 	data["beaconError"] = usingBeacon && !canBeacon ? "(BEACON ERROR)" : ""//changes button text to include an error alert if necessary
 	data["hasBeacon"] = beacon != null//is there a linked beacon?
 	data["beaconName"] = beacon ? beacon.name : "No Beacon Found"
-	data["printMsg"] = cooldown > 0 ? "Print Beacon for [BEACON_COST] credits ([cooldown])" : "Print Beacon for [BEACON_COST] credits"//buttontext for printing beacons
+	data["printMsg"] = cooldown > 0 ? "Print Beacon for [MONEY_SYMBOL][BEACON_COST] ([cooldown])" : "Print Beacon for [MONEY_SYMBOL][BEACON_COST]"//buttontext for printing beacons
 	data["supplies"] = list()
 	message = "Sales are near-instantaneous - please choose carefully."
 	if(SSshuttle.supplyBlocked)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -79,7 +79,7 @@
 				bank_card_talk("ERROR: Payday aborted, departmental funds insufficient.")
 				return FALSE
 			else
-				bank_card_talk("Payday processed, account now holds ₡[account_balance].")
+				bank_card_talk("Payday processed, account now holds [MONEY_SYMBOL][account_balance].")
 				//The bonus only resets once it goes through.
 				if(paycheck_bonus > 0) //And we're not getting rid of debt
 					paycheck_bonus = 0

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -79,7 +79,7 @@
 				bank_card_talk("ERROR: Payday aborted, departmental funds insufficient.")
 				return FALSE
 			else
-				bank_card_talk("Payday processed, account now holds $[account_balance].")
+				bank_card_talk("Payday processed, account now holds ₡[account_balance].")
 				//The bonus only resets once it goes through.
 				if(paycheck_bonus > 0) //And we're not getting rid of debt
 					paycheck_bonus = 0

--- a/code/modules/economy/pay_stand.dm
+++ b/code/modules/economy/pay_stand.dm
@@ -98,7 +98,7 @@
 
 /obj/machinery/paystand/proc/purchase(buyer, price)
 	my_card.registered_account.adjust_money(price)
-	my_card.registered_account.bank_card_talk("Purchase made at your vendor by [buyer] for [price] credits.")
+	my_card.registered_account.bank_card_talk("Purchase made at your vendor by [buyer] for [MONEY_SYMBOL][price].")
 	amount_deposited = amount_deposited + price
 	if(signaler && amount_deposited >= signaler_threshold)
 		signaler.activate()

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -29,7 +29,7 @@
 		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
 	ship_name = pick(strings(PIRATE_NAMES_FILE, "ship_names"))
 	threat.title = "Business proposition"
-	threat.content = "This is [ship_name]. Pay up [payoff] credits or you'll walk the plank."
+	threat.content = "This is [ship_name]. Pay up [MONEY_SYMBOL][payoff] or you'll walk the plank."
 	threat.possible_answers = list(
 		PIRATE_RESPONSE_PAY = "We'll pay.",
 		PIRATE_RESPONSE_NO_PAY = "No way.",

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -375,7 +375,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 /obj/item/coin/examine(mob/user)
 	. = ..()
 	if(value)
-		. += "<span class='info'>It's worth [value] credit\s.</span>"
+		. += "<span class='info'>It's worth [MONEY_SYMBOL][value].</span>"
 
 /obj/item/coin/gold
 	name = "gold coin"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -327,7 +327,7 @@
 				var/datum/data/crime/crime = GLOB.data_core.createCrimeEntry(t1, "", allowed_access, station_time_timestamp(), fine)
 				for (var/obj/item/modular_computer/tablet in GLOB.TabletMessengers)
 					if(tablet.saved_identification == R.fields["name"])
-						var/message = "You have been fined [fine] credits for '[t1]'. Fines may be paid at security."
+						var/message = "You have been fined [MONEY_SYMBOL][fine] for '[t1]'. Fines may be paid at security."
 						var/datum/signal/subspace/messaging/tablet_msg/signal = new(src, list(
 							"name" = "Security Citation",
 							"job" = "Citation Server",

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -251,14 +251,14 @@
 		if(!user.temporarilyRemoveItemFromInventory(c))
 			return
 		credits += c.value
-		visible_message("<span class='info'><span class='name'>[user]</span> inserts [c.value] credits into [src].</span>")
+		visible_message("<span class='info'><span class='name'>[user]</span> inserts [MONEY_SYMBOL][c.value] into [src].</span>")
 		qdel(c)
 		ui_update()
 		return
 	else if(istype(I, /obj/item/holochip))
 		var/obj/item/holochip/HC = I
 		credits += HC.credits
-		visible_message("<span class='info'>[user] inserts a ₡[HC.credits] holocredit chip into [src].</span>")
+		visible_message("<span class='info'>[user] inserts a [MONEY_SYMBOL][HC.credits] chip into [src].</span>")
 		qdel(HC)
 		ui_update()
 		return
@@ -272,7 +272,7 @@
 			say("Insufficient money on card to purchase!")
 			return
 		credits += target_credits
-		say("[target_credits] cr have been withdrawn from your account.")
+		say("[MONEY_SYMBOL][target_credits] has been withdrawn from your account.")
 		ui_update()
 		return
 	return ..()

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -258,7 +258,7 @@
 	else if(istype(I, /obj/item/holochip))
 		var/obj/item/holochip/HC = I
 		credits += HC.credits
-		visible_message("<span class='info'>[user] inserts a $[HC.credits] holocredit chip into [src].</span>")
+		visible_message("<span class='info'>[user] inserts a ₡[HC.credits] holocredit chip into [src].</span>")
 		qdel(HC)
 		ui_update()
 		return

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -219,9 +219,9 @@
 	forceMove(gun)
 	gun.pin = src
 	if(multi_payment)
-		gun.desc += "<span class='notice'> This [gun.name] has a per-shot cost of [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""].</span>"
+		gun.desc += "<span class='notice'> This [gun.name] has a per-shot cost of [MONEY_SYMBOL][payment_amount].</span>"
 		return
-	gun.desc += "<span class='notice'> This [gun.name] has a license permit cost of [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""].</span>"
+	gun.desc += "<span class='notice'> This [gun.name] has a license permit cost of [MONEY_SYMBOL][payment_amount].</span>"
 	return
 
 
@@ -273,7 +273,7 @@
 				return FALSE
 			return TRUE
 		if(credit_card_details && !active_prompt)
-			var/license_request = alert(usr, "Do you wish to pay [payment_amount] credit[( payment_amount > 1 ) ? "s" : ""] for [( multi_payment ) ? "each shot of [gun.name]" : "usage license of [gun.name]"]?", "Weapon Purchase", "Yes", "No")
+			var/license_request = alert(usr, "Do you wish to pay [MONEY_SYMBOL][payment_amount] for [( multi_payment ) ? "each shot of [gun.name]" : "usage license of [gun.name]"]?", "Weapon Purchase", "Yes", "No")
 			active_prompt = TRUE
 			if(!user.canUseTopic(src, BE_CLOSE))
 				active_prompt = FALSE

--- a/code/modules/ruins/spaceruin_code/listeningstation.dm
+++ b/code/modules/ruins/spaceruin_code/listeningstation.dm
@@ -32,7 +32,7 @@
 
 /obj/item/paper/fluff/ruins/listeningstation/receipt
 	name = "receipt"
-	info = "1 x Stechkin pistol - $600<br>1 x silencer - $200<br>shipping charge - $4360<br>total - $5160"
+	info = "1 x Stechkin pistol - ₡600<br>1 x silencer - ₡200<br>shipping charge - ₡4360<br>total - ₡5160"
 
 /obj/item/paper/fluff/ruins/listeningstation/odd_report
 	name = "odd report"

--- a/code/modules/ruins/spaceruin_code/listeningstation.dm
+++ b/code/modules/ruins/spaceruin_code/listeningstation.dm
@@ -32,7 +32,7 @@
 
 /obj/item/paper/fluff/ruins/listeningstation/receipt
 	name = "receipt"
-	info = "1 x Stechkin pistol - ₡600<br>1 x silencer - ₡200<br>shipping charge - ₡4360<br>total - ₡5160"
+	info = "1 x Stechkin pistol - 600 credits<br>1 x silencer - 200 credits<br>shipping charge - 4360 credits<br>total - 5160 credits"
 
 /obj/item/paper/fluff/ruins/listeningstation/odd_report
 	name = "odd report"

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -307,7 +307,7 @@
 		for(var/obj/I in counted_money)
 			qdel(I)
 		if(!check_times[AM] || check_times[AM] < world.time) //Let's not spam the message
-			say("<span class='robot'>₡[payees[AM]] received, [AM]. You need ₡[threshold-payees[AM]] more.</span>")
+			say("<span class='robot'>[MONEY_SYMBOL][payees[AM]] received, [AM]. You need [MONEY_SYMBOL][threshold-payees[AM]] more.</span>")
 			check_times[AM] = world.time + LUXURY_MESSAGE_COOLDOWN
 		return ..()
 	else

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -307,7 +307,7 @@
 		for(var/obj/I in counted_money)
 			qdel(I)
 		if(!check_times[AM] || check_times[AM] < world.time) //Let's not spam the message
-			say("<span class='robot'>$[payees[AM]] received, [AM]. You need $[threshold-payees[AM]] more.</span>")
+			say("<span class='robot'>₡[payees[AM]] received, [AM]. You need ₡[threshold-payees[AM]] more.</span>")
 			check_times[AM] = world.time + LUXURY_MESSAGE_COOLDOWN
 		return ..()
 	else

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/_orbital_objective.dm
@@ -47,7 +47,7 @@
 	SSeconomy.distribute_funds(payout)
 	GLOB.exploration_points += payout
 	//Announcement
-	priority_announce("Central Command priority objective completed. [payout] credits have been \
+	priority_announce("Central Command priority objective completed. [MONEY_SYMBOL][payout] has been \
 		distributed across departmental budgets. [payout] points have been distributed to exploration vendors.", "Central Command Report", SSstation.announcer.get_rand_report_sound())
 	//Delete
 	QDEL_NULL(SSorbits.current_objective)

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/alien_artifact.dm
@@ -26,7 +26,7 @@
 
 /datum/orbital_objective/artifact/get_text()
 	. = "Outpost [station_name] is a research outpost with an extremely powerful alien artifact on board. \
-		Recover the unknown artifact for a payout of [payout] credits."
+		Recover the unknown artifact for a payout of [MONEY_SYMBOL][payout]."
 	if(linked_beacon)
 		. += " The station is located at the beacon marked [linked_beacon.name]. Good luck."
 

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/recover_blackbox.dm
@@ -14,7 +14,7 @@
 
 /datum/orbital_objective/recover_blackbox/get_text()
 	. = "Outpost [station_name] recently went dark and is no longer responding to our attempts \
-		to contact them. Send in a team and recover the station's blackbox for a payout of [payout] credits."
+		to contact them. Send in a team and recover the station's blackbox for a payout of [MONEY_SYMBOL][payout]."
 	if(linked_beacon)
 		. += " The station is located at the beacon marked [linked_beacon.name]. Good luck."
 
@@ -76,7 +76,7 @@
 	if(linked_obj)
 		linked_obj.complete_objective()
 	else
-		parentobj.say("Non-priority item recovered, dispensing 2000 credit reward.")
+		parentobj.say("Non-priority item recovered, dispensing [MONEY_SYMBOL]2000 reward.")
 		new /obj/item/stack/spacecash/c1000(get_turf(parent), 2)
 	//Fly away
 	var/mutable_appearance/balloon

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -109,11 +109,11 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		if(D)
 			if(!D.adjust_money(-price))
 				if(SO.paying_account)
-					D.bank_card_talk("Cargo order #[SO.id] rejected due to lack of funds. Credits required: [price]")
+					D.bank_card_talk("Cargo order #[SO.id] rejected due to lack of funds. Credits required: [MONEY_SYMBOL][price]")
 				continue
 
 		if(SO.paying_account)
-			D.bank_card_talk("Cargo order #[SO.id] has shipped. [price] credits have been charged to your bank account.")
+			D.bank_card_talk("Cargo order #[SO.id] has shipped. [MONEY_SYMBOL][price] has been charged to your bank account.")
 			var/datum/bank_account/department/cargo = SSeconomy.get_dep_account(ACCOUNT_CAR)
 			cargo.adjust_money(price - SO.pack.get_cost()) //Cargo gets the handling fee
 		value += SO.pack.get_cost()
@@ -160,7 +160,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		qdel(SO)
 
 	var/datum/bank_account/cargo_budget = SSeconomy.get_dep_account(ACCOUNT_CAR)
-	investigate_log("[purchases] orders in this shipment, worth [value] credits. [cargo_budget.account_balance] credits left.", INVESTIGATE_CARGO)
+	investigate_log("[purchases] orders in this shipment, worth [MONEY_SYMBOL][value]. [MONEY_SYMBOL][cargo_budget.account_balance] left.", INVESTIGATE_CARGO)
 
 /obj/docking_port/mobile/supply/proc/sell()
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
@@ -202,7 +202,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		D.adjust_money(ex.total_value[E])
 
 	SSshuttle.centcom_message = msg
-	investigate_log("Shuttle contents sold for [D.account_balance - presale_points] credits. Contents: [ex.exported_atoms ? ex.exported_atoms.Join(",") + "." : "none."] Message: [SSshuttle.centcom_message || "none."]", INVESTIGATE_CARGO)
+	investigate_log("Shuttle contents sold for [MONEY_SYMBOL][D.account_balance - presale_points]. Contents: [ex.exported_atoms ? ex.exported_atoms.Join(",") + "." : "none."] Message: [SSshuttle.centcom_message || "none."]", INVESTIGATE_CARGO)
 
 
 //	Generates a box of mail depending on our exports and imports.

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2349,7 +2349,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/badass/syndiecash
 	name = "Syndicate Briefcase Full of Cash"
-	desc = "A secure briefcase containing 5000 space credits. Useful for bribing personnel, or purchasing goods \
+	desc = "A secure briefcase containing 5000 credits. Useful for bribing personnel, or purchasing goods \
 			and services at lucrative prices. The briefcase also feels a little heavier to hold; it has been \
 			manufactured to pack a little bit more of a punch if your client needs some convincing."
 	item = /obj/item/storage/secure/briefcase/syndie

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1096,7 +1096,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 /obj/item/price_tagger/attack_self(mob/user)
 	price = max(1, round(input(user,"set price","price") as num|null, 1))
-	to_chat(user, "<span class='notice'> The [src] will now give things a [price] cr tag.</span>")
+	to_chat(user, "<span class='notice'> The [src] will now give things a [MONEY_SYMBOL][price] tag.</span>")
 
 /obj/item/price_tagger/afterattack(atom/target, mob/user, proximity)
 	. = ..()
@@ -1105,4 +1105,4 @@ GLOBAL_LIST_EMPTY(vending_products)
 	if(isitem(target))
 		var/obj/item/I = target
 		I.custom_price = price
-		to_chat(user, "<span class='notice'>You set the price of [I] to [price] cr.</span>")
+		to_chat(user, "<span class='notice'>You set the price of [I] to [MONEY_SYMBOL][price].</span>")

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -139,7 +139,7 @@
 		return
 
 	attached_bot.add_money(amount_to_insert)
-	balloon_alert(attacker, "Inserted [amount_to_insert] credits.")
+	balloon_alert(attacker, "Inserted [MONEY_SYMBOL][amount_to_insert].")
 	money_input.set_output(amount_to_insert)
 	payer.set_output(attacker)
 	money_trigger.set_output(COMPONENT_SIGNAL)

--- a/code/modules/xenoarchaeology/xenoartifact_console.dm
+++ b/code/modules/xenoarchaeology/xenoartifact_console.dm
@@ -20,7 +20,7 @@
 	icon_screen = "xenoartifact_console"
 	icon_keyboard = "rd_key"
 	circuit = /obj/item/circuitboard/computer/xenoartifact_console
-	
+
 	///Sellers give artifacts
 	var/list/sellers = list()
 	///Buyers take artifacts
@@ -85,7 +85,7 @@
 			"main" = E.main, //Sold time
 			"gain" = E.gain, //Profits
 			"traits" = E.traits //traits
-		))	
+		))
 	data["tab_index"] = tab_index
 	data["current_tab"] = current_tab
 	data["tab_info"] = current_tab_info
@@ -132,7 +132,7 @@
 				X.price = S.price //dont bother trying to use internal singals for this
 				sellers -= S
 				budget.adjust_money(-1*S.price)
-				say("Purchase complete. [budget.account_balance] credits remaining in Research Budget")
+				say("Purchase complete. [MONEY_SYMBOL][budget.account_balance] remaining in Research Budget")
 				addtimer(CALLBACK(src, .proc/generate_new_seller), (rand(1,3)*60) SECONDS)
 				A = null
 
@@ -169,7 +169,7 @@
 				linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DISCOVERY, (XENOA_SOLD_DP*(final_price/X.price)) * (final_price >= X.price))
 
 				//Handle player info
-				entry.main = "[selling_item.name] sold at [station_time_timestamp()] for [final_price] credits, bought for [X.price]."
+				entry.main = "[selling_item.name] sold at [station_time_timestamp()] for [MONEY_SYMBOL][final_price], bought for [MONEY_SYMBOL][X.price]."
 				entry.gain = "Awarded [(final_price*2.3) * (final_price >= X.price)] Research Points & [XENOA_SOLD_DP*(final_price/X.price) * (final_price >= X.price)] Discovery Points."
 				info = "[entry.main]\n[entry.gain]\n"
 
@@ -192,7 +192,7 @@
 			budget.adjust_money(final_price)
 			sold_artifacts += info
 			qdel(selling_item)
-	if(info)	
+	if(info)
 		say(info)
 
 
@@ -276,7 +276,7 @@
 /datum/xenoartifact_seller/proc/change_item()
 	generate()
 
-/datum/xenoartifact_seller/buyer //Buyer off shoot, for player-selling 
+/datum/xenoartifact_seller/buyer //Buyer off shoot, for player-selling
 	var/obj/buying
 
 /datum/xenoartifact_seller/buyer/generate()
@@ -285,7 +285,7 @@
 	if(buying == /obj/item/xenoartifact) //Don't bother trying to use istype here
 		dialogue = "[name] is requesting: Anomoly : Class : Artifact"
 	addtimer(CALLBACK(src, .proc/change_item), (rand(1,3)*60) SECONDS)
-	
+
 //Used to hold information about artifact transactions. Might get standrardized sooner or later.
 /datum/xenoartifact_info_entry
 	var/main =""


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the credits symbol from $ to ₡ (Costa Rican Colon) to match things like budget cards.

![image](https://user-images.githubusercontent.com/22421329/195667423-ff8870ed-0b30-44eb-8936-8f639ed308df.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Standardizes the Credits symbol across sprites and text, makes it less Space America
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/22421329/195667554-68ee4a40-6969-4b7f-951c-57750069c810.png)

</details>

## Changelog
:cl:
tweak: Credits now use the ₡ symbol.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
