### PR TITLE
The shuttle seat and the corporate chair are no longer pickupable

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -241,7 +241,7 @@
 	buildstackamount = 1
 	item_chair = null
 
-	/obj/structure/chair/fancy/plastic
+/obj/structure/chair/fancy/plastic
 	name = "plastic chair"
 	desc = "If you want it, then you'll have to take it."
 	icon_state = "plastic_chair"

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -231,13 +231,17 @@
 	name = "corporate chair"
 	desc = "It looks professional."
 	icon_state = "comfychair_corp"
+	buildstackamount = 1
+	item_chair = null
 
 /obj/structure/chair/fancy/shuttle
 	name = "shuttle seat"
 	desc = "A comfortable, secure seat. It has a more sturdy looking buckling system for smoother flights."
 	icon_state = "shuttle_chair"
+	buildstackamount = 1
+	item_chair = null
 
-/obj/structure/chair/fancy/plastic
+	/obj/structure/chair/fancy/plastic
 	name = "plastic chair"
 	desc = "If you want it, then you'll have to take it."
 	icon_state = "plastic_chair"


### PR DESCRIPTION
## About The Pull Request

This PR fixes an oversight related to the shuttle seat and corporate chair, in which a user would be able to just pick them up and transmute them into a normal fancy chair.

## Why It's Good For The Game

Logic is good to have in a game filled with existential horrors and magical chemicals.

## Testing Photographs and Procedure

N/A, due to the nature of the bug itself, it's just that you can't pick up a bolted down shuttle seat and magically turn it into a chair with arms.

## Changelog
:cl:
fix: Shuttle chairs and Corporate chairs are now impossible to pick up and transformed into normal Fancy chairs.
/:cl:
