### PR TITLE
Resolves a runtime preventing character slot purchases from taking effect immediately

### DIFF
--- a/code/modules/client/loadout/loadout_ooc.dm
+++ b/code/modules/client/loadout/loadout_ooc.dm
@@ -9,7 +9,7 @@
 	cost = 10000
 
 /datum/gear/ooc/char_slot/purchase(var/client/C)
-	C?.prefs?.set_max_character_slots(C.prefs.max_usable_slots = 1)
+	C?.prefs?.set_max_character_slots(C.prefs.max_usable_slots + 1)
 
 /datum/gear/ooc/real_antagtoken
 	display_name = "antag token"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This should correctly add the newly purchased character slot immediately instead of forcing the user to wait until it's refreshed next round.

## Why It's Good For The Game

It sucks to have to wait for your new character slot to pop.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<details>
<summary>Screenshots&Videos</summary>

https://user-images.githubusercontent.com/26130695/196084122-ef91bd6f-2e9d-4e1b-a7fb-c2924a5962ee.mp4

</details>

## Changelog
:cl:
fix: Purchased character slots will become available immediately
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
