### PR TITLE
Lighteater fixes

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -828,12 +828,12 @@
 /**
   * Called when lighteater is called on this.
   */
-/atom/proc/lighteater_act(obj/item/light_eater/light_eater)
+/atom/proc/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src,COMSIG_ATOM_LIGHTEATER_ACT)
 	for(var/datum/light_source/light_source in light_sources)
 		if(light_source.source_atom != src)
-			light_source.source_atom.lighteater_act(light_eater)
+			light_source.source_atom.lighteater_act(light_eater, src)
 
 /**
   * Respond to the eminence clicking on our atom

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1166,7 +1166,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 /obj/mecha/rust_heretic_act()
 	take_damage(500,  BRUTE)
 
-/obj/mecha/lighteater_act(obj/item/light_eater/light_eater)
+/obj/mecha/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	if(!lights_power)
 		return

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -23,6 +23,8 @@
 	var/radiation_count = 0
 	var/grace = RAD_GEIGER_GRACE_PERIOD
 	var/datum/looping_sound/geiger/soundloop
+	/// If the headlamp is broken, used by lighteater
+	var/light_broken = FALSE
 
 /obj/item/clothing/head/helmet/space/hardsuit/Initialize(mapload)
 	. = ..()
@@ -39,9 +41,13 @@
 	return ..()
 
 /obj/item/clothing/head/helmet/space/hardsuit/attack_self(mob/user)
-	on = !on
+	if(light_broken)
+		to_chat(user, "<span class='notice'>The headlamp has been burnt out... Looks like there's no replacing it.</span>")
+		on = FALSE
+	else
+		on = !on
 	icon_state = "[basestate][on]-[hardsuit_type]"
-	user.update_inv_head()	//so our mob-overlays update
+	user?.update_inv_head()	//so our mob-overlays update
 
 	set_light_on(on)
 
@@ -906,7 +912,7 @@
 		/datum/action/item_action/toggle_beacon_frequency
 	)
 	jetpack = /obj/item/tank/jetpack/suit
- 
+
 /obj/item/clothing/suit/space/hardsuit/shielded/syndi/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/anti_artifact, INFINITY, FALSE, 100)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -304,7 +304,7 @@
 		wisp.forceMove(src)
 		SSblackbox.record_feedback("tally", "wisp_lantern", 1, "Returned")
 
-/obj/item/wisp_lantern/lighteater_act(obj/item/light_eater/light_eater)
+/obj/item/wisp_lantern/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	. = ..()
 	wisp.lighteater_act(light_eater)
 
@@ -363,7 +363,7 @@
 	SIGNAL_HANDLER
 	src.lighteater_act(light_eater)
 
-/obj/effect/wisp/lighteater_act(obj/item/light_eater/light_eater)
+/obj/effect/wisp/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	. = ..()
 	if(home)
 		src.forceMove(home)
@@ -1217,7 +1217,7 @@
 
 /obj/item/hierophant_club/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(user.mind.martial_art.no_guns) 
+	if(user.mind.martial_art.no_guns)
 		to_chat(user, "<span class='warning'>To use this weapon would bring dishonor to the clan.</span>")
 		return
 	var/turf/T = get_turf(target)

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -243,7 +243,7 @@
 
 /obj/item/clothing/head/helmet/space/hardsuit/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	if(!light_range || !light_power || !light_on || light_broken)
-		return
+		return ..()
 	if(light_eater)
 		visible_message("<span class='danger'>The headlamp of [src] is disintegrated by [light_eater]!</span>")
 	light_broken = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -187,14 +187,14 @@
 		return
 	AM.lighteater_act(src)
 
-/atom/movable/lighteater_act(obj/item/light_eater/light_eater)
+/atom/movable/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	for(var/datum/component/overlay_lighting/light_source in affected_dynamic_lights)
 		if(light_source.parent != src)
 			var/atom/A = light_source.parent
-			A.lighteater_act(light_eater)
+			A.lighteater_act(light_eater, src)
 
-/mob/living/lighteater_act(obj/item/light_eater/light_eater)
+/mob/living/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	if(on_fire)
 		ExtinguishMob()
@@ -202,28 +202,28 @@
 	if(pulling)
 		pulling.lighteater_act(light_eater)
 
-/mob/living/carbon/human/lighteater_act(obj/item/light_eater/light_eater)
+/mob/living/carbon/human/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	if(isethereal(src))
 		emp_act(EMP_LIGHT)
 
-/mob/living/silicon/robot/lighteater_act(obj/item/light_eater/light_eater)
+/mob/living/silicon/robot/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	if(lamp_enabled)
 		smash_headlamp()
 
-/obj/structure/bonfire/lighteater_act(obj/item/light_eater/light_eater)
+/obj/structure/bonfire/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	if(burning)
 		extinguish()
 		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
 	..()
 
-/obj/structure/glowshroom/lighteater_act(obj/item/light_eater/light_eater)
+/obj/structure/glowshroom/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	if (light_power > 0)
 		acid_act()
 
-/obj/item/lighteater_act(obj/item/light_eater/light_eater)
+/obj/item/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	..()
 	if(!light_range || !light_power || !light_on)
 		return
@@ -232,16 +232,27 @@
 	burn()
 	playsound(src, 'sound/items/welder.ogg', 50, 1)
 
-/obj/item/modular_computer/tablet/lighteater_act(obj/item/light_eater/light_eater)
+/obj/item/modular_computer/tablet/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	if(light_range && light_power > 0 && light_on)
 		// Only the queen of Beetania can save our IDs from this infernal nightmare
 		var/obj/item/computer_hardware/card_slot/card_slot2 = all_components[MC_CARD2]
 		var/obj/item/computer_hardware/card_slot/card_slot = all_components[MC_CARD]
-		card_slot2.try_eject()
-		card_slot.try_eject()
+		card_slot2?.try_eject()
+		card_slot?.try_eject()
 	..()
 
-/turf/open/floor/light/lighteater_act(obj/item/light_eater/light_eater)
+/obj/item/clothing/head/helmet/space/hardsuit/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
+	if(!light_range || !light_power || !light_on || light_broken)
+		return
+	if(light_eater)
+		visible_message("<span class='danger'>The headlamp of [src] is disintegrated by [light_eater]!</span>")
+	light_broken = TRUE
+	var/mob/user = ismob(parent) ? parent : null
+	attack_self(user)
+	playsound(src, 'sound/items/welder.ogg', 50, 1)
+	..()
+
+/turf/open/floor/light/lighteater_act(obj/item/light_eater/light_eater, atom/parent)
 	. = ..()
 	if(!light_range || !light_power || !light_on)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes PDAs without card slots runtiming when hit with lighteater.
Hardsuits with headlamps will now have their headlamps broken instead of being deleted.

Fixes #7954 
Fixes #7965 

Adds a "parent" argument to lighteater_act. This is used to know what the wearer of the hardsuit helmet is so we can update the icon on their head to remove the "light".

## Why It's Good For The Game

Fixes a bug and also prevents important items/hardsuits from being deleted from the round.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Helmet light broke
![image](https://user-images.githubusercontent.com/10366817/197704647-5f0cd1ac-5ed2-4dfc-b16a-594a411f1186.png)

PDA broke
![image](https://user-images.githubusercontent.com/10366817/197704656-40cea23a-881c-44a6-9d16-d2a8b741ac0a.png)

</details>

## Changelog
:cl:
balance: Lighteaters will no longer erase hardsuits with headlamps from existence, instead, permanently disabling their headlamps.
fix: PDAs are now properly affected by lighteaters when they lack a primary/secondary card slot.
/:cl: