### PR TITLE
Adds custom title details to roundend report and credit

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -594,13 +594,13 @@
 		if(I.registered_name == mind.name) // card must be yours
 			custom_title = I.assignment // get the custom title
 		if(custom_title == mind.assigned_role) // non-custom title, lame
-			custom_title = ""
+			custom_title = null
 	if(!custom_title) // still no custom title? it seems you don't have a ID card
 		var/datum/data/record/R = find_record("name", mind.name, GLOB.data_core.general)
 		if(R)
 			custom_title = R.fields["rank"] // get a custom title from datacore
 		if(custom_title == mind.assigned_role) // lame...
-			custom_title = ""
+			return
 
 	if(custom_title)
 		return "[newline ? "<br/>" : " "](as [custom_title])" // i.e. " (as Plague Doctor)"
@@ -613,7 +613,7 @@
 		if(!jobtext)
 			jobtext = ply.special_role
 		if(jobtext)
-			jobtext = " the <b>[ply.assigned_role]</b>"
+			jobtext = " the <b>[jobtext]</b>"
 	var/jobtext_custom = get_custom_title_from_id(ply) // support the custom job title to the roundend report
 
 	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext][jobtext_custom] and"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -593,7 +593,7 @@
 	if(!.) // still no custom title? it seems you don't have a ID card
 		var/datum/data/record/R = find_record("name", mind_name, GLOB.data_core.general)
 		if(R)
-			. = R.fields["rank"] || "" // get a custom title from datacore
+			. = R.fields["rank"] // get a custom title from datacore
 		if(. == mind_job) // lame...
 			. = ""
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -587,8 +587,22 @@
 /proc/printplayer(datum/mind/ply, fleecheck)
 	var/jobtext = ""
 	if(ply.assigned_role)
-		jobtext = " the <b>[ply.assigned_role]</b>"
-	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
+		if(ply.assigned_role == "Unassigned")
+			jobtext = ply?.special_role || "" // "Unassigned" is bad. showing nothing is better.
+		else
+			jobtext = " the <b>[ply.assigned_role]</b>"
+
+	var/obj/item/card/id/I = ply?.current.get_idcard()
+
+	// support the custom job title to the roundend report
+	var/jobtext_custom = (I?.registered_name == ply.name) ? ((ply?.assigned_role == I?.assignment) ? ply?.assigned_role : I?.assignment) : ply?.assigned_role // try to get your ID card, then gets a job title
+	if(ply.assigned_role == jobtext_custom)
+		var/datum/data/record/R = find_record("name", ply.name, GLOB.data_core.general)
+		if(R)
+			jobtext_custom = R.fields["rank"] || ply?.assigned_role // gets a custom title from datacore
+	jobtext_custom = (ply.assigned_role == jobtext_custom) ? "" : " (as [jobtext_custom])" // if no custom title, don't show it.
+
+	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext][jobtext_custom] and"
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " <span class='redtext'>died</span>"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -583,7 +583,7 @@
 		Trigger()
 		return
 
-///Returns a custom title for the roundend credit
+///Returns a custom title for the roundend credit/report
 /proc/get_custom_title_from_id(obj/item/card/id/I, mind_job, mind_name)
 	if(I)
 		if(I.registered_name == mind_name) // card must be yours
@@ -598,7 +598,7 @@
 			. = ""
 
 	if(.)
-		return " (as [.])"
+		return " (as [.])" // i.e. " (as Plague Doctor)"
 
 /proc/printplayer(datum/mind/ply, fleecheck)
 	var/jobtext = ""
@@ -606,10 +606,10 @@
 		if(ply.assigned_role == "Unassigned")
 			jobtext = ply?.special_role || "" // "Unassigned" is bad. showing nothing is better.
 		else
+			jobtext = ply.assigned_role
+		if(jobtext)
 			jobtext = " the <b>[ply.assigned_role]</b>"
-
-	// support the custom job title to the roundend report
-	var/jobtext_custom = get_custom_title_from_id(ply?.current.get_idcard(), ply.assigned_role, ply.name)
+	var/jobtext_custom = get_custom_title_from_id(ply?.current.get_idcard(), ply.assigned_role, ply.name) // support the custom job title to the roundend report
 
 	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext][jobtext_custom] and"
 	if(ply.current)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -588,21 +588,22 @@
 	if(!mind)
 		return
 
+	var/custom_title
 	var/obj/item/card/id/I = mind.current?.get_idcard()
 	if(I)
 		if(I.registered_name == mind.name) // card must be yours
-			. = I.assignment // get the custom title
-		if(. == mind.assigned_role) // non-custom title, lame
-			. = ""
-	if(!.) // still no custom title? it seems you don't have a ID card
+			custom_title = I.assignment // get the custom title
+		if(custom_title == mind.assigned_role) // non-custom title, lame
+			custom_title = ""
+	if(!cusrom_title) // still no custom title? it seems you don't have a ID card
 		var/datum/data/record/R = find_record("name", mind.name, GLOB.data_core.general)
 		if(R)
-			. = R.fields["rank"] // get a custom title from datacore
-		if(. == mind.assigned_role) // lame...
-			. = ""
+			custom_title = R.fields["rank"] // get a custom title from datacore
+		if(custom_title == mind.assigned_role) // lame...
+			custom_title = ""
 
-	if(.)
-		return "[newline ? "<br/>" : " "](as [.])" // i.e. " (as Plague Doctor)"
+	if(custom_title)
+		return "[newline ? "<br/>" : " "](as [custom_title])" // i.e. " (as Plague Doctor)"
 
 /proc/printplayer(datum/mind/ply, fleecheck)
 	var/jobtext = ""

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -595,7 +595,7 @@
 			custom_title = I.assignment // get the custom title
 		if(custom_title == mind.assigned_role) // non-custom title, lame
 			custom_title = ""
-	if(!cusrom_title) // still no custom title? it seems you don't have a ID card
+	if(!custom_title) // still no custom title? it seems you don't have a ID card
 		var/datum/data/record/R = find_record("name", mind.name, GLOB.data_core.general)
 		if(R)
 			custom_title = R.fields["rank"] // get a custom title from datacore

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -584,17 +584,21 @@
 		return
 
 ///Returns a custom title for the roundend credit/report
-/proc/get_custom_title_from_id(obj/item/card/id/I, mind_job, mind_name, newline=FALSE)
+/proc/get_custom_title_from_id(datum/mind/mind, newline=FALSE)
+	if(!mind)
+		return
+
+	var/obj/item/card/id/I = mind.current?.get_idcard()
 	if(I)
-		if(I.registered_name == mind_name) // card must be yours
+		if(I.registered_name == mind.name) // card must be yours
 			. = I.assignment // get the custom title
-		if(. == mind_job) // non-custom title, lame
+		if(. == mind.assigned_role) // non-custom title, lame
 			. = ""
 	if(!.) // still no custom title? it seems you don't have a ID card
-		var/datum/data/record/R = find_record("name", mind_name, GLOB.data_core.general)
+		var/datum/data/record/R = find_record("name", mind.name, GLOB.data_core.general)
 		if(R)
 			. = R.fields["rank"] // get a custom title from datacore
-		if(. == mind_job) // lame...
+		if(. == mind.assigned_role) // lame...
 			. = ""
 
 	if(.)
@@ -609,7 +613,7 @@
 			jobtext = ply.special_role
 		if(jobtext)
 			jobtext = " the <b>[ply.assigned_role]</b>"
-	var/jobtext_custom = get_custom_title_from_id(ply?.current.get_idcard(), ply.assigned_role, ply.name) // support the custom job title to the roundend report
+	var/jobtext_custom = get_custom_title_from_id(ply) // support the custom job title to the roundend report
 
 	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext][jobtext_custom] and"
 	if(ply.current)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -584,7 +584,7 @@
 		return
 
 ///Returns a custom title for the roundend credit/report
-/proc/get_custom_title_from_id(obj/item/card/id/I, mind_job, mind_name)
+/proc/get_custom_title_from_id(obj/item/card/id/I, mind_job, mind_name, newline=FALSE)
 	if(I)
 		if(I.registered_name == mind_name) // card must be yours
 			. = I.assignment // get the custom title
@@ -598,7 +598,7 @@
 			. = ""
 
 	if(.)
-		return " (as [.])" // i.e. " (as Plague Doctor)"
+		return "[newline ? "<br/>" : " "](as [.])" // i.e. " (as Plague Doctor)"
 
 /proc/printplayer(datum/mind/ply, fleecheck)
 	var/jobtext = ""

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -583,6 +583,22 @@
 		Trigger()
 		return
 
+///Returns a custom title for the roundend credit
+/proc/get_custom_title_from_id(obj/item/card/id/I, mind_job, mind_name)
+	if(I)
+		if(I.registered_name == mind_name) // card must be yours
+			. = I.assignment // get the custom title
+		if(. == mind_job) // non-custom title, lame
+			. = ""
+	if(!.) // still no custom title? it seems you don't have a ID card
+		var/datum/data/record/R = find_record("name", mind_name, GLOB.data_core.general)
+		if(R)
+			. = R.fields["rank"] || "" // get a custom title from datacore
+		if(. == mind_job) // lame...
+			. = ""
+
+	if(.)
+		return " (as [.])"
 
 /proc/printplayer(datum/mind/ply, fleecheck)
 	var/jobtext = ""
@@ -592,15 +608,8 @@
 		else
 			jobtext = " the <b>[ply.assigned_role]</b>"
 
-	var/obj/item/card/id/I = ply?.current.get_idcard()
-
 	// support the custom job title to the roundend report
-	var/jobtext_custom = (I?.registered_name == ply.name) ? ((ply?.assigned_role == I?.assignment) ? ply?.assigned_role : I?.assignment) : ply?.assigned_role // try to get your ID card, then gets a job title
-	if(ply.assigned_role == jobtext_custom)
-		var/datum/data/record/R = find_record("name", ply.name, GLOB.data_core.general)
-		if(R)
-			jobtext_custom = R.fields["rank"] || ply?.assigned_role // gets a custom title from datacore
-	jobtext_custom = (ply.assigned_role == jobtext_custom) ? "" : " (as [jobtext_custom])" // if no custom title, don't show it.
+	var/jobtext_custom = get_custom_title_from_id(ply?.current.get_idcard(), ply.assigned_role, ply.name)
 
 	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext][jobtext_custom] and"
 	if(ply.current)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -602,11 +602,11 @@
 
 /proc/printplayer(datum/mind/ply, fleecheck)
 	var/jobtext = ""
-	if(ply.assigned_role)
-		if(ply.assigned_role == "Unassigned")
-			jobtext = ply?.special_role || "" // "Unassigned" is bad. showing nothing is better.
-		else
+	if(ply.assigned_role || ply.special_role)
+		if(ply.assigned_role != "Unassigned")
 			jobtext = ply.assigned_role
+		if(!jobtext)
+			jobtext = ply.special_role
 		if(jobtext)
 			jobtext = " the <b>[ply.assigned_role]</b>"
 	var/jobtext_custom = get_custom_title_from_id(ply?.current.get_idcard(), ply.assigned_role, ply.name) // support the custom job title to the roundend report

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -778,16 +778,17 @@
 		if(SSshuttle.emergency.is_hijacked())
 			SSticker.news_report = SHUTTLE_HIJACK
 
-
 /datum/game_mode/proc/generate_credit_text()
 	var/list/round_credits = list()
 	var/len_before_addition
+	var/custom_title_holder
 
 	// HEADS OF STAFF
 	round_credits += "<center><h1>The Glorious Command Staff:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.command_positions))
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>A serious bureaucratic error has occurred!</h2>", "<center><h2>No one was in charge of the crew!</h2>")
 	round_credits += "<br>"
@@ -796,7 +797,7 @@
 	round_credits += "<center><h1>The Silicon \"Intelligences\":</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_silicon())
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] had no silicon helpers!</h2>", "<center><h2>Not a single door was opened today!</h2>")
 	round_credits += "<br>"
