### PR TITLE
Makes oozeling melting account for clothing permeability

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -227,9 +227,12 @@
 	if(!istype(M))
 		return
 	if(isoozeling(M))
-		M.blood_volume = max(M.blood_volume - 30, 0)
-		to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
-		return
+		var/touch_mod = 0
+		if(method in list(TOUCH, VAPOR)) // No melting if you have skin protection
+			touch_mod = M.get_permeability_protection()
+		M.blood_volume = max(M.blood_volume - 30 * (1 - touch_mod), 0)
+		if(touch_mod < 0.9)
+			to_chat(M, "<span class='warning'>The water causes you to melt away!</span>")
 	if(method == TOUCH)
 		M.adjust_fire_stacks(-(reac_volume / 10))
 		M.ExtinguishMob()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This makes oozeling melting from water check for clothing/hardsuit permeability, meaning you can't melt an oozeling through a hardsuit anymore. 

This also means that some suits with low permeability will also protect oozelings more than others with high permeability. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Clothing actually applying protection from things touching is a good thing.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>


https://user-images.githubusercontent.com/9423435/198512114-ecf448bf-b020-45c9-8ac2-85892a698ab9.mp4



</details>

## Changelog
:cl:
tweak: Oozeling water melting is now affected by the clothing/suit the oozeling is wearing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
