### PR TITLE
Fixes floors constructed on a lattice by the RCD from continuing to let air escape into space

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -54,7 +54,7 @@
 
 /obj/structure/lattice/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_FLOORWALL)
-		return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 2)
+		return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
 
 /obj/structure/lattice/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
@@ -62,7 +62,6 @@
 		var/turf/T = src.loc
 		if(isspaceturf(T))
 			T.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			qdel(src)
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Fixes #7960
Thank you so much for that, this bug is disastrous with monstermos

Also fixes incongruence in build-price

## Why It's Good For The Game

Bugs are, and hear me out on this one, bad

## Testing Photographs and Procedure

### Before bug-fix
Deconstruct floor
Place lattice
Construct floor by clicking directly on the lattice with an RCD (if you were to click on the space under the lattice this would not happen)
Fill room with air

That floor will let air escape into space

### After
Repeat above, this time air will not escape

What a weird bug

## Changelog
:cl:
fix: fixed RCD-constructed floor not stopping air
fix: fixed incongruence in price between constructing floor on lattice and constructing on the space below the lattice
/:cl:
