### PR TITLE
Adds Minor Botanical Chem Dispenser to research tree and techfab

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -626,6 +626,7 @@
 
 /obj/item/circuitboard/machine/chem_dispenser/botany				//probably should be generic but who cares
 	name = "minor botanical chem dispenser (Machine Board)"
+	icon_state = "service"
 	build_path = /obj/machinery/chem_dispenser/mutagensaltpetersmall
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 2,

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -618,7 +618,7 @@
 	build_path = /obj/item/circuitboard/machine/mass_driver
 	category = list ("Misc. Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SERVICE
-	
+
 
 /datum/design/board/ore_silo
 	name = "Machine Design (Ore Silo)"
@@ -675,3 +675,11 @@
 	build_path = /obj/item/circuitboard/machine/xenoartifact_inbox
 	category = list ("Research Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/minor_botanical_dispenser
+	name = "Machine Design (Minor Botanical Chemical Dispenser)"
+	desc = "The circuit board for a minor botanical chemical dispenser."
+	id = "minor_botanical_dispenser"
+	build_path = /obj/item/circuitboard/machine/chem_dispenser/botany
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+	category = list ("Hydroponics Machinery")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -74,7 +74,7 @@
 	display_name = "Biological Technology"
 	description = "What makes us tick."	//the MC, silly!
 	prereq_ids = list("base")
-	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "sleeper", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "medspray","genescanner", "medipen_epi", "medipen_dex", "medipen_atropine")
+	design_ids = list("chem_heater", "chem_master", "chem_dispenser", "pandemic", "sleeper", "defibrillator", "defibmount", "operating", "soda_dispenser", "beer_dispenser", "medspray","genescanner", "medipen_epi", "medipen_dex", "medipen_atropine", "minor_botanical_dispenser")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It adds the machine to the Biological Technology research node (same place as the normal chem dispenser and the drink dispensers).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is a machine that exists from round start in all stations but can't currently be remade if the board is lost.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
I researched it in the R&D console, I printed the board in the Service Techfab. It is not printable if it is not researched, and it is only printable in the Service Techfab. The printed board can be used to make the machine.

<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/43103688/195968593-8625eb81-f2b5-48ea-96be-fa2eff512bfa.png)

![image](https://user-images.githubusercontent.com/43103688/195968600-f6984e6d-2fe1-487a-b813-0aabbb8c15f0.png)

![image](https://user-images.githubusercontent.com/43103688/195968607-f93deb3a-6f73-4755-a4a8-e7630a9eee8c.png)

</details>

## Changelog
:cl:
tweak: added the botany chem dispenser to research node and it can now be printed if researched.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
