### PR TITLE
Do not preprocessor error if FastDMM is parsing

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -64,7 +64,7 @@
 #define MIN_COMPILER_VERSION 514
 #define MIN_COMPILER_BUILD 1583
 //TODO Remove the SDMM check when it supports 1568
-#if !defined(SPACEMAN_DMM) && (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD)
+#if !defined(SPACEMAN_DMM) && (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(FASTDMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
 #error You need version 514.1583 or higher.
@@ -108,7 +108,7 @@
 #define CBT
 #endif
 
-#if !defined(CBT) && !defined(SPACEMAN_DMM)
+#if !defined(CBT) && !defined(SPACEMAN_DMM) && !defined(FASTDMM)
 #error Building with Dream Maker is no longer supported and will result in errors.
 #error Switch to VSCode and when prompted install the recommended extensions, you can then either use the UI or press Ctrl+Shift+B to build the codebase.
 #endif


### PR DESCRIPTION
## About The Pull Request

BeeStation is completely incompatible with FastDMM because it preprocessor errors (FastDMM does not actually compile, so it doesn't matter)

## Why It's Good For The Game

FastDMM is usable

## Testing Photographs and Procedure

Pictured: FastDMM working on this branch

![image](https://user-images.githubusercontent.com/10366817/198812964-a1a67448-6e09-4055-b275-e35c99fbeda7.png)

## Changelog

N/A
