### PR TITLE
Adds support for variably sized lobby screens

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -506,8 +506,6 @@
 /datum/config_entry/string/default_view
 	config_entry_value = "15x15"
 
-/datum/config_entry/flag/menu_square_view
-
 /datum/config_entry/flag/log_pictures
 
 /datum/config_entry/flag/picture_logging_camera

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -4,6 +4,7 @@ SUBSYSTEM_DEF(title)
 	init_order = INIT_ORDER_TITLE
 
 	var/file_path
+	var/lobby_screen_size = "15x15"
 	var/icon/icon
 	var/icon/previous_icon
 	var/turf/closed/indestructible/splashscreen/splash_turf
@@ -28,6 +29,11 @@ SUBSYSTEM_DEF(title)
 	ASSERT(fexists(file_path))
 
 	icon = new(fcopy_rsc(file_path))
+
+	//Calculate the screen size
+	var/width = round(icon.Width / world.icon_size)
+	var/height = round(icon.Height / world.icon_size)
+	lobby_screen_size = "[width]x[height]"
 
 	if(splash_turf)
 		splash_turf.icon = icon

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(title)
 	var/lobby_screen_size = "15x15"
 	var/icon/icon
 	var/icon/previous_icon
+	var/turf/newplayer_start_loc
 	var/turf/closed/indestructible/splashscreen/splash_turf
 
 /datum/controller/subsystem/title/Initialize()
@@ -34,6 +35,18 @@ SUBSYSTEM_DEF(title)
 	var/width = round(icon.Width() / world.icon_size)
 	var/height = round(icon.Height() / world.icon_size)
 	lobby_screen_size = "[width]x[height]"
+
+	//Update the new player start (views are centered)
+	var/new_player_x = splash_turf.x + FLOOR(width / 2, 1)
+	var/new_player_y = splash_turf.y + FLOOR(height / 2, 1)
+	newplayer_start_loc = locate(new_player_x, new_player_y, splash_turf.z)
+	for(var/atom/movable/new_player_start in GLOB.newplayer_start)
+		new_player_start.forceMove(newplayer_start_loc)
+
+	//Update fast joiners
+	for (var/mob/dead/new_player/fast_joiner in GLOB.new_player_list)
+		fast_joiner.client.view_size.resetToDefault(getScreenSize(fast_joiner))
+		fast_joiner.forceMove(newplayer_start_loc)
 
 	if(splash_turf)
 		splash_turf.icon = icon

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -31,8 +31,8 @@ SUBSYSTEM_DEF(title)
 	icon = new(fcopy_rsc(file_path))
 
 	//Calculate the screen size
-	var/width = round(icon.Width / world.icon_size)
-	var/height = round(icon.Height / world.icon_size)
+	var/width = round(icon.Width() / world.icon_size)
+	var/height = round(icon.Height() / world.icon_size)
 	lobby_screen_size = "[width]x[height]"
 
 	if(splash_turf)

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -45,7 +45,7 @@ SUBSYSTEM_DEF(title)
 
 	//Update fast joiners
 	for (var/mob/dead/new_player/fast_joiner in GLOB.new_player_list)
-		fast_joiner.client.view_size.resetToDefault(getScreenSize(fast_joiner))
+		fast_joiner.client?.view_size.resetToDefault(getScreenSize(fast_joiner))
 		fast_joiner.forceMove(newplayer_start_loc)
 
 	if(splash_turf)

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -121,7 +121,7 @@
 /// Returns the size that the screen should be
 /proc/getScreenSize(mob/M)
 	// New players on the menu get the size of the lobby art
-	if(M && istype(M, /mob/dead/new_player))
+	if(istype(M, /mob/dead/new_player))
 		return SStitle.lobby_screen_size
 	// Otherwise, they get the default view
 	return CONFIG_GET(string/default_view)

--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -118,7 +118,10 @@
 	//Ready for this one?
 	setTo(radius)
 
-/proc/getScreenSize(mob/M) //IMPORTANT: If widescreen toggle preference gets ported, several uses of this proc need to be changed from FALSE to the player pref
-	if(CONFIG_GET(flag/menu_square_view) && M && istype(M, /mob/dead/new_player))
-		return "15x15"	//Return 15x15 for new players because we have normal sized menu screens
-	return CONFIG_GET(string/default_view) //IMPORTANT: If widescreen toggle preference gets ported, this needs to be set to the square view config
+/// Returns the size that the screen should be
+/proc/getScreenSize(mob/M)
+	// New players on the menu get the size of the lobby art
+	if(M && istype(M, /mob/dead/new_player))
+		return SStitle.lobby_screen_size
+	// Otherwise, they get the default view
+	return CONFIG_GET(string/default_view)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -313,6 +313,8 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/start/new_player/Initialize(mapload)
 	..()
 	GLOB.newplayer_start += loc
+	if (SStitle.newplayer_start_loc)
+		forceMove(SStitle.newplayer_start_loc)
 	return INITIALIZE_HINT_QDEL
 
 /obj/effect/landmark/latejoin

--- a/config/config.txt
+++ b/config/config.txt
@@ -530,9 +530,6 @@ ROUNDS_UNTIL_HARD_RESTART 3
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
 DEFAULT_VIEW 17x15
 
-##Should we use square view (15x15) while a new player (main menu)
-MENU_SQUARE_VIEW
-
 ## Name your perpetual currency here
 ## This is used within the metashop and earned by playing the game.
 METACURRENCY_NAME BeeCoin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 - Lobby screens can now be any sized image, clients screens will resize accordingly.

## Why It's Good For The Game

We can now have 17x15 lobby screens as well as 15x15 ones, as well as 19x15 as well as 100x100 ones (Not that I'd recommend that, you'd kill server performance)

## Testing Photographs and Procedure

This was harder than you would first expect, since views are centered while the lobby screen has its origin in the bottom left. Had to move the new players and the new player spawn around to get the correct centering.

![image](https://user-images.githubusercontent.com/26465327/196028178-3447392a-11ac-41ed-b07d-330de8f5dc8f.png)
![image](https://user-images.githubusercontent.com/26465327/196028510-3724c638-4fe5-4dcf-9bcc-75597f984a21.png)


## Changelog
:cl:
add: Title screens now support images that are any aspect ratio.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
