### PR TITLE
Dynamic: Block hivemind/traitors/heretics combo

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -79,7 +79,8 @@
 		/datum/dynamic_ruleset/roundstart/clockcult,
 		/datum/dynamic_ruleset/roundstart/nuclear,
 		/datum/dynamic_ruleset/roundstart/wizard,
-		/datum/dynamic_ruleset/roundstart/revs
+		/datum/dynamic_ruleset/roundstart/revs,
+		/datum/dynamic_ruleset/roundstart/hivemind
 	)
 
 //////////////////////////////////////////////
@@ -181,5 +182,6 @@
 		/datum/dynamic_ruleset/roundstart/clockcult,
 		/datum/dynamic_ruleset/roundstart/nuclear,
 		/datum/dynamic_ruleset/roundstart/wizard,
-		/datum/dynamic_ruleset/roundstart/revs
+		/datum/dynamic_ruleset/roundstart/revs,
+		/datum/dynamic_ruleset/roundstart/hivemind
 	)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -198,7 +198,8 @@
 		/datum/dynamic_ruleset/roundstart/clockcult,
 		/datum/dynamic_ruleset/roundstart/nuclear,
 		/datum/dynamic_ruleset/roundstart/wizard,
-		/datum/dynamic_ruleset/roundstart/revs
+		/datum/dynamic_ruleset/roundstart/revs,
+		/datum/dynamic_ruleset/roundstart/hivemind
 	)
 
 /datum/dynamic_ruleset/midround/autotraitor/trim_candidates()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -696,7 +696,7 @@
 	weight = 3
 	cost = 30
 	requirements = list(100,90,80,60,40,30,10,10,10,10)
-	flags = HIGH_IMPACT_RULESET
+	flags = HIGH_IMPACT_RULESET | NO_OTHER_ROUNDSTARTS_RULESET
 
 /datum/dynamic_ruleset/roundstart/hivemind/pre_execute(population)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

An extension of https://github.com/BeeStation/BeeStation-Hornet/pull/7658
Hivemind was merged slightly after my PR so it wasn't included.

## Why It's Good For The Game

Hivemind assimilation onto a traitor can hijack the round and create weird interactions, see original PR for more details.

## Testing Photographs and Procedure

N/A

## Changelog
:cl:
balance: Dynamic: Traitors, Changelings, and Heretics can no longer spawn alongside hivemind (assimilation).
/:cl: