### PR TITLE
Fixes density on thermite effects

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -36,7 +36,7 @@
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "2" //what?
 	anchored = TRUE
-	opacity = TRUE
+	opacity = FALSE
 	density = FALSE
 	layer = FLY_LAYER
 

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -37,8 +37,22 @@
 	icon_state = "2" //what?
 	anchored = TRUE
 	opacity = TRUE
-	density = TRUE
+	density = FALSE
 	layer = FLY_LAYER
+
+/obj/effect/overlay/thermite/Initialize(mapload)
+	. = ..()
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/on_entered,
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+
+/obj/effect/overlay/thermite/proc/on_entered(datum/source, atom/movable/AM)
+	SIGNAL_HANDLER
+	if(isliving(AM))
+		var/mob/living/L = AM
+		L.adjust_fire_stacks(5)
+		L.IgniteMob()
 
 //Makes a tile fully lit no matter what
 /obj/effect/fullbright


### PR DESCRIPTION
## About The Pull Request
Ignited thermite now no longer blocks vision or movement

## Why It's Good For The Game
Thermite should act like fire, not like a wall

also someone said this was a feature and I intend to spite them

## Testing Photographs and Procedure
![image](https://user-images.githubusercontent.com/49600480/195699059-84037b8f-a2a5-4ea3-8b9b-9322102aeaaa.png)


## Changelog
:cl:
fix: Thermite clouds no longer block vision or movement, and set players moving through them on fire
/:cl:
