### PR TITLE
Fix infinite PDA bombs and PDA bomb damage

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -166,9 +166,9 @@
 	if(current_turf)
 		current_turf.hotspot_expose(700,125)
 		if(istype(all_components[MC_HDD_JOB], /obj/item/computer_hardware/hard_drive/role/virus/syndicate))
-			explosion(src, devastation_range = -1, heavy_impact_range = 1, light_impact_range = 3, flash_range = 4)
+			explosion(current_turf, devastation_range = -1, heavy_impact_range = 1, light_impact_range = 3, flash_range = 4)
 		else
-			explosion(src, devastation_range = -1, heavy_impact_range = -1, light_impact_range = 2, flash_range = 3)
+			explosion(current_turf, devastation_range = -1, heavy_impact_range = -1, light_impact_range = 2, flash_range = 3)
 	qdel(src)
 
 // SUBTYPES

--- a/code/modules/modular_computers/hardware/job_disk.dm
+++ b/code/modules/modular_computers/hardware/job_disk.dm
@@ -99,7 +99,7 @@
 // Disk Definitions
 
 /obj/item/computer_hardware/hard_drive/role/engineering
-	name = "Power-ON disk"
+	name = "\improper Power-ON disk"
 	desc = "Engineers ignoring station power-draw since 2400."
 	icon_state = "cart-engie"
 	disk_flags = DISK_POWER

--- a/code/modules/modular_computers/hardware/virus_disk.dm
+++ b/code/modules/modular_computers/hardware/virus_disk.dm
@@ -53,6 +53,7 @@
 	if(!target)
 		to_chat(user, "<span class='notice'>ERROR: Could not find device.</span>")
 		return
+	charges--
 
 	var/difficulty = 0
 	var/obj/item/computer_hardware/hard_drive/role/disk = target.all_components[MC_HDD_JOB]


### PR DESCRIPTION
## About The Pull Request

Fixes #7883

Somehow I forgot to put `charges--`.

Also it now explodes on the turf instead of the tablet item, correctly reproducing the old behavior of critting the target.

Also fixes the "Power-ON" disk not being \improper (capitalized job disks should be improper)

## Why It's Good For The Game

Not having infinite PDA bombs is good.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Charges
![image](https://user-images.githubusercontent.com/10366817/195923749-f88f39dd-96ca-4313-b340-0cc9c6a88447.png)

Crit
![image](https://user-images.githubusercontent.com/10366817/195923728-c3dc2396-a116-4e4c-9e60-8b12dc9faabe.png)


</details>

## Changelog
:cl:
fix: D.E.T.O.M.A.T.I.X. charges are no longer infinite.
fix: D.E.T.O.M.A.T.I.X. explosions now do the same damage as before tablet-PDAs.
fix: Power-ON disks are now improper nouns.
/:cl:
