### PR TITLE
Correctly loads gear from savefiles

### DIFF
--- a/tools/savefileimporter/code/character_parser.dm
+++ b/tools/savefileimporter/code/character_parser.dm
@@ -13,6 +13,13 @@ var/global/list/custom_name_types = list(
 
 // In its own file because its such a mess
 /proc/parse_characters(owning_ckey, savefile/S, list/cdirs)
+
+	// Gear is a global preference and needs to be handled separately
+	var/list/equipped_gear
+	READ_FILE_EXVAR(S["equipped_gear"], equipped_gear)
+	if(!equipped_gear)
+		equipped_gear = list()
+
 	for(var/character_dir in cdirs)
 		S.cd = "/[character_dir]"
 
@@ -79,11 +86,6 @@ var/global/list/custom_name_types = list(
 		READ_FILE_EXVAR(S["all_quirks"], all_quirks)
 		if(!all_quirks)
 			all_quirks = list()
-		// Gear
-		var/list/equipped_gear
-		READ_FILE_EXVAR(S["equipped_gear"], equipped_gear)
-		if(!equipped_gear)
-			equipped_gear = list()
 
 		// Get the slot
 		var/list/slot_list = splittext(character_dir, "character")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The savefile importer incorrectly tried to load gear from individual characters based on a since reverted PR. This caused character imports to have malformed `equipped_gear` entries. This prevents impacted characters from getting to the metacoin shop and altering their equipment.

**Note**: In order to fix this issue in post, broken characters will either need to have their equipment wiped or their entries will need to be corrected.

The following query can be used as a guide to see which characters have broken equipment.

```sql
SELECT ckey,real_name,equipped_gear FROM ss13db.SS13_characters WHERE equipped_gear NOT LIKE '[%]';
```
 
## Why It's Good For The Game

While this doesn't fix the issue in-post, it will prevent future codebases from landing in the same situation we've found ourselves in. Prevents #7864

```sql
> SELECT COUNT(*) AS "Broken Characters" FROM SS13_characters WHERE equipped_gear NOT LIKE
'[%]';
+-------------------+
| Broken Characters |
+-------------------+
|               149 |
+-------------------+
1 row in set (0.000 sec)
```

## Testing Photographs and Procedure
1. Took a savefile containing a known broken character and ran it through the importer
2. Checked the database to confirm a successful import

```sql
MariaDB [(none)]> SELECT equipped_gear FROM ss13beedb.SS13_characters LIMIT 1;
+-----------------------------------------------------------------------------------------------------------------------------------------------+
| equipped_gear                                                                                                                                 |
+-----------------------------------------------------------------------------------------------------------------------------------------------+
| ["18d1db5eee948fb743788a838d3ebe67","40dc4932780fb31a763a30cb7baa1ebc","97178c98cb1431e75a1dbf30c14b8e8e","380ff4d3619177d9a359336cdbc9dd19"] |
+-----------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.000 sec)
```

## Changelog
:cl:
fix: Corrects the savefile importer so it properly loads equipped gear into the database
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