@@ -805,7 +806,8 @@
 	round_credits += "<center><h1>The Brave Security Officers:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.security_positions))
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] has fallen to Communism!</h2>", "<center><h2>No one was there to protect the crew!</h2>")
 	round_credits += "<br>"
@@ -814,7 +816,8 @@
 	round_credits += "<center><h1>The Wise Medical Department:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.medical_positions))
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>Healthcare was not included!</h2>", "<center><h2>There were no doctors today!</h2>")
 	round_credits += "<br>"
@@ -823,7 +826,8 @@
 	round_credits += "<center><h1>The Industrious Engineers:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.engineering_positions))
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] probably did not last long!</h2>", "<center><h2>No one was holding the station together!</h2>")
 	round_credits += "<br>"
@@ -832,7 +836,8 @@
 	round_credits += "<center><h1>The Inventive Science Employees:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.science_positions))
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>No one was doing \"science\" today!</h2>", "<center><h2>Everyone probably made it out alright, then!</h2>")
 	round_credits += "<br>"
@@ -841,7 +846,8 @@
 	round_credits += "<center><h1>The Rugged Cargo Crew:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.supply_positions))
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>The station was freed from paperwork!</h2>", "<center><h2>No one worked in cargo today!</h2>")
 	round_credits += "<br>"
@@ -850,11 +856,12 @@
 	var/list/human_garbage = list()
 	round_credits += "<center><h1>The Hardy Civilians:</h1>"
 	len_before_addition = round_credits.len
-	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.civilian_positions | GLOB.gimmick_positions))
+	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.civilian_positions | GLOB.gimmick_positions)) // gimmicks shouldn't be here, but let's not make the code dirty
 		if(current.assigned_role == JOB_NAME_ASSISTANT)
 			human_garbage += current
 		else
-			round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
+			custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+			round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>Everyone was stuck in traffic this morning!</h2>", "<center><h2>No civilians made it to work!</h2>")
 	round_credits += "<br>"
@@ -862,7 +869,8 @@
 	round_credits += "<center><h1>The Helpful Assistants:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in human_garbage)
-		round_credits += "<center><h2>[current.name]</h2>"
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		round_credits += "<center><h2>[current.name][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>The station was free of <s>greytide</s> assistance!</h2>", "<center><h2>Not a single Assistant showed up on the station today!</h2>")
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -797,7 +797,7 @@
 	round_credits += "<center><h1>The Silicon \"Intelligences\":</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_silicon())
-		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
+		round_credits += "<center><h2>[current.name] as the [current.assigned_role]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] had no silicon helpers!</h2>", "<center><h2>Not a single door was opened today!</h2>")
 	round_credits += "<br>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -787,7 +787,7 @@
 	round_credits += "<center><h1>The Glorious Command Staff:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.command_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>A serious bureaucratic error has occurred!</h2>", "<center><h2>No one was in charge of the crew!</h2>")
@@ -806,7 +806,7 @@
 	round_credits += "<center><h1>The Brave Security Officers:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.security_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] has fallen to Communism!</h2>", "<center><h2>No one was there to protect the crew!</h2>")
@@ -816,7 +816,7 @@
 	round_credits += "<center><h1>The Wise Medical Department:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.medical_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>Healthcare was not included!</h2>", "<center><h2>There were no doctors today!</h2>")
@@ -826,7 +826,7 @@
 	round_credits += "<center><h1>The Industrious Engineers:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.engineering_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] probably did not last long!</h2>", "<center><h2>No one was holding the station together!</h2>")
@@ -836,7 +836,7 @@
 	round_credits += "<center><h1>The Inventive Science Employees:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.science_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>No one was doing \"science\" today!</h2>", "<center><h2>Everyone probably made it out alright, then!</h2>")
@@ -846,7 +846,7 @@
 	round_credits += "<center><h1>The Rugged Cargo Crew:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.supply_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>The station was freed from paperwork!</h2>", "<center><h2>No one worked in cargo today!</h2>")
@@ -860,7 +860,7 @@
 		if(current.assigned_role == JOB_NAME_ASSISTANT)
 			human_garbage += current
 		else
