### PR TITLE
Misc Newscaster Fixes + Silicon TGUI Picture Select

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -340,12 +340,12 @@
 				if(3)
 					dat += "<font size='4'><b>Security Record</b></font><br>"
 					if(istype(active1, /datum/data/record) && GLOB.data_core.general.Find(active1))
-						if(istype(active1.fields["photo_front"], /obj/item/photo))
-							var/obj/item/photo/P1 = active1.fields["photo_front"]
-							user << browse_rsc(P1.picture.picture_image, "photo_front")
-						if(istype(active1.fields["photo_side"], /obj/item/photo))
-							var/obj/item/photo/P2 = active1.fields["photo_side"]
-							user << browse_rsc(P2.picture.picture_image, "photo_side")
+						if(istype(active1.fields["photo_front"], /datum/picture))
+							var/datum/picture/P1 = active1.fields["photo_front"]
+							user << browse_rsc(P1.picture_image, "photo_front")
+						if(istype(active1.fields["photo_side"], /datum/picture))
+							var/datum/picture/P2 = active1.fields["photo_side"]
+							user << browse_rsc(P2.picture_image, "photo_side")
 						dat += {"<table><tr><td><table>
 						<tr><td>Name:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=name'>&nbsp;[active1.fields["name"]]&nbsp;</A></td></tr>
 						<tr><td>ID:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=id'>&nbsp;[active1.fields["id"]]&nbsp;</A></td></tr>
@@ -357,10 +357,10 @@
 						<tr><td>Physical Status:</td><td>&nbsp;[active1.fields["p_stat"]]&nbsp;</td></tr>
 						<tr><td>Mental Status:</td><td>&nbsp;[active1.fields["m_stat"]]&nbsp;</td></tr>
 						</table></td>
-						<td><table><td align = center><a href='?src=[REF(src)];choice=Edit Field;field=show_photo_front'><img src=photo_front height=80 width=80 border=4></a><br>
+						<td><table><td align = center><img src=photo_front height=80 width=80 border=4><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=print_photo_front'>Print photo</a><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=upd_photo_front'>Update front photo</a></td>
-						<td align = center><a href='?src=[REF(src)];choice=Edit Field;field=show_photo_side'><img src=photo_side height=80 width=80 border=4></a><br>
+						<td align = center><img src=photo_side height=80 width=80 border=4><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=print_photo_side'>Print photo</a><br>
 						<a href='?src=[REF(src)];choice=Edit Field;field=upd_photo_side'>Update side photo</a></td></table>
 						</td></tr></table></td></tr></table>"}
@@ -783,50 +783,40 @@ What a mess.*/
 							if(!canUseSecurityRecordsConsole(usr, t1, a1))
 								return
 							active1.fields["species"] = t1
-					if("show_photo_front")
-						if(active1.fields["photo_front"])
-							if(istype(active1.fields["photo_front"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_front"]
-								P.show(usr)
 					if("upd_photo_front")
-						var/obj/item/photo/photo = get_photo(usr)
-						if(photo)
+						var/datum/picture/picture = get_picture(usr)
+						if(picture)
 							qdel(active1.fields["photo_front"])
 							//Lets center it to a 32x32.
-							var/icon/I = photo.picture.picture_image
+							var/icon/I = picture.picture_image
 							var/w = I.Width()
 							var/h = I.Height()
 							var/dw = w - 32
 							var/dh = w - 32
 							I.Crop(dw/2, dh/2, w - dw/2, h - dh/2)
-							active1.fields["photo_front"] = photo
+							active1.fields["photo_front"] = picture
 					if("print_photo_front")
 						if(active1.fields["photo_front"])
-							if(istype(active1.fields["photo_front"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_front"]
-								print_photo(P.picture.picture_image, active1.fields["name"])
-					if("show_photo_side")
-						if(active1.fields["photo_side"])
-							if(istype(active1.fields["photo_side"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_side"]
-								P.show(usr)
+							if(istype(active1.fields["photo_front"], /datum/picture))
+								var/datum/picture/P = active1.fields["photo_front"]
+								print_photo(P.picture_image, active1.fields["name"])
 					if("upd_photo_side")
-						var/obj/item/photo/photo = get_photo(usr)
-						if(photo)
+						var/datum/picture/picture = get_picture(usr)
+						if(picture)
 							qdel(active1.fields["photo_side"])
 							//Lets center it to a 32x32.
-							var/icon/I = photo.picture.picture_image
+							var/icon/I = picture.picture_image
 							var/w = I.Width()
 							var/h = I.Height()
 							var/dw = w - 32
 							var/dh = w - 32
 							I.Crop(dw/2, dh/2, w - dw/2, h - dh/2)
-							active1.fields["photo_side"] = photo
+							active1.fields["photo_side"] = picture
 					if("print_photo_side")
 						if(active1.fields["photo_side"])
-							if(istype(active1.fields["photo_side"], /obj/item/photo))
-								var/obj/item/photo/P = active1.fields["photo_side"]
-								print_photo(P.picture.picture_image, active1.fields["name"])
+							if(istype(active1.fields["photo_side"], /datum/picture))
+								var/datum/picture/P = active1.fields["photo_side"]
+								print_photo(P.picture_image, active1.fields["name"])
 					if("crim_add")
 						if(istype(active1, /datum/data/record))
 							var/t1 = stripped_input(usr, "Please input crime name:", "Secure. records", "", null)
@@ -976,16 +966,16 @@ What a mess.*/
 	updateUsrDialog()
 	return
 
-/obj/machinery/computer/secure_data/proc/get_photo(mob/user)
-	var/obj/item/photo/P = null
+/obj/machinery/computer/secure_data/proc/get_picture(mob/user)
+	var/datum/picture/P = null
 	if(issilicon(user))
 		var/mob/living/silicon/tempAI = user
 		var/datum/picture/selection = tempAI.aicamera?.selectpicture(user)
-		if(selection)
-			P = selection.Copy()
+		P = selection
 	else if(istype(user.get_active_held_item(), /obj/item/photo))
-		P = user.get_active_held_item()
-	return P
+		var/obj/item/photo/held = user.get_active_held_item()
+		P = held.picture
+	return P?.Copy()
 
 /obj/machinery/computer/secure_data/proc/print_photo(icon/temp, person_name)
 	if (printing)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -980,9 +980,9 @@ What a mess.*/
 	var/obj/item/photo/P = null
 	if(issilicon(user))
 		var/mob/living/silicon/tempAI = user
-		var/datum/picture/selection = tempAI.GetPhoto(user)
+		var/datum/picture/selection = tempAI.aicamera?.selectpicture(user)
 		if(selection)
-			P = new(null, selection)
+			P = selection.Copy()
 	else if(istype(user.get_active_held_item(), /obj/item/photo))
 		P = user.get_active_held_item()
 	return P

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -604,20 +604,15 @@
 /obj/machinery/newscaster/proc/attach_photo(mob/user)
 	if(issilicon(user))
 		var/obj/item/camera/siliconcam/targetcam
-		if(isAI(user))
-			var/mob/living/silicon/ai/R = user
-			targetcam = R.aicamera
-		else if(ispAI(user))
-			var/mob/living/silicon/pai/R = user
-			targetcam = R.aicamera
-		else if(iscyborg(user))
+		if(iscyborg(user))
 			var/mob/living/silicon/robot/R = user
 			if(R.connected_ai)
 				targetcam = R.connected_ai.aicamera
 			else
 				targetcam = R.aicamera
 		else
-			to_chat(user, "<span class='warning'>You cannot interface with silicon photo uploading!</span>")
+			var/mob/living/silicon/S = user
+			targetcam = S.aicamera
 		if(!length(targetcam.stored))
 			to_chat(usr, "<span class='boldannounce'>No images saved.</span>")
 			return

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -603,20 +603,8 @@
  */
 /obj/machinery/newscaster/proc/attach_photo(mob/user)
 	if(issilicon(user))
-		var/obj/item/camera/siliconcam/targetcam
-		if(iscyborg(user))
-			var/mob/living/silicon/robot/R = user
-			if(R.connected_ai)
-				targetcam = R.connected_ai.aicamera
-			else
-				targetcam = R.aicamera
-		else
-			var/mob/living/silicon/S = user
-			targetcam = S.aicamera
-		if(!length(targetcam.stored))
-			to_chat(usr, "<span class='boldannounce'>No images saved.</span>")
-			return
-		var/datum/picture/selection = targetcam.selectpicture(user)
+		var/mob/living/silicon/S = user
+		var/datum/picture/selection = S.aicamera?.selectpicture(user)
 		if(selection)
 			current_image = selection
 	else

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -141,7 +141,7 @@
 		data["user"]["silicon"] = TRUE
 		data["user"]["name"] = user.name
 		data["user"]["job"] = user.job
-		data["security_mode"] = TRUE
+		data["security_mode"] = !ispAI(user)
 	else
 		data["user"]["name"] = "Unknown"
 		data["user"]["job"] = "N/A"
@@ -332,6 +332,8 @@
 			return TRUE
 
 		if("storyCensor")
+			if(ispAI(usr))
+				return TRUE
 			if(!silicon)
 				var/obj/item/card/id/id_card
 				if(isliving(usr))
@@ -347,6 +349,8 @@
 					break
 
 		if("authorCensor")
+			if(ispAI(usr))
+				return TRUE
 			if(!silicon)
 				var/obj/item/card/id/id_card
 				if(isliving(usr))
@@ -362,6 +366,8 @@
 					break
 
 		if("channelDNotice")
+			if(ispAI(usr))
+				return TRUE
 			if(!silicon)
 				var/obj/item/card/id/id_card
 				if(isliving(usr))
@@ -432,6 +438,8 @@
 			return TRUE
 
 		if("submitWantedIssue")
+			if(ispAI(usr))
+				return TRUE
 			if(!crime_description || !criminal_name)
 				say("ERROR: Missing crime details.")
 				return TRUE
@@ -439,6 +447,14 @@
 			if(!istype(account) && !silicon)
 				say("ERROR: Cannot locate linked account ID.")
 				return TRUE
+			if(!silicon)
+				var/obj/item/card/id/id_card
+				if(isliving(usr))
+					var/mob/living/living_user = usr
+					id_card = living_user.get_idcard(hand_first = TRUE)
+				if(!(ACCESS_ARMORY in id_card?.GetAccess()))
+					say("ERROR: Unauthorized request.")
+					return TRUE
 			GLOB.news_network.submit_wanted(criminal_name, crime_description, silicon ? usr.name : account.account_holder, current_image, adminMsg = FALSE, newMessage = TRUE, has_image = wanted_image)
 			current_image = null
 			viewing_wanted = FALSE
@@ -449,6 +465,16 @@
 			return TRUE
 
 		if("clearWantedIssue")
+			if(ispAI(usr))
+				return TRUE
+			if(!silicon)
+				var/obj/item/card/id/id_card
+				if(isliving(usr))
+					var/mob/living/living_user = usr
+					id_card = living_user.get_idcard(hand_first = TRUE)
+				if(!(ACCESS_ARMORY in id_card?.GetAccess()))
+					say("ERROR: Unauthorized request.")
+					return TRUE
 			clear_wanted_issue(user = usr)
 			for(var/obj/machinery/newscaster/other_newscaster in GLOB.allCasters)
 				other_newscaster.update_icon()
@@ -827,6 +853,8 @@
 			balloon_alert(usr, "no photo identified.")
 
 /obj/machinery/newscaster/proc/clear_wanted_issue(user)
+	if(ispAI(usr))
+		return FALSE
 	if(!issilicon(usr))
 		var/obj/item/card/id/id_card
 		if(isliving(usr))

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -237,10 +237,6 @@
 	data["bountyValue"] = bounty_value
 	data["bountyText"] = bounty_text
 
-	return data
-
-/obj/machinery/newscaster/ui_static_data(mob/user)
-	var/list/data = list()
 	var/list/channel_list = list()
 	for(var/datum/feed_channel/channel as anything in GLOB.news_network.network_channels)
 		channel_list += list(list(
@@ -252,6 +248,7 @@
 		))
 
 	data["channels"] = channel_list
+
 	return data
 
 
@@ -379,8 +376,6 @@
 					current_channel = potential_channel
 					break
 			current_channel.toggle_censor_D_class()
-			// Channel censor is part of static data
-			update_static_data(usr)
 			return TRUE
 
 		if("startComment")
@@ -678,7 +673,6 @@
 		GLOB.news_network.create_feed_channel(channel_name, issilicon(usr) ? usr.name : account.account_holder, channel_desc, locked = channel_locked)
 		SSblackbox.record_feedback("text", "newscaster_channels", 1, "[channel_name]")
 	stop_creating_channel()
-	update_static_data(usr)
 
 /obj/machinery/newscaster/proc/edit_channel()
 	if(!channel_name)
@@ -703,7 +697,6 @@
 	current_channel.channel_desc = channel_desc
 	current_channel.locked = channel_locked
 	stop_editing_channel()
-	update_static_data(usr)
 
 /obj/machinery/newscaster/proc/stop_editing_channel()
 	editing_channel = FALSE

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -61,7 +61,7 @@
 	var/obj/item/integrated_signaler/signaler // AI's signaller
 
 	var/obj/item/instrument/piano_synth/internal_instrument
-	var/obj/machinery/newscaster			//pAI Newscaster
+	var/obj/machinery/newscaster/pai/newscaster			//pAI Newscaster
 	var/obj/item/healthanalyzer/hostscan				//pAI healthanalyzer
 
 	var/encryptmod = FALSE
@@ -122,7 +122,7 @@
 	hostscan = new /obj/item/healthanalyzer(src)
 	if(!radio)
 		radio = new /obj/item/radio/headset/silicon/pai(src)
-	newscaster = new /obj/machinery/newscaster(src)
+	newscaster = new /obj/machinery/newscaster/pai(src)
 	if(!aicamera)
 		aicamera = new /obj/item/camera/siliconcam/ai_camera(src)
 		aicamera.flash_enabled = TRUE

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -617,3 +617,11 @@
 	dat += "<a href='byond://?src=[REF(src)];software=loudness;sub=1'>Open Synthesizer Interface</a><br>"
 	dat += "<a href='byond://?src=[REF(src)];software=loudness;sub=2'>Choose Instrument Type</a>"
 	return dat
+
+/obj/machinery/newscaster/pai/ui_data(mob/user)
+	var/list/data = ..()
+	data["user"]["pai"] = TRUE
+	return data
+
+/obj/machinery/newscaster/pai/ui_state(mob/user)
+	return GLOB.reverse_contained_state

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -463,10 +463,6 @@
 	add_sensors()
 	to_chat(src, "Sensor overlay activated.")
 
-/mob/living/silicon/proc/GetPhoto(mob/user)
-	if (aicamera)
-		return aicamera.selectpicture(user)
-
 /mob/living/silicon/update_transform()
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/changed = 0

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -203,7 +203,7 @@
 				if(ringer_status)
 					playsound(computer, 'sound/machines/terminal_error.ogg', 15, TRUE)
 				return
-			var/datum/picture/selected_photo = tgui_select_picture(user, user.aicamera.stored, "Select Message Attachment")
+			var/datum/picture/selected_photo = user.aicamera.selectpicture(user, title = "Select Message Attachment")
 			if(!istype(selected_photo, /datum/picture))
 				return
 			computer.saved_image = selected_photo

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -167,7 +167,7 @@
 			if(tempAI.aicamera.stored.len == 0)
 				to_chat(usr, "<span class='boldannounce'>No images saved.</span>")
 				return
-			var/datum/picture/selection = tempAI.aicamera.selectpicture(usr)
+			var/datum/picture/selection = tempAI.aicamera?.selectpicture(usr)
 			var/obj/item/photo/photo = new(loc, selection)
 			photo.pixel_x = rand(-10, 10)
 			photo.pixel_y = rand(-10, 10)

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -25,14 +25,14 @@
 	in_camera_mode = TRUE
 	to_chat(user, "<B>Camera Mode activated</B>")
 
-/obj/item/camera/siliconcam/proc/selectpicture(mob/user)
+/obj/item/camera/siliconcam/proc/selectpicture(mob/user, title = "Select Photo", button_text = "Select")
 	if(!length(stored))
-		to_chat(usr, "<span class='boldannounce'>No images saved.</span>")
+		to_chat(user, "<span class='boldannounce'>No images saved.</span>")
 		return
-	return tgui_select_picture(user, stored, "Select Message Attachment")
+	return tgui_select_picture(user, stored, title = title, button_text = button_text)
 
 /obj/item/camera/siliconcam/proc/viewpictures(mob/user)
-	var/datum/picture/selection = selectpicture(user)
+	var/datum/picture/selection = selectpicture(user, button_text = "View")
 	if(istype(selection))
 		show_picture(user, selection)
 
@@ -72,7 +72,7 @@
 	if(!istype(C) || C.toner < 20)
 		to_chat(user, "<span class='warning'>Insufficent toner to print image.</span>")
 		return
-	var/datum/picture/selection = selectpicture(user)
+	var/datum/picture/selection = selectpicture(user, button_text = "Print")
 	if(!istype(selection))
 		to_chat(user, "<span class='warning'>Invalid Image.</span>")
 		return

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -59,11 +59,11 @@
 		stored[picture] = TRUE
 		to_chat(usr, "<span class='unconscious'>Image recorded and saved to local storage. Upload will happen automatically if unit is lawsynced.</span>")
 
-/obj/item/camera/siliconcam/robot_camera/selectpicture(mob/user)
+/obj/item/camera/siliconcam/robot_camera/selectpicture(mob/user, title = "Select Photo", button_text = "Select")
 	var/mob/living/silicon/robot/R = loc
 	if(istype(R) && R.connected_ai)
 		R.picturesync()
-		return R.connected_ai.aicamera.selectpicture(user)
+		return R.connected_ai.aicamera.selectpicture(user, title, button_text)
 	else
 		return ..()
 

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -26,20 +26,10 @@
 	to_chat(user, "<B>Camera Mode activated</B>")
 
 /obj/item/camera/siliconcam/proc/selectpicture(mob/user)
-	var/list/nametemp = list()
-	var/find
-	if(!stored.len)
+	if(!length(stored))
 		to_chat(usr, "<span class='boldannounce'>No images saved.</span>")
 		return
-	var/list/temp = list()
-	for(var/i in stored)
-		var/datum/picture/p = i
-		nametemp += p.picture_name
-		temp[p.picture_name] = p
-	find = input(user, "Select image") in nametemp|null
-	if(!find)
-		return
-	return temp[find]
+	return tgui_select_picture(user, stored, "Select Message Attachment")
 
 /obj/item/camera/siliconcam/proc/viewpictures(mob/user)
 	var/datum/picture/selection = selectpicture(user)

--- a/code/modules/tgui/tgui_select_picture.dm
+++ b/code/modules/tgui/tgui_select_picture.dm
@@ -1,4 +1,4 @@
-/proc/tgui_select_picture(mob/user, list/datum/picture/choices, title = "Select Photo")
+/proc/tgui_select_picture(mob/user, list/datum/picture/choices, title = "Select Photo", button_text = "Select")
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -9,7 +9,9 @@
 			return
 	if(!choices)
 		return
-	var/datum/tgui_select_picture/textbox = new(user, choices, title)
+	if(length(choices) == 1)
+		return choices[1]
+	var/datum/tgui_select_picture/textbox = new(user, choices, title, button_text)
 	textbox.ui_interact(user)
 	textbox.wait()
 	if (textbox)
@@ -23,12 +25,15 @@
 	var/datum/picture/entry
 	/// The title of the TGUI window
 	var/title
+	/// The text shown on the "Selection" button
+	var/button_text
 	/// The list of picture datums to select from
 	var/list/datum/picture/choices = list()
 
-/datum/tgui_select_picture/New(mob/user, choices, title)
+/datum/tgui_select_picture/New(mob/user, choices, title, button_text)
 	src.title = title
 	src.choices = choices
+	src.button_text = button_text
 
 /datum/tgui_select_picture/Destroy(force, ...)
 	SStgui.close_uis(src)
@@ -71,7 +76,8 @@
 		))
 	return list(
 		"title" = title,
-		"pictures" = pictures
+		"pictures" = pictures,
+		"button_text" = button_text,
 	)
 
 /datum/tgui_select_picture/ui_act(action, list/params)

--- a/tgui/packages/tgui/interfaces/Newscaster.js
+++ b/tgui/packages/tgui/interfaces/Newscaster.js
@@ -34,24 +34,24 @@ export const Newscaster = (props, context) => {
       <NewscasterCommentCreation override_bg={override_bg} />
       <NewscasterWantedScreen override_bg={override_bg} />
       <Stack fill vertical>
-        <Stack.Item>
-          <Tabs fluid textAlign="center">
-            <Tabs.Tab
-              color="Green"
-              selected={screenmode === NEWSCASTER_SCREEN}
-              onClick={() => setScreenmode(NEWSCASTER_SCREEN)}>
-              Newscaster
-            </Tabs.Tab>
-            {!user?.admin && (
+        {!user?.admin && !user?.pai && (
+          <Stack.Item>
+            <Tabs fluid textAlign="center">
+              <Tabs.Tab
+                color="Green"
+                selected={screenmode === NEWSCASTER_SCREEN}
+                onClick={() => setScreenmode(NEWSCASTER_SCREEN)}>
+                Newscaster
+              </Tabs.Tab>
               <Tabs.Tab
                 Color="Blue"
                 selected={screenmode === BOUNTYBOARD_SCREEN}
                 onClick={() => setScreenmode(BOUNTYBOARD_SCREEN)}>
                 Bounty Board
               </Tabs.Tab>
-            )}
-          </Tabs>
-        </Stack.Item>
+            </Tabs>
+          </Stack.Item>
+        )}
         <Stack.Item grow>
           {screenmode === NEWSCASTER_SCREEN && (
             <NewscasterContent />

--- a/tgui/packages/tgui/interfaces/PictureSelectModal.js
+++ b/tgui/packages/tgui/interfaces/PictureSelectModal.js
@@ -7,6 +7,7 @@ export const PictureSelectModal = (_, context) => {
   const {
     title,
     pictures = [],
+    button_text,
   } = data;
   return (
     <Window title={title} width={400} height={500}>
@@ -22,7 +23,7 @@ export const PictureSelectModal = (_, context) => {
             key={picture.ref}
             buttons={(
               <Button
-                content="Select"
+                content={button_text}
                 color="green"
                 onClick={() => act('submit', { entry: picture.ref })} />
             )}


### PR DESCRIPTION
## About The Pull Request

Fixes #7938 newscasters not updating properly
Fixes #7937 pAIs not being able to use newscasters
Makes all silicon picture selects use the TGUI picture select added in the tablet PDA PR
Fixes an href allowing wanted issues without permission

## Why It's Good For The Game

Fixes bugs, and makes the picture selection process much more streamlined

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/10366817/197125748-ed105834-6dab-4399-bd7c-fb1fe5bb8eb5.png)

![image](https://user-images.githubusercontent.com/10366817/197125753-6c51ef3e-1d94-49e9-91cc-5961c9cb579c.png)

![image](https://user-images.githubusercontent.com/10366817/197125765-69ed395e-0b10-43b3-be89-963ff4caf1c6.png)

![image](https://user-images.githubusercontent.com/10366817/197125811-31d06c90-1e30-4a94-b2f5-d21101490398.png)

Doesn't break the original

![image](https://user-images.githubusercontent.com/10366817/197130990-aaeaef5a-024a-42d9-9f1a-2e59563da76f.png)

</details>

## Changelog
:cl:
fix: Fixed newscasters not updating UI when a channel is created.
fix: Fixed pAIs being unable to use their newscaster.
tweak: All silicon picture selections now use a TGUI menu with image previews and descriptions instead of a list of image names.
fix: Fixed an exploit allowing you to submit a wanted issue without permission.
fix: Fixed submitting a picture to sec records being super broken.
/:cl:
