### PR TITLE
Fix a leftover line from the null rod, or the feedback on the nullrod is no longer real

### DIFF
--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -61,6 +61,5 @@
 	if(success_feedback)
 		var/real_feedback = replacetext(success_feedback, "%THEEFFECT", "[target]")
 		real_feedback = replacetext(real_feedback, "%THEWEAPON", "[item_parent]")
-		to_chat(user, "<span class='notice'>real_feedback</span>")
 	on_clear_callback?.Invoke(target, user)
 	qdel(target)

--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -61,5 +61,6 @@
 	if(success_feedback)
 		var/real_feedback = replacetext(success_feedback, "%THEEFFECT", "[target]")
 		real_feedback = replacetext(real_feedback, "%THEWEAPON", "[item_parent]")
+		to_chat(user, "<span class='notice'>[real_feedback]</span>")
 	on_clear_callback?.Invoke(target, user)
 	qdel(target)


### PR DESCRIPTION
## About The Pull Request

This PR fixes an oversight I've done on #7081, which when you try to clean up a cult rune with the null rod, aside your character screaming whatever is done to clean up a rune, it also gives a "real_feedback" to the chat (see screenshot), which dramatically breaks immersion and snap your attention away from your chaplain duty, exposing you to the danger the cults on the station.

This bug was discovered by @EvilDragonfiend 

## Why It's Good For The Game

Immersion breaking is never good, but in truth this just fixes an oversight.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![immagine](https://user-images.githubusercontent.com/75247747/196415776-6c7a1f66-7467-4f11-91aa-ad816c71e6fa.png)

</details>

## Changelog
:cl:
fix: the text "real_feedback" is no longer yielded when cleaning a rune with a nullrod
/:cl: