### PR TITLE
Modifies the abductor balance changes as a result of testing.

### DIFF
--- a/code/modules/antagonists/abductor/machinery/camera.dm
+++ b/code/modules/antagonists/abductor/machinery/camera.dm
@@ -75,13 +75,13 @@
 		to_chat(owner, "<span class='warning'>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
-	for(var/mob/living/carbon/human/specimin in viewers(world.view, target_loc))
+	for(var/mob/living/carbon/human/specimin in view(5, target_loc))
 		var/obj/item/organ/heart/gland/temp = locate() in specimin.internal_organs
 		//Not a specimin
-		if(temp)
+		if(istype(temp))
 			continue
 		//No heart, not considered a specimin
-		if (!specimin.getorganslot(ORGAN_SLOT_HEART))
+		if (!specimin.getorganslot(ORGAN_SLOT_HEART) || isabductor(specimin))
 			continue
 		//Technically a specimin, however we should avoid meta tactics
 		if (!specimin.client)
@@ -121,13 +121,13 @@
 		to_chat(owner, "<span class='warning'>Due to significant interference, this area cannot be warped to!</span>")
 		return
 
-	for(var/mob/living/carbon/human/specimin in viewers(world.view, target_loc))
+	for(var/mob/living/carbon/human/specimin in view(5, target_loc))
 		var/obj/item/organ/heart/gland/temp = locate() in specimin.internal_organs
 		//Not a specimin
-		if(temp)
+		if(istype(temp))
 			continue
 		//No heart, not considered a specimin
-		if (!specimin.getorganslot(ORGAN_SLOT_HEART))
+		if (!specimin.getorganslot(ORGAN_SLOT_HEART) || isabductor(specimin))
 			continue
 		//Technically a specimin, however we should avoid meta tactics
 		if (!specimin.client)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -17,7 +17,7 @@
 		do_teleport(target, teleport_target, no_effects = TRUE, channel = TELEPORT_CHANNEL_BLINK, teleport_mode = TELEPORT_MODE_ABDUCTORS)
 		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 		to_chat(target, "<span class='warning'>The instability of the warp leaves you disoriented!</span>")
-		target.Stun(60)
+		target.SetSleeping(60)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 - The abductor teleport now sets a target to sleeping for 6 seconds. This means the abductors combat vest will not be able to remove that stun, and any targets put in which were asleep for another minute as a result of the sleep baton will be woken up in 6 seconds instead (It overrides existing sleeps to be 6 seconds).
 - The abductor teleporter will no longer be blocked by abductors.
 - The abductor teleport now will be blocked by specimins the camera can see within 5 tiles, rather than all mobs that can see the camera location. It can be very confusing when you can't see the mob that is actually blocking you from teleporting.

## Why It's Good For The Game

A lot of feedback has been provided about the teleport blocking being annoying, mainly from when you are blocked and cannot tell why you are being blocked.

## Testing Photographs and Procedure

![image](https://user-images.githubusercontent.com/26465327/196026937-919ff252-2179-485d-87d7-b37d0ba45ee2.png)
![image](https://user-images.githubusercontent.com/26465327/196026968-8b4de8a1-eb8a-4fd2-b2f3-70d8ba70b2d7.png)
![image](https://user-images.githubusercontent.com/26465327/196026985-40cd8cd8-ffc1-430b-8517-ba84813593e2.png)

## Changelog
:cl:
fix: Abductor teleportation is no longer blocked by the teleporting agent.
tweak: Abductor teleport console is now blocked by mobs within 5 tiles rather than mobs that can see the location, to make it less frustrating to find a valid warp point.
balance: Abductor emergency teleport now applies sleeping rather than stun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
