### PR TITLE
Fixes two bugs with hivemind

### DIFF
--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -83,8 +83,7 @@
 			break
 		if(lead)
 			unlocked_dominance = TRUE
-			var/obj/effect/proc_holder/spell/self/hive_dominance/dominance_spell = new
-			owner.AddSpell(dominance_spell)
+			owner.AddSpell(/new obj/effect/proc_holder/spell/self/hive_dominance/dominance_spell)
 			to_chat(owner, "<span class='assimilator'>Our strength overflowing and our competitors left in the dust, we can proclaim our Dominance and enter a heightened state.</span>")
 
 /datum/antagonist/hivemind/proc/add_to_hive(mob/living/carbon/C)

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -83,7 +83,7 @@
 			break
 		if(lead)
 			unlocked_dominance = TRUE
-			owner.AddSpell(/new obj/effect/proc_holder/spell/self/hive_dominance/dominance_spell)
+			owner.AddSpell(new /obj/effect/proc_holder/spell/self/hive_dominance/dominance_spell)
 			to_chat(owner, "<span class='assimilator'>Our strength overflowing and our competitors left in the dust, we can proclaim our Dominance and enter a heightened state.</span>")
 
 /datum/antagonist/hivemind/proc/add_to_hive(mob/living/carbon/C)

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -83,7 +83,8 @@
 			break
 		if(lead)
 			unlocked_dominance = TRUE
-			owner.AddSpell(/obj/effect/proc_holder/spell/self/hive_dominance)
+			var/obj/effect/proc_holder/spell/self/hive_dominance/dominance_spell = new
+			owner.AddSpell(dominance_spell)
 			to_chat(owner, "<span class='assimilator'>Our strength overflowing and our competitors left in the dust, we can proclaim our Dominance and enter a heightened state.</span>")
 
 /datum/antagonist/hivemind/proc/add_to_hive(mob/living/carbon/C)

--- a/code/modules/antagonists/hivemind/hivemind.dm
+++ b/code/modules/antagonists/hivemind/hivemind.dm
@@ -83,7 +83,7 @@
 			break
 		if(lead)
 			unlocked_dominance = TRUE
-			owner.AddSpell(new /obj/effect/proc_holder/spell/self/hive_dominance/dominance_spell)
+			owner.AddSpell(new /obj/effect/proc_holder/spell/self/hive_dominance)
 			to_chat(owner, "<span class='assimilator'>Our strength overflowing and our competitors left in the dust, we can proclaim our Dominance and enter a heightened state.</span>")
 
 /datum/antagonist/hivemind/proc/add_to_hive(mob/living/carbon/C)

--- a/code/modules/antagonists/hivemind/spells/hivemind_dominance.dm
+++ b/code/modules/antagonists/hivemind/spells/hivemind_dominance.dm
@@ -18,8 +18,8 @@
 		to_chat(user, "<span class='notice'>This is a bug. Error:HIVE1</span>")
 		return
 	hive.glow = mutable_appearance('icons/effects/hivemind.dmi', "awoken", -BODY_BEHIND_LAYER)
-	for(var/datum/antagonist/hivevessel/vessel in hive.avessels)
-		var/mob/living/carbon/C = vessel.owner?.current
+	for(var/datum/mind/vessel in hive.avessels)
+		var/mob/living/carbon/C = vessel.current
 		C.Jitter(15)
 		C.Unconscious(150)
 		to_chat(C, "<span class='boldwarning'>Something's wrong...</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Assert dominance can be acquired properly now, awakened vessels will now properly get affected by One Mind
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot_1319](https://user-images.githubusercontent.com/53474257/196009867-49795933-2549-4586-a3ed-9150e19ac77c.png)


</details>

## Changelog
:cl:
fix: Hiveminds can properly get Assert Dominance now
fix: Awakened vessels are properly affected by One Mind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