-			custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+			custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 			round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>Everyone was stuck in traffic this morning!</h2>", "<center><h2>No civilians made it to work!</h2>")
@@ -869,7 +869,7 @@
 	round_credits += "<center><h1>The Helpful Assistants:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in human_garbage)
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name)
+		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
 		round_credits += "<center><h2>[current.name][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>The station was free of <s>greytide</s> assistance!</h2>", "<center><h2>Not a single Assistant showed up on the station today!</h2>")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -787,7 +787,7 @@
 	round_credits += "<center><h1>The Glorious Command Staff:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.command_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+		custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>A serious bureaucratic error has occurred!</h2>", "<center><h2>No one was in charge of the crew!</h2>")
@@ -806,7 +806,7 @@
 	round_credits += "<center><h1>The Brave Security Officers:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.security_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+		custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] has fallen to Communism!</h2>", "<center><h2>No one was there to protect the crew!</h2>")
@@ -816,7 +816,7 @@
 	round_credits += "<center><h1>The Wise Medical Department:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.medical_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+		custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>Healthcare was not included!</h2>", "<center><h2>There were no doctors today!</h2>")
@@ -826,7 +826,7 @@
 	round_credits += "<center><h1>The Industrious Engineers:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.engineering_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+		custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>[station_name()] probably did not last long!</h2>", "<center><h2>No one was holding the station together!</h2>")
@@ -836,7 +836,7 @@
 	round_credits += "<center><h1>The Inventive Science Employees:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.science_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+		custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>No one was doing \"science\" today!</h2>", "<center><h2>Everyone probably made it out alright, then!</h2>")
@@ -846,7 +846,7 @@
 	round_credits += "<center><h1>The Rugged Cargo Crew:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in SSticker.mode.get_all_by_department(GLOB.supply_positions))
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+		custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 		round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>The station was freed from paperwork!</h2>", "<center><h2>No one worked in cargo today!</h2>")
@@ -860,7 +860,7 @@
 		if(current.assigned_role == JOB_NAME_ASSISTANT)
 			human_garbage += current
 		else
-			custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+			custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 			round_credits += "<center><h2>[current.name] as the [current.assigned_role][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>Everyone was stuck in traffic this morning!</h2>", "<center><h2>No civilians made it to work!</h2>")
@@ -869,7 +869,7 @@
 	round_credits += "<center><h1>The Helpful Assistants:</h1>"
 	len_before_addition = round_credits.len
 	for(var/datum/mind/current in human_garbage)
-		custom_title_holder = get_custom_title_from_id(current?.current.get_idcard(), current.assigned_role, current.name, newline=TRUE)
+		custom_title_holder = get_custom_title_from_id(current, newline=TRUE)
 		round_credits += "<center><h2>[current.name][custom_title_holder]</h2>"
 	if(round_credits.len == len_before_addition)
 		round_credits += list("<center><h2>The station was free of <s>greytide</s> assistance!</h2>", "<center><h2>Not a single Assistant showed up on the station today!</h2>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds custom title details to roundend report and credit

It tracks an ID card that's registered to your mind name first.
if It failed to find an ID card or a custom title, it will tract your record in datacore.
if it still failed, it will show nothing additional.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Extra flavour good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/87972842/196196040-5d5eebef-4fc6-4e7d-b60b-5b6c9eaa7ede.png)

![image](https://user-images.githubusercontent.com/87972842/196196062-d638575a-956c-4169-9068-defc7db0406a.png)

![image](https://user-images.githubusercontent.com/87972842/196196207-c5101ba8-1464-4e9e-9824-3a493d752081.png)

the wizard one should show " the Wizard", but it was force-spawned with admeme power. It will show " the wizard" correctly when the game spawned them.


---------------------

![image](https://user-images.githubusercontent.com/87972842/196414340-1c6e3b97-c178-4dac-b2d6-9255a009b963.png)

changed as `<br/>` in credit for the case when someone has a long title


</details>

## Changelog
:cl:
tweak: round end report/credit will show your custom job titles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
